### PR TITLE
docs: author Errors & pitfalls (validation, drift, timeout, circuit-open, graphql + landing)

### DIFF
--- a/apps/docs/content/docs/errors/index.mdx
+++ b/apps/docs/content/docs/errors/index.mdx
@@ -3,4 +3,88 @@ title: 'Errors & pitfalls'
 description: 'How StitchAPI errors work, the code-to-docs contract, and an index of every coded failure.'
 ---
 
-Stub — orient the reader and link into this section. See AUTHORING.md.
+When a stitch can't produce a result, it fails with a `StitchError` — an
+`Error` with `name: 'StitchError'`, a human-readable `message`, and an optional
+`.status` carrying the upstream HTTP status. Await a stitch and that error is
+what `catch` receives:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const me = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/me',
+});
+
+try {
+    await me();
+} catch (e) {
+    if (e instanceof Error && e.name === 'StitchError') {
+        const status = (e as Error & { status?: number }).status;
+        console.error(e.message, status);
+    }
+}
+```
+
+If you read the [event stream](/docs/concepts/event-stream) instead of awaiting,
+the same failure arrives as an `error` event carrying
+`{ name, message, status?, attempts, at }` — `attempts` is how many tries the
+runtime made before giving up, `at` is when it gave up.
+
+## The code-to-docs contract
+
+Each catalog page below owns a stable **code** (`STITCH_VALIDATION`,
+`STITCH_DRIFT`, and so on). The code's page **slug is its URL** — the failure
+documented at `/errors/<slug>` is the page the runtime will deep-link to from a
+thrown error. Slugs are an API: once a page is published its slug is never
+renamed, only added-and-redirected, so a link a runtime emitted a year ago still
+resolves.
+
+<Callout type="warn">
+    These codes are **provisional**. Today the runtime throws a `StitchError`
+    with a `message` and optional `.status` — the stable `code` and `url` fields
+    land with the error-taxonomy refactor. The slugs below are already fixed, so
+    you can rely on the URLs even while the in-runtime codes are still on the way.
+</Callout>
+
+## Every coded failure
+
+<Cards>
+    <Card
+        title="STITCH_VALIDATION"
+        href="/docs/errors/stitch-validation"
+    >
+        A response failed its output schema — the shape you asked for isn't the
+        shape you got.
+    </Card>
+    <Card title="STITCH_DRIFT" href="/docs/errors/stitch-drift">
+        A response drifted from the schema past the level you allowed, so the
+        stitch refused it.
+    </Card>
+    <Card title="STITCH_AUTH_WALL" href="/docs/errors/stitch-auth-wall">
+        Authentication failed, or a soft 200 login wall was hit and couldn't be
+        refreshed.
+    </Card>
+    <Card title="STITCH_TIMEOUT" href="/docs/errors/stitch-timeout">
+        A call exceeded its timeout budget before a response arrived.
+    </Card>
+    <Card
+        title="STITCH_CIRCUIT_OPEN"
+        href="/docs/errors/stitch-circuit-open"
+    >
+        The circuit breaker is open after repeated failures and is short-circuiting
+        calls.
+    </Card>
+    <Card title="STITCH_GRAPHQL" href="/docs/errors/stitch-graphql">
+        A GraphQL-over-HTTP response came back `200` but carried an `errors`
+        array.
+    </Card>
+</Cards>
+
+## See also
+
+<Cards>
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+    <Card title="STITCH_VALIDATION" href="/docs/errors/stitch-validation" />
+    <Card title="STITCH_DRIFT" href="/docs/errors/stitch-drift" />
+</Cards>

--- a/apps/docs/content/docs/errors/index.mdx
+++ b/apps/docs/content/docs/errors/index.mdx
@@ -44,16 +44,14 @@ resolves.
     These codes are **provisional**. Today the runtime throws a `StitchError`
     with a `message` and optional `.status` — the stable `code` and `url` fields
     land with the error-taxonomy refactor. The slugs below are already fixed, so
-    you can rely on the URLs even while the in-runtime codes are still on the way.
+    you can rely on the URLs even while the in-runtime codes are still on the
+    way.
 </Callout>
 
 ## Every coded failure
 
 <Cards>
-    <Card
-        title="STITCH_VALIDATION"
-        href="/docs/errors/stitch-validation"
-    >
+    <Card title="STITCH_VALIDATION" href="/docs/errors/stitch-validation">
         A response failed its output schema — the shape you asked for isn't the
         shape you got.
     </Card>
@@ -68,12 +66,9 @@ resolves.
     <Card title="STITCH_TIMEOUT" href="/docs/errors/stitch-timeout">
         A call exceeded its timeout budget before a response arrived.
     </Card>
-    <Card
-        title="STITCH_CIRCUIT_OPEN"
-        href="/docs/errors/stitch-circuit-open"
-    >
-        The circuit breaker is open after repeated failures and is short-circuiting
-        calls.
+    <Card title="STITCH_CIRCUIT_OPEN" href="/docs/errors/stitch-circuit-open">
+        The circuit breaker is open after repeated failures and is
+        short-circuiting calls.
     </Card>
     <Card title="STITCH_GRAPHQL" href="/docs/errors/stitch-graphql">
         A GraphQL-over-HTTP response came back `200` but carried an `errors`

--- a/apps/docs/content/docs/errors/stitch-circuit-open.mdx
+++ b/apps/docs/content/docs/errors/stitch-circuit-open.mdx
@@ -5,16 +5,60 @@ description: 'The circuit breaker is open after repeated failures and short-circ
 
 ## What you'll see
 
-Stub.
+A stitch configured with a [`circuit`](/docs/guides/resilience/circuit-breaker)
+fails _immediately_ — no request leaves the process — with a `StitchError`
+surfaced on the event stream as an `error` event (phase `circuit`). The
+dependency itself isn't being hit: the breaker tripped open after repeated
+failures and is now fast-failing every call to protect it. This is the breaker
+doing its job, not a fresh failure.
+
+<Callout type="info">
+    `STITCH_CIRCUIT_OPEN` is provisional — the stable error-code registry lands
+    with the runtime taxonomy refactor. Today the short-circuit surfaces as a
+    `StitchError`; match on the breaker's `circuit` phase rather than the code
+    string.
+</Callout>
 
 ## Why it happens
 
-Stub.
+The breaker counts _consecutive_ failures. Once it reaches `failureThreshold`,
+it trips **open** and records the moment. While open, every call fast-fails for
+`cooldownMs` instead of touching the dependency. Seeing this error means you are
+inside that cooldown window — the breaker hasn't yet allowed the **half-open**
+trial that decides whether to close again. The real failures that tripped it
+happened on earlier calls; this one is just being short-circuited.
 
 ## How to fix
 
-Stub.
+Most of the time this is working as intended — a failing dependency is being
+shielded from a stampede. Work through these in order:
+
+-   **Wait it out.** After `cooldownMs` (or `halfOpenAfterMs`, if set) the breaker
+    goes half-open and lets a single trial through; a success closes it and traffic
+    resumes. If the dependency has recovered, the next call after the window will
+    succeed.
+-   **Fix the underlying dependency.** The breaker is a symptom, not the cause. Find
+    and fix the real failures — the earlier errors that incremented the count to
+    `failureThreshold` — so the half-open trial can close it.
+-   **Tune the thresholds.** Raise `failureThreshold` if the breaker trips on
+    transient blips; adjust `cooldownMs` / `halfOpenAfterMs` to control how long it
+    fast-fails before retesting.
+-   **Check the `key`.** Breakers are keyed (default: the stitch/host key). If two
+    unrelated stitches share a `key`, one failing dependency trips the breaker for
+    both — give them distinct keys so they don't share a breaker.
+
+Pair the breaker with [retry](/docs/guides/resilience/retry) and
+[timeout](/docs/guides/resilience/timeout): timeouts and retries absorb the
+transient failures, and the breaker steps in only once those keep failing.
 
 ## Related
 
-Stub.
+<Cards>
+    <Card
+        title="Guide: circuit breaker"
+        href="/docs/guides/resilience/circuit-breaker"
+    />
+    <Card title="Guide: timeout" href="/docs/guides/resilience/timeout" />
+    <Card title="Guide: retry" href="/docs/guides/resilience/retry" />
+    <Card title="Reference: config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/errors/stitch-drift.mdx
+++ b/apps/docs/content/docs/errors/stitch-drift.mdx
@@ -5,16 +5,66 @@ description: 'An error-level drift finding broke the response contract.'
 
 ## What you'll see
 
-Stub.
+A call fails right after a `drift` event whose finding carries `level: 'error'`.
+The event names the offending `path` and the `change` it detected — `missing`,
+`type-changed`, or `nullable` — and the call then surfaces a `StitchError`
+instead of a `result`. The stable code is `STITCH_DRIFT` (provisional while the
+runtime error taxonomy settles).
+
+<Callout type="info">
+    `warn`- and `info`-level findings still stream as `drift` events, but they
+    do not fail the call — only an `error`-level finding breaks the contract.
+</Callout>
 
 ## Why it happens
 
-Stub.
+Drift compares the live response's shape against a committed snapshot
+(`snapshotFile`, the `<name>.contract.json` baseline) and classifies each delta
+by level. A path you listed under `critical` changed shape versus that baseline:
+a field went missing, switched type, or became nullable. That is a real contract
+break on a path you declared fatal, so the finding is raised to `error` and the
+call stops rather than handing back a response that no longer matches what you
+committed to.
 
 ## How to fix
 
-Stub.
+Read the finding's `path` and `change` to see exactly what moved, then decide
+which of two cases you're in:
+
+-   **The change is intended.** The upstream shape genuinely changed and you want
+    the new shape. Update the committed snapshot (and any output schema) to match,
+    re-commit the `<name>.contract.json` baseline, and the path stops drifting.
+-   **It's a vendor regression.** You did not expect this change — that is the
+    signal `critical` exists to give you. Treat the broken call as the alert and
+    act on the upstream break.
+
+If a path shouldn't be fatal at all, re-level it from `critical` to `watch` so
+its changes stream as `warn` findings without failing the call:
+
+```ts twoslash
+import { drift, stitch } from 'stitchapi';
+
+const user = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/user',
+    output: drift((body: unknown) => body, {
+        // `id` must never change shape — a change here fails the call.
+        critical: ['id'],
+        // `displayName` is allowed to drift; it only warns.
+        watch: ['displayName'],
+        snapshotFile: 'user.contract.json',
+    }),
+});
+```
+
+See the [drift guide](/docs/guides/validation/drift) for how `critical`,
+`watch`, and `onNew` map onto finding levels.
 
 ## Related
 
-Stub.
+<Cards>
+    <Card title="Guide: drift detection" href="/docs/guides/validation/drift" />
+    <Card title="Guide: validation" href="/docs/guides/validation/validation" />
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+    <Card title="Reference: config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/errors/stitch-graphql.mdx
+++ b/apps/docs/content/docs/errors/stitch-graphql.mdx
@@ -5,16 +5,69 @@ description: 'A GraphQL 200 response carried an errors array and failed the call
 
 ## What you'll see
 
-Stub.
+A stitch built with [`graphql()`](/docs/guides/data/graphql) throws a
+`StitchError` even though the HTTP status was `200`. The response body carried a
+non-empty top-level `errors` array, so the stitch refused to unwrap `data` and
+surfaced the failure instead. The thrown error carries the GraphQL message(s),
+prefixed `GraphQL:` and joined with `; ` when there is more than one:
+
+```ts twoslash
+import { graphql } from 'stitchapi';
+
+const user = graphql({
+    baseUrl: 'https://api.example.com',
+    path: '/graphql',
+    query: `query ($id: ID!) { user(id: $id) { name } }`,
+});
+
+try {
+    await user({ body: { variables: { id: '42' } } });
+} catch (err) {
+    // err.name === 'StitchError'
+    // err.message === 'GraphQL: Variable "$id" of required type "ID!" was not provided.'
+    console.error(err);
+}
+```
+
+(`STITCH_GRAPHQL` is the provisional registry code for this failure; the runtime
+throws a `StitchError` today.)
 
 ## Why it happens
 
-Stub.
+GraphQL-over-HTTP commonly answers with HTTP `200` even when the operation
+failed, reporting the failure in a top-level `errors` array rather than via the
+status line. A `graphql()` stitch treats a `200` that carries a non-empty
+`errors` array as a failure instead of silently unwrapping `data` — so a request
+that "looked successful" at the transport layer still throws.
+
+The entries in `errors` come from the GraphQL server: a malformed query or
+missing variable, a resolver that threw, or an authorization check the server
+enforced in-band. Whatever the cause, the server signalled it in the body, and
+the stitch honours that signal.
 
 ## How to fix
 
-Stub.
+Read the GraphQL message(s) on the thrown `StitchError` — they are the server's
+own description of what went wrong — and fix the cause:
+
+-   **Bad query or variables.** Correct the operation string or the `variables`
+    you pass so they satisfy the schema (right field names, required variables
+    provided, correct types).
+-   **Resolver error.** The fault is server-side; reproduce the operation against
+    the GraphQL server and fix it there.
+-   **Authorization.** The server rejected the operation in the `errors` array,
+    not with a status code — supply the credential or capability the operation
+    requires.
+
+Remember that GraphQL signals failure in the response body, not through the HTTP
+status: a `200` is not proof of success. See the
+[GraphQL guide](/docs/guides/data/graphql) for how `graphql()` posts the
+operation and unwraps `data` on the success path.
 
 ## Related
 
-Stub.
+<Cards>
+    <Card title="Guide: GraphQL" href="/docs/guides/data/graphql" />
+    <Card title="Validation" href="/docs/guides/validation/validation" />
+    <Card title="Reference: Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/errors/stitch-timeout.mdx
+++ b/apps/docs/content/docs/errors/stitch-timeout.mdx
@@ -5,16 +5,67 @@ description: 'A total or per-attempt timeout aborted the call.'
 
 ## What you'll see
 
-Stub.
+A call aborts and throws a `StitchError` once a configured timeout elapses.
+`timeout.total` bounds the whole call across every retry and its backoff;
+`timeout.perAttempt` bounds a single attempt. The runtime enforces these with a
+real `AbortSignal`, so the in-flight request is actually aborted rather than left
+running while the call gives up — the underlying request receives the abort.
+
+<Callout type="info">
+    The stable code `STITCH_TIMEOUT` is provisional: the error surfaces as a
+    `StitchError` today, and the code is pending the runtime taxonomy refactor.
+</Callout>
 
 ## Why it happens
 
-Stub.
+Two distinct triggers land here:
+
+-   **The dependency is slow or unreachable.** The request genuinely takes longer
+    than the budget you allowed — a degraded upstream, a cold start, or a host that
+    never answers and ties up the attempt until the signal fires.
+-   **The budget is too tight.** `perAttempt` is shorter than the dependency's
+    normal latency, so healthy responses get cut off; or `total` doesn't leave room
+    for every attempt plus the backoff between them, so the whole call aborts mid-
+    way through a retry sequence that would otherwise have succeeded.
 
 ## How to fix
 
-Stub.
+Raise `total` and `perAttempt` to a realistic budget for the dependency's actual
+latency. When you also configure [retry](/docs/guides/resilience/retry), make
+`total` large enough to cover the full sequence — as a rule of thumb,
+`total ≥ attempts × (perAttempt + backoff)` — so the call isn't aborted partway
+through a retry that would have landed.
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const report = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/reports/slow',
+    retry: { attempts: 3, baseMs: 200 },
+    timeout: {
+        // Each attempt gets 5s; the whole call (3 attempts + backoff) gets 20s.
+        perAttempt: '5s',
+        total: '20s',
+    },
+});
+```
+
+Check the dependency's measured latency before widening the budget — if it is
+consistently slow or flapping, a longer timeout only delays the failure. For a
+dependency that is genuinely failing, pair the timeout with
+[retry](/docs/guides/resilience/retry) for transient blips and a
+[circuit breaker](/docs/guides/resilience/circuit-breaker) to fast-fail once it
+stops responding, instead of waiting out the timeout on every call.
 
 ## Related
 
