### PR TITLE
docs: code-variant tabs convention + Twoslash-checked examples

### DIFF
--- a/apps/docs/AUTHORING.md
+++ b/apps/docs/AUTHORING.md
@@ -74,7 +74,7 @@ for you.
 {/* The smallest stitch that uses the feature, above the fold. Twoslash — see
 "Code examples" below. */}
 ```ts twoslash
-import { stitch, cookieSession, env } from '@stitchapi/core';
+import { stitch, cookieSession, env } from 'stitchapi';
 
 const me = stitch({
     url: 'https://api.example.com/me',
@@ -158,7 +158,7 @@ The configuration object accepted by `stitch()`.
 ## StitchConfig {/* (required: signature) */}
 
 ```ts twoslash
-import type { StitchConfig } from '@stitchapi/core';
+import type { StitchConfig } from 'stitchapi';
 ```
 
 {/* (required: the no-drift table) Generated from the real type — never
@@ -210,7 +210,7 @@ description: Authentication failed, or a soft 200 login wall was hit and could n
 ## Authoring rules
 
 1. **Examples are Twoslash, always.** Every code block is type-checked against
-   the real `@stitchapi/core` at build time. A snippet that calls a renamed
+   the real `stitchapi` at build time. A snippet that calls a renamed
    option fails the build. See [Code examples](#code-examples--twoslash).
 2. **Frontmatter is `title` + `description`, both mandatory.** `description` is a
    real sentence — it's the search result, the `llms.txt` line, and the agent's
@@ -236,6 +236,11 @@ description: Authentication failed, or a soft 200 login wall was hit and could n
    extending TSDoc on the types it documents — that's what enriches the
    generated `AutoTypeTable`, and it pays down the near-empty TSDoc on
    `types.ts`.
+9. **Alternatives are tabs, not prose.** When the same outcome has more than one
+   equivalent form — package manager, import style, how a stitch is declared, how
+   its result is consumed — show the forms as tabs and let the reader's pick
+   persist. Never write "you can also…" and never pick one form for the reader
+   while hiding the rest. See [Code variants — tabs](#code-variants--tabs).
 
 ---
 
@@ -245,23 +250,124 @@ Write the fence as `ts twoslash`:
 
 ````md
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 // ...
 ```
 ````
 
-Twoslash compiles the snippet against the workspace's real `@stitchapi/core`
+Twoslash compiles the snippet against the workspace's real `stitchapi`
 types during the docs build, renders inline type hovers, and **fails the build
 on a type error**. That's the whole point: examples cannot silently drift from
 the runtime.
 
--   Imports must resolve to published entry points (`@stitchapi/core`), not deep
+-   Imports must resolve to published entry points (`stitchapi`), not deep
     paths.
 -   To intentionally show an error, use Twoslash's `// @errors:` directive — don't
     ship an un-annotated broken snippet.
 -   One-time pipeline wiring (the `fumadocs-twoslash` transformer in
     `source.config.ts`) is a tooling task, separate from writing pages.
+
+## Code variants — tabs
+
+If a snippet has an equivalent alternative, show the alternatives as **tabs**
+(rule 9). The reader chooses once and the choice persists across the whole site.
+Three mechanisms, by case.
+
+### Install commands → `package-install`
+
+One fence tagged `package-install` becomes npm / pnpm / yarn / bun tabs,
+auto-converted from the npm form. Write only the package name(s):
+
+````md
+```package-install
+stitchapi
+```
+````
+
+This is the **one** code block that isn't Twoslash (rule 1) — it's a shell
+command, not TypeScript. The package-manager pick persists site-wide; that's
+wired once in [`source.config.ts`](./source.config.ts) via
+`remarkNpmOptions.persist`, so individual pages do nothing.
+
+### Equivalent code → `tab=` on consecutive fences
+
+Give each equivalent form its own `ts twoslash` fence, tagged with a `tab` label
+and a shared `tabGroup`. Consecutive tagged fences merge into one tabbed block,
+and every one still type-checks (rule 1):
+
+````md
+```ts twoslash tab="Config object" tabGroup="definition-style"
+import { stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const getUser = stitch({
+    path: 'https://api.example.com/users/{id}',
+    output: z.object({ id: z.number(), name: z.string() }),
+});
+```
+
+```ts twoslash tab="Fluent builder" tabGroup="definition-style"
+import { stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const getUser = stitch
+    .get('https://api.example.com/users/{id}')
+    .returns(z.object({ id: z.number(), name: z.string() }));
+```
+````
+
+`tabGroup` is the **persistence key**: the same id on every page means a reader
+who picks "Fluent builder" once sees it everywhere. Drop `tabGroup` and the tabs
+still render, but the choice won't stick.
+
+### Code + prose per variant → `<Tabs>`
+
+When a variant needs a sentence of explanation, not just code, use the component
+and set `groupId` + `persist` so it persists like the fenced form:
+
+````mdx
+<Tabs groupId="runtime" persist items={['Programmatic', 'CLI']}>
+  <Tab value="Programmatic">
+    ```ts twoslash
+    import { stitch } from 'stitchapi';
+
+    const getUser = stitch('https://api.example.com/users/{id}');
+    const user = await getUser({ params: { id: 7 } });
+    ```
+
+  </Tab>
+  <Tab value="CLI">
+    The same stitch, no app boot — flags map to `params` / `query` / `body`.
+    ```bash
+    stitch run getUser --id 7
+    ```
+  </Tab>
+</Tabs>
+````
+
+### The canonical axes
+
+Reuse these `tabGroup` ids and labels **exactly** — matching ids are what let a
+choice persist from page to page. The first label is the default the reader
+lands on, so make it the recommended form.
+
+| `tabGroup`         | Use when                                | Labels — first is the default                           |
+| ------------------ | --------------------------------------- | ------------------------------------------------------- |
+| `package-manager`  | install / `npx` commands                | npm · pnpm · yarn · bun — _generated, don't hand-write_ |
+| `definition-style` | a stitch is declared ≥2 equivalent ways | `Config object` · `Fluent builder` · `defineStitch`     |
+| `module`           | imports differ by module system         | `ESM` · `CommonJS`                                      |
+| `consumption`      | how a stitch's result is consumed       | `await` · `Stream` · `.then()`                          |
+| `runtime`          | the same operation in code vs the shell | `Programmatic` · `CLI`                                  |
+
+Four rules keep it coherent:
+
+-   **Always set `tabGroup`.** It's the persistence key, not decoration.
+-   **Lead with the recommended form.** The first tab is where the reader lands.
+-   **Show 2–4 relevant variants, not all of them.** The `defineStitch` page
+    leads with the `defineStitch` tab; it doesn't parade all twelve call styles.
+-   **A new axis is a new row here first.** Don't coin ad-hoc `tabGroup` values
+    inline — add the row above, then use it, so persistence stays consistent.
 
 ## Type tables — AutoTypeTable
 
