### PR TITLE
docs: author Guides · Resilience (retry, throttle, timeout, circuit-breaker, idempotency)

### DIFF
--- a/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
+++ b/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
@@ -58,8 +58,5 @@ See [Reference → Config types](/docs/reference/config-types) for every field.
     <Card title="Retry" href="/docs/guides/resilience/retry" />
     <Card title="Timeout" href="/docs/guides/resilience/timeout" />
     <Card title="Pluggable store" href="/docs/guides/state/pluggable-store" />
-    <Card
-        title="STITCH_CIRCUIT_OPEN"
-        href="/docs/errors/stitch-circuit-open"
-    />
+    <Card title="STITCH_CIRCUIT_OPEN" href="/docs/errors/stitch-circuit-open" />
 </Cards>

--- a/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
+++ b/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
@@ -3,16 +3,63 @@ title: 'Circuit breaker'
 description: 'Stop hammering a failing dependency by opening a circuit after repeated failures.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Add `circuit` when a dependency is failing and you want the stitch to stop
+hammering it — after a run of failures the breaker opens and calls fast-fail
+for a cooldown, giving the dependency room to recover before a single trial
+call probes it again.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const orders = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/orders',
+    circuit: { failureThreshold: 5, cooldownMs: 30_000 },
+});
+```
+
+After 5 consecutive failures the breaker opens; for the next 30 seconds calls
+to `orders()` fast-fail instead of hitting `api.example.com`.
 
 ## Options
 
-Stub.
+The breaker moves through four states. It starts **closed** (calls pass
+through). After `failureThreshold` consecutive failures it trips **open** and
+calls fast-fail for `cooldownMs`. It then goes **half-open** and lets a single
+trial call through: a success **closes** it and clears the count, another
+failure re-**opens** it for a fresh cooldown. The breaker emits `progress`
+events with phase `circuit`.
+
+`failureThreshold` and `cooldownMs` are both required — `failureThreshold` is
+the count of consecutive failures that trips the breaker open, and `cooldownMs`
+is the fast-fail window after opening, before a half-open trial is allowed.
+
+`halfOpenAfterMs` controls when the half-open trial is permitted (default
+`cooldownMs`), letting you fast-fail and probe on different clocks.
+
+`key` is a store namespace: give two stitches the same `key` plus a shared
+[`store`](/docs/guides/state/pluggable-store) to share one breaker, so a failing
+host opens the circuit for every stitch that talks to it. The default key is the
+stitch/host key.
+
+<Callout type="warn">
+    While the breaker is open, a call fast-fails instead of reaching the
+    dependency — see [STITCH_CIRCUIT_OPEN](/docs/errors/stitch-circuit-open) for
+    what callers see and how to handle it.
+</Callout>
+
+See [Reference → Config types](/docs/reference/config-types) for every field.
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Retry" href="/docs/guides/resilience/retry" />
+    <Card title="Timeout" href="/docs/guides/resilience/timeout" />
+    <Card title="Pluggable store" href="/docs/guides/state/pluggable-store" />
+    <Card
+        title="STITCH_CIRCUIT_OPEN"
+        href="/docs/errors/stitch-circuit-open"
+    />
+</Cards>

--- a/apps/docs/content/docs/guides/resilience/idempotency.mdx
+++ b/apps/docs/content/docs/guides/resilience/idempotency.mdx
@@ -3,16 +3,68 @@ title: 'Idempotency keys'
 description: "Attach idempotency keys to writes so safe retries don't duplicate side effects."
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Add `idempotency` to a write stitch so each logical call carries a stable
+`Idempotency-Key` header — when a retry replays the same write, the server sees
+the same key and dedupes the side effect instead of running it twice. Reach for
+it on `POST`/`PUT` where a duplicate would double-charge, double-ship, or
+double-create.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+// Default: a fresh random key per call, sent as 'Idempotency-Key'.
+const charge = stitch({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/charges',
+    idempotency: {},
+});
+
+// Custom: derive a stable key from the input. `body` is `unknown`, so narrow it.
+const createOrder = stitch({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/orders',
+    idempotency: {
+        key: (input) => `order-${(input.body as { ref: string }).ref}`,
+    },
+});
+```
+
+A single `charge()` call generates one key and reuses it across every retry of
+that call, so a network blip that triggers a retry settles a single charge.
 
 ## Options
 
