### PR TITLE
docs: author Guides · Data shaping (unwrap, transform, pagination, body-encoding, graphql)

### DIFF
--- a/apps/docs/content/docs/guides/data/body-encoding.mdx
+++ b/apps/docs/content/docs/guides/data/body-encoding.mdx
@@ -3,16 +3,48 @@ title: 'Body encoding'
 description: 'Send request bodies as json, form, or multipart.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Set `bodyType` when an API expects a request body in a particular wire format —
+JSON, URL-encoded form, or multipart form data — and you want the stitch to
+serialize the `body` you pass at call time into that shape.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const submit = stitch({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/submit',
+    bodyType: 'form',
+});
+
+await submit({ body: { name: 'mango', qty: 3 } });
+```
+
+The body travels in the call input, not the config: `submit` encodes
+`{ name: 'mango', qty: 3 }` as an `application/x-www-form-urlencoded` body
+because `bodyType` is `'form'`.
 
 ## Options
 
-Stub.
+`bodyType` chooses how the call-time `body` is encoded (default `'json'`):
+
+-   `json` — a JSON body with `Content-Type: application/json`. The default;
+    reach for it for ordinary REST payloads.
+-   `form` — a URL-encoded `application/x-www-form-urlencoded` body, for APIs
+    that expect classic HTML-form fields (login forms, OAuth token exchanges).
+-   `multipart` — multipart form data, for file uploads and mixed
+    field-plus-binary payloads; the boundary is set for you.
+
+The body itself always comes from the call input (`await submit({ body })`),
+never from the config — so one stitch encodes whatever you pass it. See
+[Guide → stitch()](/docs/guides/authoring/stitch) for the full configuration.
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="stitch()" href="/docs/guides/authoring/stitch" />
+    <Card title="GraphQL" href="/docs/guides/data/graphql" />
+    <Card title="Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/guides/data/graphql.mdx
+++ b/apps/docs/content/docs/guides/data/graphql.mdx
@@ -3,16 +3,52 @@ title: 'GraphQL'
 description: 'Call a GraphQL endpoint with variables, unwrap data, and treat a 200 carrying errors as a failure.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Use `graphql()` when an API speaks GraphQL-over-HTTP and you want a stitch that
+POSTs a query, passes variables per call, and hands back the `data` payload
+already unwrapped — with a `200` that carries an `errors` array treated as a
+failure, not a success.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { graphql } from '@stitchapi/core';
+
+const getUser = graphql<{ user: { id: string; name: string } }>({
+    baseUrl: 'https://api.example.com',
+    path: '/graphql',
+    query: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
+});
+
+// Variables travel in the input; the result is already unwrapped from `data`.
+const data = await getUser({ variables: { id: '1' } });
+```
 
 ## Options
 
-Stub.
+`graphql()` is a preset over `stitch()`: it fixes `kind: 'graphql'`,
+`method: 'POST'`, and `unwrap: 'data'` for you. You supply the GraphQL document
+as `query`, plus a `baseUrl`/`path` pointing at the endpoint.
+
+Pass GraphQL variables through the input's `variables` field at call time —
+`getUser({ variables: { id: '1' } })` — so one stitch serves every set of
+arguments. Because `unwrap` defaults to `'data'`, the resolved value is the
+contents of the response's `data` object; override `unwrap` if you need a
+different field or the raw envelope.
+
+<Callout type="warn">
+    A GraphQL endpoint can return HTTP `200` while reporting an `errors` array
+    in the body. The stitch treats that as a failure and surfaces it — see
+    [STITCH_GRAPHQL](/docs/errors/stitch-graphql).
+</Callout>
+
+For the full set of fields a stitch accepts, see
+[Reference → Config types](/docs/reference/config-types).
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Unwrap" href="/docs/guides/data/unwrap" />
+    <Card title="Validation" href="/docs/guides/validation/validation" />
+    <Card title="STITCH_GRAPHQL" href="/docs/errors/stitch-graphql" />
+    <Card title="Reference: Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/guides/data/pagination.mdx
+++ b/apps/docs/content/docs/guides/data/pagination.mdx
@@ -3,16 +3,63 @@ title: 'Pagination'
 description: 'Auto-loop pages and aggregate items, with auth, retry, and throttle applied to every page.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Add `paginate` when one logical call spans many pages and you want the stitch to
