### PR TITLE
docs: rewrite README for the agent-native stitch runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 ---
 
-> WARNING: This lib is still under heavy construction. Despite it feedback is appreciated.
+> **Status:** v1 runtime, under active development. The shape below is real and runnable; feedback is welcome.
 
-StitchAPI is a tool designed to seamlessly integrate (or “stitch”) any JSON-based API into your project, simplifying the process of integrating any JSON-based APIs.
+**StitchAPI is an agent-native runtime whose core primitive — a _stitch_ — replaces `fetch`** for both humans and agents.
 
-The name StitchAPI combines the words “stitch” and “API,” reflecting its core purpose: to “stitch” or seamlessly connect any JSON-based API into your project. The term “stitch” conveys the idea of binding or linking various APIs into a unified system within your project.
+A stitch is a typed, declarative, composable unit: `input → validated output`, wrapped with auth, retries, throttling, timeouts, lifecycle hooks, and observability. You declare it once and call it many times. The smallest possible stitch is `stitch('https://…')`; every capability beyond that is opt-in.
+
+A stitch is a **per-call primitive, not a workflow / queue / iPaaS engine.** Orchestration, job queues, inbound webhooks, and business state stay your app's job (see [Scope](#scope--what-a-stitch-is-not)). That boundary is the point: absorbing them is how a small library drifts into a heavy platform.
 
 <div align="center">
 
@@ -30,230 +32,457 @@ The name StitchAPI combines the words “stitch” and “API,” reflecting its
 
 ## Table of Contents
 
