### PR TITLE
docs: author Guides · Observability + State & stores (5 pages)

### DIFF
--- a/apps/docs/content/docs/guides/observability/otlp.mdx
+++ b/apps/docs/content/docs/guides/observability/otlp.mdx
@@ -3,16 +3,64 @@ title: 'OTLP export'
 description: 'Export traces as OpenTelemetry spans for your existing observability stack.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Reach for OTLP export when you want a stitch's events as OpenTelemetry spans in
+the observability stack you already run — each call's event stream maps to one
+CLIENT span, so a stitch drops into your existing OTel collector with no new
+plumbing. It is just another [trace sink](/docs/guides/observability/trace-sinks),
+teed alongside the console/JSONL sink rather than replacing it.
 
 ## Example
 
-Stub.
+The zero-code path is an env toggle: set `STITCH_EXPORT=otlp` and every stitch
+also fans its events to an OTLP collector (default
+`http://localhost:4318/v1/traces`, or `OTEL_EXPORTER_OTLP_ENDPOINT`).
+
+```bash
+STITCH_EXPORT=otlp OTEL_EXPORTER_OTLP_ENDPOINT=https://api.example.com node app.js
+```
+
+To wire it yourself — to set headers, or to tee OTLP next to your own sink —
+build the sink with `otlpTrace()` and combine sinks with `multiplex`:
+
+```ts twoslash
+import { createTrace, multiplex, otlpTrace } from '@stitchapi/core';
+
+const trace = multiplex(
+    createTrace({ console: true }),
+    otlpTrace({
+        endpoint: 'https://api.example.com',
+        headers: { authorization: 'Bearer token' },
+    }),
+);
+```
 
 ## Options
 
-Stub.
+`STITCH_EXPORT=otlp` is the toggle (a comma list, e.g. `console,otlp`);
+`OTEL_EXPORTER_OTLP_ENDPOINT` sets the collector base URL.
+
+`otlpTrace(opts?)` returns a sink. `OtlpOptions` carries `endpoint` (OTLP/HTTP
+base URL), `headers` (extra headers on the POST, e.g. auth), and `exporter` (a
+custom `SpanExporter` destination, defaulting to the built-in HTTP exporter).
+
+`otlpHttpExporter({ endpoint?, headers? })` is that default exporter — it POSTs
+OTLP/JSON to `${endpoint}/v1/traces`. `toOtlpJson(spans)` serializes collected
+spans to the OTLP/JSON `ResourceSpans` shape a collector accepts, if you ship
+them some other way.
+
+See [Reference → Helpers](/docs/reference/helpers) for the helper signatures and
+[Reference → Events](/docs/reference/events) for the event types each span is
+built from.
+
+<Callout type="warn">
+    Export is fire-and-forget: a missing collector or network error drops the
+    batch and never breaks a stitch call.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Trace sinks" href="/docs/guides/observability/trace-sinks" />
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+    <Card title="Reference: Helpers" href="/docs/reference/helpers" />
+</Cards>

--- a/apps/docs/content/docs/guides/observability/trace-sinks.mdx
+++ b/apps/docs/content/docs/guides/observability/trace-sinks.mdx
@@ -3,16 +3,74 @@ title: 'Trace sinks'
 description: 'Emit the event stream to the console or a JSONL file, or plug in your own TraceSink.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+A trace sink is any consumer of a stitch's [event stream](/docs/concepts/event-stream) —
+reach for one when you want every `start → progress → drift → result → done`
+teed somewhere durable. By default a stitch writes JSONL to disk with zero infra;
+flip an env var for a console stream, or iterate `.stream()` to handle events
+yourself.
 
 ## Example
 
