### PR TITLE
docs: author Guides · Authoring & composition (6 pages)

### DIFF
--- a/apps/docs/content/docs/guides/authoring/define-stitch.mdx
+++ b/apps/docs/content/docs/guides/authoring/define-stitch.mdx
@@ -3,16 +3,55 @@ title: 'defineStitch()'
 description: 'Bind a set of base fragments once and get a reusable stitch factory.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Use `defineStitch` when many stitches share the same defaults — a base URL,
+retry policy, headers — and you want to bind those once and stamp out each
+stitch from the resulting factory instead of repeating the base on every call.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { defineStitch } from '@stitchapi/core';
+
+// Bind the base once; the factory carries it into every stitch it builds.
+const api = defineStitch({
+    baseUrl: 'https://api.example.com',
+    retry: { attempts: 3 },
+});
+
+const getUser = api('/users/{id}'); // inherits baseUrl + retry
+const createUser = api({ method: 'POST', path: '/users' });
+```
+
+Both `getUser` and `createUser` inherit `baseUrl` and `retry` from the bound
+base; each call adds only what is specific to that stitch.
 
 ## Options
 
-Stub.
+`defineStitch(...fragments)` takes one or more fragments — a `Partial<StitchConfig>`,
+a [`preset()`](/docs/guides/authoring/preset), another stitch, or a bare string
+(shorthand for `{ path }`) — and returns a factory. Calling the factory with a
+string or a partial config produces a stitch whose own config is layered on top
+of the bound fragments.
+
+The split is: `defineStitch` binds what is **shared** across the family; each
+factory call adds what is **unique** to that one stitch. A
+[`preset()`](/docs/guides/authoring/preset) is a named fragment you can pass in
+as a base, reuse across several factories, or merge per call.
+
+Under the hood the bound fragments are prepended to each stitch's
+[`extends`](/docs/guides/authoring/extends) list, so they deep-merge with
+later layers winning. The merge order and precedence rules live with `extends`.
+
+<Callout type="warn">
+    The bound base is prepended, so a value set on an individual factory call
+    overrides the same value from `defineStitch` — later layers win.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="preset()" href="/docs/guides/authoring/preset" />
+    <Card title="extends" href="/docs/guides/authoring/extends" />
+    <Card title="stitch()" href="/docs/guides/authoring/stitch" />
+    <Card title="Reference: stitch()" href="/docs/reference/stitch" />
+</Cards>

--- a/apps/docs/content/docs/guides/authoring/extends.mdx
+++ b/apps/docs/content/docs/guides/authoring/extends.mdx
@@ -3,16 +3,56 @@ title: 'extends'
 description: 'Layer fragments — strings, objects, or other stitches — with deep-merge to compose configuration.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Use `extends` to build a stitch from layered fragments — a shared base, an
+options object, and the stitch's own inline fields — deep-merged in order so the
+common configuration lives in one place and each stitch states only what differs.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+// A base stitch carrying the shared host and headers.
+const base = stitch({
+    baseUrl: 'https://api.example.com',
+    headers: { accept: 'application/json' },
+});
+
+const getUser = stitch({
+    extends: [base, { retry: { attempts: 3 } }],
+    path: '/users/{id}',
+});
+```
+
+`getUser` deep-merges three layers: `base`'s config, the inline retry object, and
+its own `path`. The result carries `baseUrl`, `headers`, `retry`, and `path`.
 
 ## Options
 
-Stub.
+`extends` takes an array of fragments, each normalized to a partial config: a
+**string** becomes `{ path: string }`; another **stitch** contributes its
+resolved config; a plain **object** is used as-is. Nested `extends` inside any
+fragment are flattened first, so a base can itself extend another base.
+
+Layers are deep-merged left to right, and **later layers win** — the stitch's own
+inline fields are the last layer, so they override everything they extend.
+Two exceptions: hooks **chain** instead of overwriting (every layer's
+`onRequest`/`onResponse`/`onError`/`onRetry` runs), and `store` is taken from the
+last layer that sets one.
+
+<Callout type="info">
+    [`preset()`](/docs/guides/authoring/preset) and
+    [`defineStitch()`](/docs/guides/authoring/define-stitch) are conveniences
+    built on this: a preset is a named fragment you drop into `extends`, and
+    `defineStitch()` pre-binds base fragments so every stitch it produces extends
+    them automatically.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="preset()" href="/docs/guides/authoring/preset" />
+    <Card title="defineStitch()" href="/docs/guides/authoring/define-stitch" />
+    <Card title="stitch()" href="/docs/guides/authoring/stitch" />
+    <Card title="Reference: config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/guides/authoring/extends.mdx
+++ b/apps/docs/content/docs/guides/authoring/extends.mdx
@@ -44,8 +44,8 @@ last layer that sets one.
     [`preset()`](/docs/guides/authoring/preset) and
     [`defineStitch()`](/docs/guides/authoring/define-stitch) are conveniences
     built on this: a preset is a named fragment you drop into `extends`, and
