### PR TITLE
docs: package-naming ADR + align sandbox to `stitchapi`

### DIFF
--- a/docs/adr/0001-package-naming-and-distribution.md
+++ b/docs/adr/0001-package-naming-and-distribution.md
@@ -1,0 +1,114 @@
+# ADR 0001 — Package naming & distribution model
+
+-   **Status:** Accepted
+-   **Date:** 2026-06-12
+-   **Tags:** packaging, npm, public-api, plugins
+
+## Context
+
+StitchAPI ships from a pnpm monorepo (`packages/*`, `apps/*`). The core library is
+published to npm as **`stitchapi`** (unscoped), currently v0.7.0, exposing a `stitch`
+bin. The repo also contains private, unpublished workspace packages under the
+`@stitchapi/*` scope (`@stitchapi/workspace`, `@stitchapi/docs`).
+
+We plan to grow an ecosystem around core: request/response **transformers**,
+framework **adapters** (e.g. React), observability sinks, and other **plugins** —
+first-party now, potentially third-party later. Several of these will carry their
+own (sometimes heavy or optional) dependencies, and adapters need framework peer
+dependencies.
+
+A naming drift had crept into the docs: authored examples and the Twoslash sandbox
+imported from `@stitchapi/core` — a name that is **not published** and does not match
+the workspace package (`stitchapi`). `apps/docs` already depends on `stitchapi`
+(`workspace:*`) and `apps/docs/AUTHORING.md` already mandates importing the published
+entry point `stitchapi`, so the drift contradicted the project's own standard. This
+forced the question: what is our canonical naming and distribution convention as we
+add plugins?
+
+## Decision
+
+1. **Core stays `stitchapi`** (unscoped). We do **not** rename it to `@stitchapi/core`.
+   The thing users reach for most keeps the cleanest name, and it reads with the
+   `stitch` verb / `stitch` bin.
+
+2. **First-party plugins, adapters, and transformers are published as separate
+   scoped packages: `@stitchapi/<name>`** — e.g. `@stitchapi/react`,
+   `@stitchapi/transform-xml`, `@stitchapi/otlp`. Each is independently versioned and
+   pulls its own dependencies, keeping core lean.
+
+3. **Community / third-party plugins use the unscoped `stitchapi-plugin-<name>`
+   convention** (the `eslint-plugin-*` / `vite-plugin-*` pattern). The `@stitchapi/*`
+   scope is reserved for first-party packages only.
+
+4. **Plugins declare `stitchapi` as a `peerDependency`** (not a regular dependency),
+   so every plugin binds to the single core instance the application installs. This is
+   mandatory for a plugin host: it prevents two physical copies of core from loading
+   and splitting the plugin registry / breaking `instanceof`.
+
+5. **No `@stitchapi/core` alias.** We do not publish `@stitchapi/core` as a re-export
+   or duplicate of `stitchapi`. The `@stitchapi` scope is owned, so the name cannot be
+   squatted; an `npm i @stitchapi/core` simply 404s, which is an adequate "wrong name"
+   signal. (If users are observed tripping over it, we may publish `@stitchapi/core`
+   **once** as a deprecated, no-op signpost whose deprecation message points to
+   `stitchapi` — never a working re-export.)
+
+6. **Subpath exports are for in-package code splitting, not for plugins.** Use them
+   for dependency-free helpers within a package (e.g. `stitchapi/testing`) and for
+   grouping lightweight, dependency-free built-in transformers inside a single package
+   (e.g. `@stitchapi/transformers/json`). Any transformer/plugin that carries its own
+   dependency gets its own `@stitchapi/<name>` package instead.
+
+7. **Directory name ≠ package name.** `packages/core/` publishes `stitchapi`; this is
+   intentional and fine.
+
+## Consequences
+
+**Positive**
+
+-   Cleanest install/import for the 90% path: `npm i stitchapi`,
+    `import { stitch } from 'stitchapi'`.
+-   Lean core: a plugin's (often heavy/optional) dependencies are installed only when
+    that plugin is.
+-   One core identity: the `peerDependency` rule keeps a single physical core module,
+    avoiding dual-instance bugs in an extensible / registry-based library.
+-   Owned namespace: `@stitchapi/*` can only be published by us → supply-chain trust (a
+    scoped plugin is provably first-party) and a browsable family on npm.
+-   No breaking change to the already-published `stitchapi` package.
+
+**Accepted trade-offs**
+
+-   The surface is intentionally "mixed": unscoped core (`stitchapi`) alongside scoped
+    plugins (`@stitchapi/react`). This is cosmetic and follows established precedent
+    (`vite` + `@vitejs/plugin-*`, `rollup` + `@rollup/plugin-*`, `astro` + `@astrojs/*`,
+    `svelte` + `@sveltejs/*`). The asymmetry encodes meaning: bare = the library,
+    scoped = its official add-ons.
+
+**Required follow-ups**
+
+-   Docs and the Twoslash sandbox import `stitchapi` (Twoslash type-checks every
+    ` ```ts twoslash ` block against the real workspace `stitchapi`). The pre-existing
+    `@stitchapi/core` drift was swept to `stitchapi`: content pages in PR #39, and the
+    sandbox runtime + contracts alongside this ADR.
+-   Before publishing the first `@stitchapi/*` plugin, **register / confirm ownership of
+    the npm org (scope) `stitchapi`** — the unscoped `stitchapi` package alone does not
+    reserve the scope.
+
+## Alternatives considered
+
+-   **A. Scope everything: `@stitchapi/core` + `@stitchapi/react` (Babel model).** Fully
+    symmetric, but a breaking rename of a published package, worse ergonomics on the
+    primary path, and it loses the "bare name = the main thing" signal. Babel is the lone
+    major ecosystem that scopes core, and it is widely regarded as friction. Rejected.
+-   **B. Subpath monolith: `stitchapi/react` + `stitchapi/transform-xml`.** One install,
+    but every consumer downloads every plugin's dependencies (transformers often wrap
+    parser libs), per-subpath peer deps aren't expressible, and third parties can't
+    extend it. Rejected for plugins; retained for in-package dependency-free helpers
+    (decision 6).
+-   **C. All-unscoped: `stitchapi` + `stitchapi-react`.** Internally consistent and keeps
+    core ergonomics, but gives up the owned namespace (typosquat / malware risk, no scope
+    page). Rejected for first-party; adopted as the **community** convention
+    (`stitchapi-plugin-*`, decision 3).
+-   **D. `@stitchapi/core` as an alias alongside `stitchapi`.** Reintroduces the naming
+    ambiguity we are resolving, imposes a permanent dual-publish / version-skew tax, and
+    — for a plugin host — invites dual-instance / identity bugs when app and plugins
+    resolve different specifiers. Rejected.

--- a/docs/sandbox/contracts/dispatch.test.ts
+++ b/docs/sandbox/contracts/dispatch.test.ts
@@ -106,9 +106,9 @@ check('each NODE_ONLY_SURFACES identifier → server + hit', () => {
 });
 
 // Named import from a stitch module is detected.
-check('imported Node-only binding from @stitchapi/core → server', () => {
+check('imported Node-only binding from stitchapi → server', () => {
     const scan = scanSurface(
-        `import { keychain } from '@stitchapi/core';\nawait keychain().get('k');`,
+        `import { keychain } from 'stitchapi';\nawait keychain().get('k');`,
     );
     assert.equal(scan.tier, 'server');
     assert.ok(scan.nodeOnlyHits.includes('keychain'));
@@ -144,7 +144,7 @@ check(
     'clear hit + ambiguity → reports hit but routes browser (precedence)',
     () => {
         const scan = scanSurface(
-            `import { keychain } from '@stitchapi/core';\n` +
+            `import { keychain } from 'stitchapi';\n` +
                 `keychain();\nconst k = core['ot' + 'lpTrace'];`,
         );
         assert.equal(scan.ambiguous, true);

--- a/docs/sandbox/contracts/scan-surface.ts
+++ b/docs/sandbox/contracts/scan-surface.ts
@@ -9,7 +9,7 @@
  *
  * ─── The conservative contract (SEC-46..48) ────────────────────────────────────
  *   - A CLEAR reference to a Node-only surface (called identifier, imported binding
- *     from `@stitchapi/core` / `stitchapi`, or a member access `x.keychain`) →
+ *     from `stitchapi`, or a member access `x.keychain`) →
  *     `tier:'server'` with the matched identifiers in `nodeOnlyHits`.
  *   - AMBIGUOUS / DYNAMIC access that cannot be statically resolved (computed member
  *     `core['key'+'chain']`, `eval`, a re-aliased import we cannot follow) →
@@ -37,7 +37,7 @@ import {
 } from './dispatch';
 
 /** Import specifiers whose bindings we treat as the stitch core surface. */
-const STITCH_MODULES = new Set(['@stitchapi/core', 'stitchapi']);
+const STITCH_MODULES = new Set(['stitchapi']);
 
 /**
  * Set form of the frozen Node-only list, for O(1) membership checks.
@@ -175,7 +175,7 @@ function isNodeOnly(name: string): name is NodeOnlySurface {
 /**
  * Collect Node-only identifiers that are *clearly* referenced in the (de-strung)
  * source as one of:
- *   - a named import from a stitch module:  import { keychain } from '@stitchapi/core'
+ *   - a named import from a stitch module:  import { keychain } from 'stitchapi'
  *   - a called identifier:                  keychain(...)
  *   - a member access:                      core.keychain / x.env
  *   - a bare word boundary occurrence       (catch-all; only over-shims)

--- a/docs/sandbox/runtime/B1-README.md
+++ b/docs/sandbox/runtime/B1-README.md
@@ -39,7 +39,7 @@ Three knobs, all proven in the spike (B1-SPIKE §4):
    `node:crypto → shims/node-crypto.ts`, `node:fs → shims/node-fs.ts`,
    `node:path → shims/node-path.ts`. These are the _only_ three built-ins reachable
    from core's barrel (7 import sites across `engine/otlp/auth/trace/drift`).
-2. **alias** `@stitchapi/core → packages/core/src/index.ts` so the bundle resolves
+2. **alias** `stitchapi → packages/core/src/index.ts` so the bundle resolves
    **without `pnpm install`** (zod is unused in the reachable graph — B1-SPIKE §1).
    In R1's installed workspace this alias is unnecessary; point it at the published
    entry instead.
@@ -70,7 +70,7 @@ npx -y esbuild docs/sandbox/runtime/stitch-browser.ts \
   --alias:node:crypto=docs/sandbox/runtime/shims/node-crypto.ts \
   --alias:node:fs=docs/sandbox/runtime/shims/node-fs.ts \
   --alias:node:path=docs/sandbox/runtime/shims/node-path.ts \
-  --alias:@stitchapi/core=packages/core/src/index.ts \
+  --alias:stitchapi=packages/core/src/index.ts \
   --define:process='{"env":{},"platform":"browser","versions":{}}' \
   --outfile=/tmp/b1-out/stitch-browser.mjs
 ```
@@ -149,7 +149,7 @@ Lifted from B1-SPIKE §7, plus what this implementation adds:
    re-enable core console trace in the browser (and must not set
    `STITCH_TRACE_CONSOLE=1` in any injected `process.env`). Trace is surfaced via
    `StitchTraceEntry`, not stderr.
-5. **The `@stitchapi/core` alias is a spike/no-install convenience.** It points at
+5. **The `stitchapi` alias is a spike/no-install convenience.** It points at
    `packages/core/src/index.ts`. In R1's installed workspace, drop the alias (or
    point it at the package's published ESM entry) — the result is the same or better
    (B1-SPIKE §7).

--- a/docs/sandbox/runtime/build-stitch-browser.mjs
+++ b/docs/sandbox/runtime/build-stitch-browser.mjs
@@ -10,7 +10,7 @@
  *        node:crypto → ./shims/node-crypto.ts   (Web Crypto randomUUID/randomBytes)
  *        node:fs     → ./shims/node-fs.ts        (no-op writes, existsSync→false)
  *        node:path   → ./shims/node-path.ts      (regex dirname)
- *   2. alias `@stitchapi/core` → packages/core/src/index.ts so the bundle resolves
+ *   2. alias `stitchapi` → packages/core/src/index.ts so the bundle resolves
  *      WITHOUT `pnpm install` (zod is unused in the reachable graph — B1-SPIKE §1).
  *   3. define `process` → the browser process value (./shims/process.ts), so every
  *      runtime `process.env.*` read inlines to `{}` and the bundle has ZERO
@@ -88,7 +88,7 @@ const result = await esbuild.build({
         'node:crypto': resolve(__dirname, 'shims/node-crypto.ts'),
         'node:fs': resolve(__dirname, 'shims/node-fs.ts'),
         'node:path': resolve(__dirname, 'shims/node-path.ts'),
-        '@stitchapi/core': CORE,
+        stitchapi: CORE,
     },
     // Knob 3: inline `process` so no `process.env` survives. We also point the
     // injected identifier at the shim module for any bare `process` reference.

--- a/docs/sandbox/runtime/shims/node-surfaces.ts
+++ b/docs/sandbox/runtime/shims/node-surfaces.ts
@@ -18,7 +18,7 @@
  */
 import { emitShimNotice } from './notices';
 
-import { cookieSession as coreCookieSession } from '@stitchapi/core';
+import { cookieSession as coreCookieSession } from 'stitchapi';
 
 // `CookieSessionOpts`/`AuthStrategy` aren't re-exported from core's barrel, so we
 // derive the exact param/return types from the function itself — keeps the shim

--- a/docs/sandbox/runtime/shims/otlp-browser.ts
+++ b/docs/sandbox/runtime/shims/otlp-browser.ts
@@ -18,13 +18,8 @@
  */
 import { emitShimNotice } from './notices';
 
-import { otlpTrace as coreOtlpTrace } from '@stitchapi/core';
-import type {
-    OtelSpan,
-    OtlpOptions,
-    SpanExporter,
-    TraceSink,
-} from '@stitchapi/core';
+import { otlpTrace as coreOtlpTrace } from 'stitchapi';
+import type { OtelSpan, OtlpOptions, SpanExporter, TraceSink } from 'stitchapi';
 
 const OTLP_NOTICE =
     'OTLP export is simulated in the browser sandbox — spans are built but not ' +

--- a/docs/sandbox/runtime/stitch-browser.ts
+++ b/docs/sandbox/runtime/stitch-browser.ts
@@ -1,13 +1,13 @@
 import { emitShimNotice } from './shims/notices';
 
-import { createTrace as coreCreateTrace } from '@stitchapi/core';
-import type { TraceSink } from '@stitchapi/core';
+import { createTrace as coreCreateTrace } from 'stitchapi';
+import type { TraceSink } from 'stitchapi';
 
 /**
  * Browser-targeted `stitch` build entry — B1 (Tier-3).
  *
  * This is the docs-side entry the R1 Worker runner injects as the snippet scope's
- * stitch API. It re-exports the BROWSER-SAFE surface of `@stitchapi/core` and wires
+ * stitch API. It re-exports the BROWSER-SAFE surface of `stitchapi` and wires
  * the shims for the Node-only surfaces, per the spike's recommended shape
  * (B1-SPIKE §6 — a thin entry + bundler alias/define, NO fork of packages/core).
  *
@@ -48,7 +48,7 @@ export {
     multiplex,
     // `toOtlpJson` is a pure span→JSON mapper (no Node) — safe verbatim.
     toOtlpJson,
-} from '@stitchapi/core';
+} from 'stitchapi';
 
 // All public types — none carry runtime Node weight. Core's barrel re-exports
 // `./types` via `export *`, so every public type is reachable from the main entry.
@@ -58,8 +58,8 @@ export type {
     OtelSpanEvent,
     SpanAttributes,
     OtlpOptions,
-} from '@stitchapi/core';
-export type * from '@stitchapi/core';
+} from 'stitchapi';
+export type * from 'stitchapi';
 
 /* ---- Node-only surfaces, shimmed (emit a RunNotice) ---------------------- */
 export { keychain, env, cookieSession } from './shims/node-surfaces';

--- a/docs/sandbox/runtime/tsconfig.browser.json
+++ b/docs/sandbox/runtime/tsconfig.browser.json
@@ -1,5 +1,5 @@
 {
-    "//": "B1 browser stitch build. These files import @stitchapi/core and shim node:* builtins, so they type-check only with the workspace installed (pnpm install) + @types/node — run in CI, NOT in the dependency-free no-install smoke. B1 verified clean under this config; see B1-README.md.",
+    "//": "B1 browser stitch build. These files import stitchapi and shim node:* builtins, so they type-check only with the workspace installed (pnpm install) + @types/node — run in CI, NOT in the dependency-free no-install smoke. B1 verified clean under this config; see B1-README.md.",
     "compilerOptions": {
         "target": "ES2022",
         "lib": ["ES2022", "DOM", "DOM.Iterable"],
@@ -13,7 +13,7 @@
         "exactOptionalPropertyTypes": true,
         "types": ["node"],
         "paths": {
-            "@stitchapi/core": ["../../../packages/core/src/index.ts"]
+            "stitchapi": ["../../../packages/core/src/index.ts"]
         }
     },
     "include": ["stitch-browser.ts", "shims/**/*.ts"]

--- a/docs/sandbox/runtime/tsconfig.json
+++ b/docs/sandbox/runtime/tsconfig.json
@@ -10,7 +10,7 @@
         "noEmit": true,
         "strict": true
     },
-    "comment-scope": "Scoped to R2's dependency-free transpile module. B1's stitch-browser.ts + shims/ import @stitchapi/core and are type-checked via tsconfig.browser.json under pnpm install (CI), not here.",
+    "comment-scope": "Scoped to R2's dependency-free transpile module. B1's stitch-browser.ts + shims/ import stitchapi and are type-checked via tsconfig.browser.json under pnpm install (CI), not here.",
     "include": [
         "transpile.ts",
         "transpile.test.ts",


### PR DESCRIPTION
## What

- **ADR 0001 — Package naming & distribution model** (`docs/adr/0001-package-naming-and-distribution.md`) records the convention:
  - core stays the unscoped **`stitchapi`** (not `@stitchapi/core`)
  - first-party plugins / adapters / transformers → **`@stitchapi/<name>`**
  - community plugins → **`stitchapi-plugin-*`**
  - plugins **peer-depend** on `stitchapi` (one core instance — no dual-instance bugs)
  - **no `@stitchapi/core` alias**
- **Sandbox alignment**: sweep the docs sandbox (runtime + contracts) from the unpublished `@stitchapi/core` to the real package name `stitchapi` — the tsconfig `paths` key, the esbuild `alias` key, the `STITCH_MODULES` recognizer (deduped), contract-test inputs, and comments.

## Why

`@stitchapi/core` is not published and contradicts `apps/docs/AUTHORING.md`, which mandates importing the published `stitchapi`. The content-page sweep already merged in #39; this finishes it for the sandbox and records the decision as an ADR.

## Verification

- Pre-commit gates green: **format / lint / typecheck**.
- Residual `@stitchapi/core` = **0**; diff is a clean specifier-only swap.
- Sandbox path alias resolves to core (no `Cannot find module 'stitchapi'`).

## Follow-up (tracked in the ADR)

Claim the npm **org/scope `stitchapi`** before publishing any `@stitchapi/*` plugin — the unscoped package alone doesn't reserve the scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)