-Stub.
+<Cards>
+    <Card title="Guide: timeout" href="/docs/guides/resilience/timeout" />
+    <Card title="Guide: retry" href="/docs/guides/resilience/retry" />
+    <Card
+        title="Guide: circuit breaker"
+        href="/docs/guides/resilience/circuit-breaker"
+    />
+    <Card title="Reference: config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/errors/stitch-validation.mdx
+++ b/apps/docs/content/docs/errors/stitch-validation.mdx
@@ -5,16 +5,88 @@ description: 'Input or response failed schema validation.'
 
 ## What you'll see
 
-Stub.
+A stitch with an `input` or `output` schema throws a `StitchError` whose message
+names the failing path and the issue, e.g. `invalid body: name is required` or a
+type mismatch on the response. Where it throws tells you which side failed:
+
+-   **Input, before the request.** When call input doesn't match the `input`
+    schema, the stitch fails fast — the error is thrown _before_ any network call,
+    so nothing leaves the process. This is the common case for a malformed
+    `params`, `query`, `body`, or `headers`.
+-   **Response, after the request.** When the response doesn't match `output`, the
+    error is thrown after the response returns and has been transformed and
+    unwrapped — the request did go out, and the failure describes how the payload
+    diverged from the contract.
+
+<Callout type="warn">
+    The stable code `STITCH_VALIDATION` is provisional. Today the runtime throws a
+    `StitchError` carrying the failing path and message; the coded error taxonomy
+    that will populate `error.code` and `error.url` is still landing, so don't
+    match on a literal code string yet — match on the path in the message.
+</Callout>
 
 ## Why it happens
 
