### PR TITLE
feat(core): infer a stitch's call-argument types from config.input

### DIFF
--- a/packages/core/src/infer.ts
+++ b/packages/core/src/infer.ts
@@ -3,7 +3,7 @@
 // (the actual coercion is `toValidator()` in validator.ts). This is what lets
 // `stitch({ output: userSchema })` resolve to `Stitch<User>` with no explicit generic and no cast.
 import type { StandardSchemaV1 } from './standard-schema';
-import type { DriftSpec } from './types';
+import type { DriftSpec, InputSchemas, StitchInput } from './types';
 import type { Validator } from './validator';
 
 /**
@@ -71,3 +71,88 @@ export type OutputOf<C> = C extends { output: infer O }
 export type ResolveOutput<TExplicit, C> = [TExplicit] extends [never]
     ? OutputOf<C>
     : TExplicit;
+
+// ---- Call-argument inference (Phase 2) ------------------------------------
+// Type the call argument from the `input` schemas the caller already declares, mirroring how
+// `OutputOf` reads `output`. Pure types: the runtime input path (`normalizeInput` → `validateInput`)
+// is unchanged — it reads input by field name regardless of its static type.
+
+/**
+ * Flatten an intersection of mapped types into a single object literal. Without this the call-arg
+ * type stays an `A & B & C` intersection: unreadable in errors and — crucially — NOT
+ * identity-comparable in tsd, so `Parameters<S>[0]` assertions couldn't bite. The trailing `& {}`
+ * forces eager evaluation.
+ */
+type Prettify<T> = { [K in keyof T]: T[K] } & {};
+
+/** The slots an `input` schema can validate (see {@link InputSchemas}): params, query, body, headers. */
+type SchemaSlots = keyof InputSchemas;
+/** {@link StitchInput} keys with no schema slot — `variables` (GraphQL). Carried through untyped. */
+type ExtraSlots = Exclude<keyof StitchInput, SchemaSlots>;
+/**
+ * The pre-coercion input type a declared slot accepts. `NonNullable` keeps it sound when `I` is the
+ * declared (optional-slot) {@link InputSchemas} type rather than the inline object literal the caller
+ * wrote — in the literal case the written key is already required and `NonNullable` is a no-op.
+ */
+type SlotInput<I, K extends keyof I> = InferInput<NonNullable<I[K]>>;
+
+/**
+ * Which declared slots are REQUIRED in the call argument: a slot is required iff its input type does
+ * not accept `undefined`. So a `.optional()` schema (input includes `undefined`), or an unrecognized
+ * schema that falls through to `unknown`, yields an OPTIONAL slot — the test fails open, never closed.
+ */
+type RequiredSchemaKeys<I> = {
+    [K in SchemaSlots]: K extends keyof I
+        ? undefined extends SlotInput<I, K>
+            ? never
+            : K
+        : never;
+}[SchemaSlots];
+
+/**
+ * The typed call argument for a config whose `input` is `I`: required schema slots, optional schema
+ * slots, and the untyped `variables` passthrough (always optional). {@link Prettify} collapses the
+ * required∩optional split into one flat object.
+ */
+type CallInput<I> = Prettify<
+    { [K in RequiredSchemaKeys<I> & keyof I]: SlotInput<I, K> } & {
+        [K in Exclude<SchemaSlots, RequiredSchemaKeys<I>> & keyof I]?: Exclude<
+            SlotInput<I, K>,
+            undefined
+        >;
+    } & { [K in ExtraSlots]?: StitchInput[K] }
+>;
+
+/**
+ * Map a config object's `input` slot to the typed call argument. No `input` key → the loose
+ * {@link StitchInput} (the historical default), so a stitch with no input schemas is unchanged and
+ * its argument stays fully optional. Like {@link OutputOf}, this reads only the top-level `input`
+ * key, not `extends` fragments.
+ */
+export type InputOf<C> = C extends { input: infer I }
+    ? CallInput<I>
+    : StitchInput;
+
+/** The required (non-optional) keys of `T`. (`Record<never, never>` is the empty object `{}` — the
+ * standard "is this key optional?" probe — spelled to avoid a bare `{}` type.) */
+type RequiredKeys<T> = {
+    [K in keyof T]-?: Record<never, never> extends Pick<T, K> ? never : K;
+}[keyof T];
+/** Whether `T` has any required key. Degenerate `unknown`/`any` → `false` (fails open to optional). */
+type HasRequired<T> = [RequiredKeys<T>] extends [never] ? false : true;
+/**
+ * The call/`stream` parameter list for an input type `TIn`: a single argument that is REQUIRED when
+ * `TIn` has a required key (e.g. a non-optional `body` schema) and OPTIONAL otherwise. So `ping()`
+ * (no input schemas → loose {@link StitchInput}, no required keys) stays legal, while `createUser()`
+ * (required body) is a compile error.
+ */
+export type Args<TIn> =
+    HasRequired<TIn> extends true ? [input: TIn] : [input?: TIn];
+/**
+ * Relax the top-level slots named by `K` to optional, leaving the rest of `T` unchanged — the
+ * type-level image of `.with()`'s shallow per-slot bind: after binding `body`, the returned stitch's
+ * call argument no longer requires it (but a still-unbound required slot stays required).
+ */
+export type RelaxKeys<T, K extends PropertyKey> = Prettify<
+    Omit<T, Extract<keyof T, K>> & Partial<Pick<T, Extract<keyof T, K>>>
+>;

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -2,7 +2,7 @@
 // `.with()` partial application, all resolving to one canonical config. For a shared surface —
 // shared runtime + a trusted principal boundary — reach for `seam` (see seam.ts).
 import { type Runtime, execute, executeRaw, makeRuntime } from './engine';
