### PR TITLE
docs(adr): ADR 0002 — the seam primitive & principal-scoped auth

### DIFF
--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -1,0 +1,95 @@
+# StitchAPI — Feature Ideas
+
+> The backlog of **forward-looking feature ideas** — things we might build, captured before
+> they're committed. This is upstream of [`OVERVIEW.md`](OVERVIEW.md) §10 (the _sequenced_
+> roadmap): an idea lives here while it's still a sketch, and **graduates to the §10 roadmap**
+> when we commit to building it. Keep entries honest about status; an idea is not a promise.
+> Working draft · 2026-06.
+
+Every idea must answer the same questions, so they stay comparable and we never lose the
+"why." Use the template below.
+
+```markdown
+## <Idea name>
+
+-   **Status:** idea | exploring | accepted → §10
+-   **Date:** YYYY-MM
+-   **Tags:** …
+-   **Gates:** browser-first? · bundle-frugal? (the two gates — FEATURE-LENSES)
+
+**Problem / why** — what's painful or missing today.
+**Sketch** — what it is, concretely.
+**Backed by / builds on** — existing primitives it reuses.
+**Open questions** — what we'd need to resolve before committing.
+```
+
+---
+
+## Studio — the visual surface
+
+-   **Status:** idea
+-   **Date:** 2026-06
+-   **Tags:** surface, visual, authoring, observability, DX
+-   **Gates:** browser-first ✅ (it _is_ the FE surface) · bundle-frugal — must not pull weight
+    into the core import; ships as its own surface, not bundled into `stitch()`.
+
+**Problem / why** — Two pains share one missing surface. (1) You can't _see_ what a stitch is
+doing — traces, drift, and health are JSONL today, not a picture. (2) Authoring a stitch still
+means hand-writing the validation shape, even though the spec-less promise is "one example."
+
+**Sketch** — A browser app with two halves over the same runtime:
+
+-   **Inspect** — see what's happening: live trace overlay, drift/health signals, and
+    Mermaid-from-definition (git-friendly) for any stitch. _(This supersedes and expands the
+    §10 "Visual" roadmap line.)_
+-   **Author from a request** — fire a real call, **infer the validation shape** from the
+    response, and emit copy-paste `stitch({...})` code. The spec-less "one example" promise
+    (OVERVIEW §1, §5.1) made visual: request → inferred schema → ready-to-paste stitch, no
+    hand-written types.
+
+**Backed by / builds on** — the event stream (trace overlay), leveled drift (health signals),
+the existing playground/sandbox surface, and Standard-Schema validation (the inferred shape
+emits as Zod/Valibot/ArkType).
+
+**Open questions** — Where does it run (docs-site embed vs standalone vs CLI-served local)?
+How is the inferred schema kept honest as the API drifts — does Studio round-trip into a drift
+snapshot? How much of the inspect half is just the planned trace overlay vs net-new?
+
+---
+
+## `seam` — a primitive stitches belong to
+
+-   **Status:** exploring → see [`adr/0002`](adr/0002-seam-primitive-and-principal-scoped-auth.md)
+-   **Date:** 2026-06
+-   **Tags:** authoring-surface, auth, security, multi-tenant, agents, runtime
+-   **Gates:** browser-first — must hold without an OS keychain (vault default = memory/opaque
+    in-browser); principal binding + sealing are pure runtime, no lint. · bundle-frugal —
+    reuses `extends`/store keying/sink flush; avoid a _second mandatory_ storage backend.
+
+**Problem / why** — Shared defaults (baseUrl, throttle, retry, sink) get threaded into every
+`stitch()` by hand; `defineStitch` shares **config** but not **runtime**, so "this third-party
+API has one global limit across all my calls" needs a shared `store` passed everywhere — the
+same boilerplate, error-prone to forget. Deeper: on a long-lived shared surface, `cookieSession`
+mints a per-login session into the shared store keyed by **cookie name, not principal**, so user
+A's session can be served to user B (bleed); the live store is also reachable via public
+`__config` (exfil-at-rest) and the cookie lands in traces (exfil-at-use).
+
+**Sketch** — A long-lived **entity** (not a factory) that owns a shared fragment, shared runtime
+(`store` + sink), and a registry/lifecycle (`flush`/`close`). Its decisive job: the **trusted
+principal boundary** — `const userApi = seam.as(req.user.id)` binds identity in the closure, so
+the agent/caller can never name another principal (the principal is **never** in `StitchInput`).
+Auth/session is principal-scoped; throttle/circuit stay host/app-scoped (separate sessions, one
+shared bucket). Storage splits into `store` (sharable, inspectable) and a `vault` namespace
+(off `__config`, redacted from traces, read only by auth strategies, keyed by scope) — split by
+**visibility, not backend**; both can be distributed. Per-stitch overrides may only **tighten** a
+shared budget, never escape. `defineStitch` retires; raw `stitch()` stays as the standalone peer.
+
+**Backed by / builds on** — `extends`/`flatten` composition, `createStoreThrottle` store keying,
+the `AuthStrategy` + `StitchStore` contracts, trace-sink `flush()`. Net-new is mostly plumbing.
+
+**Open questions** — Threading a principal into `AuthContext` on a path `StitchInput` **can't**
+write to (forgery is the whole risk); making `cookieSession.key`/`oauth2.key` principal-aware
+(static strings today); throttle **chaining** for tighten-only; `StitchStore.close()` + vault
+TTL/eviction (per-principal in-memory grows unbounded); `__config` redaction; nested-seam
+teardown order + GC. Dropped along the way: request dedup, abandoned-request cancellation, a
+`strict` boolean, and ESLint-based enforcement (see ADR 0002 §7).

