### PR TITLE
feat(playground): default to a complete example with a Complete/Simple switch

### DIFF
--- a/apps/docs/app/(home)/playground/PlaygroundClient.tsx
+++ b/apps/docs/app/(home)/playground/PlaygroundClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { CodeEditor } from './CodeEditor';
+import { PLAYGROUND_EXAMPLES } from './playground-examples';
 
 import { StitchPlayground } from '@stitchapi/sandbox/component/StitchPlayground';
 import { dispatchRunner } from '@stitchapi/sandbox/contracts/dispatch';
@@ -9,7 +10,7 @@ import {
     makeBrowserWorkerRunner,
 } from '@stitchapi/sandbox/runtime/browser-runner';
 import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 /** Same-origin module Worker emitted by `build:sandbox` into /public/sandbox. */
 const WORKER_URL = '/sandbox/sandbox-worker.mjs';
@@ -33,7 +34,7 @@ function jsonLog(text: string): boolean {
  * highlighted result (`renderValue`). The heavy lifting lives in the engine;
  * the shell only knows the `CodeRunner` contract + the two render hooks.
  */
-export function PlaygroundClient({ initialCode }: { initialCode?: string }) {
+export function PlaygroundClient() {
     // Build the runner once, on the client. A fresh Worker per run is what gives
     // SEC-36/37 (no cross-run global bleed) for free. A real DOM Worker
     // structurally satisfies WorkerLike — the cast only bridges the DOM's
@@ -51,27 +52,62 @@ export function PlaygroundClient({ initialCode }: { initialCode?: string }) {
         [],
     );
 
+    // Defaults to the first preset (the complete tour). Switching presets
+    // remounts <StitchPlayground> via `key` so its editor re-seeds from the
+    // chosen `initialCode`; the runner above is stable across the remount.
+    const [exampleId, setExampleId] = useState(PLAYGROUND_EXAMPLES[0].id);
+    const active =
+        PLAYGROUND_EXAMPLES.find((e) => e.id === exampleId) ??
+        PLAYGROUND_EXAMPLES[0];
+
     return (
-        <StitchPlayground
-            initialCode={initialCode}
-            runner={runner}
-            renderEditor={(props) => <CodeEditor {...props} />}
-            renderValue={(text) => (
-                <div className="stitch-playground__result">
-                    <span className="stitch-playground__result-label">
-                        returned
-                    </span>
-                    <DynamicCodeBlock lang="json" code={text} />
-                </div>
-            )}
-            renderLog={(text) =>
-                jsonLog(text) ? (
-                    <DynamicCodeBlock lang="json" code={text} />
-                ) : (
-                    text
-                )
-            }
-        />
+        <>
+            <div
+                className="stitch-playground-examples"
+                role="tablist"
+                aria-label="Example complexity"
+            >
+                {PLAYGROUND_EXAMPLES.map((ex) => (
+                    <button
+                        key={ex.id}
+                        type="button"
+                        role="tab"
+                        aria-selected={ex.id === exampleId}
+                        data-active={ex.id === exampleId}
+                        className="stitch-playground-examples__tab"
+                        title={ex.description}
+                        onClick={() => setExampleId(ex.id)}
+                    >
+                        {ex.label}
+                    </button>
+                ))}
+                <span className="stitch-playground-examples__hint">
+                    {active.description}
+                </span>
+            </div>
+
+            <StitchPlayground
+                key={active.id}
+                initialCode={active.code}
+                runner={runner}
+                renderEditor={(props) => <CodeEditor {...props} />}
+                renderValue={(text) => (
+                    <div className="stitch-playground__result">
+                        <span className="stitch-playground__result-label">
+                            returned
+                        </span>
+                        <DynamicCodeBlock lang="json" code={text} />
+                    </div>
+                )}
+                renderLog={(text) =>
+                    jsonLog(text) ? (
+                        <DynamicCodeBlock lang="json" code={text} />
+                    ) : (
+                        text
+                    )
+                }
+            />
+        </>
     );
 }
 

--- a/apps/docs/app/(home)/playground/page.tsx
+++ b/apps/docs/app/(home)/playground/page.tsx
@@ -9,16 +9,6 @@ export const metadata: Metadata = {
         'Run StitchAPI snippets in your browser against a built-in fake API. No real network, no install.',
 };
 
-const INITIAL_CODE = `// Edit and run — this executes in a sandboxed Web Worker.
-// Requests never hit the real network: they're served by an in-browser
-// StitchAPI simulator. Try /users, /users/2, /status/500, /drift?__drift=1,
-// or /stream?__stream=sse on the demo.stitchapi.dev host.
-const getUser = stitch('https://demo.stitchapi.dev/users/2');
-const user = await getUser();
-console.log(user);
-return user.data;
-`;
-
 export default function PlaygroundPage() {
     return (
         <main className="stitch-playground-page">
@@ -26,15 +16,16 @@ export default function PlaygroundPage() {
                 <header className="stitch-playground-page__header">
                     <h1>Playground</h1>
                     <p>
-                        Write a StitchAPI snippet and run it in an isolated
+                        A complete StitchAPI snippet, running in an isolated
                         browser sandbox. Calls are served by a built-in fake API
-                        — no real network, nothing to install. Use{' '}
-                        <code>__status</code>, <code>__stream</code>,{' '}
+                        — no real network, nothing to install. It loads the full
+                        tour on purpose — keep what you need and delete the
+                        rest. Use <code>__status</code>, <code>__stream</code>,{' '}
                         <code>__drift</code>, <code>__latencyMs</code>, or{' '}
                         <code>__flaky</code> query knobs to shape the response.
                     </p>
                 </header>
-                <PlaygroundClient initialCode={INITIAL_CODE} />
+                <PlaygroundClient />
             </div>
         </main>
     );

--- a/apps/docs/app/(home)/playground/playground-examples.ts
+++ b/apps/docs/app/(home)/playground/playground-examples.ts
@@ -1,0 +1,125 @@
+/**
+ * Playground example presets. The playground defaults to the COMPLETE tour so
+ * users see the full surface at once, and can switch DOWN to a minimal snippet
+ * — simplify when you need to, rather than build up from nothing.
+ */
+export interface PlaygroundExample {
+    /** Stable id, used as the React remount key and the active-tab marker. */
+    id: string;
+    /** Short tab label. */
+    label: string;
+    /** One-line hint shown as the tab's title/tooltip. */
+    description: string;
+    /** Editor contents for this preset. */
+    code: string;
+}
+
+const COMPLETE_EXAMPLE = `// StitchAPI - the whole library in one runnable file.
+//
+// This runs in a sandboxed Web Worker against an in-browser fake API
+// (demo.stitchapi.dev). No real network, nothing installed. It's the
+// *complete* example on purpose: keep what you need, delete the rest -
+// every numbered block stands on its own. (Use the Simple tab above for
+// the bare minimum.)
+
+// 1 - One declarative client. Config is data, not glue code: a base URL,
+//     default headers, an auth credential the stitch holds for you, and a
+//     full resilience policy - all described in a single object.
+const api = stitch({
+  name: 'demo-api',
+  baseUrl: 'https://demo.stitchapi.dev',
+  headers: { accept: 'application/json' },
+  auth: bearer('demo-token'), // sent as Authorization: Bearer ... on every call
+  retry: {
+    attempts: 4,
+    on: [429, 502, 503, 504],
+    backoff: 'expo-jitter',
+    baseMs: 100,
+    maxMs: 400,
+  },
+  timeout: { total: '4s', perAttempt: '2s' }, // fail fast instead of hanging
+  throttle: { rate: '50/s' }, // client-side rate limit
+  circuit: { failureThreshold: 5, cooldownMs: 1000 }, // stop hammering a dead dep
+  idempotency: { header: 'Idempotency-Key' }, // safe-retry writes (GET ignores it)
+  hooks: {
+    onRetry: () => console.log('   retrying after a transient failure...'),
+  },
+});
+
+// 2 - Derive endpoint clients with extends: each inherits everything above.
+//     unwrap pulls a value out of an envelope ({ data: ... } -> ...), and
+//     output validates what you actually receive (pass a Zod / Standard
+//     Schema validator in real code; a plain predicate works too).
+const getUser = stitch({
+  extends: [api],
+  path: '/users/{id}',
+  unwrap: 'data',
+  output: toValidator(
+    (u) => !!u && typeof u.id === 'number' && typeof u.email === 'string',
+  ),
+});
+
+// 3 - .with(...) is partial application: bind input now, reuse the call later.
+const user = await getUser.with({ params: { id: 2 } })();
+console.log('1) validated + unwrapped user:');
+console.log(user);
+
+// 4 - transform reshapes the raw body before unwrap and validation run.
+const listNames = stitch({
+  extends: [api],
+  path: '/users',
+  transform: (body) => body.data.map((u) => u.name),
+});
+const names = await listNames();
+console.log('2) names via transform:', names);
+
+// 5 - Auth, proven. /auth/me echoes the capability, never the token - the
+//     bearer credential from step 1 was applied for you.
+const me = await stitch({ extends: [api], path: '/auth/me' })();
+console.log('3) whoami:', me);
+
+// 6 - Resilience, live. This route fails twice (__flaky=2) before it
+//     succeeds; the retry policy + onRetry hook recover it. .stream() yields
+//     every lifecycle event (start -> progress -> result -> done) so you can
+//     watch the recovery happen instead of just awaiting a value.
+const flaky = stitch({ extends: [api], path: '/users', unwrap: 'data' });
+let recovered, attempts;
+for await (const event of flaky.stream({ query: { __flaky: 2 } })) {
+  if (event.type === 'result') recovered = event.value;
+  if (event.type === 'done') attempts = event.attempts;
+}
+console.log(
+  '4) recovered after ' + attempts + ' attempts, ' + recovered.length + ' users',
+);
+
+// Shape the response any way you like - try other routes and knobs:
+//   /users/9 (404), /status/500, /malformed (HTML), /limited (429),
+//   /drift?__drift=1, ?__latencyMs=800, ?__status=503
+// The returned value is shown in the Result panel below.
+return { user, names, me, recovered: recovered.length };
+`;
+
+const SIMPLE_EXAMPLE = `// The simplest call: give stitch a URL, await typed data back.
+// Runs against the in-browser fake API (demo.stitchapi.dev) - no real network.
+// Switch to the Complete tab above to see the full library in action.
+const getUser = stitch('https://demo.stitchapi.dev/users/2');
+const res = await getUser();
+console.log(res);
+return res.data;
+`;
+
+export const PLAYGROUND_EXAMPLES: PlaygroundExample[] = [
+    {
+        id: 'complete',
+        label: 'Complete',
+        description:
+            'The full tour - config, auth, validation, retries, and streaming.',
+        code: COMPLETE_EXAMPLE,
+    },
+    {
+        id: 'simple',
+        label: 'Simple',
+        description: 'One URL in, typed data out.',
+        code: SIMPLE_EXAMPLE,
+    },
+];

--- a/apps/docs/app/(home)/playground/playground.css
+++ b/apps/docs/app/(home)/playground/playground.css
@@ -34,6 +34,52 @@
     color: var(--color-fd-foreground);
 }
 
+/* ── Example switcher (Complete ↔ Simple) ───────────────────────────────── */
+.stitch-playground-examples {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-bottom: 0.6rem;
+    flex-wrap: wrap;
+}
+.stitch-playground-examples__tab {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    padding: 0.3rem 0.85rem;
+    border-radius: 999px;
+    border: 1px solid var(--color-fd-border);
+    background: transparent;
+    color: var(--color-fd-muted-foreground);
+    cursor: pointer;
+    transition:
+        background 0.15s ease,
+        color 0.15s ease,
+        border-color 0.15s ease;
+}
+.stitch-playground-examples__tab:hover {
+    color: var(--color-fd-foreground);
+    background: color-mix(in srgb, var(--color-fd-foreground) 6%, transparent);
+}
+.stitch-playground-examples__tab[data-active='true'] {
+    background: var(--stitch);
+    border-color: var(--stitch-border);
+    color: #fff;
+}
+.stitch-playground-examples__tab[data-active='true']:hover {
+    background: var(--stitch-strong);
+    color: #fff;
+}
+.stitch-playground-examples__hint {
+    margin-left: 0.35rem;
+    font-size: 0.78rem;
+    color: var(--color-fd-muted-foreground);
+}
+@media (max-width: 30rem) {
+    .stitch-playground-examples__hint {
+        display: none;
+    }
+}
+
 /* ── Shell ──────────────────────────────────────────────────────────────── */
 .stitch-playground {
     border: 1px solid var(--color-fd-border);


### PR DESCRIPTION
## What & why

The playground's default snippet was a 4-line stub. This makes the default a **complete, runnable tour of the library** so users see the full surface at once, and adds a **Complete ↔ Simple** preset switch so they can simplify *down* to a minimal example instead of building up from nothing.

The complete preset exercises, in one cohesive program:

- **Declarative config as data** — one `stitch({...})` base with `baseUrl`, `headers`, `auth: bearer(...)`, `retry`, `timeout`, `throttle`, `circuit`, `idempotency`, and `hooks`
- **`extends`** to derive endpoint clients that inherit the base
- **`unwrap`** + **`output` validation** via `toValidator(...)`
- **`.with(...)`** partial application
- **`transform`** to reshape the body
- **Auth proven** against `/auth/me` (capability returned, token never exposed)
- **Resilience, live** — a `__flaky=2` route that fails twice then recovers, watched event-by-event via **`.stream()`** with the `onRetry` hook firing

The **Simple** preset is a one-URL-in, typed-data-out snippet.

## Changes

- `playground-examples.ts` *(new)* — both presets in one module; Complete is the default
- `PlaygroundClient.tsx` — segmented switch; remounts the editor (React `key`) on preset change so it re-seeds from the chosen preset; the worker `runner` stays stable
- `page.tsx` — drop the inline `INITIAL_CODE`; presets live in the module
- `playground.css` — pill-style tab styling using existing Fumadocs `--color-fd-*` + `--stitch` tokens

## Verification

- The complete example was run **end-to-end against the real `stitch` engine + the real sandbox handlers** (`createFetchShim(allHandlers)`) with exact-value assertions on every feature path (user fetch, transform, bearer-auth capability, retry recovering after 2×503 → 3 attempts, `onRetry` firing twice).
- Local gates pass: pre-commit (format/lint/typecheck) and pre-push (typecheck/test/`@stitchapi/docs` build).
- Verified in the dev server: `/playground` compiles clean, renders both tabs with **Complete** active by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)