-import type { InferOutput, ResolveOutput } from './infer';
+import type { InferOutput, InputOf, ResolveOutput } from './infer';
 import { otlpTrace } from './otlp';
 import { createThrottle } from './resilience';
 import { createStoreThrottle, memoryStore } from './store';
@@ -320,16 +320,19 @@ export function makeStitch<T = unknown>(
 export interface StitchFn {
     /**
      * Build a stitch from a config object. The result type is inferred from `config.output`'s
-     * schema (Zod / Standard Schema / Validator / `drift()`), so no hand-written generic is
-     * needed. Supply one explicitly — `stitch<Foo>(config)` — only to override the inferred type;
-     * the explicit generic always wins.
+     * schema (Zod / Standard Schema / Validator / `drift()`) and the CALL-ARGUMENT type from the
+     * `config.input` schemas (see {@link InputOf}), so no hand-written generic is needed. Supply one
+     * explicitly — `stitch<Foo>(config)` — only to override the inferred result type; the explicit
+     * generic always wins. Note: passing the explicit generic stops TypeScript from inferring the
+     * config type, so the call argument falls back to the loose `StitchInput` in that form (a
+     * limitation of partial type-argument inference — never worse than pre-inference).
      */
     <
         TExplicit = never,
         C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
         config: C,
-    ): Stitch<ResolveOutput<TExplicit, C>>;
+    ): Stitch<ResolveOutput<TExplicit, C>, InputOf<C>>;
     /**
      * Non-inferring fallback: a bare path string, or any argument whose static type is the union
      * `string | Partial<StitchConfig>` (e.g. a wrapper that forwards either spelling). Neither can
@@ -339,6 +342,9 @@ export interface StitchFn {
     use(...fragments: Fragment[]): Builder;
 }
 
+// The impl is the loose `<T>(config) => Stitch<T>`; the rich `InputOf<C>` lives only in the
+// `StitchFn` overloads it is checked against. TypeScript's overload-assignability is lenient enough
+// that no cast is needed here (the same reason `seam.ts`'s handle needs none).
 export const stitch: StitchFn = Object.assign(
     <T = unknown>(config: string | Partial<StitchConfig>) =>
         makeStitch<T>(config as Fragment),
@@ -371,7 +377,7 @@ export function graphql<
     } = Partial<StitchConfig> & {
         query: string;
     },
->(config: C): Stitch<ResolveOutput<TExplicit, C>> {
+>(config: C): Stitch<ResolveOutput<TExplicit, C>, InputOf<C>> {
     return makeStitch<ResolveOutput<TExplicit, C>>({
         ...config,
         kind: 'graphql',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,12 @@
 // Shared vocabulary for the prototype. Leaf modules (resilience, trace, http-adapter,
 // auth, mock-server) and the engine all code against these types.
-import type { ResolveOutput, SchemaLike } from './infer';
+import type {
+    Args,
+    InputOf,
+    RelaxKeys,
+    ResolveOutput,
+    SchemaLike,
+} from './infer';
 import type { Validator } from './validator';
 
 export interface StitchInput {
@@ -268,10 +274,20 @@ export interface StitchConfig {
 export interface StitchResult<T> extends PromiseLike<T> {
     stream(): AsyncGenerator<StitchEvent<T>, void>;
 }
-export interface Stitch<T = unknown> {
-    (input?: StitchInput): StitchResult<T>;
-    stream(input?: StitchInput): AsyncGenerator<StitchEvent<T>, void>;
-    with(partial: StitchInput): Stitch<T>;
+/**
+ * The callable a stitch resolves to. `TOut` is the result type (inferred from `config.output`);
+ * `TIn` is the call-argument type (inferred from `config.input` — see {@link InputOf}). `TIn`
+ * defaults to the loose {@link StitchInput}, which has no required keys, so a stitch with no input
+ * schemas keeps its fully-optional argument and every pre-Phase-2 `Stitch<T>` usage is unchanged.
+ * No `extends StitchInput` bound on `TIn`: a `headers` schema can infer non-string values, which
+ * `Record<string, string>` would reject.
+ */
+export interface Stitch<TOut = unknown, TIn = StitchInput> {
+    (...args: Args<TIn>): StitchResult<TOut>;
+    stream(...args: Args<TIn>): AsyncGenerator<StitchEvent<TOut>, void>;
+    with<const P extends Partial<TIn>>(
+        partial: P,
+    ): Stitch<TOut, RelaxKeys<TIn, keyof P>>;
     readonly __config: StitchConfig;
     readonly __stitch: true;
 }
