### PR TITLE
feat(core): add `url` as an atomic alternative to baseUrl/path

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -54,7 +54,12 @@ const listWebsites = stitch({
 });
 ```
 
-Everything except a target (a URL or `path`) is optional. The smallest possible stitch is `stitch('https://…')`.
+Everything except a target is optional. Spell the target one of two ways:
+
+-   **`url`** — the whole endpoint as one string (`url: 'https://api.example.com/users/{id}'`). The **atomic spelling**: reach for it when a stitch is exactly one endpoint with no base to share, so you don't pre-split into base + path for a composition that doesn't exist. Templated (`{param}`, including the host) and `?query`-aware just like `path`, and may be a function for lazy/env resolution.
+-   **`baseUrl` + `path`** — a shareable base joined to a per-endpoint path. The **composition spelling**: a `preset` supplies `baseUrl` once and each stitch supplies its own `path` (§4).
+
+The two are mutually exclusive — when both appear, `url` wins. The smallest possible stitch is `stitch('https://…')` (a bare string is shorthand for `path`; an absolute one resolves as-is). A target that resolves to a relative URL (a `path` with no `baseUrl`) is a config error under the default transport.
 
 ### Call convention **[decided]**
 
@@ -154,7 +159,7 @@ const getWebsite = stitch({
 
 ### Merge semantics **[proposed]**
 
--   **Scalars** (`path`, `method`, `baseUrl`, `unwrap`): replace.
+-   **Scalars** (`path`, `method`, `baseUrl`, `url`, `unwrap`): replace. The endpoint is one slot: `url` and `baseUrl`/`path` are mutually exclusive, so the last fragment to set either spelling wins it whole — a child `url` clears an inherited `baseUrl`/`path`, and a child `baseUrl`/`path` clears an inherited `url`.
 -   **Objects** (`retry`, `throttle`, `timeout`, `input`, auth options): deep-merge field-wise.
 -   **`hooks`**: **chain**, don't replace — base `onRequest` runs, then child's; `onResponse` unwinds child→base (middleware order). This is what makes a base like "always log + add trace header" actually composable.
 -   **`output` / contracts**: replace (a child declares its own); compose explicitly with `schema.merge(...)` when you want to extend.
@@ -296,7 +301,7 @@ await user({ params: { id: 1 }, query: { expand: 'roles' } });
 
 ```ts
 const users = stitch({
-    path: 'https://reqres.in/api/users',
+    url: 'https://reqres.in/api/users',
     output: User.array(),
     unwrap: 'data',
 });

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -104,11 +104,18 @@ function applyIdempotency(
         : randomUUID();
 }
 