-Stub.
+`header` is the header name the key rides on, default `'Idempotency-Key'`. Set
+it when the API expects a different header.
+
+`key` builds the key from the call's [`StitchInput`](/docs/reference/config-types)
+(`params`, `query`, `body`, `headers`, `variables`). The default is a random
+uuid generated once per logical call; a custom `key` lets you derive a stable
+key from the request — for example an order reference — so the same logical
+write maps to the same key. `body` is typed `unknown`, so narrow or cast it
+before reading a property, as the `createOrder` example does.
+
+Why it matters: idempotency only pays off alongside [retries](/docs/guides/resilience/retry).
+A retried write replays the same key, so the server can recognize the duplicate
+and skip the side effect — safe retries don't double-charge.
+
+<Callout type="warn">
+    A custom `key` derived from `body` must be stable for a given logical call
+    and unique across distinct ones — colliding keys make the server dedupe two
+    different writes into one.
+</Callout>
+
+See [Reference → Config types](/docs/reference/config-types) for the full
+`IdempotencyOptions` shape.
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Retry" href="/docs/guides/resilience/retry" />
+    <Card title="Body encoding" href="/docs/guides/data/body-encoding" />
+    <Card title="Reference: Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/guides/resilience/retry.mdx
+++ b/apps/docs/content/docs/guides/resilience/retry.mdx
@@ -53,7 +53,10 @@ re-attempt. For the exhaustive field list and defaults, see
 
 <Cards>
     <Card title="Timeout" href="/docs/guides/resilience/timeout" />
-    <Card title="Circuit breaker" href="/docs/guides/resilience/circuit-breaker" />
+    <Card
+        title="Circuit breaker"
+        href="/docs/guides/resilience/circuit-breaker"
+    />
     <Card title="Idempotency" href="/docs/guides/resilience/idempotency" />
     <Card title="The event stream" href="/docs/concepts/event-stream" />
     <Card title="Config types" href="/docs/reference/config-types" />

--- a/apps/docs/content/docs/guides/resilience/retry.mdx
+++ b/apps/docs/content/docs/guides/resilience/retry.mdx
@@ -3,16 +3,58 @@ title: 'Retry & backoff'
 description: 'Retry on configurable status codes with expo/jitter/fixed backoff and respect for Retry-After.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Add `retry` when an API returns transient failures — rate limits and gateway
+hiccups — and you want the stitch to wait and try again instead of surfacing the
+first error.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    retry: {
+        attempts: 3,
+        on: [429, 503],
+        backoff: 'expo-jitter',
+        baseMs: 200,
+        respectRetryAfter: true,
+    },
+});
+```
 
 ## Options
 
-Stub.
+`attempts` is the **total** number of attempts including the first call, so
+`attempts: 3` means up to two retries; the default is `1`, which disables
+retrying.
+
+`on` lists the response status codes that trigger a retry. It defaults to
+`[429, 502, 503, 504]` — the usual transient set — and you narrow or widen it
+per stitch.
+
+`backoff` chooses how long to wait between attempts, paced from `baseMs` and
+clamped to `maxMs`: `'expo'` doubles the delay each attempt, `'expo-jitter'`
+spreads it randomly up to that exponential value to avoid thundering herds, and
+`'fixed'` waits a constant `baseMs` every time.
+
+`respectRetryAfter` honors a `Retry-After` header on the failing response —
+delta-seconds or an HTTP-date — using it in place of the computed backoff when
+the server tells you when to come back.
+
+Each retry surfaces as a `progress` event (phase `retry`) on the
+[event stream](/docs/concepts/event-stream), so a trace sees every wait and
+re-attempt. For the exhaustive field list and defaults, see
+[Reference → Config types](/docs/reference/config-types).
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Timeout" href="/docs/guides/resilience/timeout" />
+    <Card title="Circuit breaker" href="/docs/guides/resilience/circuit-breaker" />
+    <Card title="Idempotency" href="/docs/guides/resilience/idempotency" />
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+    <Card title="Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/guides/resilience/throttle.mdx
+++ b/apps/docs/content/docs/guides/resilience/throttle.mdx
@@ -3,16 +3,56 @@ title: 'Throttle'
 description: 'Space requests by rate and cap concurrency, scoped per stitch or per host.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Add `throttle` to a stitch when you need to stay under an API's rate limit and
+keep in-flight requests bounded — it spaces calls to a target rate and caps how
+many run at once, before any request leaves.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const search = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/search',
+    throttle: { rate: '5/s', concurrency: 2, scope: 'host' },
+});
+```
+
+Calls to `search()` are spaced to five per second with at most two running
+concurrently. When a call has to wait, the stitch emits a `progress` event with
+phase `throttled`, so a waiting call is visible on the event stream rather than
+silently stalled.
 
 ## Options
 
