### PR TITLE
docs: author For agents (use-from-agent, run_stitch, author-from-example, llms.txt)

### DIFF
--- a/apps/docs/content/docs/agents/author-from-one-example.mdx
+++ b/apps/docs/content/docs/agents/author-from-one-example.mdx
@@ -3,16 +3,68 @@ title: 'Author from one example'
 description: 'Have an agent emit a stitch declaration from a single curl, HAR, or doc snippet.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+An agent can write a complete stitch from one example — a `curl`, a HAR entry, a
+doc snippet — because a stitch is declarative and atomic: it needs only a URL and
+one example, never an OpenAPI spec and never codegen. The agent reads the
+example, maps its parts onto the authoring surface, and emits a `stitch({...})`
+declaration — the same surface a human writes by hand.
 
 ## Example
 
-Stub.
+Give the agent a single `curl`:
+
+```bash
+curl https://api.example.com/users/1
+```
+
+It emits the stitch that example describes:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    method: 'GET',
+});
+
+await getUser({ params: { id: 1 } });
+```
+
+That declaration is the whole integration — no spec to ingest, no generated code
+to commit.
 
 ## Options
 
-Stub.
+The agent maps each part of the one example onto a config field:
+
+-   **URL → `baseUrl` + `path`.** The origin becomes `baseUrl`; the rest becomes
+    `path`, with concrete segments lifted into `{param}` slots (so `/users/1`
+    becomes `/users/{id}`, called with `{ params: { id: 1 } }`).
+-   **Headers → `auth` / `headers`.** An `Authorization: Bearer …` or
+    `x-api-key` header becomes an `auth` strategy resolved at call time; other
+    headers become static `headers`.
+-   **An example response → an `output` schema.** When the example carries a
+    response body, the agent can add an `output` schema — turning one move into
+    TypeScript types, runtime validation, and drift detection.
+
+This works because a stitch is atomic, not spec-first — no OpenAPI document, no
+codegen step. And what the agent emits is the normal authoring surface: a plain
+`stitch({...})` declaration, identical to a hand-written one, that you can read,
+review, and extend.
+
+<Callout type="info">
+    The emitted `stitch({...})` is the same call documented in
+    [stitch()](/docs/guides/authoring/stitch) — add an `output` schema with
+    [validation](/docs/guides/validation/validation) exactly as you would for a
+    hand-authored stitch.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="stitch()" href="/docs/guides/authoring/stitch" />
+    <Card title="Validation" href="/docs/guides/validation/validation" />
+    <Card title="Run a stitch as a tool" href="/docs/agents/run-stitch-tool" />
+    <Card title="Principles" href="/docs/concepts/principles" />
+</Cards>

--- a/apps/docs/content/docs/agents/index.mdx
+++ b/apps/docs/content/docs/agents/index.mdx
@@ -32,8 +32,16 @@ One tool keeps the context budget flat as the catalog grows, and the credential
 stays behind the boundary — the agent sees the user, never the token.
 
 <Cards>
-    <Card title="run_stitch & code-mode" href="/docs/agents/run-stitch-tool" description="The single tool an agent calls, plus list_stitches for discovery." />
-    <Card title="MCP surface" href="/docs/surfaces/mcp" description="How those tools reach the agent over MCP." />
+    <Card
+        title="run_stitch & code-mode"
+        href="/docs/agents/run-stitch-tool"
+        description="The single tool an agent calls, plus list_stitches for discovery."
+    />
+    <Card
+        title="MCP surface"
+        href="/docs/surfaces/mcp"
+        description="How those tools reach the agent over MCP."
+    />
 </Cards>
 
 ## Author
@@ -45,7 +53,11 @@ one response it saw. The declaration is committable code the agent (or you) can
 review.
 
 <Cards>
-    <Card title="Author from one example" href="/docs/agents/author-from-one-example" description="Turn one curl, HAR, or doc snippet into a stitch declaration." />
+    <Card
+        title="Author from one example"
+        href="/docs/agents/author-from-one-example"
+        description="Turn one curl, HAR, or doc snippet into a stitch declaration."
+    />
 </Cards>
 
 ## Reason over
@@ -58,8 +70,16 @@ agent reads not just the final value but the retry that succeeded, the throttle
 that paused, and the field that drifted.
 
 <Cards>
-    <Card title="Point an agent at llms.txt" href="/docs/agents/llms-txt" description="Feed the auto-generated llms.txt and per-page llms.mdx for context-frugal docs." />
-    <Card title="The event stream" href="/docs/concepts/event-stream" description="The typed events a stitch emits, and why an agent reads them." />
+    <Card
+        title="Point an agent at llms.txt"
+        href="/docs/agents/llms-txt"
+        description="Feed the auto-generated llms.txt and per-page llms.mdx for context-frugal docs."
+    />
+    <Card
+        title="The event stream"
+        href="/docs/concepts/event-stream"
+        description="The typed events a stitch emits, and why an agent reads them."
+    />
 </Cards>
 
 <Callout type="info">
@@ -71,9 +91,20 @@ that paused, and the field that drifted.
 ## See also
 
 <Cards>
-    <Card title="Capability, not credential" href="/docs/concepts/capability-not-credential" description="Why an agent gets data, never the secret." />
-    <Card title="The event stream" href="/docs/concepts/event-stream" description="The typed events behind every call." />
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+        description="Why an agent gets data, never the secret."
+    />
+    <Card
+        title="The event stream"
+        href="/docs/concepts/event-stream"
+        description="The typed events behind every call."
+    />
     <Card title="run_stitch & code-mode" href="/docs/agents/run-stitch-tool" />
-    <Card title="Author from one example" href="/docs/agents/author-from-one-example" />
+    <Card
+        title="Author from one example"
+        href="/docs/agents/author-from-one-example"
+    />
     <Card title="Point an agent at llms.txt" href="/docs/agents/llms-txt" />
 </Cards>

--- a/apps/docs/content/docs/agents/index.mdx
+++ b/apps/docs/content/docs/agents/index.mdx
@@ -3,4 +3,77 @@ title: 'Use from an agent'
 description: 'How an agent invokes, authors, and reasons over stitches — the agent entry point.'
 ---
 
-Stub — orient the reader and link into this section. See AUTHORING.md.
+StitchAPI is agent-native because of two choices that fall out of the stitch
+primitive: an agent receives a **capability, not a credential** — it invokes a
+stitch and gets back structured, validated, traceable data without ever touching
+the secret — and it works through **one context-frugal tool**, not one tool per
+endpoint, so adding APIs never floods the model's context window.
+
+The rest of this section is three things an agent does with a stitch: it invokes
+them, it authors them, and it reasons over them.
+
+## Invoke
+
+An agent drives stitches from a sandbox through a single **code-mode** tool,
+`run_stitch`, rather than a generated tool per endpoint. The agent writes a small
+TypeScript snippet that imports `stitchapi`, calls the stitch, and returns
+the result — and `list_stitches` tells it what is available to call.
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const getUser = stitch('https://api.example.com/users/{id}');
+
+// The agent writes this in the sandbox; run_stitch executes it.
+const user = await getUser({ params: { id: 7 } });
+```
+
+One tool keeps the context budget flat as the catalog grows, and the credential
+stays behind the boundary — the agent sees the user, never the token.
+
+<Cards>
+    <Card title="run_stitch & code-mode" href="/docs/agents/run-stitch-tool" description="The single tool an agent calls, plus list_stitches for discovery." />
+    <Card title="MCP surface" href="/docs/surfaces/mcp" description="How those tools reach the agent over MCP." />
+</Cards>
+
+## Author
+
+An agent does not need a spec to add an API. Hand it a single example — a `curl`
+command, a HAR entry, or a snippet from a vendor's docs — and it emits a stitch
+declaration: the URL, the input shape, and an `output` schema inferred from the
+one response it saw. The declaration is committable code the agent (or you) can
+review.
+
+<Cards>
+    <Card title="Author from one example" href="/docs/agents/author-from-one-example" description="Turn one curl, HAR, or doc snippet into a stitch declaration." />
+</Cards>
+
+## Reason over
+
+Two outputs let an agent reason about stitches cheaply. The docs build emits an
+auto-generated `llms.txt` and a per-page `llms.mdx`, so an agent pulls just the
+one page it needs into context instead of the whole manual. And every call is a
+typed **event stream** — `start → progress → drift → result → done` — so the
+agent reads not just the final value but the retry that succeeded, the throttle
+that paused, and the field that drifted.
+
+<Cards>
+    <Card title="Point an agent at llms.txt" href="/docs/agents/llms-txt" description="Feed the auto-generated llms.txt and per-page llms.mdx for context-frugal docs." />
+    <Card title="The event stream" href="/docs/concepts/event-stream" description="The typed events a stitch emits, and why an agent reads them." />
+</Cards>
+
+<Callout type="info">
+    These three pages assume the runtime is already installed and a stitch is
+    declared. Start at the [Quickstart](/docs/getting-started/quickstart) if it
+    is not.
+</Callout>
+
+## See also
+
+<Cards>
+    <Card title="Capability, not credential" href="/docs/concepts/capability-not-credential" description="Why an agent gets data, never the secret." />
+    <Card title="The event stream" href="/docs/concepts/event-stream" description="The typed events behind every call." />
+    <Card title="run_stitch & code-mode" href="/docs/agents/run-stitch-tool" />
+    <Card title="Author from one example" href="/docs/agents/author-from-one-example" />
+    <Card title="Point an agent at llms.txt" href="/docs/agents/llms-txt" />
+</Cards>

