### PR TITLE
test(core): typecheck the test suite under the strict flags

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
         "test": "vitest run",
         "test:watch": "vitest",
         "test:coverage": "vitest run --coverage",
-        "check:types": "tsc --noEmit",
+        "check:types": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
         "check:lint": "eslint src test",
         "check:exports": "attw --pack .",
         "lint": "eslint src test",

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -7,6 +7,7 @@ import type {
     AdapterResponse,
     AuthContext,
     AuthStrategy,
+    Stitch,
     StitchInput,
 } from './types';
 import { now } from './util';
@@ -176,8 +177,8 @@ export function oauth2(opts: OAuth2Opts): AuthStrategy {
 }
 
 export interface CookieSessionOpts {
-    /** The login stitch (exposes __raw to read response headers). */
-    login: { __raw: (input?: StitchInput) => Promise<AdapterResponse> };
+    /** The login stitch — its raw response (the Set-Cookie headers) seeds the session. */
+    login: Stitch;
     /**
      * Cookie name to capture from Set-Cookie and replay on each request, or `'*'` to capture and
      * replay the WHOLE Set-Cookie jar (every cookie the login set, not just one named cookie).
@@ -204,7 +205,13 @@ export function cookieSession(opts: CookieSessionOpts): AuthStrategy {
 
     const doRefresh = async (ctx: AuthContext) => {
         ctx.emit('auth', 'login');
-        const res = await opts.login.__raw(opts.loginInput?.());
+        // `__raw` runs the login once and returns its raw AdapterResponse (headers and all).
+        // It is intentionally not on the public Stitch type, so reach it through a cast.
+        const res = await (
+            opts.login as unknown as {
+                __raw: (input?: StitchInput) => Promise<AdapterResponse>;
+            }
+        ).__raw(opts.loginInput?.());
         const setCookie =
             res.headers['set-cookie'] ?? res.headers['Set-Cookie'];
         if (jarMode) {

--- a/packages/core/test/auth-trace.spec.ts
+++ b/packages/core/test/auth-trace.spec.ts
@@ -9,11 +9,11 @@ import { join } from 'node:path';
 // We must control the JSONL trace path BEFORE importing `../src`: getTrace() reads
 // STITCH_TRACE_FILE when each stitch is constructed. Capture the path so scenario 3
 // can read the records back and prove zero-infra observability.
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-auth-${process.pid}.jsonl`,
 );
-const TRACE_FILE = process.env.STITCH_TRACE_FILE;
+const TRACE_FILE = process.env['STITCH_TRACE_FILE'];
 
 let server: MockServer;
 
@@ -53,10 +53,10 @@ test('auth-wall: me() auto-logs-in and never asks the caller for a secret', asyn
 
     // Set per the task. STITCH_USER/STITCH_PASS are inert here; the loginInput below
     // resolves DEMO_USER / DEMO_PASS at call time via env().
-    process.env.STITCH_USER = 'u';
-    process.env.STITCH_PASS = 'p';
-    process.env.DEMO_USER = 'u';
-    process.env.DEMO_PASS = 'p';
+    process.env['STITCH_USER'] = 'u';
+    process.env['STITCH_PASS'] = 'p';
+    process.env['DEMO_USER'] = 'u';
+    process.env['DEMO_PASS'] = 'p';
 
     const me = stitch({
         baseUrl: server.url,
@@ -76,7 +76,7 @@ test('auth-wall: me() auto-logs-in and never asks the caller for a secret', asyn
     expect(server.callCount('/login')).toBe(1);
 
     const meReq = server.calls('/me')[0];
-    expect(meReq?.cookies.sid).toBe('GOOD');
+    expect(meReq?.cookies['sid']).toBe('GOOD');
 });
 
 // Scenario 2 — Refresh on the 401 wall.

--- a/packages/core/test/binary-responses.spec.ts
+++ b/packages/core/test/binary-responses.spec.ts
@@ -9,7 +9,7 @@ import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-binary-${process.pid}.jsonl`,
 );

--- a/packages/core/test/body-encoding.spec.ts
+++ b/packages/core/test/body-encoding.spec.ts
@@ -7,7 +7,7 @@ import type { MockServer } from './support/mock-server';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-encoding-${process.pid}.jsonl`,
 );
@@ -94,8 +94,8 @@ describe('Body encoding', () => {
 
 describe('cookieSession content-aware refresh (soft wall)', () => {
     test('re-logs-in when a 200 response is actually a login page', async () => {
-        process.env.SOFT_USER = 'u';
-        process.env.SOFT_PASS = 'p';
+        process.env['SOFT_USER'] = 'u';
+        process.env['SOFT_PASS'] = 'p';
         server.route('POST', '/auth', {
             setCookie: { name: 'SID', value: 'OK' },
             body: 'ok',

--- a/packages/core/test/circuit-breaker.spec.ts
+++ b/packages/core/test/circuit-breaker.spec.ts
@@ -9,7 +9,7 @@ import type { MockServer } from './support/mock-server';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-circuit-${process.pid}.jsonl`,
 );

--- a/packages/core/test/cli.spec.ts
+++ b/packages/core/test/cli.spec.ts
@@ -10,13 +10,14 @@ import {
 import { collectStitches, loadStitches, selectStitch } from '../src/registry';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
+import { asValidator } from './support/schema';
 
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-cli-${process.pid}.jsonl`,
 );
@@ -169,7 +170,9 @@ describe('runStitch (arg → input → JSONL)', () => {
             baseUrl: server.url,
             path: '/widgets',
             unwrap: 'data',
-            output: z.array(z.object({ id: z.number(), name: z.string() })),
+            output: asValidator(
+                z.array(z.object({ id: z.number(), name: z.string() })),
+            ),
         });
 
         const lines: string[] = [];

--- a/packages/core/test/composition.spec.ts
+++ b/packages/core/test/composition.spec.ts
@@ -2,12 +2,13 @@ import { defineStitch, preset, stitch } from '../src';
 import type { StitchEvent } from '../src';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
+import { asValidator } from './support/schema';
 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     'stitch-composition-' + process.pid + '.jsonl',
 );
@@ -43,7 +44,9 @@ const resultOf = <T>(events: StitchEvent<T>[]) =>
 test('three facades (extends / defineStitch / builder) are equivalent', async () => {
     server.route('GET', '/items', { body: { data: [{ id: 1, name: 'Ada' }] } });
 
-    const schema = z.array(z.object({ id: z.number(), name: z.string() }));
+    const schema = asValidator(
+        z.array(z.object({ id: z.number(), name: z.string() })),
+    );
     const base = preset({ baseUrl: server.url, unwrap: 'data' });
 
     // (a) extends

--- a/packages/core/test/cookie-jar.spec.ts
+++ b/packages/core/test/cookie-jar.spec.ts
@@ -8,7 +8,7 @@ import type { MockServer } from './support/mock-server';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-cookiejar-${process.pid}.jsonl`,
 );
@@ -22,8 +22,8 @@ afterAll(async () => {
 });
 beforeEach(() => {
     server.reset();
-    process.env.CJ_USER = 'u';
-    process.env.CJ_PASS = 'p';
+    process.env['CJ_USER'] = 'u';
+    process.env['CJ_PASS'] = 'p';
 });
 
 const loginInput = () => ({
@@ -60,9 +60,9 @@ test('cookie: "*" captures and replays every cookie the login set', async () => 
     await expect(data()).resolves.toEqual({ ok: true });
     expect(server.callCount('/login')).toBe(1);
 
-    const req = server.calls('/data')[0];
-    expect(req.cookies.sid).toBe('ABC'); // both cookies from the jar replay together
-    expect(req.cookies.csrf).toBe('XYZ');
+    const req = server.calls('/data')[0]!;
+    expect(req.cookies['sid']).toBe('ABC'); // both cookies from the jar replay together
+    expect(req.cookies['csrf']).toBe('XYZ');
 });
 
 test('jar: true is equivalent to cookie: "*"', async () => {
@@ -90,9 +90,9 @@ test('jar: true is equivalent to cookie: "*"', async () => {
     });
 
     await expect(data()).resolves.toEqual({ ok: true });
-    const req = server.calls('/data')[0];
-    expect(req.cookies.sid).toBe('ABC');
-    expect(req.cookies.csrf).toBe('XYZ');
+    const req = server.calls('/data')[0]!;
+    expect(req.cookies['sid']).toBe('ABC');
+    expect(req.cookies['csrf']).toBe('XYZ');
 });
 
 test('a single named cookie still replays only that one (regression)', async () => {
@@ -119,7 +119,7 @@ test('a single named cookie still replays only that one (regression)', async () 
     });
 
     await expect(data()).resolves.toEqual({ ok: true });
-    const req = server.calls('/data')[0];
-    expect(req.cookies.sid).toBe('ABC'); // captured
-    expect(req.cookies.csrf).toBeUndefined(); // NOT captured — named mode is scoped to one cookie
+    const req = server.calls('/data')[0]!;
+    expect(req.cookies['sid']).toBe('ABC'); // captured
+    expect(req.cookies['csrf']).toBeUndefined(); // NOT captured — named mode is scoped to one cookie
 });

--- a/packages/core/test/graphql-and-headers.spec.ts
+++ b/packages/core/test/graphql-and-headers.spec.ts
@@ -7,7 +7,7 @@ import type { MockServer } from './support/mock-server';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-gql-${process.pid}.jsonl`,
 );
@@ -25,7 +25,7 @@ beforeEach(() => {
 
 describe('GraphQL kind', () => {
     test('POSTs { query, variables }, sends auth, and unwraps data', async () => {
-        process.env.GQL_KEY = 'gql_tok';
+        process.env['GQL_KEY'] = 'gql_tok';
         server.route('POST', '/graphql', {
             body: { data: { thing: { name: 'Ada' } } },
         });
@@ -40,7 +40,7 @@ describe('GraphQL kind', () => {
         expect(out).toEqual({ thing: { name: 'Ada' } }); // unwrapped `data`
 
         const call = server.calls('/graphql')[0];
-        expect(call?.headers.apikey).toBe('gql_tok');
+        expect(call?.headers['apikey']).toBe('gql_tok');
         expect((call?.body as { variables: unknown })?.variables).toEqual({
             id: 1,
         });

--- a/packages/core/test/idempotency.spec.ts
+++ b/packages/core/test/idempotency.spec.ts
@@ -8,7 +8,7 @@ import type { MockServer } from './support/mock-server';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-idempotency-${process.pid}.jsonl`,
 );
@@ -41,9 +41,9 @@ test('injects a stable Idempotency-Key on a write, unchanged across a retry', as
 
     const calls = server.calls('/create');
     expect(calls.length).toBe(2); // 503 then 200
-    const key = calls[0].headers['idempotency-key'];
+    const key = calls[0]!.headers['idempotency-key'];
     expect(key).toBeTruthy();
-    expect(calls[1].headers['idempotency-key']).toBe(key); // identical across the retry
+    expect(calls[1]!.headers['idempotency-key']).toBe(key); // identical across the retry
 });
 
 test('uses a custom key function derived from the input', async () => {
@@ -65,8 +65,8 @@ test('uses a custom key function derived from the input', async () => {
     await create({ body: { id: 42 } });
 
     const calls = server.calls('/orders');
-    expect(calls[0].headers['x-idempotency-key']).toBe('order-42');
-    expect(calls[1].headers['x-idempotency-key']).toBe('order-42'); // stable + deterministic
+    expect(calls[0]!.headers['x-idempotency-key']).toBe('order-42');
+    expect(calls[1]!.headers['x-idempotency-key']).toBe('order-42'); // stable + deterministic
 });
 
 test('separate logical calls get distinct generated keys', async () => {
@@ -82,8 +82,8 @@ test('separate logical calls get distinct generated keys', async () => {
     await create({ body: {} });
 
     const calls = server.calls('/c');
-    expect(calls[0].headers['idempotency-key']).not.toBe(
-        calls[1].headers['idempotency-key'],
+    expect(calls[0]!.headers['idempotency-key']).not.toBe(
+        calls[1]!.headers['idempotency-key'],
     );
 });
 
@@ -96,5 +96,7 @@ test('does not inject on GET (writes only)', async () => {
     });
 
     await read();
-    expect(server.calls('/read')[0].headers['idempotency-key']).toBeUndefined();
+    expect(
+        server.calls('/read')[0]!.headers['idempotency-key'],
+    ).toBeUndefined();
 });

--- a/packages/core/test/integration-patterns.spec.ts
+++ b/packages/core/test/integration-patterns.spec.ts
@@ -10,7 +10,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-patterns-${process.pid}.jsonl`,
 );
@@ -43,10 +43,10 @@ function scrapeListings(html: unknown): {
             row,
         )?.[1];
         if (title) {
-            item.title = title[2].trim();
-            item.link = title[1];
+            item['title'] = title[2]!.trim();
+            item['link'] = title[1];
         }
-        if (score) item.score = Number(score); // omitted when the selector misses
+        if (score) item['score'] = Number(score); // omitted when the selector misses
         return item;
     });
     return { items };
@@ -59,7 +59,7 @@ const listingRow = (scoreClass: string) =>
 // =========================================================================================
 describe('GraphQL-over-HTTP API (ApiKey header, 1 req/s bucket, retry on 429/5xx)', () => {
     test('sends the ApiKey header and retries on 429, then succeeds', async () => {
-        process.env.METADATA_API_KEY = 'sk_meta_123';
+        process.env['METADATA_API_KEY'] = 'sk_meta_123';
         server.route('POST', '/graphql', {
             statuses: [429, 200],
             body: { data: { query: { count: 1 } } },
@@ -79,7 +79,7 @@ describe('GraphQL-over-HTTP API (ApiKey header, 1 req/s bucket, retry on 429/5xx
         });
         expect(out).toEqual({ query: { count: 1 } });
         expect(server.callCount('/graphql')).toBe(2); // 429 then 200
-        expect(server.calls('/graphql').at(-1)?.headers.apikey).toBe(
+        expect(server.calls('/graphql').at(-1)?.headers['apikey']).toBe(
             'sk_meta_123',
         );
     });
@@ -103,8 +103,8 @@ describe('GraphQL-over-HTTP API (ApiKey header, 1 req/s bucket, retry on 429/5xx
 // =========================================================================================
 describe('Session-cookie admin API (auto re-login on 403)', () => {
     test('auto-logs-in, replays the session cookie, and re-logs-in on a 403 — never exposing the password', async () => {
-        process.env.CLIENT_USER = 'admin';
-        process.env.CLIENT_PASS = 'secret';
+        process.env['CLIENT_USER'] = 'admin';
+        process.env['CLIENT_PASS'] = 'secret';
         server.route('POST', '/auth/login', {
             setCookie: { name: 'SID', value: 'SID-OK' },
             body: { ok: true },
@@ -141,15 +141,17 @@ describe('Session-cookie admin API (auto re-login on 403)', () => {
         expect(out).toEqual([{ id: 'abc', state: 'active' }]);
         expect(server.callCount('/auth/login')).toBe(2); // initial auto-login + refresh after 403
         expect(server.callCount('/resources')).toBe(2);
-        expect(server.calls('/resources').at(-1)?.cookies.SID).toBe('SID-OK');
+        expect(server.calls('/resources').at(-1)?.cookies['SID']).toBe(
+            'SID-OK',
+        );
     });
 });
 
 // =========================================================================================
 describe('HTML scrape provider — silent markup breakage becomes a loud drift error', () => {
     test('a markup class rename (score -> rank) is caught as a drift ERROR instead of silent undefined', async () => {
-        process.env.SCRAPE_USER = 'u';
-        process.env.SCRAPE_PASS = 'p';
+        process.env['SCRAPE_USER'] = 'u';
+        process.env['SCRAPE_PASS'] = 'p';
         const snapshotFile = join(
             tmpdir(),
             `patterns-scrape-${process.pid}-${Date.now()}.contract.json`,
@@ -231,9 +233,9 @@ describe('HTML scrape provider — silent markup breakage becomes a loud drift e
 // =========================================================================================
 describe('Diverse co-located auth (three providers, three header formats)', () => {
     test('each provider sends its own auth header format', async () => {
-        process.env.REST_API_KEY = 'rest_tok';
-        process.env.MEDIA_A_TOKEN = 'media_a';
-        process.env.MEDIA_B_TOKEN = 'media_b';
+        process.env['REST_API_KEY'] = 'rest_tok';
+        process.env['MEDIA_A_TOKEN'] = 'media_a';
+        process.env['MEDIA_B_TOKEN'] = 'media_b';
         server.route('GET', '/catalog', { body: { results: [] } });
         server.route('GET', '/system', { body: { name: 'a' } });
         server.route('GET', '/node', { body: { name: 'b' } });
@@ -268,10 +270,10 @@ describe('Diverse co-located auth (three providers, three header formats)', () =
         await mediaA();
         await mediaB();
 
-        expect(server.calls('/catalog')[0]?.headers.authorization).toBe(
+        expect(server.calls('/catalog')[0]?.headers['authorization']).toBe(
             'Bearer rest_tok',
         );
-        expect(server.calls('/system')[0]?.headers.authorization).toBe(
+        expect(server.calls('/system')[0]?.headers['authorization']).toBe(
             'MediaToken token="media_a"',
         );
         expect(server.calls('/node')[0]?.headers['x-media-token']).toBe(

--- a/packages/core/test/mcp.spec.ts
+++ b/packages/core/test/mcp.spec.ts
@@ -4,13 +4,14 @@ import { createMcpServer, serveStdio } from '../src/mcp';
 import type { JsonRpcMessage } from '../src/mcp';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
+import { asValidator } from './support/schema';
 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PassThrough, type Readable } from 'node:stream';
 import { z } from 'zod';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-mcp-${process.pid}.jsonl`,
 );
@@ -39,7 +40,7 @@ beforeEach(() => {
         baseUrl: api.url,
         path: '/widgets/{id}',
         unwrap: 'data',
-        output: z.object({ id: z.number() }),
+        output: asValidator(z.object({ id: z.number() })),
     });
     const ping = stitch({ baseUrl: api.url, path: '/ping' });
     server = createMcpServer({ getWidget, ping });
@@ -91,7 +92,7 @@ test('tools/call run_stitch maps input and returns the validated result', async 
     );
     const result = res?.result as ToolCallResult;
     expect(result.isError).toBeFalsy();
-    expect(JSON.parse(result.content[0].text)).toEqual({ id: 7 });
+    expect(JSON.parse(result.content[0]!.text)).toEqual({ id: 7 });
     expect(api.callCount('/widgets/7')).toBe(1);
 });
 
@@ -101,7 +102,7 @@ test('tools/call run_stitch on an unknown stitch is a tool error, not a crash', 
     );
     const result = res?.result as ToolCallResult;
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain('unknown stitch "nope"');
+    expect(result.content[0]!.text).toContain('unknown stitch "nope"');
 });
 
 test('tools/call list_stitches enumerates name/method/path', async () => {
@@ -109,7 +110,7 @@ test('tools/call list_stitches enumerates name/method/path', async () => {
         req('tools/call', { name: 'list_stitches' }),
     );
     const result = res?.result as ToolCallResult;
-    const list = JSON.parse(result.content[0].text) as {
+    const list = JSON.parse(result.content[0]!.text) as {
         name: string;
         method: string;
         path: string;
@@ -192,7 +193,7 @@ test('a run_stitch call over stdio returns the result', async () => {
         );
         const res = await pending;
         const result = res.result as ToolCallResult;
-        expect(JSON.parse(result.content[0].text)).toEqual({ ok: true });
+        expect(JSON.parse(result.content[0]!.text)).toEqual({ ok: true });
     } finally {
         close();
     }

--- a/packages/core/test/oauth2.spec.ts
+++ b/packages/core/test/oauth2.spec.ts
@@ -9,7 +9,7 @@ import type { MockServer } from './support/mock-server';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-oauth2-${process.pid}.jsonl`,
 );
@@ -23,8 +23,8 @@ afterAll(async () => {
 });
 beforeEach(() => {
     server.reset();
-    process.env.OAUTH_CLIENT_ID = 'cid';
-    process.env.OAUTH_CLIENT_SECRET = 'csecret';
+    process.env['OAUTH_CLIENT_ID'] = 'cid';
+    process.env['OAUTH_CLIENT_SECRET'] = 'csecret';
 });
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -38,7 +38,7 @@ const protectedStitch = (
     stitch({
         baseUrl: server.url,
         path,
-        store,
+        ...(store ? { store } : {}),
         auth: oauth2({
             tokenUrl: `${server.url}/token`,
             clientId: env('OAUTH_CLIENT_ID'),
@@ -64,7 +64,7 @@ test('fetches one token, reuses it across calls, and sends it as a Bearer', asyn
     expect(server.callCount('/data')).toBe(2);
 
     // The token POST is a form-encoded client_credentials grant carrying the resolved id.
-    const tokenReq = server.calls('/token')[0];
+    const tokenReq = server.calls('/token')[0]!;
     expect(String(tokenReq.body)).toContain('grant_type=client_credentials');
     expect(String(tokenReq.body)).toContain('client_id=cid');
 });
@@ -93,7 +93,7 @@ test('a SHARED store lets two stitches share one token', async () => {
 
 test('refreshes the token after it expires', async () => {
     server.route('POST', '/token', {
-        body: (i) => ({
+        body: (i: number) => ({
             access_token: i === 0 ? 'T1' : 'T2',
             token_type: 'Bearer',
             expires_in: 1, // 1s TTL
@@ -112,13 +112,13 @@ test('refreshes the token after it expires', async () => {
 
     expect(server.callCount('/token')).toBe(2); // expired → re-fetched
     const calls = server.calls('/data');
-    expect(calls[0].headers.authorization).toBe('Bearer T1');
-    expect(calls[1].headers.authorization).toBe('Bearer T2'); // the refreshed token
+    expect(calls[0]!.headers['authorization']).toBe('Bearer T1');
+    expect(calls[1]!.headers['authorization']).toBe('Bearer T2'); // the refreshed token
 }, 10000);
 
 test('refreshes proactively BEFORE expiry using refreshSkewMs', async () => {
     server.route('POST', '/token', {
-        body: (i) => ({
+        body: (i: number) => ({
             access_token: i === 0 ? 'T1' : 'T2',
             token_type: 'Bearer',
             expires_in: 2, // real expiry at +2s
@@ -137,12 +137,12 @@ test('refreshes proactively BEFORE expiry using refreshSkewMs', async () => {
 
     expect(server.callCount('/token')).toBe(2); // refreshed early, not at the 2s boundary
     const calls = server.calls('/data');
-    expect(calls[1].headers.authorization).toBe('Bearer T2');
+    expect(calls[1]!.headers['authorization']).toBe('Bearer T2');
 }, 10000);
 
 test('re-fetches the token when the resource server rejects it (401)', async () => {
     server.route('POST', '/token', {
-        body: (i) => ({
+        body: (i: number) => ({
             access_token: i === 0 ? 'STALE' : 'FRESH',
             token_type: 'Bearer',
             expires_in: 3600,
@@ -159,6 +159,6 @@ test('re-fetches the token when the resource server rejects it (401)', async () 
 
     expect(server.callCount('/token')).toBe(2); // initial fetch + forced refresh on 401
     const calls = server.calls('/data');
-    expect(calls[0].headers.authorization).toBe('Bearer STALE');
-    expect(calls[1].headers.authorization).toBe('Bearer FRESH');
+    expect(calls[0]!.headers['authorization']).toBe('Bearer STALE');
+    expect(calls[1]!.headers['authorization']).toBe('Bearer FRESH');
 });

--- a/packages/core/test/otlp-export.spec.ts
+++ b/packages/core/test/otlp-export.spec.ts
@@ -10,7 +10,7 @@ import type { MockServer } from './support/mock-server';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-otlp-${process.pid}.jsonl`,
 );
@@ -65,7 +65,7 @@ test('maps a successful call to one CLIENT span with OTel HTTP semconv attribute
     for (const ev of events) sink.handle(ev, { name });
 
     expect(spans).toHaveLength(1);
-    const span = spans[0];
+    const span = spans[0]!;
     expect(span.kind).toBe('CLIENT');
     expect(span.attributes['http.request.method']).toBe('GET');
     expect(span.attributes['url.full']).toBe('http://api.example.com/x');
@@ -103,10 +103,10 @@ test('maps an error to an ERROR span with error.type and status_code', () => {
     for (const ev of events) sink.handle(ev, { name });
 
     expect(spans).toHaveLength(1);
-    expect(spans[0].status.code).toBe('ERROR');
-    expect(spans[0].status.message).toBe('HTTP 500');
-    expect(spans[0].attributes['http.response.status_code']).toBe(500);
-    expect(spans[0].attributes['error.type']).toBe('500');
+    expect(spans[0]!.status.code).toBe('ERROR');
+    expect(spans[0]!.status.message).toBe('HTTP 500');
+    expect(spans[0]!.attributes['http.response.status_code']).toBe(500);
+    expect(spans[0]!.attributes['error.type']).toBe('500');
 });
 
 test('end-to-end: a real stitch call exports one span to the stub exporter', async () => {
@@ -119,10 +119,10 @@ test('end-to-end: a real stitch call exports one span to the stub exporter', asy
     for await (const ev of ping.stream()) sink.handle(ev, { name: 'ping' });
 
     expect(spans).toHaveLength(1);
-    expect(spans[0].attributes['http.request.method']).toBe('GET');
-    expect(String(spans[0].attributes['url.full'])).toContain('/ping');
-    expect(spans[0].attributes['http.response.status_code']).toBe(200);
-    expect(spans[0].status.code).toBe('OK');
+    expect(spans[0]!.attributes['http.request.method']).toBe('GET');
+    expect(String(spans[0]!.attributes['url.full'])).toContain('/ping');
+    expect(spans[0]!.attributes['http.response.status_code']).toBe(200);
+    expect(spans[0]!.status.code).toBe('OK');
 });
 
 test('STITCH_EXPORT parses to a list and multiplex fans out to every sink', () => {

--- a/packages/core/test/pagination.spec.ts
+++ b/packages/core/test/pagination.spec.ts
@@ -7,7 +7,7 @@ import type { MockServer } from './support/mock-server';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-paginate-${process.pid}.jsonl`,
 );
@@ -26,7 +26,7 @@ beforeEach(() => {
 // A 3-page endpoint keyed off ?page=N.
 function paged() {
     return (_i: number, req: { query: Record<string, string> }) => {
-        const page = Number(req.query.page ?? '1');
+        const page = Number(req.query['page'] ?? '1');
         const pages = [[1, 2], [3, 4], [5]];
         const data = pages[page - 1] ?? [];
         return { data, page, hasMore: page < pages.length };

--- a/packages/core/test/resilience.spec.ts
+++ b/packages/core/test/resilience.spec.ts
@@ -6,7 +6,7 @@ import type { MockServer } from './support/mock-server';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-resilience-${process.pid}.jsonl`,
 );

--- a/packages/core/test/serve.spec.ts
+++ b/packages/core/test/serve.spec.ts
@@ -4,12 +4,13 @@ import { serve } from '../src/serve';
 import type { ServeHandle } from '../src/serve';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
+import { asValidator } from './support/schema';
 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-serve-${process.pid}.jsonl`,
 );
@@ -40,7 +41,7 @@ beforeAll(async () => {
         baseUrl: api.url,
         path: '/widgets/{id}',
         unwrap: 'data',
-        output: z.object({ id: z.number() }),
+        output: asValidator(z.object({ id: z.number() })),
     });
     const ping = stitch({ baseUrl: api.url, path: '/ping' });
     handle = await serve({ getWidget, ping }, { port: 0 });

--- a/packages/core/test/smoke.spec.ts
+++ b/packages/core/test/smoke.spec.ts
@@ -1,12 +1,13 @@
 import { stitch } from '../src';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
+import { asValidator } from './support/schema';
 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-smoke-${process.pid}.jsonl`,
 );
@@ -29,7 +30,9 @@ test('await sugar returns the unwrapped, validated result', async () => {
         baseUrl: server.url,
         path: '/users',
         unwrap: 'data',
-        output: z.array(z.object({ id: z.number(), name: z.string() })),
+        output: asValidator(
+            z.array(z.object({ id: z.number(), name: z.string() })),
+        ),
     });
     await expect(users()).resolves.toEqual([{ id: 1, name: 'Ada' }]);
 });

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -9,7 +9,7 @@ import type { MockServer } from './support/mock-server';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-store-${process.pid}.jsonl`,
 );
@@ -44,8 +44,8 @@ async function wasThrottled(s: Stitch): Promise<number> {
 
 describe('Pluggable store — sessions', () => {
     test('a SHARED store makes two stitches share one login', async () => {
-        process.env.ST_USER = 'u';
-        process.env.ST_PASS = 'p';
+        process.env['ST_USER'] = 'u';
+        process.env['ST_PASS'] = 'p';
         server.route('POST', '/login', {
             setCookie: { name: 'SID', value: 'OK' },
             body: { ok: true },
@@ -95,8 +95,8 @@ describe('Pluggable store — sessions', () => {
     });
 
     test('default (separate) stores → each stitch logs in independently', async () => {
-        process.env.ST_USER = 'u';
-        process.env.ST_PASS = 'p';
+        process.env['ST_USER'] = 'u';
+        process.env['ST_PASS'] = 'p';
         server.route('POST', '/login', {
             setCookie: { name: 'SID', value: 'OK' },
             body: { ok: true },

--- a/packages/core/test/support/mock-server.ts
+++ b/packages/core/test/support/mock-server.ts
@@ -97,7 +97,7 @@ export function startMockServer(): Promise<MockServer> {
             method,
             path,
             headers,
-            cookies: parseCookies(headers.cookie),
+            cookies: parseCookies(headers['cookie']),
             query,
             body: await readBody(req),
         };

--- a/packages/core/test/support/schema.ts
+++ b/packages/core/test/support/schema.ts
@@ -1,0 +1,13 @@
+import type { Validator } from '../../src/validator';
+
+/**
+ * `StitchConfig.output` (and the `input` schemas) are typed as `Validator`, but at
+ * runtime stitch() coerces any Zod or Standard Schema through `toValidator()` — see
+ * `normalizeOutput` in src/stitch.ts. The tests pass raw schemas on purpose: that
+ * Zod-first ergonomics is exactly what's under test.
+ *
+ * This is a type-only assertion (the runtime value is returned unchanged), so the raw
+ * schema still flows through the real coercion path — unlike `toValidator(schema)`,
+ * which would pre-coerce and skip the behaviour the tests mean to exercise.
+ */
+export const asValidator = (schema: unknown): Validator => schema as Validator;

--- a/packages/core/test/validation-drift.spec.ts
+++ b/packages/core/test/validation-drift.spec.ts
@@ -2,12 +2,13 @@ import { drift, stitch } from '../src';
 import type { DriftFinding, StitchEvent } from '../src';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
+import { asValidator } from './support/schema';
 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
 
-process.env.STITCH_TRACE_FILE = join(
+process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
     `stitch-drift-${process.pid}.jsonl`,
 );
@@ -57,7 +58,7 @@ test('schema valid: await resolves with the validated value', async () => {
     const s = stitch({
         baseUrl: server.url,
         path: '/ok',
-        output: z.object({ id: z.number(), name: z.string() }),
+        output: asValidator(z.object({ id: z.number(), name: z.string() })),
     });
     await expect(s()).resolves.toEqual({ id: 1, name: 'Ada' });
 
@@ -76,7 +77,7 @@ test('schema invalid: await rejects and stream emits error/invalid drift', async
     const s = stitch({
         baseUrl: server.url,
         path: '/bad',
-        output: z.object({ id: z.number() }),
+        output: asValidator(z.object({ id: z.number() })),
     });
 
     await expect(s()).rejects.toThrow();
@@ -221,13 +222,21 @@ test('standard schema (non-Zod): valid resolves, invalid rejects with error/inva
 
     // Valid response resolves.
     server.route('GET', '/std', { body: { id: 7 } });
-    const ok = stitch({ baseUrl: server.url, path: '/std', output: standard });
+    const ok = stitch({
+        baseUrl: server.url,
+        path: '/std',
+        output: asValidator(standard),
+    });
     await expect(ok()).resolves.toEqual({ id: 7 });
 
     // Invalid response (id is a string) rejects with an error/invalid drift finding.
     server.reset();
     server.route('GET', '/std', { body: { id: 'nope' } });
-    const bad = stitch({ baseUrl: server.url, path: '/std', output: standard });
+    const bad = stitch({
+        baseUrl: server.url,
+        path: '/std',
+        output: asValidator(standard),
+    });
 
     await expect(bad()).rejects.toThrow();
 

--- a/packages/core/tsconfig.eslint.json
+++ b/packages/core/tsconfig.eslint.json
@@ -1,9 +1,6 @@
 {
-    // Type-aware lint project: same strict options as the typecheck config, but
-    // also covers tests (with vitest globals). `check:types` stays src-only.
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "types": ["node", "vitest/globals"]
-    },
-    "include": ["src/**/*.ts", "test/**/*.ts"]
+    // Type-aware lint project. Identical to the test typecheck project (src + test
+    // under the strict flags, with vitest globals), so it just extends it — keeping a
+    // stable filename for eslint.config.ts's `parserOptions.project` reference.
+    "extends": "./tsconfig.test.json"
 }

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    // Typecheck project that also covers the test suite. Same strict options as
+    // tsconfig.json, plus the vitest globals (`describe`/`it`/`expect`) that the
+    // suite relies on (vitest.config.ts sets `globals: true`). Wired into the
+    // `check:types` script so test code is held to the same bar as `src/`.
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "types": ["node", "vitest/globals"]
+    },
+    "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/playground/demos.ts
+++ b/packages/playground/demos.ts
@@ -108,7 +108,6 @@ export const demos: Demo[] = [
                 baseUrl: mock.url,
                 path: '/me',
                 auth: cookieSession({
-                    // @ts-expect-error login expects { __raw }; stitch() returns Stitch (core type gap, runtime is fine)
                     login,
                     cookie: 'SID',
                     loginInput: () => ({
@@ -301,7 +300,6 @@ export const demos: Demo[] = [
                 baseUrl: mock.url,
                 path: '/data',
                 auth: cookieSession({
-                    // @ts-expect-error login expects { __raw }; stitch() returns Stitch (core type gap, runtime is fine)
                     login,
                     cookie: 'SID',
                     // status is 200, so only a content predicate can catch this wall:


### PR DESCRIPTION
## What

Core's `check:types` only type-checked `src/` — the test suite was linted but **never tsc-checked** (`tsconfig.json`'s `include` is `["src/**/*.ts"]`). That blind spot is what let the public-types bug in `cookieSession`'s `login` option (fixed in #19) ship unnoticed.

This PR makes the typecheck cover `test/` too and fixes everything that surfaces.

- **`tsconfig.test.json`** (new) — extends `tsconfig.json`, adds `types: ["node", "vitest/globals"]` (the suite runs with vitest `globals: true`, so `describe`/`it`/`expect` need the ambient types) and includes `test/`.
- **`check:types`** now runs `tsc --noEmit && tsc --noEmit -p tsconfig.test.json` — src stays the fast first gate, then the whole tree (src + test) is checked under the **same strict flag set** (the 8 extra strict flags from #17 are unchanged).
- **`tsconfig.eslint.json`** was byte-for-byte identical to the new file, so it now just `extends: "./tsconfig.test.json"` — one source of truth, no drift, and `eslint.config.ts`'s `parserOptions.project` reference stays put.

## Fixes (test-only — no strict flag was relaxed)

~121 pre-existing errors across ~20 spec files, all fixed in test code:

| Cause | Fix | Count |
|---|---|---|
| `noPropertyAccessFromIndexSignature` | bracket-access `process.env['X']`, request headers, parsed cookies, scraped bodies, query maps | 65 |
| `noUncheckedIndexedAccess` | assert/guard possibly-undefined indexed access (`server.calls()[n]`, `spans[0]`, a regex capture group) | 42 |
| Zod/Standard schema as a stitch `output` | `asValidator()` test helper (see below) | 10 |
| implicit-any mock callback param | annotate `(i: number)` | 3 |
| `exactOptionalPropertyTypes` on optional `store` | conditional spread `...(store ? { store } : {})` | 1 |

### The `asValidator()` helper

`StitchConfig.output` is typed `Validator`, but `stitch()` coerces any Zod or Standard Schema at runtime (`normalizeOutput` → `toValidator` in `src/stitch.ts`). The fixtures pass **raw schemas on purpose** — that Zod-first ergonomics is exactly what's under test. `test/support/schema.ts` adds a tiny, documented **type-only assertion** so the raw value still flows through the real coercion path (unlike `toValidator(schema)`, which would pre-coerce and skip the behaviour the test means to exercise).

## Note on the base / #19

The new test typecheck only goes green once `cookieSession`'s `login` accepts a `Stitch` — the fix in **#19**. This branch is cut from `chore/workspaces-migration` and **merges #19 in** so CI is green standalone. Please **land #19 first**; once it's on `chore/workspaces-migration` this PR's diff reduces to just the test-typecheck changes (the `src/auth.ts` + `demos.ts` lines drop out).

## Verification

From the workspace root, all green:

- `pnpm check:types` ✓ (core + playground)
- `pnpm check:lint` ✓
- `pnpm test` ✓ — 19 files, **99 tests**
- `pnpm check:format` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
