### PR TITLE
docs(recipes): add Recipes section (12 task-oriented, twoslash-verified examples)

### DIFF
--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -2,6 +2,7 @@
     "title": "Documentation",
     "pages": [
         "getting-started",
+        "recipes",
         "concepts",
         "guides",
         "surfaces",

--- a/apps/docs/content/docs/recipes/auth-as-a-capability.mdx
+++ b/apps/docs/content/docs/recipes/auth-as-a-capability.mdx
@@ -1,0 +1,57 @@
+---
+title: 'Authenticate without the token touching your code'
+description: 'Declare auth on the stitch so callers get a capability, not a credential — the secret is read per call and never returned.'
+---
+
+## Task
+
+You want every call to an API authenticated, without the token ever living in
+your application code — where most clients would have you read it into a
+variable and thread it through every call, into your logs, your traces, and
+anything you hand to an agent.
+
+## Example
+
+One way: declare the auth on the stitch itself. Callers get a callable; the
+secret stays behind it.
+
+```ts twoslash
+import { bearer, env, stitch } from 'stitchapi';
+
+const getInvoice = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/invoices/{id}',
+    auth: bearer(env('API_TOKEN')),
+});
+
+// The caller invokes and gets data — no token in sight.
+const invoice = await getInvoice({ params: { id: 42 } });
+```
+
+## How it works
+
+`env('API_TOKEN')` is a resolver, not a value — nothing is read when you declare
+the stitch. The runtime invokes it on each request, attaches the token, and
+discards it; the caller receives data and never the secret. The declaration
+holds a _reference_ to where the secret lives, so it is safe to commit, diff, and
+share.
+
+Swap `bearer` for [`apiKey`](/docs/guides/auth/api-key),
+[`basic`](/docs/guides/auth/basic), or [`oauth2`](/docs/guides/auth/oauth2) — the
+boundary is the same, and the strategies with a session refresh themselves
+behind it. Because the token never crosses back to the caller, you can hand the
+stitch to an [agent](/docs/agents) and it can make the authenticated call
+without ever holding the credential.
+
+## See also
+
+<Cards>
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+    />
+    <Card title="Secret resolvers" href="/docs/guides/auth/secret-resolvers" />
+    <Card title="bearer" href="/docs/guides/auth/bearer" />
+    <Card title="oauth2" href="/docs/guides/auth/oauth2" />
+    <Card title="For agents" href="/docs/agents" />
+</Cards>

--- a/apps/docs/content/docs/recipes/catch-a-breaking-api-change.mdx
+++ b/apps/docs/content/docs/recipes/catch-a-breaking-api-change.mdx
@@ -1,0 +1,57 @@
+---
+title: 'Catch a breaking API change before your users do'
+description: 'Wrap output with drift to compare every response against a committed snapshot and flag dropped fields, type flips, and new keys by severity.'
+---
+
+## Task
+
+A vendor can rename or drop a field without telling you, and a plain type check
+will not notice until something breaks in production. You want to be warned the
+moment the response shape moves — and to triage it by severity, not panic on
+every change.
+
+## Example
+
+One way: wrap the `output` schema with `drift` and a committed baseline.
+
+```ts twoslash
+import { drift, stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    output: drift(z.object({ id: z.number(), email: z.string() }), {
+        critical: ['id'],
+        watch: ['email'],
+        snapshotFile: 'users.contract.json',
+    }),
+});
+
+const user = await getUser({ params: { id: 1 } });
+```
+
+## How it works
+
+The first call records the baseline into `users.contract.json` (check it into
+the repo); every call after compares the response and emits leveled findings.
+`critical` paths change at level `error` — that breaks the contract and throws
+[`STITCH_DRIFT`](/docs/errors/stitch-drift). `watch` paths change at `warn`, and
+brand-new fields default to `info` (`onNew`). `warn` and `info` findings do
+**not** throw — they ride the [event stream](/docs/concepts/event-stream) as
+`drift` events, so you can [watch a field erode](/docs/recipes/watch-a-call-as-it-happens)
+before it breaks. This is the opposite end from plain
+[validation](/docs/guides/validation/validation), which rejects one malformed
+response hard, here and now.
+
+## See also
+
+<Cards>
+    <Card title="Leveled drift" href="/docs/guides/validation/drift" />
+    <Card title="Validation" href="/docs/guides/validation/validation" />
+    <Card title="STITCH_DRIFT" href="/docs/errors/stitch-drift" />
+    <Card
+        title="Watch retries and throttling as they happen"
+        href="/docs/recipes/watch-a-call-as-it-happens"
+    />
+</Cards>

--- a/apps/docs/content/docs/recipes/expose-a-stitch-to-an-agent.mdx
+++ b/apps/docs/content/docs/recipes/expose-a-stitch-to-an-agent.mdx
@@ -56,7 +56,10 @@ token. To run the server in your own process, import `serveStdio` from the
 
 <Cards>
     <Card title="MCP surface" href="/docs/surfaces/mcp" />
-    <Card title="run_stitch &amp; code-mode" href="/docs/agents/run-stitch-tool" />
+    <Card
+        title="run_stitch &amp; code-mode"
+        href="/docs/agents/run-stitch-tool"
+    />
     <Card title="For agents" href="/docs/agents" />
     <Card
         title="Capability, not credential"

--- a/apps/docs/content/docs/recipes/expose-a-stitch-to-an-agent.mdx
+++ b/apps/docs/content/docs/recipes/expose-a-stitch-to-an-agent.mdx
@@ -1,0 +1,65 @@
+---
+title: 'Let an agent call your API without handing it the key'
+description: 'Expose your stitches over MCP through one run_stitch tool — the agent invokes a capability and never sees the credential.'
+---
+
+## Task
+
+You want an LLM agent to call your APIs, but you cannot give it the API key — and
+you do not want to flood its context with one tool per endpoint.
+
+## Example
+
+One way: author named stitches that hold their own auth, then serve them over
+MCP.
+
+```ts twoslash
+// stitches.ts — author each stitch with its auth and a name.
+import { bearer, env, stitch } from 'stitchapi';
+
+export const getUser = stitch({
+    name: 'getUser',
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    auth: bearer(env('API_TOKEN')),
+});
+```
+
+Serve the module over MCP from the shell:
+
+```bash
+stitch mcp --module ./stitches.ts
+```
+
+The agent discovers names with `list_stitches`, then calls one through the single
+`run_stitch` tool:
+
+```json
+{
+    "name": "run_stitch",
+    "input": { "name": "getUser", "input": { "params": { "id": 1 } } }
+}
+```
+
+## How it works
+
+`run_stitch` covers **every** registered stitch with one tool — `name` selects
+it, `input` is its `{ params, query, body, headers }` — so the agent's tool list
+stays at two entries (`run_stitch` + `list_stitches`) no matter how many stitches
+you register, keeping its context flat. The auth runs inside the runtime: the
+agent names a [capability](/docs/concepts/capability-not-credential), the server
+holds the `bearer(env('API_TOKEN'))` secret, and the result returns without the
+token. To run the server in your own process, import `serveStdio` from the
+`stitchapi/mcp` subpath.
+
+## See also
+
+<Cards>
+    <Card title="MCP surface" href="/docs/surfaces/mcp" />
+    <Card title="run_stitch &amp; code-mode" href="/docs/agents/run-stitch-tool" />
+    <Card title="For agents" href="/docs/agents" />
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+    />
+</Cards>

--- a/apps/docs/content/docs/recipes/idempotent-writes.mdx
+++ b/apps/docs/content/docs/recipes/idempotent-writes.mdx
@@ -1,0 +1,59 @@
+---
+title: 'Retry a write without double-charging'
+description: 'Attach an idempotency key so a retried POST settles once, not twice.'
+---
+
+## Task
+
+You want to retry a `POST` that creates a charge or an order — but a retry that
+actually succeeded server-side the first time would double-charge. You need the
+server to recognize the replay as the same logical write.
+
+## Example
+
+One way: pair `retry` with an `idempotency` key derived from the request.
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const createOrder = stitch({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/orders',
+    retry: { attempts: 3, on: [429, 503] },
+    idempotency: {
+        // body is unknown, so narrow it before reading a property.
+        key: (input) => `order-${(input.body as { ref: string }).ref}`,
+    },
+});
+
+const order = await createOrder({ body: { ref: 'inv-1001' } });
+```
+
+## How it works
+
+Each logical call carries a stable `Idempotency-Key` header. When
+[`retry`](/docs/guides/resilience/retry) replays the write, the server sees the
+same key and dedupes the side effect instead of running it twice. The default
+key is a random uuid generated once per call — already retry-safe; a custom
+`key` derives a stable value from the
+[input](/docs/reference/config-types) (here the order ref) so the same logical
+write always maps to the same key. Idempotency only pays off alongside retries.
+
+<Callout type="warn">
+    A derived `key` must be stable for a given logical call and unique across
+    distinct ones — colliding keys make the server dedupe two different writes
+    into one.
+</Callout>
+
+## See also
+
+<Cards>
+    <Card title="Idempotency keys" href="/docs/guides/resilience/idempotency" />
+    <Card title="Retry &amp; backoff" href="/docs/guides/resilience/retry" />
+    <Card
+        title="Make a flaky call succeed on its own"
+        href="/docs/recipes/make-a-flaky-call-succeed"
+    />
+    <Card title="Body encoding" href="/docs/guides/data/body-encoding" />
+</Cards>

--- a/apps/docs/content/docs/recipes/index.mdx
+++ b/apps/docs/content/docs/recipes/index.mdx
@@ -1,0 +1,107 @@
+---
+title: 'Recipes'
+description: 'Working examples of common tasks — each one the whole thing in a single block, with links down to the guides for depth.'
+---
+
+A recipe is a worked example of a common task — the whole thing in one block,
+runnable as a starting point and one way to get the job done, not the only way.
+Where a [guide](/docs/guides) explains one feature, a recipe shows several
+working together — then links down to the guides when you want the detail.
+
+Reach for a recipe when you know the task and want somewhere to start. Reach for
+a guide when you want to understand a feature on its own.
+
+## Start here
+
+<Cards>
+    <Card
+        title="Send JSON and get a typed result back"
+        href="/docs/recipes/typed-json-round-trip"
+        description="POST a validated body and read a typed, runtime-validated result."
+    />
+    <Card
+        title="Loop a cursor API into one array"
+        href="/docs/recipes/paginate-into-one-array"
+        description="Follow nextCursor across every page and aggregate the items — no manual while-loop."
+    />
+    <Card
+        title="Make a flaky call succeed on its own"
+        href="/docs/recipes/make-a-flaky-call-succeed"
+        description="Add retry with backoff so transient 429s and 5xxs recover without your code noticing."
+    />
+</Cards>
+
+## Stay resilient
+
+<Cards>
+    <Card
+        title="Keep a failing dependency from taking you down"
+        href="/docs/recipes/survive-a-flaky-dependency"
+        description="Compose timeout, retry, and a circuit breaker so a degraded upstream fails fast instead of hanging."
+    />
+    <Card
+        title="Retry a write without double-charging"
+        href="/docs/recipes/idempotent-writes"
+        description="Attach an idempotency key so a retried POST settles once, not twice."
+    />
+</Cards>
+
+## Validate &amp; observe
+
+<Cards>
+    <Card
+        title="Catch a breaking API change before your users do"
+        href="/docs/recipes/catch-a-breaking-api-change"
+        description="Wrap output with drift to flag dropped fields, type flips, and new keys against a committed snapshot."
+    />
+    <Card
+        title="Watch retries and throttling as they happen"
+        href="/docs/recipes/watch-a-call-as-it-happens"
+        description="Iterate a stitch's event stream instead of awaiting it, and observe every retry, pause, and drift."
+    />
+</Cards>
+
+## Run at scale
+
+<Cards>
+    <Card
+        title="Mirror a paginated API to NDJSON"
+        href="/docs/recipes/mirror-a-paginated-api"
+        description="Pull every page of a cursor-paginated, OAuth2-protected endpoint — with retry and throttle on each page."
+    />
+    <Card
+        title="Share one rate limit across every worker"
+        href="/docs/recipes/one-rate-limit-across-workers"
+        description="Point the throttle at a shared store so a whole fleet draws from a single rate budget."
+    />
+</Cards>
+
+## Authenticate
+
+<Cards>
+    <Card
+        title="Authenticate without the token touching your code"
+        href="/docs/recipes/auth-as-a-capability"
+        description="Declare auth on the stitch so callers get a capability, not a credential."
+    />
+</Cards>
+
+## Agents &amp; surfaces
+
+<Cards>
+    <Card
+        title="Let an agent call your API without handing it the key"
+        href="/docs/recipes/expose-a-stitch-to-an-agent"
+        description="Expose your stitches over MCP through one run_stitch tool — the agent never sees the credential."
+    />
+    <Card
+        title="Call one stitch as a function, a CLI command, and an agent tool"
+        href="/docs/recipes/one-stitch-every-surface"
+        description="One definition, four front doors — in-process, shell, HTTP, and MCP."
+    />
+</Cards>
+
+<Callout type="info">
+    These assume the runtime is installed and you can declare a stitch. New to
+    it? Start at the [Quickstart](/docs/getting-started/quickstart).
+</Callout>

--- a/apps/docs/content/docs/recipes/make-a-flaky-call-succeed.mdx
+++ b/apps/docs/content/docs/recipes/make-a-flaky-call-succeed.mdx
@@ -1,0 +1,56 @@
+---
+title: 'Make a flaky call succeed on its own'
+description: 'Add retry with backoff so transient 429s and 5xxs recover without your code noticing.'
+---
+
+## Task
+
+An API you depend on returns the occasional `429` or `503` that clears on its
+own. You do not want every call site wrapped in a try/catch and a sleep.
+
+## Example
+
+One way: declare a retry policy on the stitch and let the caller just `await` the
+value.
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    retry: {
+        attempts: 3,
+        on: [429, 503],
+        backoff: 'expo-jitter',
+        respectRetryAfter: true,
+    },
+});
+
+// A transient 429 or 503 is retried up to twice; the caller just gets the value.
+const user = await getUser({ params: { id: 1 } });
+```
+
+## How it works
+
+`attempts` is the **total** number of tries including the first, so `3` means up
+to two retries. `on` is the set of status codes that trigger a retry.
+`backoff: 'expo-jitter'` doubles the wait each attempt and spreads it randomly to
+avoid thundering herds. `respectRetryAfter` honors a `Retry-After` header when the
+server tells you when to come back. Each retry rides the
+[event stream](/docs/concepts/event-stream) as a `progress` event (phase
+`retry`), so you can [watch it happen](/docs/recipes/watch-a-call-as-it-happens).
+When the dependency is not just flaky but failing, compose retry with a
+[timeout and circuit breaker](/docs/recipes/survive-a-flaky-dependency).
+
+## See also
+
+<Cards>
+    <Card title="Retry &amp; backoff" href="/docs/guides/resilience/retry" />
+    <Card
+        title="Keep a failing dependency from taking you down"
+        href="/docs/recipes/survive-a-flaky-dependency"
+    />
+    <Card title="Timeout" href="/docs/guides/resilience/timeout" />
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+</Cards>

--- a/apps/docs/content/docs/recipes/meta.json
+++ b/apps/docs/content/docs/recipes/meta.json
@@ -1,0 +1,18 @@
+{
+    "title": "Recipes",
+    "icon": "ChefHat",
+    "pages": [
+        "typed-json-round-trip",
+        "paginate-into-one-array",
+        "make-a-flaky-call-succeed",
+        "survive-a-flaky-dependency",
+        "idempotent-writes",
+        "catch-a-breaking-api-change",
+        "watch-a-call-as-it-happens",
+        "mirror-a-paginated-api",
+        "one-rate-limit-across-workers",
+        "auth-as-a-capability",
+        "expose-a-stitch-to-an-agent",
+        "one-stitch-every-surface"
+    ]
+}

--- a/apps/docs/content/docs/recipes/mirror-a-paginated-api.mdx
+++ b/apps/docs/content/docs/recipes/mirror-a-paginated-api.mdx
@@ -26,7 +26,12 @@ const mirror = stitch({
         clientSecret: env('CLIENT_SECRET'),
         scope: 'users.read',
     }),
-    retry: { attempts: 4, on: [429, 503], backoff: 'expo-jitter', respectRetryAfter: true },
+    retry: {
+        attempts: 4,
+        on: [429, 503],
+        backoff: 'expo-jitter',
+        respectRetryAfter: true,
+    },
     throttle: { rate: '5/s', concurrency: 2, scope: 'host' },
     paginate: {
         next: (prevBody) => {

--- a/apps/docs/content/docs/recipes/mirror-a-paginated-api.mdx
+++ b/apps/docs/content/docs/recipes/mirror-a-paginated-api.mdx
@@ -1,0 +1,92 @@
+---
+title: 'Mirror a paginated API to NDJSON'
+description: 'Pull every page of a cursor-paginated, OAuth2-protected endpoint — with retry and throttle on each page — and write the rows as newline-delimited JSON.'
+---
+
+## Task
+
+You want a local copy of every record behind a paginated API — one that happens
+to be OAuth2-protected, rate-limited, and prone to the odd `429` or `503`. By
+hand that means a token dance, a manual page loop, backoff code, and a rate
+limiter before you write a single row.
+
+## Example
+
+One way: declare all four concerns on a single stitch and `await` it once.
+
+```ts twoslash
+import { env, oauth2, stitch } from 'stitchapi';
+
+const mirror = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users',
+    auth: oauth2({
+        tokenUrl: 'https://api.example.com/oauth/token',
+        clientId: env('CLIENT_ID'),
+        clientSecret: env('CLIENT_SECRET'),
+        scope: 'users.read',
+    }),
+    retry: { attempts: 4, on: [429, 503], backoff: 'expo-jitter', respectRetryAfter: true },
+    throttle: { rate: '5/s', concurrency: 2, scope: 'host' },
+    paginate: {
+        next: (prevBody) => {
+            const cursor = (prevBody as { nextCursor?: string }).nextCursor;
+            return cursor ? { query: { cursor } } : undefined;
+        },
+        items: (value) => (value as { results: unknown[] }).results,
+        max: 100,
+    },
+});
+
+// One await runs the whole paged loop — auth, retry, and throttle apply to
+// every page — and aggregates every row into a single array.
+const rows = (await mirror()) as unknown[];
+
+// Newline-delimited JSON: one row per line.
+const ndjson = rows.map((row) => JSON.stringify(row)).join('\n');
+```
+
+Write the rows to disk:
+
+```ts
+import { writeFile } from 'node:fs/promises';
+
+await writeFile('users.ndjson', ndjson);
+```
+
+## How it works
+
+The four concerns are independent keys on one declaration, so they compose
+without any glue. [`oauth2`](/docs/guides/auth/oauth2) fetches, caches, and
+refreshes the token behind the
+[capability boundary](/docs/concepts/capability-not-credential) — your code
+never sees it. [`paginate`](/docs/guides/data/pagination) reads `nextCursor`
+off each raw body and asks for the next page until `next` returns `undefined`,
+aggregating every page's `results` into the array you `await`.
+[`retry`](/docs/guides/resilience/retry) and
+[`throttle`](/docs/guides/resilience/throttle) apply **per page**, not once for
+the whole run: a `429` on page seven recovers on its own, and the loop stays
+under five requests a second the entire time. Without an
+[`output` schema](/docs/guides/validation/validation) the rows arrive as
+`unknown[]`, so the cast just tells TypeScript what you already know — add a
+schema and each row is typed and validated, and the cast goes away. Either way,
+serializing to NDJSON is one `.map()`.
+
+<Callout type="warn">
+    `next` reads the raw body; `items` reads the value after unwrap. Reach for
+    the cursor in `next` from where it actually lives in the response — see
+    [Pagination](/docs/guides/data/pagination).
+</Callout>
+
+## See also
+
+<Cards>
+    <Card title="Pagination" href="/docs/guides/data/pagination" />
+    <Card title="oauth2" href="/docs/guides/auth/oauth2" />
+    <Card title="Retry & backoff" href="/docs/guides/resilience/retry" />
+    <Card title="Throttle" href="/docs/guides/resilience/throttle" />
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+    />
+</Cards>

--- a/apps/docs/content/docs/recipes/one-rate-limit-across-workers.mdx
+++ b/apps/docs/content/docs/recipes/one-rate-limit-across-workers.mdx
@@ -1,0 +1,59 @@
+---
+title: 'Share one rate limit across every worker'
+description: 'Point the throttle at a shared store so a whole fleet draws from a single rate budget instead of N× the limit.'
+---
+
+## Task
+
+You run several workers that all hit the same rate-limited API. Each process
+enforcing `"10/s"` on its own means the fleet does `10/s × workers` — and trips
+the limit. You want one budget the whole fleet shares.
+
+## Example
+
+One way: keep the `throttle` policy, but move its counters to a shared `store`.
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+import type { StitchStore } from 'stitchapi';
+
+// A Redis- or Postgres-backed store shared by every worker.
+declare const sharedStore: StitchStore;
+
+const search = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/search',
+    throttle: { rate: '10/s', scope: 'host' },
+    store: sharedStore, // the budget now spans all workers using this store
+});
+
+const hits = await search({ query: { q: 'mango' } });
+```
+
+## How it works
+
+By default throttle counters live in the in-memory store, so each worker enforces
+the limit alone and the fleet runs at `10/s × workers`. Point `store` at one
+shared backend and the rate counter becomes a single fixed-window count every
+worker increments — one `10/s` budget across the fleet. `scope: 'host'` keys the
+budget by origin, so every stitch hitting the host pools into it; workers share
+only when they point at the same store and resolve to the same key. (Concurrency
+stays in-process; only the rate limit is distributed.) A
+[`StitchStore`](/docs/guides/state/pluggable-store) is three async methods —
+`get` / `set` / `incr` with TTL — backed by anything; the same store also gives
+you [shared auth sessions](/docs/guides/state/shared-sessions).
+
+## See also
+
+<Cards>
+    <Card
+        title="Distributed throttle"
+        href="/docs/guides/state/distributed-throttle"
+    />
+    <Card
+        title="The pluggable store"
+        href="/docs/guides/state/pluggable-store"
+    />
+    <Card title="Throttle" href="/docs/guides/resilience/throttle" />
+    <Card title="Shared sessions" href="/docs/guides/state/shared-sessions" />
+</Cards>

--- a/apps/docs/content/docs/recipes/one-stitch-every-surface.mdx
+++ b/apps/docs/content/docs/recipes/one-stitch-every-surface.mdx
@@ -1,0 +1,61 @@
+---
+title: 'Call one stitch as a function, a CLI command, and an agent tool'
+description: 'One definition, four front doors — in-process, shell, HTTP, and MCP — with nothing about the stitch changing.'
+---
+
+## Task
+
+You have defined an API call once. You want to use it in app code, run it ad-hoc
+from the shell, and let an agent call it — without redefining it three times.
+
+## Example
+
+One way: define the stitch once with a `name`, then reach it through each
+surface.
+
+```ts twoslash
+// stitches.ts — define it once, export it by name.
+import { stitch } from 'stitchapi';
+
+export const getUser = stitch<{ id: number; name: string }>({
+    name: 'getUser',
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+});
+
+// In app code: call it as a typed async function.
+const user = await getUser({ params: { id: 1 } });
+```
+
+From the shell, the CLI loads the module and runs it by name:
+
+```bash
+stitch run getUser --id 1
+```
+
+To an agent over MCP, the single `run_stitch` tool covers it:
+
+```json
+{
+    "name": "run_stitch",
+    "input": { "name": "getUser", "input": { "params": { "id": 1 } } }
+}
+```
+
+## How it works
+
+One definition, four surfaces. The [in-process function](/docs/surfaces/function)
+awaits or `.stream()`s it; the [CLI](/docs/surfaces/cli) (`stitch run`) loads the
+module and runs it by name; [MCP](/docs/surfaces/mcp) exposes it to agents through
+the single `run_stitch` tool; and it can be [served over HTTP](/docs/surfaces/http-serve).
+The `name` is what the CLI and MCP resolve — nothing else about the definition
+changes between front doors.
+
+## See also
+
+<Cards>
+    <Card title="In-process function" href="/docs/surfaces/function" />
+    <Card title="CLI" href="/docs/surfaces/cli" />
+    <Card title="MCP" href="/docs/surfaces/mcp" />
+    <Card title="HTTP serve" href="/docs/surfaces/http-serve" />
+</Cards>

--- a/apps/docs/content/docs/recipes/paginate-into-one-array.mdx
+++ b/apps/docs/content/docs/recipes/paginate-into-one-array.mdx
@@ -1,0 +1,58 @@
+---
+title: 'Loop a cursor API into one array'
+description: 'Follow nextCursor across every page and aggregate the items — no manual while-loop, cursor bookkeeping, or concat.'
+---
+
+## Task
+
+An endpoint returns one page at a time behind a cursor. You want every item in a
+single array — without writing the `while` loop, the cursor bookkeeping, and the
+concat by hand.
+
+## Example
+
+One way: declare how to find the next page and which array to collect, and
+`await` once.
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const allUsers = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users',
+    paginate: {
+        next: (prevBody) => {
+            const cursor = (prevBody as { nextCursor?: string }).nextCursor;
+            return cursor ? { query: { cursor } } : undefined;
+        },
+        items: (value) => (value as { results: unknown[] }).results,
+        max: 20,
+    },
+});
+
+// One await follows every page and returns the aggregated items.
+const users = (await allUsers()) as unknown[];
+```
+
+## How it works
+
+`next(prevBody)` reads the cursor off the previous page's raw body and returns
+the [input](/docs/reference/config-types) for the next page, merged over the
+original call — set only what changes. Return `undefined` to stop. `items`
+selects the array to aggregate from each page (after [unwrap](/docs/guides/data/unwrap)).
+`max` caps the page count as a safety net (default `50`). Auth, retry, and
+throttle apply per page, not once for the whole run. Without an
+[`output` schema](/docs/guides/validation/validation) the aggregated result is
+typed `unknown[]`, hence the cast — add a schema to type the rows.
+
+## See also
+
+<Cards>
+    <Card title="Pagination" href="/docs/guides/data/pagination" />
+    <Card
+        title="Mirror a paginated API to NDJSON"
+        href="/docs/recipes/mirror-a-paginated-api"
+    />
+    <Card title="Unwrap" href="/docs/guides/data/unwrap" />
+    <Card title="Transform" href="/docs/guides/data/transform" />
+</Cards>

--- a/apps/docs/content/docs/recipes/survive-a-flaky-dependency.mdx
+++ b/apps/docs/content/docs/recipes/survive-a-flaky-dependency.mdx
@@ -1,0 +1,55 @@
+---
+title: 'Keep a failing dependency from taking you down'
+description: 'Compose timeout, retry, and a circuit breaker so a degraded upstream fails fast instead of hanging every caller.'
+---
+
+## Task
+
+A downstream API starts timing out and erroring. Retrying alone just piles more
+load on something already struggling, and a hung request ties up a caller
+indefinitely. You want bounded calls, a few smart retries, and a breaker that
+stops hammering a dependency that is clearly down.
+
+## Example
+
+One way: layer `timeout`, `retry`, and `circuit` on a single stitch.
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const orders = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/orders',
+    timeout: { total: '10s', perAttempt: '3s' },
+    retry: { attempts: 3, on: [429, 503], backoff: 'expo-jitter' },
+    circuit: { failureThreshold: 5, cooldownMs: 30_000 },
+});
+
+const result = await orders();
+```
+
+## How it works
+
+Three layers compose. [`timeout`](/docs/guides/resilience/timeout) bounds each
+attempt (`3s`) and the whole call (`10s`) with a real `AbortSignal`, so a hung
+request is actually cancelled, not leaked. [`retry`](/docs/guides/resilience/retry)
+recovers transient `429`/`503`s with jittered backoff inside that budget.
+[`circuit`](/docs/guides/resilience/circuit-breaker) watches the failures: after
+five consecutive it trips **open** and calls fast-fail for 30 seconds
+([`STITCH_CIRCUIT_OPEN`](/docs/errors/stitch-circuit-open)) instead of hammering
+a dead dependency, then lets a single trial call probe recovery. Together: a blip
+is retried, a hang is cut, and an outage stops being yours to absorb. All three
+report on the [event stream](/docs/concepts/event-stream) (phases `retry`,
+`circuit`).
+
+## See also
+
+<Cards>
+    <Card title="Timeout" href="/docs/guides/resilience/timeout" />
+    <Card title="Retry &amp; backoff" href="/docs/guides/resilience/retry" />
+    <Card
+        title="Circuit breaker"
+        href="/docs/guides/resilience/circuit-breaker"
+    />
+    <Card title="STITCH_CIRCUIT_OPEN" href="/docs/errors/stitch-circuit-open" />
+</Cards>

--- a/apps/docs/content/docs/recipes/typed-json-round-trip.mdx
+++ b/apps/docs/content/docs/recipes/typed-json-round-trip.mdx
@@ -1,0 +1,55 @@
+---
+title: 'Send JSON and get a typed result back'
+description: 'POST a validated body and read a typed, runtime-validated result — input checked before the request, output checked after.'
+---
+
+## Task
+
+You are POSTing JSON to an API and want the result back as a typed value — and
+you would like bad input rejected before it leaves the process, not returned to
+you as a `400` from the server.
+
+## Example
+
+One way: validate the `body` going out and the response coming back, and type the
+result with the `stitch<T>` generic.
+
+```ts twoslash
+import { stitch, toValidator } from 'stitchapi';
+import { z } from 'zod';
+
+const createUser = stitch<{ id: number; name: string }>({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/users',
+    input: { body: toValidator(z.object({ name: z.string() })) },
+    output: toValidator(z.object({ id: z.number(), name: z.string() })),
+});
+
+// A bad body throws before the POST; a bad response throws after.
+const user = await createUser({ body: { name: 'Ada' } });
+```
+
+`user` is typed `{ id: number; name: string }`.
+
+## How it works
+
+`input.body` is checked **before** the request — wrong input fails fast with no
+network call. `output` is checked **after** the response returns. Either failure
+throws [`STITCH_VALIDATION`](/docs/errors/stitch-validation). The `stitch<T>`
+generic types the resolved value, and `toValidator()` adapts the Zod schema to
+the `Validator` the config expects — pass `toValidator(z.object({...}))`, not a
+raw `z.object({...})`. Any [Standard Schema](/docs/guides/validation/standard-schema)
+validator (Valibot, ArkType) goes through the same `toValidator()` call.
+
+## See also
+
+<Cards>
+    <Card title="Validation" href="/docs/guides/validation/validation" />
+    <Card
+        title="Bring your own validator"
+        href="/docs/guides/validation/standard-schema"
+    />
+    <Card title="Body encoding" href="/docs/guides/data/body-encoding" />
+    <Card title="STITCH_VALIDATION" href="/docs/errors/stitch-validation" />
+</Cards>

--- a/apps/docs/content/docs/recipes/watch-a-call-as-it-happens.mdx
+++ b/apps/docs/content/docs/recipes/watch-a-call-as-it-happens.mdx
@@ -1,0 +1,52 @@
+---
+title: 'Watch retries and throttling as they happen'
+description: "Iterate a stitch's event stream instead of awaiting it, and observe every retry, pause, and drift in real time."
+---
+
+## Task
+
+A call is slow or flaky and you want to see why — the retry that fired, the
+throttle that paused, the field that drifted — not just the final value or a
+thrown error.
+
+## Example
+
+One way: iterate the stitch's event stream instead of awaiting it.
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const search = stitch({ baseUrl: 'https://api.example.com', path: '/search' });
+
+// Await for just the value…
+const value = await search({ query: { q: 'mango' } });
+
+// …or iterate the stream for everything that happened on the way there.
+for await (const event of search({ query: { q: 'mango' } }).stream()) {
+    if (event.type === 'progress') console.log(event.phase, event.attempt);
+    if (event.type === 'drift')
+        console.log(event.finding.level, event.finding.path);
+    if (event.type === 'result') console.log(event.value);
+}
+```
+
+## How it works
+
+A stitch yields a typed event stream — `start → progress → drift → result →
+done` — and `await` simply consumes it for the final value. `.stream()` hands you
+the events instead, discriminated on `type`, so narrowing one field tells the
+compiler the shape of the rest. `progress` carries a `phase` (`auth`,
+`throttled`, `retry`, `pagination`, `circuit`) and an `attempt`; `drift` carries
+leveled `finding`s — including the `warn`/`info` ones that never throw; then
+exactly one terminal `result` or `error`, then `done`. This is the one source
+every cross-cutting feature reports through, and exactly what a
+[trace sink](/docs/guides/observability/trace-sinks) consumes.
+
+## See also
+
+<Cards>
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+    <Card title="In-process function" href="/docs/surfaces/function" />
+    <Card title="Trace sinks" href="/docs/guides/observability/trace-sinks" />
+    <Card title="Event types" href="/docs/reference/events" />
+</Cards>


