### PR TITLE
docs: author Reference (stitch & builder, auth strategies, helpers, event types)

### DIFF
--- a/apps/docs/content/docs/reference/auth-strategies.mdx
+++ b/apps/docs/content/docs/reference/auth-strategies.mdx
@@ -3,12 +3,71 @@ title: 'Auth strategies'
 description: 'bearer, apiKey, basic, cookieSession, oauth2, and the env() and keychain() resolvers.'
 ---
 
-Stub — what this page documents. See AUTHORING.md.
+The signatures for every auth strategy and secret resolver. Each strategy holds
+the credential and resolves it at call time, so the caller never sees it. The
+guides under [Auth](/docs/guides/auth/secret-resolvers) show how to use them.
 
-## Signature
+## bearer
 
-Stub.
+Attaches `Authorization: Bearer <token>`.
+
+```ts twoslash
+import { bearer } from 'stitchapi';
+```
+
+## apiKey
+
+Sends a secret in a header (`x-api-key` by default).
+
+```ts twoslash
+import { apiKey } from 'stitchapi';
+```
+
+## basic
+
+Base64-encodes `user:pass` into `Authorization: Basic …`.
+
+```ts twoslash
+import { basic } from 'stitchapi';
+```
+
+## cookieSession
+
+Logs in once, captures the cookie from `Set-Cookie`, replays it on each request,
+and re-logs in on a status code or a soft 200 wall.
+
+<AutoTypeTable path="../../packages/core/src/auth.ts" name="CookieSessionOpts" />
+
+## oauth2
+
+Performs the `client_credentials` grant, caches the access token, refreshes it
+before expiry, and attaches it as `Authorization: Bearer …`.
+
+<AutoTypeTable path="../../packages/core/src/auth.ts" name="OAuth2Opts" />
+
+## env
+
+Resolves a secret from an environment variable at call time.
+
+```ts twoslash
+import { env } from 'stitchapi';
+```
+
+## keychain
+
+Resolves a secret from `~/.stitch/secrets.json`, falling back to the environment.
+
+```ts twoslash
+import { keychain } from 'stitchapi';
+```
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Guide: secret resolvers" href="/docs/guides/auth/secret-resolvers" />
+    <Card title="Guide: cookieSession" href="/docs/guides/auth/cookie-session" />
+    <Card title="Guide: oauth2" href="/docs/guides/auth/oauth2" />
+    <Card title="Capability, not credential" href="/docs/concepts/capability-not-credential" />
+    <Card title="STITCH_AUTH_WALL" href="/docs/errors/stitch-auth-wall" />
+    <Card title="Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/reference/auth-strategies.mdx
+++ b/apps/docs/content/docs/reference/auth-strategies.mdx
@@ -36,7 +36,10 @@ import { basic } from 'stitchapi';
 Logs in once, captures the cookie from `Set-Cookie`, replays it on each request,
 and re-logs in on a status code or a soft 200 wall.
 
-<AutoTypeTable path="../../packages/core/src/auth.ts" name="CookieSessionOpts" />
+<AutoTypeTable
+    path="../../packages/core/src/auth.ts"
+    name="CookieSessionOpts"
+/>
 
 ## oauth2
 
@@ -64,10 +67,19 @@ import { keychain } from 'stitchapi';
 ## See also
 
 <Cards>
-    <Card title="Guide: secret resolvers" href="/docs/guides/auth/secret-resolvers" />
-    <Card title="Guide: cookieSession" href="/docs/guides/auth/cookie-session" />
+    <Card
+        title="Guide: secret resolvers"
+        href="/docs/guides/auth/secret-resolvers"
+    />
+    <Card
+        title="Guide: cookieSession"
+        href="/docs/guides/auth/cookie-session"
+    />
     <Card title="Guide: oauth2" href="/docs/guides/auth/oauth2" />
-    <Card title="Capability, not credential" href="/docs/concepts/capability-not-credential" />
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+    />
     <Card title="STITCH_AUTH_WALL" href="/docs/errors/stitch-auth-wall" />
     <Card title="Config types" href="/docs/reference/config-types" />
 </Cards>

--- a/apps/docs/content/docs/reference/events.mdx
+++ b/apps/docs/content/docs/reference/events.mdx
@@ -3,12 +3,55 @@ title: 'Event types'
 description: 'The StitchEvent union and the shape of each event in the stream.'
 ---
 
-Stub — what this page documents. See AUTHORING.md.
+The events a stitch emits as it runs. A stitch streams an async iterable of
+`StitchEvent` values; this page documents their shapes.
 
-## Signature
+## StitchEvent
 
