### PR TITLE
docs: document the new core capabilities

### DIFF
--- a/apps/docs/content/docs/guides/auth/secret-resolvers.mdx
+++ b/apps/docs/content/docs/guides/auth/secret-resolvers.mdx
@@ -1,16 +1,16 @@
 ---
 title: 'Secret resolvers'
-description: 'Resolve secrets lazily at call time with env() and keychain() instead of hard-coding them.'
+description: 'Resolve secrets lazily at call time with env() and secretsFile() instead of hard-coding them.'
 ---
 
 Every auth strategy takes a secret as a reference, not a value, and resolves it
-at call time — reach for `env()` and `keychain()` so the declaration carries a
+at call time — reach for `env()` and `secretsFile()` so the declaration carries a
 capability, not a credential you have to commit.
 
 ## Example
 
 ```ts twoslash
-import { bearer, env, keychain, stitch } from 'stitchapi';
+import { bearer, env, secretsFile, stitch } from 'stitchapi';
 
 // env() reads process.env.API_TOKEN when the stitch is called, not now.
 const me = stitch({
@@ -19,11 +19,11 @@ const me = stitch({
     auth: bearer(env('API_TOKEN')),
 });
 
-// keychain() resolves from ~/.stitch/secrets.json, falling back to the env var.
+// secretsFile() resolves from ~/.stitch/secrets.json, falling back to the env var.
 const billing = stitch({
     baseUrl: 'https://api.example.com',
     path: '/billing',
-    auth: bearer(keychain('BILLING_TOKEN')),
+    auth: bearer(secretsFile('BILLING_TOKEN')),
 });
 ```
 
@@ -41,9 +41,17 @@ value in.
 throws `missing env var <name>` if it is unset — failing loudly at the call
 rather than silently sending an empty token.
 
-`keychain(name)` is a lightweight keychain over a JSON file: it reads
-`~/.stitch/secrets.json` if present and the key is there, otherwise falls back
-to the environment variable of the same name, and throws if neither has it.
+`secretsFile(name)` reads `~/.stitch/secrets.json` if present and the key is
+there, otherwise falls back to the environment variable of the same name, and
+throws if neither has it.
+
+<Callout type="warn">
+    `~/.stitch/secrets.json` is **unencrypted plaintext JSON**. Restrict its
+    permissions (`chmod 600 ~/.stitch/secrets.json`), add it to your
+    `.gitignore`, and never commit it. For production workloads prefer a proper
+    secrets manager or `env()` backed by your deployment platform's secret
+    injection.
+</Callout>
 
 Why call-time resolution matters: the value is fetched only when a call is
 made, so you never commit a secret and the stitch holds a capability rather than
@@ -54,9 +62,15 @@ secrets manager is just supplying a different resolver.
 
 <Callout type="warn">
     A plain-string secret is read at declaration time and lives in your source
-    and history. Prefer `env()` or `keychain()` so the value is resolved at call
-    time instead.
+    and history. Prefer `env()` or `secretsFile()` so the value is resolved at
+    call time instead.
 </Callout>
+
+## Deprecated: keychain()
+
+`keychain(name)` is a deprecated alias for `secretsFile(name)` — identical
+behaviour, retained for backwards compatibility. Migrate any existing calls to
+`secretsFile`.
 
 ## See also
 

--- a/apps/docs/content/docs/guides/observability/trace-sinks.mdx
+++ b/apps/docs/content/docs/guides/observability/trace-sinks.mdx
@@ -11,9 +11,9 @@ yourself.
 
 ## Example
 
-Sinks are wired globally by environment variable — there is no per-stitch `trace`
-config field. With no flags set, a stitch already appends every event as JSONL to
-`~/.stitch/runs/proto.jsonl`; nothing to deploy.
+Sinks are wired globally by environment variable, with a per-stitch `trace` config
+field that overrides the environment. With no flags set, a stitch already appends
+every event as JSONL to `~/.stitch/runs/proto.jsonl`; nothing to deploy.
 
 ```bash
 # Pretty one-line-per-event stream to stderr, on top of the JSONL file.
@@ -24,6 +24,9 @@ STITCH_TRACE_FILE=./runs/today.jsonl node run.js
 
 # ALSO fan the same events to an OTLP collector.
 STITCH_EXPORT=otlp node run.js
+
+# Turn file tracing OFF: 0, false, or an empty value disable it (no file is written).
+STITCH_TRACE_FILE=0 node run.js
 ```
 
 To consume events as your own sink, iterate the stream — that's the public seam