-    `defineStitch()` pre-binds base fragments so every stitch it produces extends
-    them automatically.
+    `defineStitch()` pre-binds base fragments so every stitch it produces
+    extends them automatically.
 </Callout>
 
 ## See also

--- a/apps/docs/content/docs/guides/authoring/fluent-builder.mdx
+++ b/apps/docs/content/docs/guides/authoring/fluent-builder.mdx
@@ -3,16 +3,63 @@ title: 'The fluent builder'
 description: 'Build a stitch step by step with .get/.post/.returns/.auth/.retry/.throttle/.timeout.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Start from `stitch.use(...)` and chain methods to assemble a stitch piece by
+piece, then call the result like a function — handy when you build the request
+incrementally or add behavior conditionally rather than declaring it all at once.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch, bearer, env } from '@stitchapi/core';
+
+const getUser = stitch
+    .use({ baseUrl: 'https://api.example.com' })
+    .get('/users/{id}')
+    .auth(bearer(env('API_TOKEN')))
+    .retry({ attempts: 3 });
+
+const user = await getUser({ params: { id: 1 } });
+```
+
+Each method returns the same builder, so the chain reads top to bottom; the
+final value is callable, so `getUser(...)` runs the request.
 
 ## Options
 
-Stub.
+The builder is just another facade over the same engine — every chain resolves
+to one canonical config, exactly as if you had passed that object to
+[`stitch()`](/docs/guides/authoring/stitch). Reach for it when the shape is not
+known up front: build the base, then add `.auth(...)` or `.retry(...)` only when
+a flag says so. When the whole config is static, the object form reads just as
+well.
+
+The chainable methods, each returning the builder:
+
+- `.use(...fragments)` merges config fragments into the accumulator.
+- `.get(path)` / `.post(path)` / `.put(path)` / `.delete(path)` set both the
+  method and the path.
+- `.returns(schema)` sets the output schema; `.unwrap(key)` pulls a nested key
+  out of the response.
+- `.auth(strategy)` attaches an auth strategy such as `bearer(env(...))`.
+- `.retry(opts)` / `.throttle(opts)` / `.timeout(opts)` add resilience options.
+
+The result also carries `.stream(input)` for the event stream and
+[`.with(partial)`](/docs/guides/authoring/with) for partial application.
+
+<Callout type="info">
+    The builder is callable: the value at the end of the chain is the stitch,
+    so you invoke it directly — there is no separate build step.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="stitch()" href="/docs/guides/authoring/stitch" />
+    <Card title="extends and preset" href="/docs/guides/authoring/extends" />
+    <Card
+        title="Partial application with .with()"
+        href="/docs/guides/authoring/with"
+    />
+    <Card title="Principles" href="/docs/concepts/principles" />
+    <Card title="Reference: stitch()" href="/docs/reference/stitch" />
+</Cards>

--- a/apps/docs/content/docs/guides/authoring/fluent-builder.mdx
+++ b/apps/docs/content/docs/guides/authoring/fluent-builder.mdx
@@ -10,7 +10,7 @@ incrementally or add behavior conditionally rather than declaring it all at once
 ## Example
 
 ```ts twoslash
-import { stitch, bearer, env } from '@stitchapi/core';
+import { bearer, env, stitch } from '@stitchapi/core';
 
 const getUser = stitch
     .use({ baseUrl: 'https://api.example.com' })
@@ -35,20 +35,20 @@ well.
 
 The chainable methods, each returning the builder:
 
