### PR TITLE
feat(cli): `stitch run` + `stitch trace` — the CLI surface

### DIFF
--- a/bin/stitch
+++ b/bin/stitch
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+'use strict';
+
+// Thin shim: the implementation lives in src/cli.ts and is bundled to lib/cli.js
+// by the build. Keep this file dependency-free and logic-free.
+require('../lib/cli.js')
+    .main(process.argv.slice(2))
+    .then((code) => {
+        process.exitCode = code || 0;
+    })
+    .catch((err) => {
+        process.stderr.write(`${(err && err.stack) || err}\n`);
+        process.exitCode = 1;
+    });

--- a/package.json
+++ b/package.json
@@ -18,8 +18,12 @@
         }
     },
     "sideEffects": false,
+    "bin": {
+        "stitch": "bin/stitch"
+    },
     "files": [
-        "lib"
+        "lib",
+        "bin"
     ],
     "scripts": {
         "test": "jest",
@@ -29,7 +33,7 @@
         "check:exports": "attw --pack .",
         "lint": "eslint src --flag unstable_ts_config",
         "format": "jiti ./node_modules/.bin/prettier --write .",
-        "build": "tsup src/index.ts --format cjs,esm --minify --dts --out-dir lib",
+        "build": "tsup",
         "prepare": "husky",
         "prepack": "npm run build"
     },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,474 @@
