### PR TITLE
feat(core): infer Stitch<T> result type from the output schema

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -74,8 +74,8 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
         {
             label: 'output',
             type: 'property',
-            detail: 'Validator | DriftSpec',
-            info: 'Response schema, or a  for leveled drift detection.',
+            detail: 'SchemaLike | DriftSpec',
+            info: 'Response schema, or a  for leveled drift detection. Accepts any (raw Zod / Standard Schema / Validator / predicate); the stitch infers its result type from it (see `InferOutput`), so a hand-written generic is rarely needed.',
         },
         {
             label: 'unwrap',

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -31,6 +31,10 @@ pre-push:
           run: pnpm check:lint
         - name: typecheck
           run: pnpm check:types
+        # Type-level tests (tsd) for the inferred public API — builds the package's d.ts and
+        # asserts `stitch({ output: schema })` resolves to the right `Stitch<T>`.
+        - name: typecheck-d
+          run: pnpm check:types-d
         - name: test
           run: pnpm test
         - name: exports

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "test": "pnpm -r test",
         "test:coverage": "pnpm -r test:coverage",
         "check:types": "pnpm -r check:types",
+        "check:types-d": "pnpm -r check:types-d",
         "check:lint": "pnpm -r check:lint",
         "check:exports": "pnpm -r check:exports",
         "check:format": "prettier --check .",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,6 +70,7 @@
         "test:watch": "vitest",
         "test:coverage": "vitest run --coverage",
         "check:types": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+        "check:types-d": "tsup --silent && tsd",
         "check:lint": "eslint src test",
         "check:exports": "attw --pack . --ignore-rules no-resolution",
         "lint": "eslint src test",
@@ -130,10 +131,27 @@
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
         "jiti": "^2.7.0",
+        "tsd": "^0.33.0",
         "tsup": "^8.3.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.61.0",
         "vitest": "^4.1.8",
         "zod": "^3.23.8"
+    },
+    "tsd": {
+        "directory": "test-d",
+        "compilerOptions": {
+            "strict": true,
+            "exactOptionalPropertyTypes": true,
+            "noUncheckedIndexedAccess": true,
+            "skipLibCheck": true,
+            "target": "ES2022",
+            "module": "ESNext",
+            "moduleResolution": "bundler",
+            "lib": [
+                "ES2022",
+                "DOM"
+            ]
+        }
     }
 }

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -226,7 +226,9 @@ async function validateInput(
     input: StitchInput,
 ): Promise<void> {
     for (const part of ['params', 'query', 'body', 'headers'] as const) {
-        const v = cfg.input?.[part];
+        // `input.*` is widened to SchemaLike for authoring ergonomics, but `compose` →
+        // `normalizeInput` has already coerced every present slot to a Validator by now.
+        const v = cfg.input?.[part] as Validator | undefined;
         if (!v) continue;
         const r = await v.validate((input as Record<string, unknown>)[part]);
         if (!r.ok) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,5 +26,7 @@ export type {
     OtlpOptions,
 } from './otlp';
 export { toValidator } from './validator';
+export type { Issue, ValidationResult, Validator } from './validator';
+export type { InferInput, InferOutput, SchemaLike } from './infer';
 export { memoryStore } from './store';
 export * from './types';

--- a/packages/core/src/infer.ts
+++ b/packages/core/src/infer.ts
@@ -21,7 +21,9 @@ export type SchemaLike =
  * Extract the validated RESULT type a schema produces, in priority order: a `drift()` wrapper,
  * any Standard Schema (`~standard.types.output` — Valibot, ArkType, Zod ≥3.24, Zod 4), a Zod
  * schema (its `_output` phantom, covering Zod < 3.24 which predates Standard Schema), a
- * hand-rolled {@link Validator}, and a user-defined type-guard predicate. Anything else → unknown.
+ * hand-rolled {@link Validator}, and a type-guard predicate (the guarded type). Anything else →
+ * unknown. Note a predicate TypeScript infers as a guard counts here: `(v) => v != null` is typed
+ * `(v) => v is {}`, so it yields `{}`; only a non-narrowing `(v) => boolean` falls through to unknown.
  */
 export type InferOutput<S> =
     S extends DriftSpec<infer D>

--- a/packages/core/src/infer.ts
+++ b/packages/core/src/infer.ts
@@ -1,0 +1,71 @@
+// Type-level inference: read the result type straight off a validation schema, so a stitch's
+// generic can be inferred instead of hand-written. Pure types — nothing here exists at runtime
+// (the actual coercion is `toValidator()` in validator.ts). This is what lets
+// `stitch({ output: userSchema })` resolve to `Stitch<User>` with no explicit generic and no cast.
+import type { StandardSchemaV1 } from './standard-schema';
+import type { DriftSpec } from './types';
+import type { Validator } from './validator';
+
+/**
+ * Any schema shape a stitch accepts wherever a {@link Validator} was previously required —
+ * `output` and the `input.*` slots. Widening to this union is what removes the old `asValidator`
+ * cast: a raw Zod / Standard Schema / predicate now type-checks directly.
+ */
+export type SchemaLike =
+    | Validator
+    | StandardSchemaV1<unknown, unknown>
+    | { readonly _output: unknown } // Zod (v3/v4) phantom marker
+    | ((value: unknown) => boolean); // plain predicate / type guard
+
+/**
+ * Extract the validated RESULT type a schema produces, in priority order: a `drift()` wrapper,
+ * any Standard Schema (`~standard.types.output` — Valibot, ArkType, Zod ≥3.24, Zod 4), a Zod
+ * schema (its `_output` phantom, covering Zod < 3.24 which predates Standard Schema), a
+ * hand-rolled {@link Validator}, and a user-defined type-guard predicate. Anything else → unknown.
+ */
+export type InferOutput<S> =
+    S extends DriftSpec<infer D>
+        ? D
+        : S extends StandardSchemaV1<unknown, infer O>
+          ? O
+          : S extends { readonly _output: infer O }
+            ? O
+            : S extends Validator<infer O>
+              ? O
+              : S extends (value: unknown) => value is infer G
+                ? G
+                : unknown;
+
+/**
+ * Extract the INPUT type a schema accepts (pre-coercion). Used to type call arguments from
+ * `input` schemas (Phase 2). A {@link Validator} carries a single type, so it stands in for both
+ * sides; a plain predicate / type guard narrows to its guarded type. Anything else → unknown.
+ */
+export type InferInput<S> =
+    S extends StandardSchemaV1<infer I, unknown>
+        ? I
+        : S extends { readonly _input: infer I }
+          ? I
+          : S extends Validator<infer O>
+            ? O
+            : S extends (value: unknown) => value is infer G
+              ? G
+              : unknown;
+
+/**
+ * Map a config object's `output` slot to the stitch result type. No `output` key → `unknown`
+ * (the historical default), so a stitch with no response schema is unchanged.
+ */
+export type OutputOf<C> = C extends { output: infer O }
+    ? InferOutput<O>
+    : unknown;
+
+/**
+ * Resolve a stitch's result type at the call boundary: an explicitly supplied generic always
+ * wins (the escape hatch — `stitch<Foo>(...)`); otherwise infer from the config's `output`
+ * schema. `[TExplicit] extends [never]` is the "was a generic given?" test (`never` is the
+ * default, and the tuple wrapper stops `never` from distributing).
+ */
+export type ResolveOutput<TExplicit, C> = [TExplicit] extends [never]
+    ? OutputOf<C>
+    : TExplicit;

--- a/packages/core/src/seam.ts
+++ b/packages/core/src/seam.ts
@@ -107,8 +107,11 @@ function makeHandle(shared: SharedSeam, principal: string | undefined): Seam {
     };
 
     return {
-        stitch: (config) => build(config),
-        graphql: (config) => build(config, true),
+        // `build` is generic at runtime; the inferring overloads come from the `Seam` interface,
+        // which the object literal is checked against (function return type).
+        stitch: (config: string | Partial<StitchConfig>) => build(config),
+        graphql: (config: Partial<StitchConfig> & { query: string }) =>
+            build(config, true),
         as: (p) => makeHandle(shared, p),
         async flush() {
             await shared.trace.flush?.();

--- a/packages/core/src/standard-schema.ts
+++ b/packages/core/src/standard-schema.ts
@@ -1,13 +1,24 @@
 // Minimal local copy of the Standard Schema v1 interface (https://standardschema.dev).
-// Zod >=3.24, Valibot, ArkType all expose `~standard`. We only need the validate entry point.
-
-export interface StandardSchemaV1<Output = unknown> {
+// Zod >=3.24, Valibot, ArkType all expose `~standard`. We need the validate entry point at
+// runtime and the optional `types` phantom at compile time: that is how a Standard Schema carries
+// its inferred input/output types, which `InferInput`/`InferOutput` (src/infer.ts) read so a
+// stitch can infer its result type from the schema instead of a hand-written generic.
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
     readonly '~standard': {
         readonly version: 1;
         readonly vendor: string;
         readonly validate: (
             value: unknown,
         ) => StandardResult<Output> | Promise<StandardResult<Output>>;
+        /**
+         * Phantom carrier for the inferred types — never present at runtime (validators don't set
+         * it), so it is typed optional and read only at the type level. `input` is what the schema
+         * accepts; `output` is what it produces after coercion.
+         */
+        readonly types?: {
+            readonly input: Input;
+            readonly output: Output;
+        };
     };
 }
 

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -330,8 +330,12 @@ export interface StitchFn {
     >(
         config: C,
     ): Stitch<ResolveOutput<TExplicit, C>>;
-    /** Shorthand: a bare path string (no schema, so the result type is `unknown`). */
-    <T = unknown>(config: string): Stitch<T>;
+    /**
+     * Non-inferring fallback: a bare path string, or any argument whose static type is the union
+     * `string | Partial<StitchConfig>` (e.g. a wrapper that forwards either spelling). Neither can
+     * match the inferring overload above, so the result is `Stitch<unknown>` — override with `<T>`.
+     */
+    <T = unknown>(config: string | Partial<StitchConfig>): Stitch<T>;
     use(...fragments: Fragment[]): Builder;
 }
 

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -2,6 +2,7 @@
 // `.with()` partial application, all resolving to one canonical config. For a shared surface —
 // shared runtime + a trusted principal boundary — reach for `seam` (see seam.ts).
 import { type Runtime, execute, executeRaw, makeRuntime } from './engine';
+import type { InferOutput, ResolveOutput } from './infer';
 import { otlpTrace } from './otlp';
 import { createThrottle } from './resilience';
 import { createStoreThrottle, memoryStore } from './store';
@@ -317,9 +318,20 @@ export function makeStitch<T = unknown>(
 
 // ---- public API -----------------------------------------------------------
 export interface StitchFn {
-    <T = unknown>(
-        config: string | (Partial<StitchConfig> & { path?: string }),
-    ): Stitch<T>;
+    /**
+     * Build a stitch from a config object. The result type is inferred from `config.output`'s
+     * schema (Zod / Standard Schema / Validator / `drift()`), so no hand-written generic is
+     * needed. Supply one explicitly — `stitch<Foo>(config)` — only to override the inferred type;
+     * the explicit generic always wins.
+     */
+    <
+        TExplicit = never,
+        C extends Partial<StitchConfig> = Partial<StitchConfig>,
+    >(
+        config: C,
+    ): Stitch<ResolveOutput<TExplicit, C>>;
+    /** Shorthand: a bare path string (no schema, so the result type is `unknown`). */
+    <T = unknown>(config: string): Stitch<T>;
     use(...fragments: Fragment[]): Builder;
 }
 
@@ -331,20 +343,32 @@ export const stitch: StitchFn = Object.assign(
     },
 );
 
-/** drift(): wrap an output schema with leveled drift options. */
-export function drift(schema: unknown, options: DriftOptions = {}): DriftSpec {
+/**
+ * drift(): wrap an output schema with leveled drift options. The wrapped contract type is
+ * inferred from the schema, so `stitch({ output: drift(userSchema) })` still resolves to
+ * `Stitch<User>`.
+ */
+export function drift<S>(
+    schema: S,
+    options: DriftOptions = {},
+): DriftSpec<InferOutput<S>> {
     return {
         __kind: 'drift',
-        schema: toValidator(schema) as Validator,
+        schema: toValidator(schema) as Validator<InferOutput<S>>,
         options,
     };
 }
 
 /** graphql(): a stitch preset for GraphQL-over-HTTP — POST { query, variables }, unwrap `data`. */
-export function graphql<T = unknown>(
-    config: Partial<StitchConfig> & { query: string },
-): Stitch<T> {
-    return makeStitch<T>({
+export function graphql<
+    TExplicit = never,
+    C extends Partial<StitchConfig> & {
+        query: string;
+    } = Partial<StitchConfig> & {
+        query: string;
+    },
+>(config: C): Stitch<ResolveOutput<TExplicit, C>> {
+    return makeStitch<ResolveOutput<TExplicit, C>>({
         ...config,
         kind: 'graphql',
         method: 'POST',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -336,7 +336,8 @@ export interface Seam {
     >(
         config: C,
     ): Stitch<ResolveOutput<TExplicit, C>>;
-    stitch<T = unknown>(config: string): Stitch<T>;
+    /** Non-inferring fallback: a path string or a `string | Partial<StitchConfig>` value (see {@link StitchFn}). */
+    stitch<T = unknown>(config: string | Partial<StitchConfig>): Stitch<T>;
     /** GraphQL-over-HTTP member stitch (POST `{ query, variables }`, unwrap `data`). */
     graphql<
         TExplicit = never,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,6 @@
 // Shared vocabulary for the prototype. Leaf modules (resilience, trace, http-adapter,
 // auth, mock-server) and the engine all code against these types.
+import type { ResolveOutput, SchemaLike } from './infer';
 import type { Validator } from './validator';
 
 export interface StitchInput {
@@ -30,9 +31,9 @@ export interface DriftOptions {
     onNew?: DriftLevel; // level for brand-new fields (default 'info')
     snapshotFile?: string; // committed baseline (`<name>.contract.json`)
 }
-export interface DriftSpec {
+export interface DriftSpec<T = unknown> {
     __kind: 'drift';
-    schema: Validator;
+    schema: Validator<T>;
     options: DriftOptions;
 }
 
@@ -163,11 +164,13 @@ export type StitchEvent<T = unknown> =
     | { type: 'done'; ok: boolean; ms: number; attempts: number; at: number };
 
 // ---- Config & the Stitch callable ----------------------------------------
+// Each slot accepts any {@link SchemaLike} (raw Zod / Standard Schema / Validator / predicate) —
+// no `toValidator()` cast required; `normalizeInput` coerces them at compose time.
 export interface InputSchemas {
-    params?: Validator;
-    query?: Validator;
-    body?: Validator;
-    headers?: Validator;
+    params?: SchemaLike;
+    query?: SchemaLike;
+    body?: SchemaLike;
+    headers?: SchemaLike;
 }
 export interface StitchConfig {
     /** Label used in events and traces; defaults to `path` or `'stitch'`. */
@@ -198,8 +201,12 @@ export interface StitchConfig {
     query?: string;
     /** Schemas validating params, query, body, and headers before the request. */
     input?: InputSchemas;
-    /** Response schema, or a {@link DriftSpec} for leveled drift detection. */
-    output?: Validator | DriftSpec;
+    /**
+     * Response schema, or a {@link DriftSpec} for leveled drift detection. Accepts any
+     * {@link SchemaLike} (raw Zod / Standard Schema / Validator / predicate); the stitch infers
+     * its result type from it (see `InferOutput`), so a hand-written generic is rarely needed.
+     */
+    output?: SchemaLike | DriftSpec;
     /** Dot-path selecting the part of the response to return. */
     unwrap?: string;
     /** Reshape the raw body before unwrap and validation (e.g. scrape HTML to structured data). */
@@ -318,12 +325,29 @@ export type SeamOptions = Partial<StitchConfig> & {
  * one-off endpoints stay on the low-level `stitch()` peer (ADR 0002).
  */
 export interface Seam {
-    /** Create a stitch belonging to this seam — inherits the shared fragment and shares the runtime. */
-    stitch<T = unknown>(config: string | Partial<StitchConfig>): Stitch<T>;
+    /**
+     * Create a stitch belonging to this seam — inherits the shared fragment and shares the
+     * runtime. Like top-level `stitch`, the result type is inferred from `config.output`; pass an
+     * explicit generic (`api.stitch<Foo>(...)`) only to override the inferred type.
+     */
+    stitch<
+        TExplicit = never,
+        C extends Partial<StitchConfig> = Partial<StitchConfig>,
+    >(
+        config: C,
+    ): Stitch<ResolveOutput<TExplicit, C>>;
+    stitch<T = unknown>(config: string): Stitch<T>;
     /** GraphQL-over-HTTP member stitch (POST `{ query, variables }`, unwrap `data`). */
-    graphql<T = unknown>(
-        config: Partial<StitchConfig> & { query: string },
-    ): Stitch<T>;
+    graphql<
+        TExplicit = never,
+        C extends Partial<StitchConfig> & {
+            query: string;
+        } = Partial<StitchConfig> & {
+            query: string;
+        },
+    >(
+        config: C,
+    ): Stitch<ResolveOutput<TExplicit, C>>;
     /**
      * A principal-bound handle reusing the same shared runtime, but whose stitches carry
      * `principal` in their AuthContext: separate sessions per principal, one shared throttle

--- a/packages/core/test-d/_util.ts
+++ b/packages/core/test-d/_util.ts
@@ -1,0 +1,12 @@
+// Helpers for the type tests. NOT a `*.test-d.ts` file, so tsd treats it as a plain module.
+//
+// Why not `expectType<Stitch<User>>(...)`? tsd's identity check short-circuits on `Stitch<T>`'s
+// recursive `with(): Stitch<T>` self-reference and reports any two `Stitch<X>` as identical. So we
+// assert on the UNWRAPPED result type instead — `output(call)` is typed as exactly what
+// `await call()` resolves to, a plain type tsd compares precisely.
+import type { Stitch } from '..';
+
+/** Returns a value typed as the stitch's resolved (awaited, unwrapped) output. */
+export declare function output<S extends Stitch<unknown>>(
+    stitch: S,
+): Awaited<ReturnType<S>>;

--- a/packages/core/test-d/overloads.test-d.ts
+++ b/packages/core/test-d/overloads.test-d.ts
@@ -1,0 +1,38 @@
+// Overload-resolution contract. Splitting stitch()/seam.stitch() into inferring object + string
+// overloads must NOT regress a previously-valid call: an argument whose STATIC type is the union
+// `string | Partial<StitchConfig>` matched the old single signature, so a fallback overload keeps
+// it compiling (TS rejects a union value against either split overload alone — TS2769).
+import { seam, stitch } from '..';
+import type { Stitch, StitchConfig } from '..';
+import { output } from './_util';
+
+import { expectType } from 'tsd';
+import { z } from 'zod';
+
+const userSchema = z.object({ id: z.number() });
+
+declare const either: string | Partial<StitchConfig>;
+
+// 1) a union-typed argument still resolves (to unknown, exactly as before the split).
+expectType<unknown>(output(stitch(either)));
+
+// 2) the idiomatic forwarding wrapper from the review must compile.
+function makeApi(cfg: string | Partial<StitchConfig>): Stitch<unknown> {
+    return stitch(cfg);
+}
+expectType<unknown>(output(makeApi('/x')));
+
+// 3) seam member: same union-argument contract.
+const api = seam({ baseUrl: 'x' });
+expectType<unknown>(output(api.stitch(either)));
+
+// 4) graphql is a single overload, so a union of query-configs already resolves (no fallback needed).
+declare const gqlEither:
+    | (Partial<StitchConfig> & { query: string })
+    | (Partial<StitchConfig> & { query: string; method: string });
+expectType<unknown>(output(api.graphql(gqlEither)));
+
+// 5) REGRESSION GUARD: the fallback overload must NOT shadow inference for concrete literals.
+expectType<{ id: number }>(output(stitch({ output: userSchema })));
+expectType<unknown>(output(stitch('/path')));
+expectType<{ id: number }>(output(api.stitch({ output: userSchema })));

--- a/packages/core/test-d/schema-flavors.test-d.ts
+++ b/packages/core/test-d/schema-flavors.test-d.ts
@@ -1,0 +1,49 @@
+// Inference works across every schema flavour the runtime already accepts, plus the exported
+// `InferOutput` / `InferInput` helpers.
+import { drift, stitch } from '..';
+import type { InferInput, InferOutput, Validator } from '..';
+import { output } from './_util';
+
+import { expectType } from 'tsd';
+import { z } from 'zod';
+
+const userSchema = z.object({ id: z.number(), name: z.string() });
+type User = z.infer<typeof userSchema>;
+
+// 1) drift() wrapper still infers the inner contract type.
+expectType<User>(
+    output(stitch({ output: drift(userSchema, { critical: ['id'] }) })),
+);
+
+// 2) Standard Schema (non-Zod): infers OUTPUT from `~standard.types`, distinct from input.
+declare const std: {
+    readonly '~standard': {
+        readonly version: 1;
+        readonly vendor: string;
+        readonly validate: (v: unknown) => { value: { id: number } };
+        readonly types?: {
+            readonly input: { raw: string };
+            readonly output: { id: number };
+        };
+    };
+};
+expectType<{ id: number }>(output(stitch({ output: std })));
+
+// 3) a hand-rolled Validator<T>.
+declare const val: Validator<{ v: boolean }>;
+expectType<{ v: boolean }>(output(stitch({ output: val })));
+
+// 4) a user-defined type guard narrows the result.
+const isThing = (v: unknown): v is { kind: 'thing' } =>
+    typeof v === 'object' && v !== null;
+expectType<{ kind: 'thing' }>(output(stitch({ output: isThing })));
+
+// 5) the exported helpers read straight off a schema type.
+expectType<User>(null as unknown as InferOutput<typeof userSchema>);
+expectType<{ id: number }>(null as unknown as InferOutput<typeof std>);
+expectType<{ raw: string }>(null as unknown as InferInput<typeof std>);
+
+// 6) input vs output on a coercing schema: InferInput is the accepted type, InferOutput the result.
+const lengthSchema = z.string().transform((s) => s.length);
+expectType<number>(null as unknown as InferOutput<typeof lengthSchema>);
+expectType<string>(null as unknown as InferInput<typeof lengthSchema>);

--- a/packages/core/test-d/seam.test-d.ts
+++ b/packages/core/test-d/seam.test-d.ts
@@ -1,0 +1,32 @@
+// Seam members infer their result type exactly like top-level `stitch`.
+import { seam } from '..';
+import { output } from './_util';
+
+import { expectType } from 'tsd';
+import { z } from 'zod';
+
+const userSchema = z.object({ id: z.number(), name: z.string() });
+type User = z.infer<typeof userSchema>;
+
+const api = seam({ baseUrl: 'https://x' });
+
+// member stitch infers from `output`
+expectType<User>(output(api.stitch({ path: '/u', output: userSchema })));
+
+// bare path-string member → unknown
+expectType<unknown>(output(api.stitch('/ping')));
+
+// explicit generic overrides on a member too
+expectType<number>(output(api.stitch<number>({ output: userSchema })));
+
+// a principal-bound handle infers identically
+expectType<User>(
+    output(api.as('u1').stitch({ path: '/u', output: userSchema })),
+);
+
+// graphql member infers from `output`
+expectType<User>(
+    output(
+        api.graphql({ query: 'query { u { id name } }', output: userSchema }),
+    ),
+);

--- a/packages/core/test-d/stitch.test-d.ts
+++ b/packages/core/test-d/stitch.test-d.ts
@@ -1,0 +1,38 @@
+// `stitch()` infers its result type from `config.output` — the headline of this feature.
+import { stitch } from '..';
+import { output } from './_util';
+
+import { expectError, expectType } from 'tsd';
+import { z } from 'zod';
+
+const userSchema = z.object({ id: z.number(), name: z.string() });
+type User = z.infer<typeof userSchema>;
+
+// 1) plain object schema → inferred result, no generic, no cast.
+expectType<User>(
+    output(stitch({ baseUrl: 'x', path: '/u', output: userSchema })),
+);
+
+// 2) array schema → inferred array result.
+expectType<User[]>(output(stitch({ path: '/u', output: z.array(userSchema) })));
+
+// 3) the schema's OUTPUT (post-coercion) is used, not its input — a `.transform` proves it:
+//    input is `string`, output is `number`, and the stitch resolves to `number`.
+const lengthSchema = z.string().transform((s) => s.length);
+expectType<number>(output(stitch({ output: lengthSchema })));
+
+// 4) an explicit generic always wins (backwards-compatible escape hatch).
+expectType<number[]>(output(stitch<number[]>({ output: userSchema })));
+
+// 5) no `output` schema → `unknown` (unchanged historical default).
+expectType<unknown>(output(stitch({ path: '/ping' })));
+
+// 6) bare path-string shorthand → `unknown`.
+expectType<unknown>(output(stitch('/ping')));
+
+// 7) a raw Zod schema flows in WITHOUT `toValidator()` / `as Validator` (the old cast is gone).
+expectType<User>(output(stitch({ output: userSchema, unwrap: 'data' })));
+
+// 8) a non-schema `output` is rejected at compile time.
+expectError(stitch({ output: 123 }));
+expectError(stitch({ output: 'not-a-schema' }));

--- a/packages/core/test/output-inference.spec.ts
+++ b/packages/core/test/output-inference.spec.ts
@@ -1,0 +1,66 @@
+// Output-schema inference: a raw schema passed to `output` needs no `asValidator` cast, the
+// runtime still validates exactly as before, and the resolved TYPE is inferred from the schema.
+// The typed bindings below (`user.name`, `users.map(...)`) are compile-time assertions too —
+// tsconfig.test.json typechecks this file, so they fail the build if inference regresses.
+import { seam, stitch } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { z } from 'zod';
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+const userSchema = z.object({ id: z.number(), name: z.string() });
+
+test('raw Zod `output` (no asValidator cast) validates and resolves the value', async () => {
+    server.route('GET', '/u', { body: { id: 1, name: 'Ada' } });
+    const getUser = stitch({
+        baseUrl: server.url,
+        path: '/u',
+        output: userSchema,
+    });
+    const user = await getUser();
+    // Inferred as { id: number; name: string } — this assignment is itself a type assertion.
+    const typed: { id: number; name: string } = user;
+    expect(typed).toEqual({ id: 1, name: 'Ada' });
+});
+
+test('inferred element type flows through `unwrap`', async () => {
+    server.route('GET', '/list', { body: { data: [{ id: 1, name: 'Ada' }] } });
+    const list = stitch({
+        baseUrl: server.url,
+        path: '/list',
+        unwrap: 'data',
+        output: z.array(userSchema),
+    });
+    const users = await list();
+    // `.map`/`u.name` only typecheck if `users` is inferred as User[], not unknown.
+    expect(users.map((u) => u.name)).toEqual(['Ada']);
+});
+
+test('a response that violates the schema still rejects (validation unchanged)', async () => {
+    server.route('GET', '/bad', { body: { id: 'not-a-number', name: 'Ada' } });
+    const getUser = stitch({
+        baseUrl: server.url,
+        path: '/bad',
+        output: userSchema,
+    });
+    await expect(getUser()).rejects.toThrow();
+});
+
+test('seam members infer and validate identically', async () => {
+    server.route('GET', '/u', { body: { id: 2, name: 'Bo' } });
+    const api = seam({ baseUrl: server.url });
+    const getUser = api.stitch({ path: '/u', output: userSchema });
+    const user = await getUser();
+    expect(user.name).toBe('Bo');
+});

--- a/packages/core/test/smoke.spec.ts
+++ b/packages/core/test/smoke.spec.ts
@@ -1,7 +1,6 @@
 import { stitch } from '../src';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
-import { asValidator } from './support/schema';
 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -30,9 +29,8 @@ test('await sugar returns the unwrapped, validated result', async () => {
         baseUrl: server.url,
         path: '/users',
         unwrap: 'data',
-        output: asValidator(
-            z.array(z.object({ id: z.number(), name: z.string() })),
-        ),
+        // raw Zod schema — inference removes the old `asValidator()` cast.
+        output: z.array(z.object({ id: z.number(), name: z.string() })),
     });
     await expect(users()).resolves.toEqual([{ id: 1, name: 'Ada' }]);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
+      tsd:
+        specifier: ^0.33.0
+        version: 0.33.0
       tsup:
         specifier: ^8.3.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
@@ -916,6 +919,10 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1673,6 +1680,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@sinclair/typebox@0.27.10':
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
+
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
@@ -1787,6 +1797,10 @@ packages:
   '@ts-morph/common@0.29.0':
     resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
 
+  '@tsd/typescript@5.9.3':
+    resolution: {integrity: sha512-JSSdNiS0wgd8GHhBwnMAI18Y8XPhLVN+dNelPfZCXFhy9Lb3NbnFyp9JKxxr54jSUkEJPk3cidvCoHducSaRMQ==}
+    engines: {node: '>=14.17'}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -1798,6 +1812,9 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/eslint@7.29.0':
+    resolution: {integrity: sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -1820,6 +1837,9 @@ packages:
   '@types/mdx@2.0.14':
     resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
 
+  '@types/minimist@1.2.5':
+    resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
+
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -1828,6 +1848,9 @@ packages:
 
   '@types/node@25.9.3':
     resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
+
+  '@types/normalize-package-data@2.4.4':
+    resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -2119,6 +2142,10 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ansi-escapes@4.3.2:
+    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
+    engines: {node: '>=8'}
+
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
@@ -2134,6 +2161,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -2156,6 +2187,10 @@ packages:
   array-includes@3.1.9:
     resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
     engines: {node: '>= 0.4'}
+
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
 
   array.prototype.findlast@1.2.5:
     resolution: {integrity: sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==}
@@ -2180,6 +2215,10 @@ packages:
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
+
+  arrify@1.0.1:
+    resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
+    engines: {node: '>=0.10.0'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -2266,6 +2305,14 @@ packages:
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  camelcase-keys@6.2.2:
+    resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
+    engines: {node: '>=8'}
+
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
 
   caniuse-lite@1.0.30001799:
@@ -2420,6 +2467,14 @@ packages:
       supports-color:
         optional: true
 
+  decamelize-keys@1.1.1:
+    resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
+    engines: {node: '>=0.10.0'}
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
@@ -2447,6 +2502,14 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -2479,6 +2542,9 @@ packages:
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -2558,6 +2624,10 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
+  eslint-formatter-pretty@4.1.0:
+    resolution: {integrity: sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==}
+    engines: {node: '>=10'}
+
   eslint-import-resolver-node@0.3.10:
     resolution: {integrity: sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==}
 
@@ -2622,6 +2692,9 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-rule-docs@1.1.235:
+    resolution: {integrity: sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==}
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -2734,6 +2807,10 @@ packages:
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
   find-up@5.0.0:
@@ -2987,12 +3064,20 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  hard-rejection@2.1.0:
+    resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
+    engines: {node: '>=6'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -3057,6 +3142,13 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
+  hosted-git-info@2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+
+  hosted-git-info@4.1.0:
+    resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
+    engines: {node: '>=10'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -3079,12 +3171,20 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  irregular-plurals@3.5.0:
+    resolution: {integrity: sha512-1ANGLZ+Nkv1ptFb2pa8oG8Lem4krflKuX/gINiHJHjJUKaJHk/SXk5x6K3J+39/p0h1RQ2saROclJJ+QLvETCQ==}
+    engines: {node: '>=8'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -3095,6 +3195,9 @@ packages:
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
@@ -3169,6 +3272,10 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-plain-obj@1.1.0:
+    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
+    engines: {node: '>=0.10.0'}
+
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
@@ -3196,6 +3303,10 @@ packages:
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
+
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -3234,6 +3345,14 @@ packages:
   javascript-natural-sort@0.7.1:
     resolution: {integrity: sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==}
 
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-get-type@29.6.3:
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -3265,6 +3384,9 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -3286,6 +3408,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -3437,6 +3563,10 @@ packages:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -3446,6 +3576,10 @@ packages:
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -3461,6 +3595,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
   lucide-react@1.17.0:
     resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
     peerDependencies:
@@ -3475,6 +3613,14 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  map-obj@1.0.1:
+    resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
+    engines: {node: '>=0.10.0'}
+
+  map-obj@4.3.0:
+    resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
+    engines: {node: '>=8'}
 
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
@@ -3545,6 +3691,10 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  meow@9.0.0:
+    resolution: {integrity: sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==}
+    engines: {node: '>=10'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -3659,12 +3809,20 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimist-options@4.1.0:
+    resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
+    engines: {node: '>= 6'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -3750,6 +3908,13 @@ packages:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
     engines: {node: '>=18'}
 
+  normalize-package-data@2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+
+  normalize-package-data@3.0.3:
+    resolution: {integrity: sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==}
+    engines: {node: '>=10'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3800,13 +3965,25 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -3814,6 +3991,10 @@ packages:
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
@@ -3841,6 +4022,10 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -3861,6 +4046,10 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  plur@4.0.0:
+    resolution: {integrity: sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==}
+    engines: {node: '>=10'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3897,6 +4086,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -3910,6 +4103,10 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  quick-lru@4.0.1:
+    resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
+    engines: {node: '>=8'}
+
   react-dom@19.2.7:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
@@ -3917,6 +4114,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -3952,6 +4152,14 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
+  read-pkg-up@7.0.1:
+    resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
+    engines: {node: '>=8'}
+
+  read-pkg@5.2.0:
+    resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
+    engines: {node: '>=8'}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -3973,6 +4181,10 @@ packages:
 
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -4030,6 +4242,11 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   resolve@2.0.0-next.7:
     resolution: {integrity: sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==}
     engines: {node: '>= 0.4'}
@@ -4069,6 +4286,10 @@ packages:
 
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -4130,6 +4351,10 @@ packages:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
 
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -4144,6 +4369,18 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -4196,6 +4433,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -4229,6 +4470,10 @@ packages:
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-hyperlinks@2.3.0:
+    resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
     engines: {node: '>=8'}
 
   supports-hyperlinks@3.2.0:
@@ -4289,6 +4534,10 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
+  trim-newlines@3.0.1:
+    resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
+    engines: {node: '>=8'}
+
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
@@ -4306,6 +4555,11 @@ packages:
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
+
+  tsd@0.33.0:
+    resolution: {integrity: sha512-/PQtykJFVw90QICG7zyPDMIyueOXKL7jOJVoX5pILnb3Ux+7QqynOxfVvarE+K+yi7BZyOSY4r+OZNWSWRiEwQ==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -4345,6 +4599,22 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@0.18.1:
+    resolution: {integrity: sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==}
+    engines: {node: '>=10'}
+
+  type-fest@0.21.3:
+    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
+    engines: {node: '>=10'}
+
+  type-fest@0.6.0:
+    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
+    engines: {node: '>=8'}
+
+  type-fest@0.8.1:
+    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
+    engines: {node: '>=8'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -4456,6 +4726,9 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
@@ -4600,6 +4873,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
@@ -5229,6 +5505,10 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@jest/schemas@29.6.3':
+    dependencies:
+      '@sinclair/typebox': 0.27.10
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -5881,6 +6161,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@sinclair/typebox@0.27.10': {}
+
   '@sindresorhus/is@4.6.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -5976,6 +6258,8 @@ snapshots:
       path-browserify: 1.0.1
       tinyglobby: 0.2.17
 
+  '@tsd/typescript@5.9.3': {}
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -5991,6 +6275,11 @@ snapshots:
       '@types/ms': 2.1.0
 
   '@types/deep-eql@4.0.2': {}
+
+  '@types/eslint@7.29.0':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -6012,6 +6301,8 @@ snapshots:
 
   '@types/mdx@2.0.14': {}
 
+  '@types/minimist@1.2.5': {}
+
   '@types/ms@2.1.0': {}
 
   '@types/node@22.19.21':
@@ -6021,6 +6312,8 @@ snapshots:
   '@types/node@25.9.3':
     dependencies:
       undici-types: 7.24.6
+
+  '@types/normalize-package-data@2.4.4': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
@@ -6390,6 +6683,10 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-escapes@4.3.2:
+    dependencies:
+      type-fest: 0.21.3
+
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
@@ -6401,6 +6698,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   any-promise@1.3.0: {}
 
@@ -6427,6 +6726,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-string: 1.1.1
       math-intrinsics: 1.1.0
+
+  array-union@2.1.0: {}
 
   array.prototype.findlast@1.2.5:
     dependencies:
@@ -6478,6 +6779,8 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
+
+  arrify@1.0.1: {}
 
   assertion-error@2.0.1: {}
 
@@ -6555,6 +6858,14 @@ snapshots:
       get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
+
+  camelcase-keys@6.2.2:
+    dependencies:
+      camelcase: 5.3.1
+      map-obj: 4.3.0
+      quick-lru: 4.0.1
+
+  camelcase@5.3.1: {}
 
   caniuse-lite@1.0.30001799: {}
 
@@ -6692,6 +7003,13 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize-keys@1.1.1:
+    dependencies:
+      decamelize: 1.2.0
+      map-obj: 1.0.1
+
+  decamelize@1.2.0: {}
+
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
@@ -6720,6 +7038,12 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  diff-sequences@29.6.3: {}
+
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
+
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
@@ -6746,6 +7070,10 @@ snapshots:
   entities@6.0.1: {}
 
   environment@1.1.0: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-abstract@1.24.2:
     dependencies:
@@ -6952,6 +7280,17 @@ snapshots:
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
 
+  eslint-formatter-pretty@4.1.0:
+    dependencies:
+      '@types/eslint': 7.29.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      eslint-rule-docs: 1.1.235
+      log-symbols: 4.1.0
+      plur: 4.0.0
+      string-width: 4.2.3
+      supports-hyperlinks: 2.3.0
+
   eslint-import-resolver-node@0.3.10:
     dependencies:
       debug: 3.2.7
@@ -7063,6 +7402,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
+
+  eslint-rule-docs@1.1.235: {}
 
   eslint-scope@8.4.0:
     dependencies:
@@ -7206,6 +7547,11 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
 
   find-up@5.0.0:
     dependencies:
@@ -7456,9 +7802,20 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.1
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  hard-rejection@2.1.0: {}
 
   has-bigints@1.1.0: {}
 
@@ -7598,6 +7955,12 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
+  hosted-git-info@2.8.9: {}
+
+  hosted-git-info@4.1.0:
+    dependencies:
+      lru-cache: 6.0.0
+
   html-escaper@2.0.2: {}
 
   html-void-elements@3.0.0: {}
@@ -7613,6 +7976,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   inline-style-parser@0.2.7: {}
 
   internal-slot@1.1.0:
@@ -7620,6 +7985,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.1
+
+  irregular-plurals@3.5.0: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -7633,6 +8000,8 @@ snapshots:
       call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-arrayish@0.2.1: {}
 
   is-async-function@2.1.1:
     dependencies:
@@ -7707,6 +8076,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-plain-obj@1.1.0: {}
+
   is-plain-obj@4.1.0: {}
 
   is-regex@1.2.1:
@@ -7736,6 +8107,8 @@ snapshots:
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.22
+
+  is-unicode-supported@0.1.0: {}
 
   is-weakmap@2.0.2: {}
 
@@ -7776,6 +8149,15 @@ snapshots:
 
   javascript-natural-sort@0.7.1: {}
 
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
+  jest-get-type@29.6.3: {}
+
   jiti@2.7.0: {}
 
   joycon@3.1.1: {}
@@ -7793,6 +8175,8 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
 
@@ -7814,6 +8198,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kind-of@6.0.3: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -7924,6 +8310,10 @@ snapshots:
 
   load-tsconfig@0.2.5: {}
 
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -7931,6 +8321,11 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   lodash@4.18.1: {}
+
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
 
   longest-streak@3.1.0: {}
 
@@ -7943,6 +8338,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
 
   lucide-react@1.17.0(react@19.2.7):
     dependencies:
@@ -7961,6 +8360,10 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.4
+
+  map-obj@1.0.1: {}
+
+  map-obj@4.3.0: {}
 
   markdown-extensions@2.0.0: {}
 
@@ -8143,6 +8546,21 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  meow@9.0.0:
+    dependencies:
+      '@types/minimist': 1.2.5
+      camelcase-keys: 6.2.2
+      decamelize: 1.2.0
+      decamelize-keys: 1.1.1
+      hard-rejection: 2.1.0
+      minimist-options: 4.1.0
+      normalize-package-data: 3.0.3
+      read-pkg-up: 7.0.1
+      redent: 3.0.0
+      trim-newlines: 3.0.1
+      type-fest: 0.18.1
+      yargs-parser: 20.2.9
 
   merge2@1.4.1: {}
 
@@ -8415,6 +8833,8 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  min-indent@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -8422,6 +8842,12 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.15
+
+  minimist-options@4.1.0:
+    dependencies:
+      arrify: 1.0.1
+      is-plain-obj: 1.1.0
+      kind-of: 6.0.3
 
   minimist@1.2.8: {}
 
@@ -8505,6 +8931,20 @@ snapshots:
 
   node-releases@2.0.47: {}
 
+  normalize-package-data@2.5.0:
+    dependencies:
+      hosted-git-info: 2.8.9
+      resolve: 1.22.12
+      semver: 5.7.2
+      validate-npm-package-license: 3.0.4
+
+  normalize-package-data@3.0.3:
+    dependencies:
+      hosted-git-info: 4.1.0
+      is-core-module: 2.16.2
+      semver: 7.8.4
+      validate-npm-package-license: 3.0.4
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -8572,13 +9012,23 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-try@2.2.0: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -8593,6 +9043,13 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
 
   parse5-htmlparser2-tree-adapter@6.0.1:
     dependencies:
@@ -8614,6 +9071,8 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  path-type@4.0.0: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -8629,6 +9088,10 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  plur@4.0.0:
+    dependencies:
+      irregular-plurals: 3.5.0
 
   possible-typed-array-names@1.1.0: {}
 
@@ -8650,6 +9113,12 @@ snapshots:
 
   prettier@3.3.3: {}
 
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -8662,12 +9131,16 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  quick-lru@4.0.1: {}
+
   react-dom@19.2.7(react@19.2.7):
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
+
+  react-is@18.3.1: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
     dependencies:
@@ -8697,6 +9170,19 @@ snapshots:
       '@types/react': 19.2.17
 
   react@19.2.7: {}
+
+  read-pkg-up@7.0.1:
+    dependencies:
+      find-up: 4.1.0
+      read-pkg: 5.2.0
+      type-fest: 0.8.1
+
+  read-pkg@5.2.0:
+    dependencies:
+      '@types/normalize-package-data': 2.4.4
+      normalize-package-data: 2.5.0
+      parse-json: 5.2.0
+      type-fest: 0.6.0
 
   readdirp@4.1.2: {}
 
@@ -8730,6 +9216,11 @@ snapshots:
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -8833,6 +9324,13 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
   resolve@2.0.0-next.7:
     dependencies:
       es-errors: 1.3.0
@@ -8924,6 +9422,8 @@ snapshots:
   scroll-into-view-if-needed@3.1.0:
     dependencies:
       compute-scroll-into-view: 3.1.1
+
+  semver@5.7.2: {}
 
   semver@6.3.1: {}
 
@@ -9034,6 +9534,8 @@ snapshots:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
 
+  slash@3.0.0: {}
+
   source-map-js@1.2.1: {}
 
   source-map@0.5.7: {}
@@ -9041,6 +9543,20 @@ snapshots:
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
+
+  spdx-correct@3.2.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.23
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
 
   stable-hash@0.0.5: {}
 
@@ -9121,6 +9637,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   style-mod@4.1.3: {}
@@ -9153,6 +9673,11 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  supports-hyperlinks@2.3.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
 
   supports-hyperlinks@3.2.0:
     dependencies:
@@ -9198,6 +9723,8 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
+  trim-newlines@3.0.1: {}
+
   trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
@@ -9221,6 +9748,16 @@ snapshots:
       json5: 1.0.2
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tsd@0.33.0:
+    dependencies:
+      '@tsd/typescript': 5.9.3
+      eslint-formatter-pretty: 4.1.0
+      globby: 11.1.0
+      jest-diff: 29.7.0
+      meow: 9.0.0
+      path-exists: 4.0.0
+      read-pkg-up: 7.0.1
 
   tslib@2.8.1: {}
 
@@ -9272,6 +9809,14 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@0.18.1: {}
+
+  type-fest@0.21.3: {}
+
+  type-fest@0.6.0: {}
+
+  type-fest@0.8.1: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -9443,6 +9988,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  validate-npm-package-license@3.0.4:
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
+
   validate-npm-package-name@5.0.1: {}
 
   vfile-location@5.0.3:
@@ -9582,6 +10132,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yargs-parser@20.2.9: {}
 


### PR DESCRIPTION
## Problem

A typed stitch cost the caller **twice**: an explicit `stitch<User>(...)` generic **and** an `asValidator(...)` cast — a raw Zod/Standard schema isn't structurally a `Validator`, so `output` rejected it. The schema already encodes the type, so both were redundant and could silently disagree.

## Change

`stitch({ output: userSchema })` now resolves to `Stitch<User>` — no generic, no cast:

```ts
// before
stitch<User>({ output: asValidator(userSchema) })
// after
stitch({ output: userSchema })            // ⇒ Stitch<User>, await ⇒ User
```

A **pure type-level change** — runtime (`makeStitch`/`compose`/`normalizeOutput`/engine) is unchanged; raw schemas still coerce through `toValidator()`. An explicit `stitch<T>(...)` still wins, so it's backward compatible. Works across `stitch`, `seam.stitch`, `seam.as(p).stitch`, `graphql`, and `drift()`, for Zod (v3 `_output` phantom + v4/Standard Schema), Valibot/ArkType, hand-rolled `Validator`, and type-guard predicates.

### Files
- **`src/infer.ts`** (new) — `InferOutput`/`InferInput`/`SchemaLike`/`OutputOf`/`ResolveOutput`.
- `src/standard-schema.ts` — restore the optional `types` phantom (`<Input, Output>`).
- `src/types.ts` — `DriftSpec<T>` generic; widen `StitchConfig.output` + `InputSchemas` to `SchemaLike`; dual-generic `Seam.stitch`/`graphql`.
- `src/stitch.ts` / `src/seam.ts` — inferring overloads; generic `drift<S>`.
- `src/index.ts` — export `InferOutput`, `InferInput`, `SchemaLike`, `Validator`, `ValidationResult`, `Issue`.

## Tests
- **tsd type-level suite** in `packages/core/test-d/` behind a new `check:types-d` gate (`tsup && tsd`, wired into lefthook pre-push). Note: assertions target the *unwrapped* output type, because tsd's identity check short-circuits on `Stitch<T>`'s recursive `with(): Stitch<T>`.
- Runtime regression in `test/output-inference.spec.ts`; dropped a now-needless `asValidator` cast in `smoke.spec.ts`.

Verified: `tsc` (strict + `exactOptionalPropertyTypes`), eslint, tsd, **202** vitest tests, attw exports, docs build — all green; inference confirmed against the built `.d.ts` with real Zod 3.25.

## Follow-up (not in this PR)
Input-argument inference (`config.input` → typed call args) — a larger, more invasive change deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)