@@ -335,7 +351,7 @@ export interface Seam {
         C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
         config: C,
-    ): Stitch<ResolveOutput<TExplicit, C>>;
+    ): Stitch<ResolveOutput<TExplicit, C>, InputOf<C>>;
     /** Non-inferring fallback: a path string or a `string | Partial<StitchConfig>` value (see {@link StitchFn}). */
     stitch<T = unknown>(config: string | Partial<StitchConfig>): Stitch<T>;
     /** GraphQL-over-HTTP member stitch (POST `{ query, variables }`, unwrap `data`). */
@@ -348,7 +364,7 @@ export interface Seam {
         },
     >(
         config: C,
-    ): Stitch<ResolveOutput<TExplicit, C>>;
+    ): Stitch<ResolveOutput<TExplicit, C>, InputOf<C>>;
     /**
      * A principal-bound handle reusing the same shared runtime, but whose stitches carry
      * `principal` in their AuthContext: separate sessions per principal, one shared throttle

--- a/packages/core/test-d/_util.ts
+++ b/packages/core/test-d/_util.ts
@@ -10,3 +10,11 @@ import type { Stitch } from '..';
 export declare function output<S extends Stitch<unknown>>(
     stitch: S,
 ): Awaited<ReturnType<S>>;
+
+// The Phase 2 analogue for INPUTS. `expectType<Stitch<…>>` is still useless (same recursive-`with`
+// reason), so assert on the call-ARGUMENT type instead. The constraint is a universal function, not
+// `Stitch<unknown>`: a stitch with a REQUIRED first argument (e.g. a non-optional `body` schema) is
+// not assignable to any `Stitch` whose call signature has an OPTIONAL first arg, so a `Stitch<…>`
+// bound would reject exactly the typed-input stitches we want to test.
+/** The stitch's (single) call-argument type — `TIn` for a required arg, `TIn | undefined` for an optional one. */
+export type CallArg<S extends (...args: never[]) => unknown> = Parameters<S>[0];