-- `.use(...fragments)` merges config fragments into the accumulator.
-- `.get(path)` / `.post(path)` / `.put(path)` / `.delete(path)` set both the
-  method and the path.
-- `.returns(schema)` sets the output schema; `.unwrap(key)` pulls a nested key
-  out of the response.
-- `.auth(strategy)` attaches an auth strategy such as `bearer(env(...))`.
-- `.retry(opts)` / `.throttle(opts)` / `.timeout(opts)` add resilience options.
+-   `.use(...fragments)` merges config fragments into the accumulator.
+-   `.get(path)` / `.post(path)` / `.put(path)` / `.delete(path)` set both the
+    method and the path.
+-   `.returns(schema)` sets the output schema; `.unwrap(key)` pulls a nested key
+    out of the response.
+-   `.auth(strategy)` attaches an auth strategy such as `bearer(env(...))`.
+-   `.retry(opts)` / `.throttle(opts)` / `.timeout(opts)` add resilience options.
 
 The result also carries `.stream(input)` for the event stream and
 [`.with(partial)`](/docs/guides/authoring/with) for partial application.
 
 <Callout type="info">
-    The builder is callable: the value at the end of the chain is the stitch,
-    so you invoke it directly — there is no separate build step.
+    The builder is callable: the value at the end of the chain is the stitch, so
+    you invoke it directly — there is no separate build step.
 </Callout>
 
 ## See also

--- a/apps/docs/content/docs/guides/authoring/preset.mdx
+++ b/apps/docs/content/docs/guides/authoring/preset.mdx
@@ -3,16 +3,58 @@ title: 'preset()'
 description: 'Bundle reusable defaults under a name and apply them across many stitches.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Use `preset()` to bundle cross-cutting defaults — retries, timeouts, headers —
+under a name, then apply that bundle to many stitches instead of repeating the
+same fields on each one.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { defineStitch, preset, stitch } from '@stitchapi/core';
+
+// A named bundle of reusable defaults. It does nothing on its own.
+const resilient = preset({
+    retry: { attempts: 3, on: [429, 503] },
+    timeout: { total: '10s' },
+});
+
+// Apply it to a single stitch via `extends`.
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    extends: [resilient],
+});
+
+// Or bind it as a base, so every stitch from this factory inherits it.
+const api = defineStitch(resilient);
+```
+
+A `preset()` is just an identity-tagged fragment: a plain `Partial<StitchConfig>`
+that exists to be reused. You apply it with [`extends`](/docs/guides/authoring/extends)
+or bind it through [`defineStitch()`](/docs/guides/authoring/define-stitch).
 
 ## Options
 
-Stub.
+`preset()` accepts a `Partial<StitchConfig>`, so anything a stitch accepts can
+live in one. Reach for it to centralize cross-cutting defaults: `baseUrl`,
+`retry`, `throttle`, `timeout`, `headers`, and `auth`.
+
+Fragments deep-merge when applied, and later layers — including the stitch's own
+fields — win over the preset. So a stitch can adopt `resilient` and still
+override its `timeout` inline. See [`extends`](/docs/guides/authoring/extends)
+for the full deep-merge and override semantics, and
+[Reference → Config types](/docs/reference/config-types) for every field a
+preset may carry.
+
+<Callout type="info">
+    A `preset()` is inert until applied — nothing runs at definition time. It is
+    only the bundle; `extends` and `defineStitch()` are what consume it.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="extends" href="/docs/guides/authoring/extends" />
+    <Card title="defineStitch()" href="/docs/guides/authoring/define-stitch" />
+    <Card title="Reference: Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/guides/authoring/stitch.mdx
+++ b/apps/docs/content/docs/guides/authoring/stitch.mdx
@@ -3,16 +3,63 @@ title: 'stitch()'
 description: 'Declare an endpoint and get back a typed, callable function — the core authoring move.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Reach for `stitch()` to declare a single HTTP call once and get back a typed,
+callable function — it is the core authoring move that every other feature
+layers onto.
 
 ## Example
 
-Stub.
+Pass a string when the URL is all you need; pass a config object when you want a
+`baseUrl`, a parameterized `path`, or a non-GET `method`. The generic types the
+awaited value.
+
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+// String form — the string becomes the path; a full URL is fine.
+const listUsers = stitch<{ id: number; name: string }[]>(
+    'https://api.example.com/users',
+);
+
+// Config form — baseUrl + a {param} slot; method defaults to GET.
+const createUser = stitch<{ id: number; name: string }>({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    method: 'POST',
+});
+
+const users = await listUsers();
+const user = await createUser({ params: { id: 1 } });
+```
 
 ## Options
 