--- a/apps/docs/content/docs/agents/llms-txt.mdx
+++ b/apps/docs/content/docs/agents/llms-txt.mdx
@@ -3,16 +3,61 @@ title: 'Point an agent at llms.txt'
 description: 'Feed the auto-generated llms.txt and per-page llms.mdx to an agent for context-frugal docs.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Point an agent at this site's auto-generated `llms.txt` and per-page `llms.mdx`
+instead of scraping rendered HTML — it discovers the docs from a clean index and
+pulls just the page it needs into context, no markup, no token waste.
 
 ## Example
 
-Stub.
+Fetch the index to discover structure, then pull a single page as Markdown:
+
+```bash
+# The curated index of every docs page, one line per page.
+curl https://docs.example.com/llms.txt
+
+# The clean Markdown form of one page — just this feature, into context.
+curl https://docs.example.com/docs/agents/run-stitch-tool/llms.mdx
+
+# When the agent needs everything at once, the whole docs concatenated.
+curl https://docs.example.com/llms-full.txt
+```
+
+Each page already stands on its own — restating its premise rather than leaning
+on neighbors — so the Markdown the agent pulls reads correctly in isolation. The
+stitch it documents is the same one-source-of-truth definition the runtime uses.
 
 ## Options
 
-Stub.
+The site emits three machine-readable outputs automatically; you never
+hand-author them.
+
+`/llms.txt` is the curated index — one line per page, title plus description — so
+an agent maps the docs structure before pulling anything.
+
+A page's `llms.mdx` variant is the same page as clean Markdown, with rendered
+chrome stripped. Because guides are fine-grained — one page per feature — an
+agent pulls exactly one feature's page into context (say, just
+[`run_stitch`](/docs/agents/run-stitch-tool)) rather than the whole manual. That
+fine-grained, self-contained-pages design is what makes each `llms.mdx` a
+focused, extractable unit.
+
+`/llms-full.txt` is every page concatenated, for when an agent genuinely needs
+the entire corpus in one fetch.
+
+<Callout type="info">
+    These are generated from the page content itself, so they never drift from
+    what a human reads — the same anti-drift, one-source-of-truth principle the
+    stitch enforces at runtime.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Run a stitch as a tool" href="/docs/agents/run-stitch-tool" />
+    <Card
+        title="Author from one example"
+        href="/docs/agents/author-from-one-example"
+    />
+    <Card title="For agents" href="/docs/agents" />
+    <Card title="The stitch" href="/docs/concepts/the-stitch" />
+</Cards>