--- a/docs/adr/0002-seam-primitive-and-principal-scoped-auth.md
+++ b/docs/adr/0002-seam-primitive-and-principal-scoped-auth.md
@@ -89,9 +89,9 @@ deprecation window, and no migration path is owed.
         `loginInput` / `StitchInput`. `loginInput` gains the principal —
         `loginInput?: (principal: string) => StitchInput` — so trusted code maps the identity to
         _that user's_ login credentials; credentials still never originate from the caller.
-    -   Session bytes land in the **vault** namespace (off `__config`, redacted); `scope:
-'principal'` wants `ttlMs` set and a distributed/secret backend at scale (per-user
-        sessions multiply; the in-memory default must evict).
+    -   Session bytes land in the **vault** namespace (off `__config`, redacted). With
+        `scope: 'principal'`, set `ttlMs` and use a distributed/secret backend at scale —
+        per-user sessions multiply and the in-memory default must evict.
 
 4.  **Split storage into two namespaces by capability/visibility — not by backend.**
 

--- a/docs/adr/0002-seam-primitive-and-principal-scoped-auth.md
+++ b/docs/adr/0002-seam-primitive-and-principal-scoped-auth.md
@@ -1,0 +1,192 @@
+# ADR 0002 — The `seam` primitive & principal-scoped auth
+
+-   **Status:** Proposed (decisions firm; implementation pending — tracked in [`IDEAS.md`](../IDEAS.md))
+-   **Date:** 2026-06-13
+-   **Tags:** authoring-surface, auth, security, multi-tenant, runtime, agents
+
+## Context
+
+Composing a stitch from shared defaults today means threading a fragment (baseUrl,
+throttle, retry, observability sink) into every `stitch()` call, or wrapping it in
+`defineStitch(...fragments)` — a factory that just prepends those fragments before
+delegating to `makeStitch`. Both share **config** but not **runtime**: every stitch gets
+its own `store` and `throttle` instance ([`packages/core/src/stitch.ts`](../../packages/core/src/stitch.ts) —
+`makeStitch`), so "this third-party API has one global rate limit across all my calls"
+isn't expressible without manually passing one shared `store` everywhere — the same
+threading boilerplate we set out to remove.
+
+The request that started this: a primitive a user configures **once** (baseUrl, throttle,
+retry, sink) that every stitch then **belongs to**, so the shared policy can't be
+forgotten. Grilling that idea moved it well past "config DRY":
+
+-   `defineStitch` already does config inheritance, so a new primitive only earns its keep
+    if it owns something a fragment/factory cannot: **shared runtime**, a **registry /
+    lifecycle**, and — the decisive one — a **trusted identity boundary**.
+-   "Share the third-party's global limit" is keyed on the **credential/host**, not on the
+    object graph, and is already half-served by a shared `store` + `throttle.scope: 'host'`.
+    So shared limits alone do not justify a primitive.
+-   The genuinely new, primitive-worthy job emerged from auth. Of the five auth strategies,
+    four are stateless or app-identity (`bearer`/`apiKey`/`basic` write straight to headers;
+    `oauth2` is `client_credentials`, an app token deliberately shared across workers —
+    [`auth.ts`](../../packages/core/src/auth.ts)). Exactly one, `cookieSession`, mints a
+    **per-login session** into the shared `StitchStore` keyed by **cookie name, not
+    principal**. A long-lived shared surface therefore risks serving user A's session to
+    user B — a cross-principal **bleed**. Two further leak surfaces exist: the live `store`
+    is reachable via the public `Stitch.__config` (**exfil-at-rest**), and the session is
+    written into `req.headers` and thence any trace/hook/error (**exfil-at-use**).
+
+This ADR records the design we converged on. It is **forward-looking** — none of it ships
+yet — but the core decisions (principal bound by the handle; seam as an entity; the
+store/vault split; tighten-only overrides) are firm.
+
+There are **no production users yet**, so every choice below optimises for correctness and
+safety over continuity: defaults are chosen to **fail closed** (a security-determining option
+defaults to its _safe_ value — e.g. `cookieSession` scope defaults to per-user `'principal'`,
+which can only throw, never to shared `'app'`), `defineStitch` is **deleted outright** with no
+deprecation window, and no migration path is owed.
+
+## Decision
+
+1.  **Introduce `seam` as a first-class primitive; retire `defineStitch`.** A seam is a
+    **long-lived entity**, not a one-shot factory. It owns (a) a shared config fragment its
+    stitches inherit, (b) shared **runtime** instances (`store`, trace sink), and (c) a
+    **registry** of the stitches it created, with a lifecycle (`flush()` / `close()`).
+    `stitch()` survives as the **low-level peer** for standalone, one-off endpoints that
+    belong to no surface; docs and the README lead with `seam` for any shared surface.
+    `defineStitch` is removed — it models an alias, not an entity.
+
+2.  **A seam is the trusted principal-binding boundary; the principal is bound by the
+    handle, NEVER passed in call input.** Trusted server code derives a per-principal
+    handle — `const userApi = seam.as(req.user.id)` — and the agent/caller receives only
+    that handle. The principal lives in the closure, not in `StitchInput`. A caller cannot
+    name another principal, so principal-keyed secrets cannot be impersonated. This mirrors
+    the library's existing rule that the credential is bound at construction and "the caller
+    never sees it" ([`auth.ts`](../../packages/core/src/auth.ts) header).
+
+3.  **Scope is per-resource, not a global switch: auth/session is principal-scoped;
+    throttle/circuit are host/app-scoped.** `seam.as('A')` and `seam.as('B')` get **separate
+    sessions** but **share one throttle bucket** (the partner rate-limits per API key, not
+    per end-user). With **no** principal bound, the key resolves to a single shared **app**
+    identity — semantically correct for `oauth2` client_credentials (an app token, one for all
+    workers), not a compat concession. Principal partitioning is opt-in via `seam.as(...)`.
+
+    **`cookieSession` is the only strategy this reshapes** — it is the lone strategy that mints
+    per-login session state (`bearer`/`apiKey`/`basic` are stateless; `oauth2` is
+    `client_credentials`, correctly app-shared). Its scope becomes **explicit and fail-closed**:
+
+    -   `scope` **defaults to `'principal'`** — the safe, fail-closed value. A missing scope can
+        only ever _throw_ (when no principal is bound), never silently share a session. Sharing
+        is opt-in: `scope: 'app'` must be written explicitly, because sharing one session across
+        callers is a decision that should be stated out loud. The default `'principal'` branch
+        still _requires_ the principal-aware `loginInput` at the type level (omitting both is a
+        type error); `scope: 'app'` is the member that opts out. `'app'` as the default is the
+        one choice rejected — it reintroduces the bleed.
+    -   `scope: 'principal'` folds the **seam-bound** principal into both the store key and the
+        single-flight key (the latter also fixes cross-user login coalescing), and **throws at
+        call time if no principal is bound**. Per-user auth cannot silently run app-scoped — the
+        bleed becomes a fail-closed error, not a prod leak.
+    -   The principal is read from `AuthContext` (threaded from `seam.as(id)`), never from
+        `loginInput` / `StitchInput`. `loginInput` gains the principal —
+        `loginInput?: (principal: string) => StitchInput` — so trusted code maps the identity to
+        _that user's_ login credentials; credentials still never originate from the caller.
+    -   Session bytes land in the **vault** namespace (off `__config`, redacted); `scope:
+'principal'` wants `ttlMs` set and a distributed/secret backend at scale (per-user
+        sessions multiply; the in-memory default must evict).
+
+4.  **Split storage into two namespaces by capability/visibility — not by backend.**
+
+    -   `store` — throttle counters, circuit state: freely shared, inspectable.
+    -   `vault` — auth tokens / sessions: (a) never exposed on `__config`, (b) redacted from
+        trace/hook/error payloads, (c) read only by auth strategies, (d) keyed by scope
+        (principal for sessions).
+
+    Both may be in-memory **or** distributed. The default is **one `StitchStore` with a
+    reserved, redacted secret namespace**; a separate `secretStore` is an _optional_ override
+    for a hardened vault (KMS/Vault with audit). The vault is **not** memory-only — sensitive
+    ≠ unshareable, and shared tokens/sessions across workers are deliberate features.
+
+5.  **Shared budgets are sealed; per-stitch override may only TIGHTEN, never escape.** A
+    stitch may add a stricter local throttle that **stacks** on the seam's (both gates must
+    pass); it cannot replace or remove a shared budget. Plain config keys (headers, unwrap,
+    name, retry values…) remain freely overridable (last-writer-wins via `deepMerge`). There
+    is no per-stitch "escape the shared limit" — that would defeat the seam.
+
+6.  **Bleed, exfil-at-rest, and exfil-at-use are three independent problems; each needs its
+    own fix.** Bleed ← principal in the key (decisions 2–3). Exfil-at-rest ← vault off
+    `__config` (decision 4). Exfil-at-use ← redact `cookie`/`authorization` from
+    trace/hook/error payloads. Storage relocation alone fixes **none** of them.
+
+7.  **Explicitly out of scope (considered and dropped).**
+    -   **Request dedup / single-flight as a user feature** — cross-principal coalescing
+        hazard (two users' identical in-flight requests sharing one response).
+    -   **Abandoned-request cancellation** — undetectable on the awaited-promise path (JS
+        gives no "no listener" signal). Reframed as: honour a caller `AbortSignal` + abort on
+        stream break, gated on write-safety — **deferred**, not part of the seam.
+    -   **A seam-level `strict` boolean** — too blunt; sealing is per-resource (decision 5).
+    -   **A custom ESLint plugin enforcing "all stitches via the seam"** — advisory, opt-in,
+        and absent in the browser/REPL (violates the browser-first gate). Enforcement is by
+        **runtime composition + encapsulation** (don't re-export raw `stitch` from a surface
+        module; `no-restricted-imports` if any lint at all), not a bespoke plugin.
+
+## Consequences
+
+**Positive**
+
+-   The seam finally owns a capability no fragment or factory can express: a **trusted
+    principal boundary** plus lifecycle/registry. After a long grilling, that — not config
+    DRY — is its reason to exist.
+-   Per-user secrets become **safe in an agent setting**: no impersonation (principal bound,
+    not passed), no bleed (principal in the key), no exfil (vault off `__config` + redaction)
+    — without giving up shared app-identity tokens.
+-   Reuses existing machinery: `extends`/`flatten` composition, store keying
+    (`createStoreThrottle`), sink `flush()`. Net-new surface is small.
+
+**Accepted trade-offs**
+
+-   Real engine work (not a config tweak): throttle must evaluate a **chain** (intersection),
+    not a merged config; `AuthContext` gains a **principal** threaded from the trusted bind
+    point; `StitchStore` gains `close()` for lifecycle.
+-   **Two creation paths** (`seam` and `stitch`) coexist — accepted because standalone
+    stitches are legitimate; docs steer shared surfaces to `seam`.
+-   **Per-principal in-memory state grows unbounded** → per-user sessions require
+    TTL-eviction or a distributed vault; the in-memory default is for single-identity / dev.
+
+**Required follow-ups**
+
+-   Design the `AuthContext` identity field + `seam.as()` plumbing so the principal is
+    **unwritable from `StitchInput`** (forgery is the whole risk).
+-   Implement `cookieSession` with `scope` **defaulting to `'principal'`** (the fail-closed
+    value; throws if no principal is bound; `scope: 'app'` is the explicit opt-in to sharing;
+    principal folded into store + single-flight keys; `'principal'` requires
+    `loginInput(principal)`) per decision 3.
+    `oauth2` needs no change today (client_credentials only); a future per-user OAuth flow takes
+    the same `scope` treatment.
+-   Throttle **chaining** (tighten-only intersection) in the engine.
+-   `StitchStore.close()` + vault **eviction/TTL** semantics.
+-   `__config` **redaction**: drop `store` / `auth` / `adapter` (or expose a redacted view);
+    confirm nothing reads them.
+-   **Nested seams**: teardown order (flush children before the parent sink) and parent-ref
+    GC retention.
+-   **Gates:** browser-first — vault default backend in-browser is memory/opaque, **no OS
+    keychain**; bundle-frugal — avoid a second _mandatory_ backend.
+
+## Alternatives considered
+
+-   **A. Keep `defineStitch`; no new primitive.** Rejected: a factory cannot own
+    runtime/registry/principal binding. "Belongs to" needs an entity; `defineStitch` is an
+    alias and is retired.
+-   **B. Pass the principal in `StitchInput`.** Rejected: in the agent model the caller
+    chooses its own input, so `principal: 'user-A'` is impersonation-by-design — an IDOR
+    with extra steps. The principal must be bound by trusted code.
+-   **C. Move secrets to the OS keychain, or a memory-only vault.** Rejected on two counts:
+    the OS keychain is **host-wide** (worse bleed, not better) and Node-only (breaks the
+    browser gate); **memory-only** breaks the deliberate shared-token / shared-session
+    features. Sensitivity and shareability are orthogonal axes — the fix is the **key**
+    (scope) and **visibility** (off `__config`, redacted), not the storage backend.
+-   **D. Enforce "all stitches via the seam" with a custom ESLint plugin.** Rejected:
+    advisory, opt-in, defeated by `eslint-disable`, and absent in the browser/REPL — the
+    exact runtimes the project prioritises. Runtime composition + module encapsulation
+    enforce membership instead.
+-   **E. A seam-level `strict` boolean to forbid budget escape.** Rejected: one flag seals
+    everything or nothing; you want `throttle` sealed while `headers` stay overridable.
+    Sealing rides on the per-resource declaration (decision 5).


### PR DESCRIPTION
## ADR 0002 — the seam primitive & principal-scoped auth

Adds Architecture Decision Record 0002 documenting the **seam** primitive and
principal-scoped auth, plus an `IDEAS.md` feature backlog that cross-links it.

### Contents
- `docs/adr/0002-seam-primitive-and-principal-scoped-auth.md` — the decision record.
- `docs/IDEAS.md` — feature-idea backlog (incl. the Studio app idea; upstream of OVERVIEW §10), with a seam entry cross-linking ADR 0002.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