--- a/packages/core/test-d/input-inference.test-d.ts
+++ b/packages/core/test-d/input-inference.test-d.ts
@@ -1,0 +1,101 @@
+// `stitch()` infers its CALL-ARGUMENT type from `config.input` — the Phase 2 headline. We assert on
+// the call-argument type via `CallArg` (a `Stitch<…>` bound can't see required-arg stitches, and
+// `expectType<Stitch<…>>` is broken by the recursive `with()`), and use `expectError` /
+// `expectNotAssignable` for missing / wrong fields. Positive "this call compiles" cases live in the
+// runtime spec (test/input-inference.spec.ts) with `await`, so they aren't floating promises here.
+import { seam, stitch } from '..';
+import type { StitchInput } from '..';
+import { type CallArg } from './_util';
+
+import { expectAssignable, expectError, expectType } from 'tsd';
+import { z } from 'zod';
+
+const userSchema = z.object({ id: z.number(), name: z.string() });
+
+// 1) a required body: the slot is present and fully shaped; the argument is required.
+const createUser = stitch({
+    input: { body: z.object({ name: z.string(), age: z.number() }) },
+    output: userSchema,
+});
+expectType<{ name: string; age: number }>(
+    null as unknown as CallArg<typeof createUser>['body'],
+);
+expectError(createUser()); // body is required → no-arg call is an error
+expectError(createUser({ body: { name: 'Ada' } })); // missing `age`
+expectError(createUser({ body: {} })); // missing both
+
+// 2) params required + query optional in ONE config — proves per-slot required-ness.
+//    A required `params` schema → required slot; a `.optional()` `query` schema → optional slot.
+const search = stitch({
+    input: {
+        params: z.object({ id: z.string() }),
+        query: z.object({ page: z.number() }).optional(),
+    },
+});
+expectType<{ id: string }>(null as unknown as CallArg<typeof search>['params']);
+expectType<{ page: number } | undefined>(
+    null as unknown as CallArg<typeof search>['query'],
+);
+expectError(search()); // params required
+expectError(search({ query: { page: 1 } })); // params still required
+
+// 3) no `input` schemas → the loose StitchInput, and the argument stays OPTIONAL (backward compat).
+const ping = stitch({ path: '/ping' });
+expectType<StitchInput | undefined>(null as unknown as CallArg<typeof ping>);
+expectAssignable<CallArg<typeof ping>>(undefined); // arg is optional
+
+// 4) the explicit OUTPUT generic is an escape hatch: it still wins for the result type, but giving
+//    a type argument stops TypeScript from inferring the config type `C` (partial type-argument
+//    inference is unsupported), so input inference falls back to the loose StitchInput. This is a
+//    documented limitation of the explicit-generic form — never worse than pre-Phase-2.
+const explicit = stitch<{ ok: boolean }>({
+    input: { body: z.object({ x: z.number() }) },
+});
+expectType<StitchInput | undefined>(
+    null as unknown as CallArg<typeof explicit>,
+);
+// the bare string shorthand keeps the loose, optional argument too.
+const str = stitch('/ping');
+expectType<StitchInput | undefined>(null as unknown as CallArg<typeof str>);
+
+// 5) `.with()` relaxes ONLY the bound top-level slots (the `const P` capture). Binding `params`
+//    must NOT relax a still-required `body`.
+const multi = stitch({
+    input: {
+        params: z.object({ id: z.string() }),
+        body: z.object({ x: z.number() }),
+    },
+});
+const partial = multi.with({ params: { id: 'x' } });
+expectError(partial()); // body still required — only `params` was bound
+const partial2 = partial.with({ body: { x: 1 } });
+expectAssignable<CallArg<typeof partial2>>(undefined); // both bound now → arg optional
+// binding `body` directly relaxes it to optional.
+const bound = createUser.with({ body: { name: 'Ada', age: 30 } });
+expectAssignable<CallArg<typeof bound>>(undefined);
+
+// 6) seam members (root, principal-bound, and graphql) infer call args identically.
+const api = seam({ baseUrl: 'https://x' });
+const member = api.stitch({ input: { body: z.object({ name: z.string() }) } });
+expectType<{ name: string }>(null as unknown as CallArg<typeof member>['body']);
+expectError(member());
+const asMember = api
+    .as('u1')
+    .stitch({ input: { params: z.object({ id: z.string() }) } });
+expectType<{ id: string }>(
+    null as unknown as CallArg<typeof asMember>['params'],
+);
+const gqlTyped = api.graphql({
+    query: 'query { ok }',
+    input: { params: z.object({ region: z.string() }) },
+});
+expectType<{ region: string }>(
+    null as unknown as CallArg<typeof gqlTyped>['params'],
+);
+// GraphQL `variables` stay an untyped passthrough (typing them is deferred — see follow-up issue).
+const gqlLoose = api.graphql({ query: 'query { ok }', output: userSchema });
+expectAssignable<CallArg<typeof gqlLoose>>({ variables: { region: 'eu' } });
+
+// 7) a non-schema `input` slot value is rejected at compile time.
+expectError(stitch({ input: { body: 123 } }));
+expectError(stitch({ input: { params: 'nope' } }));

