### PR TITLE
docs: author Guides · Validation & drift (validation, drift, standard-schema)

### DIFF
--- a/apps/docs/content/docs/guides/validation/drift.mdx
+++ b/apps/docs/content/docs/guides/validation/drift.mdx
@@ -3,16 +3,62 @@ title: 'Leveled drift'
 description: 'Detect silent contract changes as leveled findings (error/warn/info) against a committed snapshot.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Wrap a stitch's `output` with `drift` when you want to catch an API quietly
+changing shape — a field dropped, a type flipped, a new key appearing — and
+classify each change as `error`, `warn`, or `info` against a committed
+baseline.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { drift, stitch } from '@stitchapi/core';
+import { z } from 'zod';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    output: drift(z.object({ id: z.number(), email: z.string() }), {
+        critical: ['id'],
+        watch: ['email'],
+        snapshotFile: 'users.contract.json',
+    }),
+});
+```
+
+The first call records the baseline; every call after compares the response
+against `users.contract.json` and emits any deltas as leveled findings.
 
 ## Options
 
-Stub.
+`critical` lists paths whose change is an `error`; `watch` lists paths whose
+change is a `warn`; everything else that moves is a `warn` too. `onNew` sets the
+level for brand-new fields (default `'info'`). `snapshotFile` names the
+committed baseline — a `<name>.contract.json` you check into the repo.
+
+Each finding rides the event stream as a `drift` event. An `error`-level finding
+breaks the contract and surfaces as
+[STITCH_DRIFT](/docs/errors/stitch-drift); `warn` and `info` findings are
+reported but do not fail the call, so you watch a field erode before it breaks.
+
+This is the opposite end from plain
+[Validation](/docs/guides/validation/validation): validation rejects a single
+malformed response hard, here and now, while drift watches for the _silent_
+contract change across calls and lets you triage it by severity.
+
+<Callout type="info">
+    Findings arrive as `drift` events on
+    [the event stream](/docs/concepts/event-stream) — subscribe to inspect
+    `warn` and `info` levels that never throw.
+</Callout>
+
+See [Reference → Config types](/docs/reference/config-types) for the full
+`DriftOptions` and `DriftFinding` tables.
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Validation" href="/docs/guides/validation/validation" />
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+    <Card title="STITCH_DRIFT" href="/docs/errors/stitch-drift" />
+    <Card title="Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/guides/validation/drift.mdx
+++ b/apps/docs/content/docs/guides/validation/drift.mdx
@@ -46,9 +46,9 @@ malformed response hard, here and now, while drift watches for the _silent_
 contract change across calls and lets you triage it by severity.
 
 <Callout type="info">
-    Findings arrive as `drift` events on
-    [the event stream](/docs/concepts/event-stream) — subscribe to inspect
-    `warn` and `info` levels that never throw.
+    Findings arrive as `drift` events on [the event
+    stream](/docs/concepts/event-stream) — subscribe to inspect `warn` and
+    `info` levels that never throw.
 </Callout>
 
 See [Reference → Config types](/docs/reference/config-types) for the full

--- a/apps/docs/content/docs/guides/validation/standard-schema.mdx
+++ b/apps/docs/content/docs/guides/validation/standard-schema.mdx
@@ -3,16 +3,49 @@ title: 'Standard Schema'
 description: 'Bring any Standard Schema validator — Zod, Valibot, ArkType — for validation and inferred types.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Reach for this when you already have a schema and want a stitch to validate
+against it — StitchAPI is validator-agnostic, so any [Standard Schema](https://standardschema.dev)
+validator (Zod, Valibot, ArkType), a plain predicate, or a `Validator` works,
+adapted by the single `toValidator()` helper.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch, toValidator } from '@stitchapi/core';
+import { z } from 'zod';
+
+const User = z.object({ id: z.number(), name: z.string() });
+
+const getUser = stitch<{ id: number; name: string }>({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    output: toValidator(User),
+});
+```
+
+The `output` schema runs against each response; pairing it with the
+`stitch<{ id: number; name: string }>` generic types the validated result.
 
 ## Options
 