-Stub.
+Sinks are wired globally by environment variable — there is no per-stitch `trace`
+config field. With no flags set, a stitch already appends every event as JSONL to
+`~/.stitch/runs/proto.jsonl`; nothing to deploy.
+
+```bash
+# Pretty one-line-per-event stream to stderr, on top of the JSONL file.
+STITCH_TRACE_CONSOLE=1 node run.js
+
+# Send the JSONL somewhere else.
+STITCH_TRACE_FILE=./runs/today.jsonl node run.js
+
+# ALSO fan the same events to an OTLP collector.
+STITCH_EXPORT=otlp node run.js
+```
+
+To consume events as your own sink, iterate the stream — that's the public seam
+for custom handling:
+
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+
+const search = stitch({ baseUrl: 'https://api.example.com', path: '/search' });
+
+for await (const event of search({ query: { q: 'mango' } }).stream()) {
+    if (event.type === 'drift')
+        console.log(event.finding.level, event.finding.path);
+    if (event.type === 'result') console.log(event.value);
+}
+```
 
 ## Options
 
-Stub.
+The built-in sink is controlled by three env vars: `STITCH_TRACE_CONSOLE=1`
+turns on the colored stderr stream (off unless set); `STITCH_TRACE_FILE=<path>`
+overrides the JSONL destination, which defaults to `~/.stitch/runs/proto.jsonl`;
+and `STITCH_EXPORT=otlp` adds OTLP as one more sink fed from the same events —
+see [OTLP export](/docs/guides/observability/otlp).
+
+To build sinks in code instead, `createTrace({ console, file })` returns a sink
+that writes JSONL and/or the console stream, and `multiplex(a, b, ...)` fans one
+event stream out to several sinks at once. Both are exported from
+[`@stitchapi/core`](/docs/reference/helpers).
+
+A `TraceSink` is just `{ handle(event, ctx), flush?() }` — implement those two
+and you have a custom consumer you can pass to `multiplex`. The same shape backs
+the console, JSONL, and OTLP sinks, which is why all three come from one source
+without the call site knowing. See [Reference → Helpers](/docs/reference/helpers)
+for the exported building blocks and [Reference → Event types](/docs/reference/events)
+for the `StitchEvent` union a sink receives.
+
+<Callout type="warn">
+    `STITCH_TRACE_CONSOLE` is off by default — a bare run writes the JSONL file
+    but prints nothing. Set it to `1` when you want events on the terminal.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+    <Card title="OTLP export" href="/docs/guides/observability/otlp" />
+    <Card title="Helpers" href="/docs/reference/helpers" />
+    <Card title="Event types" href="/docs/reference/events" />
+</Cards>

--- a/apps/docs/content/docs/guides/state/distributed-throttle.mdx
+++ b/apps/docs/content/docs/guides/state/distributed-throttle.mdx
@@ -3,16 +3,55 @@ title: 'Distributed throttle'
 description: 'Share one rate budget across workers by pointing the throttle at a shared store.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+By default a stitch keeps its throttle counters in the in-memory store, so the
+rate budget is per process — each worker gets its own. Point the throttle at a
+shared `store` and one budget spans every worker that uses it.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+import type { StitchStore } from '@stitchapi/core';
+
+// A Redis- or Postgres-backed store, shared across workers — see The pluggable store.
+declare const sharedStore: StitchStore;
+
+const search = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/search',
+    throttle: { rate: '10/s', scope: 'host' },
+    store: sharedStore, // the budget now spans all workers using this store
+});
+```
 
 ## Options
 
-Stub.
+`throttle` sets the limits — `rate` (e.g. `'10/s'`), `concurrency`, and
+`scope` — while `store` decides where the counters live. The default in-memory
+store is single-process, so each worker enforces `10/s` on its own and the fleet
+runs at `10/s × workers`. A shared store holds the rate counter as a fixed-window
+count every worker increments, so the whole fleet shares one `10/s` budget.
+(Concurrency stays in-process; only the rate limit is distributed.)
+
+`scope` decides what shares a budget: `'stitch'` (the default) gives each stitch
+its own counter keyed by name, while `'host'` keys by origin so every stitch
+hitting `api.example.com` draws from one budget. Workers share a budget only when
+they point at the same store and resolve to the same key — same scope, same
+stitch name or host.
+
+<Callout type="info">
+    The same shared store also backs auth sessions, so one store gives you both
+    a fleet-wide rate budget and a shared session — see Shared sessions.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card
+        title="The pluggable store"
+        href="/docs/guides/state/pluggable-store"
+    />
+    <Card title="Throttle" href="/docs/guides/resilience/throttle" />
+    <Card title="Shared sessions" href="/docs/guides/state/shared-sessions" />
+    <Card title="Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/guides/state/pluggable-store.mdx
+++ b/apps/docs/content/docs/guides/state/pluggable-store.mdx
@@ -3,16 +3,70 @@ title: 'The pluggable store'
 description: 'Swap the in-memory store for a shared one to back throttle and sessions with get/set/incr + TTL.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Swap the in-memory store for a shared one when you want throttle counters and