--- a/apps/docs/content/docs/agents/run-stitch-tool.mdx
+++ b/apps/docs/content/docs/agents/run-stitch-tool.mdx
@@ -3,16 +3,75 @@ title: 'run_stitch & code-mode'
 description: 'Drive stitches from a sandbox with one context-frugal tool instead of flooding the model with per-endpoint tools.'
 ---
 
-Stub — what this does and when you reach for it. See AUTHORING.md.
+Drive stitches from an agent sandbox with a single `run_stitch` tool — pass
+`{ name, input }` and it covers every stitch you register, so the model's tool
+list (and its context) stays tiny no matter how many stitches there are. A
+companion `list_stitches` tool discovers the available names.
 
 ## Example
 
-Stub.
+The agent first discovers what is available, then runs one by name. Both are
+plain MCP tool calls — there is no library import on the agent side.
+
+```json
+{ "name": "list_stitches", "input": {} }
+```
+
+`list_stitches` returns the registered stitches with their method and path, so
+the agent knows what to pass to `run_stitch`:
+
+```json
+{
+  "name": "run_stitch",
+  "input": { "name": "getUser", "input": { "params": { "id": 1 } } }
+}
+```
+
+Here the inner `input` is the stitch input — `{ params?, query?, body?,
+headers? }` — and the stitch runs against `api.example.com` behind the
+capability boundary. The agent never sees the credential.
 
 ## Options
 