-Stub.
+A config's `input` and `output` fields are typed as `Validator`, so a raw
+`z.object(...)` is not directly assignable — wrap it with `toValidator()`. That
+helper is the single adapter: it coerces Zod (`safeParse`), any Standard Schema
+(`~standard`), or a plain predicate into the `Validator` the config expects.
+
+Valibot and ArkType need no special handling — they implement Standard Schema,
+so they go through the same `toValidator()` call identically. Pass an
+already-built `Validator` straight through.
+
+<Callout type="info">
+    Pair `toValidator()` with the `stitch<T>()` generic so the typed result and
+    the runtime check come from one source.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Validation" href="/docs/guides/validation/validation" />
+    <Card title="Drift" href="/docs/guides/validation/drift" />
+    <Card title="Reference → Helpers" href="/docs/reference/helpers" />
+</Cards>

--- a/apps/docs/content/docs/guides/validation/validation.mdx
+++ b/apps/docs/content/docs/guides/validation/validation.mdx
@@ -3,16 +3,64 @@ title: 'Validation'
 description: 'Validate params, query, body, headers, and the response, failing fast before the request when input is wrong.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Use validation when you want a stitch to reject bad input before it leaves the
+process and to verify the response once it arrives — input is checked _before_
+the request, so wrong params, query, body, or headers fail fast with no network
+call.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch, toValidator } from '@stitchapi/core';
+import { z } from 'zod';
+
+const createUser = stitch<{ id: number; name: string }>({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/users',
+    input: { body: toValidator(z.object({ name: z.string() })) },
+    output: toValidator(z.object({ id: z.number(), name: z.string() })),
+});
+```
+
+A bad `body` rejects before the POST is sent; a response that doesn't match
+`output` rejects after. Either way the stitch throws
+[STITCH_VALIDATION](/docs/errors/stitch-validation), and the `stitch<T>` generic
+keeps the resolved value typed as `{ id: number; name: string }`.
 
 ## Options
 
-Stub.
+`input` is a map of `{ params, query, body, headers }`, each an optional
+`Validator`. Every entry present is validated against the call input _before_
+the request — the fail-fast guarantee — so the request never goes out with input
+the API would reject.
+
+`output` is a single `Validator` that checks the response body after it returns.
+(Pass a `drift()` spec here instead to report changes without throwing — see
+[Schema drift detection](/docs/guides/validation/drift).)
+
+The config fields are typed as `Validator`, and a raw Zod, Valibot, or ArkType
+schema is not structurally a `Validator`. Adapt it with `toValidator()`, which
+coerces a Zod schema, any Standard Schema, or a predicate into a `Validator` —
+see [Bring your own validator](/docs/guides/validation/standard-schema) for the
+full story.
+
+<Callout type="warn">
+    Pass `toValidator(z.object({...}))`, not a raw `z.object({...})` — the raw
+    schema won't satisfy the `Validator` type on `input`/`output`.
+</Callout>
+
+See [Reference → Config types](/docs/reference/config-types) for every field on
+`input` and `output`.
 
 ## See also
 
-Stub.
+<Cards>
+    <Card
+        title="Bring your own validator"
+        href="/docs/guides/validation/standard-schema"
+    />
+    <Card title="Schema drift detection" href="/docs/guides/validation/drift" />
+    <Card title="STITCH_VALIDATION" href="/docs/errors/stitch-validation" />
+    <Card title="Reference: Config types" href="/docs/reference/config-types" />
+</Cards>


### PR DESCRIPTION
Fills all three **Guides · Validation & drift** stubs — one agent per page, centrally verified. Guide template throughout.

## Pages
- **Validation** — `input` (params/query/body/headers) validated fail-fast *before* the request, plus response `output` validation.
- **Leveled drift** — `drift(schema, options)`: error/warn/info findings against a committed snapshot; an error-level finding breaks the contract (`STITCH_DRIFT`), emitted as `drift` events.
- **Standard Schema** — bring Zod / Valibot / ArkType via the exported `toValidator()` adapter.

## Accuracy note (worth a follow-up)
The config's `input`/`output` are typed as `Validator`, but a raw `z.object(...)` is **not** structurally a `Validator` — so the examples wrap schemas with the exported **`toValidator()`** to stay type-correct (`drift()` takes a raw schema directly, so it doesn't need wrapping). The runtime's `toValidator` already coerces raw Zod/Standard Schema, so relaxing the `input`/`output` field types to accept `StandardSchemaV1` directly would let users drop the `toValidator()` wrapper — a small type-relaxation worth making (same family as the `@stitchapi/core` naming gap).

## Verification
- Every Twoslash example imports `@stitchapi/core` (+ `zod`) and is type-correct against `types.ts`/`validator.ts`.
- All links resolve; full `next build` renders all 180 pages clean (exit 0).

Independent, content-only branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)