### PR TITLE
docs: author Surfaces (function, cli, http-serve, mcp)

### DIFF
--- a/apps/docs/content/docs/surfaces/cli.mdx
+++ b/apps/docs/content/docs/surfaces/cli.mdx
@@ -3,16 +3,74 @@ title: 'CLI'
 description: 'Run and trace stitches from the shell with stitch run and stitch trace.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Reach for the `stitch` CLI when you want to run a stitch and read its trace from
+the shell — no app boot. `stitch run <name>` streams a named stitch's events to
+stdout as JSONL, and `stitch trace` summarizes the run log those events leave
+behind.
 
 ## Example
 
-Stub.
+Author your stitches in a module that exports each one by name; the CLI
+discovers them there (default `./stitches.ts`, or pass `--module`).
+
+```ts twoslash
+// stitches.ts
+import { stitch } from 'stitchapi';
+
+export const getUser = stitch({
+    name: 'getUser',
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+});
+```
+
+Run it by name. A bare `--id` routes to the `{id}` path param, and every event
+is printed as one line of JSON, so the stream pipes straight into `jq`:
+
+```bash
+stitch run getUser --id 1
+```
+
+Then summarize what those runs recorded:
+
+```bash
+stitch trace --since 1h
+```
 
 ## Options
 
-Stub.
+**`stitch run <name> [--module <path>] [--flags…]`** resolves the stitch named
+`<name>` from the module and streams its event stream to stdout as JSONL — one
+JSON object per line, exit code `1` if an `error` event is seen. Flags map onto
+the stitch's single input object: a bare `--<k>` becomes a path param when `<k>`
+is a `{param}` in the path and a query param otherwise, while `--params.<k>`,
+`--query.<k>`, `--headers.<k>`, and `--body '<json>'` (or `--body.<k> <v>`)
+target a bucket explicitly. `--module, -m` points at the stitches module
+(default `./stitches.ts` and friends).
+
+**`stitch trace [--file <path>] [--since 1h] [--name <x>] [--json]`** folds the
+JSONL run log into per-stitch stats (runs, ok/failed, retries, drift, latency
+percentiles). `--file` picks the log (default `~/.stitch/runs/proto.jsonl`),
+`--since` keeps only records inside a window like `1h`/`30m`/`45s`/`2d`,
+`--name` filters to one stitch, and `--json` emits the raw summary instead of
+the aligned table.
+
+The CLI runs the very same stitch definition as the in-process
+[function](/docs/surfaces/function) — one source of truth, just a different
+front door. The JSONL that `run` streams and `trace` reads is the same log the
+built-in [trace sinks](/docs/guides/observability/trace-sinks) append to, so a
+stitch already records to `~/.stitch/runs/proto.jsonl` with no flags set.
+
+<Callout type="warn">
+    A `.ts` module loads only when the host has a TypeScript loader registered
+    (run under `tsx`); otherwise point `--module` at compiled JS.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Function" href="/docs/surfaces/function" />
+    <Card title="HTTP serve" href="/docs/surfaces/http-serve" />
+    <Card title="Trace sinks" href="/docs/guides/observability/trace-sinks" />
+    <Card title="run_stitch tool" href="/docs/agents/run-stitch-tool" />
+</Cards>

--- a/apps/docs/content/docs/surfaces/function.mdx
+++ b/apps/docs/content/docs/surfaces/function.mdx
@@ -3,16 +3,61 @@ title: 'In-process function'
 description: 'Call a stitch directly as a typed async function, awaited or streamed.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+A stitch is a typed async function — no server, no transport. `await` it for the
+final unwrapped, validated value, or iterate its event stream for everything that
+happened on the way there. This is the closest of the four surfaces: the same
+definition you call here also runs from the CLI, over HTTP, and through MCP.
 
 ## Example
 