-Stub.
+`StitchEvent<T>` is a discriminated union on `type`. The `T` parameter is the
+type of the value carried by the `result` event.
+
+```ts twoslash
+import type { StitchEvent } from 'stitchapi';
+```
+
+<AutoTypeTable path="../../packages/core/src/types.ts" name="StitchEvent" />
+
+## The events
+
+A union table can render sparsely, so here is each of the seven variants and its
+fields. Every event carries an `at` field — a millisecond timestamp.
+
+-   **`start`** — the request is about to go out. Fields: `name` (the stitch
+    label), `method`, `url`, `input` (the `StitchInput` for this call), `at`.
+-   **`progress`** — a lifecycle beat within an attempt. Fields: `phase` (a
+    `ProgressPhase`), `attempt` (1-based), `detail?`, `waitedMs?` (set when the
+    phase involved a wait, e.g. `throttled` or `retry`), `at`.
+-   **`drift`** — a single contract-drift observation against the response.
+    Fields: `finding` (a `DriftFinding` with `level`, `path`, `change`,
+    `detail?`), `at`.
+-   **`delta`** — a streamed chunk of the response body. Fields: `chunk`
+    (`unknown`), `at`.
+-   **`result`** — the call succeeded and produced a value. Fields: `value` (the
+    `T`), `status` (HTTP status), `attempts` (how many it took), `at`.
+-   **`error`** — the call failed. Fields: `name`, `message`, `status?`,
+    `attempts`, `at`.
+-   **`done`** — the stream is finished, success or failure. Fields: `ok`, `ms`
+    (total duration), `attempts`, `at`.
+
+`ProgressPhase` is one of `'auth'`, `'request'`, `'throttled'`, `'retry'`,
+`'paginate'`, or `'circuit'`.
+
+<Callout>
+    `result` and `error` are mutually exclusive within one stream, but `done`
+    always fires last — read `done.ok` to know which way it went.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Concept: the event stream" href="/docs/concepts/event-stream" />
+    <Card title="Guide: trace sinks" href="/docs/guides/observability/trace-sinks" />
+    <Card title="Guide: drift" href="/docs/guides/validation/drift" />
+    <Card title="Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/reference/events.mdx
+++ b/apps/docs/content/docs/reference/events.mdx
@@ -50,8 +50,14 @@ fields. Every event carries an `at` field — a millisecond timestamp.
 ## See also
 
 <Cards>
-    <Card title="Concept: the event stream" href="/docs/concepts/event-stream" />
-    <Card title="Guide: trace sinks" href="/docs/guides/observability/trace-sinks" />
+    <Card
+        title="Concept: the event stream"
+        href="/docs/concepts/event-stream"
+    />
+    <Card
+        title="Guide: trace sinks"
+        href="/docs/guides/observability/trace-sinks"
+    />
     <Card title="Guide: drift" href="/docs/guides/validation/drift" />
     <Card title="Config types" href="/docs/reference/config-types" />
 </Cards>

--- a/apps/docs/content/docs/reference/helpers.mdx
+++ b/apps/docs/content/docs/reference/helpers.mdx
@@ -121,9 +121,18 @@ const validator = toValidator((value: unknown) => typeof value === 'string');
 ## See also
 
 <Cards>
-    <Card title="Guide: trace sinks" href="/docs/guides/observability/trace-sinks" />
+    <Card
+        title="Guide: trace sinks"
+        href="/docs/guides/observability/trace-sinks"
+    />
     <Card title="Guide: OTLP export" href="/docs/guides/observability/otlp" />
-    <Card title="Guide: pluggable store" href="/docs/guides/state/pluggable-store" />
-    <Card title="Guide: Standard Schema" href="/docs/guides/validation/standard-schema" />
+    <Card
+        title="Guide: pluggable store"
+        href="/docs/guides/state/pluggable-store"
+    />
+    <Card
+        title="Guide: Standard Schema"
+        href="/docs/guides/validation/standard-schema"
+    />
     <Card title="Config types" href="/docs/reference/config-types" />
 </Cards>

--- a/apps/docs/content/docs/reference/helpers.mdx
+++ b/apps/docs/content/docs/reference/helpers.mdx
@@ -3,12 +3,127 @@ title: 'Helpers'
 description: 'fetchAdapter, createTrace, multiplex, the OTLP exporters, memoryStore, and toValidator.'
 ---
 