-Stub.
+The value didn't satisfy the schema you adapted onto the config:
+
+-   **Input didn't match `input`.** A required field is missing, a field has the
+    wrong type, or an extra/renamed field tripped a strict schema — checked against
+    `{ params, query, body, headers }` before the request.
+-   **Response didn't match `output`.** A real contract mismatch: the API dropped a
+    field you require, returned a field with the wrong type, or changed a shape your
+    `output` schema declares. The validator reports each issue with its path.
 
 ## How to fix
 
-Stub.
+Read the failing path off the message and check it against the schema:
+
+-   **If input failed,** fix the call input — or relax the `input` schema if the
+    field really is optional. The request never went out, so there's nothing to
+    retry once the input is correct.
+-   **If the response failed,** decide whether the schema or the API is wrong.
+    Update the `output` schema to match the real payload, or fix the expectation
+    if the API contract genuinely changed.
+
+For a response whose shape shifts in noisy-but-nonbreaking ways, don't reach for
+hard validation — a single new optional field shouldn't throw. Pass a
+[`drift()`](/docs/guides/validation/drift) spec to `output` instead, which
+reports leveled findings without failing the call.
+
+Config fields are typed as `Validator`, so adapt your schema with `toValidator`
+before assigning it. It coerces a Zod schema, any Standard Schema (Valibot,
+ArkType), or a plain predicate into the `Validator` shape `input`/`output`
+expect:
+
+```ts twoslash
+import { stitch, toValidator } from 'stitchapi';
+import { z } from 'zod';
+
+const createUser = stitch<{ id: number; name: string }>({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/users',
+    // Validated before the POST is sent — bad input fails fast.
+    input: { body: toValidator(z.object({ name: z.string() })) },
+    // Validated after the response returns.
+    output: toValidator(z.object({ id: z.number(), name: z.string() })),
+});
+```
+
+See [Bring your own validator](/docs/guides/validation/standard-schema) for
+adapting non-Zod schemas, and [Validation](/docs/guides/validation/validation)
+for how `input` and `output` are checked.
 
 ## Related
 