-Stub.
+Two tools make up the whole surface. `run_stitch` takes `{ name, input }`,
+where `input` is the stitch input `{ params?, query?, body?, headers? }`;
+`list_stitches` takes no arguments and returns the names, methods, and paths.
+
+This is **code-mode**: one tool for every stitch, rather than one MCP tool per
+endpoint. One-tool-per-endpoint floods the model's context — every registered
+stitch adds another schema the model must carry — while `run_stitch` keeps the
+tool list at a constant two no matter how many stitches you register.
+
+The agent calls `run_stitch` and never touches the credential: it names a
+capability, the server holds the secret. That is
+[capability, not credential](/docs/concepts/capability-not-credential) applied
+to the agent boundary.
+
+<Callout type="info">
+    This page is about the tool shape and why code-mode. For starting the
+    server (`stitch mcp`) and the transport details, see the
+    [MCP surface](/docs/surfaces/mcp).
+</Callout>
+
+If you author the stitch that backs a name like `getUser`, it is an ordinary
+stitch from `stitchapi`:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/:id',
+});
+```
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="MCP surface" href="/docs/surfaces/mcp" />
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+    />
+    <Card title="For agents" href="/docs/agents" />
+</Cards>

--- a/apps/docs/content/docs/agents/run-stitch-tool.mdx
+++ b/apps/docs/content/docs/agents/run-stitch-tool.mdx
@@ -22,8 +22,8 @@ the agent knows what to pass to `run_stitch`:
 
 ```json
 {
-  "name": "run_stitch",
-  "input": { "name": "getUser", "input": { "params": { "id": 1 } } }
+    "name": "run_stitch",
+    "input": { "name": "getUser", "input": { "params": { "id": 1 } } }
 }
 ```
 
@@ -48,9 +48,9 @@ capability, the server holds the secret. That is
 to the agent boundary.
 
 <Callout type="info">
-    This page is about the tool shape and why code-mode. For starting the
-    server (`stitch mcp`) and the transport details, see the
-    [MCP surface](/docs/surfaces/mcp).
+    This page is about the tool shape and why code-mode. For starting the server
+    (`stitch mcp`) and the transport details, see the [MCP
+    surface](/docs/surfaces/mcp).
 </Callout>
 
 If you author the stitch that backs a name like `getUser`, it is an ordinary


### PR DESCRIPTION
Fills all four **For agents** stubs — one agent per page, centrally verified.

## Pages
- **Use from an agent** (landing) — how an agent invokes, authors, and reasons over stitches; the section entry point.
- **run_stitch & code-mode** — a single `run_stitch { name, input }` tool + `list_stitches` discovery, so the agent's tool list (and context) stays tiny vs one MCP tool per endpoint.
- **Author from one example** — an agent emits a complete `stitch({…})` declaration from a single curl/HAR/doc snippet (atomic, no spec, no codegen).
- **Point an agent at llms.txt** — the auto-generated `/llms.txt`, `/llms-full.txt`, and per-page `llms.mdx` for context-frugal docs instead of scraping HTML.

## Verification
- `run_stitch`/`list_stitches` shapes verified against `mcp.ts`; the `llms.*` routes confirmed present in the app.
- All links resolve; full `next build` renders all 182 pages clean (exit 0).

Branched off the latest `develop`. Content-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)