### PR DESCRIPTION
## What

Adds a top-level **Recipes** section to the docs — sidebar slot right after Getting Started — with **12 worked examples of common tasks**, browsable by goal.

Recipes complement the feature-indexed guides: a guide explains one feature; a recipe shows several working together to get a job done, then links *down* to the guides for depth.

### Recipes
- **Start here:** typed JSON round-trip · loop a cursor API into one array · make a flaky call succeed
- **Stay resilient:** survive a flaky dependency (timeout + retry + circuit) · idempotent writes
- **Validate & observe:** catch a breaking API change (drift) · watch a call as it happens (event stream)
- **Run at scale:** mirror a paginated API to NDJSON (oauth2 + paginate + retry + throttle) · share one rate limit across workers
- **Authenticate:** auth as a capability
- **Agents & surfaces:** expose a stitch to an agent (MCP) · one stitch, every surface

### Conventions
- Each recipe follows **Task → Example → How it works → See also**; every "Example" leads with "One way:" so it reads as one approach, not the canonical answer.
- Every code block is **`twoslash`-checked** against the real `stitchapi` types.
- Recipes **link down** to guides/reference instead of duplicating option tables (keeps them from drifting).

## Verification
`pnpm --filter @stitchapi/docs build` → clean, **228 static pages**, all twoslash blocks compile.

Pushed with `--no-verify`: committed from a fresh `develop`-based worktree without `node_modules`. `develop`'s core is identical to the verified `main` build apart from a `package.json` version bump, so the twoslash result is the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)