-Stub.
+<Cards>
+    <Card title="Guide: Validation" href="/docs/guides/validation/validation" />
+    <Card
+        title="Bring your own validator"
+        href="/docs/guides/validation/standard-schema"
+    />
+    <Card
+        title="Schema drift detection"
+        href="/docs/guides/validation/drift"
+    />
+    <Card title="Reference: Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/errors/stitch-validation.mdx
+++ b/apps/docs/content/docs/errors/stitch-validation.mdx
@@ -19,10 +19,11 @@ type mismatch on the response. Where it throws tells you which side failed:
     diverged from the contract.
 
 <Callout type="warn">
-    The stable code `STITCH_VALIDATION` is provisional. Today the runtime throws a
-    `StitchError` carrying the failing path and message; the coded error taxonomy
-    that will populate `error.code` and `error.url` is still landing, so don't
-    match on a literal code string yet — match on the path in the message.
+    The stable code `STITCH_VALIDATION` is provisional. Today the runtime throws
+    a `StitchError` carrying the failing path and message; the coded error
+    taxonomy that will populate `error.code` and `error.url` is still landing,
+    so don't match on a literal code string yet — match on the path in the
+    message.
 </Callout>
 
 ## Why it happens
@@ -84,9 +85,6 @@ for how `input` and `output` are checked.
         title="Bring your own validator"
         href="/docs/guides/validation/standard-schema"
     />
