### PR TITLE
docs: author the Concepts section (the stitch, capability-not-credential, principles)

### DIFF
--- a/apps/docs/content/docs/concepts/capability-not-credential.mdx
+++ b/apps/docs/content/docs/concepts/capability-not-credential.mdx
@@ -3,16 +3,78 @@ title: 'Capability, not credential'
 description: 'How a stitch holds the secret and hands the caller a capability, so an agent invoking it never sees the token.'
 ---
 
-Stub — what it is, in one or two sentences. See AUTHORING.md.
+A stitch holds its credential; what it hands the caller is a capability — a
+callable that, when invoked, returns data. The caller gets the ability to make
+the authenticated call, never the secret that authorizes it.
 
 ## Why it's shaped this way
 
-Stub.
+A credential is not a value you want flowing through application code. The
+moment a token is read into a variable, passed as an argument, or logged on the
+way to a request, it has more places to leak from than it should. A stitch
+removes those places by owning the secret end to end and exposing only the act
+of calling.
+
+Secrets are resolved **lazily, at call time**. `env('NAME')` and
+`keychain('NAME')` don't read anything when you declare the stitch — they return
+a `() => string` resolver that the runtime invokes on each request, reads the
+value, attaches it, and discards it. So the declaration carries a _reference_ to
+where the secret lives, not the secret itself: it is safe to commit, diff, and
+share, because there is nothing sensitive in it to commit.
+
+```ts twoslash
+import { bearer, env, stitch } from '@stitchapi/core';
+
+const getMovie = stitch({
+    path: 'https://api.example.com/movies/{id}',
+    // env('API_TOKEN') is a resolver; the runtime reads the token per call,
+    // attaches it to the request, and the caller never receives it.
+    auth: bearer(env('API_TOKEN')),
+});
+
+// The caller just calls the stitch and gets data — no token in sight.
+const movie = await getMovie({ params: { id: 1 } });
+```
+
+The stitch also owns the whole **auth lifecycle**, not just the one header. Each
+`AuthStrategy` — `bearer`, `apiKey`, `basic`, `cookieSession`, `oauth2` —
+attaches the secret to the request _inside_ the runtime; the strategies that
+have a session detect when they hit a wall and refresh it (re-login, fetch a new
+token) without the caller doing anything. Attach, detect, refresh: all of it
+happens behind the capability, so the caller never sees the token even when the
+token is rotating underneath them.
+
+That is the security boundary that makes a stitch safe to expose to an agent.
+You can hand an agent a stitch and let it invoke the call without granting it the
+credential — the agent operates with a capability scoped to exactly that
+endpoint, and a leak in the agent's context can't leak a secret that was never
+in it.
 
 ## How it relates
 
-Stub.
+This boundary is the _why_ behind the auth machinery, which the guides cover in
+detail. The [secret resolvers](/docs/guides/auth/secret-resolvers) `env()` and
+`keychain()` are the lazy lookup that keeps secrets out of the declaration; the
+[auth strategies](/docs/guides/auth/bearer) — `bearer` here,
+[`cookieSession`](/docs/guides/auth/cookie-session) for login-and-cookie APIs —
+are what attaches and refreshes the secret inside the runtime.
+
+The boundary is what lets the [agent surfaces](/docs/agents) exist: a stitch
+invoked through [MCP](/docs/surfaces/mcp) or the
+[`run_stitch`](/docs/agents/run-stitch-tool) tool runs its auth on the
+runtime's side of the line, so the agent gets a structured result and never a
+token. And when a session can't be refreshed — an expired login, a soft 200
+wall — the lifecycle surfaces a typed
+[`STITCH_AUTH_WALL`](/docs/errors/stitch-auth-wall) error rather than silently
+returning a login page, so a failed capability is a loud, structured signal too.
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="The stitch primitive" href="/docs/concepts/the-stitch" />
+    <Card title="Secret resolvers" href="/docs/guides/auth/secret-resolvers" />
+    <Card title="cookieSession" href="/docs/guides/auth/cookie-session" />
+    <Card title="MCP surface" href="/docs/surfaces/mcp" />
+    <Card title="For agents" href="/docs/agents" />
+    <Card title="STITCH_AUTH_WALL" href="/docs/errors/stitch-auth-wall" />
+</Cards>

--- a/apps/docs/content/docs/concepts/principles.mdx
+++ b/apps/docs/content/docs/concepts/principles.mdx
@@ -84,27 +84,33 @@ one tool per endpoint, which keeps its context frugal.
 
 ## How it relates
 