-Stub.
+The handful of fields that shape every stitch:
+
+-   **`baseUrl`** + **`path`** — the request target. `path` may contain `{param}`
+    slots and a `?query` string; in string form the whole string becomes `path`.
+-   **`method`** — the HTTP verb. Defaults to `GET`.
+-   **The input object** — `params`, `query`, `headers`, and `body` all travel in
+    one `StitchInput` you pass at call time: `await createUser({ params: { id: 1 } })`.
+-   **The generic** — `stitch<T>(...)` types the awaited value `T`.
+
+<Callout type="info">
+    Auth, retry, and validation are configured on the same config object but
+    documented in their own guides — see below — so there is one source of truth
+    per feature.
+</Callout>
+
+For every field and its default, see
+[Reference → stitch()](/docs/reference/stitch) and
+[Reference → Config types](/docs/reference/config-types).
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="The stitch" href="/docs/concepts/the-stitch" />
+    <Card title="Fluent builder" href="/docs/guides/authoring/fluent-builder" />
+    <Card title="extends" href="/docs/guides/authoring/extends" />
+    <Card title="Validation" href="/docs/guides/validation/validation" />
+    <Card title="The function surface" href="/docs/surfaces/function" />
+    <Card title="Reference: stitch()" href="/docs/reference/stitch" />
+</Cards>

--- a/apps/docs/content/docs/guides/authoring/with.mdx
+++ b/apps/docs/content/docs/guides/authoring/with.mdx
@@ -3,16 +3,54 @@ title: '.with() partial application'
 description: 'Pre-bind part of a call and reuse the same runtime so cookies, throttle, and sessions persist.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Use `.with()` when you want to pre-bind part of a stitch's input — a query
+param, a header, a body field — and reuse it across calls, while the bound
+stitch keeps the same runtime so cookies, throttle counters, and session state
+carry over.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const search = stitch('https://api.example.com/search');
+
+// Pre-bind a query param; per-call input merges over it.
+const inEurope = search.with({ query: { region: 'eu' } });
+
+await inEurope({ query: { q: 'mango' } }); // → region=eu&q=mango
+```
+
+`inEurope` shares one runtime with `search`, so a throttle budget or a captured
+cookie set is the same whichever you call.
 
 ## Options
 
-Stub.
+`.with(partial)` accepts any slice of `StitchInput` — `params`, `query`,
+`headers`, `body`, or `variables` — and returns a new stitch with that slice
+bound in.
+
+Each call merges its own input **over** the bound partial, so per-call values
+win on conflict (`region` here, overridden if a call passes its own `region`).
+Calls are chainable: `search.with(a).with(b)` layers both partials.
+
+The key point is the shared runtime: the bound stitch does not start fresh. The
+same [cookie session](/docs/guides/auth/cookie-session) jar, throttle counters,
+and [shared session](/docs/guides/state/shared-sessions) state persist across
+every call made through it.
+
+<Callout type="warn">
+    Because the runtime is shared, throttle and circuit state are shared too — a
+    bound stitch is not an isolated copy. See
+    [throttle](/docs/guides/resilience/throttle).
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Fluent builder" href="/docs/guides/authoring/fluent-builder" />
+    <Card title="stitch()" href="/docs/guides/authoring/stitch" />
+    <Card title="cookieSession" href="/docs/guides/auth/cookie-session" />
+    <Card title="Shared sessions" href="/docs/guides/state/shared-sessions" />
+    <Card title="Reference: stitch()" href="/docs/reference/stitch" />
+</Cards>


### PR DESCRIPTION
Fills all six **Guides · Authoring & composition** stubs — one agent per page, centrally reviewed and verified. Guide template throughout (lead → Example → Options → See also).

## Pages
- **`stitch()`** — the core authoring move: string form, config form, the `stitch<T>()` generic.
- **`defineStitch()`** — bind base fragments once, get a reusable stitch factory.
- **`preset()`** — a named bundle of reusable defaults, applied via `extends`/`defineStitch`.
- **`extends`** — layer string/object/stitch fragments with deep-merge (last-wins; hooks chain).
- **The fluent builder** — `stitch.use(...).get/.post/.returns/.auth/.retry/.throttle/.timeout`.
- **`.with()`** — pre-bind input and reuse the same runtime so cookies/throttle/sessions persist.

## Verification
- Every Twoslash example imports `@stitchapi/core` and is checked against the real API (the `Builder` interface, `defineStitch`/`preset`/`extends` composition semantics, `.with()` merge).
- All internal links resolve; one-source-of-truth respected (full option tables deferred to Reference).
- Full `next build` renders all 180 pages clean (exit 0); pre-commit/pre-push gates green.

Independent, content-only branch (no workflow files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)