-Stub — what this page documents. See AUTHORING.md.
+The exported helper functions you wire into a stitch: the default transport, the
+trace sinks (including OTLP export), the default store, and the schema adapter.
+Each signature is below; the guides cover usage in depth and are linked under
+[See also](#see-also).
 
-## Signature
+## Transport
 
-Stub.
+### fetchAdapter
+
+The default fetch-based transport. Returns an `Adapter` backed by the global
+`fetch`; it never throws on a non-2xx response — only network and abort errors
+propagate, leaving the engine to decide what a status means.
+
+```ts twoslash
+import { fetchAdapter } from 'stitchapi';
+
+const adapter = fetchAdapter();
+```
+
+## Tracing & OTLP
+
+### createTrace
+
+Build a zero-infra trace sink: a compact one-line-per-event summary on the
+console and/or an appended JSONL record per event. `console` defaults to `true`;
+`file` defaults to a path under `$HOME`, or `false` to disable the JSONL stream.
+
+```ts twoslash
+import { createTrace } from 'stitchapi';
+
+const sink = createTrace({ console: true, file: false });
+```
+
+### multiplex
+
+Fan one event stream out to several sinks — for example console/JSONL alongside
+OTLP — flushing each in turn.
+
+```ts twoslash
+import { createTrace, multiplex, otlpTrace } from 'stitchapi';
+
+const sink = multiplex(createTrace(), otlpTrace());
+```
+
+### otlpTrace
+
+An opt-in OpenTelemetry sink: it maps each stitch call's events to a single OTel
+`CLIENT` span and hands finished spans to a `SpanExporter`. With no exporter
+supplied it uses `otlpHttpExporter`. Configured by `OtlpOptions` (below).
+
+```ts twoslash
+import { otlpTrace } from 'stitchapi';
+
+const sink = otlpTrace({ endpoint: 'https://api.example.com:4318' });
+```
+
+### otlpHttpExporter
+
+The default exporter: POST spans as OTLP/JSON to `${endpoint}/v1/traces`. The
+endpoint defaults to `OTEL_EXPORTER_OTLP_ENDPOINT` or `http://localhost:4318`.
+Fire-and-forget — a missing collector never breaks a stitch call.
+
+```ts twoslash
+import { otlpHttpExporter } from 'stitchapi';
+
+const exporter = otlpHttpExporter({
+    endpoint: 'https://api.example.com:4318',
+    headers: { authorization: 'Bearer token' },
+});
+```
+
+### toOtlpJson
+
+Serialize finished spans to the OTLP/JSON `ResourceSpans` shape a collector
+accepts on `/v1/traces` — useful for a custom `SpanExporter`.
+
+```ts twoslash
+import { toOtlpJson } from 'stitchapi';
+
+const body = toOtlpJson([]);
+```
+
+#### OtlpOptions
+
+<AutoTypeTable path="../../packages/core/src/otlp.ts" name="OtlpOptions" />
+
+## Store
+
+### memoryStore
+
+The default in-memory `StitchStore`: single-process, with TTL and atomic
+increment. Swap it for a Redis/Postgres-backed store to make throttling
+distributed and sessions shared across workers, with no change to the call site.
+
+```ts twoslash
+import { memoryStore } from 'stitchapi';
+
+const store = memoryStore();
+```
+
+## Validation
+
+### toValidator
+
+Coerce a Zod schema, any Standard Schema, an existing `Validator`, or a
+predicate into a `Validator` — returning `undefined` when passed `null` or
+`undefined`. This is how Zod-first projects keep Zod while Valibot/ArkType also
+work.
+
+```ts twoslash
+import { toValidator } from 'stitchapi';
+
+const validator = toValidator((value: unknown) => typeof value === 'string');
+```
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Guide: trace sinks" href="/docs/guides/observability/trace-sinks" />
+    <Card title="Guide: OTLP export" href="/docs/guides/observability/otlp" />
+    <Card title="Guide: pluggable store" href="/docs/guides/state/pluggable-store" />
+    <Card title="Guide: Standard Schema" href="/docs/guides/validation/standard-schema" />
+    <Card title="Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/reference/stitch.mdx
+++ b/apps/docs/content/docs/reference/stitch.mdx
@@ -3,12 +3,87 @@ title: 'stitch() & the builder'
 description: 'Signatures for stitch(), defineStitch(), preset(), graphql(), and the fluent builder.'
 ---
 
-Stub — what this page documents. See AUTHORING.md.
+The authoring surface: the four exports that produce a stitch, plus the fluent
+builder they share. For what goes inside the config object, see
+[Reference → Config types](/docs/reference/config-types).
 
-## Signature
+## stitch()
 
-Stub.
+`stitch<T>(config)` takes a path string or a partial config and returns a
+`Stitch<T>`; `stitch.use(...)` starts the fluent builder instead.
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const user = stitch<{ id: string }>({
+    path: 'https://api.example.com/me',
+});
+```
+
+## defineStitch()
+
+`defineStitch(...fragments)` binds shared base fragments and returns a `stitch()`
+factory; each call deep-merges the bound fragments under the per-call config.
+
+```ts twoslash
+import { defineStitch } from 'stitchapi';
+
+const api = defineStitch({ path: 'https://api.example.com' });
+const user = api<{ id: string }>('/me');
+```
+
+## preset()
+
+`preset(cfg)` is an identity-tagged fragment — a named bundle of reusable
+defaults you pass through `extends`. It returns the same `Partial<StitchConfig>`.
+
+```ts twoslash
+import { preset } from 'stitchapi';
+
+const base = preset({ retry: { attempts: 3 } });
+```
+
+## graphql()
+
+`graphql<T>(config)` is a stitch preset for GraphQL-over-HTTP: it POSTs
+`{ query, variables }` and unwraps `data`. The config must carry a `query`.
+
+```ts twoslash
+import { graphql } from 'stitchapi';
+
+const viewer = graphql<{ viewer: { id: string } }>({
+    path: 'https://api.example.com/graphql',
+    query: 'query { viewer { id } }',
+});
+```
+
+See [Guide → graphql](/docs/guides/data/graphql) for usage.
+
+## The fluent builder
+
+`stitch.use(...)` returns a `Builder`: a callable object whose chainable methods
+accumulate config, then resolve to a stitch when you call it (or `.stream()` /
+`.with()`).
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const user = stitch.use().get('https://api.example.com/me');
+```
+
+<AutoTypeTable path="../../packages/core/src/stitch.ts" name="Builder" />
+
+<Callout>
+    Setter methods (`.get`, `.auth`, `.retry`, ...) return the same `Builder` for
+    chaining; `.with()` and `.stream()` build and return a `Stitch`.
+</Callout>
 
 ## See also
 
-Stub.
+<Cards>
+    <Card title="Config types" href="/docs/reference/config-types" />
+    <Card title="Guide: stitch()" href="/docs/guides/authoring/stitch" />
+    <Card title="Guide: the fluent builder" href="/docs/guides/authoring/fluent-builder" />
+    <Card title="Guide: graphql" href="/docs/guides/data/graphql" />
+    <Card title="Auth strategies" href="/docs/reference/auth-strategies" />
+</Cards>

--- a/apps/docs/content/docs/reference/stitch.mdx
+++ b/apps/docs/content/docs/reference/stitch.mdx
@@ -74,8 +74,8 @@ const user = stitch.use().get('https://api.example.com/me');
 <AutoTypeTable path="../../packages/core/src/stitch.ts" name="Builder" />
 
 <Callout>
-    Setter methods (`.get`, `.auth`, `.retry`, ...) return the same `Builder` for
-    chaining; `.with()` and `.stream()` build and return a `Stitch`.
+    Setter methods (`.get`, `.auth`, `.retry`, ...) return the same `Builder`
+    for chaining; `.with()` and `.stream()` build and return a `Stitch`.
 </Callout>
 
 ## See also
@@ -83,7 +83,10 @@ const user = stitch.use().get('https://api.example.com/me');
 <Cards>
     <Card title="Config types" href="/docs/reference/config-types" />
     <Card title="Guide: stitch()" href="/docs/guides/authoring/stitch" />
-    <Card title="Guide: the fluent builder" href="/docs/guides/authoring/fluent-builder" />
+    <Card
+        title="Guide: the fluent builder"
+        href="/docs/guides/authoring/fluent-builder"
+    />
     <Card title="Guide: graphql" href="/docs/guides/data/graphql" />
     <Card title="Auth strategies" href="/docs/reference/auth-strategies" />
 </Cards>


### PR DESCRIPTION
Fills four of five **Reference** stubs (`config-types` is already on develop from #24) — prose + `AutoTypeTable`, one agent per page, centrally verified.

## Pages
- **stitch() & the builder** — signatures for `stitch`/`defineStitch`/`preset`/`graphql` + `AutoTypeTable` for the `Builder` interface.
- **Auth strategies** — `bearer`/`apiKey`/`basic`/`env`/`keychain` signatures + `AutoTypeTable` for `CookieSessionOpts` and `OAuth2Opts` (read by file path — they aren't re-exported from the package index).
- **Helpers** — `fetchAdapter`/`createTrace`/`multiplex`/`otlpTrace`/`otlpHttpExporter`/`toOtlpJson`/`memoryStore`/`toValidator` + `AutoTypeTable` for `OtlpOptions`.
- **Event types** — `AutoTypeTable` for the `StitchEvent` union + a per-variant field breakdown (so the page is complete even if the union table is terse).

## Verification
- Every `AutoTypeTable` renders from real source; signature examples import only the public `@stitchapi/core` exports.
- Full `next build` renders all 182 pages clean (exit 0) — confirms the `Builder` and `StitchEvent` (union) AutoTypeTables don't error.

Branched off the latest `develop`. Content + (already-merged) AutoTypeTable tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)