### PR TITLE
docs: author Guides · Auth (bearer, apiKey, basic, oauth2, secret-resolvers)

### DIFF
--- a/apps/docs/content/docs/guides/auth/api-key.mdx
+++ b/apps/docs/content/docs/guides/auth/api-key.mdx
@@ -3,16 +3,55 @@ title: 'apiKey'
 description: 'Send an API key as a header or query parameter, resolved at call time.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Use `apiKey` when an API authenticates with a static key and you want the stitch
+to attach it as a request header, resolved at call time so the caller never sees
+the secret.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { apiKey, env, stitch } from '@stitchapi/core';
+
+const search = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/search',
+    auth: apiKey({ value: env('API_KEY') }),
+});
+```
+
+Every call to `search()` sets the `x-api-key` header to the resolved key, behind
+the capability boundary.
 
 ## Options
 
-Stub.
+`value` is the key itself — a literal string, or (preferred) a resolver like
+[`env('API_KEY')`](/docs/guides/auth/secret-resolvers) so the secret is read at
+call time and never committed.
+
+`header` overrides the header name (default `x-api-key`, lowercased): pass
+`apiKey({ header: 'X-My-Key', value: env('API_KEY') })` to send the key under a
+custom header.
+
+<Callout type="warn">
+    `apiKey` only sets a header — it does not add a query parameter. For an API
+    that wants the key in the query string, set it through the request `query`
+    input instead.
+</Callout>
+
+See [Reference → Auth strategies](/docs/reference/auth-strategies) for every
+field.
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Secret resolvers" href="/docs/guides/auth/secret-resolvers" />
+    <Card title="bearer" href="/docs/guides/auth/bearer" />
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+    />
+    <Card
+        title="Reference: Auth strategies"
+        href="/docs/reference/auth-strategies"
+    />
+</Cards>

--- a/apps/docs/content/docs/guides/auth/basic.mdx
+++ b/apps/docs/content/docs/guides/auth/basic.mdx
@@ -3,16 +3,46 @@ title: 'basic'
 description: 'HTTP Basic authentication with credentials resolved from a secret resolver.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Use `basic` when an API authenticates with HTTP Basic — it base64-encodes
+`user:pass` and sets the `Authorization: Basic …` header, with both halves
+resolved at call time so the caller never holds the credential.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { basic, env, stitch } from '@stitchapi/core';
+
+const report = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/report',
+    auth: basic({ user: env('API_USER'), pass: env('API_PASS') }),
+});
+```
+
+Each call to `report()` resolves `API_USER` and `API_PASS`, encodes them, and
+attaches the header — behind the capability boundary, so the credential is never
+passed in by the caller.
 
 ## Options
 
-Stub.
+`user` and `pass` each take a string or a resolver. Prefer a resolver like
+[`env()`](/docs/guides/auth/secret-resolvers): it reads the secret per call, so
+nothing is captured in the config or committed to source — the
+[capability, not credential](/docs/concepts/capability-not-credential) boundary.
+A literal string works but bakes the secret into the stitch. See
+[Reference → Auth strategies](/docs/reference/auth-strategies) for every field.
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Secret resolvers" href="/docs/guides/auth/secret-resolvers" />
+    <Card title="bearer" href="/docs/guides/auth/bearer" />
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+    />
+    <Card
+        title="Reference: Auth strategies"
+        href="/docs/reference/auth-strategies"
+    />
+</Cards>

--- a/apps/docs/content/docs/guides/auth/bearer.mdx
+++ b/apps/docs/content/docs/guides/auth/bearer.mdx
@@ -3,16 +3,51 @@ title: 'bearer'
 description: 'Attach a bearer token resolved at call time from an env var or the keychain.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Use `bearer` when an API authenticates with a token sent as
