### PR TITLE
fix(core): type cookieSession login as Stitch (not { __raw })

### DIFF
--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -7,6 +7,7 @@ import type {
     AdapterResponse,
     AuthContext,
     AuthStrategy,
+    Stitch,
     StitchInput,
 } from './types';
 import { now } from './util';
@@ -176,8 +177,8 @@ export function oauth2(opts: OAuth2Opts): AuthStrategy {
 }
 
 export interface CookieSessionOpts {
-    /** The login stitch (exposes __raw to read response headers). */
-    login: { __raw: (input?: StitchInput) => Promise<AdapterResponse> };
+    /** The login stitch — its raw response (the Set-Cookie headers) seeds the session. */
+    login: Stitch;
     /**
      * Cookie name to capture from Set-Cookie and replay on each request, or `'*'` to capture and
      * replay the WHOLE Set-Cookie jar (every cookie the login set, not just one named cookie).
@@ -204,7 +205,13 @@ export function cookieSession(opts: CookieSessionOpts): AuthStrategy {
 
     const doRefresh = async (ctx: AuthContext) => {
         ctx.emit('auth', 'login');
-        const res = await opts.login.__raw(opts.loginInput?.());
+        // `__raw` runs the login once and returns its raw AdapterResponse (headers and all).
+        // It is intentionally not on the public Stitch type, so reach it through a cast.
+        const res = await (
+            opts.login as unknown as {
+                __raw: (input?: StitchInput) => Promise<AdapterResponse>;
+            }
+        ).__raw(opts.loginInput?.());
         const setCookie =
             res.headers['set-cookie'] ?? res.headers['Set-Cookie'];
         if (jarMode) {

--- a/packages/playground/demos.ts
+++ b/packages/playground/demos.ts
@@ -108,7 +108,6 @@ export const demos: Demo[] = [
                 baseUrl: mock.url,
                 path: '/me',
                 auth: cookieSession({
-                    // @ts-expect-error login expects { __raw }; stitch() returns Stitch (core type gap, runtime is fine)
                     login,
                     cookie: 'SID',
                     loginInput: () => ({
@@ -301,7 +300,6 @@ export const demos: Demo[] = [
                 baseUrl: mock.url,
                 path: '/data',
                 auth: cookieSession({
-                    // @ts-expect-error login expects { __raw }; stitch() returns Stitch (core type gap, runtime is fine)
                     login,
                     cookie: 'SID',
                     // status is 200, so only a content predicate can catch this wall:


### PR DESCRIPTION
## Problem

`cookieSession`'s `login` option was typed `{ __raw: (input?: StitchInput) => Promise<AdapterResponse> }`, but `__raw` is an internal escape hatch attached at runtime in `stitch.ts` — it is **not** on the public `Stitch` interface. So the documented marquee usage `cookieSession({ login: stitch(...) })` did **not** type-check.

It was masked because `packages/core`'s `tsc` only covers `src/` (not `test/`), and it was held behind two `// @ts-expect-error` lines in `packages/playground/demos.ts`. The playground typecheck gate added in [#18](https://github.com/rejifald/StitchAPI/pull/18) was the first place it surfaced.

## Fix

Retype `CookieSessionOpts.login: Stitch` (the documented shape) and reach the internal `__raw` through a localized cast in `auth.ts`, keeping `__raw` **off** the published API surface. Removes the two playground suppressions (now unnecessary).

Chosen over exposing `__raw` on the public `Stitch` interface — that would commit a `__`-prefixed internal to the published API, a bigger and hard-to-reverse decision.

## Public types impact

This changes the published `cookieSession` `.d.ts`: `login` goes from `{ __raw }` → `Stitch`. Strictly looser for real usage (passing `stitch(...)` now compiles) and backward compatible. Landed as its own PR rather than folded into the migration.

## Verification

- `pnpm check:types` ✅ (core `src/` + playground)
- `pnpm test` ✅ (99 tests, 19 files)
- `pnpm check:exports` ✅ (attw — green across node10 / node16 CJS+ESM / bundler)
- `pnpm check:lint` ✅ &nbsp;·&nbsp; `pnpm check:format` ✅

## Base / stacking

Targets `chore/workspaces-migration` ([#18](https://github.com/rejifald/StitchAPI/pull/18)), since the `packages/` layout exists only there. Retarget to `develop` once #18 lands.

## Known follow-up (out of scope)

Core's `check:types` still covers only `src/`, not `test/` — which is why this slipped through. Extending it to `test/` under the current strict set surfaces **121 pre-existing errors** across 20 spec files (65× `TS4111` `process.env.X`→`['X']`; 25× `TS2532` + 17× `TS18048` `noUncheckedIndexedAccess`; 10× `TS2322` Zod-schema-vs-`Validator`; 3× `TS7006`; 1× `TS2345`). None is the `cookieSession` error — that one is fixed here. The `test/` typecheck is a separate cleanup, tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
