### PR TITLE
feat(docs): wire stitchapi.dev as the canonical domain

### DIFF
--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -5,12 +5,32 @@ import { Hero } from './components/hero';
 import { Problem } from './components/problem';
 import { Surfaces } from './components/surfaces';
 
+import { appName } from '@/lib/shared';
+
 import type { Metadata } from 'next';
 
+const title = 'StitchAPI — a typed stitch replaces fetch';
+const description =
+    'StitchAPI is an agent-native runtime whose core primitive — a stitch — replaces fetch. Declare one endpoint or one example and call it as a function, CLI, HTTP route, or MCP tool.';
+
 export const metadata: Metadata = {
-    title: 'StitchAPI — a typed stitch replaces fetch',
-    description:
-        'StitchAPI is an agent-native runtime whose core primitive — a stitch — replaces fetch. Declare one endpoint or one example and call it as a function, CLI, HTTP route, or MCP tool.',
+    title,
+    description,
+    alternates: { canonical: '/' },
+    openGraph: {
+        type: 'website',
+        url: '/',
+        siteName: appName,
+        title,
+        description,
+        images: '/og/home',
+    },
+    twitter: {
+        card: 'summary_large_image',
+        title,
+        description,
+        images: '/og/home',
+    },
 };
 
 export default function HomePage() {

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,14 +1,21 @@
 import './global.css';
 
+import { siteUrl } from '@/lib/shared';
+
 import 'fumadocs-twoslash/twoslash.css';
 import { Banner } from 'fumadocs-ui/components/banner';
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import { Construction } from 'lucide-react';
+import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 
 const inter = Inter({
     subsets: ['latin'],
 });
+
+export const metadata: Metadata = {
+    metadataBase: new URL(siteUrl),
+};
 
 export default function Layout({ children }: LayoutProps<'/'>) {
     return (

--- a/apps/docs/app/og/home/route.tsx
+++ b/apps/docs/app/og/home/route.tsx
@@ -1,0 +1,19 @@
+import { appName } from '@/lib/shared';
+
+import { generate as DefaultImage } from 'fumadocs-ui/og';
+import { ImageResponse } from 'next/og';
+
+export const revalidate = false;
+
+export function GET() {
+    return new ImageResponse(
+        (
+            <DefaultImage
+                title="A typed stitch replaces fetch"
+                description="An agent-native runtime whose core primitive — a stitch — replaces fetch. Call one endpoint as a function, CLI, HTTP route, or MCP tool."
+                site={appName}
+            />
+        ),
+        { width: 1200, height: 630 },
+    );
+}

--- a/apps/docs/app/robots.ts
+++ b/apps/docs/app/robots.ts
@@ -1,0 +1,16 @@
+import { siteUrl } from '@/lib/shared';
+
+import type { MetadataRoute } from 'next';
+
+export const revalidate = false;
+
+export default function robots(): MetadataRoute.Robots {
+    return {
+        rules: {
+            userAgent: '*',
+            allow: '/',
+        },
+        sitemap: new URL('/sitemap.xml', siteUrl).toString(),
+        host: siteUrl,
+    };
+}

--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -1,0 +1,23 @@
+import { siteUrl } from '@/lib/shared';
+import { source } from '@/lib/source';
+
+import type { MetadataRoute } from 'next';
+
+export const revalidate = false;
+
+const absolute = (path: string) => new URL(path, siteUrl).toString();
+
+export default function sitemap(): MetadataRoute.Sitemap {
+    return [
+        {
+            url: absolute('/'),
+            changeFrequency: 'monthly',
+            priority: 1,
+        },
+        ...source.getPages().map((page) => ({
+            url: absolute(page.url),
+            changeFrequency: 'weekly' as const,
+            priority: 0.8,
+        })),
+    ];
+}

--- a/apps/docs/content/docs/agents/llms-txt.mdx
+++ b/apps/docs/content/docs/agents/llms-txt.mdx
@@ -13,13 +13,13 @@ Fetch the index to discover structure, then pull a single page as Markdown:
 
 ```bash
 # The curated index of every docs page, one line per page.
-curl https://docs.example.com/llms.txt
+curl https://stitchapi.dev/llms.txt
 
 # The clean Markdown form of one page — just this feature, into context.
-curl https://docs.example.com/docs/agents/run-stitch-tool/llms.mdx
+curl https://stitchapi.dev/docs/agents/run-stitch-tool/llms.mdx
 
 # When the agent needs everything at once, the whole docs concatenated.
-curl https://docs.example.com/llms-full.txt
+curl https://stitchapi.dev/llms-full.txt
 ```
 
 Each page already stands on its own — restating its premise rather than leaning

--- a/apps/docs/lib/shared.ts
+++ b/apps/docs/lib/shared.ts
@@ -1,4 +1,9 @@
 export const appName = 'StitchAPI';
+
+// Canonical production origin — the single source of truth for absolute URLs
+// (metadataBase, sitemap, robots, Open Graph images, llms.txt examples).
+export const siteUrl = 'https://stitchapi.dev';
+
 export const docsRoute = '/docs';
 export const docsImageRoute = '/og/docs';
 export const docsContentRoute = '/llms.mdx/docs';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,7 +80,7 @@
     "bugs": {
         "url": "https://github.com/rejifald/StitchAPI/issues"
     },
-    "homepage": "https://github.com/rejifald/StitchAPI#readme",
+    "homepage": "https://stitchapi.dev",
     "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.3",
         "@eslint/js": "^9.39.4",


### PR DESCRIPTION
Wires the newly acquired **stitchapi.dev** domain into the docs site and the published package. Developed in an isolated git worktree off `main`.

## What changed
- **Single source of truth** — `siteUrl` in `apps/docs/lib/shared.ts`; every absolute URL derives from it.
- **`metadataBase`** (`app/layout.tsx`) — Open Graph / Twitter / canonical URLs now resolve to `https://stitchapi.dev` instead of falling back to `localhost` (or the `*.vercel.app` deploy URL on Vercel).
- **`sitemap.ts` + `robots.ts`** — generated against the canonical origin (home + all docs pages).
- **Landing-page OG card** — `app/og/home/route.tsx` (route handler, same pattern as the docs OG route) plus `openGraph`/`twitter` metadata on the home page.
- **`llms.txt` guide** — replaced `docs.example.com` placeholders with `stitchapi.dev`.
- **Published package homepage** — `packages/core/package.json` now points at `https://stitchapi.dev`.

## Verified locally (dev server)
- `robots.txt` → `Host`/`Sitemap` on `stitchapi.dev`; `sitemap.xml` → 59 absolute URLs.
- A docs page's `og:image`/`twitter:image` → `https://stitchapi.dev/og/docs/.../image.png`.
- Landing page `og:image`/`twitter:image` → `https://stitchapi.dev/og/home` (renders, 1200×630 PNG).
- `prettier --check`, `tsc --noEmit`, `eslint` pass.

## Out of scope (hosting/DNS — done in the Vercel dashboard)
Pointing the domain at the deployment is a Vercel + registrar step: add `stitchapi.dev` as a custom domain, then set the apex A / `www` CNAME records Vercel shows. `.dev` is HSTS-preloaded, so HTTPS is automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)