### PR TITLE
feat(observability): OTLP / OpenTelemetry export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,15 @@
 export { stitch, defineStitch, preset, drift, graphql } from './stitch';
 export { bearer, apiKey, basic, cookieSession, env, keychain } from './auth';
 export { fetchAdapter } from './http-adapter';
-export { createTrace } from './trace';
+export { createTrace, multiplex } from './trace';
+export { otlpTrace, otlpHttpExporter, toOtlpJson } from './otlp';
+export type {
+    SpanExporter,
+    OtelSpan,
+    OtelSpanEvent,
+    SpanAttributes,
+    OtlpOptions,
+} from './otlp';
 export { toValidator } from './validator';
 export { memoryStore } from './store';
 export * from './types';

--- a/src/otlp.ts
+++ b/src/otlp.ts
@@ -1,0 +1,260 @@
+// Opt-in OpenTelemetry/OTLP trace sink: maps a stitch's event stream to one CLIENT span per
+// logical call, using OTel HTTP semantic-convention attributes, and hands finished spans to a
+// SpanExporter. The default exporter POSTs OTLP/JSON to a collector; tests inject a stub
+// exporter (no running collector). It is a normal TraceSink, so it tees alongside console/JSONL.
+import type { StitchEvent, TraceSink } from './types';
+
+import { randomBytes } from 'node:crypto';
+
+export type SpanAttributes = Record<string, string | number | boolean>;
+
+export interface OtelSpanEvent {
+    name: string;
+    timeUnixMs: number;
+    attributes?: SpanAttributes;
+}
+
+export interface OtelSpan {
+    name: string;
+    kind: 'CLIENT';
+    traceId: string; // 32 hex chars
+    spanId: string; // 16 hex chars
+    startUnixMs: number;
+    endUnixMs: number;
+    attributes: SpanAttributes;
+    status: { code: 'UNSET' | 'OK' | 'ERROR'; message?: string };
+    events: OtelSpanEvent[];
+}
+
+/** Receives finished spans. Implement this to ship spans anywhere; the default POSTs OTLP/JSON. */
+export interface SpanExporter {
+    export(spans: OtelSpan[]): void | Promise<void>;
+}
+
+export interface OtlpOptions {
+    exporter?: SpanExporter; // override the destination (e.g. a stub in tests)
+    endpoint?: string; // OTLP/HTTP base URL (default: env OTEL_EXPORTER_OTLP_ENDPOINT or localhost:4318)
+    headers?: Record<string, string>; // extra headers for the OTLP POST (e.g. auth)
+}
+
+const hex = (bytes: number): string => randomBytes(bytes).toString('hex');
+
+function serverAddress(url: string): string | undefined {
+    try {
+        return new URL(url).hostname;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * A TraceSink that turns each stitch call's events (start → … → done) into a single OTel CLIENT
+ * span, exported on `done`. Attributes follow the OTel HTTP semantic conventions
+ * (`http.request.method`, `url.full`, `server.address`, `http.response.status_code`,
+ * `error.type`); a future LLM-kind stitch would map to the gen_ai.* conventions the same way.
+ * Spans are correlated per stitch name (sequential calls keep 0–1 open; a stack tolerates nesting).
+ */
+export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
+    const exporter =
+        opts.exporter ??
+        otlpHttpExporter({ endpoint: opts.endpoint, headers: opts.headers });
+    const open = new Map<string, OtelSpan[]>();
+    const push = (name: string, span: OtelSpan): void => {
+        const stack = open.get(name) ?? [];
+        stack.push(span);
+        open.set(name, stack);
+    };
+    const top = (name: string): OtelSpan | undefined => {
+        const stack = open.get(name);
+        return stack && stack[stack.length - 1];
+    };
+
+    const emit = (span: OtelSpan): void => {
+        try {
+            const r = exporter.export([span]) as unknown;
+            if (r instanceof Promise) r.catch(() => {});
+        } catch {
+            /* an exporter failure must never break the event stream */
+        }
+    };
+
+    return {
+        handle(event: StitchEvent, ctx: { name: string }): void {
+            const name = ctx.name;
+            switch (event.type) {
+                case 'start': {
+                    const attributes: SpanAttributes = {
+                        'http.request.method': event.method,
+                        'url.full': event.url,
+                    };
+                    const host = serverAddress(event.url);
+                    if (host) attributes['server.address'] = host;
+                    push(name, {
+                        name: `${event.method} ${name}`,
+                        kind: 'CLIENT',
+                        traceId: hex(16),
+                        spanId: hex(8),
+                        startUnixMs: event.at,
+                        endUnixMs: event.at,
+                        attributes,
+                        status: { code: 'UNSET' },
+                        events: [],
+                    });
+                    break;
+                }
+                case 'progress': {
+                    top(name)?.events.push({
+                        name: event.phase,
+                        timeUnixMs: event.at,
+                        attributes: {
+                            'stitch.attempt': event.attempt,
+                            ...(event.detail
+                                ? { 'stitch.detail': event.detail }
+                                : {}),
+                            ...(event.waitedMs != null
+                                ? { 'stitch.waited_ms': event.waitedMs }
+                                : {}),
+                        },
+                    });
+                    break;
+                }
+                case 'drift': {
+                    top(name)?.events.push({
+                        name: 'drift',
+                        timeUnixMs: event.at,
+                        attributes: {
+                            'stitch.drift.level': event.finding.level,
+                            'stitch.drift.path': event.finding.path,
+                            'stitch.drift.change': event.finding.change,
+                        },
+                    });
+                    break;
+                }
+                case 'result': {
+                    const span = top(name);
+                    if (span) {
+                        span.attributes['http.response.status_code'] =
+                            event.status;
+                        if (span.status.code === 'UNSET')
+                            span.status = { code: 'OK' };
+                    }
+                    break;
+                }
+                case 'error': {
+                    const span = top(name);
+                    if (span) {
+                        if (event.status != null)
+                            span.attributes['http.response.status_code'] =
+                                event.status;
+                        span.attributes['error.type'] =
+                            event.status != null
+                                ? String(event.status)
+                                : 'error';
+                        span.status = { code: 'ERROR', message: event.message };
+                    }
+                    break;
+                }
+                case 'done': {
+                    const span = open.get(name)?.pop();
+                    if (span) {
+                        span.endUnixMs = event.at;
+                        emit(span);
+                    }
+                    break;
+                }
+            }
+        },
+        flush(): void {},
+    };
+}
+
+const OTLP_STATUS = { UNSET: 0, OK: 1, ERROR: 2 } as const;
+const SPAN_KIND_CLIENT = 3;
+const toNano = (ms: number): string => String(Math.round(ms * 1e6));
+
+function toOtlpAttributes(attrs: SpanAttributes): unknown[] {
+    return Object.entries(attrs).map(([key, v]) => ({
+        key,
+        value:
+            typeof v === 'number'
+                ? Number.isInteger(v)
+                    ? { intValue: String(v) }
+                    : { doubleValue: v }
+                : typeof v === 'boolean'
+                  ? { boolValue: v }
+                  : { stringValue: v },
+    }));
+}
+
+/** Serialize spans to the OTLP/JSON `ResourceSpans` shape a collector accepts on `/v1/traces`. */
+export function toOtlpJson(spans: OtelSpan[]): unknown {
+    return {
+        resourceSpans: [
+            {
+                resource: {
+                    attributes: toOtlpAttributes({
+                        'service.name': 'stitchapi',
+                    }),
+                },
+                scopeSpans: [
+                    {
+                        scope: { name: 'stitchapi' },
+                        spans: spans.map((s) => ({
+                            traceId: s.traceId,
+                            spanId: s.spanId,
+                            name: s.name,
+                            kind: SPAN_KIND_CLIENT,
+                            startTimeUnixNano: toNano(s.startUnixMs),
+                            endTimeUnixNano: toNano(s.endUnixMs),
+                            attributes: toOtlpAttributes(s.attributes),
+                            status: {
+                                code: OTLP_STATUS[s.status.code],
+                                ...(s.status.message
+                                    ? { message: s.status.message }
+                                    : {}),
+                            },
+                            events: s.events.map((e) => ({
+                                name: e.name,
+                                timeUnixNano: toNano(e.timeUnixMs),
+                                attributes: toOtlpAttributes(
+                                    e.attributes ?? {},
+                                ),
+                            })),
+                        })),
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+/**
+ * Default exporter: POST spans as OTLP/JSON to `${endpoint}/v1/traces` (endpoint defaults to
+ * `OTEL_EXPORTER_OTLP_ENDPOINT` or `http://localhost:4318`). Fire-and-forget — failures are
+ * swallowed so a missing collector never breaks a stitch call.
+ */
+export function otlpHttpExporter(
+    opts: { endpoint?: string; headers?: Record<string, string> } = {},
+): SpanExporter {
+    const base =
+        opts.endpoint ??
+        process.env.OTEL_EXPORTER_OTLP_ENDPOINT ??
+        'http://localhost:4318';
+    const url = base.replace(/\/+$/, '') + '/v1/traces';
+    return {
+        async export(spans: OtelSpan[]): Promise<void> {
+            try {
+                await fetch(url, {
+                    method: 'POST',
+                    headers: {
+                        'content-type': 'application/json',
+                        ...(opts.headers ?? {}),
+                    },
+                    body: JSON.stringify(toOtlpJson(spans)),
+                });
+            } catch {
+                /* no collector / network error — drop the batch, never throw */
+            }
+        },
+    };
+}

--- a/src/stitch.ts
+++ b/src/stitch.ts
@@ -1,9 +1,10 @@
 // The authoring surface: stitch() + the three composition facades (extends / defineStitch /
 // builder) + `.with()` partial application, all resolving to one canonical config.
 import { type Runtime, execute, executeRaw, makeRuntime } from './engine';
+import { otlpTrace } from './otlp';
 import { createThrottle } from './resilience';
 import { createStoreThrottle, memoryStore } from './store';
-import { createTrace } from './trace';
+import { createTrace, exportsFromEnv, multiplex } from './trace';
 import {
     type DriftOptions,
     type DriftSpec,
@@ -105,11 +106,15 @@ function compose(config: Fragment): StitchConfig {
 }
 
 // ---- shared trace sink (zero-infra: console off in tests, JSONL file) ------
+// Always tees console/JSONL; STITCH_EXPORT=otlp ALSO fans the same events to an OTLP collector.
 function getTrace(): TraceSink {
-    return createTrace({
+    const base = createTrace({
         console: process.env.STITCH_TRACE_CONSOLE === '1',
         file: process.env.STITCH_TRACE_FILE || undefined,
     });
+    if (!exportsFromEnv(process.env.STITCH_EXPORT).includes('otlp'))
+        return base;
+    return multiplex(base, otlpTrace());
 }
 
 // ---- the streaming spine + await sugar ------------------------------------

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -99,3 +99,23 @@ export function createTrace(
         flush(): void {},
     };
 }
+
+/** Fan every event out to several sinks (e.g. console/JSONL + OTLP) — one event stream, many consumers. */
+export function multiplex(...sinks: TraceSink[]): TraceSink {
+    return {
+        handle(event, ctx): void {
+            for (const sink of sinks) sink.handle(event, ctx);
+        },
+        async flush(): Promise<void> {
+            for (const sink of sinks) await sink.flush?.();
+        },
+    };
+}
+
+/** Parse `STITCH_EXPORT` (comma list, e.g. "otlp" or "console,otlp") into lowercased export names. */
+export function exportsFromEnv(value: string | undefined): string[] {
+    return (value ?? '')
+        .split(',')
+        .map((s) => s.trim().toLowerCase())
+        .filter(Boolean);
+}

--- a/test/otlp-export.spec.ts
+++ b/test/otlp-export.spec.ts
@@ -1,0 +1,143 @@
+// OTLP export: an opt-in trace sink maps the event stream to OpenTelemetry CLIENT spans (OTel
+// HTTP semconv attributes) and hands them to a SpanExporter. Tested with a STUB exporter that
+// captures spans in memory — no running collector, no network.
+import { otlpTrace, stitch } from '../src';
+import type { OtelSpan, SpanExporter, StitchEvent } from '../src';
+import { exportsFromEnv, multiplex } from '../src/trace';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.STITCH_TRACE_FILE = join(
+    tmpdir(),
+    `stitch-otlp-${process.pid}.jsonl`,
+);
+
+// A stub exporter: captures exported spans in memory (no collector, no network).
+function stubExporter(): { exporter: SpanExporter; spans: OtelSpan[] } {
+    const spans: OtelSpan[] = [];
+    return {
+        spans,
+        exporter: {
+            export(batch) {
+                spans.push(...batch);
+            },
+        },
+    };
+}
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => server.reset());
+
+test('maps a successful call to one CLIENT span with OTel HTTP semconv attributes', () => {
+    const { exporter, spans } = stubExporter();
+    const sink = otlpTrace({ exporter });
+    const name = 'getThing';
+    const events: StitchEvent[] = [
+        {
+            type: 'start',
+            name,
+            method: 'GET',
+            url: 'http://api.example.com/x',
+            input: {},
+            at: 1000,
+        },
+        {
+            type: 'progress',
+            phase: 'retry',
+            attempt: 1,
+            detail: '503',
+            at: 1010,
+        },
+        { type: 'result', value: {}, status: 200, attempts: 2, at: 1050 },
+        { type: 'done', ok: true, ms: 50, attempts: 2, at: 1050 },
+    ];
+    for (const ev of events) sink.handle(ev, { name });
+
+    expect(spans).toHaveLength(1);
+    const span = spans[0];
+    expect(span.kind).toBe('CLIENT');
+    expect(span.attributes['http.request.method']).toBe('GET');
+    expect(span.attributes['url.full']).toBe('http://api.example.com/x');
+    expect(span.attributes['server.address']).toBe('api.example.com');
+    expect(span.attributes['http.response.status_code']).toBe(200);
+    expect(span.status.code).toBe('OK');
+    expect(span.events.some((e) => e.name === 'retry')).toBe(true);
+    expect(span.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(span.spanId).toMatch(/^[0-9a-f]{16}$/);
+});
+
+test('maps an error to an ERROR span with error.type and status_code', () => {
+    const { exporter, spans } = stubExporter();
+    const sink = otlpTrace({ exporter });
+    const name = 'createThing';
+    const events: StitchEvent[] = [
+        {
+            type: 'start',
+            name,
+            method: 'POST',
+            url: 'http://api.example.com/x',
+            input: {},
+            at: 1000,
+        },
+        {
+            type: 'error',
+            name,
+            message: 'HTTP 500',
+            status: 500,
+            attempts: 1,
+            at: 1020,
+        },
+        { type: 'done', ok: false, ms: 20, attempts: 1, at: 1020 },
+    ];
+    for (const ev of events) sink.handle(ev, { name });
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0].status.code).toBe('ERROR');
+    expect(spans[0].status.message).toBe('HTTP 500');
+    expect(spans[0].attributes['http.response.status_code']).toBe(500);
+    expect(spans[0].attributes['error.type']).toBe('500');
+});
+
+test('end-to-end: a real stitch call exports one span to the stub exporter', async () => {
+    const { exporter, spans } = stubExporter();
+    const sink = otlpTrace({ exporter });
+    server.route('GET', '/ping', { body: { ok: true } });
+    const ping = stitch({ name: 'ping', baseUrl: server.url, path: '/ping' });
+
+    // Tap the public event stream and feed it through the OTLP sink (as the trace tee would).
+    for await (const ev of ping.stream()) sink.handle(ev, { name: 'ping' });
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0].attributes['http.request.method']).toBe('GET');
+    expect(String(spans[0].attributes['url.full'])).toContain('/ping');
+    expect(spans[0].attributes['http.response.status_code']).toBe(200);
+    expect(spans[0].status.code).toBe('OK');
+});
+
+test('STITCH_EXPORT parses to a list and multiplex fans out to every sink', () => {
+    expect(exportsFromEnv('otlp')).toEqual(['otlp']);
+    expect(exportsFromEnv(' Console , OTLP ')).toEqual(['console', 'otlp']);
+    expect(exportsFromEnv(undefined)).toEqual([]);
+
+    const seenA: string[] = [];
+    const seenB: string[] = [];
+    const into = (sink: string[]) => ({
+        handle: (e: StitchEvent) => sink.push(e.type),
+    });
+    const mux = multiplex(into(seenA), into(seenB));
+    mux.handle(
+        { type: 'done', ok: true, ms: 1, attempts: 1, at: 0 },
+        { name: 'x' },
+    );
+    expect(seenA).toEqual(['done']);
+    expect(seenB).toEqual(['done']);
+});


### PR DESCRIPTION
Closes the **OTLP export** mechanical gap from the coverage audit (DESIGN.md §9 / §12; roadmap §14 item 7).

## What
An opt-in trace sink (`src/otlp.ts`) maps the event stream to **one OTel CLIENT span per logical call**, then hands finished spans to a pluggable `SpanExporter`:

- **OTel HTTP semconv** attributes — `http.request.method`, `url.full`, `server.address`, `http.response.status_code`, `error.type`; progress/drift become span events. (A future LLM-kind stitch maps to the `gen_ai.*` conventions the same way.)
- **`STITCH_EXPORT=otlp`** fans the same events to the collector **alongside** the existing console/JSONL trace, via a new `multiplex()` sink — zero-infra stays the default, OTLP is additive.
- Default exporter POSTs **OTLP/JSON** to `${endpoint}/v1/traces` (`OTEL_EXPORTER_OTLP_ENDPOINT` or `localhost:4318`), fire-and-forget so a missing collector never breaks a call.

New public API: `otlpTrace`, `otlpHttpExporter`, `toOtlpJson`, `multiplex`, and types `SpanExporter` / `OtelSpan` / `OtlpOptions`.

## Tests — `test/otlp-export.spec.ts` (stub exporter, **no running collector**)
- success → one `OK` CLIENT span with HTTP attrs + a `retry` span-event + valid trace/span ids;
- error → `ERROR` span with `error.type` + `http.response.status_code`;
- a **real stitch call** exports one span end-to-end;
- `STITCH_EXPORT` parsing + `multiplex` fan-out.

Full pre-commit gate green: eslint · prettier · tsc · attw · jest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)