### PR TITLE
feat(docs): adopt Signal brand & color system

### DIFF
--- a/apps/docs/app/(home)/components/cta.tsx
+++ b/apps/docs/app/(home)/components/cta.tsx
@@ -1,5 +1,5 @@
 import { BrandBackdrop } from './brand-backdrop';
-import { GithubIcon, PrimaryButton, SecondaryButton } from './primitives';
+import { PrimaryButton } from './primitives';
 
 import { gitConfig } from '@/lib/shared';
 
@@ -11,7 +11,7 @@ export function Cta() {
         <section className="relative overflow-hidden border-b border-fd-border px-6 py-24 text-center">
             <BrandBackdrop variant="cta" />
             <div className="relative z-10 mx-auto max-w-2xl">
-                <h2 className="text-3xl font-extrabold tracking-tight text-fd-foreground sm:text-4xl">
+                <h2 className="font-display text-3xl font-extrabold tracking-[-0.02em] text-fd-foreground sm:text-4xl">
                     Replace fetch. Start with one endpoint.
                 </h2>
                 <p className="mx-auto mt-4 max-w-xl text-lg leading-relaxed text-fd-muted-foreground">
@@ -24,13 +24,6 @@ export function Cta() {
                         Start the quickstart
                         <ArrowRight className="size-4" />
                     </PrimaryButton>
-                    <SecondaryButton
-                        href={`https://github.com/${gitConfig.user}/${gitConfig.repo}`}
-                        external
-                    >
-                        <GithubIcon />
-                        View on GitHub
-                    </SecondaryButton>
                 </div>
             </div>
         </section>

--- a/apps/docs/app/(home)/components/hero.tsx
+++ b/apps/docs/app/(home)/components/hero.tsx
@@ -1,8 +1,6 @@
 import { BrandBackdrop } from './brand-backdrop';
 import { Code, CodePanel } from './code-panel';
-import { GithubIcon, PrimaryButton, SecondaryButton } from './primitives';
-
-import { gitConfig } from '@/lib/shared';
+import { PrimaryButton, SecondaryButton } from './primitives';
 
 import { ArrowRight, Bot, Code2, Server, Terminal } from 'lucide-react';
 
@@ -25,7 +23,7 @@ export function Hero() {
                         Agent-native API runtime
                     </span>
 
-                    <h1 className="mt-6 text-4xl font-extrabold leading-[1.08] tracking-tight text-fd-foreground sm:text-6xl">
+                    <h1 className="mt-6 font-display text-4xl font-black leading-[1.02] tracking-[-0.035em] text-fd-foreground sm:text-6xl">
                         A typed <span className="text-stitch">stitch</span>{' '}
                         replaces{' '}
                         <code className="rounded-lg bg-fd-muted px-2 py-0.5 align-middle font-mono text-[0.7em] text-fd-muted-foreground">
@@ -52,13 +50,6 @@ export function Hero() {
                         <SecondaryButton href="/playground">
                             <Terminal className="size-4 text-stitch" />
                             Try the playground
-                        </SecondaryButton>
-                        <SecondaryButton
-                            href={`https://github.com/${gitConfig.user}/${gitConfig.repo}`}
-                            external
-                        >
-                            <GithubIcon />
-                            View on GitHub
                         </SecondaryButton>
                     </div>
 

--- a/apps/docs/app/(home)/components/primitives.tsx
+++ b/apps/docs/app/(home)/components/primitives.tsx
@@ -46,7 +46,7 @@ export function SectionHeading({
             )}
         >
             {eyebrow ? <Eyebrow>{eyebrow}</Eyebrow> : null}
-            <h2 className="mt-3 text-3xl font-bold tracking-tight text-fd-foreground sm:text-4xl">
+            <h2 className="mt-3 font-display text-3xl font-extrabold tracking-[-0.02em] text-fd-foreground sm:text-4xl">
                 {title}
             </h2>
             {lead ? (

--- a/apps/docs/app/(home)/components/problem.tsx
+++ b/apps/docs/app/(home)/components/problem.tsx
@@ -59,7 +59,7 @@ export function Problem() {
                     >
                         <div className="flex items-start gap-3 px-6 py-4 sm:border-r sm:border-fd-border">
                             <span className="mt-2 size-1.5 shrink-0 rounded-full bg-fd-border" />
-                            <span className="text-sm text-fd-muted-foreground line-through decoration-fd-border decoration-1">
+                            <span className="text-sm text-fd-muted-foreground">
                                 {row.fetch}
                             </span>
                         </div>

--- a/apps/docs/app/(home)/playground/CodeEditor.tsx
+++ b/apps/docs/app/(home)/playground/CodeEditor.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { signalCodeMirrorTheme } from './codemirror-theme';
 import {
     instanceCompletionSource,
     playgroundCompletionSource,
@@ -13,22 +14,8 @@ import {
 } from '@codemirror/lang-javascript';
 import type { EditorRenderProps } from '@stitchapi/sandbox/component/StitchPlayground';
 import CodeMirror from '@uiw/react-codemirror';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { stitch } from 'stitchapi';
-
-/** Track the docs theme — Fumadocs toggles a `dark` class on <html>. */
-function useIsDark(): boolean {
-    const [dark, setDark] = useState(false);
-    useEffect(() => {
-        const el = document.documentElement;
-        const update = () => setDark(el.classList.contains('dark'));
-        update();
-        const obs = new MutationObserver(update);
-        obs.observe(el, { attributes: true, attributeFilter: ['class'] });
-        return () => obs.disconnect();
-    }, []);
-    return dark;
-}
 
 /**
  * Globals available inside every playground snippet.
@@ -59,8 +46,6 @@ export function CodeEditor({
     readOnly,
     height,
 }: EditorRenderProps) {
-    const dark = useIsDark();
-
     const extensions = useMemo(
         () => [
             javascript({ typescript: true, jsx: true }),
@@ -84,7 +69,7 @@ export function CodeEditor({
             className="stitch-playground__cm"
             value={value}
             height={`${height}px`}
-            theme={dark ? 'dark' : 'light'}
+            theme={signalCodeMirrorTheme}
             editable={!readOnly}
             readOnly={readOnly}
             extensions={extensions}

--- a/apps/docs/app/(home)/playground/codemirror-theme.ts
+++ b/apps/docs/app/(home)/playground/codemirror-theme.ts
@@ -1,0 +1,127 @@
+/**
+ * Signal-aligned CodeMirror 6 theme for the playground editor.
+ *
+ * Every color is a CSS custom property from the design-token layer
+ * (tokens.css / global.css), so the editor tracks light/dark on its own —
+ * no `dark` branch needed — and its syntax colors match the static `.tok-*`
+ * code panels (keyword → brand, function/type → accent, comment → faint…).
+ */
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { tags as t } from '@lezer/highlight';
+import { EditorView } from '@uiw/react-codemirror';
+
+/* Editor chrome: surface, gutters, cursor, selection, tooltips. */
+const editorChrome = EditorView.theme({
+    '&': {
+        color: 'var(--color-fd-foreground)',
+        backgroundColor: 'var(--color-fd-background)',
+    },
+    '.cm-content': {
+        caretColor: 'var(--brand)',
+        fontFamily: 'var(--font-mono)',
+    },
+    '.cm-cursor, .cm-dropCursor': { borderLeftColor: 'var(--brand)' },
+    '&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection':
+        { backgroundColor: 'var(--brand-soft)' },
+    '.cm-activeLine': {
+        backgroundColor: 'color-mix(in srgb, var(--brand) 6%, transparent)',
+    },
+    '.cm-gutters': {
+        backgroundColor: 'var(--color-fd-background)',
+        color: 'var(--text-faint)',
+        border: 'none',
+    },
+    '.cm-activeLineGutter': {
+        backgroundColor: 'transparent',
+        color: 'var(--text-muted)',
+    },
+    '.cm-tooltip': {
+        backgroundColor: 'var(--color-fd-popover)',
+        border: '1px solid var(--color-fd-border)',
+        color: 'var(--color-fd-foreground)',
+    },
+    '.cm-tooltip-autocomplete ul li[aria-selected]': {
+        backgroundColor: 'var(--brand)',
+        color: 'var(--brand-ink)',
+    },
+});
+
+/* Syntax: maps lezer highlight tags onto the Signal `--syn-*` tokens. */
+const signalHighlight = HighlightStyle.define([
+    {
+        tag: [t.comment, t.lineComment, t.blockComment],
+        color: 'var(--syn-comment)',
+        fontStyle: 'italic',
+    },
+    {
+        tag: [
+            t.keyword,
+            t.controlKeyword,
+            t.operatorKeyword,
+            t.definitionKeyword,
+            t.moduleKeyword,
+            t.modifier,
+            t.self,
+            t.null,
+        ],
+        color: 'var(--syn-keyword)',
+    },
+    {
+        tag: [
+            t.function(t.variableName),
+            t.function(t.propertyName),
+            t.labelName,
+            t.typeName,
+            t.className,
+            t.namespace,
+        ],
+        color: 'var(--syn-func)',
+    },
+    {
+        tag: [
+            t.string,
+            t.special(t.string),
+            t.regexp,
+            t.number,
+            t.integer,
+            t.float,
+            t.bool,
+            t.atom,
+            t.unit,
+        ],
+        color: 'var(--syn-string)',
+    },
+    {
+        tag: [
+            t.propertyName,
+            t.attributeName,
+            t.variableName,
+            t.definition(t.variableName),
+        ],
+        color: 'var(--syn-name)',
+    },
+    {
+        tag: [
+            t.punctuation,
+            t.separator,
+            t.bracket,
+            t.squareBracket,
+            t.paren,
+            t.brace,
+            t.angleBracket,
+            t.derefOperator,
+            t.operator,
+            t.compareOperator,
+            t.arithmeticOperator,
+            t.logicOperator,
+        ],
+        color: 'var(--syn-punct)',
+    },
+    { tag: [t.meta, t.escape], color: 'var(--accent)' },
+    { tag: t.invalid, color: '#ff6b4a' },
+]);
+
+export const signalCodeMirrorTheme = [
+    editorChrome,
+    syntaxHighlighting(signalHighlight),
+];

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -1,27 +1,69 @@
 @import 'tailwindcss';
 @import 'fumadocs-ui/css/neutral.css';
 @import 'fumadocs-ui/css/preset.css';
+@import './tokens.css';
 
-/* --- StitchAPI brand accent (logo blue), theme-aware ----------------------- */
+/* --- Design tokens → Tailwind theme --------------------------------------- *
+ * The Signal brand routes through the legacy `--stitch*` names so existing
+ * `text-stitch`, `bg-stitch`, `border-stitch-border` utilities keep working —
+ * they now resolve to the adopted brand tokens (see tokens.css). The amber
+ * `accent` and the three type families are exposed as utilities too.
+ * `inline` keeps the values theme-aware (they reference runtime vars).        */
 @theme inline {
     --color-stitch: var(--stitch);
     --color-stitch-strong: var(--stitch-strong);
     --color-stitch-soft: var(--stitch-soft);
     --color-stitch-border: var(--stitch-border);
+
+    /* Complementary amber accent — use sparingly. */
+    --color-accent: var(--accent);
+    --color-accent-ink: var(--accent-ink);
+    --color-accent-soft: var(--accent-soft);
+    --color-accent-line: var(--accent-line);
+
+    /* Type families (mirror the stacks in tokens.css; the bare --font-*
+       vars come from next/font in layout.tsx). */
+    --font-display: var(--font-schibsted), 'Schibsted Grotesk', system-ui,
+        sans-serif;
+    --font-sans: var(--font-hanken), 'Hanken Grotesk', system-ui, sans-serif;
+    --font-mono: var(--font-ibm-plex-mono), 'IBM Plex Mono', ui-monospace,
+        'SF Mono', monospace;
 }
 
+/* Brand alias: point the site's brand handles at the Signal tokens. These
+   reference theme-scoped vars, so one block covers light + dark. */
 :root {
-    --stitch: #3b82f6; /* brand blue, straight from the logo */
-    --stitch-strong: #2563eb;
-    --stitch-soft: #eff6ff;
-    --stitch-border: #bfdbfe;
+    --stitch: var(--brand);
+    --stitch-strong: var(--brand-strong);
+    --stitch-soft: var(--brand-soft);
+    --stitch-border: var(--brand-line);
 }
 
-.dark {
-    --stitch: #60a5fa; /* brighter on dark surfaces, matches the dark banner */
-    --stitch-strong: #93c5fd;
-    --stitch-soft: color-mix(in srgb, #1e3a8a 32%, transparent);
-    --stitch-border: color-mix(in srgb, #60a5fa 26%, transparent);
+/* Adopt the Signal neutral scaffold + brand across Fumadocs' semantic tokens.
+   Each value is a theme-aware design token, so this single block recolors both
+   light and dark (it follows the preset imports, so it wins on source order). */
+:root {
+    --color-fd-background: var(--bg);
+    --color-fd-foreground: var(--text);
+    --color-fd-muted: var(--surface-2);
+    --color-fd-muted-foreground: var(--text-muted);
+    --color-fd-popover: var(--surface);
+    --color-fd-popover-foreground: var(--text);
+    --color-fd-card: var(--surface);
+    --color-fd-card-foreground: var(--text);
+    --color-fd-border: var(--border);
+    --color-fd-primary: var(--brand);
+    --color-fd-primary-foreground: var(--brand-ink);
+    --color-fd-secondary: var(--surface-2);
+    --color-fd-secondary-foreground: var(--text);
+    --color-fd-accent: var(--surface-3);
+    --color-fd-accent-foreground: var(--text);
+    --color-fd-ring: var(--brand);
+    --color-fd-font-mono: var(--font-mono);
+}
+
+body {
+    font-family: var(--font-sans);
 }
 
 html {
@@ -130,31 +172,25 @@ html > body[data-scroll-locked] {
     }
 }
 
-/* --- Minimal token coloring for the static code panels -------------------- */
+/* --- Code-panel syntax: adopted Signal syntax tokens (theme-aware) --------- */
 .code-panel {
     tab-size: 4;
 }
 .tok-key {
-    color: var(--stitch);
+    color: var(--syn-keyword); /* keywords → brand */
 }
 .tok-str {
-    color: #c2882a;
-}
-.dark .tok-str {
-    color: #e0b252;
+    color: var(--syn-string); /* strings → accent/text mix */
 }
 .tok-fn {
-    color: #2563eb;
-}
-.dark .tok-fn {
-    color: #7aa2f7;
+    color: var(--syn-func); /* functions/types → accent */
 }
 .tok-com {
-    color: var(--color-fd-muted-foreground);
+    color: var(--syn-comment); /* comments → faint */
     font-style: italic;
 }
 .tok-punc {
-    color: var(--color-fd-muted-foreground);
+    color: var(--syn-punct); /* punctuation → muted */
 }
 
 /* --- Twoslash hover affordance: only underline the token under the cursor ----

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -7,11 +7,33 @@ import { Banner } from 'fumadocs-ui/components/banner';
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import { Construction } from 'lucide-react';
 import type { Metadata } from 'next';
-import { Inter } from 'next/font/google';
+import {
+    Hanken_Grotesk,
+    IBM_Plex_Mono,
+    Schibsted_Grotesk,
+} from 'next/font/google';
 
-const inter = Inter({
+/* Signal type system — display / body / mono (Brand & Color System). */
+const fontDisplay = Schibsted_Grotesk({
     subsets: ['latin'],
+    weight: ['400', '500', '600', '700', '800', '900'],
+    variable: '--font-schibsted',
+    display: 'swap',
 });
+const fontSans = Hanken_Grotesk({
+    subsets: ['latin'],
+    weight: ['400', '500', '600', '700'],
+    variable: '--font-hanken',
+    display: 'swap',
+});
+const fontMono = IBM_Plex_Mono({
+    subsets: ['latin'],
+    weight: ['400', '500', '600', '700'],
+    variable: '--font-ibm-plex-mono',
+    display: 'swap',
+});
+
+const fontVariables = `${fontDisplay.variable} ${fontSans.variable} ${fontMono.variable}`;
 
 export const metadata: Metadata = {
     metadataBase: new URL(siteUrl),
@@ -19,7 +41,7 @@ export const metadata: Metadata = {
 
 export default function Layout({ children }: LayoutProps<'/'>) {
     return (
-        <html lang="en" className={inter.className} suppressHydrationWarning>
+        <html lang="en" className={fontVariables} suppressHydrationWarning>
             <body className="flex flex-col min-h-screen">
                 <RootProvider>
                     <Banner

--- a/apps/docs/app/tokens.css
+++ b/apps/docs/app/tokens.css
@@ -1,0 +1,152 @@
+/* ============================================================
+   StitchAPI — Design Tokens
+   Brand: Signal (electric blue + amber) — LOCKED
+   ------------------------------------------------------------
+   Adopted from the Claude Design "Brand & Color System" handoff
+   (claude.ai/design). The exploration landed on the *Signal*
+   direction; these are its finalized semantic + typographic
+   tokens, re-keyed onto Fumadocs' `:root` (light) / `.dark`
+   theming so the whole site tracks the active theme.
+
+   Reference tokens only via var(--*); never hard-code a hex in
+   product code. The family stacks below are mirrored into
+   Tailwind's @theme in global.css so the font-* utilities match.
+   ============================================================ */
+
+/* ---------- Theme-agnostic foundations ---------- */
+:root {
+    /* Type families — Schibsted Grotesk (display), Hanken Grotesk
+       (body), IBM Plex Mono (code). The bare --font-* vars are
+       supplied by next/font in layout.tsx. */
+    --font-display: var(--font-schibsted), 'Schibsted Grotesk', system-ui,
+        sans-serif;
+    --font-sans: var(--font-hanken), 'Hanken Grotesk', system-ui, sans-serif;
+    --font-mono: var(--font-ibm-plex-mono), 'IBM Plex Mono', ui-monospace,
+        'SF Mono', monospace;
+
+    /* Type scale — display & h2 are fluid (clamp). */
+    --fs-display: clamp(40px, 5.6vw, 68px);
+    --fs-h2: clamp(28px, 3.4vw, 42px);
+    --fs-h3: 21px;
+    --fs-lg: 19px;
+    --fs-body: 16px;
+    --fs-sm: 14px;
+    --fs-xs: 12.5px;
+
+    /* Weights */
+    --fw-regular: 400;
+    --fw-medium: 500;
+    --fw-semibold: 600;
+    --fw-bold: 700;
+    --fw-heavy: 800;
+    --fw-black: 900;
+
+    /* Tracking */
+    --ls-tight: -0.035em;
+    --ls-snug: -0.02em;
+    --ls-label: 0.14em;
+
+    /* Radii */
+    --r-sm: 8px;
+    --r-md: 12px;
+    --r-lg: 16px;
+    --r-xl: 22px;
+    --r-pill: 999px;
+
+    --ease: cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+/* ============================================================
+   SEMANTIC COLOR — LIGHT (default)
+   ============================================================ */
+:root {
+    /* Background & surfaces */
+    --bg: #fbfbfd; /* app background */
+    --surface: #ffffff; /* cards, panels */
+    --surface-2: #f6f7f9; /* raised / inset sections */
+    --surface-3: #f0f2f6; /* hover, controls */
+
+    /* Lines */
+    --border: #e4e7ee; /* component borders */
+    --hairline: #edeff4; /* faint dividers */
+
+    /* Text */
+    --text: #0c1019; /* primary copy */
+    --text-muted: #58616f; /* secondary copy */
+    --text-faint: #8b94a2; /* captions, meta, code comments */
+
+    /* Code surfaces */
+    --code-bg: #f7f8fa;
+    --code-border: #e9ecf2;
+
+    /* Brand — Signal (deeper blue holds contrast on light) */
+    --brand: #2563eb; /* primary fill / line / link */
+    --brand-strong: #1d4fd0; /* hover */
+    --brand-ink: #ffffff; /* text/glyph ON brand fill */
+
+    /* Accent — complementary amber (use sparingly) */
+    --accent: #b4690a;
+    --accent-ink: #ffffff; /* text ON accent fill */
+
+    /* Elevation */
+    --shadow-sm: 0 1px 2px rgba(16, 22, 40, 0.06);
+    --shadow-md: 0 12px 30px -14px rgba(16, 22, 40, 0.18);
+    --shadow-lg: 0 30px 70px -28px rgba(16, 22, 40, 0.26);
+    --on-brand-shadow: 0 10px 24px -10px;
+}
+
+/* ============================================================
+   SEMANTIC COLOR — DARK
+   `.dark` follows `:root` in source order so it wins on <html>.
+   ============================================================ */
+.dark {
+    --bg: #0a0d13;
+    --surface: #0f141c;
+    --surface-2: #151b26;
+    --surface-3: #1a2230;
+
+    --border: #232b3a;
+    --hairline: #19202c;
+
+    --text: #e9edf4;
+    --text-muted: #98a2b3;
+    --text-faint: #616b7c;
+
+    --code-bg: #0c1119;
+    --code-border: #1b2330;
+
+    /* Brand — Signal (brighter on dark surfaces) */
+    --brand: #4c8dff;
+    --brand-strong: #6ba1ff;
+    --brand-ink: #06101f;
+
+    --accent: #f6a823;
+    --accent-ink: #1a1305;
+
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 10px 30px -12px rgba(0, 0, 0, 0.7);
+    --shadow-lg: 0 28px 70px -24px rgba(0, 0, 0, 0.85);
+    --on-brand-shadow: 0 8px 24px -8px;
+}
+
+/* ============================================================
+   DERIVED TINTS + SYNTAX — theme-agnostic.
+   These reference the theme-scoped brand/accent/text vars above,
+   so color-mix re-resolves per theme automatically.
+   ============================================================ */
+:root {
+    /* Soft fills, focus rings, hairline accents. */
+    --brand-soft: color-mix(in srgb, var(--brand) 14%, transparent);
+    --brand-softer: color-mix(in srgb, var(--brand) 7%, transparent);
+    --brand-line: color-mix(in srgb, var(--brand) 38%, transparent);
+    --accent-soft: color-mix(in srgb, var(--accent) 16%, transparent);
+    --accent-line: color-mix(in srgb, var(--accent) 42%, transparent);
+
+    /* Code-sample token roles. */
+    --syn-comment: var(--text-faint); /* comments (italic) */
+    --syn-keyword: var(--brand); /* keywords */
+    --syn-func: var(--accent); /* functions / types */
+    --syn-string: color-mix(in srgb, var(--accent) 80%, var(--text));
+    --syn-punct: var(--text-muted); /* punctuation */
+    --syn-name: var(--text); /* identifiers */
+}

--- a/apps/docs/components/logo.tsx
+++ b/apps/docs/components/logo.tsx
@@ -2,9 +2,11 @@ import { cn } from '@/lib/cn';
 
 /**
  * StitchAPI logomark — cloud + `</>` + the dashed "stitch" seam.
- * Cloud arcs use the brand blue; the code/stitch use currentColor so the mark
- * reads correctly on light and dark surfaces alike. Paths and the viewBox are
- * taken straight from the official logomark artwork (tile background dropped).
+ * Uses the Signal palette: cloud arcs in the brand blue, the dashed "stitch"
+ * seam in the complementary amber accent, and the `</>` brackets in
+ * currentColor so they stay legible on light and dark surfaces alike. Paths
+ * and the viewBox are taken straight from the official logomark artwork (tile
+ * background dropped).
  */
 export function Logomark({ className }: { className?: string }) {
     return (
@@ -22,10 +24,13 @@ export function Logomark({ className }: { className?: string }) {
                 <path d="M785.69,637.78h-28.08c-10.96,0-19.7-9.68-18.12-20.94c1.08-7.65,7-13.9,14.59-15.34c0.17-0.03,0.33-0.06,0.5-0.08c0.45-0.07,0.86-0.29,1.18-0.61l4.9-4.9c0.64-0.64,0.26-1.75-0.64-1.83c-0.8-0.08-1.61-0.12-2.42-0.12c-13.92,0-25.27,11.21-25.51,25.07c-0.24,14.27,11.74,25.95,26.02,25.95h26.09c0.86,0,1.62-0.57,1.87-1.4l1.11-3.81C787.49,638.78,786.73,637.78,785.69,637.78z" />
                 <path d="M767.79,588.79l3.47-3.47c0.46-0.46,0.63-1.13,0.48-1.76c-0.16-0.69-0.29-1.4-0.38-2.12c-1.62-12.52,7.25-24.02,19.76-25.64c6.55-0.85,12.81,1.19,17.54,5.11c0.95,0.79,2.38,0.36,2.74-0.82l0.97-3.23c0.33-1.09-0.07-2.28-1-2.94c-6.51-4.59-14.84-6.64-23.4-4.89c-13.84,2.83-23.98,15.18-24.01,29.31c-0.01,3.53,0.58,6.88,1.66,9.98C765.93,589.22,767.1,589.48,767.79,588.79z" />
             </g>
-            {/* code brackets + dashed stitch (ink / currentColor) */}
+            {/* code brackets </> (ink / currentColor) */}
             <g fill="currentColor">
                 <path d="M827.87,590.84l14.04,14.04l-14.04,14.04c-0.96,0.96-0.96,2.52,0,3.49l2.95,2.95c0.96,0.96,2.52,0.96,3.49,0l18.8-18.8c0.92-0.92,0.92-2.42,0-3.35l-18.8-18.8c-0.96-0.96-2.52-0.96-3.49,0l-2.95,2.95C826.91,588.31,826.91,589.87,827.87,590.84z" />
                 <path d="M787.83,587.35l-2.95-2.95c-0.96-0.96-2.52-0.96-3.49,0l-18.8,18.8c-0.92,0.92-0.92,2.42,0,3.35l18.8,18.8c0.96,0.96,2.52,0.96,3.49,0l2.95-2.95c0.96-0.96,0.96-2.52,0-3.49l-14.04-14.04l14.04-14.04C788.79,589.87,788.79,588.31,787.83,587.35z" />
+            </g>
+            {/* dashed "stitch" seam — complementary amber accent */}
+            <g fill="var(--accent)">
                 <path d="M810.42,605.48h-3.45c-1.52,0-2.86,1-3.3,2.45l-4.6,15.28c-0.5,1.67,0.75,3.35,2.49,3.35H805c1.52,0,2.86-1,3.3-2.45l4.6-15.28C813.41,607.17,812.16,605.48,810.42,605.48z" />
                 <path d="M817.93,580.53h-3.45c-1.52,0-2.86,1-3.3,2.45l-4.6,15.28c-0.5,1.67,0.75,3.35,2.49,3.35h3.45c1.52,0,2.86-1,3.3-2.45l4.6-15.28C820.93,582.22,819.68,580.53,817.93,580.53z" />
                 <path d="M802.9,630.43h-3.45c-1.52,0-2.86,1-3.3,2.45l-4.6,15.28c-0.5,1.67,0.75,3.35,2.49,3.35h3.45c1.52,0,2.86-1,3.3-2.45l4.6-15.28C805.89,632.11,804.64,630.43,802.9,630.43z" />

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -17,6 +17,8 @@
     "dependencies": {
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/lang-javascript": "^6.2.2",
+        "@codemirror/language": "^6.12.3",
+        "@lezer/highlight": "^1.2.3",
         "@stitchapi/sandbox": "workspace:*",
         "@uiw/react-codemirror": "^4.23.0",
         "fumadocs-core": "^16.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
       '@codemirror/lang-javascript':
         specifier: ^6.2.2
         version: 6.2.5
+      '@codemirror/language':
+        specifier: ^6.12.3
+        version: 6.12.3
+      '@lezer/highlight':
+        specifier: ^1.2.3
+        version: 1.2.3
       '@stitchapi/sandbox':
         specifier: workspace:*
         version: link:../../docs/sandbox
@@ -6927,8 +6933,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.7
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -6954,7 +6960,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6965,21 +6971,21 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6990,7 +6996,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
Adopts the finalized **Signal** direction (electric blue + complementary amber) from the [claude.ai/design](https://claude.ai/design) **Brand & Color System** handoff. The design exploration tried four palettes and landed on Signal; this brings its exported semantic + typography tokens into the docs site.

## Color system
- **`app/tokens.css`** (new) — adopted semantic colors (light `:root` / dark `.dark`), typography families/scale/weights/tracking, radii, derived brand/accent tints, and syntax tokens.
- **`app/global.css`** — rewires `--stitch*` to the Signal brand (so every existing `text-stitch`/`bg-stitch` utility rebrands automatically), maps Fumadocs `--color-fd-*` neutrals/primary/ring onto the design tokens, exposes `accent` + `font-*` utilities, and retargets the static code-panel syntax colors.

## Typography
- Schibsted Grotesk (display), Hanken Grotesk (body), **IBM Plex Mono** (code) via `next/font` (replacing Inter). IBM Plex Mono stands in for JetBrains Mono. Display font applied to the landing headlines.

## Refinements
- **Playground CodeMirror** themed to the Signal spec — keyword → brand, function/type → accent, comment → faint italic, etc., theme-aware via CSS vars (adds `@codemirror/language` + `@lezer/highlight`).
- **Logo** — the dashed "stitch" seam now uses the amber accent (cloud stays brand blue, `</>` brackets stay foreground).
- Removed the "View on GitHub" buttons from the hero + CTA (the header GitHub link is enough).
- Dropped the strikethrough in the fetch-vs-stitch table.

## Verification
- Pre-push gate green: `format`, `lint`, `typecheck`, `test`, `exports`, **`build-docs`** (`next build`).
- Verified live in light + dark on `/` and `/playground`: brand `#2563EB`/`#4C8DFF`, accent `#B4690A`/`#F6A823`, neutral scaffold, fonts, and on-spec CodeMirror syntax colors.

## Follow-up
The favicons (`app/icon.png`, `app/apple-icon.png`), README banner PNGs (`docs/media/baner_{light,dark}.png`), and the in-repo brandbook (`docs/brand/`) still bake in the old logo blue (`#3B82F6`) and need regenerating to Signal — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)