### PR TITLE
docs: author the Getting Started section (intro, installation, quickstart)

### DIFF
--- a/apps/docs/content/docs/getting-started/index.mdx
+++ b/apps/docs/content/docs/getting-started/index.mdx
@@ -3,4 +3,108 @@ title: 'Introduction'
 description: 'What a stitch is, the integration pain it removes, and how this documentation is organized.'
 ---
 
-Stub — orient the reader and link into this section. See AUTHORING.md.
+A **stitch** is a typed, declarative, composable unit that turns one endpoint
+into a resilient, validated, observable function. You declare it once; your code
+calls it, the CLI runs it, and an agent invokes it — without any of them ever
+touching a credential.
+
+That is the whole idea, and the rest of these docs are an expansion of it. A
+stitch is atomic (one endpoint at a time, no spec required) and it hands the
+caller a capability, not a secret. Everything that normally rots in a `src/api/`
+folder — auth lifecycle, retries, validation, drift detection, tracing — folds
+into the call itself.
+
+## The pain it removes
+
+Most integrations start as a thin wrapper over `fetch` that returns opaque
+bytes, and then every reliability concern gets re-implemented by hand at each
+call site, separately, where it quietly drifts out of date. A stitch replaces
+that wrapper with a declaration:
+
+-   **No spec, no codegen, no server.** A stitch needs a URL and an example
+    response — so it works on the long tail of internal and undocumented APIs
+    that never get a complete OpenAPI document.
+-   **Auth is a boundary.** Bearer, API key, cookie sessions, OAuth2 client
+    credentials — the stitch owns the secret and its lifecycle, and the caller
+    receives data, never the credential.
+-   **Resilience is declared.** Retry with backoff, proactive throttling, and
+    real timeouts are configuration, uniform across every stitch.
+-   **Validation and drift are live.** Responses are validated on every call, and
+    a silently renamed field surfaces as a loud, leveled drift signal instead of
+    an `undefined` three layers downstream.
+-   **Observability ships with it.** Every call emits a typed event stream,
+    traced to a local JSONL log by default — no collector, nothing to deploy.
+
+## The smallest stitch
+
+The smallest stitch is a URL. Declare it once, call it as a typed function:
+
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const getUsers = stitch('https://api.example.com/users');
+
+const users = await getUsers(); // GET, parsed JSON
+```
+
+That is the entire surface for a basic call. Adding path params, an output
+schema, auth, and resilience is the job of the
+[Quickstart](/docs/getting-started/quickstart), which walks the full first run
+end to end.
+
+<Callout type="info">
+    Awaiting a stitch gives you just the final validated value. The same call is
+    also an event stream you can iterate — that is how progress, retries, and
+    drift become observable for free.
+</Callout>
+
+## How this documentation is organized
+
+The docs are seven top-level sections, ordered for a first read. Start at the
+top and move down, or jump straight to the section that matches what you need.
+
+<Cards>
+    <Card
+        title="Getting started"
+        href="/docs/getting-started/quickstart"
+        description="Install the runtime and declare your first stitch in five minutes."
+    />
+    <Card
+        title="Concepts"
+        href="/docs/concepts/the-stitch"
+        description="The mental model — the stitch primitive, the event stream, capability over credential."
+    />
+    <Card
+        title="Guides"
+        href="/docs/guides/authoring/stitch"
+        description="One focused page per feature: authoring, auth, resilience, data, validation, observability, state."
+    />
+    <Card
+        title="Surfaces"
+        href="/docs/surfaces/function"
+        description="The front doors to one definition — in-process function, CLI, HTTP, and MCP."
+    />
+    <Card
+        title="For agents"
+        href="/docs/agents"
+        description="How an agent invokes, authors, and reasons over stitches without seeing a secret."
+    />
+    <Card
+        title="Reference"
+        href="/docs/reference/stitch"
+        description="Signatures and option shapes, generated from the real types."
+    />
+    <Card
+        title="Errors & pitfalls"
+        href="/docs/errors"
+        description="One catalog page per coded failure, keyed to the URL the runtime points you at."
+    />
+</Cards>
+
+## Next steps
+
+<Cards>
+    <Card title="Installation" href="/docs/getting-started/installation" />
+    <Card title="Quickstart" href="/docs/getting-started/quickstart" />
+    <Card title="The stitch primitive" href="/docs/concepts/the-stitch" />
+</Cards>

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -54,8 +54,8 @@ const me = stitch({
 ```
 
 <Callout type="info">