--   [Motivation](#motivation)
--   [Features](#features)
--   [Installing](#installing)
--   [Live example](#live-example)
--   [Example](#example)
--   [Platform agnostic](#platform-agnostic)
--   [URL Templates](#url-templates)
--   [URL Query String Builder](#url-query-string-builder)
--   [Response unwrap](#response-uwnrap)
--   [On-the-Fly Validation](#on-the-fly-validation)
--   [Type Inference](#type-inference)
+-   [Why a new primitive](#why-a-new-primitive)
+-   [Install](#install)
+-   [Quick start](#quick-start)
+-   [The event stream + `await` sugar](#the-event-stream--await-sugar)
+-   [Composition: extends / defineStitch / builder / `.with()`](#composition-extends--definestitch--builder--with)
+-   [Validation & leveled drift](#validation--leveled-drift)
+-   [Resilience: retry, throttle, timeout](#resilience-retry-throttle-timeout)
+-   [Auth as a boundary — capability, not credential](#auth-as-a-boundary--capability-not-credential)
+-   [Pluggable store: distributed throttle & shared sessions](#pluggable-store-distributed-throttle--shared-sessions)
+-   [Request body encoding](#request-body-encoding)
+-   [GraphQL kind](#graphql-kind)
+-   [Pagination](#pagination)
+-   [Transform (e.g. scrape → structured)](#transform-eg-scrape--structured)
+-   [Zero-infra observability](#zero-infra-observability)
+-   [Zero dependencies](#zero-dependencies)
+-   [Live playground](#live-playground)
+-   [Scope — what a stitch is _not_](#scope--what-a-stitch-is-not)
+-   [Roadmap](#roadmap)
 
-## Motivation
+## Why a new primitive
 
-In almost every project involving HTTP calls, there’s usually a src/api directory filled with simple functions that make HTTP requests using a chosen HTTP library. These functions often do the bare minimum: send an HTTP request and “unwrap” the response.
+`fetch` returns bytes. Everything that makes an integration _reliable_ — auth, retries, rate limits, timeouts, response validation, schema-drift detection, observability — is left for you (or an agent) to re-implement at every call site. The result is the `src/api` folder every project grows: dozens of hand-rolled wrappers that each do the bare minimum and rot independently.
 
-This project aims to streamline and enhance the process of integrating with APIs by allowing you to declare an endpoint (or “stitch”) and receive a ready-to-use function in return. In essence, this library helps you create a robust and feature-rich API client, or as we like to say, it helps you “stitch” any JSON-based API into your project.
+A stitch folds those concerns into the call itself:
 
-## Features
+-   **Progressive disclosure.** Zero-config to start; opt-in depth. `stitch('https://…')` just works; knobs appear only when you reach for them.
+-   **Atomic & composable.** A stitch can be exactly one endpoint and nothing else — **no global config is ever required.** Cross-cutting concerns (`baseUrl`, `auth`, `retry`, `throttle`, …) are named, shareable values you compose, not a central config far from the call site.
+-   **The stitch is the boundary.** Auth, validation, and observability live _at_ the stitch. An agent receives a **capability** — it calls the stitch and gets typed data — and never sees the secret.
+-   **The event stream is the spine.** Streaming output, observability, and drift detection all read the _same_ event stream a stitch emits.
+-   **Kind-agnostic core.** HTTP and GraphQL today; the internal interface is built so shell/LLM kinds slot in later as symmetric building blocks.
 
--   **Platform agnostic** - Works in browser and Node thanks to [cross-fetch](https://www.npmjs.com/package/cross-fetch).
--   **URL Templates** - Supports dynamic URL generation using the [RFC 6570 URI Template specification](https://datatracker.ietf.org/doc/html/rfc6570), allowing for flexible and customizable API endpoint construction.
--   **URL Query String Builder** - Leverages the [qs](https://www.npmjs.com/package/qs) library to efficiently build and manage query strings, ensuring accurate and consistent URL query parameters.
--   **Response unwrap** - Automatically extracts and returns the core data from the API response, simplifying access to the information you need without additional processing.
--   **On-the-Fly Validation** - Performs real-time validation of query parameters, request bodies, path parameters, and API responses using the Zod library, ensuring data integrity and type safety throughout every interaction.
--   **Type Inference** - Automatically generates TypeScript types from your validation schemas, ensuring strong typing and reducing the need for manual type definitions, making your API interactions type-safe and more maintainable.
--   **Flexible Adapters** - Offers the ability to use different HTTP adapters, such as Axios, or even your very own solution, allowing you to choose the best-suited tool for making API requests in your project.
--   **_Coming soon_**: **Code Generation** - Generate API stitches and corresponding TypeScript type definitions directly from your OpenAPI specification.
--   **_Coming soon_**: **Modular structure** - Allows each library component to be bundled separately, providing flexibility and enabling you to include only the specific functionalities you need in your project.
+For the full rationale and scope, see [`docs/DESIGN.md`](docs/DESIGN.md).
 
-## Installing
-
-Using npm:
-
-```bash
-$ npm install stitchapi
-```
-
-Using yarn:
+## Install
 
 ```bash
-$ yarn add stitchapi
+npm install stitchapi
+# or: yarn add stitchapi
+# or: pnpm add stitchapi
 ```
 
-Using pnpm:
-
-```bash
-$ pnpm add stitchapi
-```
-
-Once the package is installed, you can import the library using `import` or `require` approach:
-
-```js
-import { stitch } from "stitchapi";
-// either
-const { stitch } = require("stitchapi");
-```
-
-## Live example
-
-[![Edit StitchAPI Get Users](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/sandbox/stitchapi-get-users-4y7y2d)
-
-## Example
-
-Create the first stitch
-
-```js
+```ts
 import { stitch } from 'stitchapi';
 
-// Refer to https://reqres.in for API description
-// Assuming we have a GET https://reqres.in/api/users that responds with
-// {
-//  "page": 1,
-//  "per_page": 10,
-//  "total": 12,
-//  "total_pages": 2,
-//  "data": [
-//      {
-//          "id": 7,
-//          "email": "michael.lawson@reqres.in",
-//          "first_name": "Michael",
-//          "last_name": "Lawson",
-//          "avatar": "https://reqres.in/img/faces/7-image.jpg"
-//      },
-//   ...
-//  ]
-// }
-
-const findUsers = stitch('https://reqres.in/api/users');
-
-// Call it whenever needed to retrieve data from the "stitched" endpoint
-const users = await findUsers();
-console.log(users); // -> JSON response from above
+// or: const { stitch } = require('stitchapi');
 ```
 
-Use URL Templates
+StitchAPI ships its runtime with **zero dependencies**. Schema validation is _bring-your-own_ — see [Zero dependencies](#zero-dependencies).
 
-```js
-const findUser = stitch('/api/users/{id}');
+## Quick start
 
-const user = await findUser({ params: { id: 1 } });
-console.log(user); // -> {id: 1, name: "John Doe"}
+A stitch is defined once and called many times. The smallest one is a URL:
+
+```ts
+import { stitch } from 'stitchapi';
+
+const getUsers = stitch('https://api.example.com/users');
+
+const users = await getUsers(); // GET, parsed JSON
 ```
 
-Use Query Strings
+Path params (RFC 6570-style `{id}`) and query come in via a single input object:
 
-```js
-const findUsers = stitch('/api/users');
+```ts
+const getUser = stitch('https://api.example.com/users/{id}');
 
-const users = await findUsers({
-    query: { type: 'admin' },
-}); // Calls /api/users?type=admin
+await getUser({ params: { id: 1 }, query: { expand: 'roles' } });
+// → GET https://api.example.com/users/1?expand=roles
 ```
 
-Predefined Query Parameters
+Add a contract and you get types **and** validation **and** drift detection in one move:
 
-> **Note**: Arguments passed as query will overwrite conflicting keys in predefined queries.
+```ts
+import { stitch } from 'stitchapi';
+import { z } from 'zod';
 
-```js
-const findUsers = stitch('/api/users?sort=name&type=admin');
+const getUser = stitch({
+    path: 'https://api.example.com/users/{id}',
+    output: z.object({ id: z.number(), name: z.string() }),
+});
 
-const users = await findUsers({
-    query: { type: 'user' },
-}); // Will call /api/users?sort=name&type=user
+const user = await getUser({ params: { id: 1 } }); // typed { id: number; name: string }
 ```
 
-Response validation
+## The event stream + `await` sugar
 
-```js
-const findUsers = stitch({
-    path: '/api/users?sort=name&type=admin',
-    validate: z.object({
-        id: z.number(),
-        name: z.string(),
+A stitch does **not** return `Promise<bytes>`. It yields a typed event stream — and `await` is sugar that consumes that stream and returns the final, validated, unwrapped `result` (or throws a `StitchError`):
+
+```ts
+const users = await getUsers(); // sugar: consume the stream → the result value
+```
+
+Consume the stream directly when you want progress, retries, throttling waits, and drift as they happen — it's the same spine that powers observability:
+
+```ts
+for await (const ev of getUsers.stream()) {
+    switch (ev.type) {
+        case 'start': // { name, method, url, input }
+        case 'progress': // { phase: 'auth'|'request'|'throttled'|'retry'|'paginate', attempt, waitedMs? }
+            break;
+        case 'drift': // { finding: { level: 'error'|'warn'|'info', path, change } }
+            if (ev.finding.level === 'info')
+                console.log('new field:', ev.finding.path);
+            break;
+        case 'result': // { value, status, attempts }
+            render(ev.value);
+            break;
+        case 'error': // { message, status?, attempts }
+        case 'done': // { ok, ms, attempts }
+            break;
+    }
+}
+```
+
+## Composition: extends / defineStitch / builder / `.with()`
+
+Everything reusable is a named value, and a stitch composes values. The three authoring facades are thin surfaces over **one** resolved config — pick whichever fits your code, or mix them.
+
+First, define reusable fragments once:
+
+```ts
+import { defineStitch, preset, stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const api = preset({
+    baseUrl: 'https://api.example.com',
+    retry: { attempts: 3, on: [429, 503] },
+    timeout: { total: '30s' },
+});
+
+const Website = z.object({ id: z.number(), host: z.string() });
+```
+
+**A — `extends: [...]`** (left→right precedence; own fields win last):
+
+```ts
+const listWebsites = stitch({
+    extends: [api],
+    path: '/websites',
+    output: Website.array(),
+    unwrap: 'data',
+});
+```
+
+**B — bound factory `defineStitch(...)`** (best when every stitch shares the same base):
+
+```ts
+const apiStitch = defineStitch(api);
+
+const getWebsite = apiStitch({ path: '/websites/{id}', output: Website });
+```
+
+**C — fluent builder**:
+
+```ts
+const search = stitch
+    .use(api)
+    .get('/websites')
+    .returns(Website.array())
+    .unwrap('data');
+```
+
+A stitch is itself a composable value — **extend another stitch** and override only the diff:
+
+```ts
+const getWebsite = stitch({
+    extends: [listWebsites], // inherits base + retry + unwrap
+    path: '/websites/{id}', // override
+    output: Website, // override
+});
+```
+
+Merge semantics: scalars (`path`, `method`, `baseUrl`, `unwrap`) **replace**; objects (`retry`, `throttle`, `timeout`, `input`) **deep-merge**; `hooks` **chain** (base runs, then child) so a shared "log + add trace header" base is genuinely composable.
+
+**`.with()`** pre-binds part of the input and returns a new, still-reusable stitch (call-time overrides per field):
+
+```ts
+const search = stitch({ path: 'https://api.example.com/search' });
+const adminHits = search.with({ query: { role: 'admin' } });
+
+await adminHits({ query: { q: 'ada' } }); // → /search?role=admin&q=ada
+```
+
+## Validation & leveled drift
+
+Validation is **not** binary pass/fail. A stitch compares each live response against its `output` schema **and** a committed contract snapshot, and classifies every difference by level:
+
+| Level     | Trigger                                             | Behavior                         |
+| --------- | --------------------------------------------------- | -------------------------------- |
+| **error** | a field you _rely on_ is missing or changed type    | fails the call / `error` event   |
+| **warn**  | a watched, non-critical field changed               | `warn` event; call succeeds      |
+| **info**  | a **new** field appeared that isn't in the contract | `info` event — "want to use it?" |
+
+```ts
+import { drift, stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const listListings = stitch({
+    path: 'https://api.example.com/listings',
+    output: drift(
+        z.array(z.object({ id: z.number(), score: z.number().optional() })),
+        {
+            critical: ['[].id'], // error if these break — you depend on them
+            watch: ['[].score'], // warn if this changes
+            onNew: 'info', // surface brand-new fields as info (default)
+            snapshotFile: 'listings.contract.json', // committed baseline
+        },
+    ),
+});
+```
+
+The snapshot is what makes "a _new_ field appeared" detectable (diff the live shape vs the last-known shape, not just vs the schema). The first run records the baseline and reports nothing; later runs surface leveled `drift` events on the stream. This turns a silently-dropped field — the classic cause of breakage — into a loud, leveled signal instead of an `undefined` three layers deep.
+
+You can also validate the request side. `input` takes a schema per part:
+
+```ts
+const createUser = stitch({
+    method: 'POST',
+    path: 'https://api.example.com/users',
+    input: { body: z.object({ name: z.string() }) },
+    output: z.object({ id: z.number(), name: z.string() }),
+});
+```
+
+## Resilience: retry, throttle, timeout
+
+```ts
+const metadata = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/metadata',
+    retry: { attempts: 4, on: [429, 502, 503], respectRetryAfter: true },
+    throttle: { rate: '1/s', concurrency: 2, scope: 'host' },
+    timeout: { total: '30s', perAttempt: '10s' },
+});
+```
+
+-   **`throttle`** is _proactive_ — a rate (`'1/s'`) + concurrency cap that keeps you _under_ a vendor's limit, replacing the hand-rolled token buckets integrations write by hand. `scope: 'host'` shares one limiter across every stitch hitting the same host.
+-   **`retry`** is _reactive_ — exponential backoff with jitter, honoring `Retry-After` when `respectRetryAfter` is set.
+-   **`timeout`** aborts a slow call (`total`, and/or `perAttempt`) instead of hanging.
+
+All three emit events (`throttled`, `retry`) onto the stream, so the waits and retries are visible in the trace for free.
+
+## Auth as a boundary — capability, not credential
+
+Auth is a field on the stitch (or on a fragment it extends), **never global**. The secret resolves at call time from `env()` / `keychain()` — the stitch _declaration_ is committed; the secret is not. A caller (an agent) invokes the stitch and gets data **without ever seeing the credential.**
+
+Header strategies — `bearer`, `apiKey`, `basic`:
+
+```ts
+import { bearer, env, stitch } from 'stitchapi';
+
+const getMovie = stitch({
+    path: 'https://api.example.com/movies/{id}',
+    auth: bearer(env('API_TOKEN')), // resolved per call; the caller passes no secret
+});
+```
+
+The marquee case — a cookie wall dissolved. `cookieSession` runs a login (itself a stitch), manages the cookie jar, and re-logs-in on the wall:
+
+```ts
+import { cookieSession, env, keychain, stitch } from 'stitchapi';
+
+const signIn = stitch({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/auth/sign-in',
+    bodyType: 'form',
+});
+
+const listWebsites = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/websites',
+    output: Website.array(),
+    unwrap: 'data',
+    auth: cookieSession({
+        login: signIn,
+        cookie: 'session_token',
+        loginInput: () => ({
+            body: {
+                email: env('APP_USER')(),
+                password: keychain('APP_PASS')(),
+            },
+        }),
+        refreshOn: [401], // re-login when the wall returns
     }),
 });
 
-await findUsers(); // Will throw an error: Validation error: Expected number, received string at "id"
+await listWebsites();
+// → logs in, replays the cookie, retries the 401 wall, returns typed Website[].
+//   The caller never saw the password and never wrote the cookie dance.
 ```
 
-Validating Query, URL Parameters, and Request Body
+A 200 that is _really_ a login page is a soft wall — pass a content predicate to catch it:
 
-```js
-const findUsers = stitch({
-    path: '/api/users?sort=name&type=admin',
-    // Specify the validate option with at least one schema. If some schemas are omitted, validation for those components is disabled.
-    validate: {
-        query: z.object({}),
-        params: z.object({}),
-        body: z.object({}),
-        response: z.object({}),
-    },
+```ts
+auth: cookieSession({
+    login: signIn,
+    cookie: 'session_token',
+    refreshWhen: (res) =>
+        typeof res.body === 'string' && /log in/i.test(res.body),
 });
 ```
 
-Unwrap Response Data
+## Pluggable store: distributed throttle & shared sessions
 
-```js
-// Assuming we have a GET /api/users endpoint that responds with { total: 100, items: [{id: 1, name: "John Doe"}, ...] }
-const findUsers = stitch({ path: '/api/users', unwrap: 'items' });
+Throttle counters and session/token state are process-local by default. The fix is one small seam — a `store` you compose like any other value. The default is in-memory (zero-config, single process); a Redis/Postgres-backed store makes throttle **distributed** and sessions **persistent & shared across workers**, with no change to the call site.
 
-// Call it whenever needed to retrieve data from "stitched" endpoint
-const users = await findUsers();
-console.log(users); // -> [{id: 1, name: "John Doe"}, ...]
+```ts
+export interface StitchStore {
+    get(key: string): Promise<unknown | undefined>;
+    set(key: string, value: unknown, ttlMs?: number): Promise<void>;
+    incr(key: string, ttlMs: number): Promise<number>; // atomic — for rate windows
+}
 ```
 
-## Platform agnostic
+```ts
+import { defineStitch, memoryStore, preset } from 'stitchapi';
 
-In today’s diverse development environments, it’s essential to have tools that work seamlessly across various platforms, whether it’s in the browser, Node.js, or even mobile applications. Ensuring that your API client functions consistently across these environments can be challenging.
+// memoryStore() is the shipped default. Implement the 3-method interface over
+// Redis/Postgres to go distributed — same call site, no other change.
+const api = defineStitch(preset({ store: memoryStore() }));
+```
 
-Our Platform Agnostic feature addresses this by relying on the [cross-fetch](https://www.npmjs.com/package/cross-fetch) package, a lightweight polyfill that brings the Fetch API to every JavaScript environment. With cross-fetch, your API requests are handled uniformly, regardless of where your code runs.
+-   **Throttle** reads/writes its rate counters through the store → a shared store paces calls _across processes_.
+-   **Auth** (`cookieSession`) reads/writes the cookie jar through the store → give two stitches the same `cookieSession({ key })` plus a shared `store` and they **share one session**, surviving restarts.
 
-This means you can build once and deploy anywhere, knowing that your HTTP requests will behave consistently across all platforms. The Platform Agnostic feature ensures that your API client is versatile, reliable, and ready to support a wide range of deployment targets without additional configuration.
+You opt into a real store only when you scale out — progressive disclosure applied to state.
 
-## URL Templates
+## Request body encoding
 
-In many cases, URLs are constructed using string literals, such as /api/users/${userId}, which works perfectly fine in most scenarios. However, as your project grows, this approach can become cumbersome, especially when dealing with more complex or dynamic URLs.
+`bodyType` controls request encoding (`'json'` default, `'form'`, `'multipart'`):
 
-This is where URL Templates come in. By leveraging the [RFC 6570 URI Template specification](https://datatracker.ietf.org/doc/html/rfc6570) and the [url-template](https://www.npmjs.com/package/url-template) npm package, this feature allows you to define flexible and reusable URL patterns. Instead of manually concatenating strings, you can define a template like /api/users/{id} and let the library handle the rest.
+```ts
+const submit = stitch({
+    method: 'POST',
+    path: 'https://api.example.com/form',
+    bodyType: 'form', // application/x-www-form-urlencoded
+});
+await submit({ body: { a: 1, b: 'x y' } });
 
-URL Templates not only make your code cleaner and easier to maintain, but they also reduce the risk of errors in URL construction. They enable you to manage complex routing scenarios effortlessly, whether you’re dealing with optional parameters, query strings, or nested resources.
+const upload = stitch({
+    method: 'POST',
+    path: 'https://api.example.com/upload',
+    bodyType: 'multipart', // multipart/form-data, with a named file part
+});
+await upload({
+    body: { field: 'v', file: { value: bytes, filename: 'a.bin' } },
+});
+```
 
-## URL Query String Builder
+## GraphQL kind
 
-In many projects, constructing query strings for URLs is often done manually by concatenating key-value pairs, which can be error-prone and tedious, especially as the number of parameters grows or when dealing with complex query structures.
+`graphql()` is a stitch preset for GraphQL-over-HTTP: it `POST`s `{ query, variables }` and unwraps `data`. A 200 that carries `errors[]` is treated as a failure.
 
-To simplify this process, our library includes a powerful URL Query String Builder that leverages the [qs](https://www.npmjs.com/package/qs) npm package under the hood. The qs package is a widely used and robust tool for parsing and stringifying query strings, ensuring that your query parameters are accurately encoded and handled.
+```ts
+import { graphql } from 'stitchapi';
 
-With the URL Query String Builder, you can easily define query parameters in a clean, declarative manner. The library automatically constructs and appends these parameters to your URLs, whether you’re working with simple queries or more advanced nested structures.
+const getThing = graphql({
+    baseUrl: 'https://api.example.com',
+    query: 'query($id: ID) { thing(id: $id) { name } }',
+});
 
-This feature not only reduces boilerplate code but also ensures that your query strings are consistently formatted and compliant with best practices, making your API interactions more reliable and maintainable.
+const thing = await getThing({ variables: { id: 1 } });
+```
 
-## Response unwrap
+It composes with everything else — `auth`, `throttle`, `retry`, `output`/`drift` all apply, because under the hood it's just a stitch.
 
-When working with APIs, it’s common to receive responses that contain more data than you actually need. Extracting the essential parts of the response often requires repetitive and manual data manipulation, which can clutter your code and introduce errors.
+## Pagination
 
-To address this, our Response Unwrap feature simplifies the process by using the [lodash/get](https://lodash.com/docs/4.17.15#get) function to automatically retrieve only the essential part of the response. With this feature, you can specify the exact path to the data you need, and the library will handle the rest, ensuring that you always get the most relevant information without unnecessary boilerplate.
+One logical call follows pages until `next` returns `undefined` (or `max` is hit), aggregating items into a single result. Each page is a **full request**, so auth / retry / throttle apply per page, and a `paginate` progress event fires for each.
 
-Whether you’re working with deeply nested objects or large payloads, Response Unwrap streamlines your API interactions by focusing on the data that matters most. This leads to cleaner, more maintainable code and reduces the risk of errors when accessing response data.
+```ts
+const listAll = stitch({
+    path: 'https://api.example.com/list',
+    unwrap: 'data',
+    paginate: {
+        // given the previous page's raw body + how many pages were fetched,
+        // return the input for the next page, or undefined to stop
+        next: (body, fetched) =>
+            body.hasMore ? { query: { page: fetched + 1 } } : undefined,
+        max: 50, // safety cap (default 50)
+    },
+});
 
-## On-the-Fly Validation
+const everything = await listAll(); // [...page1, ...page2, ...] as one array
+```
 
-In API interactions, ensuring that every aspect of a request is valid is crucial for maintaining data integrity and preventing errors. However, manually validating path parameters, query strings, request bodies, and responses can be time-consuming and error-prone.
+## Transform (e.g. scrape → structured)
 
-Our On-the-Fly Validation feature addresses this by allowing you to validate every part of an API request and response in real-time. Leveraging the power of the Zod validation library, this feature lets you define schemas for each component of your request, whether it’s path parameters, query parameters, the request body, or the response itself.
+`transform` runs **before** unwrap and validation — turn an arbitrary payload (HTML, text, a legacy shape) into structured data, then let `unwrap` + `output`/`drift` treat it like any other contract:
 
-With On-the-Fly Validation, you can ensure that:
+```ts
+const search = stitch({
+    path: 'https://api.example.com/search',
+    transform: (html) => scrape(html), // your parser: HTML/text → { items: [...] }
+    unwrap: 'items',
+    output: z.array(z.object({ title: z.string(), score: z.number() })),
+});
+```
 
--   Path Parameters are correctly formatted and meet required constraints.
--   Query Parameters adhere to expected types and values.
--   Request Bodies contain all necessary fields and conform to your data structure.
--   Responses from the API are exactly as expected, avoiding unexpected data issues downstream.
+Pair this with `drift` and a renamed HTML selector that silently drops a field becomes a fatal contract error instead of a quiet data loss.
 
-This comprehensive validation happens automatically as your requests are made, catching potential issues at the earliest possible stage. This leads to more robust, reliable API integrations, reduces debugging time, and enhances the overall quality of your application’s data handling.
+## Zero-infra observability
 
-## Type Inference
+Observability is a **consumer of the event stream**, not a separate system — you never need infra to get insight. Every run is recorded as JSONL with no configuration:
 
-In modern TypeScript projects, maintaining accurate types is key to ensuring code reliability and reducing runtime errors. However, manually defining types for API requests and responses can be tedious and prone to mistakes, especially as your application evolves.
+```bash
+# every event of every run, appended as JSONL — zero infra
+cat ~/.stitch/runs/proto.jsonl
 
-Our Type Inference feature simplifies this process by automatically inferring types directly from your validation schemas. By leveraging the Zod library, this feature ensures that the types used in your code are always in sync with the actual data structures being validated.
+# opt into a live, pretty, one-line-per-event trace on stderr
+STITCH_TRACE_CONSOLE=1 node app.js
 
-Here’s how it works:
+# choose where the JSONL goes
+STITCH_TRACE_FILE=./run.jsonl node app.js
+```
 
--   When you define a validation schema for path parameters, query parameters, request bodies, or responses, Type Inference automatically generates the corresponding TypeScript types.
--   These inferred types are then seamlessly integrated into your code, providing strong typing for your API interactions without the need for manual type definitions.
+You instantly have per-call latency, status, retry counts, throttle waits, and drift flags. Because drift and observability read the same events, a leveled drift signal shows up in the trace for free. For a custom sink, `createTrace` is exported. (An OTLP/Langfuse bridge and a terminal trace viewer are on the [roadmap](#roadmap).)
 
-This not only eliminates the risk of type mismatches but also enhances the developer experience by reducing boilerplate code and making your API calls type-safe by default. With Type Inference, your code becomes more maintainable, and you can confidently refactor your application, knowing that your types are always accurate and up to date.
+## Zero dependencies
+
+The runtime ships with **`"dependencies": {}`** — nothing is pulled into your tree, and it's tree-shakeable. Schema validation is _bring-your-own_: pass a [Zod](https://zod.dev) schema, any [Standard Schema](https://standardschema.dev) validator ([Valibot](https://valibot.dev), [ArkType](https://arktype.io)), a plain `Validator`, or a predicate. None of them is bundled — you depend only on the validator you already use. The examples here use Zod for familiarity.
+
+## Live playground
+
+A separate, runnable showcase streams the stitch event stream to the browser **live** over SSE — every feature above against a behavior-simulating mock backend, no build step:
+
+```bash
+bash playground/run.sh   # → http://localhost:5174
+```
+
+See [`playground/README.md`](playground/README.md) for how it's wired.
+
+## Scope — what a stitch is _not_
+
+A stitch is a **per-call primitive**, not a platform. These stay your app's concern — absorbing them is exactly how StitchAPI would become the heavy engine it's positioned against:
+
+-   job queues and scheduling
+-   inbound webhooks
+-   multi-step orchestration / broad fan-out
+-   business/DB idempotency and multi-step rollback or compensation
+-   app-level response-cache policy and business state
+
+See [`docs/DESIGN.md`](docs/DESIGN.md) §12 for the validated coverage analysis.
+
+## Roadmap
+
+Built today: HTTP + GraphQL kinds; composition (`extends` / `defineStitch` / builder / `.with()`); the event stream + `await`; validation + leveled drift; retry / throttle / timeout; auth (`bearer` / `apiKey` / `basic` / `cookieSession` + content-aware refresh); pluggable store; form/multipart encoding; static headers; transform; pagination; zero-infra JSONL trace.
+
+Next, in leverage order: OAuth2 `client_credentials`; multi-cookie jar; binary/blob responses; circuit breaker + idempotency keys; OTLP export + a terminal trace viewer; the four surfaces (CLI / HTTP / MCP) of one definition; then shell → LLM kinds and `pipe()` composition.
+
+## License
+
+[Apache-2.0](LICENSE)


### PR DESCRIPTION
## What

Rewrites `README.md`, which still described the old per-endpoint `stitch(url) → typed function` library. That library was replaced by the v1 runtime folded into `src/` (#5). The rewrite is built from the real public API in `src/index.ts` and the canonical `docs/DESIGN.md`.

## Positioning

A **stitch** is the per-call primitive that replaces `fetch` for humans and agents — **not** a workflow / queue / iPaaS engine. The scope boundary is stated explicitly.

## Covers

- Quick start (`stitch('https://…')`)
- The event-stream return + `await` sugar
- Composition: `extends` / `defineStitch` / fluent builder / `.with()`
- Validation + leveled drift (error / warn / info)
- Resilience: retry / throttle / timeout
- Auth as a boundary (capability, not credential) + the pluggable `StitchStore` for distributed throttle / shared sessions
- Request body encoding (form / multipart), the `graphql` kind, pagination, transform
- Zero-infra observability; zero dependencies
- The live playground (`bash playground/run.sh`)

Brand-neutral throughout (generic `api.example.com` archetypes).

## Gate

Ran the full pre-commit gate (lint, format, types, exports, test) in an isolated worktree — all green. Note: `test/store.spec.ts` › "default (separate) stores do NOT share the rate budget" is a **pre-existing timing flake** (asserts elapsed `waitedMs === 0`); it passed on five isolated re-runs and is unrelated to this docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)