+`Authorization: Bearer <token>`, and you want the token resolved at call time so
+the secret stays out of your code and out of the caller's hands.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { bearer, env, stitch } from '@stitchapi/core';
+
+const me = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/me',
+    auth: bearer(env('API_TOKEN')),
+});
+```
+
+The token is read each time `me()` runs, so a rotated secret takes effect on the
+next call with no rewiring.
 
 ## Options
 
-Stub.
+`bearer` accepts either a literal string or a resolver thunk (`() => string`).
+Strongly prefer a resolver: it reads the secret per call from the environment or
+the keychain, so nothing is committed and the stitch hands callers a capability,
+not the credential — see
+[Capability, not credential](/docs/concepts/capability-not-credential).
+
+Use [`env('API_TOKEN')`](/docs/guides/auth/secret-resolvers) for an environment
+variable or `keychain('API_TOKEN')` for the spike keychain; both return a thunk
+resolved at call time. See
+[Reference → Auth strategies](/docs/reference/auth-strategies) for the full auth
+table.
+
+<Callout type="warn">
+    Passing a literal string bakes the secret into your source. Reach for a
+    resolver unless the token is a non-secret placeholder.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Secret resolvers" href="/docs/guides/auth/secret-resolvers" />
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+    />
+    <Card title="Auth strategies" href="/docs/reference/auth-strategies" />
+</Cards>

--- a/apps/docs/content/docs/guides/auth/oauth2.mdx
+++ b/apps/docs/content/docs/guides/auth/oauth2.mdx
@@ -48,8 +48,8 @@ all — across stitches and across workers, surviving restarts. See
 <Callout type="warn">
     The token lives only in the store and the outgoing `Authorization` header —
     the caller, an agent included, never receives it. That is the capability
-    boundary; see
-    [Capability, not credential](/docs/concepts/capability-not-credential).
+    boundary; see [Capability, not
+    credential](/docs/concepts/capability-not-credential).
 </Callout>
 
 ## See also

--- a/apps/docs/content/docs/guides/auth/oauth2.mdx
+++ b/apps/docs/content/docs/guides/auth/oauth2.mdx
@@ -3,16 +3,64 @@ title: 'oauth2'
 description: 'OAuth2 client_credentials: fetch, cache, and auto-refresh a token behind the capability boundary.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Use `oauth2` when an API authenticates with the OAuth2 `client_credentials`
+grant and you want the access token fetched, cached, and refreshed for you — the
+stitch holds the client id and secret, the caller never sees the token.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { env, oauth2, stitch } from '@stitchapi/core';
+
+const orders = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/orders',
+    auth: oauth2({
+        tokenUrl: 'https://api.example.com/oauth/token',
+        clientId: env('CLIENT_ID'),
+        clientSecret: env('CLIENT_SECRET'),
+        scope: 'orders.read',
+    }),
+});
+```
+
+The first call to `orders()` POSTs the form-encoded token request, caches the
+token in the stitch store (TTL from `expires_in`), and attaches it as
+`Authorization: Bearer …`; later calls reuse the cached token until it nears
+expiry, all behind the capability boundary.
 
 ## Options
 
-Stub.
+`tokenUrl` is the `client_credentials` token endpoint. Pass `clientId` and
+`clientSecret` as [secret resolvers](/docs/guides/auth/secret-resolvers) — e.g.
+`env('CLIENT_ID')` — so the credentials are read at call time and never
+committed. `scope` is an optional space-delimited scope string.
+
+The token is cached and auto-refreshed: `refreshSkewMs` (default `30_000`)
+refreshes it that many milliseconds before expiry, so it is never used
+mid-flight, and `refreshOn` (default `[401]`) lists the statuses that mean the
+token was rejected and force a fresh fetch plus retry.
+
+Give two stitches the same `key` plus a shared `store` and one token serves them
+all — across stitches and across workers, surviving restarts. See
+[Reference → Auth strategies](/docs/reference/auth-strategies) for every field.
+
+<Callout type="warn">
+    The token lives only in the store and the outgoing `Authorization` header —
+    the caller, an agent included, never receives it. That is the capability
+    boundary; see
+    [Capability, not credential](/docs/concepts/capability-not-credential).
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Secret resolvers" href="/docs/guides/auth/secret-resolvers" />
+    <Card title="bearer" href="/docs/guides/auth/bearer" />
+    <Card title="Pluggable store" href="/docs/guides/state/pluggable-store" />
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+    />
+    <Card title="Auth strategies" href="/docs/reference/auth-strategies" />
+</Cards>

