### PR TITLE
feat(playground): full-height 3-pane layout with auto-applied server knobs

### DIFF
--- a/apps/docs/app/(home)/playground/KnobsBuilder.tsx
+++ b/apps/docs/app/(home)/playground/KnobsBuilder.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import type { SimKnobs } from '@stitchapi/sandbox/contracts/sim';
+import { useState } from 'react';
+
+/**
+ * Controls for the fake API's reserved response knobs (`__status`,
+ * `__latencyMs`, `__stream`, `__drift`, `__flaky` — see
+ * docs/sandbox/contracts/sim.ts `SimKnobs`). Whatever is configured here is
+ * applied AUTOMATICALLY to every call the next run makes — no copy/paste. The
+ * builder owns the raw input strings and emits the parsed `SimKnobs` upward via
+ * `onChange`; an explicit `?__…` in the snippet still wins for that call.
+ *
+ * Renders its own header bar (title + Clear) so it fills the aside pane on its
+ * own, keeping the footer out of the way of the controls.
+ */
+
+type StreamMode = 'off' | 'chunked' | 'sse';
+
+interface KnobsState {
+    status: string;
+    latencyMs: string;
+    stream: StreamMode;
+    drift: boolean;
+    flaky: string;
+}
+
+const INITIAL: KnobsState = {
+    status: '',
+    latencyMs: '',
+    stream: 'off',
+    drift: false,
+    flaky: '',
+};
+
+/** Parse the raw UI state into `SimKnobs`, dropping empty / off / invalid knobs
+ *  so a blank field never shapes the response. */
+function toSimKnobs(s: KnobsState): SimKnobs {
+    const knobs: SimKnobs = {};
+    const status = parseInt(s.status, 10);
+    if (s.status.trim() && !isNaN(status)) knobs.status = status;
+    const latencyMs = parseInt(s.latencyMs, 10);
+    if (s.latencyMs.trim() && !isNaN(latencyMs)) knobs.latencyMs = latencyMs;
+    if (s.stream !== 'off') knobs.stream = s.stream;
+    if (s.drift) knobs.drift = true;
+    const flaky = parseInt(s.flaky, 10);
+    if (s.flaky.trim() && !isNaN(flaky)) knobs.flaky = flaky;
+    return knobs;
+}
+
+/** Short header chips for the active knobs (in panel order). */
+function activeChips(knobs: SimKnobs): string[] {
+    const chips: string[] = [];
+    if (knobs.status !== undefined) chips.push(`status ${knobs.status}`);
+    if (knobs.latencyMs !== undefined) chips.push(`${knobs.latencyMs}ms`);
+    if (knobs.stream !== undefined) chips.push(knobs.stream);
+    if (knobs.flaky !== undefined) chips.push(`flaky ${knobs.flaky}`);
+    if (knobs.drift) chips.push('drift');
+    return chips;
+}
+
+export function KnobsBuilder({
+    onChange,
+}: {
+    /** Called with the parsed knobs whenever the controls change. */
+    onChange: (knobs: SimKnobs) => void;
+}) {
+    const [state, setState] = useState<KnobsState>(INITIAL);
+
+    // Apply on every edit: merge the patch, push the parsed knobs upward. No
+    // copy step — the next run reads these directly.
+    const update = (patch: Partial<KnobsState>) => {
+        const next = { ...state, ...patch };
+        setState(next);
+        onChange(toSimKnobs(next));
+    };
+
+    const clear = () => {
+        setState(INITIAL);
+        onChange({});
+    };
+
+    const chips = activeChips(toSimKnobs(state));
+
+    return (
+        <div className="stitch-knobs">
+            <div
+                className="stitch-knobs__head"
+                title="Applied automatically to every call the next run makes"
+            >
+                <span className="stitch-knobs__head-title">Server knobs</span>
+                {chips.length > 0 && (
+                    <span className="stitch-knobs__chips">
+                        {chips.map((c) => (
+                            <span key={c} className="stitch-knobs__chip">
+                                {c}
+                            </span>
+                        ))}
+                    </span>
+                )}
+                <button
+                    type="button"
+                    className="stitch-knobs__clear"
+                    onClick={clear}
+                    disabled={!chips.length}
+                >
+                    Clear
+                </button>
+            </div>
+
+            {/* Compact control bar: label + control only (the meaning is in each
+                field's `title` tooltip), so the Console can dominate the column. */}
+            <div className="stitch-knobs__body">
+                <div className="stitch-knobs__grid">
+                    <label
+                        className="stitch-knobs__field"
+                        title="Force the HTTP response status"
+                    >
+                        <span className="stitch-knobs__label">Status</span>
+                        <input
+                            type="text"
+                            inputMode="numeric"
+                            maxLength={3}
+                            className="stitch-knobs__input stitch-knobs__input--num"
+                            placeholder="200"
+                            value={state.status}
+                            onChange={(e) =>
+                                update({
+                                    status: e.target.value
+                                        .replace(/\D/g, '')
+                                        .slice(0, 3),
+                                })
+                            }
+                        />
+                    </label>
+
+                    <label
+                        className="stitch-knobs__field"
+                        title="Delay every call by this many milliseconds"
+                    >
+                        <span className="stitch-knobs__label">Latency ms</span>
+                        <input
+                            type="text"
+                            inputMode="numeric"
+                            maxLength={6}
+                            className="stitch-knobs__input stitch-knobs__input--num-wide"
+                            placeholder="0"
+                            value={state.latencyMs}
+                            onChange={(e) =>
+                                update({
+                                    latencyMs: e.target.value
+                                        .replace(/\D/g, '')
+                                        .slice(0, 6),
+                                })
+                            }
+                        />
+                    </label>
+
+                    <label
+                        className="stitch-knobs__field"
+                        title="Stream the response body"
+                    >
+                        <span className="stitch-knobs__label">Stream</span>
+                        <select
+                            className="stitch-knobs__input stitch-knobs__input--select"
+                            value={state.stream}
+                            onChange={(e) =>
+                                update({ stream: e.target.value as StreamMode })
+                            }
+                        >
+                            <option value="off">Off</option>
+                            <option value="chunked">Chunked</option>
+                            <option value="sse">SSE</option>
+                        </select>
+                    </label>
+
+                    <label
+                        className="stitch-knobs__field"
+                        title="Fail the first N calls, then succeed"
+                    >
+                        <span className="stitch-knobs__label">Flaky</span>
+                        <input
+                            type="text"
+                            inputMode="numeric"
+                            maxLength={3}
+                            className="stitch-knobs__input stitch-knobs__input--num"
+                            placeholder="0"
+                            value={state.flaky}
+                            onChange={(e) =>
+                                update({
+                                    flaky: e.target.value
+                                        .replace(/\D/g, '')
+                                        .slice(0, 3),
+                                })
+                            }
+                        />
+                    </label>
+
+                    <div
+                        className="stitch-knobs__field stitch-knobs__field--switch"
+                        title="Return a body that fails validation"
+                    >
+                        <span className="stitch-knobs__label">Drift</span>
+                        <button
+                            type="button"
+                            role="switch"
+                            aria-checked={state.drift}
+                            aria-label="Schema drift"
+                            className="stitch-knobs__switch"
+                            data-on={state.drift}
+                            onClick={() => update({ drift: !state.drift })}
+                        >
+                            <span className="stitch-knobs__switch-thumb" />
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default KnobsBuilder;

--- a/apps/docs/app/(home)/playground/PlaygroundClient.tsx
+++ b/apps/docs/app/(home)/playground/PlaygroundClient.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { CodeEditor } from './CodeEditor';
+import { KnobsBuilder } from './KnobsBuilder';
 import { PLAYGROUND_EXAMPLES } from './playground-examples';
 
 import { StitchPlayground } from '@stitchapi/sandbox/component/StitchPlayground';
 import { dispatchRunner } from '@stitchapi/sandbox/contracts/dispatch';
+import type { SimKnobs } from '@stitchapi/sandbox/contracts/sim';
 import {
     type WorkerLike,
     makeBrowserWorkerRunner,
@@ -30,9 +32,10 @@ function jsonLog(text: string): boolean {
 
 /**
  * Client wrapper that wires the in-house sandbox engine into the UI shell, plus
- * a CodeMirror editor (`renderEditor`) and a Fumadocs `DynamicCodeBlock` for the
- * highlighted result (`renderValue`). The heavy lifting lives in the engine;
- * the shell only knows the `CodeRunner` contract + the two render hooks.
+ * a CodeMirror editor (`renderEditor`), Fumadocs `DynamicCodeBlock` highlighting
+ * for JSON console lines (`renderLog`), and the interactive Server-knobs panel
+ * (`aside`). The heavy lifting lives in the engine; the shell only knows the
+ * `CodeRunner` contract + the render hooks.
  */
 export function PlaygroundClient() {
     // Build the runner once, on the client. A fresh Worker per run is what gives
@@ -60,54 +63,53 @@ export function PlaygroundClient() {
         PLAYGROUND_EXAMPLES.find((e) => e.id === exampleId) ??
         PLAYGROUND_EXAMPLES[0];
 
-    return (
-        <>
-            <div
-                className="stitch-playground-examples"
-                role="tablist"
-                aria-label="Example complexity"
-            >
-                {PLAYGROUND_EXAMPLES.map((ex) => (
-                    <button
-                        key={ex.id}
-                        type="button"
-                        role="tab"
-                        aria-selected={ex.id === exampleId}
-                        data-active={ex.id === exampleId}
-                        className="stitch-playground-examples__tab"
-                        title={ex.description}
-                        onClick={() => setExampleId(ex.id)}
-                    >
-                        {ex.label}
-                    </button>
-                ))}
-                <span className="stitch-playground-examples__hint">
-                    {active.description}
-                </span>
-            </div>
+    // Baseline response knobs from the panel below. Persisted across example
+    // switches (it lives here, not under <StitchPlayground>'s remount key) and
+    // forwarded into every run, where the sim fetch shim applies them.
+    const [knobs, setKnobs] = useState<SimKnobs>({});
 
-            <StitchPlayground
-                key={active.id}
-                initialCode={active.code}
-                runner={runner}
-                renderEditor={(props) => <CodeEditor {...props} />}
-                renderValue={(text) => (
-                    <div className="stitch-playground__result">
-                        <span className="stitch-playground__result-label">
-                            returned
-                        </span>
-                        <DynamicCodeBlock lang="json" code={text} />
-                    </div>
-                )}
-                renderLog={(text) =>
-                    jsonLog(text) ? (
-                        <DynamicCodeBlock lang="json" code={text} />
-                    ) : (
-                        text
-                    )
-                }
-            />
-        </>
+    // Example switcher — rendered into the shell's toolbar (the `tabs` slot).
+    const exampleTabs = (
+        <div
+            className="stitch-playground-examples"
+            role="tablist"
+            aria-label="Example complexity"
+        >
+            {PLAYGROUND_EXAMPLES.map((ex) => (
+                <button
+                    key={ex.id}
+                    type="button"
+                    role="tab"
+                    aria-selected={ex.id === exampleId}
+                    data-active={ex.id === exampleId}
+                    className="stitch-playground-examples__tab"
+                    title={ex.description}
+                    onClick={() => setExampleId(ex.id)}
+                >
+                    {ex.label}
+                </button>
+            ))}
+        </div>
+    );
+
+    return (
+        <StitchPlayground
+            key={active.id}
+            initialCode={active.code}
+            runner={runner}
+            knobs={knobs}
+            tabs={exampleTabs}
+            renderEditor={(props) => <CodeEditor {...props} />}
+            renderLog={(text) =>
+                jsonLog(text) ? (
+                    <DynamicCodeBlock lang="json" code={text} />
+                ) : (
+                    text
+                )
+            }
+            asideLabel="Server knobs"
+            aside={<KnobsBuilder onChange={setKnobs} />}
+        />
     );
 }
 

--- a/apps/docs/app/(home)/playground/page.tsx
+++ b/apps/docs/app/(home)/playground/page.tsx
@@ -13,18 +13,10 @@ export default function PlaygroundPage() {
     return (
         <main className="stitch-playground-page">
             <div className="stitch-playground-page__inner">
-                <header className="stitch-playground-page__header">
-                    <h1>Playground</h1>
-                    <p>
-                        A complete StitchAPI snippet, running in an isolated
-                        browser sandbox. Calls are served by a built-in fake API
-                        — no real network, nothing to install. It loads the full
-                        tour on purpose — keep what you need and delete the
-                        rest. Use <code>__status</code>, <code>__stream</code>,{' '}
-                        <code>__drift</code>, <code>__latencyMs</code>, or{' '}
-                        <code>__flaky</code> query knobs to shape the response.
-                    </p>
-                </header>
+                {/* The title/intro lived here; the context now lives in the
+                    snippet's own comments. Keep an accessible page heading
+                    (visually hidden) so the document still has an h1. */}
+                <h1 className="sr-only">Playground</h1>
                 <PlaygroundClient />
             </div>
         </main>

--- a/apps/docs/app/(home)/playground/playground-examples.ts
+++ b/apps/docs/app/(home)/playground/playground-examples.ts
@@ -92,11 +92,11 @@ console.log(
   '4) recovered after ' + attempts + ' attempts, ' + recovered.length + ' users',
 );
 
-// Shape the response any way you like - try other routes and knobs:
-//   /users/9 (404), /status/500, /malformed (HTML), /limited (429),
-//   /drift?__drift=1, ?__latencyMs=800, ?__status=503
-// The returned value is shown in the Result panel below.
-return { user, names, me, recovered: recovered.length };
+// Tip: shape any call without touching the code - use the Server knobs
+// panel (status, latency, streaming, flaky failures, schema drift). They
+// apply to every call the next run makes. Or try other routes by hand:
+//   /users/9 (404), /status/500, /malformed (HTML), /limited (429)
+console.log('done:', { users: recovered.length });
 `;
 
 const SIMPLE_EXAMPLE = `// The simplest call: give stitch a URL, await typed data back.
@@ -105,7 +105,6 @@ const SIMPLE_EXAMPLE = `// The simplest call: give stitch a URL, await typed dat
 const getUser = stitch('https://demo.stitchapi.dev/users/2');
 const res = await getUser();
 console.log(res);
-return res.data;
 `;
 
 export const PLAYGROUND_EXAMPLES: PlaygroundExample[] = [

--- a/apps/docs/app/(home)/playground/playground.css
+++ b/apps/docs/app/(home)/playground/playground.css
@@ -5,79 +5,70 @@
  * The markup uses the BEM classes from docs/sandbox/component/StitchPlayground.tsx. */
 
 .stitch-playground-page {
-    padding: 2.5rem 1.5rem 4rem;
+    padding: 0.85rem 1.5rem 1.25rem;
 }
 .stitch-playground-page__inner {
-    margin: 0 auto;
-    max-width: 56rem;
-}
-.stitch-playground-page__header {
-    margin-bottom: 1.5rem;
-}
-.stitch-playground-page__header h1 {
-    font-size: 2rem;
-    font-weight: 800;
-    letter-spacing: -0.02em;
-    color: var(--color-fd-foreground);
-}
-.stitch-playground-page__header p {
-    margin-top: 0.5rem;
-    max-width: 44rem;
-    line-height: 1.6;
-    color: var(--color-fd-muted-foreground);
-}
-.stitch-playground-page__header code {
-    font-size: 0.8em;
-    padding: 0.05rem 0.3rem;
-    border-radius: 0.3rem;
-    background: color-mix(in srgb, var(--stitch) 12%, transparent);
-    color: var(--color-fd-foreground);
+    /* Full-width: span the available column instead of a centered 56rem block,
+       so the horizontal editor | console split gets real room. */
+    width: 100%;
+    margin: 0;
 }
 
-/* ── Example switcher (Complete ↔ Simple) ───────────────────────────────── */
+/* Full-height app layout (wide screens): the page fills the viewport below the
+   site header (banner + 3.5rem nav) and the sandbox shell flexes to fill it, so
+   the editor/console/knobs panes own the screen and scroll internally rather
+   than the page scrolling. The page title/intro is removed (it lives in the
+   snippet comments now), so the shell starts right under the toolbar. */
+@media (min-width: 52rem) {
+    .stitch-playground-page {
+        display: flex;
+        flex-direction: column;
+        box-sizing: border-box;
+        height: calc(100dvh - var(--fd-banner-height, 0px) - 3.5rem);
+    }
+    .stitch-playground-page__inner,
+    .stitch-playground {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-height: 0;
+    }
+    .stitch-playground__body {
+        flex: 1;
+        min-height: 0;
+        height: auto;
+    }
+}
+
+/* ── Example tabs (Complete ↔ Simple) — segmented control in the toolbar ─── */
 .stitch-playground-examples {
     display: flex;
     align-items: center;
-    gap: 0.4rem;
-    margin-bottom: 0.6rem;
-    flex-wrap: wrap;
+    gap: 0.2rem;
+    padding: 0.15rem;
+    border-radius: 0.5rem;
+    background: color-mix(in srgb, var(--color-fd-foreground) 6%, transparent);
 }
 .stitch-playground-examples__tab {
     font-size: 0.8125rem;
     font-weight: 600;
-    padding: 0.3rem 0.85rem;
-    border-radius: 999px;
-    border: 1px solid var(--color-fd-border);
+    padding: 0.3rem 0.75rem;
+    border: 0;
+    border-radius: 0.4rem;
     background: transparent;
     color: var(--color-fd-muted-foreground);
     cursor: pointer;
     transition:
-        background 0.15s ease,
         color 0.15s ease,
-        border-color 0.15s ease;
+        background 0.15s ease;
 }
 .stitch-playground-examples__tab:hover {
     color: var(--color-fd-foreground);
-    background: color-mix(in srgb, var(--color-fd-foreground) 6%, transparent);
 }
 .stitch-playground-examples__tab[data-active='true'] {
-    background: var(--stitch);
-    border-color: var(--stitch-border);
-    color: #fff;
-}
-.stitch-playground-examples__tab[data-active='true']:hover {
-    background: var(--stitch-strong);
-    color: #fff;
-}
-.stitch-playground-examples__hint {
-    margin-left: 0.35rem;
-    font-size: 0.78rem;
-    color: var(--color-fd-muted-foreground);
-}
-@media (max-width: 30rem) {
-    .stitch-playground-examples__hint {
-        display: none;
-    }
+    color: var(--color-fd-foreground);
+    background: var(--color-fd-background);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
 }
 
 /* ── Shell ──────────────────────────────────────────────────────────────── */
@@ -93,48 +84,166 @@
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
+    row-gap: 0.5rem;
+    flex-wrap: wrap;
     padding: 0.5rem 0.75rem;
     border-bottom: 1px solid var(--color-fd-border);
     background: color-mix(in srgb, var(--stitch) 6%, transparent);
 }
-.stitch-playground__status {
-    font-family: var(--color-fd-font-mono, ui-monospace, monospace);
-    font-size: 0.8125rem;
-    color: var(--color-fd-muted-foreground);
+.stitch-playground__toolbar-start {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+}
+/* Very narrow: tabs on their own row, run controls right-aligned below. */
+@media (max-width: 30rem) {
+    .stitch-playground__toolbar-start,
+    .stitch-playground__actions {
+        flex: 1 1 100%;
+    }
+    .stitch-playground__actions {
+        justify-content: flex-end;
+    }
 }
 .stitch-playground__actions {
     display: flex;
     gap: 0.5rem;
 }
-.stitch-playground__actions button {
-    font-size: 0.8125rem;
+.stitch-playground__btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.875rem;
     font-weight: 600;
-    padding: 0.3rem 0.9rem;
+    padding: 0.45rem 1rem;
     border-radius: 0.5rem;
-    border: 1px solid var(--stitch-border);
-    background: var(--stitch);
-    color: #fff;
+    border: 1px solid transparent;
     cursor: pointer;
     transition:
         background 0.15s ease,
+        color 0.15s ease,
+        border-color 0.15s ease,
         opacity 0.15s ease;
 }
-.stitch-playground__actions button:hover {
-    background: var(--stitch-strong);
+.stitch-playground__btn svg {
+    width: 1.05rem;
+    height: 1.05rem;
+    flex: none;
 }
-.stitch-playground__actions button:disabled {
+.stitch-playground__btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
 }
-/* Reset / secondary action (the trailing button when Run/Stop is also shown). */
-.stitch-playground__actions button:last-child:not(:only-child) {
+/* Run / Stop — the primary action. */
+.stitch-playground__btn--run {
+    border-color: var(--stitch-border);
+    background: var(--stitch);
+    color: #fff;
+}
+.stitch-playground__btn--run:hover:not(:disabled) {
+    background: var(--stitch-strong);
+}
+/* Reset — secondary. */
+.stitch-playground__btn--reset {
     background: transparent;
     color: var(--color-fd-muted-foreground);
     border-color: var(--color-fd-border);
 }
-.stitch-playground__actions button:last-child:not(:only-child):hover {
+.stitch-playground__btn--reset:hover:not(:disabled) {
     color: var(--color-fd-foreground);
     background: color-mix(in srgb, var(--color-fd-foreground) 6%, transparent);
+}
+
+/* ── Body: pane layout ───────────────────────────────────────────────────
+   Code spans the full-height left column; the Console fills the right. When an
+   `aside` (Server knobs) is present, it takes the bottom-right slot and the
+   console shrinks to the top-right. Stacks to one column on narrow viewports. */
+.stitch-playground__body {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr);
+    grid-template-areas: 'editor console';
+    height: 30rem;
+}
+.stitch-playground__body[data-has-aside='true'] {
+    grid-template-rows: minmax(0, 1fr) auto;
+    grid-template-areas:
+        'editor console'
+        'editor aside';
+}
+.stitch-playground__pane--editor {
+    grid-area: editor;
+}
+.stitch-playground__pane--console {
+    grid-area: console;
+}
+.stitch-playground__pane--aside {
+    grid-area: aside;
+}
+/* Each pane is a titled, internally-scrolling block. */
+.stitch-playground__pane {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+}
+/* Dividers between the panes. */
+.stitch-playground__pane--console,
+.stitch-playground__pane--aside {
+    border-left: 1px solid var(--color-fd-border);
+}
+.stitch-playground__pane--aside {
+    border-top: 1px solid var(--color-fd-border);
+}
+
+/* Pane title bar (Code / Console / Server knobs). */
+.stitch-playground__pane-head {
+    flex: none;
+    padding: 0.3rem 0.75rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-fd-muted-foreground);
+    background: color-mix(in srgb, var(--color-fd-foreground) 3%, transparent);
+    border-bottom: 1px solid var(--color-fd-border);
+}
+
+/* The editor fills the remaining height of its pane and scrolls internally. */
+.stitch-playground__pane--editor .stitch-playground__cm,
+.stitch-playground__pane--editor .stitch-playground__editor {
+    flex: 1;
+    min-height: 0;
+}
+.stitch-playground .cm-editor {
+    height: 100% !important;
+}
+
+/* Stack to a single column on narrow viewports: Code, Console, Server knobs. */
+@media (max-width: 52rem) {
+    .stitch-playground__body,
+    .stitch-playground__body[data-has-aside='true'] {
+        grid-template-columns: 1fr;
+        grid-template-rows: auto auto auto;
+        grid-template-areas:
+            'editor'
+            'console'
+            'aside';
+        height: auto;
+    }
+    .stitch-playground__pane--console,
+    .stitch-playground__pane--aside {
+        border-left: 0;
+        border-top: 1px solid var(--color-fd-border);
+    }
+    .stitch-playground__pane--editor .stitch-playground__cm,
+    .stitch-playground__pane--editor .stitch-playground__editor {
+        height: 14rem;
+        flex: none;
+    }
+    .stitch-playground__pane--console .stitch-playground__output {
+        max-height: 18rem;
+    }
 }
 
 /* ── Editor ─────────────────────────────────────────────────────────────── */
@@ -161,12 +270,11 @@
     outline-offset: -2px;
 }
 
-/* ── Output: a console ──────────────────────────────────────────────────── */
+/* ── Output surface (Console + Result pane bodies) ──────────────────────── */
 .stitch-playground__output {
-    border-top: 1px solid var(--color-fd-border);
+    flex: 1;
+    min-height: 0;
     padding: 0.75rem 1rem;
-    min-height: 3rem;
-    max-height: 24rem;
     overflow: auto;
     /* A console surface — `secondary` sits a touch deeper than card/background. */
     background: var(--color-fd-secondary);
@@ -180,7 +288,8 @@
     line-height: 1.55;
     color: var(--color-fd-foreground);
 }
-.stitch-playground__output--deferred {
+.stitch-playground__output--deferred,
+.stitch-playground__output--placeholder {
     color: var(--color-fd-muted-foreground);
 }
 .stitch-playground__log {
@@ -214,11 +323,6 @@
 .dark .stitch-playground__error {
     color: #f87171;
     border-left-color: #f87171;
-}
-.stitch-playground__value {
-    margin: 0.25rem 0 0;
-    white-space: pre-wrap;
-    word-break: break-word;
 }
 .stitch-playground__notices {
     margin-top: 0.6rem;
@@ -282,18 +386,165 @@
     display: none !important;
 }
 
-/* The returned value, set apart from the log stream. */
-.stitch-playground__result {
-    margin-top: 0.55rem;
-    padding-top: 0.5rem;
-    border-top: 1px dashed var(--color-fd-border);
+/* ── Server-knobs builder — fills the aside pane: own header bar + control row */
+.stitch-knobs {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
 }
-.stitch-playground__result-label {
-    display: block;
-    margin-bottom: 0.15rem;
+/* Header bar — matches the Code/Console pane heads, with the active chips and
+   Clear folded in. */
+.stitch-knobs__head {
+    flex: none;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.3rem 0.5rem;
+    padding: 0.2rem 0.4rem 0.2rem 0.75rem;
+    background: color-mix(in srgb, var(--color-fd-foreground) 3%, transparent);
+    border-bottom: 1px solid var(--color-fd-border);
+}
+.stitch-knobs__head-title {
+    flex: none;
     font-size: 0.7rem;
     font-weight: 600;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: var(--stitch-strong);
+    color: var(--color-fd-muted-foreground);
+}
+/* Active-knob chips — a quick glance at what the next run applies. */
+.stitch-knobs__chips {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.25rem;
+}
+.stitch-knobs__chip {
+    padding: 0.02rem 0.4rem;
+    border-radius: 0.3rem;
+    border: 1px solid var(--stitch-border);
+    background: color-mix(in srgb, var(--stitch) 14%, transparent);
+    font-size: 0.68rem;
+    font-weight: 600;
+    color: var(--color-fd-foreground);
+    white-space: nowrap;
+}
+.stitch-knobs__clear {
+    flex: none;
+    margin-left: auto;
+    font-size: 0.68rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    padding: 0.12rem 0.5rem;
+    border-radius: 0.3rem;
+    border: 1px solid var(--color-fd-border);
+    background: transparent;
+    color: var(--color-fd-muted-foreground);
+    cursor: pointer;
+    transition:
+        background 0.15s ease,
+        color 0.15s ease,
+        opacity 0.15s ease;
+}
+.stitch-knobs__clear:hover:not(:disabled) {
+    color: var(--color-fd-foreground);
+    background: color-mix(in srgb, var(--color-fd-foreground) 6%, transparent);
+}
+.stitch-knobs__clear:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+.stitch-knobs__body {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+    padding: 0.6rem 0.85rem 0.7rem;
+}
+.stitch-knobs__grid {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 0.4rem 0.75rem;
+}
+.stitch-knobs__field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+.stitch-knobs__label {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--color-fd-muted-foreground);
+    white-space: nowrap;
+}
+.stitch-knobs__input {
+    /* Shared box so the <select> matches the <input> heights exactly. */
+    box-sizing: border-box;
+    height: 1.9rem;
+    font-size: 0.8rem;
+    padding: 0.28rem 0.45rem;
+    border-radius: 0.4rem;
+    border: 1px solid var(--color-fd-border);
+    background: var(--color-fd-background);
+    color: var(--color-fd-foreground);
+}
+/* Numeric inputs are sized to their digits (Status / Flaky hold 3, Latency a
+   few more) rather than stretching the whole field. */
+.stitch-knobs__input--num {
+    width: 3rem;
+}
+.stitch-knobs__input--num-wide {
+    width: 4rem;
+}
+.stitch-knobs__input--select {
+    width: auto;
+}
+.stitch-knobs__input:focus {
+    outline: 2px solid color-mix(in srgb, var(--stitch) 45%, transparent);
+    outline-offset: -1px;
+    border-color: var(--stitch-border);
+}
+
+/* ── Drift: an on/off switch (the sandbox's drift is binary) ──────────────── */
+.stitch-knobs__field--switch {
+    padding-bottom: 0.3rem; /* lift the switch to line up with the inputs */
+}
+.stitch-knobs__switch {
+    /* The thumb is a flex item positioned by justify-content (flow layout) — a
+       data-on toggle of left↔right that isn't affected by transform resets. */
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+    flex: none;
+    box-sizing: border-box;
+    width: 2.1rem;
+    height: 1.15rem;
+    padding: 0 0.13rem;
+    border-radius: 999px;
+    border: 1px solid var(--color-fd-border);
+    background: color-mix(in srgb, var(--color-fd-foreground) 14%, transparent);
+    cursor: pointer;
+    transition:
+        background 0.15s ease,
+        border-color 0.15s ease;
+}
+.stitch-knobs__switch[data-on='true'] {
+    justify-content: flex-end;
+    background: var(--stitch);
+    border-color: var(--stitch-border);
+}
+.stitch-knobs__switch:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--stitch) 45%, transparent);
+    outline-offset: 2px;
+}
+.stitch-knobs__switch-thumb {
+    width: 0.85rem;
+    height: 0.85rem;
+    border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
 }

--- a/docs/sandbox/component/StitchPlayground.tsx
+++ b/docs/sandbox/component/StitchPlayground.tsx
@@ -15,6 +15,7 @@
  * library build (tsconfig `include` is `src/**\/*.ts`). Requires `react` (and later
  * `@codemirror/*`) once relocated into the docs app.
  */
+import type { SimKnobs } from '../contracts/sim';
 import {
     type RunView,
     applyEvent,
@@ -28,7 +29,7 @@ import {
     mockRunner,
 } from './runner';
 
-import { type ReactNode, useCallback, useMemo, useRef, useState } from 'react';
+import { type ReactNode, useCallback, useRef, useState } from 'react';
 
 /**
  * Props passed to a custom editor (the EDITOR INTEGRATION POINT). A renderer
@@ -63,6 +64,18 @@ export interface StitchPlaygroundProps {
     runner?: CodeRunner;
     /** Globals exposed to the snippet (the browser `stitch` build goes here). */
     scope?: Record<string, unknown>;
+    /**
+     * Optional content for the start of the toolbar (e.g. the docs example
+     * switcher tabs). When present it replaces the standalone status label there,
+     * and the run status moves next to the Run/Reset actions.
+     */
+    tabs?: ReactNode;
+    /**
+     * Baseline simulator knobs applied to every request a run makes — the
+     * "Response knobs" panel. Forwarded to `runner.run` as `RunRequest.knobs`;
+     * an explicit `?__…` in the snippet still wins. Absent → unmodified responses.
+     */
+    knobs?: SimKnobs;
     /** Editor height in px. */
     height?: number;
     /** Read-only display (docs example you can't edit). */
@@ -74,15 +87,19 @@ export interface StitchPlaygroundProps {
      */
     renderEditor?: (props: EditorRenderProps) => ReactNode;
     /**
-     * Custom renderer for the resolved-value text (e.g. a syntax-highlighted
-     * code block). Defaults to a <pre>.
-     */
-    renderValue?: (text: string) => ReactNode;
-    /**
      * Custom renderer for a single console log line (e.g. highlight JSON output).
      * Receives the formatted line + its level. Defaults to the raw text.
      */
     renderLog?: (text: string, level: string) => ReactNode;
+    /**
+     * Optional panel rendered in the bottom-right slot, beside the editor and
+     * below the console (e.g. the docs "Server knobs"). When provided, the body
+     * becomes a three-pane grid; when omitted, the console spans the full right
+     * column. Titled by {@link asideLabel}.
+     */
+    aside?: ReactNode;
+    /** Title bar text for the {@link aside} pane. */
+    asideLabel?: string;
 }
 
 const DEFAULT_SNIPPET = `// Edit and run. Output appears below.
@@ -90,15 +107,51 @@ const user = await stitch('https://reqres.in/api/users/2');
 console.log(user);
 `;
 
+/* Inline icons keep this shell dependency-light (no icon package). Sized in CSS
+   via `.stitch-playground__actions svg`. */
+function PlayIcon() {
+    return (
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M8 5v14l11-7z" />
+        </svg>
+    );
+}
+function StopIcon() {
+    return (
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <rect x="6" y="6" width="12" height="12" rx="1.5" />
+        </svg>
+    );
+}
+function ResetIcon() {
+    return (
+        <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+        >
+            <polyline points="1 4 1 10 7 10" />
+            <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+        </svg>
+    );
+}
+
 export function StitchPlayground({
     initialCode = DEFAULT_SNIPPET,
     runner = mockRunner,
     scope,
+    knobs,
+    tabs,
     height = 220,
     readOnly = false,
     renderEditor,
-    renderValue,
     renderLog,
+    aside,
+    asideLabel = 'Server knobs',
 }: StitchPlaygroundProps) {
     const [code, setCode] = useState(initialCode);
     const [result, setResult] = useState<RunResult | null>(null);
@@ -133,6 +186,7 @@ export function StitchPlayground({
             const res = await runner.run({
                 code,
                 scope,
+                knobs,
                 signal: ac.signal,
                 onEvent,
             });
@@ -144,17 +198,9 @@ export function StitchPlayground({
         } finally {
             if (!ac.signal.aborted) setRunning(false);
         }
-    }, [code, runner, scope]);
+    }, [code, runner, scope, knobs]);
 
     const stop = useCallback(() => abortRef.current?.abort(), []);
-
-    const status = useMemo(() => {
-        if (isDeferred) return 'engine deferred';
-        if (running) return 'running…';
-        if (result?.error) return `error · ${result.error.phase}`;
-        if (result) return `done · ${result.durationMs}ms`;
-        return 'ready';
-    }, [isDeferred, running, result]);
 
     // Reset view and result together when resetting the editor.
     const reset = useCallback(() => {
@@ -166,10 +212,21 @@ export function StitchPlayground({
     return (
         <div className="stitch-playground" data-runner={runner.id}>
             <div className="stitch-playground__toolbar">
-                <span className="stitch-playground__status">{status}</span>
+                {/* Tabs (e.g. the docs example switcher) sit at the start of the
+                    toolbar; the run controls sit at the end. */}
+                {tabs && (
+                    <div className="stitch-playground__toolbar-start">
+                        {tabs}
+                    </div>
+                )}
                 <div className="stitch-playground__actions">
                     {running ? (
-                        <button type="button" onClick={stop}>
+                        <button
+                            type="button"
+                            onClick={stop}
+                            className="stitch-playground__btn stitch-playground__btn--run"
+                        >
+                            <StopIcon />
                             Stop
                         </button>
                     ) : (
@@ -177,61 +234,102 @@ export function StitchPlayground({
                             type="button"
                             onClick={run}
                             disabled={isDeferred}
+                            className="stitch-playground__btn stitch-playground__btn--run"
                         >
+                            <PlayIcon />
                             Run
                         </button>
                     )}
-                    <button type="button" onClick={reset} disabled={running}>
+                    <button
+                        type="button"
+                        onClick={reset}
+                        disabled={running}
+                        className="stitch-playground__btn stitch-playground__btn--reset"
+                    >
+                        <ResetIcon />
                         Reset
                     </button>
                 </div>
             </div>
 
-            {/* EDITOR INTEGRATION POINT — `renderEditor` swaps in a real editor
-                (e.g. CodeMirror 6) while keeping the `code`/`setCode` controlled
-                contract; the default is a dependency-free <textarea>. */}
-            {renderEditor ? (
-                renderEditor({
-                    value: code,
-                    onChange: setCode,
-                    readOnly,
-                    height,
-                })
-            ) : (
-                <textarea
-                    className="stitch-playground__editor"
-                    style={{ height, width: '100%', fontFamily: 'monospace' }}
-                    value={code}
-                    spellCheck={false}
-                    readOnly={readOnly}
-                    onChange={(e) => setCode(e.target.value)}
-                    aria-label="StitchAPI playground editor"
-                />
-            )}
+            {/* Pane layout: Code (left, full height) · Console (right). When an
+                `aside` is supplied (the docs "Server knobs"), it takes the
+                bottom-right slot and the console shrinks to the top-right.
+                Stacks to one column on narrow viewports — see playground.css. */}
+            <div
+                className="stitch-playground__body"
+                data-has-aside={aside ? 'true' : undefined}
+            >
+                <section
+                    className="stitch-playground__pane stitch-playground__pane--editor"
+                    aria-label="Code"
+                >
+                    <div className="stitch-playground__pane-head">Code</div>
+                    {/* EDITOR INTEGRATION POINT — `renderEditor` swaps in a real
+                        editor (e.g. CodeMirror 6) while keeping the `code`/`setCode`
+                        controlled contract; the default is a dependency-free
+                        <textarea>. */}
+                    {renderEditor ? (
+                        renderEditor({
+                            value: code,
+                            onChange: setCode,
+                            readOnly,
+                            height,
+                        })
+                    ) : (
+                        <textarea
+                            className="stitch-playground__editor"
+                            style={{
+                                height,
+                                width: '100%',
+                                fontFamily: 'monospace',
+                            }}
+                            value={code}
+                            spellCheck={false}
+                            readOnly={readOnly}
+                            onChange={(e) => setCode(e.target.value)}
+                            aria-label="StitchAPI playground editor"
+                        />
+                    )}
+                </section>
 
-            <StitchOutput
-                view={view}
-                result={result}
-                deferred={isDeferred}
-                running={running}
-                renderValue={renderValue}
-                renderLog={renderLog}
-            />
+                <StitchOutput
+                    view={view}
+                    result={result}
+                    deferred={isDeferred}
+                    running={running}
+                    renderLog={renderLog}
+                />
+
+                {/* The aside owns its full chrome (header bar + body), so it can
+                    fold actions like "Clear" into its own header. */}
+                {aside && (
+                    <section
+                        className="stitch-playground__pane stitch-playground__pane--aside"
+                        aria-label={asideLabel}
+                    >
+                        {aside}
+                    </section>
+                )}
+            </div>
         </div>
     );
 }
 
 /**
- * Output panel — renders incrementally as RunEvents arrive via onEvent, and
- * reconciles with the final RunResult on resolve.
+ * Console pane — the log stream plus errors, shim notices, and the trace DAG.
+ * It does NOT render the snippet's return value: the playground is logs-first
+ * (snippets `console.log` what they want to show), so a returned value is not
+ * surfaced. Renders incrementally as RunEvents arrive via onEvent and reconciles
+ * with the final RunResult on resolve.
  *
  * Rendering strategy:
  *   · During a run: `view` is updated by `applyEvent` for every RunEvent the runner
  *     emits, so logs, streamed chunks, trace DAG, and notices appear immediately.
- *   · After a run: `view` is replaced by `buildRunView(result)` so value/error/
- *     durationMs always reflect the authoritative final state.
+ *   · After a run: `view` is replaced by `buildRunView(result)` so error/durationMs
+ *     always reflect the authoritative final state.
  *   · Runners that do not emit onEvent (e.g. mockRunner, DeferredRunner) never call
- *     the callback; the panel simply shows the final result after run() resolves.
+ *     the callback; the pane simply shows the final result after run() resolves.
  *
  * The `result` prop is still accepted for the `data-level` log attribute lookup
  * (log level is not part of RunView's flat string array, only the formatted text).
@@ -242,100 +340,105 @@ function StitchOutput({
     result,
     deferred,
     running,
-    renderValue,
     renderLog,
 }: {
     view: RunView | null;
     result: RunResult | null;
     deferred: boolean;
     running: boolean;
-    renderValue?: (text: string) => ReactNode;
     renderLog?: (text: string, level: string) => ReactNode;
 }) {
+    let body: ReactNode;
     if (deferred) {
-        return (
+        body = (
             <div className="stitch-playground__output stitch-playground__output--deferred">
                 ⏳ Execution engine not wired up yet. This shell is running
                 against the mock or deferred runner — see{' '}
                 <code>docs/playground/REQUIREMENTS.md</code>.
             </div>
         );
-    }
-    if (!view && !running)
-        return (
-            <div className="stitch-playground__output">
-                Run a snippet to see output.
+    } else if (!view && !running) {
+        body = (
+            <div className="stitch-playground__output stitch-playground__output--placeholder">
+                Run a snippet to see console output.
             </div>
         );
-    if (!view) return <div className="stitch-playground__output">running…</div>;
+    } else if (!view) {
+        body = (
+            <div className="stitch-playground__output stitch-playground__output--placeholder">
+                running…
+            </div>
+        );
+    } else {
+        body = (
+            <div className="stitch-playground__output">
+                {/* ── Logs ───────────────────────────────────────────── */}
+                {view.logs.map((line, i) => {
+                    const level = result?.logs[i]?.level ?? 'log';
+                    return (
+                        <div
+                            key={i}
+                            data-level={result?.logs[i]?.level}
+                            className="stitch-playground__log"
+                        >
+                            {renderLog ? renderLog(line, level) : line}
+                        </div>
+                    );
+                })}
+
+                {/* ── Error ──────────────────────────────────────────── */}
+                {view.errorText !== null && (
+                    <pre className="stitch-playground__error">
+                        {view.errorText}
+                    </pre>
+                )}
+
+                {/* ── Notices strip ──────────────────────────────────── */}
+                {view.notices.length > 0 && (
+                    <div className="stitch-playground__notices" role="note">
+                        {view.notices.map((n, i) => (
+                            <div key={i} className="stitch-playground__notice">
+                                ⚠ {n}
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                {/* ── Mermaid DAG ────────────────────────────────────── */}
+                {/* Show the DAG as soon as any trace event has been folded in. */}
+                {view.mermaid && !view.mermaid.includes('_empty') && (
+                    <div className="stitch-playground__dag">
+                        {/* Streaming badge: shown when any chunk event arrived or any
+                            trace entry carries `.stream`. Active during and after the run. */}
+                        {view.isStreaming && (
+                            <span className="stitch-playground__dag-streaming-badge">
+                                streaming
+                            </span>
+                        )}
+                        {/* The Mermaid flowchart is rendered by the docs framework's
+                            <Mermaid> component (Fumadocs / MDX). We emit the raw graph
+                            string into a <pre data-mermaid> block; the framework's script
+                            picks it up and renders the SVG DAG. */}
+                        <pre
+                            className="stitch-playground__mermaid"
+                            data-mermaid="true"
+                        >
+                            {view.mermaid}
+                        </pre>
+                    </div>
+                )}
+            </div>
+        );
+    }
 
     return (
-        <div className="stitch-playground__output">
-            {/* ── Logs ─────────────────────────────────────────────────── */}
-            {view.logs.map((line, i) => {
-                const level = result?.logs[i]?.level ?? 'log';
-                return (
-                    <div
-                        key={i}
-                        data-level={result?.logs[i]?.level}
-                        className="stitch-playground__log"
-                    >
-                        {renderLog ? renderLog(line, level) : line}
-                    </div>
-                );
-            })}
-
-            {/* ── Error ────────────────────────────────────────────────── */}
-            {view.errorText !== null && (
-                <pre className="stitch-playground__error">{view.errorText}</pre>
-            )}
-
-            {/* ── Resolved value / streamed text ───────────────────────── */}
-            {view.errorText === null &&
-                view.valueText !== null &&
-                (renderValue ? (
-                    renderValue(view.valueText)
-                ) : (
-                    <pre className="stitch-playground__value">
-                        {view.valueText}
-                    </pre>
-                ))}
-
-            {/* ── Notices strip ────────────────────────────────────────── */}
-            {view.notices.length > 0 && (
-                <div className="stitch-playground__notices" role="note">
-                    {view.notices.map((n, i) => (
-                        <div key={i} className="stitch-playground__notice">
-                            ⚠ {n}
-                        </div>
-                    ))}
-                </div>
-            )}
-
-            {/* ── Mermaid DAG ──────────────────────────────────────────── */}
-            {/* Show the DAG as soon as any trace event has been folded in. */}
-            {view.mermaid && !view.mermaid.includes('_empty') && (
-                <div className="stitch-playground__dag">
-                    {/* Streaming badge: shown when any chunk event arrived or any
-                        trace entry carries `.stream`. Active during and after the run. */}
-                    {view.isStreaming && (
-                        <span className="stitch-playground__dag-streaming-badge">
-                            streaming
-                        </span>
-                    )}
-                    {/* The Mermaid flowchart is rendered by the docs framework's
-                        <Mermaid> component (Fumadocs / MDX). We emit the raw graph
-                        string into a <pre data-mermaid> block; the framework's script
-                        picks it up and renders the SVG DAG. */}
-                    <pre
-                        className="stitch-playground__mermaid"
-                        data-mermaid="true"
-                    >
-                        {view.mermaid}
-                    </pre>
-                </div>
-            )}
-        </div>
+        <section
+            className="stitch-playground__pane stitch-playground__pane--console"
+            aria-label="Console"
+        >
+            <div className="stitch-playground__pane-head">Console</div>
+            {body}
+        </section>
     );
 }
 

--- a/docs/sandbox/component/runner.ts
+++ b/docs/sandbox/component/runner.ts
@@ -17,6 +17,7 @@
  * library build (tsconfig `include` is `src/**\/*.ts` only). It will be relocated
  * into the Fumadocs app when the docs site is scaffolded.
  */
+import type { SimKnobs } from '../contracts/sim';
 
 /* -------------------------------------------------------------------------- */
 /*  Output model — what a run produces                                        */
@@ -144,6 +145,15 @@ export interface RunRequest {
      * the final result. Snippet code never sees this — it's runner→host only.
      */
     onEvent?: (event: RunEvent) => void;
+    /**
+     * Baseline simulator knobs applied to EVERY request this run makes (added
+     * additively). The playground's "Response knobs" panel sets these so a
+     * configured knob (`__status`, `__flaky`, …) shapes the whole run without
+     * editing the snippet. An explicit `?__…` knob in the code still wins for
+     * that call. Snippet code never sees this; the browser runner carries it to
+     * the worker's fetch shim. Absent → responses are unmodified.
+     */
+    knobs?: SimKnobs;
 }
 
 /**

--- a/docs/sandbox/package.json
+++ b/docs/sandbox/package.json
@@ -6,6 +6,7 @@
     "exports": {
         "./component/StitchPlayground": "./component/StitchPlayground.tsx",
         "./contracts/dispatch": "./contracts/dispatch.ts",
+        "./contracts/sim": "./contracts/sim.ts",
         "./runtime/browser-runner": "./runtime/browser-runner.ts"
     },
     "bin": {

--- a/docs/sandbox/runtime/browser-runner.ts
+++ b/docs/sandbox/runtime/browser-runner.ts
@@ -256,6 +256,9 @@ class BrowserWorkerRunner implements CodeRunner {
                 type: 'run',
                 js,
                 extraScopeNames: req.scope ? Object.keys(req.scope) : [],
+                // Baseline knobs from the "Response knobs" panel; the worker
+                // hands them to the sim fetch shim. Omitted → unmodified responses.
+                knobs: req.knobs,
             };
             try {
                 worker.postMessage(msg);

--- a/docs/sandbox/runtime/worker-entry.ts
+++ b/docs/sandbox/runtime/worker-entry.ts
@@ -37,6 +37,7 @@
  *     thread classifies timeout/abort/internal — see worker-protocol.ts.
  */
 import type { LogEntry, LogLevel, RunEvent } from '../component/runner';
+import type { SimKnobs } from '../contracts/sim';
 import type {
     ProgressMessage,
     ResultMessage,
@@ -104,6 +105,14 @@ export interface WorkerEnv {
      * capturing console), so an env need only wire chunk/trace/notice here.
      */
     bindProgress?: (sink: ProgressSink) => (() => void) | void;
+    /**
+     * OPTIONAL: install the run's baseline simulator knobs (`RunMessage.knobs`,
+     * from the playground's "Response knobs" panel) so the env's `fetch` shim
+     * applies them to every request. Called ONCE at the start of each run with
+     * the message's knobs (or `undefined` to clear). A fresh Worker per run means
+     * there's nothing to reset afterwards. Envs without a knob-aware shim omit it.
+     */
+    applyKnobs?: (knobs: SimKnobs | undefined) => void;
 }
 
 /**
@@ -238,6 +247,17 @@ export async function runSnippetInWorker(
     onProgress?: ProgressSink,
 ): Promise<ResultMessage> {
     const t0 = Date.now();
+
+    // Install this run's baseline knobs into the env's fetch shim BEFORE any
+    // snippet code (and thus any `fetch`) runs. Best-effort: a shim-less env
+    // (or a throwing setter) must never derail the run.
+    if (env.applyKnobs) {
+        try {
+            env.applyKnobs(msg.knobs);
+        } catch {
+            /* swallow — knob install is a convenience, not correctness */
+        }
+    }
 
     // A1: wrap the host sink so a throwing onEvent/relay can never derail the
     // snippet, and so a `log` emitted by the console capture and a chunk/trace/

--- a/docs/sandbox/runtime/worker-main.node.ts
+++ b/docs/sandbox/runtime/worker-main.node.ts
@@ -18,6 +18,7 @@
  */
 import { createFetchShim } from '../../../packages/sandbox-sim/src/adapters/node';
 import { allHandlers } from '../../../packages/sandbox-sim/src/handlers';
+import type { SimKnobs } from '../contracts/sim';
 import {
     type WorkerEnv,
     type WorkerGlobal,
@@ -27,9 +28,13 @@ import {
 import { parentPort } from 'node:worker_threads';
 import * as stitchBuild from 'stitchapi';
 
+// Baseline knobs for the current run, mutated by `env.applyKnobs`; the shim
+// reads it on every request. URL-explicit knobs still win (see dispatch).
+let currentKnobs: SimKnobs | undefined;
+
 // The sandbox-sim dispatch shim — the only `fetch` reachable from a snippet. No
 // real socket is opened; an unknown route returns the sandbox-404 (SEC-01..04).
-const simFetch = createFetchShim(allHandlers);
+const simFetch = createFetchShim(allHandlers, () => currentKnobs);
 
 // Route the bundled `stitch` core through the sim too (it calls the bare global
 // `fetch`), not just snippet-level `fetch(...)`. This is what guarantees the
@@ -46,6 +51,10 @@ const env: WorkerEnv = {
     crypto: (globalThis as { crypto?: unknown }).crypto,
     // The real `stitchapi` has no browser shim-notice buffer.
     drainNotices: () => [],
+    // Install the run's baseline knobs so `simFetch` applies them to every call.
+    applyKnobs: (knobs) => {
+        currentKnobs = knobs;
+    },
 };
 
 if (!parentPort) {

--- a/docs/sandbox/runtime/worker-main.ts
+++ b/docs/sandbox/runtime/worker-main.ts
@@ -21,6 +21,7 @@
  */
 import { createFetchShim } from '../../../packages/sandbox-sim/src/adapters/browser';
 import { allHandlers } from '../../../packages/sandbox-sim/src/handlers';
+import type { SimKnobs } from '../contracts/sim';
 import { browserProcess } from './shims/process';
 import * as stitchBuild from './stitch-browser';
 import {
@@ -29,9 +30,14 @@ import {
     installWorkerEntry,
 } from './worker-entry';
 
+// Baseline knobs for the current run (the "Response knobs" panel). Mutated by
+// `env.applyKnobs` before each run; the shim reads it on every request so a
+// configured knob shapes the whole run. URL-explicit knobs still win (dispatch).
+let currentKnobs: SimKnobs | undefined;
+
 // The sandbox-sim dispatch shim — the only `fetch` reachable in this Worker. No
 // real socket is ever opened; an unknown route returns the sandbox-404 (SEC-01..04).
-const simFetch = createFetchShim(allHandlers);
+const simFetch = createFetchShim(allHandlers, () => currentKnobs);
 
 // Replace the Worker's GLOBAL `fetch` so the bundled `stitch` core routes through
 // the simulator too — not just snippet-level `fetch(...)`. Core resolves `fetch`
@@ -54,6 +60,10 @@ const env: WorkerEnv = {
     // Drain the B1 shim-notice buffer after each run → RunResult.notices (SEC-33).
     // The shims' RunNotice is structurally identical to the wire WireNotice.
     drainNotices: stitchBuild.drainNotices,
+    // Install the run's baseline knobs so `simFetch` applies them to every call.
+    applyKnobs: (knobs) => {
+        currentKnobs = knobs;
+    },
 };
 
 // `self` is the Worker global; the only WebWorker-touching line in the build.

--- a/docs/sandbox/runtime/worker-protocol.ts
+++ b/docs/sandbox/runtime/worker-protocol.ts
@@ -21,6 +21,7 @@
  * `RunEvent` shapes mirror the frozen `runner.ts` union, carried by value.
  */
 import type { LogLevel, RunEvent } from '../component/runner';
+import type { SimKnobs } from '../contracts/sim';
 
 /* -------------------------------------------------------------------------- */
 /*  Main thread → Worker                                                       */
@@ -41,6 +42,13 @@ export interface RunMessage {
      * the wire.
      */
     extraScopeNames: string[];
+    /**
+     * Baseline simulator knobs to apply to every request this run makes (the
+     * playground's "Response knobs" panel — `RunRequest.knobs`). Pure data, so
+     * it rides the wire as-is; the worker hands it to the sim fetch shim before
+     * executing. Absent → responses are unmodified. URL-explicit knobs still win.
+     */
+    knobs?: SimKnobs;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/packages/sandbox-sim/src/adapters/browser.ts
+++ b/packages/sandbox-sim/src/adapters/browser.ts
@@ -13,6 +13,7 @@
  */
 import type {
     SimHandler,
+    SimKnobs,
     SimRequest,
 } from '../../../../docs/sandbox/contracts/sim';
 import { dispatch } from '../dispatch';
@@ -122,16 +123,21 @@ function toResponse(
 /**
  * Creates a `fetch`-shaped function backed entirely by the sandbox-sim dispatch.
  * Inject this into the Worker scope in place of the real `fetch`.
+ *
+ * `getDefaultKnobs` (optional) is read on EVERY call, so the host can mutate the
+ * baseline knobs between runs (the playground's "Response knobs" panel) without
+ * rebuilding the shim. URL knobs still win — see `dispatch`.
  */
 export function createFetchShim(
     handlers: SimHandler[],
+    getDefaultKnobs?: () => SimKnobs | undefined,
 ): (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> {
     return async function sandboxFetch(
         input: RequestInfo | URL,
         init?: RequestInit,
     ): Promise<Response> {
         const simReq = await toSimRequest(input, init);
-        const simRes = await dispatch(handlers, simReq);
+        const simRes = await dispatch(handlers, simReq, getDefaultKnobs?.());
         return toResponse(simRes);
     };
 }

--- a/packages/sandbox-sim/src/adapters/node.ts
+++ b/packages/sandbox-sim/src/adapters/node.ts
@@ -16,6 +16,7 @@
  */
 import type {
     SimHandler,
+    SimKnobs,
     SimRequest,
 } from '../../../../docs/sandbox/contracts/sim';
 import { dispatch } from '../dispatch';
@@ -118,16 +119,20 @@ function toResponse(
 /**
  * Creates a `fetch`-shaped function backed entirely by the sandbox-sim dispatch.
  * Inject this into the Node isolate scope in place of the real `fetch`.
+ *
+ * `getDefaultKnobs` (optional) is read on EVERY call so the host can vary the
+ * baseline knobs between runs without rebuilding the shim. URL knobs still win.
  */
 export function createFetchShim(
     handlers: SimHandler[],
+    getDefaultKnobs?: () => SimKnobs | undefined,
 ): (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> {
     return async function sandboxFetch(
         input: RequestInfo | URL,
         init?: RequestInit,
     ): Promise<Response> {
         const simReq = await toSimRequest(input, init);
-        const simRes = await dispatch(handlers, simReq);
+        const simRes = await dispatch(handlers, simReq, getDefaultKnobs?.());
         return toResponse(simRes);
     };
 }

--- a/packages/sandbox-sim/src/dispatch.ts
+++ b/packages/sandbox-sim/src/dispatch.ts
@@ -126,13 +126,21 @@ async function* wrapBodyAsSse(body: unknown): AsyncIterable<Uint8Array> {
 /**
  * Dispatch a `SimRequest` through the handler list, apply knobs, return a
  * `SimResponse`. Never touches real network.
+ *
+ * `defaultKnobs` (optional) are baseline knobs applied to EVERY request — the
+ * playground's "Response knobs" panel sets these so a configured knob shapes
+ * the whole run without editing the snippet. URL knobs always win: an explicit
+ * `?__flaky=2` in the code overrides the panel's default for that one call.
  */
 export async function dispatch(
     handlers: SimHandler[],
     req: SimRequest,
+    defaultKnobs?: SimKnobs,
 ): Promise<SimResponse> {
-    // 1. Parse knobs and produce a clean request (no __ params in URL).
-    const { knobs, cleanUrl } = parseKnobs(req.url);
+    // 1. Parse knobs off the URL and produce a clean request (no __ params),
+    //    then layer them over the panel defaults — URL-explicit knobs win.
+    const { knobs: urlKnobs, cleanUrl } = parseKnobs(req.url);
+    const knobs: SimKnobs = { ...defaultKnobs, ...urlKnobs };
     const cleanReq: SimRequest = { ...req, url: cleanUrl };
 
     // 2. Find first matching handler.


### PR DESCRIPTION
## What

Redesigns the docs **Playground** into a full-height, app-like workspace and makes the response simulator interactive.

### Layout & chrome
- Full-height shell that fills the viewport below the site header: **Code** editor spans the left; **Console** (top-right) over **Server knobs** (bottom-right). Stacks to one column on narrow viewports.
- Example tabs (Complete | Simple) fold into the toolbar as a segmented control.
- Removed the page title/subtitle (context now lives in the snippet comments), the run-status label, the example descriptions, and the resolved-value pane.
- Console is **logs-only** — the example snippets no longer `return`.

### Server knobs (interactive, auto-applied)
- The panel shapes **every call the next run makes** — no copy/paste. Knobs are threaded `RunRequest.knobs → RunMessage → worker applyKnobs → sim dispatch`, merging panel defaults *under* URL `?__…` knobs (which still win). Exposed the `@stitchapi/sandbox/contracts/sim` entrypoint for the shared `SimKnobs` type.
- Compact one-row control bar with friendly labels; Status/Flaky capped to 3 digits; Stream `<select>` height matched to the inputs; **Drift** is an on/off switch. The panel header holds the title, concise active-knob chips, and Clear.

Contracts are widened **additively only**: `RunRequest`/`RunMessage` gain an optional `knobs` field, and sandbox-sim `dispatch`/`createFetchShim` take an optional default-knobs argument.

## Verification
- Full local CI gate green: `check:format`, `check:lint`, `check:types`, `test` (198 passed), `check:exports`, and `pnpm --filter @stitchapi/docs build` (`/playground` prerendered static).
- Browser-verified in light + dark + mobile: layout, tab switching, knob auto-apply (latency → timeout, `status 500` → `StitchError: HTTP 500` in the Console), the Drift switch, and the header chips.

## Follow-ups (not in this PR)
- Per-chip remove (×) button + clearer chip labels.
- Consider rendering the Console as a readonly CodeMirror (line numbers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