+auth sessions to live outside a single process — back them with Redis, Postgres,
+or anything else by implementing three async methods and attaching it via
+`store`.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch } from '@stitchapi/core';
+import type { StitchStore } from '@stitchapi/core';
+
+// A StitchStore is just three async methods + TTL — back it with anything.
+const redisStore: StitchStore = {
+    async get(key) {
+        /* read from your shared backend */
+        return undefined;
+    },
+    async set(key, value, ttlMs) {
+        /* write, honoring ttlMs */
+    },
+    async incr(key, ttlMs) {
+        /* atomic counter with a TTL window */
+        return 1;
+    },
+};
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    store: redisStore,
+});
+```
 
 ## Options
 
-Stub.
+A store is the `StitchStore` contract — three async methods: `get(key)` returns
+the value or `undefined`, `set(key, value, ttlMs?)` writes with an optional
+expiry, and `incr(key, ttlMs)` is an atomic counter scoped to a TTL window. The
+runtime holds two kinds of state behind this interface: throttle counters (the
+fixed-window rate counter) and auth session/token state (captured cookies and
+refreshed tokens).
+
+The default is `memoryStore()` — single process, in-memory. It works until you
+run more than one worker, where each process keeps its own counters and its own
+sessions.
+
+Point `store` at one shared backend and that splits apart: the rate counter
+becomes a single window every process increments, so the limit holds across the
+fleet — see [Distributed throttle](/docs/guides/state/distributed-throttle) —
+and a captured session is written once and replayed everywhere, so workers don't
+each re-run the login — see [Shared sessions](/docs/guides/state/shared-sessions).
+
+<Callout type="info">
+    Concurrency limits stay in-process even with a shared store; only the rate
+    counter is distributed. See [throttle](/docs/guides/resilience/throttle).
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card
+        title="Distributed throttle"
+        href="/docs/guides/state/distributed-throttle"
+    />
+    <Card title="Shared sessions" href="/docs/guides/state/shared-sessions" />
+    <Card title="Reference: Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/guides/state/shared-sessions.mdx
+++ b/apps/docs/content/docs/guides/state/shared-sessions.mdx
@@ -3,16 +3,83 @@ title: 'Shared sessions'
 description: 'Persist and share a login across stitches and workers via a session key and a shared store.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Give two stitches the same auth `key` plus a shared `store` and they share one
+login: the session is captured once, replayed by every stitch that names the
+key, and — because the store backs it — it survives restarts and is shared
+across workers, not just within a single process.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { cookieSession, env, stitch } from '@stitchapi/core';
+import type { StitchStore } from '@stitchapi/core';
+
+// A Redis-backed StitchStore — see The pluggable store.
+declare const sharedStore: StitchStore;
+
+// The login is itself a stitch — its Set-Cookie response seeds the session.
+const login = stitch({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/login',
+    bodyType: 'form',
+});
+
+const me = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/me',
+    store: sharedStore,
+    auth: cookieSession({
+        login,
+        cookie: '*',
+        key: 'acme-session', // same key + same store = one shared session
+        loginInput: () => ({
+            body: { user: env('USER')(), pass: env('PASS')() },
+        }),
+    }),
+});
+```
+
+Any other stitch that points its `store` at `sharedStore` and passes
+`key: 'acme-session'` reuses the same captured session — it never re-runs the
+login.
 
 ## Options
 
-Stub.
+`key` is the store namespace the session is filed under. Two stitches that share
+a `key` read and write the same session entry; without it each stitch namespaces
+by its own cookie name (or token URL) and stays isolated.
+
+`store` is the backing store the session lives in. The default is in-memory and
+single-process; pointing `store` at a shared, durable store (Redis/Postgres) is
+what makes one login persist across restarts and serve every worker — see
+[The pluggable store](/docs/guides/state/pluggable-store). Within one process,
+[`.with()`](/docs/guides/authoring/with) already reuses the same in-memory
+session across calls.
+
+This works the same for tokens:
+[`oauth2`](/docs/guides/auth/oauth2) caches its access token under `key`, so a
+shared key plus a shared store means one token serves many stitches and workers
+and survives restarts, refreshed once for all of them.
+
+<Callout type="warn">
+    Sharing a session shares the capability, not the credential: callers still
+    only invoke the stitch. The boundary holds — the credential stays inside the
+    stitch and is never handed to the caller.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="cookieSession" href="/docs/guides/auth/cookie-session" />
+    <Card title="oauth2" href="/docs/guides/auth/oauth2" />
+    <Card
+        title="The pluggable store"
+        href="/docs/guides/state/pluggable-store"
+    />
+    <Card title=".with()" href="/docs/guides/authoring/with" />
+    <Card
+        title="Reference: Auth strategies"
+        href="/docs/reference/auth-strategies"
+    />
+</Cards>


### PR DESCRIPTION
Finishes the **Guides** section — the last five stubs (Observability + State & stores). One agent per page, centrally verified. Guide template throughout.

## Pages
- **Trace sinks** — tee the event stream to console/JSONL via env vars, compose with `createTrace`/`multiplex`, or consume `.stream()` yourself (the trace sink is env-wired — there's no per-stitch `trace` field).
- **OTLP export** — `STITCH_EXPORT=otlp`; `otlpTrace`/`otlpHttpExporter`/`toOtlpJson`.
- **The pluggable store** — the `StitchStore` `get`/`set`/`incr` + TTL contract; default `memoryStore()`.
- **Distributed throttle** — point `throttle` at a shared `store` to share one rate budget across workers.
- **Shared sessions** — `cookieSession`/`oauth2` `key` + a shared `store` to share/persist a login.

## Verification
- Examples match `trace.ts`/`otlp.ts`/`store.ts`/`auth.ts`; `StitchStore` typed via `import type` + `declare const` for shared-store snippets (type-correct without a concrete impl).
- All links resolve; full `next build` renders all 180 pages clean (exit 0).

With this, **all 28 Guides pages are authored** (across #24, #27, #28, #30, #31, #32, and this PR). Independent, content-only branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)