--- a/apps/docs/content/docs/guides/auth/secret-resolvers.mdx
+++ b/apps/docs/content/docs/guides/auth/secret-resolvers.mdx
@@ -3,16 +3,72 @@ title: 'Secret resolvers'
 description: 'Resolve secrets lazily at call time with env() and keychain() instead of hard-coding them.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Every auth strategy takes a secret as a reference, not a value, and resolves it
+at call time — reach for `env()` and `keychain()` so the declaration carries a
+capability, not a credential you have to commit.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch, bearer, env, keychain } from '@stitchapi/core';
+
+// env() reads process.env.API_TOKEN when the stitch is called, not now.
+const me = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/me',
+    auth: bearer(env('API_TOKEN')),
+});
+
+// keychain() resolves from ~/.stitch/secrets.json, falling back to the env var.
+const billing = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/billing',
+    auth: bearer(keychain('BILLING_TOKEN')),
+});
+```
+
+The token is never read at declaration time, so the secret never enters the
+stitch's source — only the name of where to find it does.
 
 ## Options
 
-Stub.
+A secret is a `string | (() => string)`. Every strategy — `bearer`, `apiKey`,
+`basic`, `oauth2` — accepts one and resolves it the moment a request goes out,
+so the same declaration works across processes and machines without baking a
+value in.
+
+`env(name)` returns a thunk that reads `process.env[name]` at call time and
+throws `missing env var <name>` if it is unset — failing loudly at the call
+rather than silently sending an empty token.
+
+`keychain(name)` is a lightweight keychain over a JSON file: it reads
+`~/.stitch/secrets.json` if present and the key is there, otherwise falls back
+to the environment variable of the same name, and throws if neither has it.
+
+Why call-time resolution matters: the value is fetched only when a call is
+made, so you never commit a secret and the stitch holds a capability rather than
+the credential itself — the [capability boundary](/docs/concepts/capability-not-credential)
+the product is built on. You can pass a plain `string` (discouraged — that hard-codes
+the value), or any `() => string` thunk of your own, so plugging in a vault or
+secrets manager is just supplying a different resolver.
+
+<Callout type="warn">
+    A plain-string secret is read at declaration time and lives in your source
+    and history. Prefer `env()` or `keychain()` so the value is resolved at call
+    time instead.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+    />
+    <Card title="bearer" href="/docs/guides/auth/bearer" />
+    <Card title="oauth2" href="/docs/guides/auth/oauth2" />
+    <Card
+        title="Reference: Auth strategies"
+        href="/docs/reference/auth-strategies"
+    />
+</Cards>

--- a/apps/docs/content/docs/guides/auth/secret-resolvers.mdx
+++ b/apps/docs/content/docs/guides/auth/secret-resolvers.mdx
@@ -10,7 +10,7 @@ capability, not a credential you have to commit.
 ## Example
 
 ```ts twoslash
-import { stitch, bearer, env, keychain } from '@stitchapi/core';
+import { bearer, env, keychain, stitch } from '@stitchapi/core';
 
 // env() reads process.env.API_TOKEN when the stitch is called, not now.
 const me = stitch({


### PR DESCRIPTION
Fills five of six **Guides · Auth** stubs (`cookie-session` is in #24). One agent per page, centrally verified. Guide template throughout.

## Pages
- **bearer** / **apiKey** / **basic** — attach a token / key / credentials from a secret resolver.
- **oauth2** — `client_credentials`: fetch, cache, and auto-refresh a token behind the capability boundary; `key` + a shared store can share one token across stitches/workers.
- **Secret resolvers** — `env()` and `keychain()`, the call-time resolution model the others link to.

## Accuracy note
`apiKey` is documented as **header-only** to match the implementation — the code (`auth.ts`) only sets a request header (default `x-api-key`); it has no query-parameter mode despite the frontmatter description mentioning one. Worth reconciling the description (or adding query support) separately.

## Verification
- Every Twoslash example imports `@stitchapi/core` and matches `auth.ts` (`bearer`/`apiKey`/`basic`/`oauth2` signatures, `Secret` resolvers).
- All links resolve; full `next build` renders all 180 pages clean (exit 0).

Independent, content-only branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)