### PR TITLE
feat(auth): OAuth2 client_credentials strategy

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,12 +1,15 @@
 // Auth strategies + secret resolvers. The key idea: the stitch holds the credential,
 // resolved at call time — the caller (an agent) never sees it. `cookieSession` performs
 // a login (another stitch) and manages the cookie jar, refreshing on a 401 wall.
+import { fetchAdapter } from './http-adapter';
 import type {
+    Adapter,
     AdapterResponse,
     AuthContext,
     AuthStrategy,
     StitchInput,
 } from './types';
+import { now } from './util';
 
 import { existsSync, readFileSync } from 'node:fs';
 
@@ -70,6 +73,104 @@ export function basic(opts: { user: Secret; pass: Secret }): AuthStrategy {
                 `${resolve(opts.user)}:${resolve(opts.pass)}`,
             ).toString('base64');
             req.headers['authorization'] = `Basic ${token}`;
+        },
+    };
+}
+
+export interface OAuth2Opts {
+    /** The `client_credentials` token endpoint (POST, form-encoded). */
+    tokenUrl: string;
+    /** OAuth2 client id; resolved at call time (env/keychain), never committed. */
+    clientId: Secret;
+    /** OAuth2 client secret; resolved at call time. */
+    clientSecret: Secret;
+    /** Optional space-delimited scopes. */
+    scope?: string;
+    /** Statuses that mean the token was rejected and should force a refresh. Default [401]. */
+    refreshOn?: number[];
+    /** Refresh this many ms BEFORE the token's expiry, so it is never used mid-flight. Default 30_000. */
+    refreshSkewMs?: number;
+    /** Store namespace — give two stitches the same `key` + a shared `store` to share one token. Default: `tokenUrl`. */
+    key?: string;
+    /** Test seam / custom transport for the token request (default `fetchAdapter()`). */
+    adapter?: Adapter;
+}
+
+interface CachedToken {
+    token: string;
+    expiresAt: number; // epoch ms; 0 = no known expiry (never proactively refreshed)
+}
+
+/**
+ * OAuth2 `client_credentials`: POST the token endpoint, cache the access token in the
+ * StitchStore (TTL from `expires_in`), refresh it `refreshSkewMs` before expiry, and attach
+ * it as `Authorization: Bearer …`. A SHARED store makes one token serve many stitches/workers
+ * and survive restarts; a rejected token (status in `refreshOn`) forces a fresh fetch + retry.
+ */
+export function oauth2(opts: OAuth2Opts): AuthStrategy {
+    const refreshOn = opts.refreshOn ?? [401];
+    const skew = opts.refreshSkewMs ?? 30_000;
+    const nsKey = 'oauth2:' + (opts.key ?? opts.tokenUrl);
+    const adapter = opts.adapter ?? fetchAdapter();
+
+    const isFresh = (t: CachedToken | undefined): boolean =>
+        !!t && (t.expiresAt === 0 || now() < t.expiresAt - skew);
+
+    // Fetch a new token from the endpoint and cache it (with TTL = expires_in). Always hits
+    // the network; callers gate on `isFresh` to reuse the cached token instead.
+    const fetchToken = async (ctx: AuthContext): Promise<string> => {
+        ctx.emit('auth', 'token');
+        const body: Record<string, string> = {
+            grant_type: 'client_credentials',
+            client_id: resolve(opts.clientId),
+            client_secret: resolve(opts.clientSecret),
+        };
+        if (opts.scope) body.scope = opts.scope;
+
+        const res = await adapter({
+            url: opts.tokenUrl,
+            method: 'POST',
+            headers: { accept: 'application/json' },
+            body,
+            bodyType: 'form',
+        });
+        if (res.status >= 400)
+            throw new Error(`oauth2 token request failed: HTTP ${res.status}`);
+
+        const payload = (res.body ?? {}) as {
+            access_token?: string;
+            expires_in?: number;
+        };
+        if (!payload.access_token)
+            throw new Error('oauth2 token response missing access_token');
+
+        const ttlMs =
+            typeof payload.expires_in === 'number'
+                ? payload.expires_in * 1000
+                : undefined;
+        const cached: CachedToken = {
+            token: payload.access_token,
+            expiresAt: ttlMs ? now() + ttlMs : 0,
+        };
+        await ctx.store.set(nsKey, cached, ttlMs);
+        return cached.token;
+    };
+
+    const tokenFor = async (ctx: AuthContext): Promise<string> => {
+        const cached = (await ctx.store.get(nsKey)) as CachedToken | undefined;
+        return isFresh(cached) ? cached!.token : fetchToken(ctx);
+    };
+
+    return {
+        name: 'oauth2',
+        async apply(req, ctx) {
+            req.headers['authorization'] = `Bearer ${await tokenFor(ctx)}`;
+        },
+        shouldRefresh(res) {
+            return refreshOn.includes(res.status);
+        },
+        async refresh(ctx) {
+            await fetchToken(ctx); // force a fresh token, ignoring the cache
         },
     };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,13 @@
 export { stitch, defineStitch, preset, drift, graphql } from './stitch';
-export { bearer, apiKey, basic, cookieSession, env, keychain } from './auth';
+export {
+    bearer,
+    apiKey,
+    basic,
+    cookieSession,
+    oauth2,
+    env,
+    keychain,
+} from './auth';
 export { fetchAdapter } from './http-adapter';
 export { createTrace } from './trace';
 export { toValidator } from './validator';

--- a/test/oauth2.spec.ts
+++ b/test/oauth2.spec.ts
@@ -1,0 +1,164 @@
+// OAuth2 `client_credentials`: the strategy fetches a token from the token endpoint, caches
+// it in the StitchStore (TTL from `expires_in`), reuses it across calls, refreshes it before
+// expiry, and re-fetches when the resource server rejects it. The caller never sees the secret.
+import { env, memoryStore, oauth2, stitch } from '../src';
+import type { Stitch, StitchStore } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.STITCH_TRACE_FILE = join(
+    tmpdir(),
+    `stitch-oauth2-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+    process.env.OAUTH_CLIENT_ID = 'cid';
+    process.env.OAUTH_CLIENT_SECRET = 'csecret';
+});
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// A stitch protected by an oauth2 client_credentials token, with knobs per test.
+const protectedStitch = (
+    path: string,
+    extra: Record<string, unknown> = {},
+    store?: StitchStore,
+): Stitch =>
+    stitch({
+        baseUrl: server.url,
+        path,
+        store,
+        auth: oauth2({
+            tokenUrl: `${server.url}/token`,
+            clientId: env('OAUTH_CLIENT_ID'),
+            clientSecret: env('OAUTH_CLIENT_SECRET'),
+            ...extra,
+        }),
+    });
+
+test('fetches one token, reuses it across calls, and sends it as a Bearer', async () => {
+    server.route('POST', '/token', {
+        body: { access_token: 'T1', token_type: 'Bearer', expires_in: 3600 },
+    });
+    server.route('GET', '/data', {
+        requireHeader: { name: 'authorization', value: 'Bearer T1' },
+        body: { ok: true },
+    });
+
+    const data = protectedStitch('/data');
+    await expect(data()).resolves.toEqual({ ok: true });
+    await expect(data()).resolves.toEqual({ ok: true });
+
+    expect(server.callCount('/token')).toBe(1); // one fetch, reused on the second call
+    expect(server.callCount('/data')).toBe(2);
+
+    // The token POST is a form-encoded client_credentials grant carrying the resolved id.
+    const tokenReq = server.calls('/token')[0];
+    expect(String(tokenReq.body)).toContain('grant_type=client_credentials');
+    expect(String(tokenReq.body)).toContain('client_id=cid');
+});
+
+test('a SHARED store lets two stitches share one token', async () => {
+    server.route('POST', '/token', {
+        body: { access_token: 'T1', token_type: 'Bearer', expires_in: 3600 },
+    });
+    server.route('GET', '/a', {
+        requireHeader: { name: 'authorization', value: 'Bearer T1' },
+        body: { r: 'a' },
+    });
+    server.route('GET', '/b', {
+        requireHeader: { name: 'authorization', value: 'Bearer T1' },
+        body: { r: 'b' },
+    });
+
+    const store = memoryStore();
+    const a = protectedStitch('/a', {}, store);
+    const b = protectedStitch('/b', {}, store);
+
+    expect(await a()).toEqual({ r: 'a' });
+    expect(await b()).toEqual({ r: 'b' });
+    expect(server.callCount('/token')).toBe(1); // ONE token, shared via the store
+});
+
+test('refreshes the token after it expires', async () => {
+    server.route('POST', '/token', {
+        body: (i) => ({
+            access_token: i === 0 ? 'T1' : 'T2',
+            token_type: 'Bearer',
+            expires_in: 1, // 1s TTL
+        }),
+    });
+    server.route('GET', '/data', {
+        requireHeader: { name: 'authorization' },
+        body: { ok: true },
+    });
+
+    // skew 0 so the token stays usable until its real expiry, isolating the expiry path.
+    const data = protectedStitch('/data', { refreshSkewMs: 0 });
+    await data();
+    await sleep(1100); // let the cached token (and its store TTL) expire
+    await data();
+
+    expect(server.callCount('/token')).toBe(2); // expired → re-fetched
+    const calls = server.calls('/data');
+    expect(calls[0].headers['authorization']).toBe('Bearer T1');
+    expect(calls[1].headers['authorization']).toBe('Bearer T2'); // the refreshed token
+}, 10000);
+
+test('refreshes proactively BEFORE expiry using refreshSkewMs', async () => {
+    server.route('POST', '/token', {
+        body: (i) => ({
+            access_token: i === 0 ? 'T1' : 'T2',
+            token_type: 'Bearer',
+            expires_in: 2, // real expiry at +2s
+        }),
+    });
+    server.route('GET', '/data', {
+        requireHeader: { name: 'authorization' },
+        body: { ok: true },
+    });
+
+    // With a 1.5s skew the token is treated as stale ~0.5s in, well before the 2s expiry.
+    const data = protectedStitch('/data', { refreshSkewMs: 1500 });
+    await data();
+    await sleep(600);
+    await data();
+
+    expect(server.callCount('/token')).toBe(2); // refreshed early, not at the 2s boundary
+    const calls = server.calls('/data');
+    expect(calls[1].headers['authorization']).toBe('Bearer T2');
+}, 10000);
+
+test('re-fetches the token when the resource server rejects it (401)', async () => {
+    server.route('POST', '/token', {
+        body: (i) => ({
+            access_token: i === 0 ? 'STALE' : 'FRESH',
+            token_type: 'Bearer',
+            expires_in: 3600,
+        }),
+    });
+    // First hit 401s (token rejected); after the forced refresh the retry succeeds.
+    server.route('GET', '/data', {
+        statuses: [401, 200],
+        body: { ok: true },
+    });
+
+    const data = protectedStitch('/data');
+    await expect(data()).resolves.toEqual({ ok: true });
+
+    expect(server.callCount('/token')).toBe(2); // initial fetch + forced refresh on 401
+    const calls = server.calls('/data');
+    expect(calls[0].headers['authorization']).toBe('Bearer STALE');
+    expect(calls[1].headers['authorization']).toBe('Bearer FRESH');
+});


### PR DESCRIPTION
Closes the **OAuth2 `client_credentials`** mechanical gap from the coverage audit (DESIGN.md §12; roadmap §14 item 3).

## What
`oauth2({ tokenUrl, clientId, clientSecret, scope? })` in `src/auth.ts`:
- POSTs the token endpoint with `grant_type=client_credentials` (form-encoded; id/secret/scope in the body).
- Caches the access token in the `StitchStore` with **TTL = `expires_in`**, keyed so a *shared* store serves many stitches/workers and survives restarts.
- Refreshes **proactively** `refreshSkewMs` (default 30s) before expiry, and **reactively** when the resource server returns a status in `refreshOn` (default `[401]`) — reusing the engine's existing auth-refresh loop.
- Attaches the token as `Authorization: Bearer …`. Secrets resolve at call time (`env()`/`keychain()`); the caller never sees them.

## Tests — `test/oauth2.spec.ts`
- one token fetched once, reused across calls;
- a **shared store** shares one token across two stitches;
- refresh **after** expiry;
- proactive refresh **before** expiry (skew);
- re-fetch on a **401** from the resource server.

Full pre-commit gate green: eslint · prettier · tsc · attw · jest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)