### PR TITLE
feat(auth): multi-cookie jar for cookieSession

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -77,8 +77,13 @@ export function basic(opts: { user: Secret; pass: Secret }): AuthStrategy {
 export interface CookieSessionOpts {
     /** The login stitch (exposes __raw to read response headers). */
     login: { __raw: (input?: StitchInput) => Promise<AdapterResponse> };
-    /** Cookie name to capture from Set-Cookie and replay on each request. */
+    /**
+     * Cookie name to capture from Set-Cookie and replay on each request, or `'*'` to capture and
+     * replay the WHOLE Set-Cookie jar (every cookie the login set, not just one named cookie).
+     */
     cookie: string;
+    /** Capture/replay the full Set-Cookie set — equivalent to `cookie: '*'` (in jar mode `cookie` only seeds the store key). */
+    jar?: boolean;
     /** Inputs (credentials) for the login call, resolved at call time. */
     loginInput?: () => StitchInput;
     /** Statuses that mean "the wall" and should trigger a re-login. Default [401]. */
@@ -93,26 +98,42 @@ export interface CookieSessionOpts {
 
 export function cookieSession(opts: CookieSessionOpts): AuthStrategy {
     const refreshOn = opts.refreshOn ?? [401];
-    const nsKey = 'cookie:' + (opts.key ?? opts.cookie);
+    const jarMode = opts.jar === true || opts.cookie === '*';
+    const nsKey = (jarMode ? 'jar:' : 'cookie:') + (opts.key ?? opts.cookie);
 
     const doRefresh = async (ctx: AuthContext) => {
         ctx.emit('auth', 'login');
         const res = await opts.login.__raw(opts.loginInput?.());
         const setCookie = (res.headers['set-cookie'] ??
             res.headers['Set-Cookie']) as string | undefined;
-        const value = parseCookie(setCookie, opts.cookie);
-        if (value != null)
-            await ctx.store.set(nsKey, `${opts.cookie}=${value}`, opts.ttlMs);
+        if (jarMode) {
+            // Capture the full jar: every name=value pair the login set.
+            const jar = parseCookieJar(setCookie);
+            if (Object.keys(jar).length > 0)
+                await ctx.store.set(nsKey, jar, opts.ttlMs);
+        } else {
+            const value = parseCookie(setCookie, opts.cookie);
+            if (value != null)
+                await ctx.store.set(
+                    nsKey,
+                    `${opts.cookie}=${value}`,
+                    opts.ttlMs,
+                );
+        }
     };
 
     return {
         name: 'cookieSession',
         async apply(req, ctx) {
-            let cookie = (await ctx.store.get(nsKey)) as string | undefined;
-            if (!cookie) {
+            let stored = await ctx.store.get(nsKey);
+            if (!stored) {
                 await doRefresh(ctx);
-                cookie = (await ctx.store.get(nsKey)) as string | undefined;
+                stored = await ctx.store.get(nsKey);
             }
+            // Non-jar: a stored `name=value` string. Jar: a stored map → serialize all pairs.
+            const cookie = jarMode
+                ? serializeJar(stored as Record<string, string> | undefined)
+                : (stored as string | undefined);
             if (cookie) {
                 req.headers['cookie'] = [req.headers['cookie'], cookie]
                     .filter(Boolean)
@@ -128,16 +149,32 @@ export function cookieSession(opts: CookieSessionOpts): AuthStrategy {
     };
 }
 
+/**
+ * Parse every `name=value` pair from a (possibly comma-joined) Set-Cookie header into a jar,
+ * keeping only the cookie value (the first segment) and dropping attributes (Path, HttpOnly, …).
+ */
+function parseCookieJar(setCookie: string | undefined): Record<string, string> {
+    const jar: Record<string, string> = {};
+    if (!setCookie) return jar;
+    for (const part of setCookie.split(/,(?=[^;]+=)/)) {
+        const seg = part.trim().split(';')[0];
+        const eq = seg.indexOf('=');
+        if (eq > 0) jar[seg.slice(0, eq).trim()] = seg.slice(eq + 1).trim();
+    }
+    return jar;
+}
+
 function parseCookie(
     setCookie: string | undefined,
     name: string,
 ): string | undefined {
-    if (!setCookie) return undefined;
-    for (const part of setCookie.split(/,(?=[^;]+=)/)) {
-        const seg = part.trim().split(';')[0];
-        const eq = seg.indexOf('=');
-        if (eq > 0 && seg.slice(0, eq).trim() === name)
-            return seg.slice(eq + 1).trim();
-    }
-    return undefined;
+    return parseCookieJar(setCookie)[name];
+}
+
+/** Serialize a captured jar back into a `name=value; name=value` Cookie header. */
+function serializeJar(jar: Record<string, string> | undefined): string {
+    if (!jar) return '';
+    return Object.entries(jar)
+        .map(([k, v]) => `${k}=${v}`)
+        .join('; ');
 }

--- a/test/cookie-jar.spec.ts
+++ b/test/cookie-jar.spec.ts
@@ -1,0 +1,125 @@
+// Multi-cookie jar: with `cookie: '*'` (or `jar: true`) cookieSession captures the FULL
+// Set-Cookie set from the login and replays every cookie on subsequent requests — not just
+// one named cookie. A login that sets two cookies should make both ride along next time.
+import { cookieSession, env, stitch } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.STITCH_TRACE_FILE = join(
+    tmpdir(),
+    `stitch-cookiejar-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+    process.env.CJ_USER = 'u';
+    process.env.CJ_PASS = 'p';
+});
+
+const loginInput = () => ({
+    body: { u: env('CJ_USER')(), p: env('CJ_PASS')() },
+});
+
+const loginStitch = () =>
+    stitch({
+        method: 'POST',
+        baseUrl: server.url,
+        path: '/login',
+        bodyType: 'form',
+    });
+
+test('cookie: "*" captures and replays every cookie the login set', async () => {
+    server.route('POST', '/login', {
+        setCookies: [
+            { name: 'sid', value: 'ABC' },
+            { name: 'csrf', value: 'XYZ' },
+        ],
+        body: { ok: true },
+    });
+    server.route('GET', '/data', {
+        requireCookie: { name: 'sid' },
+        body: { ok: true },
+    });
+
+    const data = stitch({
+        baseUrl: server.url,
+        path: '/data',
+        auth: cookieSession({ login: loginStitch(), cookie: '*', loginInput }),
+    });
+
+    await expect(data()).resolves.toEqual({ ok: true });
+    expect(server.callCount('/login')).toBe(1);
+
+    const req = server.calls('/data')[0];
+    expect(req.cookies.sid).toBe('ABC'); // both cookies from the jar replay together
+    expect(req.cookies.csrf).toBe('XYZ');
+});
+
+test('jar: true is equivalent to cookie: "*"', async () => {
+    server.route('POST', '/login', {
+        setCookies: [
+            { name: 'sid', value: 'ABC' },
+            { name: 'csrf', value: 'XYZ' },
+        ],
+        body: { ok: true },
+    });
+    server.route('GET', '/data', {
+        requireCookie: { name: 'sid' },
+        body: { ok: true },
+    });
+
+    const data = stitch({
+        baseUrl: server.url,
+        path: '/data',
+        auth: cookieSession({
+            login: loginStitch(),
+            cookie: 'session', // only seeds the store key in jar mode
+            jar: true,
+            loginInput,
+        }),
+    });
+
+    await expect(data()).resolves.toEqual({ ok: true });
+    const req = server.calls('/data')[0];
+    expect(req.cookies.sid).toBe('ABC');
+    expect(req.cookies.csrf).toBe('XYZ');
+});
+
+test('a single named cookie still replays only that one (regression)', async () => {
+    server.route('POST', '/login', {
+        setCookies: [
+            { name: 'sid', value: 'ABC' },
+            { name: 'csrf', value: 'XYZ' },
+        ],
+        body: { ok: true },
+    });
+    server.route('GET', '/data', {
+        requireCookie: { name: 'sid' },
+        body: { ok: true },
+    });
+
+    const data = stitch({
+        baseUrl: server.url,
+        path: '/data',
+        auth: cookieSession({
+            login: loginStitch(),
+            cookie: 'sid',
+            loginInput,
+        }),
+    });
+
+    await expect(data()).resolves.toEqual({ ok: true });
+    const req = server.calls('/data')[0];
+    expect(req.cookies.sid).toBe('ABC'); // captured
+    expect(req.cookies.csrf).toBeUndefined(); // NOT captured — named mode is scoped to one cookie
+});

--- a/test/support/mock-server.ts
+++ b/test/support/mock-server.ts
@@ -17,6 +17,7 @@ export interface RouteBehavior {
     requireCookie?: { name: string; value?: string };
     requireHeader?: { name: string; value?: string };
     setCookie?: { name: string; value: string };
+    setCookies?: Array<{ name: string; value: string }>;
     retryAfter?: number;
     headers?: Record<string, string>;
 }
@@ -104,13 +105,18 @@ export function startMockServer(): Promise<MockServer> {
             payload: unknown,
             extra?: RouteBehavior,
         ): void => {
-            const out: Record<string, string> = {
+            const out: Record<string, string | string[]> = {
                 'content-type': 'application/json',
             };
             if (extra?.headers) Object.assign(out, extra.headers);
             if (extra?.setCookie)
                 out['Set-Cookie'] =
                     `${extra.setCookie.name}=${extra.setCookie.value}`;
+            if (extra?.setCookies)
+                // Multiple Set-Cookie headers (array value → one header line each).
+                out['Set-Cookie'] = extra.setCookies.map(
+                    (c) => `${c.name}=${c.value}`,
+                );
             if (extra?.retryAfter !== undefined)
                 out['Retry-After'] = String(extra.retryAfter);
             res.writeHead(status, out);


### PR DESCRIPTION
Closes the **multi-cookie jar** mechanical gap from the coverage audit (DESIGN.md §12; roadmap §14 item 4).

## What
`cookieSession({ cookie: '*' })` — or the explicit `jar: true` — captures the **entire `Set-Cookie` set** the login returns into a small jar in the `StitchStore`, and replays **every** cookie on subsequent requests, instead of one named cookie.

- `parseCookie` now delegates to a shared `parseCookieJar` (no behaviour change for named mode).
- `serializeJar` rebuilds the `Cookie` header from the stored jar.
- Jar lives in the store under a `jar:` namespace, so a shared store still shares the session.

## Test support
The mock server gains `setCookies[]` to emit multiple `Set-Cookie` header lines (the fetch adapter already coalesces them via `getSetCookie()`).

## Tests — `test/cookie-jar.spec.ts`
- a login setting **two** cookies → both replay via `cookie: '*'`;
- `jar: true` behaves identically;
- a single named cookie still replays **only** that one (regression).

Full pre-commit gate green: eslint · prettier · tsc · attw · jest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)