-    No type error means `@stitchapi/core` resolved and `me` is a typed,
-    callable stitch — you are ready to write a real one.
+    No type error means `@stitchapi/core` resolved and `me` is a typed, callable
+    stitch — you are ready to write a real one.
 </Callout>
 
 ## Next steps
@@ -63,5 +63,8 @@ const me = stitch({
 <Cards>
     <Card title="Quickstart" href="/docs/getting-started/quickstart" />
     <Card title="The stitch primitive" href="/docs/concepts/the-stitch" />
-    <Card title="Standard Schema" href="/docs/guides/validation/standard-schema" />
+    <Card
+        title="Standard Schema"
+        href="/docs/guides/validation/standard-schema"
+    />
 </Cards>

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -3,8 +3,65 @@ title: 'Installation'
 description: 'Install @stitchapi/core and set up the zero-dependency runtime in Node or the browser.'
 ---
 
-Stub — what the reader will achieve, then the steps. See AUTHORING.md.
+Install the `@stitchapi/core` runtime and confirm it resolves, in a Node
+project or a browser bundle. The runtime ships with zero dependencies, so this
+is one install and a one-line type check — no peer packages required to get a
+stitch type-checking.
 
-## Steps
+## Install
 
-Stub.
+Add `@stitchapi/core` with your package manager:
+
+```bash
+npm install @stitchapi/core
+```
+
+```bash
+pnpm add @stitchapi/core
+```
+
+```bash
+yarn add @stitchapi/core
+```
+
+```bash
+bun add @stitchapi/core
+```
+
+## Requirements
+
+The runtime has zero dependencies. It runs on a modern Node runtime, and in the
+browser via any bundler — there is no minimum Node version to pin and nothing to
+install alongside it.
+
+Validation is optional. If you want runtime validation of params, body, or the
+response, bring any [Standard Schema](https://standardschema.dev) validator —
+Zod, Valibot, or ArkType — as your own dependency. It is an optional add-on, not
+a requirement; see [Standard Schema](/docs/guides/validation/standard-schema).
+
+## Verify
+
+Declare a trivial stitch and confirm the types resolve. If this snippet
+type-checks, the install is good:
+
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const me = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/me',
+});
+```
+
+<Callout type="info">
+    No type error means `@stitchapi/core` resolved and `me` is a typed,
+    callable stitch — you are ready to write a real one.
+</Callout>
+
+## Next steps
+
+<Cards>
+    <Card title="Quickstart" href="/docs/getting-started/quickstart" />
+    <Card title="The stitch primitive" href="/docs/concepts/the-stitch" />
+    <Card title="Standard Schema" href="/docs/guides/validation/standard-schema" />
+</Cards>

--- a/apps/docs/content/docs/getting-started/quickstart.mdx
+++ b/apps/docs/content/docs/getting-started/quickstart.mdx
@@ -3,8 +3,96 @@ title: 'Quickstart'
 description: 'Declare your first stitch from one endpoint and call it as a typed function in five minutes.'
 ---
 
-Stub — what the reader will achieve, then the steps. See AUTHORING.md.
+In about five minutes you will declare your first stitch from a single endpoint
+and call it as a typed, async function — no spec, no codegen, no server. This
+page assumes the package is already installed; if not, start with
+[Installation](/docs/getting-started/installation).
 
-## Steps
+## Declare a stitch
 
-Stub.
+The smallest stitch is a URL. Pass it to `stitch()` as a string and you get back
+a callable — the string sets the `path`:
+
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const getUsers = stitch('https://api.example.com/users');
+```
+
+## Call it as a typed function
+
+The returned value is a function. Call it and `await` the result — `await` is
+sugar that consumes the underlying stream and returns the final, validated
+value (a `GET` with parsed JSON here):
+
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const getUsers = stitch('https://api.example.com/users');
+
+const users = await getUsers();
+```
+
+## Add path params and query
+
+Use `{param}` slots in the path. Params, query, headers, and body all travel in
+a single input object, so a path param goes under `params` and query keys under
+`query`:
+
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const getUser = stitch('https://api.example.com/users/{id}');
+
+await getUser({ params: { id: 1 }, query: { expand: 'roles' } });
+// → GET https://api.example.com/users/1?expand=roles
+```
+
+## Type the result
+
+Pass a type argument to `stitch<T>()` and the awaited value is typed as `T`,
+with no extra dependency:
+
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const getUser = stitch<{ id: number; name: string }>(
+    'https://api.example.com/users/{id}',
+);
+
+const user = await getUser({ params: { id: 1 } });
+```
+
+The generic gives you compile-time types only. To also validate the response at
+runtime — and catch a vendor silently renaming a field — bring a
+[Standard Schema](/docs/guides/validation/standard-schema) validator as the
+`output`; see [Validation](/docs/guides/validation/validation).
+
+## Observe the event stream
+
+A stitch does not return `Promise<bytes>` — it yields a typed event stream, and
+`await` simply consumes it for you. Call `.stream()` instead to watch progress,
+retries, and drift as they happen:
+
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const getUsers = stitch('https://api.example.com/users');
+
+for await (const ev of getUsers.stream()) {
+    if (ev.type === 'result') console.log(ev.value);
+}
+```
+
+The [event stream](/docs/concepts/event-stream) concept covers every event type
+in depth.
+
+## Next steps
+
+<Cards>
+    <Card title="The stitch" href="/docs/concepts/the-stitch" />
+    <Card title="stitch()" href="/docs/guides/authoring/stitch" />
+    <Card title="Validation" href="/docs/guides/validation/validation" />
+    <Card title="Call from a function" href="/docs/surfaces/function" />
+    <Card title="For agents" href="/docs/agents" />
+</Cards>


### PR DESCRIPTION
Fills in the three **Getting Started** stubs with full pages — one agent per page, then centrally reviewed and verified.

## Pages
- **Introduction** (`getting-started/index`, landing) — what a stitch is, the integration pain it removes, and a Cards map of the 7-section IA.
- **Installation** (`getting-started/installation`, tutorial) — install the zero-dependency `@stitchapi/core`, requirements, and a verify snippet.
- **Quickstart** (`getting-started/quickstart`, tutorial) — declare a stitch from one endpoint, call it as a typed function, add params/query, type the result with `stitch<T>()`, and peek at the event stream.

## Authoring conformance
- Examples written against the real API (`@stitchapi/core`, string-form `stitch()`, `StitchInput` shape, `stitch<T>()` generic, `.stream()`).
- Neutral `api.example.com` host; "stitch" lowercase; only Fumadocs' default-registered MDX components (`Cards`/`Card`/`Callout`).
- Every internal link verified to resolve (folder `index.mdx` → `/docs/<folder>`, not `/index`).

## Verification
- All three pages render **200**; full `next build` prerenders all 180 pages clean (exit 0).
- Pre-commit (format + workspace typecheck) and pre-push (typecheck + tests) gates green.

## Note
Pages import `@stitchapi/core` (the docs/manifest convention) while the published package is currently `stitchapi` — the same scoped-rename follow-up tracked elsewhere. Independent of #24 (no dependency on the AutoTypeTable tooling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)