-Stub.
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const getUser = stitch<{ id: number; name: string }>({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+});
+
+// Await it for just the value…
+const user = await getUser({ params: { id: 1 } });
+
+// …or iterate the typed event stream for everything that happened.
+for await (const event of getUser.stream({ params: { id: 1 } })) {
+    if (event.type === 'result') console.log(event.value);
+}
+```
 
 ## Options
 
-Stub.
+**Awaited vs streamed.** `await getUser(input)` resolves to the final value,
+already unwrapped and validated. `getUser.stream(input)` yields the typed
+[event stream](/docs/concepts/event-stream) — `start → progress → drift →
+result → done` — so you can observe retries, throttling, and drift as they
+happen. Same call, two altitudes.
+
+**Pre-binding input.** `getUser.with(partial)` returns a new stitch with part of
+the input baked in, so a shared header or a fixed path param is set once and
+reused across calls. See [`.with()` partial application](/docs/guides/authoring/with).
+
+**One definition, four surfaces.** The in-process function is one surface over a
+single definition. The same stitch is reachable from the [CLI](/docs/surfaces/cli),
+served over [HTTP](/docs/surfaces/http-serve), and exposed to agents through
+[MCP](/docs/surfaces/mcp) — nothing about the definition changes.
+
+<Callout type="info">
+    Calling the stitch returns a result you can both `await` and `.stream()`;
+    `getUser.stream(input)` is shorthand for streaming that same result.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+    <Card
+        title=".with() partial application"
+        href="/docs/guides/authoring/with"
+    />
+    <Card title="CLI" href="/docs/surfaces/cli" />
+    <Card title="HTTP serve" href="/docs/surfaces/http-serve" />
+    <Card title="MCP" href="/docs/surfaces/mcp" />
+</Cards>

--- a/apps/docs/content/docs/surfaces/http-serve.mdx
+++ b/apps/docs/content/docs/surfaces/http-serve.mdx
@@ -3,16 +3,61 @@ title: 'HTTP serve'
 description: "Expose a stitch over HTTP for callers that aren't in-process."
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Reach for `stitch serve` when a caller can't import your stitches in-process —
+a remote service, another language, a shell script — and you want to expose the
+registry of named stitches over a thin local HTTP front door instead.
 
 ## Example
 
-Stub.
+Start the server, then call a registered stitch by name with a JSON body:
+
+```bash
+# Serves the registry on http://127.0.0.1:8787 by default.
+stitch serve
+
+# List the available stitch names.
+curl http://127.0.0.1:8787/
+
+# Run the `me` stitch; the request body is its input.
+curl -X POST http://127.0.0.1:8787/stitch/me \
+  -H 'content-type: application/json' \
+  -d '{}'
+```
+
+The server runs the named stitch through the same engine as an in-process call
+and returns the final validated result as JSON.
 
 ## Options
 
-Stub.
+Two routes serve the registry of named stitches:
+
+- `GET /` lists the available stitch names.
+- `POST /stitch/:name` runs that stitch; the JSON request body is its input.
+  Any other method returns `405`, and an unknown name returns `404`.
+
+The server binds to `127.0.0.1:8787` by default. Responses are the final
+validated result as JSON; send `Accept: text/event-stream` (or add `?stream=1`)
+to receive the live event stream as SSE instead.
+
+<Callout type="warn">
+    Serving a stitch over HTTP changes nothing about the capability boundary —
+    auth, validation, and resilience still run server-side, exactly as they do
+    in-process. The HTTP route exposes the same stitch definition, not a looser
+    one.
+</Callout>
+
+A served stitch is the same definition as the in-process
+[function surface](/docs/surfaces/function) and the
+[`stitch` CLI](/docs/surfaces/cli) — one source of truth, three ways to call it.
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Function surface" href="/docs/surfaces/function" />
+    <Card title="CLI surface" href="/docs/surfaces/cli" />
+    <Card title="MCP surface" href="/docs/surfaces/mcp" />
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+    />
+</Cards>

--- a/apps/docs/content/docs/surfaces/http-serve.mdx
+++ b/apps/docs/content/docs/surfaces/http-serve.mdx
@@ -31,9 +31,9 @@ and returns the final validated result as JSON.
 
 Two routes serve the registry of named stitches:
 
-- `GET /` lists the available stitch names.
-- `POST /stitch/:name` runs that stitch; the JSON request body is its input.
-  Any other method returns `405`, and an unknown name returns `404`.
+-   `GET /` lists the available stitch names.
+-   `POST /stitch/:name` runs that stitch; the JSON request body is its input.
+    Any other method returns `405`, and an unknown name returns `404`.
 
 The server binds to `127.0.0.1:8787` by default. Responses are the final
 validated result as JSON; send `Accept: text/event-stream` (or add `?stream=1`)

--- a/apps/docs/content/docs/surfaces/mcp.mdx
+++ b/apps/docs/content/docs/surfaces/mcp.mdx
@@ -3,16 +3,68 @@ title: 'MCP'
 description: 'Expose a single code-mode run_stitch tool to agents instead of one tool per endpoint.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Reach for the MCP surface when an agent should call your stitches: it exposes a
+single code-mode `run_stitch` tool over MCP, plus a `list_stitches` discovery
+tool — so the agent's tool list stays tiny no matter how many stitches you
+register, and never touches a credential.
 
 ## Example
 
-Stub.
+Start the server with the `stitch` CLI. It loads your stitches module and speaks
+JSON-RPC over stdio (newline-delimited), with a startup notice on stderr:
+
+```bash
+stitch mcp --module ./stitches.ts
+```
+
+The agent then calls one tool — `run_stitch` — passing the stitch name and its
+input. The tool call looks like this:
+
+```json
+{
+    "name": "run_stitch",
+    "input": { "params": { "id": "42" }, "query": { "expand": "owner" } }
+}
+```
+
+`input` carries `{ params, query, body, headers }`; `run_stitch` runs the named
+stitch behind the [capability boundary](/docs/concepts/capability-not-credential)
+and returns its validated result.
 
 ## Options
 
-Stub.
+`run_stitch` takes `{ name, input }` and covers **every** registered stitch with
+one tool — `name` selects the stitch, `input` is its `{ params, query, body,
+headers }` object. This is code-mode: one tool, not one tool per path.
+
+`list_stitches` is the discovery tool. It takes no arguments and returns each
+stitch's `name`, `method`, and `path`, so the agent knows what to pass to
+`run_stitch`.
+
+Why one tool beats one-per-path: a tool per registered stitch floods the agent's
+context — every name, description, and input schema is re-sent on each turn. Code
+mode keeps the tool list at two entries however many stitches you register, so
+the agent spends its context on the task, not on a tool catalog. The full design
+of the tool lives in the agents section; see
+[run_stitch & code mode](/docs/agents/run-stitch-tool).
+
+The capability boundary holds here: the agent calls `run_stitch` by name and
+never sees the token, cookie, or signing key the stitch holds — it invokes a
+capability, not a credential.
+
+<Callout type="warn">
+    `stitch mcp` writes JSON-RPC to stdout and its startup notice to stderr —
+    keep stdout clean and don't pipe anything else through it.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="run_stitch & code mode" href="/docs/agents/run-stitch-tool" />
+    <Card title="For agents" href="/docs/agents" />
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+    />
+    <Card title="Function surface" href="/docs/surfaces/function" />
+</Cards>


### PR DESCRIPTION
Fills all four **Surfaces** stubs — one agent per page, centrally verified. The four front doors to one stitch definition.

## Pages
- **In-process function** — a stitch *is* a typed async function: `await` it or iterate `.stream()`; `.with()` pre-binds input.
- **CLI** — `stitch run <name>` (flags → input, JSONL event stream) + `stitch trace` (summarize the run log).
- **HTTP serve** — `stitch serve` (binds `127.0.0.1:8787`; `GET /` lists names, `POST /stitch/:name` runs; SSE via `Accept: text/event-stream`).
- **MCP** — code-mode: a single `run_stitch { name, input }` tool + `list_stitches` discovery, so the agent's tool list stays tiny (`stitch mcp` over stdio).

## Verification
- Commands and route shapes verified against `cli.ts`/`serve.ts`/`mcp.ts`. Since the serve/mcp/registry internals aren't exported from `@stitchapi/core`, those pages use shell + conceptual examples and only the public API in Twoslash.
- All links resolve; full `next build` renders all pages clean (exit 0).

Branched off the latest `develop` (post #24–#33 merges). Content-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)