### PR TITLE
feat(resilience): circuit breaker

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4,7 +4,13 @@
 // response (used by cookieSession to read Set-Cookie from a login stitch).
 import { classifyDrift, loadSnapshot, saveSnapshot } from './drift';
 import { fetchAdapter } from './http-adapter';
-import { backoffDelay, parseRetryAfter, withTimeout } from './resilience';
+import {
+    CircuitOpenError,
+    backoffDelay,
+    createCircuit,
+    parseRetryAfter,
+    withTimeout,
+} from './resilience';
 import type {
     Adapter,
     AdapterRequest,
@@ -308,6 +314,50 @@ async function* attemptLoop(
     throw new Error('retry attempts exhausted');
 }
 
+// Wraps attemptLoop with a circuit breaker (when configured). When the breaker is OPEN it
+// fast-fails BEFORE any network call (emitting a `circuit` progress event), so a failing
+// dependency stops being hammered; a success closes it, a failure (re)opens it. With no
+// `circuit` config this is a transparent pass-through.
+async function* attemptWithCircuit(
+    rt: Runtime,
+    baseReq: AdapterRequest,
+    state: { attempts: number },
+): AsyncGenerator<StitchEvent, AdapterResponse, unknown> {
+    const { cfg } = rt;
+    if (!cfg.circuit) {
+        return yield* attemptLoop(rt, baseReq, state);
+    }
+    const circuit = createCircuit(cfg.circuit, rt.store, hostKey(baseReq, cfg));
+    if ((await circuit.phase()) === 'open') {
+        yield {
+            type: 'progress',
+            phase: 'circuit',
+            attempt: state.attempts,
+            detail: 'open',
+            at: now(),
+        };
+        throw new CircuitOpenError(); // fast-fail: do NOT touch the network
+    }
+    try {
+        const res = yield* attemptLoop(rt, baseReq, state);
+        await circuit.onSuccess();
+        return res;
+    } catch (e) {
+        if (!(e instanceof CircuitOpenError)) {
+            const opened = await circuit.onFailure();
+            if (opened)
+                yield {
+                    type: 'progress',
+                    phase: 'circuit',
+                    attempt: state.attempts,
+                    detail: 'open',
+                    at: now(),
+                };
+        }
+        throw e;
+    }
+}
+
 function mergeInput(a: StitchInput, b: StitchInput): StitchInput {
     return {
         params: { ...(a.params ?? {}), ...(b.params ?? {}) },
@@ -348,7 +398,7 @@ async function* paginated(
         const req = buildRequest(cfg, pageInput);
         let res: AdapterResponse;
         try {
-            res = yield* attemptLoop(rt, req, state);
+            res = yield* attemptWithCircuit(rt, req, state);
         } catch (e) {
             yield errEvt(e, name, state.attempts);
             yield doneEvt(false, t0, state.attempts);
@@ -443,7 +493,7 @@ export async function* execute(
 
     let res: AdapterResponse;
     try {
-        res = yield* attemptLoop(rt, baseReq, state);
+        res = yield* attemptWithCircuit(rt, baseReq, state);
     } catch (e) {
         yield errEvt(e, name, state.attempts);
         yield doneEvt(false, t0, state.attempts);

--- a/src/resilience.ts
+++ b/src/resilience.ts
@@ -1,7 +1,12 @@
 // Resilience primitives: retry backoff math, Retry-After parsing, a proactive
 // throttle (rate + concurrency, per key), and a timeout wrapper. Dependency-free;
 // pacing/cancellation go through the shared `sleep`/`now` helpers from `./util`.
-import type { RetryOptions, ThrottleOptions } from './types';
+import type {
+    CircuitOptions,
+    RetryOptions,
+    StitchStore,
+    ThrottleOptions,
+} from './types';
 import { now, parseRate, sleep } from './util';
 
 export class TimeoutError extends Error {}
@@ -131,4 +136,70 @@ export function withTimeout<T>(
             },
         );
     });
+}
+
+/** Thrown (and surfaced as an `error` event) when a stitch fast-fails because its breaker is open. */
+export class CircuitOpenError extends Error {
+    readonly status = 503;
+    constructor(message = 'circuit open') {
+        super(message);
+        this.name = 'CircuitOpenError';
+    }
+}
+
+export type CircuitPhase = 'closed' | 'open' | 'half-open';
+interface CircuitRecord {
+    failures: number; // consecutive failures
+    openedAt: number; // epoch ms the breaker opened; 0 = closed
+}
+
+/**
+ * A store-backed circuit breaker. After `failureThreshold` consecutive failures it OPENS:
+ * calls fast-fail for `cooldownMs`, then it goes HALF-OPEN and lets a single trial through —
+ * a success closes it, another failure re-opens it. State lives in the StitchStore, so a shared
+ * store gives a breaker shared across workers (DESIGN.md §13).
+ */
+export function createCircuit(
+    opts: CircuitOptions,
+    store: StitchStore,
+    fallbackKey: string,
+): {
+    phase(): Promise<CircuitPhase>;
+    onSuccess(): Promise<void>;
+    onFailure(): Promise<boolean>;
+} {
+    const halfOpenAfter = opts.halfOpenAfterMs ?? opts.cooldownMs;
+    const nsKey = 'circuit:' + (opts.key ?? fallbackKey);
+
+    const read = async (): Promise<CircuitRecord> =>
+        ((await store.get(nsKey)) as CircuitRecord | undefined) ?? {
+            failures: 0,
+            openedAt: 0,
+        };
+
+    return {
+        // Current phase given the clock: closed, open (fast-fail), or half-open (one trial).
+        async phase(): Promise<CircuitPhase> {
+            const r = await read();
+            if (r.openedAt === 0) return 'closed';
+            return now() - r.openedAt >= halfOpenAfter ? 'half-open' : 'open';
+        },
+        // A success closes the breaker and clears the failure count.
+        async onSuccess(): Promise<void> {
+            await store.set(nsKey, { failures: 0, openedAt: 0 });
+        },
+        // A failure increments the count; returns true iff THIS failure opened the breaker.
+        async onFailure(): Promise<boolean> {
+            const r = await read();
+            const failures = r.failures + 1;
+            const wasOpen = r.openedAt !== 0;
+            if (wasOpen || failures >= opts.failureThreshold) {
+                // (re)open — arm a fresh cooldown window.
+                await store.set(nsKey, { failures, openedAt: now() });
+                return !wasOpen; // "newly opened" only when it had been closed
+            }
+            await store.set(nsKey, { failures, openedAt: 0 });
+            return false;
+        },
+    };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,12 @@ export interface TimeoutOptions {
     total?: number | string;
     perAttempt?: number | string;
 }
+export interface CircuitOptions {
+    failureThreshold: number; // consecutive failures that trip the breaker OPEN
+    cooldownMs: number; // fast-fail window after opening, before a half-open trial
+    halfOpenAfterMs?: number; // when to allow a half-open trial (default cooldownMs)
+    key?: string; // store namespace to share a breaker across stitches (default: stitch/host key)
+}
 
 // ---- Auth -----------------------------------------------------------------
 export interface AuthContext {
@@ -105,7 +111,8 @@ export type ProgressPhase =
     | 'request'
     | 'throttled'
     | 'retry'
-    | 'paginate';
+    | 'paginate'
+    | 'circuit';
 export type StitchEvent<T = unknown> =
     | {
           type: 'start';
@@ -170,6 +177,7 @@ export interface StitchConfig {
     retry?: RetryOptions;
     throttle?: ThrottleOptions;
     timeout?: TimeoutOptions;
+    circuit?: CircuitOptions;
     hooks?: Hooks;
     extends?: Array<Partial<StitchConfig> | Stitch | string>;
     adapter?: Adapter; // test seam / custom transport

--- a/test/circuit-breaker.spec.ts
+++ b/test/circuit-breaker.spec.ts
@@ -1,0 +1,93 @@
+// Circuit breaker: after N consecutive failures the breaker OPENS and calls fast-fail
+// without touching the network (proven by an unchanged server hit-count) while emitting a
+// `circuit` event; after the cooldown it goes HALF-OPEN and a trial request can recover it.
+import { stitch } from '../src';
+import type { StitchEvent } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.STITCH_TRACE_FILE = join(
+    tmpdir(),
+    `stitch-circuit-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => server.reset());
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const collect = async (s: {
+    stream(): AsyncGenerator<StitchEvent>;
+}): Promise<StitchEvent[]> => {
+    const events: StitchEvent[] = [];
+    for await (const ev of s.stream()) events.push(ev);
+    return events;
+};
+
+test('opens after N consecutive failures, fast-fails without hitting the server, then recovers', async () => {
+    // 3×500 then 200. Fast-failed calls never reach the server, so the status sequence
+    // only advances on REAL hits — the 4th real hit (recovery) gets the 200.
+    server.route('GET', '/svc', {
+        statuses: [500, 500, 500, 200],
+        body: { ok: true },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/svc',
+        // default retry attempts = 1, so each call is exactly one server hit = one failure.
+        circuit: { failureThreshold: 3, cooldownMs: 300 },
+    });
+
+    // Three failing calls trip the breaker.
+    for (let i = 0; i < 3; i++) await expect(call()).rejects.toBeDefined();
+    expect(server.callCount('/svc')).toBe(3);
+
+    // 4th call: breaker OPEN → fast-fail. A `circuit` event fires, an error is emitted,
+    // and the server is NOT hit.
+    const events = await collect(call());
+    expect(
+        events.some((e) => e.type === 'progress' && e.phase === 'circuit'),
+    ).toBe(true);
+    expect(events.some((e) => e.type === 'error')).toBe(true);
+    expect(server.callCount('/svc')).toBe(3); // unchanged — no network during cooldown
+
+    // The await form fast-fails too (503), still without a server hit.
+    await expect(call()).rejects.toMatchObject({ status: 503 });
+    expect(server.callCount('/svc')).toBe(3);
+
+    // Wait out the cooldown → HALF-OPEN. The trial reaches the server (now 200) → closes.
+    await sleep(350);
+    await expect(call()).resolves.toEqual({ ok: true });
+    expect(server.callCount('/svc')).toBe(4); // the trial request hit the server
+});
+
+test('a success resets the consecutive-failure count', async () => {
+    // fail, fail, succeed, fail, fail — never 3 failures in a row, so it never opens
+    // and every call reaches the server (none is fast-failed).
+    server.route('GET', '/svc', {
+        statuses: [500, 500, 200, 500, 500],
+        body: { ok: true },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/svc',
+        circuit: { failureThreshold: 3, cooldownMs: 300 },
+    });
+
+    await expect(call()).rejects.toBeDefined(); // failures = 1
+    await expect(call()).rejects.toBeDefined(); // failures = 2
+    await expect(call()).resolves.toEqual({ ok: true }); // success → reset to 0
+    await expect(call()).rejects.toBeDefined(); // failures = 1
+    await expect(call()).rejects.toBeDefined(); // failures = 2
+
+    expect(server.callCount('/svc')).toBe(5); // all 5 hit the server → breaker never opened
+});


### PR DESCRIPTION
Closes the **circuit breaker** mechanical gap from the coverage audit (DESIGN.md §12; roadmap §14 item 6).

## What
`circuit?: { failureThreshold, cooldownMs, halfOpenAfterMs? }` on `StitchConfig`, implemented in `src/resilience.ts` (`createCircuit` + `CircuitOpenError`) and wired into the engine's attempt path (`attemptWithCircuit`):

- **Closed** — requests flow; a success clears the failure count.
- After `failureThreshold` consecutive failures → **Open**: calls **fast-fail before any network call** (emitting a `circuit` progress event) for `cooldownMs`.
- After the cooldown → **Half-open**: a single trial request is allowed — success closes the breaker, failure re-opens it.

State lives in the `StitchStore` (keyed by stitch/host, overridable via `key`), so a shared store gives a breaker shared across workers. `executeRaw` (the auth login path) is intentionally **not** circuit-broken. Adds `'circuit'` to `ProgressPhase`.

## Tests — `test/circuit-breaker.spec.ts`
- trip it with N failures, then assert the next call **fast-fails** (status 503) with an **unchanged server hit-count** and a `circuit` event, then **half-open recovery** to a 200;
- a success **resets** the consecutive-failure count (never trips on cumulative failures).

Full pre-commit gate green: eslint · prettier · tsc · attw · jest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)