### PR TITLE
feat(playground): autocomplete for config props, instance methods, and scope primitives

### DIFF
--- a/apps/docs/app/(home)/playground/CodeEditor.tsx
+++ b/apps/docs/app/(home)/playground/CodeEditor.tsx
@@ -1,9 +1,16 @@
 'use client';
 
-import { javascript } from '@codemirror/lang-javascript';
+import { playgroundCompletionSource } from './playground-completions';
+
+import { autocompletion } from '@codemirror/autocomplete';
+import {
+    javascript,
+    localCompletionSource,
+    scopeCompletionSource,
+} from '@codemirror/lang-javascript';
 import type { EditorRenderProps } from '@stitchapi/sandbox/component/StitchPlayground';
 import CodeMirror from '@uiw/react-codemirror';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 /** Track the docs theme — Fumadocs toggles a `dark` class on <html>. */
 function useIsDark(): boolean {
@@ -20,6 +27,24 @@ function useIsDark(): boolean {
 }
 
 /**
+ * Globals available inside every playground snippet.
+ * scopeCompletionSource walks these keys to offer completions as the user types.
+ */
+const PLAYGROUND_SCOPE = {
+    stitch: () => {},
+    console,
+    JSON,
+    Math,
+    fetch,
+    Promise,
+    Array,
+    Object,
+    Error,
+    setTimeout,
+    clearTimeout,
+};
+
+/**
  * CodeMirror 6 editor for the playground — TS/JSX highlighting, line numbers,
  * theme synced to the docs light/dark mode. Implements the StitchPlayground
  * `renderEditor` contract (controlled `value`/`onChange`).
@@ -31,6 +56,24 @@ export function CodeEditor({
     height,
 }: EditorRenderProps) {
     const dark = useIsDark();
+
+    const extensions = useMemo(
+        () => [
+            javascript({ typescript: true, jsx: true }),
+            autocompletion({
+                // localCompletionSource: identifiers already in the editor
+                // scopeCompletionSource: stitch + JS globals the snippet can reach
+                override: [
+                    localCompletionSource,
+                    scopeCompletionSource(PLAYGROUND_SCOPE),
+                    playgroundCompletionSource,
+                ],
+                activateOnTyping: true,
+            }),
+        ],
+        [],
+    );
+
     return (
         <CodeMirror
             className="stitch-playground__cm"
@@ -39,7 +82,7 @@ export function CodeEditor({
             theme={dark ? 'dark' : 'light'}
             editable={!readOnly}
             readOnly={readOnly}
-            extensions={[javascript({ typescript: true, jsx: true })]}
+            extensions={extensions}
             basicSetup={{
                 lineNumbers: true,
                 foldGutter: false,

--- a/apps/docs/app/(home)/playground/CodeEditor.tsx
+++ b/apps/docs/app/(home)/playground/CodeEditor.tsx
@@ -1,6 +1,9 @@
 'use client';
 
-import { playgroundCompletionSource } from './playground-completions';
+import {
+    instanceCompletionSource,
+    playgroundCompletionSource,
+} from './playground-completions';
 
 import { autocompletion } from '@codemirror/autocomplete';
 import {
@@ -11,6 +14,7 @@ import {
 import type { EditorRenderProps } from '@stitchapi/sandbox/component/StitchPlayground';
 import CodeMirror from '@uiw/react-codemirror';
 import { useEffect, useMemo, useState } from 'react';
+import { stitch } from 'stitchapi';
 
 /** Track the docs theme — Fumadocs toggles a `dark` class on <html>. */
 function useIsDark(): boolean {
@@ -31,7 +35,7 @@ function useIsDark(): boolean {
  * scopeCompletionSource walks these keys to offer completions as the user types.
  */
 const PLAYGROUND_SCOPE = {
-    stitch: () => {},
+    stitch,
     console,
     JSON,
     Math,
@@ -67,6 +71,7 @@ export function CodeEditor({
                     localCompletionSource,
                     scopeCompletionSource(PLAYGROUND_SCOPE),
                     playgroundCompletionSource,
+                    instanceCompletionSource,
                 ],
                 activateOnTyping: true,
             }),

--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -2,169 +2,196 @@
 // Regenerate: pnpm --filter @stitchapi/docs run gen:completions
 import type { Completion } from '@codemirror/autocomplete';
 
+/** Config-key completions inside primitive({…}) call arguments. */
 export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
     stitch: [
         {
             label: 'name',
-            type: 'property' as const,
+            type: 'property',
             detail: 'string',
             info: "Label used in events and traces; defaults to `path` or `'stitch'`.",
         },
         {
             label: 'kind',
-            type: 'property' as const,
+            type: 'property',
             detail: "'http' | 'graphql'",
             info: "Request kind. `'http'` (default) or `'graphql'` for a POST `{ query, variables }`.",
         },
         {
             label: 'method',
-            type: 'property' as const,
+            type: 'property',
             detail: 'string',
             info: 'HTTP method; defaults to `GET`.',
         },
         {
             label: 'bodyType',
-            type: 'property' as const,
+            type: 'property',
             detail: "'json' | 'form' | 'multipart'",
             info: "Request body encoding. Default `'json'`.",
         },
         {
             label: 'responseType',
-            type: 'property' as const,
+            type: 'property',
             detail: 'ResponseType',
             info: 'How to read the response body. Default: auto by content-type.',
         },
         {
             label: 'url',
-            type: 'property' as const,
+            type: 'property',
             detail: 'string | (() => string)',
             info: 'Full request endpoint as one string — the atomic spelling, when a stitch is exactly one endpoint with no base to share. Templated (`{param}`, incl. the host) and `?query`-aware like `path`; may be a thunk for lazy/env resolution. Mutually exclusive with `baseUrl`/`path`: when both are set `url` wins, and across composed fragments the last fragment to write either spelling wins the whole slot.',
         },
         {
             label: 'baseUrl',
-            type: 'property' as const,
+            type: 'property',
             detail: 'string | (() => string)',
             info: 'Origin for the request, as a string or a thunk resolved at call time. Ignored when `url` is set.',
         },
         {
             label: 'path',
-            type: 'property' as const,
+            type: 'property',
             detail: 'string',
             info: 'Path appended to `baseUrl`; may include `{param}` slots and a `?query` string. Ignored when `url` is set.',
         },
         {
             label: 'headers',
-            type: 'property' as const,
+            type: 'property',
             detail: 'Record<string, string>',
             info: 'Static default headers merged into every request.',
         },
         {
             label: 'query',
-            type: 'property' as const,
+            type: 'property',
             detail: 'string',
             info: "GraphQL query string (`kind: 'graphql'`).",
         },
         {
             label: 'input',
-            type: 'property' as const,
+            type: 'property',
             detail: 'InputSchemas',
             info: 'Schemas validating params, query, body, and headers before the request.',
         },
         {
             label: 'output',
-            type: 'property' as const,
+            type: 'property',
             detail: 'Validator | DriftSpec',
             info: 'Response schema, or a  for leveled drift detection.',
         },
         {
             label: 'unwrap',
-            type: 'property' as const,
+            type: 'property',
             detail: 'string',
             info: 'Dot-path selecting the part of the response to return.',
         },
         {
             label: 'transform',
-            type: 'property' as const,
+            type: 'property',
             detail: '(body: unknown) => unknown',
             info: 'Reshape the raw body before unwrap and validation (e.g. scrape HTML to structured data).',
         },
         {
             label: 'paginate',
-            type: 'property' as const,
+            type: 'property',
             detail: "{ /** * Given the previous page's raw body and how many pages were fetched, return the * input (merged over the original) for the next page, or `undefined` to stop. */ next: ( prevBody: unknown, pagesFetched: number, ) => StitchInput | undefined; /** Pull the array from each unwrapped page. Default: the value if it is an array. */ items?: (value: unknown) => unknown[]; /** Safety cap on pages. Default 50. */ max?: number; }",
             info: 'Auto-loop pages, aggregating items, with auth/retry/throttle applied to every page.',
         },
         {
             label: 'auth',
-            type: 'property' as const,
+            type: 'property',
             detail: 'AuthStrategy',
             info: 'Auth strategy — the stitch holds the credential; the caller never sees it.',
         },
         {
             label: 'retry',
-            type: 'property' as const,
+            type: 'property',
             detail: 'RetryOptions',
             info: 'Retry-and-backoff policy.',
         },
         {
             label: 'throttle',
-            type: 'property' as const,
+            type: 'property',
             detail: 'ThrottleOptions',
             info: 'Rate and concurrency limits.',
         },
         {
             label: 'timeout',
-            type: 'property' as const,
+            type: 'property',
             detail: 'TimeoutOptions',
             info: 'Total and per-attempt timeouts.',
         },
         {
             label: 'circuit',
-            type: 'property' as const,
+            type: 'property',
             detail: 'CircuitOptions',
             info: 'Circuit breaker that fast-fails a repeatedly failing dependency.',
         },
         {
             label: 'idempotency',
-            type: 'property' as const,
+            type: 'property',
             detail: 'IdempotencyOptions',
             info: "Inject a stable Idempotency-Key header on writes so safe retries don't duplicate.",
         },
         {
             label: 'arrayFormat',
-            type: 'property' as const,
+            type: 'property',
             detail: "'indices' | 'brackets' | 'repeat'",
             info: "How arrays are serialised in the query string. - `'indices'` (default) — `ids%5B0%5D=1&ids%5B1%5D=2` - `'brackets'`          — `ids%5B%5D=1&ids%5B%5D=2` - `'repeat'`            — `ids=1&ids=2`",
         },
         {
             label: 'hooks',
-            type: 'property' as const,
+            type: 'property',
             detail: 'Hooks',
             info: 'Request/response/error/retry lifecycle hooks.',
         },
         {
             label: 'extends',
-            type: 'property' as const,
+            type: 'property',
             detail: '(Partial<StitchConfig> | Stitch | string)[]',
             info: 'Fragments to deep-merge under this config — strings, partials, or other stitches.',
         },
         {
             label: 'adapter',
-            type: 'property' as const,
+            type: 'property',
             detail: 'Adapter',
             info: 'Test seam / custom transport.',
         },
         {
             label: 'store',
-            type: 'property' as const,
+            type: 'property',
             detail: 'StitchStore',
             info: 'Pluggable state store for throttle + session. Default in-memory.',
         },
         {
             label: 'trace',
-            type: 'property' as const,
+            type: 'property',
             detail: "TraceSink | 'console' | false",
             info: "Observability sink — **off by default**, because a stitch's only effect on the world is its call. Opt in with `'console'` (the colored stderr stream), a sink from `fileSink(path)` / `createTrace(...)` for JSONL on disk, or any custom . `false` forces it off even when the `STITCH_TRACE_*` env vars are set. Unset falls back to the env-driven sink, which is itself silent unless `STITCH_TRACE_CONSOLE` / `STITCH_TRACE_FILE` / `STITCH_EXPORT` opt in.",
+        },
+    ],
+};
+
+/** Member completions on the value returned by a primitive call. */
+export const PLAYGROUND_INSTANCE_COMPLETIONS: Record<string, Completion[]> = {
+    stitch: [
+        {
+            label: 'stream',
+            type: 'method',
+            detail: '(input?: StitchInput) => AsyncGenerator<StitchEvent<T>, void>',
+        },
+        {
+            label: 'with',
+            type: 'method',
+            detail: '(partial: StitchInput) => Stitch<T>',
+        },
+        {
+            label: '__config',
+            type: 'property',
+            detail: 'StitchConfig',
+        },
+        {
+            label: '__stitch',
+            type: 'property',
+            detail: 'true',
         },
     ],
 };

--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -1,0 +1,170 @@
+// @generated — do not edit by hand.
+// Regenerate: pnpm --filter @stitchapi/docs run gen:completions
+import type { Completion } from '@codemirror/autocomplete';
+
+export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
+    stitch: [
+        {
+            label: 'name',
+            type: 'property' as const,
+            detail: 'string',
+            info: "Label used in events and traces; defaults to `path` or `'stitch'`.",
+        },
+        {
+            label: 'kind',
+            type: 'property' as const,
+            detail: "'http' | 'graphql'",
+            info: "Request kind. `'http'` (default) or `'graphql'` for a POST `{ query, variables }`.",
+        },
+        {
+            label: 'method',
+            type: 'property' as const,
+            detail: 'string',
+            info: 'HTTP method; defaults to `GET`.',
+        },
+        {
+            label: 'bodyType',
+            type: 'property' as const,
+            detail: "'json' | 'form' | 'multipart'",
+            info: "Request body encoding. Default `'json'`.",
+        },
+        {
+            label: 'responseType',
+            type: 'property' as const,
+            detail: 'ResponseType',
+            info: 'How to read the response body. Default: auto by content-type.',
+        },
+        {
+            label: 'url',
+            type: 'property' as const,
+            detail: 'string | (() => string)',
+            info: 'Full request endpoint as one string — the atomic spelling, when a stitch is exactly one endpoint with no base to share. Templated (`{param}`, incl. the host) and `?query`-aware like `path`; may be a thunk for lazy/env resolution. Mutually exclusive with `baseUrl`/`path`: when both are set `url` wins, and across composed fragments the last fragment to write either spelling wins the whole slot.',
+        },
+        {
+            label: 'baseUrl',
+            type: 'property' as const,
+            detail: 'string | (() => string)',
+            info: 'Origin for the request, as a string or a thunk resolved at call time. Ignored when `url` is set.',
+        },
+        {
+            label: 'path',
+            type: 'property' as const,
+            detail: 'string',
+            info: 'Path appended to `baseUrl`; may include `{param}` slots and a `?query` string. Ignored when `url` is set.',
+        },
+        {
+            label: 'headers',
+            type: 'property' as const,
+            detail: 'Record<string, string>',
+            info: 'Static default headers merged into every request.',
+        },
+        {
+            label: 'query',
+            type: 'property' as const,
+            detail: 'string',
+            info: "GraphQL query string (`kind: 'graphql'`).",
+        },
+        {
+            label: 'input',
+            type: 'property' as const,
+            detail: 'InputSchemas',
+            info: 'Schemas validating params, query, body, and headers before the request.',
+        },
+        {
+            label: 'output',
+            type: 'property' as const,
+            detail: 'Validator | DriftSpec',
+            info: 'Response schema, or a  for leveled drift detection.',
+        },
+        {
+            label: 'unwrap',
+            type: 'property' as const,
+            detail: 'string',
+            info: 'Dot-path selecting the part of the response to return.',
+        },
+        {
+            label: 'transform',
+            type: 'property' as const,
+            detail: '(body: unknown) => unknown',
+            info: 'Reshape the raw body before unwrap and validation (e.g. scrape HTML to structured data).',
+        },
+        {
+            label: 'paginate',
+            type: 'property' as const,
+            detail: "{ /** * Given the previous page's raw body and how many pages were fetched, return the * input (merged over the original) for the next page, or `undefined` to stop. */ next: ( prevBody: unknown, pagesFetched: number, ) => StitchInput | undefined; /** Pull the array from each unwrapped page. Default: the value if it is an array. */ items?: (value: unknown) => unknown[]; /** Safety cap on pages. Default 50. */ max?: number; }",
+            info: 'Auto-loop pages, aggregating items, with auth/retry/throttle applied to every page.',
+        },
+        {
+            label: 'auth',
+            type: 'property' as const,
+            detail: 'AuthStrategy',
+            info: 'Auth strategy — the stitch holds the credential; the caller never sees it.',
+        },
+        {
+            label: 'retry',
+            type: 'property' as const,
+            detail: 'RetryOptions',
+            info: 'Retry-and-backoff policy.',
+        },
+        {
+            label: 'throttle',
+            type: 'property' as const,
+            detail: 'ThrottleOptions',
+            info: 'Rate and concurrency limits.',
+        },
+        {
+            label: 'timeout',
+            type: 'property' as const,
+            detail: 'TimeoutOptions',
+            info: 'Total and per-attempt timeouts.',
+        },
+        {
+            label: 'circuit',
+            type: 'property' as const,
+            detail: 'CircuitOptions',
+            info: 'Circuit breaker that fast-fails a repeatedly failing dependency.',
+        },
+        {
+            label: 'idempotency',
+            type: 'property' as const,
+            detail: 'IdempotencyOptions',
+            info: "Inject a stable Idempotency-Key header on writes so safe retries don't duplicate.",
+        },
+        {
+            label: 'arrayFormat',
+            type: 'property' as const,
+            detail: "'indices' | 'brackets' | 'repeat'",
+            info: "How arrays are serialised in the query string. - `'indices'` (default) — `ids%5B0%5D=1&ids%5B1%5D=2` - `'brackets'`          — `ids%5B%5D=1&ids%5B%5D=2` - `'repeat'`            — `ids=1&ids=2`",
+        },
+        {
+            label: 'hooks',
+            type: 'property' as const,
+            detail: 'Hooks',
+            info: 'Request/response/error/retry lifecycle hooks.',
+        },
+        {
+            label: 'extends',
+            type: 'property' as const,
+            detail: '(Partial<StitchConfig> | Stitch | string)[]',
+            info: 'Fragments to deep-merge under this config — strings, partials, or other stitches.',
+        },
+        {
+            label: 'adapter',
+            type: 'property' as const,
+            detail: 'Adapter',
+            info: 'Test seam / custom transport.',
+        },
+        {
+            label: 'store',
+            type: 'property' as const,
+            detail: 'StitchStore',
+            info: 'Pluggable state store for throttle + session. Default in-memory.',
+        },
+        {
+            label: 'trace',
+            type: 'property' as const,
+            detail: "TraceSink | 'console' | false",
+            info: "Observability sink — **off by default**, because a stitch's only effect on the world is its call. Opt in with `'console'` (the colored stderr stream), a sink from `fileSink(path)` / `createTrace(...)` for JSONL on disk, or any custom . `false` forces it off even when the `STITCH_TRACE_*` env vars are set. Unset falls back to the env-driven sink, which is itself silent unless `STITCH_TRACE_CONSOLE` / `STITCH_TRACE_FILE` / `STITCH_EXPORT` opt in.",
+        },
+    ],
+};

--- a/apps/docs/app/(home)/playground/playground-completions.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.ts
@@ -1,0 +1,54 @@
+import { PLAYGROUND_COMPLETIONS } from './playground-completions.generated';
+
+import {
+    type CompletionContext,
+    type CompletionResult,
+} from '@codemirror/autocomplete';
+
+/**
+ * Returns the open-brace depth of `text` — positive when we're inside more
+ * `{` than `}`.
+ */
+function braceDepth(text: string): number {
+    let depth = 0;
+    for (const ch of text) {
+        if (ch === '{') depth++;
+        else if (ch === '}') depth--;
+    }
+    return depth;
+}
+
+/**
+ * Completion source for all known playground primitives.
+ *
+ * For each entry in PLAYGROUND_COMPLETIONS (keyed by function name), checks
+ * whether the cursor is inside a `fnName({…})` object literal and returns that
+ * function's config-key completions. Adding a new primitive requires only a new
+ * entry in the PlaygroundCompletionsPlugin config in next.config.mjs — no
+ * changes here.
+ */
+export function playgroundCompletionSource(
+    context: CompletionContext,
+): CompletionResult | null {
+    const word = context.matchBefore(/\w*/);
+    if (!word) return null;
+    if (word.from === word.to && !context.explicit) return null;
+
+    const lookback = context.state.doc.sliceString(
+        Math.max(0, context.pos - 2000),
+        context.pos,
+    );
+
+    for (const [fnName, completions] of Object.entries(
+        PLAYGROUND_COMPLETIONS,
+    )) {
+        const marker = `${fnName}(`;
+        const idx = lookback.lastIndexOf(marker);
+        if (idx === -1) continue;
+        if (braceDepth(lookback.slice(idx + marker.length)) > 0) {
+            return { from: word.from, options: completions, validFor: /^\w*$/ };
+        }
+    }
+
+    return null;
+}

--- a/apps/docs/app/(home)/playground/playground-completions.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.ts
@@ -1,4 +1,7 @@
-import { PLAYGROUND_COMPLETIONS } from './playground-completions.generated';
+import {
+    PLAYGROUND_COMPLETIONS,
+    PLAYGROUND_INSTANCE_COMPLETIONS,
+} from './playground-completions.generated';
 
 import {
     type CompletionContext,
@@ -19,13 +22,11 @@ function braceDepth(text: string): number {
 }
 
 /**
- * Completion source for all known playground primitives.
+ * Config-key completions inside primitive({…}) call arguments.
  *
  * For each entry in PLAYGROUND_COMPLETIONS (keyed by function name), checks
- * whether the cursor is inside a `fnName({…})` object literal and returns that
- * function's config-key completions. Adding a new primitive requires only a new
- * entry in the PlaygroundCompletionsPlugin config in next.config.mjs — no
- * changes here.
+ * whether the cursor is inside a `fnName({…})` object literal. Adding a new
+ * primitive only requires a new entry in PlaygroundCompletionsPlugin config.
  */
 export function playgroundCompletionSource(
     context: CompletionContext,
@@ -47,6 +48,47 @@ export function playgroundCompletionSource(
         if (idx === -1) continue;
         if (braceDepth(lookback.slice(idx + marker.length)) > 0) {
             return { from: word.from, options: completions, validFor: /^\w*$/ };
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Dot-completion source for instance members on primitive return values.
+ *
+ * Fires when the cursor is after `identifier.` and that identifier was assigned
+ * from a known primitive call (e.g. `const getUser = stitch(...)`). Suggests
+ * the methods and properties of the returned instance (stream, with, …).
+ */
+export function instanceCompletionSource(
+    context: CompletionContext,
+): CompletionResult | null {
+    // Match `identifier.partialWord`
+    const match = context.matchBefore(/\w+\.\w*/);
+    if (!match) return null;
+
+    const dotIdx = match.text.indexOf('.');
+    const receiver = match.text.slice(0, dotIdx);
+
+    const docText = context.state.doc.sliceString(
+        0,
+        Math.min(context.pos, context.state.doc.length),
+    );
+
+    for (const [fnName, completions] of Object.entries(
+        PLAYGROUND_INSTANCE_COMPLETIONS,
+    )) {
+        // Heuristic: look for `const/let/var receiver = <anything>fnName(`
+        const pattern = new RegExp(
+            `(?:const|let|var)\\s+${receiver}\\s*=\\s*[\\s\\S]*?${fnName}\\s*[\\({]`,
+        );
+        if (pattern.test(docText)) {
+            return {
+                from: match.from + dotIdx + 1,
+                options: completions,
+                validFor: /^\w*$/,
+            };
         }
     }
 

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -1,4 +1,10 @@
+import { PlaygroundCompletionsPlugin } from '@stitchapi/completions-plugin';
 import { createMDX } from 'fumadocs-mdx/next';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../..');
 
 const withMDX = createMDX();
 
@@ -8,6 +14,25 @@ const config = {
     // The playground consumes the in-repo sandbox engine (@stitchapi/sandbox), a
     // workspace package that ships raw TS/TSX source — Next must transpile it.
     transpilePackages: ['@stitchapi/sandbox'],
+    webpack(webpackConfig, { isServer }) {
+        // Guard with !isServer so codegen runs once per compilation cycle,
+        // not twice (webpack compiles server and client separately).
+        if (!isServer) {
+            webpackConfig.plugins.push(
+                new PlaygroundCompletionsPlugin({
+                    packages: [
+                        resolve(repoRoot, 'packages/core'),
+                        // Add adapter packages here as they land.
+                    ],
+                    outputFile: resolve(
+                        __dirname,
+                        'app/(home)/playground/playground-completions.generated.ts',
+                    ),
+                }),
+            );
+        }
+        return webpackConfig;
+    },
 };
 
 export default withMDX(config);

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -10,10 +10,12 @@
         "check:types": "pnpm run build:core && fumadocs-mdx && next typegen && tsc --noEmit",
         "check:lint": "eslint .",
         "gen:docs": "node scripts/generate-skeleton.mjs",
+        "gen:completions": "node scripts/gen-stitch-completions.mjs",
         "build:core": "pnpm --filter stitchapi build",
-        "build:sandbox": "node ../../docs/sandbox/runtime/build-sandbox-worker.mjs"
+        "build:sandbox": "node scripts/gen-stitch-completions.mjs && node ../../docs/sandbox/runtime/build-sandbox-worker.mjs"
     },
     "dependencies": {
+        "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/lang-javascript": "^6.2.2",
         "@stitchapi/sandbox": "workspace:*",
         "@uiw/react-codemirror": "^4.23.0",
@@ -31,6 +33,7 @@
         "zod": "^4.4.3"
     },
     "devDependencies": {
+        "@stitchapi/completions-plugin": "workspace:*",
         "@tailwindcss/postcss": "^4.3.0",
         "@types/mdx": "^2.0.13",
         "@types/node": "^25.9.1",

--- a/apps/docs/scripts/gen-stitch-completions.mjs
+++ b/apps/docs/scripts/gen-stitch-completions.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// Thin CLI wrapper — logic lives in @stitchapi/completions-plugin.
+// Run: pnpm --filter @stitchapi/docs run gen:completions
+import { generatePlaygroundCompletions } from '@stitchapi/completions-plugin';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../../..');
+
+await generatePlaygroundCompletions({
+    packages: [
+        resolve(repoRoot, 'packages/core'),
+        // Add adapter packages here if they expose *Config interfaces + exports:
+        // resolve(repoRoot, 'packages/some-adapter'),
+    ],
+    outputFile: resolve(
+        __dirname,
+        '../app/(home)/playground/playground-completions.generated.ts',
+    ),
+});

--- a/docs/sandbox/runtime/transpile.ts
+++ b/docs/sandbox/runtime/transpile.ts
@@ -170,7 +170,9 @@ async function transpileWithBabel(code: string): Promise<TranspileResult> {
     try {
         // @babel/standalone exposes `transform` as a named export (and on
         // the default export when accessed via a bundler).
-        const babel = await import('@babel/standalone');
+        const babel = await import(
+            /* webpackIgnore: true */ '@babel/standalone'
+        );
         babelTransform =
             // named export (ESM build / bundler interop)
             babel.transform ??

--- a/packages/completions-plugin/codegen.mjs
+++ b/packages/completions-plugin/codegen.mjs
@@ -1,19 +1,16 @@
 /**
- * generatePlaygroundCompletions — scans one or more packages for exported
- * *Config interfaces, cross-checks them against the package's public exports,
- * and writes a single PLAYGROUND_COMPLETIONS map for the editor.
+ * generatePlaygroundCompletions — scans packages for exported *Config
+ * interfaces and their matching instance interfaces, then writes two maps:
  *
- * Discovery rule (per package):
- *   1. Collect every exported `*Config` interface across src/**\/*.ts
- *   2. Derive the function name: `StitchConfig → stitch`, `SeamConfig → seam`
- *   3. Only include the interface if that function name appears in src/index.ts exports
+ *   PLAYGROUND_COMPLETIONS         — config keys inside primitive({…}) calls
+ *   PLAYGROUND_INSTANCE_COMPLETIONS — members on the value a primitive returns
  *
- * Adding a new primitive requires no changes here or in next.config — just
- * export `XConfig` + `x` from the package's index and it appears automatically.
+ * Discovery rules (per package):
+ *   Config  : every exported XConfig where x is in src/index.ts exports
+ *   Instance: exported X (same prefix, no Config suffix) alongside each XConfig
  *
- * @param {object} opts
- * @param {string[]} opts.packages  Absolute paths to package roots (must have src/index.ts).
- * @param {string}   opts.outputFile  Absolute path to write the generated .ts file.
+ * e.g. StitchConfig → stitch call-arg completions
+ *      Stitch        → .stream() / .with() / … on the returned instance
  */
 import { readdirSync, writeFileSync } from 'fs';
 import { createRequire } from 'module';
@@ -28,9 +25,8 @@ function findTsFiles(dir) {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
         const full = join(dir, entry.name);
         if (entry.isDirectory()) {
-            if (entry.name !== 'node_modules' && !entry.name.startsWith('.')) {
+            if (entry.name !== 'node_modules' && !entry.name.startsWith('.'))
                 results.push(...findTsFiles(full));
-            }
         } else if (
             entry.isFile() &&
             entry.name.endsWith('.ts') &&
@@ -46,7 +42,6 @@ function findTsFiles(dir) {
 
 /* ── TypeScript helpers ───────────────────────────────────────────────────── */
 
-/** Returns the set of value names exported from an index.ts file. */
 function getExportedNames(ts, indexFile) {
     const program = ts.createProgram([indexFile], {
         noEmit: true,
@@ -57,25 +52,21 @@ function getExportedNames(ts, indexFile) {
 
     const names = new Set();
     ts.forEachChild(sf, (node) => {
-        // export { a, b } from '...'
         if (
             ts.isExportDeclaration(node) &&
             node.exportClause &&
             ts.isNamedExports(node.exportClause)
         ) {
-            for (const el of node.exportClause.elements) {
+            for (const el of node.exportClause.elements)
                 names.add(el.name.text);
-            }
         }
-        // export const / export function / export class
         const hasExport = node.modifiers?.some(
             (m) => m.kind === ts.SyntaxKind.ExportKeyword,
         );
         if (hasExport) {
             if (ts.isVariableStatement(node)) {
-                for (const decl of node.declarationList.declarations) {
-                    if (ts.isIdentifier(decl.name)) names.add(decl.name.text);
-                }
+                for (const d of node.declarationList.declarations)
+                    if (ts.isIdentifier(d.name)) names.add(d.name.text);
             } else if (
                 (ts.isFunctionDeclaration(node) ||
                     ts.isClassDeclaration(node)) &&
@@ -88,85 +79,132 @@ function getExportedNames(ts, indexFile) {
     return names;
 }
 
-/** `'StitchConfig' → 'stitch'`, `'SeamConfig' → 'seam'`. */
 function configToFunctionName(interfaceName) {
     const prefix = interfaceName.replace(/Config$/, '');
     return prefix.charAt(0).toLowerCase() + prefix.slice(1);
 }
 
-/** Extract Completion entries from a *Config interface node. */
-function extractEntries(ts, iface, sf) {
-    function jsDocSummary(node) {
-        const docs = node.jsDoc;
-        if (!docs?.length) return '';
-        const last = docs[docs.length - 1];
-        if (!last.comment) return '';
-        const text =
-            typeof last.comment === 'string'
-                ? last.comment
-                : last.comment.map((c) => c.text ?? '').join('');
-        return text.trim().replace(/\s*\n\s*/g, ' ');
-    }
+function jsDocSummary(node) {
+    const docs = node.jsDoc;
+    if (!docs?.length) return '';
+    const last = docs[docs.length - 1];
+    if (!last.comment) return '';
+    const text =
+        typeof last.comment === 'string'
+            ? last.comment
+            : last.comment.map((c) => c.text ?? '').join('');
+    return text.trim().replace(/\s*\n\s*/g, ' ');
+}
 
-    function typeText(member) {
-        if (!member.type) return 'unknown';
-        return member.type
-            .getText(sf)
-            .replace(/\s*\n\s*/g, ' ')
-            .replace(/\s{2,}/g, ' ')
-            .trim();
-    }
+function collapseWhitespace(s) {
+    return s
+        .replace(/\s*\n\s*/g, ' ')
+        .replace(/\s{2,}/g, ' ')
+        .trim();
+}
 
+/** Property signatures only — used for *Config interfaces (call-arg completions). */
+function extractConfigEntries(ts, iface, sf) {
     const entries = [];
     for (const member of iface.members) {
         if (!ts.isPropertySignature(member)) continue;
         entries.push({
+            type: 'property',
             label: member.name.getText(sf),
-            detail: typeText(member),
+            detail: member.type
+                ? collapseWhitespace(member.type.getText(sf))
+                : 'unknown',
             info: jsDocSummary(member),
         });
     }
     return entries;
 }
 
-/** Scan src/ of a package for exported *Config interfaces matched to exports. */
+/** Property + method signatures — used for instance interfaces (dot completions). */
+function extractInstanceEntries(ts, iface, sf) {
+    const entries = [];
+    for (const member of iface.members) {
+        if (ts.isCallSignatureDeclaration(member)) continue; // skip callable part
+
+        if (ts.isPropertySignature(member)) {
+            entries.push({
+                type: 'property',
+                label: member.name.getText(sf),
+                detail: member.type
+                    ? collapseWhitespace(member.type.getText(sf))
+                    : 'unknown',
+                info: jsDocSummary(member),
+            });
+        } else if (ts.isMethodSignature(member)) {
+            const params = member.parameters
+                .map((p) => collapseWhitespace(p.getText(sf)))
+                .join(', ');
+            const ret = member.type
+                ? collapseWhitespace(member.type.getText(sf))
+                : 'void';
+            entries.push({
+                type: 'method',
+                label: member.name.getText(sf),
+                detail: `(${params}) => ${ret}`,
+                info: jsDocSummary(member),
+            });
+        }
+    }
+    return entries;
+}
+
+/** Scan src/ of a package, return config + instance entries per primitive. */
 function scanPackage(ts, packageRoot) {
     const srcDir = resolve(packageRoot, 'src');
     const indexFile = resolve(srcDir, 'index.ts');
-
     const exportedNames = getExportedNames(ts, indexFile);
     const srcFiles = findTsFiles(srcDir);
 
-    // Build one program over all source files for efficient shared parsing.
     const program = ts.createProgram(srcFiles, {
         noEmit: true,
         skipLibCheck: true,
     });
 
-    const found = []; // [{ functionName, interfaceName, entries }]
-
+    // Collect all exported interfaces by name across all source files.
+    const exportedIfaces = new Map(); // name → { node, sf }
     for (const file of srcFiles) {
         const sf = program.getSourceFile(file);
         if (!sf) continue;
-
         ts.forEachChild(sf, (node) => {
             if (!ts.isInterfaceDeclaration(node)) return;
-            if (!node.name.text.endsWith('Config')) return;
-
-            const isExported = node.modifiers?.some(
+            const exported = node.modifiers?.some(
                 (m) => m.kind === ts.SyntaxKind.ExportKeyword,
             );
-            if (!isExported) return;
-
-            const fnName = configToFunctionName(node.name.text);
-            if (!exportedNames.has(fnName)) return;
-
-            found.push({
-                functionName: fnName,
-                interfaceName: node.name.text,
-                entries: extractEntries(ts, node, sf),
-            });
+            if (exported) exportedIfaces.set(node.name.text, { node, sf });
         });
+    }
+
+    const found = [];
+    for (const [ifaceName, { node, sf }] of exportedIfaces) {
+        if (!ifaceName.endsWith('Config')) continue;
+        const fnName = configToFunctionName(ifaceName);
+        if (!exportedNames.has(fnName)) continue;
+
+        // Instance interface: same prefix, no Config suffix (StitchConfig → Stitch)
+        const prefix = ifaceName.replace(/Config$/, '');
+        const instanceIface = exportedIfaces.get(prefix);
+
+        found.push({
+            functionName: fnName,
+            configEntries: extractConfigEntries(ts, node, sf),
+            instanceEntries: instanceIface
+                ? extractInstanceEntries(
+                      ts,
+                      instanceIface.node,
+                      instanceIface.sf,
+                  )
+                : [],
+        });
+
+        console.log(
+            `[completions-plugin] ${fnName}: ${found[found.length - 1].configEntries.length} config, ` +
+                `${found[found.length - 1].instanceEntries.length} instance completions`,
+        );
     }
 
     return found;
@@ -174,15 +212,24 @@ function scanPackage(ts, packageRoot) {
 
 /* ── emit ─────────────────────────────────────────────────────────────────── */
 
-function renderEntry({ label, detail, info }) {
+function renderEntry({ type, label, detail, info }) {
     return (
         `        {\n` +
         `            label: ${JSON.stringify(label)},\n` +
-        `            type: 'property' as const,\n` +
+        `            type: ${JSON.stringify(type)},\n` +
         `            detail: ${JSON.stringify(detail)},\n` +
         (info ? `            info: ${JSON.stringify(info)},\n` : '') +
         `        }`
     );
+}
+
+function renderBlock(map) {
+    return Object.entries(map)
+        .map(
+            ([key, entries]) =>
+                `    ${JSON.stringify(key)}: [\n${entries.map(renderEntry).join(',\n')},\n    ]`,
+        )
+        .join(',\n');
 }
 
 /* ── public API ───────────────────────────────────────────────────────────── */
@@ -190,28 +237,30 @@ function renderEntry({ label, detail, info }) {
 export async function generatePlaygroundCompletions({ packages, outputFile }) {
     const ts = req('typescript');
 
-    const allFound = packages.flatMap((pkgRoot) => {
-        const results = scanPackage(ts, pkgRoot);
-        for (const r of results) {
-            console.log(
-                `[completions-plugin] ${r.functionName}: ${r.entries.length} completions from ${r.interfaceName} (${pkgRoot})`,
-            );
-        }
-        return results;
-    });
+    const allFound = packages.flatMap((pkgRoot) => scanPackage(ts, pkgRoot));
 
-    const blocks = allFound.map(({ functionName, entries }) => {
-        const rendered = entries.map(renderEntry).join(',\n');
-        return `    ${JSON.stringify(functionName)}: [\n${rendered},\n    ]`;
-    });
+    const configMap = Object.fromEntries(
+        allFound.map((r) => [r.functionName, r.configEntries]),
+    );
+    const instanceMap = Object.fromEntries(
+        allFound
+            .filter((r) => r.instanceEntries.length > 0)
+            .map((r) => [r.functionName, r.instanceEntries]),
+    );
 
     const content = [
         `// @generated — do not edit by hand.`,
         `// Regenerate: pnpm --filter @stitchapi/docs run gen:completions`,
         `import type { Completion } from '@codemirror/autocomplete';`,
         ``,
+        `/** Config-key completions inside primitive({…}) call arguments. */`,
         `export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {`,
-        blocks.join(',\n'),
+        renderBlock(configMap),
+        `};`,
+        ``,
+        `/** Member completions on the value returned by a primitive call. */`,
+        `export const PLAYGROUND_INSTANCE_COMPLETIONS: Record<string, Completion[]> = {`,
+        renderBlock(instanceMap),
         `};`,
         ``,
     ].join('\n');

--- a/packages/completions-plugin/codegen.mjs
+++ b/packages/completions-plugin/codegen.mjs
@@ -1,0 +1,221 @@
+/**
+ * generatePlaygroundCompletions — scans one or more packages for exported
+ * *Config interfaces, cross-checks them against the package's public exports,
+ * and writes a single PLAYGROUND_COMPLETIONS map for the editor.
+ *
+ * Discovery rule (per package):
+ *   1. Collect every exported `*Config` interface across src/**\/*.ts
+ *   2. Derive the function name: `StitchConfig → stitch`, `SeamConfig → seam`
+ *   3. Only include the interface if that function name appears in src/index.ts exports
+ *
+ * Adding a new primitive requires no changes here or in next.config — just
+ * export `XConfig` + `x` from the package's index and it appears automatically.
+ *
+ * @param {object} opts
+ * @param {string[]} opts.packages  Absolute paths to package roots (must have src/index.ts).
+ * @param {string}   opts.outputFile  Absolute path to write the generated .ts file.
+ */
+import { readdirSync, writeFileSync } from 'fs';
+import { createRequire } from 'module';
+import { join, resolve } from 'path';
+
+const req = createRequire(import.meta.url);
+
+/* ── file helpers ─────────────────────────────────────────────────────────── */
+
+function findTsFiles(dir) {
+    const results = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            if (entry.name !== 'node_modules' && !entry.name.startsWith('.')) {
+                results.push(...findTsFiles(full));
+            }
+        } else if (
+            entry.isFile() &&
+            entry.name.endsWith('.ts') &&
+            !entry.name.endsWith('.d.ts') &&
+            !entry.name.endsWith('.test.ts') &&
+            !entry.name.endsWith('.spec.ts')
+        ) {
+            results.push(full);
+        }
+    }
+    return results;
+}
+
+/* ── TypeScript helpers ───────────────────────────────────────────────────── */
+
+/** Returns the set of value names exported from an index.ts file. */
+function getExportedNames(ts, indexFile) {
+    const program = ts.createProgram([indexFile], {
+        noEmit: true,
+        skipLibCheck: true,
+    });
+    const sf = program.getSourceFile(indexFile);
+    if (!sf) return new Set();
+
+    const names = new Set();
+    ts.forEachChild(sf, (node) => {
+        // export { a, b } from '...'
+        if (
+            ts.isExportDeclaration(node) &&
+            node.exportClause &&
+            ts.isNamedExports(node.exportClause)
+        ) {
+            for (const el of node.exportClause.elements) {
+                names.add(el.name.text);
+            }
+        }
+        // export const / export function / export class
+        const hasExport = node.modifiers?.some(
+            (m) => m.kind === ts.SyntaxKind.ExportKeyword,
+        );
+        if (hasExport) {
+            if (ts.isVariableStatement(node)) {
+                for (const decl of node.declarationList.declarations) {
+                    if (ts.isIdentifier(decl.name)) names.add(decl.name.text);
+                }
+            } else if (
+                (ts.isFunctionDeclaration(node) ||
+                    ts.isClassDeclaration(node)) &&
+                node.name
+            ) {
+                names.add(node.name.text);
+            }
+        }
+    });
+    return names;
+}
+
+/** `'StitchConfig' → 'stitch'`, `'SeamConfig' → 'seam'`. */
+function configToFunctionName(interfaceName) {
+    const prefix = interfaceName.replace(/Config$/, '');
+    return prefix.charAt(0).toLowerCase() + prefix.slice(1);
+}
+
+/** Extract Completion entries from a *Config interface node. */
+function extractEntries(ts, iface, sf) {
+    function jsDocSummary(node) {
+        const docs = node.jsDoc;
+        if (!docs?.length) return '';
+        const last = docs[docs.length - 1];
+        if (!last.comment) return '';
+        const text =
+            typeof last.comment === 'string'
+                ? last.comment
+                : last.comment.map((c) => c.text ?? '').join('');
+        return text.trim().replace(/\s*\n\s*/g, ' ');
+    }
+
+    function typeText(member) {
+        if (!member.type) return 'unknown';
+        return member.type
+            .getText(sf)
+            .replace(/\s*\n\s*/g, ' ')
+            .replace(/\s{2,}/g, ' ')
+            .trim();
+    }
+
+    const entries = [];
+    for (const member of iface.members) {
+        if (!ts.isPropertySignature(member)) continue;
+        entries.push({
+            label: member.name.getText(sf),
+            detail: typeText(member),
+            info: jsDocSummary(member),
+        });
+    }
+    return entries;
+}
+
+/** Scan src/ of a package for exported *Config interfaces matched to exports. */
+function scanPackage(ts, packageRoot) {
+    const srcDir = resolve(packageRoot, 'src');
+    const indexFile = resolve(srcDir, 'index.ts');
+
+    const exportedNames = getExportedNames(ts, indexFile);
+    const srcFiles = findTsFiles(srcDir);
+
+    // Build one program over all source files for efficient shared parsing.
+    const program = ts.createProgram(srcFiles, {
+        noEmit: true,
+        skipLibCheck: true,
+    });
+
+    const found = []; // [{ functionName, interfaceName, entries }]
+
+    for (const file of srcFiles) {
+        const sf = program.getSourceFile(file);
+        if (!sf) continue;
+
+        ts.forEachChild(sf, (node) => {
+            if (!ts.isInterfaceDeclaration(node)) return;
+            if (!node.name.text.endsWith('Config')) return;
+
+            const isExported = node.modifiers?.some(
+                (m) => m.kind === ts.SyntaxKind.ExportKeyword,
+            );
+            if (!isExported) return;
+
+            const fnName = configToFunctionName(node.name.text);
+            if (!exportedNames.has(fnName)) return;
+
+            found.push({
+                functionName: fnName,
+                interfaceName: node.name.text,
+                entries: extractEntries(ts, node, sf),
+            });
+        });
+    }
+
+    return found;
+}
+
+/* ── emit ─────────────────────────────────────────────────────────────────── */
+
+function renderEntry({ label, detail, info }) {
+    return (
+        `        {\n` +
+        `            label: ${JSON.stringify(label)},\n` +
+        `            type: 'property' as const,\n` +
+        `            detail: ${JSON.stringify(detail)},\n` +
+        (info ? `            info: ${JSON.stringify(info)},\n` : '') +
+        `        }`
+    );
+}
+
+/* ── public API ───────────────────────────────────────────────────────────── */
+
+export async function generatePlaygroundCompletions({ packages, outputFile }) {
+    const ts = req('typescript');
+
+    const allFound = packages.flatMap((pkgRoot) => {
+        const results = scanPackage(ts, pkgRoot);
+        for (const r of results) {
+            console.log(
+                `[completions-plugin] ${r.functionName}: ${r.entries.length} completions from ${r.interfaceName} (${pkgRoot})`,
+            );
+        }
+        return results;
+    });
+
+    const blocks = allFound.map(({ functionName, entries }) => {
+        const rendered = entries.map(renderEntry).join(',\n');
+        return `    ${JSON.stringify(functionName)}: [\n${rendered},\n    ]`;
+    });
+
+    const content = [
+        `// @generated — do not edit by hand.`,
+        `// Regenerate: pnpm --filter @stitchapi/docs run gen:completions`,
+        `import type { Completion } from '@codemirror/autocomplete';`,
+        ``,
+        `export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {`,
+        blocks.join(',\n'),
+        `};`,
+        ``,
+    ].join('\n');
+
+    writeFileSync(outputFile, content, 'utf8');
+    console.log(`[completions-plugin] wrote → ${outputFile}`);
+}

--- a/packages/completions-plugin/index.mjs
+++ b/packages/completions-plugin/index.mjs
@@ -1,0 +1,47 @@
+/**
+ * Webpack plugin that auto-discovers playground primitives from TypeScript
+ * packages and regenerates the completions map before every compilation.
+ *
+ * Discovery rule: for every exported `*Config` interface in `src/**\/*.ts`,
+ * if the derived function name (`StitchConfig → stitch`) is also exported from
+ * `src/index.ts`, it becomes a completions entry automatically.
+ *
+ * Usage in next.config.mjs:
+ *   import { PlaygroundCompletionsPlugin } from '@stitchapi/completions-plugin';
+ *
+ *   new PlaygroundCompletionsPlugin({
+ *     packages: [
+ *       resolve(repoRoot, 'packages/core'),
+ *       // add more packages as they land
+ *     ],
+ *     outputFile: '/abs/path/to/playground-completions.generated.ts',
+ *   })
+ *
+ * @typedef {{ packages: string[], outputFile: string }} PluginOptions
+ */
+import { generatePlaygroundCompletions } from './codegen.mjs';
+
+export { generatePlaygroundCompletions } from './codegen.mjs';
+
+export class PlaygroundCompletionsPlugin {
+    /** @param {PluginOptions} opts */
+    constructor(opts) {
+        this.opts = opts;
+    }
+
+    /** @param {import('webpack').Compiler} compiler */
+    apply(compiler) {
+        compiler.hooks.beforeCompile.tapAsync(
+            'PlaygroundCompletionsPlugin',
+            async (_, callback) => {
+                try {
+                    await generatePlaygroundCompletions(this.opts);
+                } catch (err) {
+                    // Log but don't crash — stale generated file stays in place.
+                    console.error('[PlaygroundCompletionsPlugin]', err.message);
+                }
+                callback();
+            },
+        );
+    }
+}

--- a/packages/completions-plugin/package.json
+++ b/packages/completions-plugin/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "@stitchapi/completions-plugin",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Webpack plugin that generates CodeMirror completions from a TypeScript interface at build time.",
+    "exports": {
+        ".": "./index.mjs"
+    },
+    "peerDependencies": {
+        "typescript": ">=5.0.0"
+    },
+    "author": "Oleksandr Zhuravlov (rejifald@gmail.com)",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "typescript": "^6.0.3"
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   apps/docs:
     dependencies:
+      '@codemirror/autocomplete':
+        specifier: ^6.20.3
+        version: 6.20.3
       '@codemirror/lang-javascript':
         specifier: ^6.2.2
         version: 6.2.5
@@ -69,6 +72,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@stitchapi/completions-plugin':
+        specifier: workspace:*
+        version: link:../../packages/completions-plugin
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
@@ -124,6 +130,12 @@ importers:
       react:
         specifier: ^19.2.7
         version: 19.2.7
+
+  packages/completions-plugin:
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   packages/core:
     devDependencies:
@@ -6915,8 +6927,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.7
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -6942,7 +6954,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6953,21 +6965,21 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6978,7 +6990,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

- Adds `@stitchapi/completions-plugin` — a webpack plugin that scans configured packages for exported `*Config` interfaces, cross-checks each derived function name (`StitchConfig → stitch`) against the package's public `index.ts` exports, and writes `PLAYGROUND_COMPLETIONS` + `PLAYGROUND_INSTANCE_COMPLETIONS` maps on every webpack `beforeCompile` hook, so completions stay current through hot-reload with no manual entries.
- Config-key completions fire inside `fnName({…})` call arguments via a brace-depth heuristic — no primitive names hardcoded in the detection logic.
- Instance-method completions fire on `receiver.word` when `receiver` was assigned from a known primitive call (regex heuristic over doc text). Codegen discovers the `X` instance interface alongside each `XConfig` and extracts `MethodSignature` + `PropertySignature` entries.
- `PLAYGROUND_SCOPE` now imports the real `stitch` from `stitchapi` instead of `() => {}`, so `scopeCompletionSource` discovers `stitch.use` naturally without any hardcoding.
- `@codemirror/autocomplete` added as a direct dep; explicit `autocompletion()` extension replaces the `basicSetup.autocompletion` flag.

## Test plan

- [ ] Start `pnpm --filter @stitchapi/docs dev` and open the playground
- [ ] Type `stitch({` — should show 27 `StitchConfig` property completions with doc info
- [ ] Type `const x = stitch('…')` then `x.` — should show `stream`, `with`, `__config`, `__stitch`
- [ ] Type `stitch.` — should show `use`
- [ ] Add a new property to `StitchConfig` in `packages/core/src/index.ts`, save — webpack should regenerate the completions file without restarting the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)