-- **Progressive disclosure** runs from the [stitch primitive](/docs/concepts/the-stitch)
-  through the [fluent builder](/docs/guides/authoring/fluent-builder) — the
-  string, the config object, and the chainable surface are three altitudes of
-  one call.
-- **Atomic stitches** are the [stitch](/docs/concepts/the-stitch) itself: one
-  endpoint, no spec, no codegen, no server.
-- **Composition over configuration** is what [`extends`](/docs/guides/authoring/extends)
-  expresses — and `preset()` and `defineStitch()` are the fragments and factories
-  it composes.
-- **One source of truth** shows up at runtime as [leveled drift](/docs/guides/validation/drift),
-  the same anti-drift rule this documentation follows.
-- **Agent-native** is spelled out across [capability, not credential](/docs/concepts/capability-not-credential),
-  the [event stream](/docs/concepts/event-stream), and the [agent surfaces](/docs/agents).
+-   **Progressive disclosure** runs from the [stitch primitive](/docs/concepts/the-stitch)
+    through the [fluent builder](/docs/guides/authoring/fluent-builder) — the
+    string, the config object, and the chainable surface are three altitudes of
+    one call.
+-   **Atomic stitches** are the [stitch](/docs/concepts/the-stitch) itself: one
+    endpoint, no spec, no codegen, no server.
+-   **Composition over configuration** is what [`extends`](/docs/guides/authoring/extends)
+    expresses — and `preset()` and `defineStitch()` are the fragments and factories
+    it composes.
+-   **One source of truth** shows up at runtime as [leveled drift](/docs/guides/validation/drift),
+    the same anti-drift rule this documentation follows.
+-   **Agent-native** is spelled out across [capability, not credential](/docs/concepts/capability-not-credential),
+    the [event stream](/docs/concepts/event-stream), and the [agent surfaces](/docs/agents).
 
 ## See also
 
 <Cards>
     <Card title="The stitch primitive" href="/docs/concepts/the-stitch" />
     <Card title="The event stream" href="/docs/concepts/event-stream" />
-    <Card title="Capability, not credential" href="/docs/concepts/capability-not-credential" />
-    <Card title="The fluent builder" href="/docs/guides/authoring/fluent-builder" />
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+    />
+    <Card
+        title="The fluent builder"
+        href="/docs/guides/authoring/fluent-builder"
+    />
     <Card title="extends" href="/docs/guides/authoring/extends" />
     <Card title="Leveled drift" href="/docs/guides/validation/drift" />
     <Card title="For agents" href="/docs/agents" />

--- a/apps/docs/content/docs/concepts/principles.mdx
+++ b/apps/docs/content/docs/concepts/principles.mdx
@@ -3,16 +3,109 @@ title: 'Principles'
 description: 'Progressive disclosure, atomic stitches, composition over configuration, and the other ideas that shape the API.'
 ---
 
-Stub — what it is, in one or two sentences. See AUTHORING.md.
+A handful of design principles explain why the API looks the way it does — why
+the smallest stitch is a bare string, why there is no central config object, and
+why the same definition answers to an agent. This page is the synthesis; each
+principle links to the surface that embodies it.
 
 ## Why it's shaped this way
 
