### PR TITLE
test(core): harden conformance kit's incr key-isolation rule

### DIFF
--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -294,7 +294,27 @@ export async function verifyStoreContract(
             async () => {
                 await store.set(k('iso-a'), 'a');
                 await store.set(k('iso-b'), 'b');
-                await store.incr(k('iso-n'), 5_000);
+                // Counters live under their own keys, never a shared one:
+                // iso-n's first incr lands at 1, an incr on a different
+                // key (iso-m) must not advance it, so iso-n's next incr is 2.
+                const isoN = await store.incr(k('iso-n'), 5_000);
+                if (isoN !== 1) {
+                    throw new Error(
+                        `expected iso-n to start at 1, got ${show(isoN)}`,
+                    );
+                }
+                const isoM = await store.incr(k('iso-m'), 5_000);
+                if (isoM !== 1) {
+                    throw new Error(
+                        `expected iso-m to start at 1, got ${show(isoM)}`,
+                    );
+                }
+                const isoNAgain = await store.incr(k('iso-n'), 5_000);
+                if (isoNAgain !== 2) {
+                    throw new Error(
+                        `incr on iso-m leaked into iso-n: expected 2, got ${show(isoNAgain)}`,
+                    );
+                }
                 expectDeepEqual(await store.get(k('iso-a')), 'a', 'iso-a');
                 expectDeepEqual(await store.get(k('iso-b')), 'b', 'iso-b');
             },


### PR DESCRIPTION
## What

The store conformance kit's **"keys: writes are isolated by key"** rule discarded its `incr` return value and only asserted `set`-key isolation — so a store whose `incr` wrote to a single shared counter would slip through, caught only indirectly (and order-dependently) by the "increments an existing counter" rule.

This rule now proves per-key counter isolation **order-independently**:

```
incr(iso-n) === 1
incr(iso-m) === 1   // a different key
incr(iso-n) === 2   // proves iso-m's increment did not leak into iso-n
```

A leak between keys now fails with a named violation in the rule that owns the property.

## Why

Surfaced by a post-commit adversarial review of the conformance kit (the kit was committed in `bcdd4ad` but never reviewed — its verify phase crashed on a model error). Three reviewers checked the kit for doc-drift, false-greens, and contract-correctness; verdict was clean except this one medium finding. No public API change.

## Verification

- `pnpm vitest run test/conformance-kit.spec.ts` → 8/8 green (incl. `memoryStore` passes, broken store yields named violations, browser-bundle dogfood)
- `eslint` clean, `tsc -p tsconfig.test.json` clean
- byte-identical change previously passed the full lefthook gate on `feat/docs-playground`

Stacked on `feat/core-gap-audit-remediation` because it touches the kit source introduced there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)