### PR TITLE
fix(core): strip trailing slashes in joinUrl without regex (js/polynomial-redos)

### DIFF
--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -95,9 +95,12 @@ const nameOf = (cfg: StitchConfig) => cfg.name ?? cfg.path ?? 'stitch';
 function joinUrl(base: string, path: string): string {
     if (/^https?:\/\//i.test(path)) return path;
     if (!base) return path;
-    return (
-        base.replace(/\/+$/, '') + (path.startsWith('/') ? path : '/' + path)
-    );
+    // Strip trailing slashes from base with a linear scan rather than a regex.
+    // `/\/+$/` backtracks polynomially on an all-slashes string (js/polynomial-redos);
+    // this loop is O(n) and behaviourally identical (drops the whole trailing run).
+    let end = base.length;
+    while (end > 0 && base[end - 1] === '/') end--;
+    return base.slice(0, end) + (path.startsWith('/') ? path : '/' + path);
 }
 
 // Inject a stable Idempotency-Key on writes. The key is computed once per logical call (here,


### PR DESCRIPTION
## What

Replace the `base.replace(/\/+$/, '')` trailing-slash strip in `joinUrl` ([packages/core/src/engine.ts](packages/core/src/engine.ts)) with a linear, non-backtracking manual scan.

## Why

CodeQL flags `/\/+$/` as a high-severity `js/polynomial-redos` alert (pre-existing, introduced in `f0ede4f` on 2026-06-10; surfaced on #72 because that's the first PR to touch `engine.ts` and trigger CodeQL diff analysis).

**Assessment — true positive in the algorithmic sense, negligible exploitability:**

- On an all-slashes string followed by a non-slash (e.g. `"////…//x"`), the anchored greedy `\/+` matches the full run, fails `$`, then backtracks one slash per failed re-attempt — repeated from each successive start position — giving **O(n²)** worst-case time. So this is not strictly a false positive.
- However `base` is `resolveStr(cfg.baseUrl)` — the **configured base URL** (library config), used at a single internal call site, not high-volume attacker-controlled input. Real-world exploitability is effectively nil.

**Resolution:** rather than dismiss an alert that is algorithmically valid, the regex is replaced with an O(n) scan that drops the entire trailing run of slashes — **behaviourally identical** and removes the alert deterministically. No inline-suppression convention exists in this repo, and CodeQL runs as GitHub default setup (no committed config to add path filters to), so a code fix is the cleanest path.

```ts
let end = base.length;
while (end > 0 && base[end - 1] === '/') end--;
return base.slice(0, end) + (path.startsWith('/') ? path : '/' + path);
```

## Verification

Core gates all green:

- `pnpm --filter stitchapi check:types` ✅
- `pnpm --filter stitchapi test` ✅ — 198 passed (36 files)
- `pnpm --filter stitchapi check:lint` ✅
- `prettier --check` ✅

Tiny and focused — unrelated to the type-inference work in #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)