-Stub.
+### Progressive disclosure
+
+Complexity is opt-in. A bare URL string is a working stitch; reach for more and
+the same call grows into a config object, and then — when you want a chainable,
+discoverable surface — into the fluent builder. Every capability (validation,
+auth, retries, observability) has a sane default and reveals its knobs only when
+you ask, so simple things stay one line and the depth is there when you need it.
+
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+// A string is a whole stitch.
+const getUsers = stitch('https://api.example.com/users');
+
+// Grow into a config object when you want more than the default.
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    retry: { attempts: 3 },
+});
+```
+
+### Atomic stitches
+
+A stitch is one endpoint at a time and nothing else — self-contained, with no
+spec to author, no client to generate, and no server to run. It needs only a URL
+and (optionally) an example response, which is why it reaches the spec-less long
+tail of internal and undocumented APIs that codegen never covers. The
+declaration _is_ the runtime; there is nothing to commit, diff, and regenerate.
+
+### Composition over configuration
+
+Cross-cutting concerns — `baseUrl`, auth, `unwrap`, retry, throttle, timeout —
+are named, shareable values you compose, not a central config object far from the
+call site. `extends` folds fragments into a stitch, `preset()` bundles defaults
+into one such fragment, and `defineStitch()` binds a base so every stitch built
+from it inherits it. You share a fragment instead of re-typing config, and a
+stitch is itself a composable value others can extend.
+
+```ts twoslash
+import { defineStitch, preset } from '@stitchapi/core';
+
+const api = preset({
+    baseUrl: 'https://api.example.com',
+    retry: { attempts: 3, on: [429, 503] },
+});
+
+// Bind the base once; every stitch built from it inherits the fragment.
+const apiStitch = defineStitch(api);
+const getWebsite = apiStitch('/websites/{id}');
+```
+
+### One source of truth
+
+The product sells anti-drift discipline; the API holds itself to the same rule.
+Responses are validated on every live call, and differences from a committed
+contract surface as a _leveled_ drift signal — error, warn, or info — instead of
+a silent `undefined` three layers downstream. The docs apply the principle to
+themselves: a fact lives in exactly one place — full type tables only in
+Reference, error remediation only in Errors & pitfalls — and everywhere else
+links to it rather than restating (and risking drift from) it.
+
+### Agent-native
+
+An agent is a first-class caller, not an afterthought bolted on with a server.
+Three things follow. A stitch hands the caller a capability, not a credential:
+the secret resolves at call time and never reaches the caller, human or agent.
+Every call yields a typed event stream — `start → progress → drift → result →
+done` — so an agent gets structured, validated, traceable results instead of
+opaque bytes. And the agent surface is one code-mode tool the agent drives, not
+one tool per endpoint, which keeps its context frugal.
 
 ## How it relates
 
-Stub.
+- **Progressive disclosure** runs from the [stitch primitive](/docs/concepts/the-stitch)
+  through the [fluent builder](/docs/guides/authoring/fluent-builder) — the
+  string, the config object, and the chainable surface are three altitudes of
+  one call.
+- **Atomic stitches** are the [stitch](/docs/concepts/the-stitch) itself: one
+  endpoint, no spec, no codegen, no server.
+- **Composition over configuration** is what [`extends`](/docs/guides/authoring/extends)
+  expresses — and `preset()` and `defineStitch()` are the fragments and factories
+  it composes.
+- **One source of truth** shows up at runtime as [leveled drift](/docs/guides/validation/drift),
+  the same anti-drift rule this documentation follows.
+- **Agent-native** is spelled out across [capability, not credential](/docs/concepts/capability-not-credential),
+  the [event stream](/docs/concepts/event-stream), and the [agent surfaces](/docs/agents).
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="The stitch primitive" href="/docs/concepts/the-stitch" />
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+    <Card title="Capability, not credential" href="/docs/concepts/capability-not-credential" />
+    <Card title="The fluent builder" href="/docs/guides/authoring/fluent-builder" />
+    <Card title="extends" href="/docs/guides/authoring/extends" />
+    <Card title="Leveled drift" href="/docs/guides/validation/drift" />
+    <Card title="For agents" href="/docs/agents" />
+</Cards>

--- a/apps/docs/content/docs/concepts/the-stitch.mdx
+++ b/apps/docs/content/docs/concepts/the-stitch.mdx
@@ -49,7 +49,10 @@ And because the declaration is the runtime, one stitch is reachable through more
 
 <Cards>
     <Card title="The event stream" href="/docs/concepts/event-stream" />
-    <Card title="Capability, not credential" href="/docs/concepts/capability-not-credential" />
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+    />
     <Card title="Principles" href="/docs/concepts/principles" />
     <Card title="Guide: stitch()" href="/docs/guides/authoring/stitch" />
     <Card title="Surface: function" href="/docs/surfaces/function" />

--- a/apps/docs/content/docs/concepts/the-stitch.mdx
+++ b/apps/docs/content/docs/concepts/the-stitch.mdx
@@ -3,16 +3,55 @@ title: 'The stitch primitive'
 description: 'A typed, declarative, composable unit that turns input into validated output with auth, resilience, and observability built in.'
 ---
 
-Stub — what it is, in one or two sentences. See AUTHORING.md.
+A stitch is the one primitive StitchAPI is built on: a typed, declarative, composable unit that turns a single API call into a resilient, validated, observable function — declared once, callable by your code, the CLI, or an agent.
 
 ## Why it's shaped this way
 
-Stub.
+The thing every project reaches for is `fetch`, and `fetch` hands back opaque bytes. Everything that actually makes an integration reliable — the auth lifecycle, retries, rate limits, timeouts, response validation, drift detection, tracing — is left to be re-implemented at every call site, where each wrapper rots on its own. A stitch exists to make those concerns properties of the call itself rather than scaffolding you rebuild by hand.
+
+**Declarative, not an imperative wrapper.** A stitch is a description of an API call, not a function body that performs one. You state _what_ the call is — its URL, its input and output shapes, how it authenticates, how it should behave under failure — and the engine decides _how_ to carry it out. That inversion is what lets one declaration be read at runtime to validate every live response, surface drift, emit a trace, and back a CLI command. An imperative wrapper around `fetch` is just code; it can't be introspected, composed, or invoked by an agent without bespoke glue. A declaration can.
+
+**Atomic, not spec-first.** A stitch describes exactly one call, and it needs nothing more than a URL to exist. There is no OpenAPI document to obtain first, no codegen step, no generated artifact to commit and regenerate when the API changes. Spec-based generators can't emit anything until a complete, accurate spec exists — which most internal services and long-tail vendors never have. Working one call at a time means you can wrap the API in front of you today, and because every stitch carries its own schema, the contract accretes from the calls you actually make rather than from a document someone has to maintain.
+
+**One primitive, three facades.** There is exactly one thing — the stitch — reached through three authoring surfaces that all resolve to the same engine. The string form is the smallest possible declaration; the config form is the same declaration with more fields; the fluent builder is the same fields set one call at a time. None is a different kind of object: each compiles to one canonical config and produces the same callable.
+
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+// The string form: a bare URL is the smallest complete stitch.
+const a = stitch('https://api.example.com/users');
+
+// The config form: the same declaration, with room to grow.
+const b = stitch({ baseUrl: 'https://api.example.com', path: '/users' });
+```
+
+The point of three facades is reach, not variety. A single shape can't be both the one-liner a quick call wants and the structured object a fully-specified integration needs, so the surface flexes while the primitive underneath stays singular. That singularity is what keeps the mental model small: learn the stitch once, and every facade is just a different door into it.
 
 ## How it relates
 
