### PR TITLE
docs: inline anti-patterns at the point of temptation (AUTHORING rule 10)

### DIFF
--- a/apps/docs/AUTHORING.md
+++ b/apps/docs/AUTHORING.md
@@ -97,8 +97,10 @@ content predicate (for soft 200 walls). See
 [Reference → Auth strategies](/docs/reference/auth-strategies) for every field.
 
 <Callout type="warn">
-    One-line micro-gotchas go inline like this. Anything systemic gets a catalog
-    page instead — link it under See also.
+    **Anti-pattern:** don't reach for X here — do Y instead. Tempting-but-wrong
+    uses and one-line micro-gotchas go inline like this, at the point of
+    temptation (rule 10). Anything systemic gets a catalog page instead — link it
+    under See also.
 </Callout>
 
 ## See also {/* (required) */}
@@ -241,6 +243,14 @@ description: Authentication failed, or a soft 200 login wall was hit and could n
    its result is consumed — show the forms as tabs and let the reader's pick
    persist. Never write "you can also…" and never pick one form for the reader
    while hiding the rest. See [Code variants — tabs](#code-variants--tabs).
+10. **Anti-patterns go inline, at the point of temptation.** Where a feature has
+    a tempting-but-wrong use — the shortcut a reader reaches for right before it
+    bites them — flag it with a `<Callout type="warn">` in the section that
+    introduces that use, never in a separate "best/bad practices" page. Lead with
+    **Anti-pattern** and write it as _don't X — do Y instead_, so the fix travels
+    with the warning. Keep it to the one decision in front of the reader; a
+    systemic failure mode is a catalog page in Errors & pitfalls (link it under
+    `See also`), not a restated list elsewhere (rule 6).
 
 ---
 
@@ -412,3 +422,6 @@ Errors & pitfalls is keyed to a registry of stable codes (`STITCH_VALIDATION`,
 -   [ ] Neutral names only; `api.example.com` for hosts.
 -   [ ] Reads correctly in isolation (imagine it as a lone `llms.mdx`).
 -   [ ] `See also` links neighbors, the Reference entry, and any catalog pages.
+-   [ ] Any tempting-but-wrong use is flagged with an inline **Anti-pattern**
+        `<Callout type="warn">` at the point of temptation, not a separate
+        section (rule 10) — omit only when the page has no such pitfall.

--- a/apps/docs/content/docs/guides/auth/bearer.mdx
+++ b/apps/docs/content/docs/guides/auth/bearer.mdx
@@ -37,8 +37,12 @@ resolved at call time. See
 table.
 
 <Callout type="warn">
-    Passing a literal string bakes the secret into your source. Reach for a
-    resolver unless the token is a non-secret placeholder.
+    **Anti-pattern:** don't pass a literal token string — it bakes the secret
+    into your source and hands the credential straight to anyone who reads it.
+    Pass a resolver thunk instead, so the secret resolves at call time and the
+    stitch hands callers a capability, not the credential (a literal is fine
+    only for a non-secret placeholder). See [Capability, not
+    credential](/docs/concepts/capability-not-credential).
 </Callout>
 
 ## See also

--- a/apps/docs/content/docs/guides/auth/cookie-session.mdx
+++ b/apps/docs/content/docs/guides/auth/cookie-session.mdx
@@ -53,9 +53,11 @@ share one session. See
 [Reference → Auth strategies](/docs/reference/auth-strategies) for every field.
 
 <Callout type="warn">
-    A soft 200 wall — a login page returned with status `200` — slips past
-    `refreshOn`. Catch it with `refreshWhen`; see
-    [STITCH_AUTH_WALL](/docs/errors/stitch-auth-wall).
+    **Anti-pattern:** don't lean on `refreshOn` status codes alone to catch an
+    expired session — a soft 200 wall, where the login page comes back with
+    status `200`, slips straight past it and your stitch reads the login HTML as
+    data; add a `refreshWhen` content predicate so the session re-logs in on
+    that body too. See [STITCH_AUTH_WALL](/docs/errors/stitch-auth-wall).
 </Callout>
 
 ## See also

--- a/apps/docs/content/docs/guides/auth/oauth2.mdx
+++ b/apps/docs/content/docs/guides/auth/oauth2.mdx
@@ -46,6 +46,14 @@ all — across stitches and across workers, surviving restarts. See
 [Reference → Auth strategies](/docs/reference/auth-strategies) for every field.
 
 <Callout type="warn">
+    **Anti-pattern:** don't rely on the default token cache across multiple
+    workers — it lives in memory, process-local, so every worker fetches and
+    refreshes its own token and hammers the token endpoint; give the stitches a
+    shared `key` and a durable `store` so one token serves them all. See
+    [Pluggable store](/docs/guides/state/pluggable-store).
+</Callout>
+
+<Callout type="warn">
     The token lives only in the store and the outgoing `Authorization` header —
     the caller, an agent included, never receives it. That is the capability
     boundary; see [Capability, not

--- a/apps/docs/content/docs/guides/auth/secret-resolvers.mdx
+++ b/apps/docs/content/docs/guides/auth/secret-resolvers.mdx
@@ -61,9 +61,12 @@ the value), or any `() => string` thunk of your own, so plugging in a vault or
 secrets manager is just supplying a different resolver.
 
 <Callout type="warn">
-    A plain-string secret is read at declaration time and lives in your source
-    and history. Prefer `env()` or `secretsFile()` so the value is resolved at
-    call time instead.
+    **Anti-pattern:** don't pass a secret as a plain string — it is read at
+    declaration time and lives in your source and history, collapsing the
+    capability back into a committed credential; pass `env()` or `secretsFile()`
+    instead so the value resolves at call time and the stitch carries a
+    capability, not a credential. See [Capability, not
+    credential](/docs/concepts/capability-not-credential).
 </Callout>
 
 ## Deprecated: keychain()

--- a/apps/docs/content/docs/guides/authoring/with.mdx
+++ b/apps/docs/content/docs/guides/authoring/with.mdx
@@ -40,8 +40,11 @@ and [shared session](/docs/guides/state/shared-sessions) state persist across
 every call made through it.
 
 <Callout type="warn">
-    Because the runtime is shared, throttle and circuit state are shared too — a
-    bound stitch is not an isolated copy. See
+    **Anti-pattern:** don't reach for `.with()` to get an isolated copy with its
+    own throttle budget or circuit-breaker state — because the runtime is
+    shared, a bound stitch draws from the same buckets and the same breaker
+    counter as its parent. When you need separate state, declare a separate
+    stitch instead of binding one. See
     [throttle](/docs/guides/resilience/throttle).
 </Callout>
 

--- a/apps/docs/content/docs/guides/data/body-encoding.mdx
+++ b/apps/docs/content/docs/guides/data/body-encoding.mdx
@@ -41,6 +41,14 @@ The body itself always comes from the call input (`await submit({ body })`),
 never from the config — so one stitch encodes whatever you pass it. See
 [Guide → stitch()](/docs/guides/authoring/stitch) for the full configuration.
 
+<Callout type="warn">
+    **Anti-pattern:** don't hand-serialize the body before you pass it —
+    stringifying the value yourself and handing the stitch a pre-encoded string
+    double-encodes it, because `bodyType` already serializes the value into the
+    wire format you chose; pass the plain object and let the stitch encode it
+    once. See [stitch()](/docs/guides/authoring/stitch).
+</Callout>
+
 ## See also
 
 <Cards>

--- a/apps/docs/content/docs/guides/data/graphql.mdx
+++ b/apps/docs/content/docs/guides/data/graphql.mdx
@@ -36,6 +36,13 @@ contents of the response's `data` object; override `unwrap` if you need a
 different field or the raw envelope.
 
 <Callout type="warn">
+    **Anti-pattern:** don't interpolate argument values straight into the
+    `query` string and mint a fresh stitch for each set of arguments; pass them
+    through the input's `variables` field at call time so one declared stitch
+    serves every call. See [Reference → stitch](/docs/reference/stitch).
+</Callout>
+
+<Callout type="info">
     A GraphQL endpoint can return HTTP `200` while reporting an `errors` array
     in the body. The stitch treats that as a failure and surfaces it — see
     [STITCH_GRAPHQL](/docs/errors/stitch-graphql).

--- a/apps/docs/content/docs/guides/data/pagination.mdx
+++ b/apps/docs/content/docs/guides/data/pagination.mdx
@@ -50,9 +50,11 @@ Auth, retry, and throttle apply per page, not once for the whole run: a
 and a [`retry`](/docs/guides/resilience/retry) recovers each page on its own.
 
 <Callout type="warn">
-    `next` reads the raw body; `items` reads the value after `unwrap`. Reach for
-    the cursor in `next` from where it actually lives in the response, not from
-    the unwrapped array.
+    **Anti-pattern:** don't read the next-page cursor in `next` from the
+    unwrapped array, expecting it where `items` looks — `next` receives the raw
+    body and `items` receives the value after `unwrap` runs, so read the cursor
+    in `next` from where it lives in the raw response instead. See
+    [unwrap](/docs/guides/data/unwrap).
 </Callout>
 
 ## See also

--- a/apps/docs/content/docs/guides/data/transform.mdx
+++ b/apps/docs/content/docs/guides/data/transform.mdx
@@ -40,8 +40,12 @@ and return any reshaped value. See
 [Reference → Config types](/docs/reference/config-types) for every field.
 
 <Callout type="warn">
-    `transform` runs before validation, so its output is unchecked — a wrong
-    narrowing surfaces later as drift, not here.
+    **Anti-pattern:** don't reach for `transform` to pull the inner field out of
+    an envelope — a cast like reading `.results` off the body is an opaque
+    function whose output is unchecked, so a wrong narrowing slips past and only
+    surfaces later as drift. Name the path with `unwrap` instead, which is
+    declarative, round-trips as JSON, and feeds validation and drift directly.
+    See [unwrap](/docs/guides/data/unwrap).
 </Callout>
 
 ## See also

--- a/apps/docs/content/docs/guides/data/unwrap.mdx
+++ b/apps/docs/content/docs/guides/data/unwrap.mdx
@@ -40,6 +40,14 @@ returns `T` (the unwrapped value), not the envelope. See
 [Reference → Config types](/docs/reference/config-types) for the full config
 shape.
 
+<Callout type="warn">
+    **Anti-pattern:** don't reach for the dot-path to reshape, rename, or merge
+    fields — `unwrap` only _selects_ one already-nested slice, so anything
+    beyond picking an existing branch belongs in a reshape step that runs first.
+    Do the restructuring in `transform` instead, then point `unwrap` at the
+    slice it produces. See [transform](/docs/guides/data/transform).
+</Callout>
+
 ## See also
 
 <Cards>

--- a/apps/docs/content/docs/guides/observability/otlp.mdx
+++ b/apps/docs/content/docs/guides/observability/otlp.mdx
@@ -57,6 +57,17 @@ built from.
     batch and never breaks a stitch call.
 </Callout>
 
+<Callout type="warn">
+    **Anti-pattern:** don't assume OTLP export inherits the built-in sink's
+    `[REDACTED]` header scrubbing and flip it on for a stitch that carries its
+    secret in the URL query string — each span sets `url.full` to the full
+    resolved URL verbatim, so a token in the query ships to your collector in
+    the clear (the denylist only ever masks header values, and the span never
+    goes through it). Resolve the secret as a header-borne capability instead,
+    so it stays out of the URL the span exports. See [Capability, not
+    credential](/docs/concepts/capability-not-credential).
+</Callout>
+
 ## See also
 
 <Cards>

--- a/apps/docs/content/docs/guides/observability/trace-sinks.mdx
+++ b/apps/docs/content/docs/guides/observability/trace-sinks.mdx
@@ -139,6 +139,17 @@ one source without the call site knowing. See
 and [Reference → Event types](/docs/reference/events) for the `StitchEvent`
 union a sink receives.
 
+<Callout type="warn">
+    **Anti-pattern:** don't assume a custom `TraceSink` inherits the built-in
+    `[REDACTED]` scrubbing and write the raw event payload straight to your
+    destination — its headers still carry the live secret (`authorization`,
+    `cookie`, `x-api-key`), so a `handle` that logs them verbatim leaks a
+    credential the call resolves but the caller never sees; scrub the same
+    header denylist inside your `handle` before you persist, or wrap the
+    built-in sink via `multiplex` so redaction runs first. See [Capability, not
+    credential](/docs/concepts/capability-not-credential).
+</Callout>
+
 <Callout type="info">
     The CLI honors the same default: `stitch run` traces nothing until you pass
     `--trace`, which records the JSONL file (at `~/.stitch/runs/proto.jsonl`, or

--- a/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
+++ b/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
@@ -45,6 +45,16 @@ host opens the circuit for every stitch that talks to it. The default key is the
 stitch/host key.
 
 <Callout type="warn">
+    **Anti-pattern:** don't lean on the default in-memory breaker across
+    multiple workers or instances — the counter is process-local, so each
+    replica tallies its own failures and `failureThreshold` trips per process,
+    letting a failing host take many times the hits you intended before every
+    circuit opens. Give the stitches a shared `key` plus a durable `store` so
+    one breaker spans the fleet. See [Pluggable
+    store](/docs/guides/state/pluggable-store).
+</Callout>
+
+<Callout type="warn">
     While the breaker is open, a call fast-fails instead of reaching the
     dependency — see [STITCH_CIRCUIT_OPEN](/docs/errors/stitch-circuit-open) for
     what callers see and how to handle it.

--- a/apps/docs/content/docs/guides/resilience/idempotency.mdx
+++ b/apps/docs/content/docs/guides/resilience/idempotency.mdx
@@ -36,6 +36,15 @@ const createOrder = stitch({
 A single `charge()` call generates one key and reuses it across every retry of
 that call, so a network blip that triggers a retry settles a single charge.
 
+<Callout type="warn">
+    **Anti-pattern:** don't lean on the default random key to dedupe two
+    separate submissions — a double-clicked "Pay" fires two distinct `charge()`
+    calls, each with a fresh key, so the server sees two writes and charges
+    twice; derive a stable `key` from something the duplicate submissions share
+    (an order reference, a request id) so both map to one key. See [Reference →
+    Config types](/docs/reference/config-types).
+</Callout>
+
 ## Options
 
 `header` is the header name the key rides on, default `'Idempotency-Key'`. Set

--- a/apps/docs/content/docs/guides/resilience/retry.mdx
+++ b/apps/docs/content/docs/guides/resilience/retry.mdx
@@ -49,6 +49,14 @@ Each retry surfaces as a `progress` event (phase `retry`) on the
 re-attempt. For the exhaustive field list and defaults, see
 [Reference → Config types](/docs/reference/config-types).
 
+<Callout type="warn">
+    **Anti-pattern:** don't add `retry` to a stitch that performs a
+    non-idempotent write — a POST that creates an order, for instance — because
+    a re-attempt after a timeout or `503` can silently apply the side effect
+    twice; pair retries with an idempotency key so the server collapses the
+    duplicate instead. See [Idempotency](/docs/guides/resilience/idempotency).
+</Callout>
+
 ## See also
 
 <Cards>

--- a/apps/docs/content/docs/guides/resilience/throttle.mdx
+++ b/apps/docs/content/docs/guides/resilience/throttle.mdx
@@ -40,6 +40,15 @@ Giving those stitches a shared
 into a [distributed one](/docs/guides/state/distributed-throttle) that spans
 workers.
 
+<Callout type="warn">
+    **Anti-pattern:** don't rely on a host-scoped throttle to honor an
+    account-wide limit once you run more than one process — the budget lives in
+    memory and is process-local, so each of N workers keeps its own count and
+    together they hit `api.example.com` at up to N times the rate you declared;
+    pass a shared store so every worker draws from one budget instead. See
+    [Distributed throttle](/docs/guides/state/distributed-throttle).
+</Callout>
+
 <Callout type="info">
     A throttled wait surfaces as a `throttled` progress phase on the event
     stream — see [The event stream](/docs/concepts/event-stream).

--- a/apps/docs/content/docs/guides/resilience/timeout.mdx
+++ b/apps/docs/content/docs/guides/resilience/timeout.mdx
@@ -39,10 +39,16 @@ backoff waits, so a long enough `total` is what lets a slow attempt be retried a
 all.
 
 <Callout type="warn">
-    A breached deadline aborts the call and surfaces as a timeout error. See
-    [STITCH_TIMEOUT](/docs/errors/stitch-timeout) for how it reads and how to
-    fix it.
+    **Anti-pattern:** with retry enabled, don't rely on `perAttempt` alone to
+    bound how long the caller waits; it caps each individual try, not the call,
+    so several retries plus their backoff waits can block the caller far past
+    your intended deadline — set `total` to cap the whole call instead. See
+    [Retry](/docs/guides/resilience/retry).
 </Callout>
+
+A breached deadline aborts the call and surfaces as a timeout error. See
+[STITCH_TIMEOUT](/docs/errors/stitch-timeout) for how it reads and how to fix
+it.
 
 See [Reference → Config types](/docs/reference/config-types) for the full
 `TimeoutOptions` shape.

--- a/apps/docs/content/docs/guides/state/shared-sessions.mdx
+++ b/apps/docs/content/docs/guides/state/shared-sessions.mdx
@@ -57,6 +57,14 @@ what makes one login persist across restarts and serve every worker — see
 [`.with()`](/docs/guides/authoring/with) already reuses the same in-memory
 session across calls.
 
+<Callout type="warn">
+    **Anti-pattern:** don't rely on the default in-memory store to share a
+    session across workers — it's process-local, so every worker re-runs the
+    login and keeps its own isolated session; point `store` at a shared, durable
+    store so one captured login serves all of them. See [The pluggable
+    store](/docs/guides/state/pluggable-store).
+</Callout>
+
 This works the same for tokens:
 [`oauth2`](/docs/guides/auth/oauth2) caches its access token under `key`, so a
 shared key plus a shared store means one token serves many stitches and workers

--- a/apps/docs/content/docs/guides/validation/drift.mdx
+++ b/apps/docs/content/docs/guides/validation/drift.mdx
@@ -54,6 +54,15 @@ contract change across calls and lets you triage it by severity.
 See [Reference → Config types](/docs/reference/config-types) for the full
 `DriftOptions` and `DriftFinding` tables.
 
+<Callout type="warn">
+    **Anti-pattern:** don't list every path under `critical` so any change
+    breaks the call — that collapses drift back into hard validation and throws
+    away the early warning. Reserve `critical` for the few paths that must not
+    move, leave the rest to `watch` and `info`, and read those findings off the
+    event stream so you can watch a field erode before it breaks. See [the event
+    stream](/docs/concepts/event-stream).
+</Callout>
+
 ## See also
 
 <Cards>

--- a/apps/docs/content/docs/guides/validation/validation.mdx
+++ b/apps/docs/content/docs/guides/validation/validation.mdx
@@ -39,6 +39,14 @@ the API would reject.
 (Pass a `drift()` spec here instead to report changes without throwing — see
 [Schema drift detection](/docs/guides/validation/drift).)
 
+<Callout type="warn">
+    **Anti-pattern:** don't reach for a strict `output` validator to catch
+    upstream API changes — an additive, non-breaking change to the response then
+    throws `STITCH_VALIDATION` and breaks the call. Pass a `drift()` spec to
+    `output` instead, so changes are reported without failing the request. See
+    [Schema drift detection](/docs/guides/validation/drift).
+</Callout>
+
 The config fields are typed as `Validator`, and a raw Zod, Valibot, or ArkType
 schema is not structurally a `Validator`. Adapt it with `toValidator()`, which
 coerces a Zod schema, any Standard Schema, or a predicate into a `Validator` —

--- a/apps/docs/content/docs/surfaces/cli.mdx
+++ b/apps/docs/content/docs/surfaces/cli.mdx
@@ -58,6 +58,17 @@ percentiles). `--file` picks the log (default `~/.stitch/runs/proto.jsonl`),
 `--name` filters to one stitch, and `--json` emits the raw summary instead of
 the aligned table.
 
+<Callout type="warn">
+    **Anti-pattern:** don't lean on `stitch trace` and the default
+    `~/.stitch/runs/proto.jsonl` log as your production observability — that
+    file is process-local (the `proto` name is a clue: it's a prototyping
+    convenience), so its percentiles and ok/failed counts only ever cover the
+    runs from this one shell and never roll up across machines, CI jobs, or
+    workers. For durable, shared telemetry, fan the same event stream into the
+    observability stack you already run with OTLP export instead. See [OTLP
+    export](/docs/guides/observability/otlp).
+</Callout>
+
 The CLI runs the very same stitch definition as the in-process
 [function](/docs/surfaces/function) — one source of truth, just a different
 front door. Like the library, the CLI traces nothing by default; pass `--trace`

--- a/apps/docs/content/docs/surfaces/http-serve.mdx
+++ b/apps/docs/content/docs/surfaces/http-serve.mdx
@@ -40,10 +40,14 @@ validated result as JSON; send `Accept: text/event-stream` (or add `?stream=1`)
 to receive the live event stream as SSE instead.
 
 <Callout type="warn">
-    Serving a stitch over HTTP changes nothing about the capability boundary —
-    auth, validation, and resilience still run server-side, exactly as they do
-    in-process. The HTTP route exposes the same stitch definition, not a looser
-    one.
+    **Anti-pattern:** don't move the bind off the `127.0.0.1` loopback default
+    to a public interface so a remote caller can reach it directly — the front
+    door has no auth of its own, so a public bind turns the registry into an
+    open proxy that runs every stitch for anyone who can reach the port. Keep it
+    on loopback and put a fronting layer (a reverse proxy or gateway that
+    authenticates the caller) in front of it; the stitch still holds its own
+    credential and resolves it server-side, never handing it to the caller. See
+    [Capability, not credential](/docs/concepts/capability-not-credential).
 </Callout>
 
 ## Programmatic API

--- a/apps/docs/content/docs/surfaces/mcp.mdx
+++ b/apps/docs/content/docs/surfaces/mcp.mdx
@@ -48,6 +48,16 @@ the agent spends its context on the task, not on a tool catalog. The full design
 of the tool lives in the agents section; see
 [run_stitch & code mode](/docs/agents/run-stitch-tool).
 
+<Callout type="warn">
+    **Anti-pattern:** don't register one MCP tool per stitch or path — say, a
+    separate tool for each route under `api.example.com` — to make the agent's
+    calls "more explicit"; that re-sends every tool's name, description, and
+    input schema on each turn and floods the model's context. Expose the single
+    code-mode `run_stitch` tool (with `list_stitches` for discovery) and let the
+    agent select the stitch by name instead. See [run_stitch & code
+    mode](/docs/agents/run-stitch-tool).
+</Callout>
+
 ## Programmatic API
 
 The CLI is a thin wrapper. To run the MCP server in your own process, import
@@ -74,10 +84,9 @@ The capability boundary holds here: the agent calls `run_stitch` by name and
 never sees the token, cookie, or signing key the stitch holds — it invokes a
 capability, not a credential.
 
-<Callout type="warn">
-    `stitch mcp` writes JSON-RPC to stdout and its startup notice to stderr —
-    keep stdout clean and don't pipe anything else through it.
-</Callout>
+The transport writes JSON-RPC to stdout and its startup notice to stderr, so
+keep stdout clean — don't log to it or pipe anything else through it, or the
+framing breaks.
 
 ## See also
 


### PR DESCRIPTION
## Why

We considered a standalone **Best practices / Bad practices** section and decided against it: a separate section restates facts that already live in Guides, Concepts, and Recipes, and then rots — which directly fights the **one-source-of-truth** principle the product sells. Instead, anti-patterns belong **inline, at the point of temptation**, where the reader is actually deciding, with the fix riding along.

## What

**`apps/docs/AUTHORING.md`**
- **Rule 10** — anti-patterns go inline as an `**Anti-pattern:**` `<Callout type="warn">`, phrased *don't X — do Y instead* with the fix linked; systemic failures still go to **Errors & pitfalls**, not a restated list (defers to rule 6).
- **Definition-of-Done** — a conditional per-page item (omit when the page has no such pitfall, so it never forces an invented one).
- Updated the guide template's example callout to demonstrate the shape.

**23 guide/surface pages** — one anti-pattern per *genuine* point of temptation:

| Area | Anti-pattern |
|---|---|
| resilience | `retry` on a non-idempotent write · `perAttempt` vs `total` · process-local throttle & breaker across workers · random idempotency key vs a double-click |
| data | double-encoding the body · interpolating GraphQL args vs `variables` · cursor from raw vs unwrapped body · `transform` ↔ `unwrap` (each pointing at the other) |
| validation | strict `output` vs `drift()` · marking every path `critical` |
| auth/state | literal bearer token · soft-200 wall → `refreshWhen` · token cache across workers · plain-string secret · in-memory session across workers |
| observability | redaction is **not** auto-applied to a custom sink / OTLP export |
| surfaces | `proto.jsonl` isn't prod telemetry · public HTTP bind = open proxy · one MCP tool per stitch floods context |

## Deliberately *not* repeated

A first pass copy-pasted the **"don't hardcode a secret"** message onto 8 pages — the exact "restated list elsewhere" rule 10 warns against. Thinned to its canonical homes (`secret-resolvers`, `bearer`, and the *capability-not-credential* concept). On `api-key` I restored the original, more page-specific gotcha (`apiKey` sets a header, not a query param) that the pass had overwritten.

## Verification

`pnpm --filter docs build` — **225/225 pages generated, twoslash clean**. Pre-push gate (typecheck + test + build-docs) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)