--- a/packages/core/test/input-inference.spec.ts
+++ b/packages/core/test/input-inference.spec.ts
@@ -1,0 +1,101 @@
+// Input-schema inference: a raw `input` schema (no cast) still validates and REJECTS bad input at
+// runtime exactly as before, while the call argument is now TYPED from those schemas. The typed
+// calls below (`{ body: { name, age } }`, the `.with(...)` bind) are compile-time assertions too —
+// tsconfig.test.json typechecks this file, so they fail the build if call-arg inference regresses.
+import { seam, stitch } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { z } from 'zod';
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+const userSchema = z.object({ id: z.number(), name: z.string() });
+
+test('a typed call validates and resolves (raw input schema, no cast)', async () => {
+    server.route('POST', '/users', { body: { id: 1, name: 'Ada' } });
+    const createUser = stitch({
+        baseUrl: server.url,
+        path: '/users',
+        method: 'POST',
+        input: { body: z.object({ name: z.string(), age: z.number() }) },
+        output: userSchema,
+    });
+    // The argument type is inferred: `{ body: { name: string; age: number } }`. This call is itself
+    // a type assertion — it only compiles if input inference holds.
+    const user = await createUser({ body: { name: 'Ada', age: 30 } });
+    expect(user).toEqual({ id: 1, name: 'Ada' });
+    expect(server.calls('/users')[0]?.body).toEqual({ name: 'Ada', age: 30 });
+});
+
+test('bad input still rejects at runtime (validation unchanged)', async () => {
+    server.route('POST', '/users', { body: { id: 1, name: 'Ada' } });
+    const createUser = stitch({
+        baseUrl: server.url,
+        path: '/users',
+        method: 'POST',
+        input: { body: z.object({ name: z.string(), age: z.number() }) },
+        output: userSchema,
+    });
+    // The compiler would (correctly) reject a missing `age`; cast the argument past it to prove the
+    // RUNTIME validator still rejects too (the value is unchanged — only the static check is bypassed).
+    await expect(
+        createUser({ body: { name: 'Ada' } } as never),
+    ).rejects.toThrow(/invalid body/i);
+    expect(server.callCount('/users')).toBe(0); // never left the client
+});
+
+test('.with() binds part of the input and the bound stitch still validates', async () => {
+    server.route('POST', '/users', { body: { id: 2, name: 'Bo' } });
+    const createUser = stitch({
+        baseUrl: server.url,
+        path: '/users',
+        method: 'POST',
+        input: { body: z.object({ name: z.string(), age: z.number() }) },
+        output: userSchema,
+    });
+    // Binding `body` relaxes it to optional, so the bound stitch is callable with no argument.
+    const bound = createUser.with({ body: { name: 'Bo', age: 1 } });
+    const user = await bound();
+    expect(user).toEqual({ id: 2, name: 'Bo' });
+    expect(server.calls('/users')[0]?.body).toEqual({ name: 'Bo', age: 1 });
+});
+
+test('params + query schemas validate and the typed call expands them', async () => {
+    server.route('GET', '/users/1', { body: { id: 1, name: 'Ada' } });
+    const getUser = stitch({
+        baseUrl: server.url,
+        path: '/users/{id}',
+        input: {
+            params: z.object({ id: z.string() }),
+            query: z.object({ trace: z.string() }).optional(),
+        },
+        output: userSchema,
+    });
+    // params required, query optional — both inferred onto the call argument.
+    const user = await getUser({ params: { id: '1' }, query: { trace: 'on' } });
+    expect(user.name).toBe('Ada');
+    expect(server.calls('/users/1')[0]?.query).toEqual({ trace: 'on' });
+});
+
+test('seam members infer and validate input identically', async () => {
+    server.route('POST', '/users', { body: { id: 3, name: 'Cy' } });
+    const api = seam({ baseUrl: server.url });
+    const createUser = api.stitch({
+        path: '/users',
+        method: 'POST',
+        input: { body: z.object({ name: z.string() }) },
+        output: userSchema,
+    });
+    const user = await createUser({ body: { name: 'Cy' } });
+    expect(user.name).toBe('Cy');
+});