+const resolveStr = (v: string | (() => string) | undefined): string =>
+    typeof v === 'function' ? v() : (v ?? '');
+
 function buildRequest(cfg: StitchConfig, input: StitchInput): AdapterRequest {
     const isGql = cfg.kind === 'graphql';
-    const base =
-        typeof cfg.baseUrl === 'function' ? cfg.baseUrl() : (cfg.baseUrl ?? '');
-    const raw = cfg.path ?? (isGql ? '/graphql' : '');
+    // Endpoint resolution: when `url` is set it IS the whole endpoint (no base), but still
+    // templated + query-split like a path. Otherwise join `baseUrl` + `path`.
+    const usingUrl = cfg.url !== undefined;
+    const base = usingUrl ? '' : resolveStr(cfg.baseUrl);
+    const raw = usingUrl
+        ? resolveStr(cfg.url)
+        : (cfg.path ?? (isGql ? '/graphql' : ''));
     const qIdx = raw.indexOf('?');
     let tpl = raw;
     let predefined: Record<string, unknown> = {};
@@ -123,6 +130,17 @@ function buildRequest(cfg: StitchConfig, input: StitchInput): AdapterRequest {
     const { path } = expandPath(tpl, input.params ?? {});
     const query = { ...predefined, ...(input.query ?? {}) };
     const url = joinUrl(base, path) + buildQuery(query);
+    // A relative endpoint can't be fetched by the default transport — fail with a clear config
+    // error here instead of a cryptic "Failed to parse URL" from fetch. A custom `adapter` may
+    // legitimately resolve relative URLs, so this only guards the default transport.
+    if (cfg.adapter === undefined && !/^https?:\/\//i.test(url)) {
+        const e = new Error(
+            `stitch ${JSON.stringify(nameOf(cfg))}: request URL ${JSON.stringify(url)} is not absolute. ` +
+                'Set `url` to a full endpoint, or give a relative `path` a `baseUrl` (e.g. from a shared preset).',
+        );
+        e.name = 'StitchConfigError';
+        throw e;
+    }
     const method = (cfg.method ?? (isGql ? 'POST' : 'GET')).toUpperCase();
     const headers = { ...(cfg.headers ?? {}), ...(input.headers ?? {}) };
     applyIdempotency(cfg, input, method, headers);
@@ -519,7 +537,14 @@ export async function* execute(
         return;
     }
 
-    const baseReq = buildRequest(cfg, input);
+    let baseReq: AdapterRequest;
+    try {
+        baseReq = buildRequest(cfg, input);
+    } catch (e) {
+        yield errEvt(e, name, 0);
+        yield doneEvt(false, t0, 0);
+        return;
+    }
     yield {
         type: 'start',
         name,

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -102,6 +102,16 @@ function compose(config: Fragment): StitchConfig {
         delete rest.hooks;
         delete rest.store;
         merged = deepMerge(merged, rest);
+        // Endpoint slot: `url` and `baseUrl`/`path` are two spellings of the same target, and
+        // deepMerge keeps them as separate keys. Reconcile so the last fragment to write either
+        // spelling wins the whole slot — a child `url` clears an inherited baseUrl/path, and a
+        // child baseUrl/path clears an inherited `url`.
+        if (rest.url !== undefined) {
+            delete merged.baseUrl;
+            delete merged.path;
+        } else if (rest.baseUrl !== undefined || rest.path !== undefined) {
+            delete merged.url;
+        }
     }
     const hooks = chainHooks(hookLayers);
     if (hooks) merged.hooks = hooks;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -168,9 +168,17 @@ export interface StitchConfig {
     bodyType?: 'json' | 'form' | 'multipart';
     /** How to read the response body. Default: auto by content-type. */
     responseType?: ResponseType;
-    /** Origin for the request, as a string or a thunk resolved at call time. */
+    /**
+     * Full request endpoint as one string — the atomic spelling, when a stitch is exactly one
+     * endpoint with no base to share. Templated (`{param}`, incl. the host) and `?query`-aware
+     * like `path`; may be a thunk for lazy/env resolution. Mutually exclusive with
+     * `baseUrl`/`path`: when both are set `url` wins, and across composed fragments the last
+     * fragment to write either spelling wins the whole slot.
+     */
+    url?: string | (() => string);
+    /** Origin for the request, as a string or a thunk resolved at call time. Ignored when `url` is set. */
     baseUrl?: string | (() => string);
-    /** Path appended to `baseUrl`; may include `{param}` slots and a `?query` string. */
+    /** Path appended to `baseUrl`; may include `{param}` slots and a `?query` string. Ignored when `url` is set. */
     path?: string;
     /** Static default headers merged into every request. */
     headers?: Record<string, string>;

--- a/packages/core/test/url-contract.spec.ts
+++ b/packages/core/test/url-contract.spec.ts
@@ -1,0 +1,109 @@
+import { preset, stitch } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-url-contract-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+// `url` is the atomic spelling: a single full endpoint, no base to share.
+test('url alone hits the endpoint', async () => {
+    server.route('GET', '/users', { body: { ok: true } });
+    const users = stitch({ url: `${server.url}/users` });
+    await expect(users()).resolves.toEqual({ ok: true });
+});
+
+test('url supports {param} templating and an appended query', async () => {
+    server.route('GET', '/users/1', { body: { id: 1 } });
+    const getUser = stitch({ url: `${server.url}/users/{id}` });
+    await expect(
+        getUser({ params: { id: 1 }, query: { expand: 'roles' } }),
+    ).resolves.toEqual({ id: 1 });
+    expect(server.calls('/users/1')[0]?.query).toEqual({ expand: 'roles' });
+});
+
+test('url may be a function (lazy/env resolution)', async () => {
+    server.route('GET', '/ping', { body: { ok: true } });
+    const ping = stitch({ url: () => `${server.url}/ping` });
+    await expect(ping()).resolves.toEqual({ ok: true });
+});
+
+// Precedence: when both spellings are present, `url` wins (resolved away at compose time).
+test('url takes precedence over baseUrl + path', async () => {
+    server.route('GET', '/right', { body: { hit: 'url' } });
+    const s = stitch({
+        url: `${server.url}/right`,
+        baseUrl: 'https://wrong.example.com',
+        path: '/wrong',
+    });
+    expect(s.__config.url).toBe(`${server.url}/right`);
+    expect(s.__config.baseUrl).toBeUndefined();
+    expect(s.__config.path).toBeUndefined();
+    await expect(s()).resolves.toEqual({ hit: 'url' });
+    expect(server.callCount('/right')).toBe(1);
+});
+
+// Composition: the endpoint is one mutually-exclusive slot — the last writer wins it whole.
+test('a child url overrides an inherited baseUrl/path', async () => {
+    server.route('GET', '/from-url', { body: { ok: true } });
+    const base = preset({
+        baseUrl: 'https://wrong.example.com',
+        path: '/wrong',
+    });
+    const s = stitch({ extends: [base], url: `${server.url}/from-url` });
+
+    expect(s.__config.url).toBe(`${server.url}/from-url`);
+    expect(s.__config.baseUrl).toBeUndefined();
+    expect(s.__config.path).toBeUndefined();
+    await expect(s()).resolves.toEqual({ ok: true });
+});
+
+test('a child baseUrl/path overrides an inherited url', async () => {
+    server.route('GET', '/from-path', { body: { ok: true } });
+    const base = preset({ url: 'https://wrong.example.com/wrong' });
+    const s = stitch({
+        extends: [base],
+        baseUrl: server.url,
+        path: '/from-path',
+    });
+
+    expect(s.__config.baseUrl).toBe(server.url);
+    expect(s.__config.path).toBe('/from-path');
+    expect(s.__config.url).toBeUndefined();
+    await expect(s()).resolves.toEqual({ ok: true });
+});
+
+// Guard: a relative endpoint can't be fetched — fail with a clear config error rather than a
+// cryptic transport error from fetch.
+test('a relative path with no baseUrl throws a clear config error', async () => {
+    const s = stitch({ path: '/relative' });
+    await expect(s()).rejects.toThrow(/not absolute/i);
+});
+
+test('a relative url throws a clear config error', async () => {
+    const s = stitch({ url: '/relative' });
+    await expect(s()).rejects.toThrow(/not absolute/i);
+});
+
+// Regression: an absolute string in `path` still resolves (the tolerant fallback).
+test('an absolute URL in path still works', async () => {
+    server.route('GET', '/legacy', { body: { ok: true } });
+    const s = stitch({ path: `${server.url}/legacy` });
+    await expect(s()).resolves.toEqual({ ok: true });
+});


### PR DESCRIPTION
## Summary

Adds a `url` field to the stitch call contract — the **atomic spelling** of an endpoint, as an alternative to the `baseUrl` + `path` split. A one-endpoint stitch no longer has to pre-factor a shared base it never reuses.

- `url` is templated (`{param}`, including the host) and `?query`-aware just like `path`, and may be a function for lazy/env resolution.
- `url` and `baseUrl`/`path` form one **mutually-exclusive endpoint slot**: when both appear `url` wins, and across composed fragments the last fragment to write either spelling wins it whole — `compose()` reconciles the keys, so a child `url` clears an inherited `baseUrl`/`path`, and a child `baseUrl`/`path` clears an inherited `url`.
- `buildRequest()` now guards the resolved URL: a relative endpoint (a `path` with no `baseUrl`) throws a clear `StitchConfigError` under the default transport instead of a cryptic fetch *"Failed to parse URL"*. A custom `adapter` may still resolve relative URLs.

## Why

`baseUrl`/`path` is a composition-oriented split (a shared base + a per-endpoint path); `url` is the right tool when a stitch is exactly one endpoint. Both stay first-class: `url` for atomic stitches, `baseUrl`/`path` for presets that share a base across many endpoints. See `docs/DESIGN.md` §3–§4.

## Tests

New `packages/core/test/url-contract.spec.ts` (9 tests): `url` resolution, `{param}` templating + query, function form, precedence over `baseUrl`/`path`, the composition slot in both directions, and the relative-URL guard.

Local: `vitest run` **108 passed (20 files)** · `tsc --noEmit` ×2 clean · `eslint src test` clean · `prettier --check` clean.

## Notes

Docs site (`apps/docs`) untouched — only `docs/DESIGN.md` was updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