-Stub.
+A stitch is the unit everything else in StitchAPI attaches to or is built from.
+
+What a call _returns_ is the [event stream](/docs/concepts/event-stream) — an async iterable of typed events rather than `Promise<bytes>`. Awaiting a stitch is sugar that consumes that stream and hands back the final validated value; the cross-cutting features all report through the same spine.
+
+How a stitch _authenticates_ is the [capability, not credential](/docs/concepts/capability-not-credential) boundary. Auth is a field on the stitch, so a caller invokes it and receives data without ever touching the secret — which matters most when the caller is an agent.
+
+Because a stitch is itself a value, stitches _compose_: a reusable fragment can be extended, a base can be bound into a factory, and partial input can be pre-applied, all without any global configuration. The composition facades are covered in the [authoring guides](/docs/guides/authoring/stitch).
+
+And because the declaration is the runtime, one stitch is reachable through more than one [surface](/docs/surfaces/function) — an in-process function and a CLI command today — without re-describing the call for each.
+
+<Callout type="info">
+    A stitch is a per-call primitive, not a workflow engine. Multi-step
+    orchestration, queues, and inbound webhooks stay your application's job —
+    the stitch is the durable unit those things are composed _from_.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+    <Card title="Capability, not credential" href="/docs/concepts/capability-not-credential" />
+    <Card title="Principles" href="/docs/concepts/principles" />
+    <Card title="Guide: stitch()" href="/docs/guides/authoring/stitch" />
+    <Card title="Surface: function" href="/docs/surfaces/function" />
+    <Card title="Reference: stitch()" href="/docs/reference/stitch" />
+</Cards>


### PR DESCRIPTION
Fills three of the four **Concepts** stubs (the fourth, `event-stream`, is authored in #24 and left untouched here). One agent per page, then centrally reviewed and verified.

## Pages (concept template: lead → Why it's shaped this way → How it relates → See also)
- **The stitch primitive** (`concepts/the-stitch`) — what the primitive *is* and why: declarative over an imperative fetch wrapper, atomic (one endpoint, no spec), one primitive with three facades.
- **Capability, not credential** (`concepts/capability-not-credential`) — the security model: the stitch holds the secret (resolved at call time via `env()`/`keychain()`), the caller receives a capability, an agent never sees the token.
- **Principles** (`concepts/principles`) — progressive disclosure, atomic stitches, composition over configuration, one-source-of-truth/anti-drift, agent-native.

## Verification
- Examples import `@stitchapi/core` and match the real API (string/config `stitch()`, `bearer(env(...))`, `preset()`/`defineStitch()`).
- Every internal link verified to resolve; one-source-of-truth respected (each page links rather than re-explaining neighbours).
- Full `next build` renders all 180 pages clean (exit 0); pre-commit/pre-push gates green.

Independent of #24 and #25 (no shared commits, content-only — no workflow files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)