### PR DESCRIPTION
## What

Phase 2 of schema-driven inference (Phase 1 = output, #72). The `Stitch` callable gains a second generic — `Stitch<TOut = unknown, TIn = StitchInput>` — and `TIn` is derived from the `config.input` schemas (via the existing `InferInput`), so the **call argument is typed from the schemas the caller already declares**:

```ts
const createUser = stitch({
  input: { body: z.object({ name: z.string(), age: z.number() }) },
  output: userSchema,
})
createUser({ body: { name: 'Ada', age: 30 } })  // ✅ typed
createUser({ body: { name: 'Ada' } })            // ❌ missing `age`
createUser()                                     // ❌ body required

const ping = stitch({ path: '/ping' })
ping()                                           // ✅ arg stays optional (backward compatible)
```

## How

Pure **type-level** change — the runtime input path (`normalizeInput` → `validateInput`) is untouched; the engine reads input by field name regardless of its static type.

- **`infer.ts`** — new internal machinery mirroring `OutputOf`/`ResolveOutput`: `CallInput`/`InputOf` build the call-arg object from the four `InputSchemas` slots, plus `Args` (conditional rest-tuple: the argument is **required** iff a slot is required, optional otherwise), `RelaxKeys`, and a `Prettify` flattener so the result is one readable, tsd-comparable object.
- **`types.ts`** — `Stitch<TOut, TIn>` with `(...args: Args<TIn>)`, `stream(...args: Args<TIn>)`, and `with<const P>(partial: P): Stitch<TOut, RelaxKeys<TIn, keyof P>>`. `Seam.stitch`/`Seam.graphql` return `Stitch<…, InputOf<C>>`.
- **`stitch.ts`** — `StitchFn` / `graphql()` thread `InputOf<C>`.

### Design decisions
- **Required vs optional**: a slot is required iff its schema's input type excludes `undefined` (`.optional()` → optional slot). `TIn` defaults to the loose `StitchInput` (no required keys), so every pre-Phase-2 `Stitch<T>` usage and every no-input stitch is unchanged.
- **`.with()`**: `const P` capture relaxes only the **bound** top-level slots to optional (matching the runtime's shallow per-slot `mergeInput`), so `createUser.with({ body }).()` is legal while binding only `params` keeps a required `body` required.
- **No new explicit generic** — input always infers from `config.input`, preserving the exact overload arity locked by `overloads.test-d.ts`. Note: passing the explicit *output* generic (`stitch<Out>(…)`) stops TS from inferring the config type, so input falls back to loose `StitchInput` in that form (a partial-type-argument-inference limitation — never worse than pre-Phase-2; documented at the overload).
- **Scope (deferred)**: infers from the **top-level** `config.input` only (mirrors Phase 1's output behavior — `extends`/seam fragments still validate at runtime), and **GraphQL `variables` stay untyped** (typing them needs a runtime `validateInput` change). Follow-ups: #75 (variables), #76 (extends composition).

No `as`-casts were needed at the `stitch`/`graphql`/`seam` boundaries — TypeScript's overload/return assignability is lenient enough (the contravariant-input risk didn't materialize).

## Tests
- **`test-d/input-inference.test-d.ts`** (tsd) — asserts on the call-arg type via a new `CallArg<S> = Parameters<S>[0]` helper (`expectType<Stitch<…>>` is broken by the recursive `with()`), with `expectError` for missing/wrong fields. Covers required body, params-required/query-optional, no-input, `.with()` non-over-relaxation, seam members + graphql, and rejection of non-schema slots. A deliberately-wrong assertion was confirmed to fail tsd, then reverted.
- **`test/input-inference.spec.ts`** (runtime regression) — a raw input schema (no cast) still validates and **rejects** bad input at runtime; the typed calls double as compile-time assertions (the file is typechecked).

## Verification
Full gate green locally **and** in the pre-push hook: `check:types`, `check:types-d`, `check:lint`, `check:exports`, 207 tests, and the docs twoslash build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)