-Stub.
+`rate` is a string like `"5/s"` — a minimum spacing between successive calls,
+not a token bucket. `concurrency` caps simultaneous in-flight calls; either may
+be set on its own.
+
+`scope` decides what shares the budget: `'stitch'` (the default) gives each
+stitch its own budget, while `'host'` pools the budget across every stitch
+hitting the same host — use it when one API publishes a single account-wide
+limit. Throttle state lives in the stitch store, so giving stitches a shared
+[store](/docs/guides/state/pluggable-store) turns a single-process budget into a
+[distributed one](/docs/guides/state/distributed-throttle) that spans workers.
+
+<Callout type="info">
+    A throttled wait surfaces as a `throttled` progress phase on the event
+    stream — see [The event stream](/docs/concepts/event-stream).
+</Callout>
+
+See [Reference → Config types](/docs/reference/config-types) for every field.
 
 ## See also
 
-Stub.
+<Cards>
+    <Card
+        title="Distributed throttle"
+        href="/docs/guides/state/distributed-throttle"
+    />
+    <Card title="Pluggable store" href="/docs/guides/state/pluggable-store" />
+    <Card title="Retry" href="/docs/guides/resilience/retry" />
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+    <Card title="Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/guides/resilience/timeout.mdx
+++ b/apps/docs/content/docs/guides/resilience/timeout.mdx
@@ -3,16 +3,58 @@ title: 'Timeouts'
 description: 'Enforce total and per-attempt timeouts with a real AbortSignal.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Add `timeout` when a slow or hung response shouldn't be allowed to block the
+caller indefinitely — the stitch bounds the call with a real `AbortSignal`, so a
+breached deadline actually aborts the in-flight request rather than leaking it.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const report = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/report',
+    timeout: { total: '10s', perAttempt: '3s' },
+});
+```
+
+Each call to `report()` gives every attempt at most 3 seconds and the whole call
+at most 10 seconds; whichever fires first aborts the request.
 
 ## Options
 
-Stub.
+`total` bounds the entire call across every retry; `perAttempt` bounds each
+individual attempt on its own. Both accept either a number of milliseconds
+(`3000`) or a duration string (`'3s'`), so `total: '10s'` and `total: 10000` are
+equivalent.
+
+The deadline is backed by a real `AbortSignal`: when it elapses the stitch
+aborts the underlying request — the connection is actually cancelled, not just
+ignored — and the call fails with a timeout.
+
+With [retry](/docs/guides/resilience/retry), the two timeouts compose: each try
+is gated by `perAttempt`, while `total` caps the sum of all tries plus their
+backoff waits, so a long enough `total` is what lets a slow attempt be retried at
+all.
+
+<Callout type="warn">
+    A breached deadline aborts the call and surfaces as a timeout error. See
+    [STITCH_TIMEOUT](/docs/errors/stitch-timeout) for how it reads and how to
+    fix it.
+</Callout>
+
+See [Reference → Config types](/docs/reference/config-types) for the full
+`TimeoutOptions` shape.
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Retry" href="/docs/guides/resilience/retry" />
+    <Card
+        title="Circuit breaker"
+        href="/docs/guides/resilience/circuit-breaker"
+    />
+    <Card title="STITCH_TIMEOUT" href="/docs/errors/stitch-timeout" />
+    <Card title="Reference: Config types" href="/docs/reference/config-types" />
+</Cards>


### PR DESCRIPTION
Fills all five **Guides · Resilience** stubs — one agent per page, centrally verified. Guide template throughout.

## Pages
- **Retry & backoff** — `attempts`, status `on`, expo/jitter/fixed backoff, `respectRetryAfter`.
- **Throttle** — `rate` + `concurrency`, `scope` per stitch or host.
- **Timeouts** — `total` and `perAttempt`, enforced with a real `AbortSignal`.
- **Circuit breaker** — open after `failureThreshold`, `cooldownMs`, half-open trial, shared `key`.
- **Idempotency keys** — stable `key` on writes so safe retries don't duplicate side effects.

## Verification
- Every Twoslash example imports `@stitchapi/core` and matches the option types in `types.ts` (the custom idempotency `key` narrows the `unknown` body so it type-checks).
- All links resolve; cross-links to the event stream and the timeout/circuit error pages; full type tables deferred to Reference.
- Full `next build` renders all 180 pages clean (exit 0).

Independent, content-only branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)