### PR TITLE
Merge develop into main: RFC 6570 templates, nested query, and pluggable HTTP adapters

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -61,6 +61,12 @@ Everything except a target is optional. Spell the target one of two ways:
 
 The two are mutually exclusive — when both appear, `url` wins. The smallest possible stitch is `stitch('https://…')` (a bare string is shorthand for `path`; an absolute one resolves as-is). A target that resolves to a relative URL (a `path` with no `baseUrl`) is a config error under the default transport.
 
+### URL templates & query **[decided]**
+
+The target is an [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) URI template, expanded dependency-free (a faithful port of `url-template` v3): simple `{id}` is the common case, with the full operator set available — `{+reserved}`, `{#fragment}`, `{.label}`, `{/segment}`, `{;path}`, `{?query,keys}`, `{&continuation}` — plus the explode (`{list*}`) and prefix (`{var:3}`) modifiers. **Template variables are filled from `params`** (the path-scoped bucket); the `query` input carries the query string, so the two never double-encode a value.
+
+Query values serialize `qs`-style and dependency-free: nested objects expand to `a[b]=c`, arrays to indexed keys (`ids[0]=1&ids[1]=2`), with brackets percent-encoded exactly as `qs` does by default. A literal `?a=b` baked into `path`/`url` is parsed as predefined defaults that call-time `query` keys merge over. (The array serialization format is fixed for now — see [§15](#15-open-questions).)
+
 ### Call convention **[decided]**
 
 A stitch is called with a **single `input` object** and returns a value that is both awaitable _and_ streamable:
@@ -518,4 +524,5 @@ Next, to close the validated gaps (§12), in leverage order:
 -   ~~Composition syntax / call convention~~ — **resolved**: all three composition facades supported (extends / factory / builder); call = single-input-object + `.with()` + optional curried.
 -   **Validation lib** — move from Zod-locked to **Standard Schema** (Zod/Valibot/ArkType)? (Recommended; affects bundle size.)
 -   **Secret resolvers** — which to ship first: `env()`, `keychain()`, file, cloud secret managers?
+-   **Query array format** — arrays currently serialize `qs`-style indexed (`ids[0]=1&ids[1]=2`), matching the pre-rebuild baseline. Should the format be configurable (`arrayFormat: 'indices' | 'brackets' | 'repeat'`), and which is the right default for the APIs we target? (Flagged for future review; behavior is fixed until then.)
 -   **Visual** — Mermaid-from-definition first; how important is the live interactive trace view for v1?

--- a/docs/FEATURE-LENSES.md
+++ b/docs/FEATURE-LENSES.md
@@ -76,7 +76,7 @@ payload), and _Reach_ (where it runs and what it plugs into) — above which sit
     function" move — [`src/stitch.ts`](../src/stitch.ts)
 -   One handle, two modes — `await theStitch()` **or** `theStitch().stream()`
 -   Fluent builder — `.get/.post/.put/.delete/.returns/.unwrap/.auth/.retry/.throttle/.timeout`
--   URL templates (RFC 6570), query-string builder, predefined query baked into the path
+-   URL templates (full RFC 6570 — operators, explode `*`, prefix `:n`) and a `qs`-style query builder for nested objects/arrays, plus predefined query baked into the path
 -   `.with(partial)` partial application — reuses the same runtime so cookies/throttle persist
 
 ### Composability & reuse
@@ -131,6 +131,8 @@ payload), and _Reach_ (where it runs and what it plugs into) — above which sit
 
 -   Every seam is swappable — `Adapter`, `StitchStore`, `TraceSink`, `AuthStrategy`, `Hooks`,
     `transform` — [`src/http-adapter.ts`](../src/http-adapter.ts)
