### PR TITLE
feat(engine): idempotency keys on writes

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -29,6 +29,8 @@ import {
 } from './util';
 import type { Validator } from './validator';
 
+import { randomUUID } from 'node:crypto';
+
 export interface Runtime {
     cfg: StitchConfig;
     adapter: Adapter;
@@ -68,6 +70,29 @@ function joinUrl(base: string, path: string): string {
     );
 }
 
+// Inject a stable Idempotency-Key on writes. The key is computed once per logical call (here,
+// in buildRequest) and the attempt loop reuses the same request, so it stays constant across
+// retries. GET/HEAD are skipped, and a caller-provided header (case-insensitive) wins.
+function applyIdempotency(
+    cfg: StitchConfig,
+    input: StitchInput,
+    method: string,
+    headers: Record<string, string>,
+): void {
+    if (!cfg.idempotency) return;
+    if (method === 'GET' || method === 'HEAD') return; // writes only
+    const header = cfg.idempotency.header ?? 'Idempotency-Key';
+    if (
+        Object.keys(headers).some(
+            (h) => h.toLowerCase() === header.toLowerCase(),
+        )
+    )
+        return;
+    headers[header] = cfg.idempotency.key
+        ? cfg.idempotency.key(input)
+        : randomUUID();
+}
+
 function buildRequest(cfg: StitchConfig, input: StitchInput): AdapterRequest {
     const isGql = cfg.kind === 'graphql';
     const base =
@@ -87,10 +112,13 @@ function buildRequest(cfg: StitchConfig, input: StitchInput): AdapterRequest {
     const { path } = expandPath(tpl, input.params ?? {});
     const query = { ...predefined, ...(input.query ?? {}) };
     const url = joinUrl(base, path) + buildQuery(query);
+    const method = (cfg.method ?? (isGql ? 'POST' : 'GET')).toUpperCase();
+    const headers = { ...(cfg.headers ?? {}), ...(input.headers ?? {}) };
+    applyIdempotency(cfg, input, method, headers);
     return {
         url,
-        method: (cfg.method ?? (isGql ? 'POST' : 'GET')).toUpperCase(),
-        headers: { ...(cfg.headers ?? {}), ...(input.headers ?? {}) },
+        method,
+        headers,
         body: isGql
             ? {
                   query: cfg.query,

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,6 +70,10 @@ export interface TimeoutOptions {
     total?: number | string;
     perAttempt?: number | string;
 }
+export interface IdempotencyOptions {
+    header?: string; // header name (default 'Idempotency-Key')
+    key?: (input: StitchInput) => string; // stable key per logical call (default: a random uuid)
+}
 
 // ---- Auth -----------------------------------------------------------------
 export interface AuthContext {
@@ -170,6 +174,7 @@ export interface StitchConfig {
     retry?: RetryOptions;
     throttle?: ThrottleOptions;
     timeout?: TimeoutOptions;
+    idempotency?: IdempotencyOptions; // inject a stable Idempotency-Key header on writes
     hooks?: Hooks;
     extends?: Array<Partial<StitchConfig> | Stitch | string>;
     adapter?: Adapter; // test seam / custom transport

--- a/test/idempotency.spec.ts
+++ b/test/idempotency.spec.ts
@@ -1,0 +1,98 @@
+// Idempotency keys: on a write, the stitch injects an Idempotency-Key header that is STABLE
+// for one logical call — the same value rides every retry of that call — so a server can
+// dedupe a retried write. A custom key function derives a deterministic key from the input.
+import { stitch } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.STITCH_TRACE_FILE = join(
+    tmpdir(),
+    `stitch-idempotency-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => server.reset());
+
+test('injects a stable Idempotency-Key on a write, unchanged across a retry', async () => {
+    server.route('POST', '/create', {
+        statuses: [503, 200],
+        body: { ok: true },
+    });
+    const create = stitch({
+        method: 'POST',
+        baseUrl: server.url,
+        path: '/create',
+        retry: { attempts: 2, on: [503], baseMs: 5 },
+        idempotency: {}, // default header + random per-call key
+    });
+
+    await expect(create({ body: { x: 1 } })).resolves.toEqual({ ok: true });
+
+    const calls = server.calls('/create');
+    expect(calls.length).toBe(2); // 503 then 200
+    const key = calls[0].headers['idempotency-key'];
+    expect(key).toBeTruthy();
+    expect(calls[1].headers['idempotency-key']).toBe(key); // identical across the retry
+});
+
+test('uses a custom key function derived from the input', async () => {
+    server.route('POST', '/orders', {
+        statuses: [503, 200],
+        body: { ok: true },
+    });
+    const create = stitch({
+        method: 'POST',
+        baseUrl: server.url,
+        path: '/orders',
+        retry: { attempts: 2, on: [503], baseMs: 5 },
+        idempotency: {
+            header: 'X-Idempotency-Key',
+            key: (input) => `order-${(input.body as { id: number }).id}`,
+        },
+    });
+
+    await create({ body: { id: 42 } });
+
+    const calls = server.calls('/orders');
+    expect(calls[0].headers['x-idempotency-key']).toBe('order-42');
+    expect(calls[1].headers['x-idempotency-key']).toBe('order-42'); // stable + deterministic
+});
+
+test('separate logical calls get distinct generated keys', async () => {
+    server.route('POST', '/c', { body: { ok: true } });
+    const create = stitch({
+        method: 'POST',
+        baseUrl: server.url,
+        path: '/c',
+        idempotency: {},
+    });
+
+    await create({ body: {} });
+    await create({ body: {} });
+
+    const calls = server.calls('/c');
+    expect(calls[0].headers['idempotency-key']).not.toBe(
+        calls[1].headers['idempotency-key'],
+    );
+});
+
+test('does not inject on GET (writes only)', async () => {
+    server.route('GET', '/read', { body: { ok: true } });
+    const read = stitch({
+        baseUrl: server.url,
+        path: '/read',
+        idempotency: {},
+    });
+
+    await read();
+    expect(server.calls('/read')[0].headers['idempotency-key']).toBeUndefined();
+});


### PR DESCRIPTION
Closes the **idempotency keys** mechanical gap from the coverage audit (DESIGN.md §12; roadmap §14 item 6).

## What
`idempotency?: { header?, key?: (input) => string }` on `StitchConfig`:
- injects an `Idempotency-Key` header (name overridable) on **write** methods (everything except GET/HEAD);
- the key is computed **once per logical call** in `buildRequest`, and the attempt loop reuses the same request — so it stays **constant across retries**;
- default key is a random uuid (unique per call); a `key` function derives a deterministic key from the input (stable across separate invocations);
- a caller-provided header (case-insensitive) is left untouched.

## Tests — `test/idempotency.spec.ts`
- header **present and stable across a retry** (503 → 200);
- a **custom key function** derived from the input;
- **distinct** generated keys across separate calls;
- **not injected on GET** (writes only).

Full pre-commit gate green: eslint · prettier · tsc · attw · jest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)