+// `stitch` CLI — one definition, a shell front door (DESIGN.md §10).
+//   stitch run <name> [--module <path>] [--flags…]   run a stitch, stream JSONL events
+//   stitch trace [--file <path>] [--since 1h] [--name x] [--json]   summarize the run log
+// Flags map onto a stitch's single input object ({ params, query, body, headers });
+// every event the stitch emits is written to stdout as one line of JSON, so the
+// output pipes straight into jq and friends. No app boot required.
+import {
+    type StitchRegistry,
+    loadStitches,
+    resolveModulePath,
+    selectStitch,
+} from './registry';
+import type { Stitch, StitchEvent, StitchInput } from './types';
+
+import { existsSync, readFileSync } from 'node:fs';
+
+// ---- arg → input mapping --------------------------------------------------
+
+type Bucket = 'params' | 'query' | 'headers';
+
+// Best-effort scalar coercion so `--id 1` is the number 1 and `--active true` is a
+// boolean. Anything that is not valid JSON stays a string (so `--q ada` is "ada").
+function coerce(raw: string): unknown {
+    try {
+        return JSON.parse(raw);
+    } catch {
+        return raw;
+    }
+}
+
+// Path-template parameter names (`/users/{id}` → ["id"]) so a bare `--id` routes to
+// params, matching the engine's own `{param}` expansion.
+export function paramNamesOf(stitch: Stitch): string[] {
+    const path = stitch.__config.path ?? '';
+    return [...path.matchAll(/\{(\w+)\}/g)].map((m) => m[1]);
+}
+
+// Map CLI flags onto a StitchInput. Conventions:
+//   --params.<k> / --query.<k> / --headers.<k> / --header.<k>   explicit bucket
+//   --body '<json>'                                             whole request body
+//   --body.<k> <v>                                              one body field
+//   --<k> <v>                                                   params if <k> is a
+//                                                               path param, else query
+//   --<flag>                                                    boolean true
+//   --k=v also accepted; a repeated key becomes an array; header values stay strings.
+export function argsToInput(
+    argv: string[],
+    paramNames: Iterable<string> = [],
+): { input: StitchInput; positionals: string[] } {
+    const params = new Set(paramNames);
+    const input: StitchInput = {};
+    const positionals: string[] = [];
+
+    const put = (bucket: Bucket, key: string, value: unknown): void => {
+        const obj = (input[bucket] ??= {}) as Record<string, unknown>;
+        if (key in obj) {
+            const prev = obj[key];
+            obj[key] = Array.isArray(prev) ? [...prev, value] : [prev, value];
+        } else obj[key] = value;
+    };
+
+    const route = (key: string, raw: string | undefined): void => {
+        const bool = raw === undefined;
+        const dot = key.indexOf('.');
+        const head = dot >= 0 ? key.slice(0, dot) : key;
+        const tail = dot >= 0 ? key.slice(dot + 1) : '';
+
+        switch (head) {
+            case 'params':
+            case 'param':
+                return put('params', tail, bool ? true : coerce(raw));
+            case 'query':
+            case 'q':
+                return put('query', tail, bool ? true : coerce(raw));
+            case 'headers':
+            case 'header':
+            case 'H':
+                return put('headers', tail, bool ? 'true' : raw);
+            case 'body': {
+                if (!tail) {
+                    input.body = bool ? true : coerce(raw);
+                    return;
+                }
+                const body = (
+                    input.body && typeof input.body === 'object'
+                        ? input.body
+                        : (input.body = {})
+                ) as Record<string, unknown>;
+                body[tail] = bool ? true : coerce(raw);
+                return;
+            }
+            default: {
+                const bucket: Bucket = params.has(key) ? 'params' : 'query';
+                return put(bucket, key, bool ? true : coerce(raw));
+            }
+        }
+    };
+
+    for (let i = 0; i < argv.length; i++) {
+        const tok = argv[i];
+        if (!tok.startsWith('--')) {
+            positionals.push(tok);
+            continue;
+        }
+        const key = tok.slice(2);
+        const eq = key.indexOf('=');
+        if (eq >= 0) {
+            route(key.slice(0, eq), key.slice(eq + 1));
+            continue;
+        }
+        const next = argv[i + 1];
+        if (next !== undefined && !next.startsWith('--')) {
+            route(key, next);
+            i++;
+        } else {
+            route(key, undefined); // boolean flag
+        }
+    }
+
+    return { input, positionals };
+}
+
+// ---- run: stream a stitch's events to stdout as JSONL ---------------------
+
+// Drive a stitch's event stream, writing one JSON object per line. Returns the
+// process exit code: 1 if an error event was seen, else 0.
+export async function streamToJsonl(
+    stitch: Stitch,
+    input: StitchInput,
+    writeLine: (line: string) => void,
+): Promise<number> {
+    let exit = 0;
+    for await (const ev of stitch.stream(input) as AsyncIterable<StitchEvent>) {
+        writeLine(JSON.stringify(ev));
+        if (ev.type === 'error') exit = 1;
+    }
+    return exit;
+}
+
+// Resolve a named stitch in a registry, map argv → input, stream JSONL. The seam
+// the `run` command and tests share.
+export async function runStitch(
+    registry: StitchRegistry,
+    name: string,
+    flags: string[],
+    writeLine: (line: string) => void,
+): Promise<number> {
+    const stitch = selectStitch(registry, name);
+    const { input } = argsToInput(flags, paramNamesOf(stitch));
+    return streamToJsonl(stitch, input, writeLine);
+}
+
+// Pull our own options (`--module`/`-m`) and the leading stitch name out of the
+// run argv; everything else is passed through to argsToInput untouched.
+function splitRunArgs(args: string[]): {
+    name?: string;
+    modulePath?: string;
+    flags: string[];
+} {
+    const flags: string[] = [];
+    let name: string | undefined;
+    let modulePath: string | undefined;
+    for (let i = 0; i < args.length; i++) {
+        const a = args[i];
+        if (a === '--module' || a === '-m') {
+            modulePath = args[++i];
+        } else if (a.startsWith('--module=')) {
+            modulePath = a.slice('--module='.length);
+        } else if (name === undefined && !a.startsWith('-')) {
+            name = a;
+        } else {
+            flags.push(a);
+        }
+    }
+    return { name, modulePath, flags };
+}
+
+// ---- trace: summarize the JSONL run log -----------------------------------
+
+interface TraceRecord {
+    name?: string;
+    type: string;
+    at?: number;
+    ok?: boolean;
+    ms?: number;
+    phase?: string;
+    finding?: { level?: string };
+}
+export interface StitchStats {
+    name: string;
+    runs: number;
+    ok: number;
+    failed: number;
+    retries: number;
+    drift: { error: number; warn: number; info: number };
+    p50: number;
+    p95: number;
+    p99: number;
+    avgMs: number;
+}
+export interface TraceSummary {
+    stitches: StitchStats[];
+    totals: { runs: number; ok: number; failed: number };
+}
+
+function percentile(sortedAsc: number[], p: number): number {
+    if (!sortedAsc.length) return 0;
+    const idx = Math.min(
+        sortedAsc.length - 1,
+        Math.floor((p / 100) * sortedAsc.length),
+    );
+    return sortedAsc[idx];
+}
+
+// Fold a flat list of trace records into per-stitch stats. Pure: no clock, no I/O.
+export function summarizeTrace(records: TraceRecord[]): TraceSummary {
+    const byName = new Map<
+        string,
+        { stats: StitchStats; durations: number[] }
+    >();
+    const ensure = (name: string) => {
+        let e = byName.get(name);
+        if (!e) {
+            e = {
+                stats: {
+                    name,
+                    runs: 0,
+                    ok: 0,
+                    failed: 0,
+                    retries: 0,
+                    drift: { error: 0, warn: 0, info: 0 },
+                    p50: 0,
+                    p95: 0,
+                    p99: 0,
+                    avgMs: 0,
+                },
+                durations: [],
+            };
+            byName.set(name, e);
+        }
+        return e;
+    };
+
+    for (const r of records) {
+        const e = ensure(r.name ?? 'stitch');
+        switch (r.type) {
+            case 'done':
+                e.stats.runs++;
+                if (r.ok) e.stats.ok++;
+                else e.stats.failed++;
+                if (typeof r.ms === 'number') e.durations.push(r.ms);
+                break;
+            case 'progress':
+                if (r.phase === 'retry') e.stats.retries++;
+                break;
+            case 'drift': {
+                const level = r.finding?.level;
+                if (level === 'error' || level === 'warn' || level === 'info')
+                    e.stats.drift[level]++;
+                break;
+            }
+        }
+    }
+
+    const stitches: StitchStats[] = [];
+    const totals = { runs: 0, ok: 0, failed: 0 };
+    for (const { stats, durations } of [...byName.values()].sort((a, b) =>
+        a.stats.name.localeCompare(b.stats.name),
+    )) {
+        const sorted = durations.slice().sort((a, b) => a - b);
+        stats.p50 = percentile(sorted, 50);
+        stats.p95 = percentile(sorted, 95);
+        stats.p99 = percentile(sorted, 99);
+        stats.avgMs = sorted.length
+            ? Math.round(sorted.reduce((a, b) => a + b, 0) / sorted.length)
+            : 0;
+        stitches.push(stats);
+        totals.runs += stats.runs;
+        totals.ok += stats.ok;
+        totals.failed += stats.failed;
+    }
+    return { stitches, totals };
+}
+
+// Render a summary as a compact aligned table.
+export function formatTraceSummary(summary: TraceSummary): string {
+    if (!summary.stitches.length) return 'no runs in trace';
+    const rows = summary.stitches.map((s) => ({
+        name: s.name,
+        runs: String(s.runs),
+        ok: String(s.ok),
+        failed: String(s.failed),
+        retries: String(s.retries),
+        drift: `${s.drift.error}/${s.drift.warn}/${s.drift.info}`,
+        p50: `${s.p50}ms`,
+        p95: `${s.p95}ms`,
+        p99: `${s.p99}ms`,
+    }));
+    const cols: Array<[keyof (typeof rows)[0], string]> = [
+        ['name', 'stitch'],
+        ['runs', 'runs'],
+        ['ok', 'ok'],
+        ['failed', 'failed'],
+        ['retries', 'retries'],
+        ['drift', 'drift e/w/i'],
+        ['p50', 'p50'],
+        ['p95', 'p95'],
+        ['p99', 'p99'],
+    ];
+    const width = (key: keyof (typeof rows)[0], header: string) =>
+        Math.max(header.length, ...rows.map((r) => r[key].length));
+    const line = (cells: Record<string, string>) =>
+        cols.map(([k, h]) => cells[k].padEnd(width(k, h))).join('  ');
+
+    const head = line(Object.fromEntries(cols.map(([k, h]) => [k, h])));
+    const body = rows.map((r) => line(r));
+    const t = summary.totals;
+    return [
+        head,
+        ...body,
+        '',
+        `total: ${t.runs} run(s), ${t.ok} ok, ${t.failed} failed`,
+    ].join('\n');
+}
+
+// "1h" | "30m" | "45s" | "2d" → milliseconds (trace's --since window).
+function parseSince(s: string): number | undefined {
+    const m = /^(\d+(?:\.\d+)?)\s*(s|m|h|d)$/.exec(s.trim());
+    if (!m) return undefined;
+    const n = parseFloat(m[1]);
+    const unit = { s: 1e3, m: 6e4, h: 36e5, d: 864e5 }[m[2]] ?? 1;
+    return n * unit;
+}
+
+// ---- process glue ---------------------------------------------------------
+
+export interface CliIO {
+    cwd: string;
+    env: Record<string, string | undefined>;
+    now: () => number;
+    write: (s: string) => void; // stdout, raw
+    writeErr: (s: string) => void; // stderr, raw
+    load: (path: string) => Promise<StitchRegistry>;
+}
+
+function defaultIO(): CliIO {
+    return {
+        cwd: process.cwd(),
+        env: process.env,
+        now: () => Date.now(),
+        write: (s) => process.stdout.write(s),
+        writeErr: (s) => process.stderr.write(s),
+        load: loadStitches,
+    };
+}
+
+const HELP = `stitch — one stitch definition, many front doors
+
+usage:
+  stitch run <name> [--module <path>] [--flags…]   run a stitch, stream JSONL events
+  stitch trace [--file <path>] [--since 1h] [--name <x>] [--json]
+
+run:
+  --module, -m <path>   stitches module to load (default: ./stitches.{ts,js,…})
+  --params.<k> <v>      path param        (bare --<k> also routes here if <k> is in the path)
+  --query.<k> <v>       query param       (bare --<k> routes here otherwise)
+  --headers.<k> <v>     request header
+  --body '<json>' | --body.<k> <v>   request body (whole, or field by field)
+
+Every event the stitch emits is printed as one line of JSON on stdout.
+`;
+
+async function runCommand(args: string[], io: CliIO): Promise<number> {
+    const { name, modulePath, flags } = splitRunArgs(args);
+    if (!name) {
+        io.writeErr('usage: stitch run <name> [--module <path>] [--flags…]\n');
+        return 2;
+    }
+    let registry: StitchRegistry;
+    try {
+        registry = await io.load(resolveModulePath(modulePath, io.cwd));
+    } catch (e) {
+        io.writeErr(`${(e as Error).message}\n`);
+        return 1;
+    }
+    try {
+        return await runStitch(registry, name, flags, (l) =>
+            io.write(`${l}\n`),
+        );
+    } catch (e) {
+        io.writeErr(`${(e as Error).message}\n`);
+        return 1;
+    }
+}
+
+function defaultTraceFile(io: CliIO): string {
+    return (
+        io.env.STITCH_TRACE_FILE ||
+        `${io.env.HOME ?? '.'}/.stitch/runs/proto.jsonl`
+    );
+}
+
+function traceCommand(args: string[], io: CliIO): number {
+    let file: string | undefined;
+    let since: string | undefined;
+    let nameFilter: string | undefined;
+    let asJson = false;
+    for (let i = 0; i < args.length; i++) {
+        const a = args[i];
+        if (a === '--file') file = args[++i];
+        else if (a === '--since') since = args[++i];
+        else if (a === '--name') nameFilter = args[++i];
+        else if (a === '--json') asJson = true;
+    }
+
+    const path = file ?? defaultTraceFile(io);
+    if (!existsSync(path)) {
+        io.writeErr(`no trace file at ${path}\n`);
+        return 1;
+    }
+
+    const cutoff = since ? io.now() - (parseSince(since) ?? 0) : undefined;
+    const records: TraceRecord[] = [];
+    for (const raw of readFileSync(path, 'utf8').split('\n')) {
+        const trimmed = raw.trim();
+        if (!trimmed) continue;
+        let rec: TraceRecord;
+        try {
+            rec = JSON.parse(trimmed) as TraceRecord;
+        } catch {
+            continue; // tolerate partial last line / foreign lines
+        }
+        if (nameFilter && rec.name !== nameFilter) continue;
+        if (
+            cutoff !== undefined &&
+            typeof rec.at === 'number' &&
+            rec.at < cutoff
+        )
+            continue;
+        records.push(rec);
+    }
+
+    const summary = summarizeTrace(records);
+    io.write(
+        asJson
+            ? `${JSON.stringify(summary, null, 2)}\n`
+            : `${formatTraceSummary(summary)}\n`,
+    );
+    return 0;
+}
+
+// Entry point. Returns the process exit code; the bin shim calls process.exit.
+export async function main(
+    argv: string[],
+    overrides: Partial<CliIO> = {},
+): Promise<number> {
+    const io: CliIO = { ...defaultIO(), ...overrides };
+    const [cmd, ...rest] = argv;
+    switch (cmd) {
+        case 'run':
+            return runCommand(rest, io);
+        case 'trace':
+            return traceCommand(rest, io);
+        case undefined:
+        case '-h':
+        case '--help':
+            io.write(HELP);
+            return 0;
+        default:
+            io.writeErr(`unknown command: ${cmd}\n`);
+            io.writeErr(HELP);
+            return 2;
+    }
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,106 @@
+// Loads a user's stitches module and resolves stitches by name. Shared by every
+// non-function surface (CLI `run`, HTTP `serve`, MCP) so they agree on what "the
+// stitch named X" means: a stitch exported from the module, keyed by its export
+// name and, as a fallback, its configured `name`.
+import { type Stitch, isStitch } from './types';
+
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+export type StitchRegistry = Record<string, Stitch>;
+
+// Module names probed (in order) when no explicit module path is given.
+export const DEFAULT_MODULES = [
+    'stitches.ts',
+    'stitches.mjs',
+    'stitches.js',
+    'stitches.cjs',
+    'stitch.config.ts',
+    'stitch.config.mjs',
+    'stitch.config.js',
+];
+
+// Pull every stitch out of a module's exports. A stitch is recognized structurally
+// (see isStitch), so this works regardless of how the module was authored:
+//   - named exports that are stitches      → keyed by the export name
+//   - a `default` export that is a stitch  → keyed "default"
+//   - a `default` (or any) plain object    → contributes its stitch-valued members
+// Non-stitch values are ignored; later entries win on name collision.
+export function collectStitches(mod: unknown): StitchRegistry {
+    const out: StitchRegistry = {};
+    if (!mod || typeof mod !== 'object') return out;
+
+    const addMembers = (obj: Record<string, unknown>): void => {
+        for (const [k, v] of Object.entries(obj)) if (isStitch(v)) out[k] = v;
+    };
+
+    for (const [key, value] of Object.entries(mod as Record<string, unknown>)) {
+        if (isStitch(value)) {
+            out[key === 'default' ? (value.__config.name ?? 'default') : key] =
+                value;
+        } else if (
+            value &&
+            typeof value === 'object' &&
+            !Array.isArray(value)
+        ) {
+            // a registry-shaped export, e.g. `export default { listX, getY }`
+            addMembers(value as Record<string, unknown>);
+        }
+    }
+    return out;
+}
+
+// Resolve a stitch by name: exact export-key match first, then a stitch whose
+// configured `name` matches. Throws a helpful, listing error when absent.
+export function selectStitch(registry: StitchRegistry, name: string): Stitch {
+    const direct = registry[name];
+    if (direct) return direct;
+    for (const s of Object.values(registry))
+        if (s.__config.name === name) return s;
+
+    const available = Object.keys(registry).sort();
+    const err = new Error(
+        available.length
+            ? `unknown stitch "${name}". Available: ${available.join(', ')}`
+            : `unknown stitch "${name}" — no stitches found in the module`,
+    );
+    err.name = 'UnknownStitchError';
+    throw err;
+}
+
+// Find the stitches module: an explicit path (relative to cwd) or the first
+// existing default candidate. Throws when nothing is found.
+export function resolveModulePath(
+    explicit: string | undefined,
+    cwd: string,
+): string {
+    if (explicit) return resolve(cwd, explicit);
+    for (const candidate of DEFAULT_MODULES) {
+        const full = resolve(cwd, candidate);
+        if (existsSync(full)) return full;
+    }
+    const err = new Error(
+        `no stitches module found (looked for ${DEFAULT_MODULES.join(', ')}). ` +
+            `Pass --module <path>.`,
+    );
+    err.name = 'ModuleNotFoundError';
+    throw err;
+}
+
+// How a module path becomes a module object. The default uses Node's ESM loader;
+// callers can inject a TypeScript-aware importer (or a stub, in tests).
+export type ModuleImporter = (url: string) => Promise<unknown>;
+const defaultImporter: ModuleImporter = (url) => import(url);
+
+// Import a module by path and collect its stitches. `.ts` modules require the host
+// to have a TypeScript loader registered (e.g. run under tsx); point `--module` at
+// compiled JS otherwise.
+export async function loadStitches(
+    modulePath: string,
+    importer: ModuleImporter = defaultImporter,
+): Promise<StitchRegistry> {
+    const abs = resolve(modulePath);
+    const mod = await importer(pathToFileURL(abs).href);
+    return collectStitches(mod);
+}

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -1,0 +1,259 @@
+// Set the trace file before importing ../src so the JSONL sink is captured/quiet.
+import { stitch } from '../src';
+import {
+    argsToInput,
+    formatTraceSummary,
+    paramNamesOf,
+    runStitch,
+    summarizeTrace,
+} from '../src/cli';
+import { collectStitches, loadStitches, selectStitch } from '../src/registry';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { z } from 'zod';
+
+process.env.STITCH_TRACE_FILE = join(
+    tmpdir(),
+    `stitch-cli-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => server.reset());
+
+const parseLines = (lines: string[]) => lines.map((l) => JSON.parse(l));
+
+// ---- arg → input mapping --------------------------------------------------
+
+describe('argsToInput', () => {
+    test('bare flags route to params when in the path, else to query', () => {
+        const { input } = argsToInput(
+            ['--id', '7', '--expand', 'roles'],
+            ['id'],
+        );
+        expect(input.params).toEqual({ id: 7 });
+        expect(input.query).toEqual({ expand: 'roles' });
+    });
+
+    test('namespaced buckets: params / query / headers / body', () => {
+        const { input } = argsToInput([
+            '--params.id',
+            '1',
+            '--query.q',
+            'ada',
+            '--headers.x-api-key',
+            'secret',
+            '--body.name',
+            'Ada',
+        ]);
+        expect(input.params).toEqual({ id: 1 });
+        expect(input.query).toEqual({ q: 'ada' });
+        expect(input.headers).toEqual({ 'x-api-key': 'secret' });
+        expect(input.body).toEqual({ name: 'Ada' });
+    });
+
+    test('--body takes a whole JSON document', () => {
+        const { input } = argsToInput(['--body', '{"a":1,"b":[2,3]}']);
+        expect(input.body).toEqual({ a: 1, b: [2, 3] });
+    });
+
+    test('values coerce (number/boolean) but header values stay strings', () => {
+        const { input } = argsToInput([
+            '--query.n',
+            '42',
+            '--query.active',
+            'true',
+            '--headers.x-num',
+            '42',
+        ]);
+        expect(input.query).toEqual({ n: 42, active: true });
+        expect(input.headers).toEqual({ 'x-num': '42' });
+    });
+
+    test('a bare flag with no value is boolean true', () => {
+        const { input } = argsToInput(['--verbose']);
+        expect(input.query).toEqual({ verbose: true });
+    });
+
+    test('--k=v form and repeated keys (→ array) are supported', () => {
+        const { input } = argsToInput([
+            '--query.tag=a',
+            '--query.tag',
+            'b',
+            '--query.tag',
+            'c',
+        ]);
+        expect(input.query).toEqual({ tag: ['a', 'b', 'c'] });
+    });
+});
+
+test('paramNamesOf reads {param} names from the stitch path', () => {
+    const s = stitch({ baseUrl: 'http://x', path: '/orgs/{org}/repos/{repo}' });
+    expect(paramNamesOf(s)).toEqual(['org', 'repo']);
+});
+
+// ---- registry -------------------------------------------------------------
+
+describe('registry', () => {
+    test('collectStitches finds named, default-registry, and nested stitches', () => {
+        const a = stitch({ baseUrl: 'http://x', path: '/a' });
+        const b = stitch({ baseUrl: 'http://x', path: '/b' });
+        const c = stitch({ baseUrl: 'http://x', path: '/c' });
+        const reg = collectStitches({
+            a,
+            default: { b },
+            nested: { c, notAStitch: 123 },
+        });
+        expect(Object.keys(reg).sort()).toEqual(['a', 'b', 'c']);
+    });
+
+    test('selectStitch matches by export key, then by configured name', () => {
+        const listing = stitch({
+            name: 'list-things',
+            baseUrl: 'http://x',
+            path: '/things',
+        });
+        const reg = { listing };
+        expect(selectStitch(reg, 'listing')).toBe(listing);
+        expect(selectStitch(reg, 'list-things')).toBe(listing);
+    });
+
+    test('selectStitch throws a listing error for an unknown name', () => {
+        const reg = { a: stitch({ baseUrl: 'http://x', path: '/a' }) };
+        expect(() => selectStitch(reg, 'nope')).toThrow(
+            /unknown stitch "nope"/,
+        );
+        expect(() => selectStitch(reg, 'nope')).toThrow(/Available: a/);
+    });
+
+    test('loadStitches resolves a path to a file URL and collects the module', async () => {
+        const dir = mkdtempSync(join(tmpdir(), 'stitch-mod-'));
+        const file = join(dir, 'stitches.mjs');
+        writeFileSync(file, 'export const placeholder = 1;\n');
+        const listWidgets = stitch({
+            baseUrl: 'http://x',
+            path: '/widgets',
+        });
+
+        let importedUrl = '';
+        const reg = await loadStitches(file, async (url) => {
+            importedUrl = url;
+            return { listWidgets }; // stand in for the real module's exports
+        });
+
+        expect(importedUrl.startsWith('file://')).toBe(true);
+        expect(importedUrl.endsWith('stitches.mjs')).toBe(true);
+        expect(Object.keys(reg)).toEqual(['listWidgets']);
+    });
+});
+
+// ---- run: arg → input → JSONL, end to end ---------------------------------
+
+describe('runStitch (arg → input → JSONL)', () => {
+    test('maps flags onto the request and streams JSONL events', async () => {
+        server.route('GET', '/widgets', {
+            body: { data: [{ id: 1, name: 'Cog' }] },
+        });
+        const listWidgets = stitch({
+            baseUrl: server.url,
+            path: '/widgets',
+            unwrap: 'data',
+            output: z.array(z.object({ id: z.number(), name: z.string() })),
+        });
+
+        const lines: string[] = [];
+        const code = await runStitch(
+            { listWidgets },
+            'listWidgets',
+            ['--published', 'true', '--query.limit', '10'],
+            (l) => lines.push(l),
+        );
+
+        expect(code).toBe(0);
+        // the flags reached the actual request
+        expect(server.calls('/widgets')[0]?.query).toEqual({
+            published: 'true',
+            limit: '10',
+        });
+        // every line is valid JSON; the stream is start → … → result → done
+        const events = parseLines(lines);
+        expect(events[0].type).toBe('start');
+        expect(events.at(-1).type).toBe('done');
+        const result = events.find((e) => e.type === 'result');
+        expect(result.value).toEqual([{ id: 1, name: 'Cog' }]);
+    });
+
+    test('routes a bare path-param flag into the URL', async () => {
+        server.route('GET', '/widgets/7', { body: { id: 7 } });
+        const getWidget = stitch({
+            baseUrl: server.url,
+            path: '/widgets/{id}',
+        });
+        const lines: string[] = [];
+        const code = await runStitch(
+            { getWidget },
+            'getWidget',
+            ['--id', '7'],
+            (l) => lines.push(l),
+        );
+        expect(code).toBe(0);
+        expect(server.callCount('/widgets/7')).toBe(1);
+        expect(
+            parseLines(lines).find((e) => e.type === 'result').value,
+        ).toEqual({ id: 7 });
+    });
+
+    test('exit code 1 and an error event on failure', async () => {
+        server.route('GET', '/boom', { statuses: [500] });
+        const boom = stitch({ baseUrl: server.url, path: '/boom' });
+        const lines: string[] = [];
+        const code = await runStitch({ boom }, 'boom', [], (l) =>
+            lines.push(l),
+        );
+        expect(code).toBe(1);
+        expect(parseLines(lines).some((e) => e.type === 'error')).toBe(true);
+    });
+});
+
+// ---- trace summary --------------------------------------------------------
+
+describe('summarizeTrace', () => {
+    const records = [
+        { name: 'a', type: 'done', ok: true, ms: 10, at: 1 },
+        { name: 'a', type: 'progress', phase: 'retry', at: 1 },
+        { name: 'a', type: 'done', ok: true, ms: 30, at: 2 },
+        { name: 'a', type: 'done', ok: false, ms: 20, at: 3 },
+        { name: 'a', type: 'drift', finding: { level: 'warn' }, at: 3 },
+        { name: 'b', type: 'done', ok: true, ms: 5, at: 4 },
+    ];
+
+    test('aggregates runs, ok/failed, retries, drift, and percentiles per stitch', () => {
+        const { stitches, totals } = summarizeTrace(records);
+        expect(totals).toEqual({ runs: 4, ok: 3, failed: 1 });
+
+        const a = stitches.find((s) => s.name === 'a')!;
+        expect(a.runs).toBe(3);
+        expect(a.ok).toBe(2);
+        expect(a.failed).toBe(1);
+        expect(a.retries).toBe(1);
+        expect(a.drift.warn).toBe(1);
+        expect(a.p50).toBeGreaterThan(0);
+        expect(a.avgMs).toBe(20); // (10 + 30 + 20) / 3
+    });
+
+    test('formatTraceSummary renders a table mentioning each stitch', () => {
+        const out = formatTraceSummary(summarizeTrace(records));
+        expect(out).toContain('a');
+        expect(out).toContain('b');
+        expect(out).toContain('total: 4 run(s), 3 ok, 1 failed');
+    });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'tsup';
+
+// Two bundles from one source tree:
+//   lib/index.{js,mjs} (+ .d.ts) — the library (function surface), dual-format + types
+//   lib/cli.js                   — the `stitch` bin (run/trace/serve/mcp), CJS, no types
+export default defineConfig([
+    {
+        entry: ['src/index.ts'],
+        format: ['cjs', 'esm'],
+        minify: true,
+        dts: true,
+        outDir: 'lib',
+        clean: true,
+    },
+    {
+        entry: ['src/cli.ts'],
+        format: ['cjs'],
+        minify: true,
+        dts: false,
+        outDir: 'lib',
+        clean: false,
+    },
+]);


### PR DESCRIPTION
First of three **"one definition, many surfaces"** PRs (DESIGN.md §10). Adds the **CLI front door** so a stitch is callable from the shell — for scripts and agents, JSONL output, pipeable, no app boot.

### What
- **`bin/stitch` + `src/cli.ts`**
  - `stitch run <name> [--module <path>] [--flags…]` — loads a stitches module, maps CLI flags onto the stitch's single input object, and streams the **event stream to stdout as JSON-lines** (one event per line → pipes straight into `jq`).
  - `stitch trace [--file <path>] [--since 1h] [--name <x>] [--json]` — summarizes the zero-infra JSONL run log (per-stitch runs, ok/failed, retries, drift `e/w/i`, p50/p95/p99).
- **`src/registry.ts`** — loads a user's stitches module and resolves stitches by name (export key, then configured `name`). Shared seam the **serve** and **MCP** surfaces reuse.
- **Build/packaging** — `tsup.config.ts` emits `lib/cli.js` alongside the library; `package.json` gains the `stitch` bin and ships `bin/`.

### Flag → input mapping
| Flag | Goes to |
|---|---|
| `--params.<k>` / bare `--<k>` when `{k}` is in the path | `input.params` |
| `--query.<k>` / bare `--<k>` otherwise | `input.query` |
| `--headers.<k>` (values stay strings) | `input.headers` |
| `--body '<json>'` or `--body.<k> <v>` | `input.body` |

Values coerce via JSON (`--id 1` → `1`, `--active true` → `true`); repeated keys become arrays; `--k=v` accepted; a bare flag is boolean `true`.

```bash
stitch run list-widgets --id 42 --query.limit 10 | jq 'select(.type=="result").value'
```

### Tests (`test/cli.spec.ts`)
- arg→input mapping (buckets, coercion, header strings, whole/field body, repeats, `=` form, booleans)
- end-to-end `runStitch`: flags reach the actual request; output is valid JSONL `start → … → result → done`; exit code 1 + `error` event on failure
- registry collect/select (named, default-registry, nested, by configured name, unknown-name listing error)
- `trace` summary aggregation + table formatting

Full pre-commit gate green (lint, prettier, tsc, attw 🟢, jest). Neutral naming throughout.

> **Stacking:** `serve` and `mcp` build on this branch (they extend the `stitch` dispatcher), opened on top. Reviewable/mergeable in order.