@@ -298,7 +404,10 @@ Errors & pitfalls is keyed to a registry of stable codes (`STITCH_VALIDATION`,
 -   [ ] Listed in `content.manifest.ts`; file path matches.
 -   [ ] `title` + `description` frontmatter; `description` is a real sentence.
 -   [ ] Uses the correct template for its `kind`; all `(required)` sections present.
--   [ ] Every code block is `ts twoslash` and builds clean.
+-   [ ] Every TypeScript code block is `ts twoslash` and builds clean (install,
+        CLI, and CommonJS blocks are the exception — they aren't TypeScript).
+-   [ ] Equivalent forms (install, import, definition, consumption) are tabs with a
+        canonical `tabGroup`, not prose alternatives.
 -   [ ] No hand-written type tables; shapes come from `AutoTypeTable`.
 -   [ ] Neutral names only; `api.example.com` for hosts.
 -   [ ] Reads correctly in isolation (imagine it as a lone `llms.mdx`).

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,5 +1,6 @@
 import './global.css';
 
+import 'fumadocs-twoslash/twoslash.css';
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import { Inter } from 'next/font/google';
 

--- a/apps/docs/components/mdx.tsx
+++ b/apps/docs/components/mdx.tsx
@@ -1,3 +1,4 @@
+import { Popup, PopupContent, PopupTrigger } from 'fumadocs-twoslash/ui';
 import { createGenerator } from 'fumadocs-typescript';
 import { AutoTypeTable } from 'fumadocs-typescript/ui';
 import defaultMdxComponents from 'fumadocs-ui/mdx';
@@ -21,6 +22,10 @@ export function getMDXComponents(components?: MDXComponents) {
         AutoTypeTable: (props: AutoTypeTableProps) => (
             <AutoTypeTable generator={generator} {...props} />
         ),
+        // Twoslash hover popups — emitted by the transformer wired in source.config.ts.
+        Popup,
+        PopupContent,
+        PopupTrigger,
         ...components,
     } satisfies MDXComponents;
 }

--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -99,7 +99,7 @@ export const pages: Page[] = [
         path: 'getting-started/installation',
         title: 'Installation',
         description:
-            'Install @stitchapi/core and set up the zero-dependency runtime in Node or the browser.',
+            'Install stitchapi and set up the zero-dependency runtime in Node or the browser.',
         kind: 'tutorial',
     },
     {

--- a/apps/docs/content/docs/concepts/capability-not-credential.mdx
+++ b/apps/docs/content/docs/concepts/capability-not-credential.mdx
@@ -23,7 +23,7 @@ where the secret lives, not the secret itself: it is safe to commit, diff, and
 share, because there is nothing sensitive in it to commit.
 
 ```ts twoslash
-import { bearer, env, stitch } from '@stitchapi/core';
+import { bearer, env, stitch } from 'stitchapi';
 
 const getMovie = stitch({
     path: 'https://api.example.com/movies/{id}',

--- a/apps/docs/content/docs/concepts/event-stream.mdx
+++ b/apps/docs/content/docs/concepts/event-stream.mdx
@@ -19,7 +19,7 @@ and what an operator needs to debug one.
 So a stitch is a single source that you can read at the altitude you need:
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const search = stitch({ baseUrl: 'https://api.example.com', path: '/search' });
 

--- a/apps/docs/content/docs/concepts/principles.mdx
+++ b/apps/docs/content/docs/concepts/principles.mdx
@@ -19,7 +19,7 @@ auth, retries, observability) has a sane default and reveals its knobs only when
 you ask, so simple things stay one line and the depth is there when you need it.
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 // A string is a whole stitch.
 const getUsers = stitch('https://api.example.com/users');
@@ -50,7 +50,7 @@ from it inherits it. You share a fragment instead of re-typing config, and a
 stitch is itself a composable value others can extend.
 
 ```ts twoslash
-import { defineStitch, preset } from '@stitchapi/core';
+import { defineStitch, preset } from 'stitchapi';
 
 const api = preset({
     baseUrl: 'https://api.example.com',

--- a/apps/docs/content/docs/concepts/the-stitch.mdx
+++ b/apps/docs/content/docs/concepts/the-stitch.mdx
@@ -16,7 +16,7 @@ The thing every project reaches for is `fetch`, and `fetch` hands back opaque by
 **One primitive, three facades.** There is exactly one thing — the stitch — reached through three authoring surfaces that all resolve to the same engine. The string form is the smallest possible declaration; the config form is the same declaration with more fields; the fluent builder is the same fields set one call at a time. None is a different kind of object: each compiles to one canonical config and produces the same callable.
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 // The string form: a bare URL is the smallest complete stitch.
 const a = stitch('https://api.example.com/users');

--- a/apps/docs/content/docs/errors/stitch-auth-wall.mdx
+++ b/apps/docs/content/docs/errors/stitch-auth-wall.mdx
@@ -35,7 +35,7 @@ For a soft 200 wall, add `refreshWhen` so a login page served with `200`
 triggers a re-login instead of passing as data:
 
 ```ts twoslash
-import { cookieSession, env, stitch } from '@stitchapi/core';
+import { cookieSession, env, stitch } from 'stitchapi';
 
 const login = stitch({
     method: 'POST',

--- a/apps/docs/content/docs/getting-started/index.mdx
+++ b/apps/docs/content/docs/getting-started/index.mdx
@@ -40,7 +40,7 @@ that wrapper with a declaration:
 The smallest stitch is a URL. Declare it once, call it as a typed function:
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const getUsers = stitch('https://api.example.com/users');
 

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -1,70 +1,51 @@
 ---
 title: 'Installation'
-description: 'Install @stitchapi/core and set up the zero-dependency runtime in Node or the browser.'
+description: 'Install stitchapi and set up the zero-dependency runtime in Node or the browser.'
 ---
 
-Install the `@stitchapi/core` runtime and confirm it resolves, in a Node
-project or a browser bundle. The runtime ships with zero dependencies, so this
-is one install and a one-line type check — no peer packages required to get a
-stitch type-checking.
+Install the package, import `stitch`, and make one typed call to confirm the
+runtime works. `stitchapi` has zero dependencies and runs anywhere `fetch`
+does — Node, the browser, and edge runtimes.
 
 ## Install
 
-Add `@stitchapi/core` with your package manager:
-
-```bash
-npm install @stitchapi/core
+```package-install
+stitchapi
 ```
 
-```bash
-pnpm add @stitchapi/core
+## Import it
+
+`stitch` is a named export. Pick the form that matches your module system —
+everything after the import is identical.
+
+```ts twoslash tab="ESM" tabGroup="module"
+import { stitch } from 'stitchapi';
 ```
 
-```bash
-yarn add @stitchapi/core
+```js tab="CommonJS" tabGroup="module"
+const { stitch } = require('stitchapi');
 ```
-
-```bash
-bun add @stitchapi/core
-```
-
-## Requirements
-
-The runtime has zero dependencies. It runs on a modern Node runtime, and in the
-browser via any bundler — there is no minimum Node version to pin and nothing to
-install alongside it.
-
-Validation is optional. If you want runtime validation of params, body, or the
-response, bring any [Standard Schema](https://standardschema.dev) validator —
-Zod, Valibot, or ArkType — as your own dependency. It is an optional add-on, not
-a requirement; see [Standard Schema](/docs/guides/validation/standard-schema).
 
 ## Verify
 
-Declare a trivial stitch and confirm the types resolve. If this snippet
-type-checks, the install is good:
+Declare a stitch from one URL and call it like a function — no config object, no
+client to construct:
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
-const me = stitch({
-    baseUrl: 'https://api.example.com',
-    path: '/me',
-});
+const getUsers = stitch('https://api.example.com/users');
+
+const users = await getUsers(); // GET, parsed JSON
 ```
 
-<Callout type="info">
-    No type error means `@stitchapi/core` resolved and `me` is a typed, callable
-    stitch — you are ready to write a real one.
-</Callout>
+If that returns without throwing, the runtime is wired up. Add an `output` schema
+next and you get TypeScript types, runtime validation, and drift detection in one
+move — see Quickstart.
 
-## Next steps
+## See also
 
 <Cards>
     <Card title="Quickstart" href="/docs/getting-started/quickstart" />
-    <Card title="The stitch primitive" href="/docs/concepts/the-stitch" />
-    <Card
-        title="Standard Schema"
-        href="/docs/guides/validation/standard-schema"
-    />
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
 </Cards>

--- a/apps/docs/content/docs/getting-started/quickstart.mdx
+++ b/apps/docs/content/docs/getting-started/quickstart.mdx
@@ -14,7 +14,7 @@ The smallest stitch is a URL. Pass it to `stitch()` as a string and you get back
 a callable — the string sets the `path`:
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const getUsers = stitch('https://api.example.com/users');
 ```
@@ -26,7 +26,7 @@ sugar that consumes the underlying stream and returns the final, validated
 value (a `GET` with parsed JSON here):
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const getUsers = stitch('https://api.example.com/users');
 
@@ -40,7 +40,7 @@ a single input object, so a path param goes under `params` and query keys under
 `query`:
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const getUser = stitch('https://api.example.com/users/{id}');
 
@@ -54,7 +54,7 @@ Pass a type argument to `stitch<T>()` and the awaited value is typed as `T`,
 with no extra dependency:
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const getUser = stitch<{ id: number; name: string }>(
     'https://api.example.com/users/{id}',
@@ -75,7 +75,7 @@ A stitch does not return `Promise<bytes>` — it yields a typed event stream, an
 retries, and drift as they happen:
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const getUsers = stitch('https://api.example.com/users');
 

--- a/apps/docs/content/docs/guides/auth/api-key.mdx
+++ b/apps/docs/content/docs/guides/auth/api-key.mdx
@@ -10,7 +10,7 @@ the secret.
 ## Example
 
 ```ts twoslash
-import { apiKey, env, stitch } from '@stitchapi/core';
+import { apiKey, env, stitch } from 'stitchapi';
 
 const search = stitch({
     baseUrl: 'https://api.example.com',

--- a/apps/docs/content/docs/guides/auth/basic.mdx
+++ b/apps/docs/content/docs/guides/auth/basic.mdx
@@ -10,7 +10,7 @@ resolved at call time so the caller never holds the credential.
 ## Example
 
 ```ts twoslash
-import { basic, env, stitch } from '@stitchapi/core';
+import { basic, env, stitch } from 'stitchapi';
 
 const report = stitch({
     baseUrl: 'https://api.example.com',

--- a/apps/docs/content/docs/guides/auth/bearer.mdx
+++ b/apps/docs/content/docs/guides/auth/bearer.mdx
@@ -10,7 +10,7 @@ the secret stays out of your code and out of the caller's hands.
 ## Example
 
 ```ts twoslash
-import { bearer, env, stitch } from '@stitchapi/core';
+import { bearer, env, stitch } from 'stitchapi';
 
 const me = stitch({
     baseUrl: 'https://api.example.com',

--- a/apps/docs/content/docs/guides/auth/cookie-session.mdx
+++ b/apps/docs/content/docs/guides/auth/cookie-session.mdx
@@ -10,7 +10,7 @@ for you — the stitch holds the login, the caller never touches a cookie.
 ## Example
 
 ```ts twoslash
-import { cookieSession, env, stitch } from '@stitchapi/core';
+import { cookieSession, env, stitch } from 'stitchapi';
 
 // The login is itself a stitch — its Set-Cookie response seeds the session.
 const login = stitch({

--- a/apps/docs/content/docs/guides/auth/oauth2.mdx
+++ b/apps/docs/content/docs/guides/auth/oauth2.mdx
@@ -10,7 +10,7 @@ stitch holds the client id and secret, the caller never sees the token.
 ## Example
 
 ```ts twoslash
-import { env, oauth2, stitch } from '@stitchapi/core';
+import { env, oauth2, stitch } from 'stitchapi';
 
 const orders = stitch({
     baseUrl: 'https://api.example.com',

--- a/apps/docs/content/docs/guides/auth/secret-resolvers.mdx
+++ b/apps/docs/content/docs/guides/auth/secret-resolvers.mdx
@@ -10,7 +10,7 @@ capability, not a credential you have to commit.
 ## Example
 
 ```ts twoslash
-import { bearer, env, keychain, stitch } from '@stitchapi/core';
+import { bearer, env, keychain, stitch } from 'stitchapi';
 
 // env() reads process.env.API_TOKEN when the stitch is called, not now.
 const me = stitch({

--- a/apps/docs/content/docs/guides/authoring/define-stitch.mdx
+++ b/apps/docs/content/docs/guides/authoring/define-stitch.mdx
@@ -10,7 +10,7 @@ stitch from the resulting factory instead of repeating the base on every call.
 ## Example
 
 ```ts twoslash
-import { defineStitch } from '@stitchapi/core';
+import { defineStitch } from 'stitchapi';
 
 // Bind the base once; the factory carries it into every stitch it builds.
 const api = defineStitch({

--- a/apps/docs/content/docs/guides/authoring/extends.mdx
+++ b/apps/docs/content/docs/guides/authoring/extends.mdx
@@ -10,7 +10,7 @@ common configuration lives in one place and each stitch states only what differs
 ## Example
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 // A base stitch carrying the shared host and headers.
 const base = stitch({

--- a/apps/docs/content/docs/guides/authoring/fluent-builder.mdx
+++ b/apps/docs/content/docs/guides/authoring/fluent-builder.mdx
@@ -10,7 +10,7 @@ incrementally or add behavior conditionally rather than declaring it all at once
 ## Example
 
 ```ts twoslash
-import { bearer, env, stitch } from '@stitchapi/core';
+import { bearer, env, stitch } from 'stitchapi';
 
 const getUser = stitch
     .use({ baseUrl: 'https://api.example.com' })

--- a/apps/docs/content/docs/guides/authoring/preset.mdx
+++ b/apps/docs/content/docs/guides/authoring/preset.mdx
@@ -10,7 +10,7 @@ same fields on each one.
 ## Example
 
 ```ts twoslash
-import { defineStitch, preset, stitch } from '@stitchapi/core';
+import { defineStitch, preset, stitch } from 'stitchapi';
 
 // A named bundle of reusable defaults. It does nothing on its own.
 const resilient = preset({

--- a/apps/docs/content/docs/guides/authoring/stitch.mdx
+++ b/apps/docs/content/docs/guides/authoring/stitch.mdx
@@ -14,7 +14,7 @@ Pass a string when the URL is all you need; pass a config object when you want a
 awaited value.
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 // String form — the string becomes the path; a full URL is fine.
 const listUsers = stitch<{ id: number; name: string }[]>(

--- a/apps/docs/content/docs/guides/authoring/with.mdx
+++ b/apps/docs/content/docs/guides/authoring/with.mdx
@@ -11,7 +11,7 @@ carry over.
 ## Example
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const search = stitch('https://api.example.com/search');
 

--- a/apps/docs/content/docs/guides/data/body-encoding.mdx
+++ b/apps/docs/content/docs/guides/data/body-encoding.mdx
@@ -10,7 +10,7 @@ serialize the `body` you pass at call time into that shape.
 ## Example
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const submit = stitch({
     method: 'POST',

--- a/apps/docs/content/docs/guides/data/graphql.mdx
+++ b/apps/docs/content/docs/guides/data/graphql.mdx
@@ -11,7 +11,7 @@ failure, not a success.
 ## Example
 
 ```ts twoslash
-import { graphql } from '@stitchapi/core';
+import { graphql } from 'stitchapi';
 
 const getUser = graphql<{ user: { id: string; name: string } }>({
     baseUrl: 'https://api.example.com',

--- a/apps/docs/content/docs/guides/data/pagination.mdx
+++ b/apps/docs/content/docs/guides/data/pagination.mdx
@@ -10,7 +10,7 @@ into one array, and applies auth, retry, and throttle to each page along the way
 ## Example
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const allUsers = stitch({
     baseUrl: 'https://api.example.com',

--- a/apps/docs/content/docs/guides/data/transform.mdx
+++ b/apps/docs/content/docs/guides/data/transform.mdx
@@ -11,7 +11,7 @@ ever see it.
 ## Example
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const listing = stitch({
     baseUrl: 'https://api.example.com',

--- a/apps/docs/content/docs/guides/data/unwrap.mdx
+++ b/apps/docs/content/docs/guides/data/unwrap.mdx
@@ -10,7 +10,7 @@ caller never sees the wrapper.
 ## Example
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const getUser = stitch<{ id: number; name: string }>({
     baseUrl: 'https://api.example.com',

--- a/apps/docs/content/docs/guides/observability/otlp.mdx
+++ b/apps/docs/content/docs/guides/observability/otlp.mdx
@@ -23,7 +23,7 @@ To wire it yourself — to set headers, or to tee OTLP next to your own sink —
 build the sink with `otlpTrace()` and combine sinks with `multiplex`:
 
 ```ts twoslash
-import { createTrace, multiplex, otlpTrace } from '@stitchapi/core';
+import { createTrace, multiplex, otlpTrace } from 'stitchapi';
 
 const trace = multiplex(
     createTrace({ console: true }),

--- a/apps/docs/content/docs/guides/observability/trace-sinks.mdx
+++ b/apps/docs/content/docs/guides/observability/trace-sinks.mdx
@@ -30,7 +30,7 @@ To consume events as your own sink, iterate the stream — that's the public sea
 for custom handling:
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const search = stitch({ baseUrl: 'https://api.example.com', path: '/search' });
 
@@ -52,7 +52,7 @@ see [OTLP export](/docs/guides/observability/otlp).
 To build sinks in code instead, `createTrace({ console, file })` returns a sink
 that writes JSONL and/or the console stream, and `multiplex(a, b, ...)` fans one
 event stream out to several sinks at once. Both are exported from
-[`@stitchapi/core`](/docs/reference/helpers).
+[`stitchapi`](/docs/reference/helpers).
 
 A `TraceSink` is just `{ handle(event, ctx), flush?() }` — implement those two
 and you have a custom consumer you can pass to `multiplex`. The same shape backs

--- a/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
+++ b/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
@@ -11,7 +11,7 @@ call probes it again.
 ## Example
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const orders = stitch({
     baseUrl: 'https://api.example.com',

--- a/apps/docs/content/docs/guides/resilience/idempotency.mdx
+++ b/apps/docs/content/docs/guides/resilience/idempotency.mdx
@@ -12,7 +12,7 @@ double-create.
 ## Example
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 // Default: a fresh random key per call, sent as 'Idempotency-Key'.
 const charge = stitch({

--- a/apps/docs/content/docs/guides/resilience/retry.mdx
+++ b/apps/docs/content/docs/guides/resilience/retry.mdx
@@ -10,7 +10,7 @@ first error.
 ## Example
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const getUser = stitch({
     baseUrl: 'https://api.example.com',

--- a/apps/docs/content/docs/guides/resilience/throttle.mdx
+++ b/apps/docs/content/docs/guides/resilience/throttle.mdx
@@ -10,7 +10,7 @@ many run at once, before any request leaves.
 ## Example
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const search = stitch({
     baseUrl: 'https://api.example.com',

--- a/apps/docs/content/docs/guides/resilience/timeout.mdx
+++ b/apps/docs/content/docs/guides/resilience/timeout.mdx
@@ -10,7 +10,7 @@ breached deadline actually aborts the in-flight request rather than leaking it.
 ## Example
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
 
 const report = stitch({
     baseUrl: 'https://api.example.com',

--- a/apps/docs/content/docs/guides/state/distributed-throttle.mdx
+++ b/apps/docs/content/docs/guides/state/distributed-throttle.mdx
@@ -10,8 +10,8 @@ shared `store` and one budget spans every worker that uses it.
 ## Example
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
-import type { StitchStore } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
+import type { StitchStore } from 'stitchapi';
 
 // A Redis- or Postgres-backed store, shared across workers — see The pluggable store.
 declare const sharedStore: StitchStore;

--- a/apps/docs/content/docs/guides/state/pluggable-store.mdx
+++ b/apps/docs/content/docs/guides/state/pluggable-store.mdx
@@ -11,8 +11,8 @@ or anything else by implementing three async methods and attaching it via
 ## Example
 
 ```ts twoslash
-import { stitch } from '@stitchapi/core';
-import type { StitchStore } from '@stitchapi/core';
+import { stitch } from 'stitchapi';
+import type { StitchStore } from 'stitchapi';
 
 // A StitchStore is just three async methods + TTL — back it with anything.
 const redisStore: StitchStore = {

--- a/apps/docs/content/docs/guides/state/shared-sessions.mdx
+++ b/apps/docs/content/docs/guides/state/shared-sessions.mdx
@@ -11,8 +11,8 @@ across workers, not just within a single process.
 ## Example
 
 ```ts twoslash
-import { cookieSession, env, stitch } from '@stitchapi/core';
-import type { StitchStore } from '@stitchapi/core';
+import { cookieSession, env, stitch } from 'stitchapi';
+import type { StitchStore } from 'stitchapi';
 
 // A Redis-backed StitchStore — see The pluggable store.
 declare const sharedStore: StitchStore;

--- a/apps/docs/content/docs/guides/validation/drift.mdx
+++ b/apps/docs/content/docs/guides/validation/drift.mdx
@@ -11,7 +11,7 @@ baseline.
 ## Example
 
 ```ts twoslash
-import { drift, stitch } from '@stitchapi/core';
+import { drift, stitch } from 'stitchapi';
 import { z } from 'zod';
 
 const getUser = stitch({

--- a/apps/docs/content/docs/guides/validation/standard-schema.mdx
+++ b/apps/docs/content/docs/guides/validation/standard-schema.mdx
@@ -11,7 +11,7 @@ adapted by the single `toValidator()` helper.
 ## Example
 
 ```ts twoslash
-import { stitch, toValidator } from '@stitchapi/core';
+import { stitch, toValidator } from 'stitchapi';
 import { z } from 'zod';
 
 const User = z.object({ id: z.number(), name: z.string() });

--- a/apps/docs/content/docs/guides/validation/validation.mdx
+++ b/apps/docs/content/docs/guides/validation/validation.mdx
@@ -11,7 +11,7 @@ call.
 ## Example
 
 ```ts twoslash
-import { stitch, toValidator } from '@stitchapi/core';
+import { stitch, toValidator } from 'stitchapi';
 import { z } from 'zod';
 
 const createUser = stitch<{ id: number; name: string }>({

--- a/apps/docs/content/docs/reference/config-types.mdx
+++ b/apps/docs/content/docs/reference/config-types.mdx
@@ -9,7 +9,7 @@ stitch is the result of deep-merging these fragments through `extends`.
 ## StitchConfig
 
 ```ts twoslash
-import type { StitchConfig } from '@stitchapi/core';
+import type { StitchConfig } from 'stitchapi';
 ```
 
 <AutoTypeTable path="../../packages/core/src/types.ts" name="StitchConfig" />

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,22 +4,25 @@
     "private": true,
     "description": "StitchAPI documentation site — Fumadocs (Next.js App Router). Content lands in follow-up PRs.",
     "scripts": {
-        "dev": "next dev",
-        "build": "next build",
+        "dev": "pnpm run build:core && next dev",
+        "build": "pnpm run build:core && next build",
         "start": "next start",
-        "check:types": "fumadocs-mdx && next typegen && tsc --noEmit",
+        "check:types": "pnpm run build:core && fumadocs-mdx && next typegen && tsc --noEmit",
         "check:lint": "eslint .",
-        "gen:docs": "node scripts/generate-skeleton.mjs"
+        "gen:docs": "node scripts/generate-skeleton.mjs",
+        "build:core": "pnpm --filter stitchapi build"
     },
     "dependencies": {
         "fumadocs-core": "^16.10.0",
         "fumadocs-mdx": "^15.0.12",
+        "fumadocs-twoslash": "^3.2.0",
         "fumadocs-typescript": "^5.2.6",
         "fumadocs-ui": "^16.10.0",
         "lucide-react": "^1.17.0",
         "next": "16.2.7",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
+        "stitchapi": "workspace:*",
         "tailwind-merge": "^3.6.0",
         "zod": "^4.4.3"
     },

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -1,5 +1,7 @@
+import { rehypeCodeDefaultOptions } from 'fumadocs-core/mdx-plugins';
 import { metaSchema, pageSchema } from 'fumadocs-core/source/schema';
 import { defineConfig, defineDocs } from 'fumadocs-mdx/config';
+import { transformerTwoslash } from 'fumadocs-twoslash';
 
 // You can customize Zod schemas for frontmatter and `meta.json` here
 // see https://fumadocs.dev/docs/mdx/collections
@@ -18,6 +20,22 @@ export const docs = defineDocs({
 
 export default defineConfig({
     mdxOptions: {
-        // MDX options
+        // Package-manager install tabs (```package-install```) and code-variant
+        // tabs (```ts tab="…"```) ship on by default in fumadocs-mdx. `persist`
+        // makes the reader's package-manager pick stick across every page;
+        // code-variant tabs persist per `tabGroup` id set on the fence.
+        // See AUTHORING.md → "Code variants — tabs".
+        remarkNpmOptions: { persist: { id: 'package-manager' } },
+        // Twoslash type-checks every ```ts twoslash``` block against the real
+        // `stitchapi` types at build time and renders hover tooltips. Spread the
+        // defaults so the stock Shiki transformers (tab/title/icon meta) survive;
+        // the Popup components it emits are registered in components/mdx.tsx.
+        rehypeCodeOptions: {
+            ...rehypeCodeDefaultOptions,
+            transformers: [
+                ...(rehypeCodeDefaultOptions.transformers ?? []),
+                transformerTwoslash(),
+            ],
+        },
     },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       fumadocs-mdx:
         specifier: ^15.0.12
         version: 15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.7(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
+      fumadocs-twoslash:
+        specifier: ^3.2.0
+        version: 3.2.0(43bdab8e86eb78dffe042ebef153a165)
       fumadocs-typescript:
         specifier: ^5.2.6
         version: 5.2.6(ea2e056a60d562761cee7554f1f0adca)
@@ -44,6 +47,9 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
+      stitchapi:
+        specifier: workspace:*
+        version: link:../../packages/core
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
@@ -1553,6 +1559,12 @@ packages:
     resolution: {integrity: sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==}
     engines: {node: '>=20'}
 
+  '@shikijs/twoslash@4.2.0':
+    resolution: {integrity: sha512-PG/F0tMyt4zAvHVBL7Ehtk/ZpI2Rq3PwaXRYJaOO41eIK/iV9GOO/20jZhQkScOdcP6aFwHC2/x/GxmeR4tMlA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      typescript: '>=5.5.0'
+
   '@shikijs/types@4.2.0':
     resolution: {integrity: sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==}
     engines: {node: '>=20'}
@@ -1788,6 +1800,11 @@ packages:
   '@typescript-eslint/visitor-keys@8.61.0':
     resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/vfs@1.6.4':
+    resolution: {integrity: sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==}
+    peerDependencies:
+      typescript: '*'
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -2715,6 +2732,19 @@ packages:
       rolldown:
         optional: true
       vite:
+        optional: true
+
+  fumadocs-twoslash@3.2.0:
+    resolution: {integrity: sha512-hzoxc2HR9dw2z5T1NNLYCbMY1DFiSF71+X2KJS4t/BalRyiBxpCcP9zAyzofba07YkrGhZ6xW3B105EcpNI2Vw==}
+    peerDependencies:
+      '@types/react': '*'
+      fumadocs-core: ^16.7.16
+      fumadocs-ui: ^16.7.16
+      react: ^19.2.0
+      react-dom: ^19.2.0
+      shiki: 4.x.x
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   fumadocs-typescript@5.2.6:
@@ -4176,6 +4206,14 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  twoslash-protocol@0.3.8:
+    resolution: {integrity: sha512-HmvAHoiEviK8LqvAQyc9/irkdvwTUiR1fHmNwH/0gq8EHxyBt4PWVPixjEXg6wJu1u6yBrILEWXGK9Kw58/8yQ==}
+
+  twoslash@0.3.8:
+    resolution: {integrity: sha512-OeDz0kDl8sqPUN3nr7gqcvOs70f5lZsdhKYTX3/SgB9OvdadzzoYJI/4SBXhXV1HG8E9fLc+e17itoRYTxmoig==}
+    peerDependencies:
+      typescript: ^5.5.0 || ^6.0.0
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -5613,6 +5651,15 @@ snapshots:
     dependencies:
       '@shikijs/types': 4.2.0
 
+  '@shikijs/twoslash@4.2.0(typescript@6.0.3)':
+    dependencies:
+      '@shikijs/core': 4.2.0
+      '@shikijs/types': 4.2.0
+      twoslash: 0.3.8(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@shikijs/types@4.2.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
@@ -5942,6 +5989,13 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.61.0
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/vfs@1.6.4(typescript@6.0.3)':
+    dependencies:
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -6997,6 +7051,27 @@ snapshots:
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)
     transitivePeerDependencies:
       - supports-color
+
+  fumadocs-twoslash@3.2.0(43bdab8e86eb78dffe042ebef153a165):
+    dependencies:
+      '@radix-ui/react-popover': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@shikijs/twoslash': 4.2.0(typescript@6.0.3)
+      fumadocs-core: 16.10.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
+      fumadocs-ui: 16.10.0(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(next@16.2.7(@babel/core@7.29.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm: 3.1.0
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      shiki: 4.2.0
+      tailwind-merge: 3.6.0
+      twoslash: 0.3.8(typescript@6.0.3)
+    optionalDependencies:
+      '@types/react': 19.2.17
+    transitivePeerDependencies:
+      - '@types/react-dom'
+      - supports-color
+      - typescript
 
   fumadocs-typescript@5.2.6(ea2e056a60d562761cee7554f1f0adca):
     dependencies:
@@ -8934,6 +9009,16 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
     optional: true
+
+  twoslash-protocol@0.3.8: {}
+
+  twoslash@0.3.8(typescript@6.0.3):
+    dependencies:
+      '@typescript/vfs': 1.6.4(typescript@6.0.3)
+      twoslash-protocol: 0.3.8
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
## What

Establishes the convention that **equivalent code snippets render as persisted tabs**, and wires **Twoslash** so every `ts twoslash` block is type-checked against the real `stitchapi` package at build time.

### Convention + Twoslash (`4de7ce9`)
- **AUTHORING.md** — new "Code variants — tabs" section, rule 9, and a canonical `tabGroup` table (`package-manager`, `definition-style`, `module`, `consumption`, `runtime`). Equivalent forms (package manager, import style, invocation variant) become tabs; the reader's pick persists site-wide.
- **source.config.ts** — persist package-manager tabs (`remarkNpmOptions`) and wire `transformerTwoslash` into `rehypeCodeOptions`.
- **components/mdx.tsx** — register the Twoslash `Popup` components (kept alongside the existing `AutoTypeTable`).
- **app/layout.tsx** — load `fumadocs-twoslash/twoslash.css`.
- **package.json** — add `fumadocs-twoslash`; build `stitchapi` before the docs `dev`/`build`/`check:types` so a fresh clone resolves its types for Twoslash.
- **installation.mdx** — worked exemplar (package-manager + ESM/CommonJS tabs).

### Rename (`ea1778c`)
Wiring Twoslash retroactively type-checks every `ts twoslash` block. The existing content pages were authored from the template *before* Twoslash existed and import the placeholder `@stitchapi/core`, which no longer resolves. Renamed to the real `stitchapi` across **all 38 pages** so the docs-render gate stays green. The pages were otherwise type-correct — the rename alone made the build pass.

## Heads-up for review
- **installation.mdx** was also authored concurrently on `develop`. This PR keeps the tabs-convention exemplar (`package-install` + ESM/CommonJS tabs); it supersedes that version, which had a **Requirements / Standard Schema** section worth folding back in if you want it.

## Verification
Local pre-push gates all green: `typecheck` ✔️, `test` ✔️, `build-docs` ✔️ (all 38 pages compile under Twoslash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)