+-   Pluggable HTTP transport — `fetchAdapter` (default) or the shipped `axiosAdapter(client)`
+    that wraps your own axios instance; any `Adapter` function works (got, a fake, your own)
 -   The adapter doubles as a test seam (inject a fake transport)
 
 ### Protocol coverage

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -45,6 +45,7 @@ The name StitchAPI combines the words “stitch” and “API,” reflecting its
 -   [Auth as a boundary](#auth-as-a-boundary)
 -   [Pluggable state store](#pluggable-state-store)
 -   [Request body encoding](#request-body-encoding)
+-   [HTTP transport (adapters)](#http-transport-adapters)
 -   [GraphQL](#graphql)
 -   [Pagination](#pagination)
 -   [Transform](#transform)
@@ -102,6 +103,8 @@ For the full competitive landscape and positioning, see the [Overview](docs/OVER
 -   **Pluggable state store** - throttle counters and sessions/tokens live behind a 3-method store; in-memory by default, a shared store makes throttling distributed and sessions shared across workers.
 -   **Zero-infra observability** - every event is appended to a local JSONL trace by default; `stitch trace` summarizes runs, retries, drift, and latency percentiles.
 -   **CLI surface** - the definition your code imports is also runnable from the shell: `stitch run <name>` streams JSONL events (HTTP and MCP surfaces are on the roadmap).
+-   **Typed URLs** - full [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) URI templates (`{id}`, `{+path}`, `{?q,sort}`, explode `*`, prefix `:n`), and a `qs`-style query builder that serializes nested objects (`a[b]=c`) and arrays — both dependency-free.
+-   **Pluggable transport** - `fetch` by default; drop in the shipped `axiosAdapter`, or any `Adapter` function, to route requests through axios or another HTTP client.
 -   **Zero runtime dependencies** - `"dependencies": {}`; built on the platform's global `fetch`; tree-shakeable.
 
 ## Documentation
@@ -154,7 +157,7 @@ const getUsers = stitch('https://api.example.com/users');
 const users = await getUsers(); // GET, parsed JSON
 ```
 
-Path params use `{param}` templates (RFC 6570 style); params, query, headers, and body all travel in a single input object:
+Path params use [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) URI templates — simple `{id}` interpolation is the common case, with the full operator set available (`{+reserved}`, `{/segment}`, `{?query,keys}`, explode `{list*}`, prefix `{var:3}`). Template variables are filled from `params`; `params`, `query`, `headers`, and `body` all travel in a single input object:
 
 ```ts
 const getUser = stitch('https://api.example.com/users/{id}');
@@ -163,7 +166,7 @@ await getUser({ params: { id: 1 }, query: { expand: 'roles' } });
 // → GET https://api.example.com/users/1?expand=roles
 ```
 
-Query defaults can be baked into the path; call-time query keys merge over them:
+The query builder serializes nested objects and arrays `qs`-style — `{ filter: { type: 'admin' }, ids: [1, 2] }` → `filter[type]=admin&ids[0]=1&ids[1]=2`. Query defaults can be baked into the path; call-time query keys merge over them:
 
 ```ts
 const findUsers = stitch('https://api.example.com/users?sort=name&type=admin');
@@ -457,6 +460,32 @@ const upload = stitch({
 await upload({
     // a { value, filename } field becomes a named file part
     body: { field: 'v', file: { value: bytes, filename: 'a.bin' } },
+});
+```
+
+## HTTP transport (adapters)
+
+A stitch talks to the network through an `Adapter` — `(req) => Promise<{ status, headers, body }>`. The default is the global `fetch`; set `adapter` to route a stitch (or a shared preset) through a different client. The runtime stays zero-dependency, so the shipped `axiosAdapter` takes _your_ axios instance rather than importing one:
+
+```ts
+import axios from 'axios';
+import { axiosAdapter, stitch } from 'stitchapi';
+
+const getUser = stitch({
+    path: 'https://api.example.com/users/{id}',
+    adapter: axiosAdapter(axios), // body encoding, headers, and parsing match fetchAdapter
+});
+```
+
+Body encoding (`json` / `form` / `multipart`), response parsing, and `set-cookie` handling are shared across transports, so swapping adapters doesn't change behavior. Any function matching the `Adapter` shape works — wrap `got`, a test double, or your own client the same way:
+
+```ts
+import type { Adapter } from 'stitchapi';
+
+const echo: Adapter = async (req) => ({
+    status: 200,
+    headers: {},
+    body: { method: req.method, url: req.url },
 });
 ```
 

--- a/packages/core/eslint-suppressions.json
+++ b/packages/core/eslint-suppressions.json
@@ -58,11 +58,6 @@
       "count": 3
     }
   },
-  "src/util.ts": {
-    "@typescript-eslint/no-base-to-string": {
-      "count": 2
-    }
-  },
   "src/validator.ts": {
     "@typescript-eslint/no-non-null-assertion": {
       "count": 1

--- a/packages/core/src/axios-adapter.ts
+++ b/packages/core/src/axios-adapter.ts
@@ -1,0 +1,108 @@
+// An Adapter backed by a caller-supplied axios-compatible client. StitchAPI's runtime is
+// zero-dependency, so axios is never imported here — you pass in your own instance:
+//
+//   import axios from 'axios';
+//   import { axiosAdapter, stitch } from 'stitchapi';
+//   const getUser = stitch({ url: '…/users/{id}', adapter: axiosAdapter(axios) });
+//
+// Body encoding (json/form/multipart) and response parsing reuse the same helpers as
+// fetchAdapter, so behavior is identical across transports. The client is asked for raw
+// bytes (responseType 'arraybuffer') and told never to throw on non-2xx — the engine
+// decides what a given status means.
+import { decodeResponseBody, encodeRequestBody } from './http-adapter';
+import type { Adapter, AdapterRequest, AdapterResponse } from './types';
+
+/** The minimal surface of an axios instance the adapter needs — structurally satisfied by `axios`. */
+export interface AxiosLikeConfig {
+    url: string;
+    method: string;
+    headers?: Record<string, string>;
+    data?: unknown;
+    responseType?: string;
+    signal?: AbortSignal;
+    validateStatus?: ((status: number) => boolean) | null;
+    [key: string]: unknown;
+}
+export interface AxiosLikeResponse {
+    status: number;
+    headers: Record<string, string | string[] | undefined>;
+    data: unknown;
+}
+export interface AxiosLike {
+    request(config: AxiosLikeConfig): Promise<AxiosLikeResponse>;
+}
+
+/**
+ * Wrap an axios-compatible `client` (typically the default `axios` export or an
+ * `axios.create()` instance) as a stitch {@link Adapter}. `defaults` are merged under every
+ * request — e.g. `{ proxy, httpsAgent, timeout }` — and are overridden by per-call values.
+ */
+export function axiosAdapter(
+    client: AxiosLike,
+    defaults: Partial<AxiosLikeConfig> = {},
+): Adapter {
+    return async function axiosAdapterRequest(
+        req: AdapterRequest,
+    ): Promise<AdapterResponse> {
+        const headers: Record<string, string> = {
+            ...defaults.headers,
+            ...req.headers,
+        };
+        const { body, contentType } = encodeRequestBody(req);
+        if (contentType && !hasHeader(headers, 'content-type')) {
+            headers['content-type'] = contentType;
+        }
+
+        const res = await client.request({
+            ...defaults,
+            url: req.url,
+            method: req.method.toUpperCase(),
+            headers,
+            ...(body !== undefined ? { data: body } : {}),
+            responseType: 'arraybuffer',
+            ...(req.signal ? { signal: req.signal } : {}),
+            validateStatus: () => true, // never throw on non-2xx; the engine decides
+        });
+
+        const resHeaders = normalizeHeaders(res.headers);
+        const contentTypeResp = resHeaders['content-type'] ?? '';
+        const parsed = decodeResponseBody(
+            req.responseType,
+            contentTypeResp,
+            toArrayBuffer(res.data),
+        );
+        return { status: res.status, headers: resHeaders, body: parsed };
+    };
+}
+
+const hasHeader = (headers: Record<string, string>, name: string): boolean =>
+    Object.keys(headers).some((k) => k.toLowerCase() === name.toLowerCase());
+
+// Lowercase header keys to match fetchAdapter; join a multi-valued set-cookie with ', '.
+function normalizeHeaders(
+    h: Record<string, string | string[] | undefined>,
+): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(h)) {
+        if (v === undefined) continue;
+        out[k.toLowerCase()] = Array.isArray(v) ? v.join(', ') : v;
+    }
+    return out;
+}
+
+// Normalize whatever the client handed back (ArrayBuffer, Node Buffer/typed array, or — if
+// it ignored responseType — a string or already-parsed object) into raw bytes for decoding.
+function toArrayBuffer(data: unknown): ArrayBuffer {
+    if (data instanceof ArrayBuffer) return data;
+    if (ArrayBuffer.isView(data)) {
+        // copy the exact byte view into its own ArrayBuffer
+        return new Uint8Array(
+            data.buffer,
+            data.byteOffset,
+            data.byteLength,
+        ).slice().buffer;
+    }
+    if (data === undefined || data === null) return new ArrayBuffer(0);
+    const text = typeof data === 'string' ? data : JSON.stringify(data);
+    return new TextEncoder().encode(text).buffer;
+}

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -30,13 +30,22 @@ function coerce(raw: string): unknown {
     }
 }
 
-// Path-template parameter names (`/users/{id}` → ["id"]) so a bare `--id` routes to
-// params, matching the engine's own `{param}` expansion.
+// Template parameter names (`/users/{id}` → ["id"]) so a bare `--id` routes to params,
+// matching the engine's RFC 6570 expansion — operator prefixes (`{+id}`, `{?q,sort}`) and
+// `*`/`:n` modifiers are stripped to the bare names.
 export function paramNamesOf(stitch: Stitch): string[] {
-    const path = stitch.__config.path ?? '';
-    return [...path.matchAll(/\{(\w+)\}/g)]
-        .map((m) => m[1])
-        .filter((n): n is string => n !== undefined);
+    const { path, url } = stitch.__config;
+    const tpl = (path ?? '') + ' ' + (typeof url === 'string' ? url : '');
+    const names: string[] = [];
+    for (const m of tpl.matchAll(/\{([^{}]+)\}/g)) {
+        let expr = m[1] ?? '';
+        if ('+#./;?&'.includes(expr.charAt(0))) expr = expr.slice(1);
+        for (const spec of expr.split(',')) {
+            const name = spec.replace(/[:*].*$/, '').trim();
+            if (name) names.push(name);
+        }
+    }
+    return [...new Set(names)];
 }
 
 // Map CLI flags onto a StitchInput. Conventions:

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -25,6 +25,7 @@ import type {
     TraceSink,
 } from './types';
 import {
+    appendQueryString,
     buildQuery,
     expandPath,
     getPath,
@@ -32,6 +33,7 @@ import {
     now,
     parseDuration,
     sleep,
+    topLevelQueryIndex,
 } from './util';
 import type { Validator } from './validator';
 
@@ -116,7 +118,9 @@ function buildRequest(cfg: StitchConfig, input: StitchInput): AdapterRequest {
     const raw = usingUrl
         ? resolveStr(cfg.url)
         : (cfg.path ?? (isGql ? '/graphql' : ''));
-    const qIdx = raw.indexOf('?');
+    // Split off a literal `?predefined=query` (brace-aware, so a `{?x}` template operator
+    // isn't mistaken for it); the template part is expanded, the rest are query defaults.
+    const qIdx = topLevelQueryIndex(raw);
     let tpl = raw;
     let predefined: Record<string, unknown> = {};
     if (qIdx >= 0) {
@@ -127,9 +131,9 @@ function buildRequest(cfg: StitchConfig, input: StitchInput): AdapterRequest {
             >,
         );
     }
-    const { path } = expandPath(tpl, input.params ?? {});
+    const path = expandPath(tpl, input.params ?? {});
     const query = { ...predefined, ...(input.query ?? {}) };
-    const url = joinUrl(base, path) + buildQuery(query);
+    const url = appendQueryString(joinUrl(base, path), buildQuery(query));
     // A relative endpoint can't be fetched by the default transport — fail with a clear config
     // error here instead of a cryptic "Failed to parse URL" from fetch. A custom `adapter` may
     // legitimately resolve relative URLs, so this only guards the default transport.

--- a/packages/core/src/http-adapter.ts
+++ b/packages/core/src/http-adapter.ts
@@ -1,4 +1,9 @@
-import type { Adapter, AdapterRequest, AdapterResponse } from './types';
+import type {
+    Adapter,
+    AdapterRequest,
+    AdapterResponse,
+    ResponseType,
+} from './types';
 
 // Returns an Adapter backed by Node's global `fetch`. Never throws on non-2xx —
 // only network/abort errors propagate; the engine decides what to do with the response.
@@ -9,42 +14,12 @@ export function fetchAdapter(): Adapter {
         const method = req.method.toUpperCase();
         const headers: Record<string, string> = { ...req.headers };
 
-        // Body encoding: never send a body for GET/HEAD. Encode per req.bodyType
-        // (default 'json'): 'form' -> x-www-form-urlencoded, 'multipart' -> FormData.
-        let body: string | FormData | undefined;
-        const noBodyMethod = method === 'GET' || method === 'HEAD';
-        const hasContentType = () =>
-            Object.keys(headers).some(
-                (k) => k.toLowerCase() === 'content-type',
-            );
-        if (!noBodyMethod && req.body !== undefined && req.body !== null) {
-            if (typeof req.body === 'string') {
-                body = req.body;
-            } else if (req.bodyType === 'form') {
-                const params = new URLSearchParams();
-                for (const [k, v] of Object.entries(
-                    req.body as Record<string, unknown>,
-                )) {
-                    if (v !== undefined && v !== null)
-                        params.append(k, String(v));
-                }
-                body = params.toString();
-                if (!hasContentType())
-                    headers['content-type'] =
-                        'application/x-www-form-urlencoded';
-            } else if (req.bodyType === 'multipart') {
-                const form = new FormData();
-                for (const [k, v] of Object.entries(
-                    req.body as Record<string, unknown>,
-                )) {
-                    appendForm(form, k, v);
-                }
-                body = form; // do NOT set content-type — fetch adds the multipart boundary
-            } else {
-                body = JSON.stringify(req.body);
-                if (!hasContentType())
-                    headers['content-type'] = 'application/json';
-            }
+        // Encode the body per req.bodyType (shared with other transports). The returned
+        // content-type is applied only when the caller hasn't set one; multipart returns
+        // none, leaving fetch to add the boundary itself.
+        const { body, contentType } = encodeRequestBody(req);
+        if (contentType && !hasHeader(headers, 'content-type')) {
+            headers['content-type'] = contentType;
         }
 
         // Send the request. Network/abort errors propagate to the caller.
@@ -101,6 +76,71 @@ export function fetchAdapter(): Adapter {
 
         return { status: response.status, headers: resHeaders, body: parsed };
     };
+}
+
+const hasHeader = (headers: Record<string, string>, name: string): boolean =>
+    Object.keys(headers).some((k) => k.toLowerCase() === name.toLowerCase());
+
+// Encode a request body per `bodyType` (default 'json'). Shared across transports so
+// form/multipart/json encoding is identical regardless of the underlying HTTP client.
+// Returns the encoded body and the content-type to set when the caller hasn't already;
+// multipart returns no content-type, leaving the transport to add the boundary.
+export function encodeRequestBody(req: AdapterRequest): {
+    body: string | FormData | undefined;
+    contentType?: string;
+} {
+    const method = req.method.toUpperCase();
+    if (method === 'GET' || method === 'HEAD') return { body: undefined };
+    if (req.body === undefined || req.body === null) return { body: undefined };
+    if (typeof req.body === 'string') return { body: req.body };
+    if (req.bodyType === 'form') {
+        const params = new URLSearchParams();
+        for (const [k, v] of Object.entries(
+            req.body as Record<string, unknown>,
+        )) {
+            if (v !== undefined && v !== null) params.append(k, String(v));
+        }
+        return {
+            body: params.toString(),
+            contentType: 'application/x-www-form-urlencoded',
+        };
+    }
+    if (req.bodyType === 'multipart') {
+        const form = new FormData();
+        for (const [k, v] of Object.entries(
+            req.body as Record<string, unknown>,
+        )) {
+            appendForm(form, k, v);
+        }
+        return { body: form };
+    }
+    return { body: JSON.stringify(req.body), contentType: 'application/json' };
+}
+
+// Decode raw response bytes into the value the engine sees: an explicit responseType wins
+// (arrayBuffer/blob for binary, text/json to force a shape), otherwise JSON is auto-detected
+// by content-type. Shared by transports that hand back bytes (e.g. the axios adapter, which
+// requests an arraybuffer and decodes here so its parsing matches fetchAdapter exactly).
+export function decodeResponseBody(
+    responseType: ResponseType | undefined,
+    contentType: string,
+    bytes: ArrayBuffer,
+): unknown {
+    if (responseType === 'arrayBuffer') return bytes;
+    if (responseType === 'blob')
+        return new Blob(
+            [bytes],
+            contentType ? { type: contentType } : undefined,
+        );
+    const text = new TextDecoder().decode(bytes);
+    if (responseType === 'text') return text;
+    const ct = contentType.toLowerCase();
+    const isJson =
+        responseType === 'json' ||
+        ct.includes('application/json') ||
+        ct.includes('+json');
+    if (isJson) return text === '' ? undefined : JSON.parse(text);
+    return text;
 }
 
 // Append a value to multipart FormData: a Blob/Uint8Array becomes a file part; a

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,12 @@ export {
     keychain,
 } from './auth';
 export { fetchAdapter } from './http-adapter';
+export { axiosAdapter } from './axios-adapter';
+export type {
+    AxiosLike,
+    AxiosLikeConfig,
+    AxiosLikeResponse,
+} from './axios-adapter';
 export { createTrace, multiplex } from './trace';
 export { otlpTrace, otlpHttpExporter, toOtlpJson } from './otlp';
 export type {

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -74,32 +74,228 @@ export function getPath(obj: unknown, path: string): unknown {
         );
 }
 
-/** Expand `/users/{id}` with params, URL-encoding values. Returns { path, used }. */
+// ---- RFC 6570 URI Template expansion --------------------------------------
+// A dependency-free port of the `url-template` (v3) algorithm, covering RFC 6570
+// through Level 4: the operators `+ # . / ; ? &`, the explode (`*`) and prefix
+// (`:n`) modifiers, and list/object values. Plain `{id}` interpolation is the common
+// case; the operators make reserved, path, label, and query expansion available too.
+const TEMPLATE_OPERATORS = ['+', '#', '.', '/', ';', '?', '&'];
+
+// Coerce a leaf value to its string form for URL encoding. Template/query leaves are
+// expected to be primitives; a stray object is JSON-encoded rather than emitted as the
+// useless '[object Object]'.
+function stringifyLeaf(value: unknown): string {
+    if (typeof value === 'string') return value;
+    if (
+        typeof value === 'number' ||
+        typeof value === 'boolean' ||
+        typeof value === 'bigint'
+    )
+        return String(value);
+    if (value === null || value === undefined) return '';
+    return JSON.stringify(value);
+}
+
+// Percent-encode everything outside RFC 6570 *unreserved* — i.e. `encodeURIComponent`
+// plus the extra characters it leaves alone (`! ' ( ) *`).
+function encodeUnreserved(str: string): string {
+    return encodeURIComponent(str).replace(
+        /[!'()*]/g,
+        (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase(),
+    );
+}
+
+// Percent-encode but leave *reserved* characters — and existing `%XX` triples —
+// intact. Used by the `+` and `#` operators, where reserved characters pass through.
+function encodeReserved(str: string): string {
+    return str
+        .split(/(%[0-9A-Fa-f]{2})/g)
+        .map((part) =>
+            /%[0-9A-Fa-f]{2}/.test(part)
+                ? part
+                : encodeURI(part).replace(/%5B/g, '[').replace(/%5D/g, ']'),
+        )
+        .join('');
+}
+
+const isKeyOperator = (op: string | null): boolean =>
+    op === ';' || op === '&' || op === '?';
+
+function encodeTemplateValue(
+    op: string | null,
+    value: string,
+    key?: string,
+): string {
+    const v =
+        op === '+' || op === '#'
+            ? encodeReserved(value)
+            : encodeUnreserved(value);
+    return key !== undefined ? encodeUnreserved(key) + '=' + v : v;
+}
+
+// Expand one variable (the `getValues` step of RFC 6570 §3.2.1) into its rendered pieces.
+function expandTemplateVar(
+    vars: Record<string, unknown>,
+    op: string | null,
+    key: string,
+    modifier: string | undefined,
+): string[] {
+    const value = vars[key];
+    const out: string[] = [];
+    const defined = value !== undefined && value !== null;
+    if (defined && value !== '') {
+        if (
+            typeof value === 'string' ||
+            typeof value === 'number' ||
+            typeof value === 'boolean'
+        ) {
+            let s = String(value);
+            if (modifier && modifier !== '*')
+                s = s.substring(0, parseInt(modifier, 10));
+            out.push(
+                encodeTemplateValue(op, s, isKeyOperator(op) ? key : undefined),
+            );
+        } else if (modifier === '*') {
+            // explode: each list item / each object pair becomes its own piece
+            if (Array.isArray(value)) {
+                for (const item of value)
+                    if (item != null)
+                        out.push(
+                            encodeTemplateValue(
+                                op,
+                                String(item),
+                                isKeyOperator(op) ? key : undefined,
+                            ),
+                        );
+            } else {
+                for (const [k, v] of Object.entries(
+                    value as Record<string, unknown>,
+                ))
+                    if (v != null)
+                        out.push(encodeTemplateValue(op, stringifyLeaf(v), k));
+            }
+        } else {
+            // no explode: collapse the list/object into one comma-joined piece
+            const tmp: string[] = [];
+            if (Array.isArray(value)) {
+                for (const item of value)
+                    if (item != null)
+                        tmp.push(encodeTemplateValue(op, String(item)));
+            } else {
+                for (const [k, v] of Object.entries(
+                    value as Record<string, unknown>,
+                ))
+                    if (v != null) {
+                        tmp.push(encodeUnreserved(k));
+                        tmp.push(encodeTemplateValue(op, stringifyLeaf(v)));
+                    }
+            }
+            if (isKeyOperator(op))
+                out.push(encodeUnreserved(key) + '=' + tmp.join(','));
+            else if (tmp.length) out.push(tmp.join(','));
+        }
+    } else if (op === ';') {
+        if (defined) out.push(encodeUnreserved(key)); // empty string → bare `;name`
+    } else if (value === '' && (op === '&' || op === '?')) {
+        out.push(encodeUnreserved(key) + '='); // empty string → `name=`
+    } else if (value === '') {
+        out.push('');
+    }
+    return out;
+}
+
+/** Expand an RFC 6570 template (`/users/{id}`, `/files{/path*}`, `{?q,sort}`, …) against `params`. */
 export function expandPath(
     tpl: string,
     params: Record<string, unknown> = {},
-): { path: string; used: Set<string> } {
-    const used = new Set<string>();
-    const path = tpl.replace(/\{(\w+)\}/g, (_m, k: string) => {
-        used.add(k);
-        return encodeURIComponent(String(params[k] ?? ''));
-    });
-    return { path, used };
+): string {
+    return tpl.replace(
+        /\{([^{}]+)\}|([^{}]+)/g,
+        (_m, expr: string | undefined, literal: string | undefined) => {
+            if (expr === undefined) return encodeReserved(literal ?? '');
+            let body = expr;
+            let op: string | null = null;
+            if (TEMPLATE_OPERATORS.includes(body.charAt(0))) {
+                op = body.charAt(0);
+                body = body.slice(1);
+            }
+            const values: string[] = [];
+            for (const varspec of body.split(',')) {
+                const m = /([^:*]*)(?::(\d+)|(\*))?/.exec(varspec);
+                if (!m) continue;
+                values.push(
+                    ...expandTemplateVar(params, op, m[1] ?? '', m[2] ?? m[3]),
+                );
+            }
+            if (op && op !== '+') {
+                const sep = op === '?' ? '&' : op === '#' ? ',' : op;
+                return (values.length ? op : '') + values.join(sep);
+            }
+            return values.join(',');
+        },
+    );
 }
 
+// ---- Query strings --------------------------------------------------------
+// Build a query string from a possibly-nested object, `qs`-style: nested objects
+// expand to `a[b]=c`, arrays to `a[0]=x&a[1]=y`, and both the bracketed key and the
+// value are percent-encoded (so `a[b]` goes on the wire as `a%5Bb%5D`, which servers
+// decode back to `a[b]`). `null`/`undefined` are skipped; empty objects/arrays add nothing.
+// NOTE: the array format is fixed to `qs`-style indices for now; whether to make it
+// configurable (indices | brackets | repeat) is flagged for review in docs/DESIGN.md §15.
 export function buildQuery(q: Record<string, unknown> | undefined): string {
     if (!q) return '';
-    const sp = new URLSearchParams();
-    for (const [k, v] of Object.entries(q)) {
-        if (v == null) continue;
-        if (Array.isArray(v))
-            v.forEach((x) => {
-                sp.append(k, String(x));
-            });
-        else sp.append(k, String(v));
+    const parts: string[] = [];
+    for (const [k, v] of Object.entries(q)) appendQueryParam(k, v, parts);
+    return parts.length ? `?${parts.join('&')}` : '';
+}
+
+function appendQueryParam(key: string, value: unknown, out: string[]): void {
+    if (value === undefined || value === null) return;
+    if (Array.isArray(value)) {
+        value.forEach((item, i) => {
+            appendQueryParam(`${key}[${i}]`, item, out);
+        });
+    } else if (value instanceof Date) {
+        out.push(
+            `${encodeURIComponent(key)}=${encodeURIComponent(value.toISOString())}`,
+        );
+    } else if (typeof value === 'object') {
+        for (const [k, v] of Object.entries(value as Record<string, unknown>))
+            appendQueryParam(`${key}[${k}]`, v, out);
+    } else {
+        out.push(
+            `${encodeURIComponent(key)}=${encodeURIComponent(stringifyLeaf(value))}`,
+        );
     }
-    const s = sp.toString();
-    return s ? `?${s}` : '';
+}
+
+/**
+ * Index of the first `?` that is *not* inside an RFC 6570 `{…}` expression, so a `{?x}`
+ * query operator in a template isn't mistaken for the predefined-query delimiter.
+ */
+export function topLevelQueryIndex(raw: string): number {
+    let depth = 0;
+    for (let i = 0; i < raw.length; i++) {
+        const c = raw[i];
+        if (c === '{') depth++;
+        else if (c === '}') depth = Math.max(0, depth - 1);
+        else if (c === '?' && depth === 0) return i;
+    }
+    return -1;
+}
+
+/**
+ * Append an already-built query string (`?a=b`, or `''`) onto a URL that may already
+ * carry a query (e.g. from a `{?x}` template operator), switching the leading `?` to `&`
+ * as needed. A trailing `#fragment` (from a `{#…}` operator) is preserved at the end.
+ */
+export function appendQueryString(url: string, qs: string): string {
+    if (!qs) return url;
+    const hashIdx = url.indexOf('#');
+    const head = hashIdx === -1 ? url : url.slice(0, hashIdx);
+    const tail = hashIdx === -1 ? '' : url.slice(hashIdx);
+    return head + (head.includes('?') ? '&' + qs.slice(1) : qs) + tail;
 }
 
 /**

--- a/packages/core/test/adapters.spec.ts
+++ b/packages/core/test/adapters.spec.ts
@@ -1,0 +1,179 @@
+import { axiosAdapter, stitch } from '../src';
+import type { AxiosLike, AxiosLikeConfig, AxiosLikeResponse } from '../src';
+import type { Adapter } from '../src/types';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-adapters-${process.pid}.jsonl`,
+);
+
+// A fake axios instance that records the configs it received and returns a scripted response.
+function recordingClient(
+    respond: (cfg: AxiosLikeConfig) => AxiosLikeResponse,
+): AxiosLike & { calls: AxiosLikeConfig[] } {
+    const calls: AxiosLikeConfig[] = [];
+    return {
+        calls,
+        request: async (config) => {
+            calls.push(config);
+            return respond(config);
+        },
+    };
+}
+
+const jsonResp = (
+    status: number,
+    obj: unknown,
+    headers: Record<string, string | string[]> = {},
+): AxiosLikeResponse => ({
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+    data: Buffer.from(JSON.stringify(obj)),
+});
+
+describe('axiosAdapter', () => {
+    test('translates an AdapterRequest into an axios config and parses JSON', async () => {
+        const client = recordingClient(() => jsonResp(200, { id: 7 }));
+        const res = await axiosAdapter(client)({
+            url: 'http://h/u',
+            method: 'get',
+            headers: {},
+        });
+        expect(res).toEqual({
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+            body: { id: 7 },
+        });
+        const cfg = client.calls[0];
+        expect(cfg?.url).toBe('http://h/u');
+        expect(cfg?.method).toBe('GET');
+        expect(cfg?.responseType).toBe('arraybuffer');
+        expect(cfg?.validateStatus?.(500)).toBe(true); // never throw on non-2xx
+    });
+
+    test('encodes json and form bodies and sets content-type', async () => {
+        const client = recordingClient(() => jsonResp(200, {}));
+        const adapter = axiosAdapter(client);
+        await adapter({
+            url: 'http://h/u',
+            method: 'POST',
+            headers: {},
+            body: { a: 1, b: 'x y' },
+            bodyType: 'json',
+        });
+        expect(client.calls[0]?.data).toBe('{"a":1,"b":"x y"}');
+        expect(client.calls[0]?.headers?.['content-type']).toBe(
+            'application/json',
+        );
+
+        await adapter({
+            url: 'http://h/u',
+            method: 'POST',
+            headers: {},
+            body: { a: 1, b: 'x y' },
+            bodyType: 'form',
+        });
+        expect(client.calls[1]?.data).toBe('a=1&b=x+y');
+        expect(client.calls[1]?.headers?.['content-type']).toBe(
+            'application/x-www-form-urlencoded',
+        );
+    });
+
+    test('normalizes response headers and joins multi-valued set-cookie', async () => {
+        const client = recordingClient(() => ({
+            status: 200,
+            headers: {
+                'Content-Type': 'application/json',
+                'set-cookie': ['x=1', 'y=2'],
+            },
+            data: Buffer.from('{"ok":true}'),
+        }));
+        const res = await axiosAdapter(client)({
+            url: 'http://h/u',
+            method: 'GET',
+            headers: {},
+        });
+        expect(res.headers['content-type']).toBe('application/json');
+        expect(res.headers['set-cookie']).toBe('x=1, y=2');
+        expect(res.body).toEqual({ ok: true });
+    });
+
+    test('honors responseType arrayBuffer for binary downloads', async () => {
+        const bytes = new Uint8Array([1, 2, 3]);
+        const client = recordingClient(() => ({
+            status: 200,
+            headers: { 'content-type': 'application/octet-stream' },
+            data: Buffer.from(bytes),
+        }));
+        const res = await axiosAdapter(client)({
+            url: 'http://h/bin',
+            method: 'GET',
+            headers: {},
+            responseType: 'arrayBuffer',
+        });
+        expect(res.body).toBeInstanceOf(ArrayBuffer);
+        expect(new Uint8Array(res.body as ArrayBuffer)).toEqual(bytes);
+    });
+
+    test('merges defaults and forwards the abort signal', async () => {
+        const client = recordingClient(() => jsonResp(200, {}));
+        const ac = new AbortController();
+        await axiosAdapter(client, {
+            proxy: false,
+            headers: { 'x-base': '1' },
+        })({
+            url: 'http://h/u',
+            method: 'GET',
+            headers: { 'x-call': '2' },
+            signal: ac.signal,
+        });
+        const cfg = client.calls[0];
+        expect(cfg?.['proxy']).toBe(false);
+        expect(cfg?.headers).toMatchObject({ 'x-base': '1', 'x-call': '2' });
+        expect(cfg?.signal).toBe(ac.signal);
+    });
+
+    test('passes the response status through unchanged', async () => {
+        const client = recordingClient(() => jsonResp(503, { error: 'busy' }));
+        const res = await axiosAdapter(client)({
+            url: 'http://h/u',
+            method: 'GET',
+            headers: {},
+        });
+        expect(res.status).toBe(503);
+        expect(res.body).toEqual({ error: 'busy' });
+    });
+});
+
+describe('the adapter seam', () => {
+    test('a stitch runs end-to-end over the axios adapter', async () => {
+        const client = recordingClient((cfg) =>
+            jsonResp(200, { id: Number(cfg.url.split('/').pop()) }),
+        );
+        const getUser = stitch({
+            url: 'https://api.example.com/users/{id}',
+            adapter: axiosAdapter(client),
+        });
+        await expect(getUser({ params: { id: 7 } })).resolves.toEqual({
+            id: 7,
+        });
+        expect(client.calls[0]?.url).toBe('https://api.example.com/users/7');
+    });
+
+    test('any custom adapter function satisfies the seam — not just fetch', async () => {
+        let sawUrl = '';
+        const custom: Adapter = async (req) => {
+            sawUrl = req.url;
+            return { status: 200, headers: {}, body: { via: 'custom' } };
+        };
+        const ping = stitch({
+            url: 'https://api.example.com/ping',
+            adapter: custom,
+        });
+        await expect(ping()).resolves.toEqual({ via: 'custom' });
+        expect(sawUrl).toBe('https://api.example.com/ping');
+    });
+});

--- a/packages/core/test/url-query.spec.ts
+++ b/packages/core/test/url-query.spec.ts
@@ -1,0 +1,153 @@
+import { stitch } from '../src';
+import {
+    appendQueryString,
+    buildQuery,
+    expandPath,
+    topLevelQueryIndex,
+} from '../src/util';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-url-query-${process.pid}.jsonl`,
+);
+
+// ---- RFC 6570 template expansion (Level 1–4) ------------------------------
+describe('expandPath (RFC 6570)', () => {
+    test('simple expansion encodes reserved characters', () => {
+        expect(expandPath('/users/{id}', { id: 42 })).toBe('/users/42');
+        expect(expandPath('/q/{term}', { term: 'a b/c' })).toBe('/q/a%20b%2Fc');
+        expect(expandPath('/a/{x}/{y}', { x: 1, y: 2 })).toBe('/a/1/2');
+    });
+
+    test('reserved (+) and fragment (#) operators pass reserved chars through', () => {
+        expect(expandPath('/files/{+path}', { path: 'a/b/c.txt' })).toBe(
+            '/files/a/b/c.txt',
+        );
+        expect(expandPath('{#section}', { section: 'a/b' })).toBe('#a/b');
+    });
+
+    test('label, path-segment and path-style operators', () => {
+        expect(expandPath('{.ext}', { ext: 'json' })).toBe('.json');
+        expect(expandPath('/base{/a,b}', { a: 'x', b: 'y' })).toBe('/base/x/y');
+        expect(expandPath('{;k}', { k: 'v' })).toBe(';k=v');
+        expect(expandPath('{;empty}', { empty: '' })).toBe(';empty');
+    });
+
+    test('query and continuation operators with empty + missing vars', () => {
+        expect(expandPath('/s{?a,b}', { a: '1', b: '2' })).toBe('/s?a=1&b=2');
+        expect(expandPath('/s{?a,b}', { a: '1' })).toBe('/s?a=1');
+        expect(expandPath('/s{?a}{&b}', { a: '1', b: '2' })).toBe('/s?a=1&b=2');
+        expect(expandPath('/s{?a}', { a: '' })).toBe('/s?a=');
+    });
+
+    test('explode (*), prefix (:n), and list/object collapse', () => {
+        expect(expandPath('{/list*}', { list: ['a', 'b'] })).toBe('/a/b');
+        expect(expandPath('{?ids*}', { ids: [1, 2] })).toBe('?ids=1&ids=2');
+        expect(expandPath('/{token:3}', { token: 'abcdef' })).toBe('/abc');
+        expect(expandPath('/{list}', { list: ['a', 'b'] })).toBe('/a,b');
+        expect(expandPath('/{obj}', { obj: { a: 1, b: 2 } })).toBe('/a,1,b,2');
+    });
+
+    test('missing variables and literals', () => {
+        expect(expandPath('/users/{id}', {})).toBe('/users/');
+        expect(expandPath('/a b/{id}', { id: 1 })).toBe('/a%20b/1');
+        expect(expandPath('https://h.io/x/{id}', { id: 1 })).toBe(
+            'https://h.io/x/1',
+        );
+    });
+});
+
+// ---- qs-style query encoding ----------------------------------------------
+describe('buildQuery (nested, qs-style)', () => {
+    test('flat scalars', () => {
+        expect(buildQuery({ a: 1, b: 'x y' })).toBe('?a=1&b=x%20y');
+        expect(buildQuery({})).toBe('');
+        expect(buildQuery(undefined)).toBe('');
+    });
+
+    test('nested objects expand to bracketed keys', () => {
+        // `filter[type]=admin`, bracket chars percent-encoded as qs does by default
+        expect(buildQuery({ filter: { type: 'admin' } })).toBe(
+            '?filter%5Btype%5D=admin',
+        );
+        expect(buildQuery({ a: { b: { c: 1 } } })).toBe('?a%5Bb%5D%5Bc%5D=1');
+    });
+
+    test('arrays use indexed keys', () => {
+        expect(buildQuery({ ids: [1, 2] })).toBe('?ids%5B0%5D=1&ids%5B1%5D=2');
+    });
+
+    test('null/undefined and empties are skipped', () => {
+        expect(buildQuery({ a: null, b: undefined, c: 1 })).toBe('?c=1');
+        expect(buildQuery({ a: {}, b: [] })).toBe('');
+    });
+});
+
+// ---- helpers for the engine's template/query split ------------------------
+describe('topLevelQueryIndex / appendQueryString', () => {
+    test('a top-level ? is the predefined-query delimiter', () => {
+        expect(topLevelQueryIndex('/a?b=1')).toBe(2);
+    });
+    test('a ? inside a {?x} expression is not the delimiter', () => {
+        expect(topLevelQueryIndex('/search{?q}')).toBe(-1);
+        expect(topLevelQueryIndex('/search{?q}?extra=1')).toBe(11);
+    });
+    test('appendQueryString switches ? to & and preserves a fragment', () => {
+        expect(appendQueryString('http://h/p', '?a=1')).toBe('http://h/p?a=1');
+        expect(appendQueryString('http://h/p?x=1', '?a=1')).toBe(
+            'http://h/p?x=1&a=1',
+        );
+        expect(appendQueryString('http://h/p#frag', '?a=1')).toBe(
+            'http://h/p?a=1#frag',
+        );
+        expect(appendQueryString('http://h/p', '')).toBe('http://h/p');
+    });
+});
+
+// ---- end-to-end through the engine ----------------------------------------
+describe('URL building through stitch', () => {
+    let server: MockServer;
+    beforeAll(async () => {
+        server = await startMockServer();
+    });
+    afterAll(async () => {
+        await server.close();
+    });
+    beforeEach(() => {
+        server.reset();
+    });
+
+    test('nested query objects and arrays reach the wire', async () => {
+        server.route('GET', '/items', { body: { ok: true } });
+        const list = stitch({ url: `${server.url}/items` });
+        await list({ query: { filter: { type: 'admin' }, ids: [1, 2] } });
+        expect(server.calls('/items')[0]?.query).toEqual({
+            'filter[type]': 'admin',
+            'ids[0]': '1',
+            'ids[1]': '2',
+        });
+    });
+
+    test('a {+path} reserved operator keeps slashes in the path', async () => {
+        server.route('GET', '/files/a/b/c.txt', { body: { ok: true } });
+        const getFile = stitch({ url: `${server.url}/files/{+path}` });
+        await expect(
+            getFile({ params: { path: 'a/b/c.txt' } }),
+        ).resolves.toEqual({ ok: true });
+    });
+
+    test('a {?x} template operator merges with a call-time query', async () => {
+        server.route('GET', '/search', { body: { ok: true } });
+        const search = stitch({ url: `${server.url}/search{?type}` });
+        await search({ params: { type: 'admin' }, query: { q: 'ada' } });
+        expect(server.calls('/search')[0]?.query).toEqual({
+            type: 'admin',
+            q: 'ada',
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Restores RFC 6570 URI template support for path/query expansion
- Adds nested query parameter serialization
- Introduces pluggable HTTP adapters (built-in `fetch` + optional `axios`)
- 22 test files, 132 tests all passing; full docs build verified

## Test plan

- [x] `pnpm check:types` passes across all workspace packages
- [x] `pnpm test` — 132 tests pass (22 test files)
- [x] `pnpm build` (docs) — 183 static pages generated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)