-    <Card
-        title="Schema drift detection"
-        href="/docs/guides/validation/drift"
-    />
+    <Card title="Schema drift detection" href="/docs/guides/validation/drift" />
     <Card title="Reference: Config types" href="/docs/reference/config-types" />
 </Cards>


### PR DESCRIPTION
Fills six of seven **Errors & pitfalls** stubs (`stitch-auth-wall` is already on develop from #24) — one agent per page, centrally verified.

## Pages
- **Errors & pitfalls** (landing) — how a `StitchError` surfaces (`name`/`message`/`status` + the `error` event), the code → `/errors/<slug>` contract (slugs are an API), and a `Cards` index of every coded failure.
- **STITCH_VALIDATION** — input fail-fast-before-request, or response schema failure.
- **STITCH_DRIFT** — an error-level (critical-path) drift finding broke the contract.
- **STITCH_TIMEOUT** — `total`/`perAttempt` budget aborted the call via a real `AbortSignal`.
- **STITCH_CIRCUIT_OPEN** — the breaker fast-fails during `cooldownMs` after repeated failures.
- **STITCH_GRAPHQL** — a `200` carrying a non-empty `errors` array failed the call.

## Verification
- Each follows the error template (What you'll see → Why it happens → How to fix → Related), grounded in real runtime behavior (validation/drift/timeout/circuit/graphql flows in `engine.ts`/`resilience.ts`), and is **honest that the codes are provisional** until the runtime error-taxonomy refactor lands (no fabricated literal code strings).
- All links resolve; full `next build` renders all 182 pages clean (exit 0).

Branched off the latest `develop`. Content-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)