### PR TITLE
feat(http): binary/blob responses via responseType

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -98,6 +98,7 @@ function buildRequest(cfg: StitchConfig, input: StitchInput): AdapterRequest {
               }
             : input.body,
         bodyType: isGql ? 'json' : cfg.bodyType,
+        responseType: cfg.responseType,
     };
 }
 

--- a/src/http-adapter.ts
+++ b/src/http-adapter.ts
@@ -73,17 +73,30 @@ export function fetchAdapter(): Adapter {
             }
         }
 
-        // Parse the body: JSON when content-type is json-ish, else text.
-        const contentType = (resHeaders['content-type'] || '').toLowerCase();
-        const isJson =
-            contentType.includes('application/json') ||
-            contentType.includes('+json');
+        // Read the body. An explicit responseType wins (arrayBuffer/blob for binary
+        // downloads, text/json to force a shape); otherwise auto-detect by content-type.
         let parsed: unknown;
-        if (isJson) {
-            const text = await response.text();
-            parsed = text === '' ? undefined : JSON.parse(text);
-        } else {
+        const responseType = req.responseType;
+        if (responseType === 'arrayBuffer') {
+            parsed = await response.arrayBuffer();
+        } else if (responseType === 'blob') {
+            parsed = await response.blob();
+        } else if (responseType === 'text') {
             parsed = await response.text();
+        } else {
+            const contentType = (
+                resHeaders['content-type'] || ''
+            ).toLowerCase();
+            const isJson =
+                responseType === 'json' ||
+                contentType.includes('application/json') ||
+                contentType.includes('+json');
+            if (isJson) {
+                const text = await response.text();
+                parsed = text === '' ? undefined : JSON.parse(text);
+            } else {
+                parsed = await response.text();
+            }
         }
 
         return { status: response.status, headers: resHeaders, body: parsed };

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,12 +37,15 @@ export interface DriftSpec {
 }
 
 // ---- Adapter (HTTP kind) --------------------------------------------------
+/** How to read the response body. Default (unset) = auto: JSON when the content-type is json-ish, else text. */
+export type ResponseType = 'json' | 'text' | 'arrayBuffer' | 'blob';
 export interface AdapterRequest {
     url: string;
     method: string;
     headers: Record<string, string>;
     body?: unknown;
     bodyType?: 'json' | 'form' | 'multipart';
+    responseType?: ResponseType;
     signal?: AbortSignal;
 }
 export interface AdapterResponse {
@@ -148,6 +151,7 @@ export interface StitchConfig {
     kind?: 'http' | 'graphql';
     method?: string;
     bodyType?: 'json' | 'form' | 'multipart'; // request body encoding (default 'json')
+    responseType?: ResponseType; // how to read the response body (default: auto by content-type)
     baseUrl?: string | (() => string);
     path?: string;
     headers?: Record<string, string>; // static default headers merged into every request

--- a/test/binary-responses.spec.ts
+++ b/test/binary-responses.spec.ts
@@ -1,0 +1,87 @@
+// Binary/blob responses: `responseType` controls how the adapter reads the body —
+// 'arrayBuffer'/'blob' for downloads, 'text' for raw strings, 'json' to force parsing.
+// Bytes must round-trip exactly, proven by hashing the payload on both ends.
+import { stitch } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.STITCH_TRACE_FILE = join(
+    tmpdir(),
+    `stitch-binary-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => server.reset());
+
+const sha = (b: Buffer): string => createHash('sha256').update(b).digest('hex');
+// A deterministic payload spanning every byte value 0..255 (catches encoding corruption).
+const payload = Buffer.from(Array.from({ length: 256 }, (_, i) => i));
+
+test('responseType: "arrayBuffer" round-trips raw bytes (hash matches)', async () => {
+    server.route('GET', '/blob', { body: payload });
+    const download = stitch({
+        baseUrl: server.url,
+        path: '/blob',
+        responseType: 'arrayBuffer',
+    });
+
+    const ab = (await download()) as ArrayBuffer;
+    expect(ab).toBeInstanceOf(ArrayBuffer);
+    expect(sha(Buffer.from(ab))).toBe(sha(payload));
+});
+
+test('responseType: "blob" round-trips raw bytes (hash matches)', async () => {
+    server.route('GET', '/blob', { body: payload });
+    const download = stitch({
+        baseUrl: server.url,
+        path: '/blob',
+        responseType: 'blob',
+    });
+
+    const blob = (await download()) as Blob;
+    expect(blob).toBeInstanceOf(Blob);
+    expect(sha(Buffer.from(await blob.arrayBuffer()))).toBe(sha(payload));
+});
+
+test('responseType: "text" returns the raw decoded string', async () => {
+    const text = 'hello bytes — ☃ unicode survives';
+    server.route('GET', '/text', { body: Buffer.from(text, 'utf8') });
+    const read = stitch({
+        baseUrl: server.url,
+        path: '/text',
+        responseType: 'text',
+    });
+
+    await expect(read()).resolves.toBe(text);
+});
+
+test('responseType: "json" forces parsing regardless of content-type', async () => {
+    // Served as octet-stream bytes, but parsed as JSON because responseType says so.
+    server.route('GET', '/forced', {
+        body: Buffer.from(JSON.stringify({ forced: true }), 'utf8'),
+    });
+    const f = stitch({
+        baseUrl: server.url,
+        path: '/forced',
+        responseType: 'json',
+    });
+
+    await expect(f()).resolves.toEqual({ forced: true });
+});
+
+test('default (no responseType) still auto-parses JSON', async () => {
+    server.route('GET', '/json', { body: { a: 1, nested: { b: 2 } } });
+    const j = stitch({ baseUrl: server.url, path: '/json' });
+
+    await expect(j()).resolves.toEqual({ a: 1, nested: { b: 2 } });
+});

--- a/test/support/mock-server.ts
+++ b/test/support/mock-server.ts
@@ -104,8 +104,14 @@ export function startMockServer(): Promise<MockServer> {
             payload: unknown,
             extra?: RouteBehavior,
         ): void => {
+            // A Buffer/Uint8Array body is sent as raw bytes (octet-stream by default);
+            // anything else is JSON-encoded. Lets routes serve binary downloads.
+            const isBytes =
+                Buffer.isBuffer(payload) || payload instanceof Uint8Array;
             const out: Record<string, string> = {
-                'content-type': 'application/json',
+                'content-type': isBytes
+                    ? 'application/octet-stream'
+                    : 'application/json',
             };
             if (extra?.headers) Object.assign(out, extra.headers);
             if (extra?.setCookie)
@@ -114,7 +120,11 @@ export function startMockServer(): Promise<MockServer> {
             if (extra?.retryAfter !== undefined)
                 out['Retry-After'] = String(extra.retryAfter);
             res.writeHead(status, out);
-            res.end(JSON.stringify(payload));
+            res.end(
+                isBytes
+                    ? Buffer.from(payload as Uint8Array)
+                    : JSON.stringify(payload),
+            );
         };
 
         if (!behavior) return send(404, { error: 'not_found' });


### PR DESCRIPTION
Closes the **binary/blob responses** mechanical gap from the coverage audit (DESIGN.md §12; roadmap §14 item 5).

## What
`responseType?: 'json' | 'text' | 'arrayBuffer' | 'blob'` on `StitchConfig`, threaded to the http-adapter via `AdapterRequest`:
- `'arrayBuffer'` / `'blob'` — return the raw body for downloads;
- `'text'` — return the decoded string;
- `'json'` — force JSON parsing regardless of content-type;
- unset — unchanged auto-detect (JSON when content-type is json-ish, else text).

## Test support
The mock server now serves a `Buffer`/`Uint8Array` body as raw bytes (`application/octet-stream`).

## Tests — `test/binary-responses.spec.ts`
- a 256-byte payload (every byte value 0–255) round-trips **byte-exact** via `arrayBuffer` and `blob`, verified by **sha256** over both ends;
- `text` decodes (incl. unicode);
- `json` forces parsing of an octet-stream body;
- default (no `responseType`) still auto-parses JSON.

Full pre-commit gate green: eslint · prettier · tsc · attw · jest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)