+follow them for you — it loops until you say stop, aggregates every page's items
+into one array, and applies auth, retry, and throttle to each page along the way.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const allUsers = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users',
+    paginate: {
+        next: (prevBody) => {
+            const cursor = (prevBody as { nextCursor?: string }).nextCursor;
+            return cursor ? { query: { cursor } } : undefined;
+        },
+        items: (value) => (value as { results: unknown[] }).results,
+        max: 20,
+    },
+});
+```
+
+Each page reads `nextCursor` off the raw body and asks for the next page; when
+the body has no cursor, `next` returns `undefined` and the loop stops. `prevBody`
+and `value` arrive as `unknown` — narrow them before you reach in.
 
 ## Options
 
-Stub.
+`next(prevBody, pagesFetched)` receives the previous page's raw body plus the
+page count and returns the [`StitchInput`](/docs/reference/config-types) for the
+next page, merged over the original call — set only what changes, like a cursor
+or page number. Return `undefined` to stop.
+
+`items(value)` selects the array to aggregate from each page's unwrapped value;
+it defaults to the value itself when that value is already an array. The unwrap
+runs first, so pair `items` with [`unwrap`](/docs/guides/data/unwrap) when the
+array sits under an envelope, and use `items` to dig into a nested shape.
+
+`max` caps the page count as a safety net (default `50`) so a misbehaving
+`next` can't loop forever.
+
+Auth, retry, and throttle apply per page, not once for the whole run: a
+[`throttle`](/docs/guides/resilience/throttle) of `"2/s"` paces the page loop,
+and a [`retry`](/docs/guides/resilience/retry) recovers each page on its own.
+
+<Callout type="warn">
+    `next` reads the raw body; `items` reads the value after `unwrap`. Reach for
+    the cursor in `next` from where it actually lives in the response, not from
+    the unwrapped array.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="unwrap" href="/docs/guides/data/unwrap" />
+    <Card title="throttle" href="/docs/guides/resilience/throttle" />
+    <Card title="retry" href="/docs/guides/resilience/retry" />
+    <Card title="Reference: Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/guides/data/transform.mdx
+++ b/apps/docs/content/docs/guides/data/transform.mdx
@@ -3,16 +3,52 @@ title: 'transform'
 description: 'Reshape a response before unwrap and validation — for example, scrape HTML into structured data.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Use `transform` when the raw response isn't yet the shape the rest of the
+pipeline expects — scrape HTML text into a structured object, or flatten an odd
+envelope — so a single function reshapes the body before unwrap and validation
+ever see it.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const listing = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/listings',
+    // The body is `unknown` — narrow it, then reshape the raw envelope into a
+    // plain array before unwrap and validation run.
+    transform: (body) => (body as { results: unknown[] }).results,
+});
+```
+
+The raw body arrives as a wrapped `{ results: [...] }`; `transform` returns the
+inner array, and everything downstream works against that array instead.
 
 ## Options
 
-Stub.
+`transform?: (body: unknown) => unknown` runs **first** in the response
+pipeline — before [`unwrap`](/docs/guides/data/unwrap) and before
+[validation](/docs/guides/validation/validation) (and
+[drift](/docs/guides/validation/drift)). That ordering is the point: reshape a
+raw body — scrape HTML text into a structured object, or flatten an odd
+envelope — into the shape unwrap and validation are written for, rather than
+bending them around the source's quirks.
+
+`body` is typed `unknown`, so narrow it before reading (a cast or a type guard)
+and return any reshaped value. See
+[Reference → Config types](/docs/reference/config-types) for every field.
+
+<Callout type="warn">
+    `transform` runs before validation, so its output is unchecked — a wrong
+    narrowing surfaces later as drift, not here.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="unwrap" href="/docs/guides/data/unwrap" />
+    <Card title="Validation" href="/docs/guides/validation/validation" />
+    <Card title="Drift" href="/docs/guides/validation/drift" />
+    <Card title="Reference: Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/guides/data/unwrap.mdx
+++ b/apps/docs/content/docs/guides/data/unwrap.mdx
@@ -3,16 +3,48 @@ title: 'unwrap'
 description: 'Pull just the part of the response you want by dot-path.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Use `unwrap` when an API wraps the value you want in an envelope and you want
+the stitch to hand back the inner field directly — give it a dot-path and the
+caller never sees the wrapper.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const getUser = stitch<{ id: number; name: string }>({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    unwrap: 'data.user',
+});
+
+// `user` is the inner { id, name } object, not the { data: { user } } envelope.
+const user = await getUser({ params: { id: 1 } });
+```
 
 ## Options
 
-Stub.
+`unwrap` takes a **dot-path** — each segment selects a nested key, so
+`'data.user'` reaches into `{ data: { user: ... } }` and returns the inner
+object.
+
+It sits late in the pipeline: a response is reshaped by
+[`transform`](/docs/guides/data/transform) first, then `unwrap` selects the
+slice, and only then does [validation](/docs/guides/validation/validation) run —
+so a schema sees the unwrapped value, not the envelope. For paged calls, each
+page is unwrapped before its items are collected; see
+[Pagination](/docs/guides/data/pagination).
+
+Pair `unwrap` with the generic on `stitch<T>()` to type the result: the stitch
+returns `T` (the unwrapped value), not the envelope. See
+[Reference → Config types](/docs/reference/config-types) for the full config
+shape.
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="transform" href="/docs/guides/data/transform" />
+    <Card title="Pagination" href="/docs/guides/data/pagination" />
+    <Card title="Validation" href="/docs/guides/validation/validation" />
+    <Card title="Config types" href="/docs/reference/config-types" />
+</Cards>


### PR DESCRIPTION
Fills all five **Guides · Data shaping** stubs — one agent per page, centrally verified. Guide template throughout.

## Pages
- **unwrap** — pull a nested field by dot-path (runs after `transform`, before validation; pairs with the generic for typing).
- **transform** — reshape the raw body before unwrap/validation (e.g. scrape an envelope; the `unknown` body is narrowed).
- **Pagination** — auto-loop via `next(prevBody, n)`, aggregate `items`, `max` cap; auth/retry/throttle applied per page.
- **Body encoding** — `bodyType`: `json` / `form` / `multipart`.
- **GraphQL** — the `graphql()` preset (POST, `unwrap: 'data'`), `variables` input, and 200-carrying-errors → failure.

## Verification
- Every Twoslash example imports `@stitchapi/core` and matches `types.ts` + the `graphql()` helper; all `unknown` bodies are narrowed so the snippets type-check.
- Pipeline order (transform → unwrap → validate) confirmed against `engine.ts`.
- All links resolve; full `next build` renders all 180 pages clean (exit 0).

Independent, content-only branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)