@@ -45,14 +48,55 @@ for await (const event of search({ query: { q: 'mango' } }).stream()) {
 
 The built-in sink is controlled by three env vars: `STITCH_TRACE_CONSOLE=1`
 turns on the colored stderr stream (off unless set); `STITCH_TRACE_FILE=<path>`
-overrides the JSONL destination, which defaults to `~/.stitch/runs/proto.jsonl`;
-and `STITCH_EXPORT=otlp` adds OTLP as one more sink fed from the same events —
-see [OTLP export](/docs/guides/observability/otlp).
+overrides the JSONL destination, which defaults to `~/.stitch/runs/proto.jsonl`
+(or `0`/`false`/empty to disable file tracing); and `STITCH_EXPORT=otlp` adds OTLP
+as one more sink fed from the same events — see
+[OTLP export](/docs/guides/observability/otlp). The per-stitch `trace` config field
+overrides all of these: `trace: false` silences the built-in sinks, and a custom
+`TraceSink` replaces them.
 
 To build sinks in code instead, `createTrace({ console, file })` returns a sink
 that writes JSONL and/or the console stream, and `multiplex(a, b, ...)` fans one
 event stream out to several sinks at once. Both are exported from
 [`stitchapi`](/docs/reference/helpers).
+
+## Turning tracing off
+
+There are two off switches, both of which disable the built-in sinks:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+// ---cut---
+// Per-stitch: `trace: false` disables ALL built-in sinks for this stitch and wins
+// over every STITCH_TRACE_* env var. (A `TraceSink` value replaces them instead.)
+const quiet = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/health',
+    trace: false,
+});
+```
+
+Globally, set `STITCH_TRACE_FILE` to `0`, `false`, or an empty string to turn file
+tracing off — these are treated as the off switch, not as a path, so no file named
+`0` or `false` is ever written to the working directory.
+
+## Default secret redaction
+
+Before any event is written to the built-in JSONL (or console) sink, header values
+for a fixed denylist are replaced with the literal `[REDACTED]`, matched
+case-insensitively wherever headers appear in the event payload (the `start`
+event's input headers, response headers, and so on):
+
+- `authorization`
+- `proxy-authorization`
+- `cookie`
+- `set-cookie`
+- `x-api-key`
+
+So a call carrying `authorization: 'Bearer …'` traces as
+`"authorization":"[REDACTED]"` — the raw secret never reaches disk. Redaction
+happens at the sink boundary, so the live request still sends the real header; only
+the trace copy is scrubbed.
 
 A `TraceSink` is just `{ handle(event, ctx), flush?() }` — implement those two
 and you have a custom consumer you can pass to `multiplex`. The same shape backs

--- a/apps/docs/content/docs/guides/resilience/throttle.mdx
+++ b/apps/docs/content/docs/guides/resilience/throttle.mdx
@@ -33,9 +33,12 @@ be set on its own.
 `scope` decides what shares the budget: `'stitch'` (the default) gives each
 stitch its own budget, while `'host'` pools the budget across every stitch
 hitting the same host — use it when one API publishes a single account-wide
-limit. Throttle state lives in the stitch store, so giving stitches a shared
-[store](/docs/guides/state/pluggable-store) turns a single-process budget into a
-[distributed one](/docs/guides/state/distributed-throttle) that spans workers.
+limit. Host-scoped pooling works in-process out of the box: separate stitches in
+the same process draw from one budget per host with no extra configuration.
+Giving those stitches a shared
+[store](/docs/guides/state/pluggable-store) extends that single-process budget
+into a [distributed one](/docs/guides/state/distributed-throttle) that spans
+workers.
 
 <Callout type="info">
     A throttled wait surfaces as a `throttled` progress phase on the event

--- a/apps/docs/content/docs/guides/state/distributed-throttle.mdx
+++ b/apps/docs/content/docs/guides/state/distributed-throttle.mdx
@@ -4,8 +4,11 @@ description: 'Share one rate budget across workers by pointing the throttle at a
 ---
 
 By default a stitch keeps its throttle counters in the in-memory store, so the
-rate budget is per process — each worker gets its own. Point the throttle at a
-shared `store` and one budget spans every worker that uses it.
+rate budget is per process. With `scope: 'host'` every stitch in that process
+already pools into one budget per host (see [Throttle](/docs/guides/resilience/throttle));
+the in-memory store just keeps that pooling within a single process — each worker
+gets its own. Point the throttle at a shared `store` and one budget spans every
+worker that uses it.
 
 ## Example
 

--- a/apps/docs/content/docs/reference/config-types.mdx
+++ b/apps/docs/content/docs/reference/config-types.mdx
@@ -14,6 +14,23 @@ import type { StitchConfig } from 'stitchapi';
 
 <AutoTypeTable path="../../packages/core/src/types.ts" name="StitchConfig" />
 
+### arrayFormat
+
+Controls how arrays are serialised in the query string. The default (`'indices'`) matches `qs` behaviour.
+
+| Value | Wire format |
+|---|---|
+| `'indices'` (default) | `ids%5B0%5D=1&ids%5B1%5D=2` |
+| `'brackets'` | `ids%5B%5D=1&ids%5B%5D=2` |
+| `'repeat'` | `ids=1&ids=2` |
+
+```ts
+// repeat — Laravel, Rails, and many PHP frameworks expect this
+const getUsers = stitch({ baseUrl, path: '/users', arrayFormat: 'repeat' });
+await getUsers({ query: { ids: [1, 2] } });
+// → GET /users?ids=1&ids=2
+```
+
 ## Option shapes
 
 The resilience, validation, and drift fields above are themselves typed shapes.

--- a/apps/docs/content/docs/reference/conformance-kits.mdx
+++ b/apps/docs/content/docs/reference/conformance-kits.mdx
@@ -1,0 +1,197 @@
+---
+title: 'Conformance kits'
+description: 'Prove a custom adapter, store, or trace sink implements its seam — from stitchapi/testing, in your own CI.'
+---
+
+Every pluggable seam in StitchAPI is a **contract, not a dependency**: the
+transport (`Adapter`), the state store (`StitchStore`), and the trace sink
+(`TraceSink`) each have a small documented surface, core ships only platform
+defaults for them (`fetchAdapter`, `memoryStore`, `createTrace`), and vendor
+implementations — a Redis store, an axios transport, a Datadog sink — live in
+their own packages.
+
+The `stitchapi/testing` subpath makes that contract enforceable. It ships one
+`verify*Contract` function per seam; any implementation that passes is a valid
+seam implementation, and third-party authors can prove it in their own CI
+without depending on StitchAPI internals.
+
+The kit is framework-agnostic and browser-safe: every verifier is a plain
+async function that **returns** a report (no vitest/jest imports, no `node:*`
+modules), so it runs inside any test runner — or a browser.
+
+## The report
+
+Each verifier resolves to a `ContractReport`:
+
+```ts
+interface ContractReport {
+    seam: string; // 'store' | 'adapter' | 'sink'
+    ok: boolean; // true when every rule passed
+    passed: string[]; // names of the rules that passed
+    violations: { rule: string; detail: string }[];
+}
+```
+
+Rules are checked independently — one violation never masks another — so a
+failing report lists every broken rule at once.
+
+### assertConformance
+
+`assertConformance(report)` throws one readable `Error` listing every
+violation (and is a no-op on a clean report). It is the one-liner for a test
+body:
+
+```ts
+import { assertConformance, verifyStoreContract } from 'stitchapi/testing';
+
+test('myStore implements the StitchStore contract', async () => {
+    assertConformance(await verifyStoreContract(() => myStore()));
+});
+```
+
+## verifyStoreContract
+
+`verifyStoreContract(makeStore, opts?)` verifies a [pluggable
+store](/docs/guides/state/pluggable-store) — the `get`/`set`/`incr` + TTL
+surface the engine uses for throttle counters and auth/session state:
+
+-   `set`/`get` round-trips a value; a missing key resolves to `undefined`;
+    a second `set` overwrites; writes are isolated by key.
+-   A `set` with `ttlMs` expires; a `set` without `ttlMs` does not.
+-   `incr` initializes a missing key to 1, increments an existing counter,
+    restarts at 1 once its TTL window lapses, and is atomic within a process:
+    20 concurrent calls must return 1..20 exactly.
+
+TTL rules use real timers with a small window (default 60ms). Pass
+`{ ttlMs }` to give a backend with coarser expiry more room. Keys are
+namespaced per run, so rerunning against a persistent backend never collides.
+
+## verifyAdapterContract
+
+`verifyAdapterContract(adapter, { baseUrl })` verifies a custom transport
+against a documented echo contract served at `baseUrl`:
+
+-   Status passthrough: 200, 404, and 500 all **resolve** — an adapter never
+    throws on a non-2xx status; only network and abort errors reject.
+-   Request delivery: method, headers, and the JSON-encoded body reach the
+    server intact.
+-   Response headers are readable using **lowercased** names (the
+    `AdapterResponse` case convention).
+-   A `text/plain` body round-trips as a string; an `application/json` body
+    round-trips as parsed data.
+-   A pre-aborted `AbortSignal` rejects, and an in-flight abort rejects
+    promptly instead of waiting out the response.
+
+### adapterContractFixture
+
+The echo contract itself ships as `adapterContractFixture` — a **pure**
+function (request in, response out, no server), so you can mount it on
+anything: `node:http`, hono, a service worker. The host lowercases request
+header names, hands over the raw body text, and honors the fixture's
+`delayMs` (the in-flight abort rule depends on it):
+
+```ts
+import { createServer } from 'node:http';
+import { adapterContractFixture } from 'stitchapi/testing';
+
+const server = createServer((req, res) => {
+    let raw = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => (raw += chunk));
+    req.on('end', () => {
+        const out = adapterContractFixture({
+            method: req.method ?? 'GET',
+            path: req.url ?? '/',
+            headers: Object.fromEntries(
+                Object.entries(req.headers).map(([k, v]) => [
+                    k.toLowerCase(),
+                    Array.isArray(v) ? v.join(', ') : (v ?? ''),
+                ]),
+            ),
+            ...(raw === '' ? {} : { body: raw }),
+        });
+        const respond = () => {
+            res.writeHead(out.status, out.headers);
+            res.end(out.body);
+        };
+        if (out.delayMs) setTimeout(respond, out.delayMs);
+        else respond();
+    });
+});
+```
+
+The routes are documented on the function's JSDoc (`/status/{code}`, `/echo`,
+`/text`, `/json`, `/slow`).
+
+## verifySinkContract
+
+`verifySinkContract(makeSink)` feeds one sink instance a canonical fixture
+sequence covering **all** `StitchEvent` variants — `start`, `progress`,
+`drift`, `delta`, `result`, `error`, `done` — and asserts `handle` accepts
+each without throwing, then exercises the optional `flush()` when present.
+
+<Callout>
+    The sequence includes `delta`, which the type declares ahead of engine
+    support — a conforming sink must already tolerate events it does not
+    recognize.
+</Callout>
+
+## Worked example: a community Redis store
+
+A third-party author publishing `@acme/stitch-redis-store` proves compliance
+in their own CI — no StitchAPI internals, just the kit:
+
+```ts
+import { redisStore } from '../src/redis-store';
+
+import { createClient } from 'redis';
+import { assertConformance, verifyStoreContract } from 'stitchapi/testing';
+import { test } from 'vitest';
+
+test('redisStore implements the StitchStore contract', async () => {
+    const client = createClient({ url: process.env.REDIS_URL });
+    await client.connect();
+    try {
+        assertConformance(
+            await verifyStoreContract(() => redisStore(client), {
+                // Give Redis expiry more room than the 60ms default.
+                ttlMs: 250,
+            }),
+        );
+    } finally {
+        await client.quit();
+    }
+});
+```
+
+If the store cuts a corner — a non-atomic `INCR`, a dropped TTL — the test
+fails with every broken rule named:
+
+```
+Error: StitchAPI store contract: 2 violation(s), 8 rule(s) passed
+  - set: a ttlMs entry expires: value survived its 250ms TTL: got "soon-gone"
+  - incr: 20 concurrent calls net exactly +20: sorted results of 20 concurrent incrs ...
+```
+
+Passing the kit is the compatibility claim: a store that passes can back
+[distributed throttle](/docs/guides/state/distributed-throttle) and shared
+sessions with no change at the call site.
+
+## See also
+
+<Cards>
+    <Card
+        title="Guide: pluggable store"
+        href="/docs/guides/state/pluggable-store"
+    />
+    <Card
+        title="Guide: distributed throttle"
+        href="/docs/guides/state/distributed-throttle"
+    />
+    <Card
+        title="Guide: trace sinks"
+        href="/docs/guides/observability/trace-sinks"
+    />
+    <Card title="Helpers" href="/docs/reference/helpers" />
+    <Card title="Events" href="/docs/reference/events" />
+</Cards>

--- a/apps/docs/content/docs/reference/meta.json
+++ b/apps/docs/content/docs/reference/meta.json
@@ -1,5 +1,12 @@
 {
     "title": "Reference",
     "icon": "Code",
-    "pages": ["stitch", "auth-strategies", "config-types", "helpers", "events"]
+    "pages": [
+        "stitch",
+        "auth-strategies",
+        "config-types",
+        "helpers",
+        "conformance-kits",
+        "events"
+    ]
 }

--- a/apps/docs/content/docs/surfaces/http-serve.mdx
+++ b/apps/docs/content/docs/surfaces/http-serve.mdx
@@ -46,6 +46,27 @@ to receive the live event stream as SSE instead.
     one.
 </Callout>
 
+## Programmatic API
+
+The CLI is a thin wrapper. To embed the same server in your own process, import
+`serve` from the `stitchapi/serve` subpath and hand it a registry of named
+stitches:
+
+```ts
+import { serve } from 'stitchapi/serve';
+import { me } from './stitches';
+
+const handle = await serve({ me });
+console.log(`listening on ${handle.url}`);
+
+// later
+await handle.close();
+```
+
+`serve(registry, options?)` returns a handle with the bound `url`, `port`, the
+underlying `server`, and a `close()` method. It binds `127.0.0.1:8787` by
+default; pass `{ port: 0 }` to let the OS pick an ephemeral port.
+
 A served stitch is the same definition as the in-process
 [function surface](/docs/surfaces/function) and the
 [`stitch` CLI](/docs/surfaces/cli) — one source of truth, three ways to call it.

--- a/apps/docs/content/docs/surfaces/mcp.mdx
+++ b/apps/docs/content/docs/surfaces/mcp.mdx
@@ -48,6 +48,27 @@ the agent spends its context on the task, not on a tool catalog. The full design
 of the tool lives in the agents section; see
 [run_stitch & code mode](/docs/agents/run-stitch-tool).
 
+## Programmatic API
+
+The CLI is a thin wrapper. To run the MCP server in your own process, import
+`serveStdio` from the `stitchapi/mcp` subpath and hand it a registry of named
+stitches:
+
+```ts
+import { serveStdio } from 'stitchapi/mcp';
+import * as stitches from './stitches';
+
+// Reads newline-delimited JSON-RPC from stdin, writes responses to stdout.
+const { close } = serveStdio(stitches);
+
+// later
+close();
+```
+
+`serveStdio(registry, options?)` wires the `run_stitch` / `list_stitches` server
+to stdio and returns a handle whose `close()` detaches the transport. Pass
+`{ input, output }` to bind a different stream pair instead of stdio.
+
 The capability boundary holds here: the agent calls `run_stitch` by name and
 never sees the token, cookie, or signing key the stitch holds — it invokes a
 capability, not a credential.


### PR DESCRIPTION
> **Stacked on #50** (core). The render gate (AutoTypeTable) compiles against the new core types, so this needs #50; base retargets to `develop` after #50 merges.

## Docs content: document the new core capabilities

Documents the behaviour shipped in the core PR (GAP-AUDIT remediation + the three gates). Pure docs content — no code.

### Pages
- **guides/auth/secret-resolvers** — `secretsFile()` (replaces `keychain()`), browser no-op behaviour.
- **guides/observability/trace-sinks** — `trace: false | TraceSink` override and secret-header redaction.
- **guides/resilience/throttle** + **guides/state/distributed-throttle** — `scope:'host'` in-process pooling.
- **reference/config-types** — `arrayFormat` and `trace`.
- **reference/conformance-kits** (new) + **reference/meta.json** — the `stitchapi/testing` kit.
- **surfaces/http-serve**, **surfaces/mcp** — subpath-export notes.

### Test plan
- Pre-push render gate (`pnpm --filter @stitchapi/docs build`) passes — MDX renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
