### PR TITLE
docs: highlight non-JSON fetch + transform (HTML→Markdown, scrape)

### DIFF
--- a/apps/docs/app/(home)/components/features.tsx
+++ b/apps/docs/app/(home)/components/features.tsx
@@ -2,6 +2,7 @@ import { Section, SectionHeading } from './primitives';
 
 import {
     Activity,
+    FileText,
     GitCompareArrows,
     KeyRound,
     Radio,
@@ -52,6 +53,11 @@ const features = [
         title: 'Observable by default',
         body: 'gen_ai.* and mcp.* spans carry tokens, cost, and latency, turning the agent-native layer into your integration-health layer.',
     },
+    {
+        icon: FileText,
+        title: 'More than JSON',
+        body: 'responseType reads HTML, text, or binary; a transform reshapes whatever comes back — scrape a page to typed data or pipe it through your own Markdown converter — before validation and drift see it. The runtime stays converter-agnostic, so you pay no bytes for a format you don’t use.',
+    },
 ];
 
 export function Features() {
@@ -67,10 +73,15 @@ export function Features() {
             />
 
             <div className="mt-12 grid gap-px overflow-hidden rounded-2xl border border-fd-border bg-fd-border sm:grid-cols-2 lg:grid-cols-2">
-                {features.map(({ icon: Icon, title, body }) => (
+                {features.map(({ icon: Icon, title, body }, index) => (
                     <div
                         key={title}
-                        className="flex flex-col gap-3 bg-fd-card p-6"
+                        className={`flex flex-col gap-3 bg-fd-card p-6${
+                            features.length % 2 === 1 &&
+                            index === features.length - 1
+                                ? ' sm:col-span-2'
+                                : ''
+                        }`}
                     >
                         <span className="inline-flex size-10 items-center justify-center rounded-xl bg-stitch-soft text-stitch">
                             <Icon className="size-5" />

--- a/apps/docs/content/docs/getting-started/index.mdx
+++ b/apps/docs/content/docs/getting-started/index.mdx
@@ -24,6 +24,11 @@ that wrapper with a declaration:
 -   **No spec, no codegen, no server.** A stitch needs a URL and an example
     response — so it works on the long tail of internal and undocumented APIs
     that never get a complete OpenAPI document.
+-   **Not just JSON.** `responseType` reads HTML, text, or binary, and a
+    `transform` reshapes whatever comes back — scrape a page into typed data or
+    run it through your own Markdown converter — before validation and drift see
+    it. The runtime stays converter-agnostic, so you pay no bytes for a format
+    you don't use.
 -   **Auth is a boundary.** Bearer, API key, cookie sessions, OAuth2 client
     credentials — the stitch owns the secret and its lifecycle, and the caller
     receives data, never the credential.

--- a/apps/docs/content/docs/guides/data/meta.json
+++ b/apps/docs/content/docs/guides/data/meta.json
@@ -1,4 +1,11 @@
 {
     "title": "Data shaping",
-    "pages": ["unwrap", "transform", "pagination", "body-encoding", "graphql"]
+    "pages": [
+        "unwrap",
+        "transform",
+        "response-type",
+        "pagination",
+        "body-encoding",
+        "graphql"
+    ]
 }

--- a/apps/docs/content/docs/guides/data/response-type.mdx
+++ b/apps/docs/content/docs/guides/data/response-type.mdx
@@ -1,0 +1,58 @@
+---
+title: 'responseType'
+description: 'Choose how a response body is read — JSON, text/HTML, or binary — when content-type auto-detection is not what you want.'
+---
+
+By default a stitch reads the body by its content-type: JSON when the
+content-type is json-ish, otherwise the raw text. `responseType` overrides that
+when you need a specific shape — pull an HTML page as text, force JSON on a
+server that mislabels it, or download raw bytes.
+
+## Example
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+// Force the body to be read as text — e.g. an HTML page to scrape or convert.
+const page = stitch({
+    baseUrl: 'https://example.com',
+    path: '/articles/{slug}',
+    responseType: 'text',
+});
+
+const html = await page({ params: { slug: 'hello' } });
+```
+
+## Options
+
+`responseType?: 'json' | 'text' | 'arrayBuffer' | 'blob'`. Unset (the default)
+auto-detects: JSON when the content-type contains `application/json` or `+json`,
+otherwise the raw decoded text.
+
+-   **`'json'`** — parse as JSON regardless of content-type, for a server that
+    mislabels the body. An empty body becomes `undefined`.
+-   **`'text'`** — return the raw decoded string: HTML to scrape or convert, CSV,
+    plain text. Pair it with [`transform`](/docs/guides/data/transform) to
+    reshape the string before validation runs.
+-   **`'arrayBuffer'`** — the raw bytes as an `ArrayBuffer`, for binary downloads.
+-   **`'blob'`** — a `Blob` carrying the content-type, for binary you hand to a
+    file API.
+
+<Callout type="info">
+    `responseType` only decides how the bytes are read. Reshaping the value —
+    scraping HTML, converting to Markdown, flattening an envelope — is the job
+    of [`transform`](/docs/guides/data/transform), which runs next in the
+    pipeline.
+</Callout>
+
+## See also
+
+<Cards>
+    <Card title="transform" href="/docs/guides/data/transform" />
+    <Card title="unwrap" href="/docs/guides/data/unwrap" />
+    <Card
+        title="Turn an HTML page into Markdown"
+        href="/docs/recipes/read-html-as-markdown"
+    />
+    <Card title="Reference: Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/recipes/index.mdx
+++ b/apps/docs/content/docs/recipes/index.mdx
@@ -31,6 +31,21 @@ a guide when you want to understand a feature on its own.
     />
 </Cards>
 
+## Reshape any response
+
+<Cards>
+    <Card
+        title="Turn an HTML page into Markdown"
+        href="/docs/recipes/read-html-as-markdown"
+        description="Read a page as HTML with responseType, then run it through your own Markdown converter in a transform — validation still applies."
+    />
+    <Card
+        title="Scrape an HTML page into typed data"
+        href="/docs/recipes/scrape-html-into-typed-data"
+        description="Reshape scraped HTML into a typed array and wrap it in drift, so a markup rename becomes a loud error, not silent data loss."
+    />
+</Cards>
+
 ## Stay resilient
 
 <Cards>

--- a/apps/docs/content/docs/recipes/meta.json
+++ b/apps/docs/content/docs/recipes/meta.json
@@ -5,6 +5,8 @@
         "typed-json-round-trip",
         "paginate-into-one-array",
         "make-a-flaky-call-succeed",
+        "read-html-as-markdown",
+        "scrape-html-into-typed-data",
         "survive-a-flaky-dependency",
         "idempotent-writes",
         "catch-a-breaking-api-change",

--- a/apps/docs/content/docs/recipes/read-html-as-markdown.mdx
+++ b/apps/docs/content/docs/recipes/read-html-as-markdown.mdx
@@ -1,0 +1,63 @@
+---
+title: 'Turn an HTML page into Markdown'
+description: 'Pull a page as HTML with responseType, then reshape it with your own Markdown converter in a transform — keeping validation on the result.'
+---
+
+## Task
+
+You want a page's content as Markdown — to index it, feed it to a model, or
+store it — not the raw HTML and not JSON. The endpoint returns `text/html`, so a
+client that only speaks JSON hands you nothing useful.
+
+## Example
+
+One way: read the body as text with `responseType`, convert it in a `transform`,
+and validate the result. Stitch is converter-agnostic — bring the HTML→Markdown
+library you already trust (`turndown`, `node-html-markdown`, …); it never ships
+in the runtime, so you pay no bytes for a converter you didn't choose.
+
+```ts twoslash
+import { stitch, toValidator } from 'stitchapi';
+import { z } from 'zod';
+
+// Your converter of choice, brought as a dependency. Stitch stays out of it.
+declare function htmlToMarkdown(html: string): string;
+
+const readArticle = stitch<string>({
+    baseUrl: 'https://example.com',
+    path: '/articles/{slug}',
+    responseType: 'text', // read the body as HTML, not JSON
+    transform: (body) => htmlToMarkdown(String(body)),
+    // The converter must return non-empty Markdown — validate that.
+    output: toValidator(z.string().min(1)),
+});
+
+const markdown = await readArticle({ params: { slug: 'hello-world' } });
+```
+
+## How it works
+
+[`responseType: 'text'`](/docs/guides/data/response-type) reads the response as a
+raw string instead of parsing JSON.
+[`transform`](/docs/guides/data/transform) then runs first in the response
+pipeline, handing the HTML string to your converter and returning Markdown.
+`toValidator` adapts the Zod schema to the `Validator` the config expects (the
+same step the [typed JSON round-trip](/docs/recipes/typed-json-round-trip) uses),
+and `output` then validates the result — here, that the converter produced a
+non-empty string. A converter that silently returns `''` on markup it didn't
+expect [fails loudly](/docs/errors/stitch-validation) instead of writing blanks
+downstream. Swap `z.string()` for a richer shape (a front-matter object,
+sections) and the same validation and [drift](/docs/guides/validation/drift)
+guarantees apply to a non-JSON source.
+
+## See also
+
+<Cards>
+    <Card title="responseType" href="/docs/guides/data/response-type" />
+    <Card title="transform" href="/docs/guides/data/transform" />
+    <Card
+        title="Scrape an HTML page into typed data"
+        href="/docs/recipes/scrape-html-into-typed-data"
+    />
+    <Card title="Validation" href="/docs/guides/validation/validation" />
+</Cards>

--- a/apps/docs/content/docs/recipes/scrape-html-into-typed-data.mdx
+++ b/apps/docs/content/docs/recipes/scrape-html-into-typed-data.mdx
@@ -1,0 +1,78 @@
+---
+title: 'Scrape an HTML page into typed data'
+description: 'Read a page as HTML, reshape it into a typed array with a transform, and wrap the output in drift so a markup change becomes a loud error instead of silent data loss.'
+---
+
+## Task
+
+The data you need is on an HTML page, not behind a JSON API. You can scrape it,
+but a scraper is brittle: when the site renames a class or moves a column, your
+selectors quietly return `undefined` and the bad data flows downstream
+unnoticed.
+
+## Example
+
+One way: read the body as text, scrape it in a `transform`, and wrap the
+`output` with `drift` against a committed baseline.
+
+```ts twoslash
+import { drift, stitch } from 'stitchapi';
+import { z } from 'zod';
+
+// Your scraper: HTML in, plain rows out. Use any parser; this one is regex.
+function scrapeRows(html: string): {
+    items: { title: string; score: number }[];
+} {
+    const rows = html.split(/<tr[^>]*>/i).slice(1);
+    const items = rows.flatMap((row) => {
+        const title = /<td class="title">([^<]+)<\/td>/i.exec(row)?.[1];
+        const score = /<td class="score">(\d+)<\/td>/i.exec(row)?.[1];
+        return title ? [{ title, score: Number(score) }] : [];
+    });
+    return { items };
+}
+
+const search = stitch<{ title: string; score: number }[]>({
+    baseUrl: 'https://example.com',
+    path: '/search',
+    responseType: 'text', // read the page as HTML
+    transform: (body) => scrapeRows(String(body)),
+    unwrap: 'items',
+    output: drift(z.array(z.object({ title: z.string(), score: z.number() })), {
+        critical: ['[].score'], // a dropped score must be loud, not silent
+        snapshotFile: 'search.contract.json',
+    }),
+});
+
+const items = await search({ query: { q: 'stitch' } });
+```
+
+## How it works
+
+[`responseType: 'text'`](/docs/guides/data/response-type) hands the raw HTML to
+[`transform`](/docs/guides/data/transform), which scrapes it into
+`{ items: [...] }`. [`unwrap`](/docs/guides/data/unwrap) selects the array, and
+[`drift`](/docs/guides/validation/drift) compares it against
+`search.contract.json` (check that file into the repo). The first call records
+the baseline; later calls flag changes by severity. Because `[].score` is
+`critical`, the day the site renames `class="score"` and the selector starts
+missing, the dropped field changes at level `error` and throws
+[`STITCH_DRIFT`](/docs/errors/stitch-drift) — the silent-scraper failure becomes
+a loud one. It is the same drift safety net from
+[Catch a breaking API change](/docs/recipes/catch-a-breaking-api-change), now
+guarding a scraped source instead of a JSON one.
+
+## See also
+
+<Cards>
+    <Card title="responseType" href="/docs/guides/data/response-type" />
+    <Card title="transform" href="/docs/guides/data/transform" />
+    <Card
+        title="Turn an HTML page into Markdown"
+        href="/docs/recipes/read-html-as-markdown"
+    />
+    <Card
+        title="Catch a breaking API change"
+        href="/docs/recipes/catch-a-breaking-api-change"
+    />
+</Cards>


### PR DESCRIPTION
## What

StitchAPI isn't JSON-only — but nothing in the docs said so. This surfaces the **fetch any format → reshape with `transform` → still validated + drift-checked** story across six places:

- **New guide** `guides/data/response-type` — documents the previously-undocumented `responseType` option (`json | text | arrayBuffer | blob`).
- **New recipe** `recipes/read-html-as-markdown` — pull a page as HTML (`responseType: 'text'`) and convert it with your own Markdown library inside a `transform`.
- **New recipe** `recipes/scrape-html-into-typed-data` — scrape HTML into a typed array, wrapped in `drift` so a markup rename becomes a loud error instead of silent data loss.
- **Recipes index** — new "Reshape any response" section (+ `meta.json`).
- **Getting started** — a "Not just JSON" bullet in *The pain it removes*.
- **Landing page** — a "More than JSON" card in the features grid.

## Why

A reader assumed HTML→Markdown was a built-in feature. It isn't — and shouldn't be: bundling turndown/cheerio would break the bundle-frugal / zero-dep / contract-not-dependency gates. The honest, distinctive framing is **bring-your-own converter via `transform`**, exactly like the axios BYO-adapter — with the `output` schema + drift still guarding the result.

## Reviewer notes

- All `twoslash` blocks type-check against the published core types. `output` uses `toValidator(z.…)` (a raw Zod schema is rejected by the `Validator` type; `drift(z.…)` accepts raw Zod), and result types come from the `stitch<T>` generic.
- The 9th landing card spans full width on `sm`+ (`sm:col-span-2` on the last odd card) so the 2-col grid stays clean.
- **Stacked on `docs/recipes-section`** (base), scoped to just this session's work. Retarget to `develop` if you'd rather land it independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)