### PR TITLE
chore(docs): drop the `.vercel` gitignore entry

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -22,5 +22,4 @@ yarn-error.log*
 
 # others
 .env*.local
-.vercel
 next-env.d.ts


### PR DESCRIPTION
Removes the `.vercel` entry from `apps/docs/.gitignore` (the local Vercel CLI link folder). The repo carries no Vercel config, so this leaves it with zero Vercel references.

Note: this is cosmetic. The failing `Vercel` deployment checks on PRs come from the Vercel/GitHub dashboard integration (project `stitch-api`), not the repo. Those stop only when that integration is disconnected.