### PR TITLE
fix(deps): bump vendored postcss to ≥8.5.10 (CVE-2026-41305)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,10 @@
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "lefthook": "^2.1.9",
         "prettier": "3.3.3"
+    },
+    "pnpm": {
+        "overrides": {
+            "postcss@<8.5.10": ">=8.5.10"
+        }
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss@<8.5.10: '>=8.5.10'
+
 importers:
 
   .:
@@ -3742,7 +3745,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: '>=8.5.10'
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -3754,10 +3757,6 @@ packages:
         optional: true
       yaml:
         optional: true
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -4189,7 +4188,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: ^8.4.12
+      postcss: '>=8.5.10'
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -8218,7 +8217,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.35
       caniuse-lite: 1.0.30001799
-      postcss: 8.4.31
+      postcss: 8.5.15
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
@@ -8386,12 +8385,6 @@ snapshots:
       jiti: 2.7.0
       postcss: 8.5.15
       tsx: 4.22.4
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.15:
     dependencies:


### PR DESCRIPTION
## What

Adds a pnpm `overrides` entry forcing any `postcss` below the patched floor up to `>=8.5.10`:

```json
"pnpm": { "overrides": { "postcss@<8.5.10": ">=8.5.10" } }
```

This eliminates `postcss@8.4.31` — which `next@16.2.7` vendors internally for build-time CSS processing in `apps/docs` — and dedupes the workspace to a single `postcss@8.5.15`.

## Why

Resolves Dependabot alert [#92](https://github.com/rejifald/StitchAPI/security/dependabot/92):

- **CVE-2026-41305** / `GHSA-qx2v-qp2m-jg93` — PostCSS XSS via an unescaped `</style>` in its CSS stringify output
- **Severity:** Medium · **Vulnerable:** postcss `< 8.5.10`

Our *direct* dep (`apps/docs` → `^8.5.15`) was already safe; the flagged copy was the Next-bundled `8.4.31` transitive. The override is surgical — only versions below the patched floor are rewritten, so the already-safe `8.5.15` is untouched.

## Verification

- `pnpm why postcss` → **1 version, 8.5.15** (no more `8.4.31` anywhere in the lockfile)
- `pnpm --filter ./apps/docs build` succeeds on the bumped postcss — Next is happy on 8.5.x

## Reviewer notes

- Lockfile diff is intentionally minimal (postcss only); the change was isolated in a clean worktree off `develop` so unrelated in-progress work didn't leak in.
- No axios changes here — for the record, there is **no open axios alert**; all historical axios alerts auto-resolved during the npm→pnpm migration, and axios isn't a dependency (it's a bring-your-own adapter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)