### PR TITLE
feat(core): derived-key response cache + in-process coalescing (ADR 0003 v1)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,6 +55,16 @@
                 "types": "./lib/testing.d.ts",
                 "default": "./lib/testing.js"
             }
+        },
+        "./cache": {
+            "import": {
+                "types": "./lib/cache.d.mts",
+                "default": "./lib/cache.mjs"
+            },
+            "require": {
+                "types": "./lib/cache.d.ts",
+                "default": "./lib/cache.js"
+            }
         }
     },
     "sideEffects": false,

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -1,0 +1,605 @@
+// Derived-key response cache + in-process request coalescing (ADR 0003), shipped behind the
+// `stitchapi/cache` subpath so `import { stitch }` pulls none of it (bundle-frugal gate). The
+// engine reaches this module by a LAZY dynamic import, only when a stitch carries a `cache`
+// block — so the hot path of a cache-free stitch never touches a byte of it.
+//
+// Browser-first: no `node:*`, no WebCrypto (`crypto.subtle.digest` is async and a JS crypto
+// hash is bundle weight). The key is a 128-bit SYNCHRONOUS non-cryptographic digest. It reuses
+// the `StitchStore` get/set/incr contract — no new vendor surface — exactly like throttle and
+// the circuit breaker, so a shared store makes the cache distributed for free.
+import type { CacheConfig, StitchInput, StitchStore } from './types';
+import { parseDuration } from './util';
+
+// ---------------------------------------------------------------------------
+// 128-bit synchronous non-cryptographic hash (xxHash family)
+// ---------------------------------------------------------------------------
+// v1 derives the digest from two XXH64 passes (seeds A and B) over the canonical request's
+// UTF-8 bytes — a well-specified, bit-stable xxHash member that needs only 64-bit integer math
+// (BigInt; JS has no native u64) and no async/WebCrypto. 128 bits puts a collision past ~2^64
+// entries — unreachable — so there is no verify-on-read (which would mean storing the plaintext
+// request beside the value, re-introducing the leak the opaque key avoids). The algorithm is
+// frozen behind KEY_VERSION: any change to it is a key-schema bump (mass self-healing miss).
+
+const MASK64 = (1n << 64n) - 1n;
+const P1 = 11400714785074694791n;
+const P2 = 14029467366897019727n;
+const P3 = 1609587929392839161n;
+const P4 = 9650029242287828579n;
+const P5 = 2870177450012600261n;
+const SEED_A = 0n;
+const SEED_B = 0x9e3779b185ebca87n; // a second, independent seed → the high 64 bits
+
+const mul = (a: bigint, b: bigint): bigint => (a * b) & MASK64;
+const rotl = (x: bigint, r: bigint): bigint =>
+    ((x << r) | (x >> (64n - r))) & MASK64;
+const xxhRound = (acc: bigint, input: bigint): bigint =>
+    mul(rotl((acc + mul(input, P2)) & MASK64, 31n), P1);
+const mergeRound = (acc: bigint, val: bigint): bigint =>
+    (mul(acc ^ xxhRound(0n, val), P1) + P4) & MASK64;
+
+// All reads are bounds-guaranteed by the callers' stripe arithmetic; `?? 0` keeps the indexed
+// access total without a non-null assertion (noUncheckedIndexedAccess).
+function read64LE(b: Uint8Array, i: number): bigint {
+    let v = 0n;
+    for (let j = 7; j >= 0; j--) v = (v << 8n) | BigInt(b[i + j] ?? 0);
+    return v;
+}
+function read32LE(b: Uint8Array, i: number): bigint {
+    return BigInt(
+        ((b[i] ?? 0) |
+            ((b[i + 1] ?? 0) << 8) |
+            ((b[i + 2] ?? 0) << 16) |
+            ((b[i + 3] ?? 0) << 24)) >>>
+            0,
+    );
+}
+
+function xxh64(b: Uint8Array, seed: bigint): bigint {
+    const len = b.length;
+    let h: bigint;
+    let p = 0;
+    if (len >= 32) {
+        let v1 = (seed + P1 + P2) & MASK64;
+        let v2 = (seed + P2) & MASK64;
+        let v3 = seed & MASK64;
+        let v4 = (seed - P1) & MASK64;
+        const limit = len - 32;
+        while (p <= limit) {
+            v1 = xxhRound(v1, read64LE(b, p));
+            p += 8;
+            v2 = xxhRound(v2, read64LE(b, p));
+            p += 8;
+            v3 = xxhRound(v3, read64LE(b, p));
+            p += 8;
+            v4 = xxhRound(v4, read64LE(b, p));
+            p += 8;
+        }
+        h =
+            (rotl(v1, 1n) + rotl(v2, 7n) + rotl(v3, 12n) + rotl(v4, 18n)) &
+            MASK64;
+        h = mergeRound(h, v1);
+        h = mergeRound(h, v2);
+        h = mergeRound(h, v3);
+        h = mergeRound(h, v4);
+    } else {
+        h = (seed + P5) & MASK64;
+    }
+    h = (h + BigInt(len)) & MASK64;
+    while (p + 8 <= len) {
+        h ^= xxhRound(0n, read64LE(b, p));
+        h = (mul(rotl(h, 27n), P1) + P4) & MASK64;
+        p += 8;
+    }
+    if (p + 4 <= len) {
+        h ^= mul(read32LE(b, p), P1);
+        h = (mul(rotl(h, 23n), P2) + P3) & MASK64;
+        p += 4;
+    }
+    while (p < len) {
+        h ^= mul(BigInt(b[p] ?? 0), P5);
+        h = mul(rotl(h, 11n), P1);
+        p += 1;
+    }
+    h ^= h >> 33n;
+    h = mul(h, P2);
+    h ^= h >> 29n;
+    h = mul(h, P3);
+    h ^= h >> 32n;
+    return h & MASK64;
+}
+
+const encoder = new TextEncoder();
+const toHex16 = (v: bigint): string => v.toString(16).padStart(16, '0');
+
+/** A 128-bit synchronous non-cryptographic digest of `input` as a 32-char hex string. */
+export function xxh128(input: string): string {
+    const bytes = encoder.encode(input);
+    return toHex16(xxh64(bytes, SEED_A)) + toHex16(xxh64(bytes, SEED_B));
+}
+
+// ---------------------------------------------------------------------------
+// canonicalisation
+// ---------------------------------------------------------------------------
+// A deterministic string for semantically-identical requests, so they collide intentionally:
+// object keys sorted recursively; arrays + query-param order preserved (both ordered, and we
+// build the query ourselves); `null` kept, `undefined` dropped (== absent); Dates as ISO. A
+// value that can't be canonicalised deterministically (function, Blob, FormData, stream, …)
+// throws Unhashable so the caller can warn-and-pass-through rather than store a wrong key.
+
+class Unhashable extends Error {}
+
+function stable(value: unknown): string {
+    if (value === null) return 'null';
+    const t = typeof value;
+    if (t === 'string') return JSON.stringify(value);
+    if (t === 'number')
+        return Number.isFinite(value) ? JSON.stringify(value) : 'null';
+    if (t === 'boolean') return value ? 'true' : 'false';
+    if (t === 'bigint')
+        return JSON.stringify(`${(value as bigint).toString()}n`);
+    if (t === 'undefined') return 'null'; // only reached for an array hole; objects drop it
+    if (value instanceof Date) return JSON.stringify(value.toISOString());
+    if (Array.isArray(value))
+        return `[${value.map((v) => (v === undefined ? 'null' : stable(v))).join(',')}]`;
+    if (t === 'object') {
+        const proto: unknown = Object.getPrototypeOf(value);
+        // Only plain objects (or null-proto) canonicalise deterministically; anything else
+        // (Blob/FormData/Map/Set/typed arrays/streams) is treated as unhashable.
+        if (proto !== null && proto !== Object.prototype)
+            throw new Unhashable('unhashable object');
+        const obj = value as Record<string, unknown>;
+        const keys = Object.keys(obj)
+            .filter((k) => obj[k] !== undefined)
+            .sort();
+        return `{${keys.map((k) => `${JSON.stringify(k)}:${stable(obj[k])}`).join(',')}}`;
+    }
+    throw new Unhashable(`unhashable value: ${t}`); // function, symbol
+}
+
+/** Normalise a URL through the platform `URL` only — lower-cased host, default port dropped,
+ *  dot-segments resolved, fragment dropped. A non-absolute URL (custom adapter) passes through. */
+function normalizeUrl(raw: string): string {
+    try {
+        const u = new URL(raw);
+        return `${u.protocol}//${u.host}${u.pathname}${u.search}`;
+    } catch {
+        return raw;
+    }
+}
+
+// Headers that must never enter the key: secrets (covered by principal scope instead) and
+// per-request volatile values that would make every call a miss.
+const NEVER_VARY = new Set([
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+    'x-api-key',
+    'traceparent',
+    'tracestate',
+    'x-request-id',
+    'x-correlation-id',
+    'date',
+]);
+
+function findHeader(
+    headers: Record<string, string> | undefined,
+    lowerName: string,
+): string | undefined {
+    if (!headers) return undefined;
+    for (const k of Object.keys(headers))
+        if (k.toLowerCase() === lowerName) return headers[k];
+    return undefined;
+}
+
+function varyHeaderObject(
+    headers: Record<string, string> | undefined,
+    names: string[],
+): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const name of names) {
+        const lc = name.toLowerCase();
+        if (NEVER_VARY.has(lc)) continue;
+        const val = findHeader(headers, lc);
+        if (val !== undefined) out[lc] = val;
+    }
+    return out;
+}
+
+/** The resolved request the key is derived from. `principal` here is already scope-resolved
+ *  (absent under `scope: 'app'`). */
+export interface RequestDescriptor {
+    method: string;
+    url: string;
+    body?: unknown;
+    graphql?: { query: string; variables: unknown };
+    headers?: Record<string, string>;
+    principal?: string;
+}
+
+/** The frozen key-schema version. Folded into the hashed content AND prefixed onto the stored
+ *  key, so any canonicalisation change is a mass self-healing miss, never a stale-key hit. */
+export const KEY_VERSION = 'k1';
+
+function canonicalRequest(
+    d: RequestDescriptor,
+    varyNames: string[] | undefined,
+): string {
+    const parts: Record<string, unknown> = {
+        x: KEY_VERSION,
+        m: d.method.toUpperCase(),
+        u: normalizeUrl(d.url),
+    };
+    if (d.graphql) {
+        parts['q'] = d.graphql.query; // document opaque; no GraphQL parser pulled in
+        parts['gv'] = d.graphql.variables; // variables canonicalised by stable()
+    } else if (d.body !== undefined) {
+        parts['b'] = d.body;
+    }
+    if (varyNames?.length) {
+        const h = varyHeaderObject(d.headers, varyNames);
+        if (Object.keys(h).length) parts['h'] = h;
+    }
+    if (d.principal !== undefined) parts['p'] = d.principal; // canonicalised like a body
+    return stable(parts);
+}
+
+/** Derive the opaque 128-bit key from a resolved request, or `undefined` when the request is
+ *  not hashable (an unserialisable body) — the caller then warns and passes through. With a
+ *  `userKey` (the `cache.key` sugar) the request canonicalisation is replaced, but the version
+ *  and principal still fold in so scope isolation is never lost. */
+export function deriveCacheKey(
+    d: RequestDescriptor,
+    varyNames: string[] | undefined,
+    userKey?: string,
+): string | undefined {
+    try {
+        const seed =
+            userKey !== undefined
+                ? stable({ x: KEY_VERSION, k: userKey, p: d.principal })
+                : canonicalRequest(d, varyNames);
+        return xxh128(seed);
+    } catch (e) {
+        if (e instanceof Unhashable) return undefined;
+        throw e;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// in-process request coalescing
+// ---------------------------------------------------------------------------
+// A process-local map of in-flight runs keyed by the derived key: the first caller is the
+// LEADER and runs the request; concurrent identical callers are FOLLOWERS that await the
+// leader's one shared promise. A leader failure is NOT shared (the engine catches the rejection
+// and re-runs independently). Aborts are ref-counted: the shared run is dropped — and `onCancel`
+// fired — only when the LAST participant aborts (the bounded slice of cancellation ADR 0002
+// deferred). A `Promise` can't cross processes, so this is in-process by nature (cross-process
+// coalescing is the deferred cluster mode).
+
+interface Inflight<T> {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+    reject: (err: unknown) => void;
+    refs: number;
+    onCancel?: () => void;
+}
+
+export interface LeaderClaim<T> {
+    leader: true;
+    promise: Promise<T>;
+    settle: (value: T) => void;
+    fail: (err: unknown) => void;
+}
+export interface FollowerClaim<T> {
+    leader: false;
+    promise: Promise<T>;
+}
+
+export class InflightCoalescer<T> {
+    private readonly map = new Map<string, Inflight<T>>();
+
+    get size(): number {
+        return this.map.size;
+    }
+
+    /** Join (or start) the in-flight run for `key`. The first caller leads; the rest follow.
+     *  Pass a `signal` to ref-count this participant: when every participant has aborted, the
+     *  run is dropped and `onCancel` (set by the leader) is invoked. */
+    join(
+        key: string,
+        opts?: { signal?: AbortSignal; onCancel?: () => void },
+    ): LeaderClaim<T> | FollowerClaim<T> {
+        let entry = this.map.get(key);
+        const leading = entry === undefined;
+        if (!entry) {
+            let resolve!: (value: T) => void;
+            let reject!: (err: unknown) => void;
+            const promise = new Promise<T>((res, rej) => {
+                resolve = res;
+                reject = rej;
+            });
+            entry = { promise, resolve, reject, refs: 0 };
+            if (opts?.onCancel) entry.onCancel = opts.onCancel;
+            this.map.set(key, entry);
+        }
+        const self = entry;
+        self.refs += 1;
+        if (opts?.signal) {
+            const onAbort = (): void => {
+                self.refs -= 1;
+                if (self.refs <= 0 && this.map.get(key) === self) {
+                    this.map.delete(key);
+                    self.onCancel?.();
+                }
+            };
+            if (opts.signal.aborted) onAbort();
+            else opts.signal.addEventListener('abort', onAbort, { once: true });
+        }
+        if (leading) {
+            return {
+                leader: true,
+                promise: self.promise,
+                settle: (value: T) => {
+                    if (this.map.get(key) === self) this.map.delete(key);
+                    self.resolve(value);
+                },
+                fail: (err: unknown) => {
+                    if (this.map.get(key) === self) this.map.delete(key);
+                    self.reject(err);
+                },
+            };
+        }
+        return { leader: false, promise: self.promise };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// the read-through cache controller
+// ---------------------------------------------------------------------------
+// One controller per stitch. It owns: key derivation, the TTL read-through over the store under
+// the `cache:` namespace, the generation prefixes that power bulk invalidation, the in-process
+// LRU cap, and the coalescer. Memory bounding lives HERE, not in the store (a BYO Redis store
+// inherits no eviction obligation).
+
+const NS = 'cache:';
+const GEN_TTL_MS = 30 * 24 * 60 * 60 * 1000; // generation counters effectively never expire
+const cacheGenKey = `${NS}gen`;
+const stitchGenKey = (id: string): string => `${NS}gen:${id}`;
+
+/** Stable per-stitch id used to namespace its entries and target `seam.invalidate(stitch)`. */
+export function cacheStitchId(cfg: { name?: string; path?: string }): string {
+    return cfg.name ?? cfg.path ?? 'stitch';
+}
+
+/** Bulk invalidation primitive used by the seam surface: bump the cache-wide generation (no id)
+ *  or one stitch's generation. Every prior-generation entry becomes unreachable and TTLs out —
+ *  no key enumeration, no SCAN, no store-contract extension. */
+export async function bumpCacheGeneration(
+    store: StitchStore,
+    stitchId?: string,
+): Promise<void> {
+    await store.incr(
+        stitchId ? stitchGenKey(stitchId) : cacheGenKey,
+        GEN_TTL_MS,
+    );
+}
+
+const asNum = (v: unknown): number => (typeof v === 'number' ? v : 0);
+
+// The stored shape. A direct value entry: `{ v, s, vary: [] }`. A learned-Vary pointer (no
+// value): `{ vary: [names] }`, with the real value living at a secondary key derived from the
+// request's values for those headers.
+interface StoredEntry {
+    v?: unknown;
+    s?: number;
+    vary?: string[];
+}
+
+export interface CacheHit {
+    value: unknown;
+    status: number;
+}
+
+/** A captured cache operation for one logical call: the generation prefix is read once and
+ *  reused across `get`/`set`/`delete`, so a hit costs the generation reads + one value read. */
+export interface CacheOp {
+    get(): Promise<CacheHit | null>;
+    set(
+        value: unknown,
+        status: number,
+        varyHeader: string | undefined,
+    ): Promise<void>;
+    delete(): Promise<void>;
+}
+
+export interface CacheController {
+    /** Is `method` in the cacheable set (and so eligible for coalescing)? */
+    cacheableMethod(method: string): boolean;
+    /** Derive the base key for a resolved request, or `undefined` when it is not hashable. */
+    key(d: RequestDescriptor, input: StitchInput): string | undefined;
+    /** Open a cache operation for `baseKey` (reads the live generation prefix once). */
+    open(baseKey: string, d: RequestDescriptor): Promise<CacheOp>;
+    /** Should a hit be re-validated against the output schema? True unless `cache.version` pins it. */
+    readonly revalidateOnHit: boolean;
+    /** Join (or start) the in-process coalesced run for `key`. */
+    join(key: string): LeaderClaim<CacheHit> | FollowerClaim<CacheHit>;
+    /** Coalescing mode after resolving the v1 store-aware default. */
+    readonly coalesce: 'process' | false;
+    /** Bulk-invalidate every entry this stitch produced (per-stitch generation bump). */
+    invalidate(): Promise<void>;
+}
+
+export interface CacheControllerOptions {
+    config: CacheConfig;
+    store: StitchStore;
+    stitchId: string;
+    principal?: string;
+}
+
+export function createCache(opts: CacheControllerOptions): CacheController {
+    const { config, store, stitchId } = opts;
+    const ttlMs = parseDuration(config.ttl) ?? 0;
+    const scope = config.scope ?? 'principal';
+    const methods = (config.methods ?? ['GET', 'HEAD']).map((m) =>
+        m.toUpperCase(),
+    );
+    const maxEntries = config.maxEntries ?? 1000;
+    const explicitVary = config.vary?.length
+        ? config.vary
+              .map((n) => n.toLowerCase())
+              .filter((n) => !NEVER_VARY.has(n))
+        : undefined;
+    const versionTag = config.version != null ? `u${config.version}:` : '';
+    // 'cluster' is reserved for the deferred cross-process protocol; v1 degrades it to process.
+    const coalesce: 'process' | false =
+        config.coalesce === false ? false : 'process';
+    const principalForScope = scope === 'app' ? undefined : opts.principal;
+    const coalescer = new InflightCoalescer<CacheHit>();
+    // In-process LRU of keys THIS process has written; insertion order = recency (Map preserves
+    // it; a re-touch deletes+re-sets to move the key to the most-recent end).
+    const lru = new Map<string, true>();
+
+    const remember = (k: string): void => {
+        if (lru.has(k)) lru.delete(k);
+        lru.set(k, true);
+        while (lru.size > maxEntries) {
+            const oldest = lru.keys().next().value;
+            if (oldest === undefined) break;
+            lru.delete(oldest);
+            void store.set(oldest, undefined); // evict from the store (best-effort)
+        }
+    };
+
+    const varySuffix = (d: RequestDescriptor, names: string[]): string =>
+        `:h${xxh128(stable(varyHeaderObject(d.headers, names)))}`;
+
+    const varyNamesFrom = (varyHeader: string | undefined): string[] => {
+        if (!varyHeader) return [];
+        const parts = varyHeader
+            .split(',')
+            .map((s) => s.trim().toLowerCase())
+            .filter(Boolean);
+        if (parts.includes('*')) return ['*']; // Vary:* — uncacheable
+        return parts.filter((p) => !NEVER_VARY.has(p));
+    };
+
+    const genPrefix = async (): Promise<string> => {
+        const [cg, sg] = await Promise.all([
+            store.get(cacheGenKey),
+            store.get(stitchGenKey(stitchId)),
+        ]);
+        return `g${asNum(cg)}.${asNum(sg)}.${stitchId}.`;
+    };
+
+    return {
+        revalidateOnHit: config.version == null,
+        coalesce,
+
+        cacheableMethod(method) {
+            return methods.includes(method.toUpperCase());
+        },
+
+        key(d, input) {
+            // Scope handling lives here: fold the bound principal in under 'principal' scope,
+            // omit it under 'app'. The descriptor itself carries no principal (engine concern).
+            const scoped: RequestDescriptor =
+                principalForScope !== undefined
+                    ? { ...d, principal: principalForScope }
+                    : d;
+            const userKey = config.key ? config.key(input) : undefined;
+            return deriveCacheKey(scoped, explicitVary, userKey);
+        },
+
+        join(key) {
+            return coalescer.join(key);
+        },
+
+        async invalidate() {
+            await bumpCacheGeneration(store, stitchId);
+        },
+
+        async open(baseKey, d) {
+            const prefix = await genPrefix();
+            // The stored key is prefixed with the frozen key-schema version, so a derivation
+            // change is a mass self-healing miss, never a stale-key hit (ADR 0003 follow-up).
+            const valueKey = (suffix = ''): string =>
+                `${NS}${KEY_VERSION}:${prefix}${versionTag}${baseKey}${suffix}`;
+
+            const hitFrom = (
+                entry: StoredEntry,
+                k: string,
+            ): CacheHit | null => {
+                if (entry.v === undefined) return null;
+                remember(k);
+                return { value: entry.v, status: entry.s ?? 200 };
+            };
+
+            return {
+                async get() {
+                    const raw = await store.get(valueKey());
+                    if (raw == null) return null;
+                    const entry = raw as StoredEntry;
+                    // Explicit-vary mode folds the headers into baseKey already → single level.
+                    if (explicitVary) return hitFrom(entry, valueKey());
+                    if (!entry.vary || entry.vary.length === 0)
+                        return hitFrom(entry, valueKey());
+                    // Learned-Vary pointer: the value lives at a header-derived secondary key.
+                    const sk = valueKey(varySuffix(d, entry.vary));
+                    const sraw = await store.get(sk);
+                    if (sraw == null) return null;
+                    return hitFrom(sraw, sk);
+                },
+
+                async set(value, status, varyHeader) {
+                    const names = explicitVary ? [] : varyNamesFrom(varyHeader);
+                    if (names.includes('*')) return; // Vary:* — never store
+                    if (explicitVary || names.length === 0) {
+                        const k = valueKey();
+                        await store.set(
+                            k,
+                            {
+                                v: value,
+                                s: status,
+                                vary: [],
+                            } satisfies StoredEntry,
+                            ttlMs || undefined,
+                        );
+                        remember(k);
+                        return;
+                    }
+                    // Learned Vary: a pointer at the base key + the value at the secondary key.
+                    await store.set(
+                        valueKey(),
+                        { vary: names } satisfies StoredEntry,
+                        ttlMs || undefined,
+                    );
+                    const sk = valueKey(varySuffix(d, names));
+                    await store.set(
+                        sk,
+                        {
+                            v: value,
+                            s: status,
+                            vary: names,
+                        } satisfies StoredEntry,
+                        ttlMs || undefined,
+                    );
+                    remember(sk);
+                },
+
+                async delete() {
+                    if (!explicitVary) {
+                        const raw = await store.get(valueKey());
+                        const entry = raw as StoredEntry | null | undefined;
+                        if (entry?.vary?.length)
+                            await store.set(
+                                valueKey(varySuffix(d, entry.vary)),
+                                undefined,
+                            );
+                    }
+                    await store.set(valueKey(), undefined);
+                    lru.delete(valueKey());
+                },
+            };
+        },
+    };
+}

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -2,6 +2,10 @@
 // `execute` is an async generator (start → progress → drift → result → done); the await
 // path consumes it to the result. `executeRaw` runs the request once and returns the raw
 // response (used by cookieSession to read Set-Cookie from a login stitch).
+// Type-only: erased at compile time, so the cache engine is NOT statically bundled into core.
+// The real module is reached via a lazy `import('./cache')` only when a stitch has a `cache`
+// block (bundle-frugal gate — ADR 0003 decision 11).
+import type { CacheController, CacheHit, RequestDescriptor } from './cache';
 import { classifyDrift, loadSnapshot, saveSnapshot } from './drift';
 import { fetchAdapter } from './http-adapter';
 import {
@@ -60,6 +64,9 @@ export interface Runtime {
     trace: TraceSink;
     store: StitchStore;
     authCtx: AuthContext;
+    /** Lazily-initialised cache controller (ADR 0003). Memoised so all calls of one stitch share
+     *  a single coalescer + LRU; the `import('./cache')` fires once, only for a cached stitch. */
+    cacheInit?: Promise<CacheController>;
 }
 
 export function makeRuntime(
@@ -640,53 +647,99 @@ async function* paginated(
     yield doneEvt(true, t0, state.attempts);
 }
 
-export async function* execute(
-    rt: Runtime,
-    input: StitchInput = {},
-): AsyncGenerator<StitchEvent, void> {
+// ---- cache integration (ADR 0003) -----------------------------------------
+// The cache engine lives in its own subpath module; the engine reaches it only through a lazy
+// `import('./cache')`, memoised on the runtime, and only when a stitch carries a `cache` block
+// and is not `sensitive`. A cache-free stitch never loads a byte of it.
+async function ensureCache(rt: Runtime): Promise<CacheController | null> {
     const { cfg } = rt;
-    const name = nameOf(cfg);
-    const t0 = now();
-    const state = { attempts: 0 };
-    const budget = totalBudget(cfg, t0);
+    const config = cfg.cache;
+    if (!config || cfg.sensitive) return null;
+    rt.cacheInit ??= import('./cache').then((m) =>
+        m.createCache({
+            config,
+            store: rt.store,
+            stitchId: m.cacheStitchId(cfg),
+            ...(rt.authCtx.principal !== undefined
+                ? { principal: rt.authCtx.principal }
+                : {}),
+        }),
+    );
+    return rt.cacheInit;
+}
 
-    try {
-        await validateInput(cfg, input);
-    } catch (e) {
-        yield errEvt(e, name, 0);
-        yield doneEvt(false, t0, 0);
-        return;
-    }
-
-    if (cfg.paginate) {
-        yield* paginated(rt, input, state, t0, budget);
-        return;
-    }
-
-    let baseReq: AdapterRequest;
-    try {
-        baseReq = buildRequest(cfg, input);
-    } catch (e) {
-        yield errEvt(e, name, 0);
-        yield doneEvt(false, t0, 0);
-        return;
-    }
-    yield {
-        type: 'start',
-        name,
+// The resolved request the cache key is derived from. The principal it scopes by is sourced from
+// the trusted AuthContext at controller creation, never from StitchInput (ADR 0002 §2), so the
+// descriptor itself stays principal-free; folding + scope are the controller's job.
+function describe(
+    cfg: StitchConfig,
+    input: StitchInput,
+    baseReq: AdapterRequest,
+): RequestDescriptor {
+    const d: RequestDescriptor = {
         method: baseReq.method,
         url: baseReq.url,
-        input,
-        at: now(),
+        headers: baseReq.headers,
     };
+    if (cfg.kind === 'graphql')
+        d.graphql = {
+            query: cfg.query ?? '',
+            variables: input.variables ?? input.body ?? {},
+        };
+    else if (baseReq.body !== undefined) d.body = baseReq.body;
+    return d;
+}
 
+type RunOutcome =
+    | { ok: true; value: unknown; status: number; vary?: string }
+    | { ok: false };
+
+const startEvt = (
+    name: string,
+    baseReq: AdapterRequest,
+    input: StitchInput,
+): StitchEvent => ({
+    type: 'start',
+    name,
+    method: baseReq.method,
+    url: baseReq.url,
+    input,
+    at: now(),
+});
+
+const cacheEvt = (detail: string): StitchEvent => ({
+    type: 'progress',
+    phase: 'cache',
+    attempt: 0,
+    detail,
+    at: now(),
+});
+
+const resultEvt = (
+    value: unknown,
+    status: number,
+    attempts: number,
+): StitchEvent => ({ type: 'result', value, status, attempts, at: now() });
+
+// The resilience chain from the request onward (no `start` event — the caller emits it). Returns
+// the validated outcome so the cache layer can store/share it; on any failure it yields the
+// error/done events and returns `{ ok: false }`.
+async function* runFrom(
+    rt: Runtime,
+    baseReq: AdapterRequest,
+    name: string,
+    state: { attempts: number },
+    t0: number,
+    budget?: TotalBudget,
+): AsyncGenerator<StitchEvent, RunOutcome> {
+    const { cfg } = rt;
     let res: AdapterResponse;
     try {
         res = yield* attemptWithCircuit(rt, baseReq, state, budget);
     } catch (e) {
         yield errEvt(e, name, state.attempts);
         yield doneEvt(false, t0, state.attempts);
-        return;
+        return { ok: false };
     }
 
     // GraphQL: a 200 response carrying `errors` is a failure.
@@ -702,7 +755,7 @@ export async function* execute(
                 at: now(),
             };
             yield doneEvt(false, t0, state.attempts);
-            return;
+            return { ok: false };
         }
     }
 
@@ -726,17 +779,226 @@ export async function* execute(
             at: now(),
         };
         yield doneEvt(false, t0, state.attempts);
+        return { ok: false };
+    }
+
+    yield resultEvt(value, res.status, state.attempts);
+    yield doneEvt(true, t0, state.attempts);
+    const vary = res.headers['vary'];
+    return vary !== undefined
+        ? { ok: true, value, status: res.status, vary }
+        : { ok: true, value, status: res.status };
+}
+
+// A single uncached run: build the request, emit `start`, then run the chain.
+async function* runOnce(
+    rt: Runtime,
+    input: StitchInput,
+    name: string,
+    state: { attempts: number },
+    t0: number,
+    budget?: TotalBudget,
+): AsyncGenerator<StitchEvent, RunOutcome> {
+    let baseReq: AdapterRequest;
+    try {
+        baseReq = buildRequest(rt.cfg, input);
+    } catch (e) {
+        yield errEvt(e, name, 0);
+        yield doneEvt(false, t0, 0);
+        return { ok: false };
+    }
+    yield startEvt(name, baseReq, input);
+    return yield* runFrom(rt, baseReq, name, state, t0, budget);
+}
+
+// The cached path: lookup is OUTERMOST over the expensive chain; a hit short-circuits
+// throttle/circuit/network/transform/output-validation; a miss runs the full chain (collapsed by
+// in-process coalescing) and writes the validated result to the cache LAST (ADR 0003 §7).
+async function* runCached(
+    rt: Runtime,
+    ctl: CacheController,
+    input: StitchInput,
+    name: string,
+    state: { attempts: number },
+    t0: number,
+    budget?: TotalBudget,
+): AsyncGenerator<StitchEvent, void> {
+    const { cfg } = rt;
+    let baseReq: AdapterRequest;
+    try {
+        baseReq = buildRequest(cfg, input);
+    } catch (e) {
+        yield errEvt(e, name, 0);
+        yield doneEvt(false, t0, 0);
+        return;
+    }
+    yield startEvt(name, baseReq, input);
+
+    // A non-cacheable method (a mutation sharing a fragment) runs normally, uncached.
+    if (!ctl.cacheableMethod(baseReq.method)) {
+        yield* runFrom(rt, baseReq, name, state, t0, budget);
+        return;
+    }
+    // A non-storable response (binary read straight into the store) warns and passes through —
+    // configuring `cache` here is a no-op-with-warning, never a crash (ADR 0003 §3).
+    if (cfg.responseType === 'blob' || cfg.responseType === 'arrayBuffer') {
+        yield cacheEvt('bypass: non-storable responseType');
+        yield* runFrom(rt, baseReq, name, state, t0, budget);
         return;
     }
 
-    yield {
-        type: 'result',
-        value,
-        status: res.status,
-        attempts: state.attempts,
-        at: now(),
+    const d = describe(cfg, input, baseReq);
+    const key = ctl.key(d, input);
+    if (key === undefined) {
+        yield cacheEvt('bypass: unhashable request');
+        yield* runFrom(rt, baseReq, name, state, t0, budget);
+        return;
+    }
+
+    const op = await ctl.open(key, d);
+    const found = await op.get();
+    if (found) {
+        // Re-validate on hit unless `cache.version` pins the schema (the safe default until
+        // schema fingerprinting, ADR 0004): still skips network/throttle/transform. A fatal
+        // mismatch means the stored value is stale-shaped → evict and fall through to a miss.
+        let stale = false;
+        if (ctl.revalidateOnHit && cfg.output) {
+            for (const finding of await validateOutput(cfg, found.value)) {
+                yield { type: 'drift', finding, at: now() };
+                if (finding.level === 'error') stale = true;
+            }
+        }
+        if (!stale) {
+            yield cacheEvt('hit');
+            yield resultEvt(found.value, found.status, 0);
+            yield doneEvt(true, t0, 0);
+            return;
+        }
+        await op.delete();
+    }
+
+    yield cacheEvt('miss');
+    const store = async (out: RunOutcome): Promise<void> => {
+        if (out.ok) await op.set(out.value, out.status, out.vary);
     };
-    yield doneEvt(true, t0, state.attempts);
+
+    // Coalescing disabled: run the chain, write the cache last.
+    if (ctl.coalesce === false) {
+        await store(yield* runFrom(rt, baseReq, name, state, t0, budget));
+        return;
+    }
+
+    // In-process coalescing: the leader runs the chain; followers await its one shared result.
+    const claim = ctl.join(key);
+    if (claim.leader) {
+        let out: RunOutcome;
+        try {
+            out = yield* runFrom(rt, baseReq, name, state, t0, budget);
+        } catch (e) {
+            claim.fail(e);
+            throw e;
+        }
+        if (out.ok) {
+            await store(out);
+            claim.settle({ value: out.value, status: out.status });
+        } else {
+            // Failure is not shared — waiters re-run on their own.
+            claim.fail(new Error('cache: leader run failed'));
+        }
+        return;
+    }
+
+    let shared: CacheHit;
+    try {
+        shared = await claim.promise;
+    } catch {
+        // The leader failed (or did not cache): proceed independently, uncoalesced.
+        await store(yield* runFrom(rt, baseReq, name, state, t0, budget));
+        return;
+    }
+    yield cacheEvt('coalesced');
+    yield resultEvt(shared.value, shared.status, 0);
+    yield doneEvt(true, t0, 0);
+}
+
+export async function* execute(
+    rt: Runtime,
+    input: StitchInput = {},
+): AsyncGenerator<StitchEvent, void> {
+    const { cfg } = rt;
+    const name = nameOf(cfg);
+    const t0 = now();
+    const state = { attempts: 0 };
+    const budget = totalBudget(cfg, t0);
+
+    try {
+        await validateInput(cfg, input);
+    } catch (e) {
+        yield errEvt(e, name, 0);
+        yield doneEvt(false, t0, 0);
+        return;
+    }
+
+    if (cfg.paginate) {
+        yield* paginated(rt, input, state, t0, budget);
+        return;
+    }
+
+    // Cache lookup is OUTERMOST over the expensive chain but AFTER input validation, so a hit can
+    // never tunnel an invalid call past the boundary and the key mirrors the resolved request.
+    const ctl = await ensureCache(rt);
+    if (ctl) {
+        yield* runCached(rt, ctl, input, name, state, t0, budget);
+        return;
+    }
+
+    yield* runOnce(rt, input, name, state, t0, budget);
+}
+
+// ---- cache surfaces (lazy; no static cache import on the hot path) ---------
+/** Exact, single-entry eviction for the call `input` would make. A no-op for an uncached or
+ *  non-cacheable-method stitch. Backs `stitch.invalidate(input)` (ADR 0003 §8). */
+export async function cacheInvalidateExact(
+    rt: Runtime,
+    input: StitchInput = {},
+): Promise<void> {
+    const ctl = await ensureCache(rt);
+    if (!ctl) return;
+    let baseReq: AdapterRequest;
+    try {
+        baseReq = buildRequest(rt.cfg, input);
+    } catch {
+        return;
+    }
+    if (!ctl.cacheableMethod(baseReq.method)) return;
+    const d = describe(rt.cfg, input, baseReq);
+    const key = ctl.key(d, input);
+    if (key === undefined) return;
+    await (await ctl.open(key, d)).delete();
+}
+
+/** Bulk eviction of every entry this stitch produced (per-stitch generation bump). Backs
+ *  `stitch.cache.invalidate()` and `seam.invalidate(stitch)` (ADR 0003 §8). */
+export async function cacheInvalidateBulk(rt: Runtime): Promise<void> {
+    const ctl = await ensureCache(rt);
+    if (!ctl) return;
+    await ctl.invalidate();
+}
+
+/** The derived opaque key for `input`, for introspection. Backs `stitch.cache.key(input)`. */
+export async function cacheKeyOf(
+    rt: Runtime,
+    input: StitchInput = {},
+): Promise<string | undefined> {
+    const ctl = await ensureCache(rt);
+    if (!ctl) return undefined;
+    let baseReq: AdapterRequest;
+    try {
+        baseReq = buildRequest(rt.cfg, input);
+    } catch {
+        return undefined;
+    }
+    return ctl.key(describe(rt.cfg, input, baseReq), input);
 }
 
 export async function executeRaw(

--- a/packages/core/src/seam.ts
+++ b/packages/core/src/seam.ts
@@ -113,6 +113,16 @@ function makeHandle(shared: SharedSeam, principal: string | undefined): Seam {
         graphql: (config: Partial<StitchConfig> & { query: string }) =>
             build(config, true),
         as: (p) => makeHandle(shared, p),
+        // Bulk cache invalidation over the seam's shared store (ADR 0003 §8). No argument bumps
+        // the cache-wide generation; a member `stitch` bumps just that stitch's generation. The
+        // cache engine is reached lazily — a seam with no cached members never loads it.
+        async invalidate(stitch?: Stitch) {
+            const m = await import('./cache');
+            await m.bumpCacheGeneration(
+                shared.store,
+                stitch ? m.cacheStitchId(stitch.__config) : undefined,
+            );
+        },
         async flush() {
             await shared.trace.flush?.();
         },

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -1,7 +1,15 @@
 // The authoring surface: stitch() + the two composition facades (extends / fluent builder) +
 // `.with()` partial application, all resolving to one canonical config. For a shared surface —
 // shared runtime + a trusted principal boundary — reach for `seam` (see seam.ts).
-import { type Runtime, execute, executeRaw, makeRuntime } from './engine';
+import {
+    type Runtime,
+    cacheInvalidateBulk,
+    cacheInvalidateExact,
+    cacheKeyOf,
+    execute,
+    executeRaw,
+    makeRuntime,
+} from './engine';
 import type { InferOutput, InputOf, ResolveOutput } from './infer';
 import { otlpTrace } from './otlp';
 import { createThrottle } from './resilience';
@@ -257,6 +265,26 @@ function attachMeta(target: object, cfg: StitchConfig): void {
     Object.defineProperty(target, '__stitch', { value: true });
 }
 
+// Attach the cache surface (ADR 0003 §8). All three lazily reach the cache engine via the
+// runtime, so a cache-free stitch pays nothing and `import { stitch }` stays cache-free.
+// `resolve` folds in any `.with(...)` partial so a bound stitch invalidates the right entry.
+function attachCacheSurface(
+    target: object,
+    rt: Runtime,
+    resolve: (input?: StitchInput) => StitchInput,
+): void {
+    Object.defineProperty(target, 'invalidate', {
+        value: (input?: StitchInput) =>
+            cacheInvalidateExact(rt, resolve(input)),
+    });
+    Object.defineProperty(target, 'cache', {
+        value: {
+            invalidate: () => cacheInvalidateBulk(rt),
+            key: (input?: StitchInput) => cacheKeyOf(rt, resolve(input)),
+        },
+    });
+}
+
 export function makeStitch<T = unknown>(
     config: Fragment,
     shared?: SharedRuntime,
@@ -307,10 +335,12 @@ export function makeStitch<T = unknown>(
         bound.__raw = (input?: StitchInput) =>
             executeRaw(rt, mergeInput(partial, input));
         attachMeta(bound, cfg);
+        attachCacheSurface(bound, rt, (input) => mergeInput(partial, input));
         return bound;
     };
     stitchFn.__raw = (input?: StitchInput) => executeRaw(rt, input ?? {});
     attachMeta(stitchFn, cfg);
+    attachCacheSurface(stitchFn, rt, (input) => input ?? {});
     // A seam records the stitches it created (registry/lifecycle); standalone stitches don't register.
     shared?.register?.(stitchFn);
     return stitchFn;

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -211,6 +211,27 @@ export async function verifyStoreContract(
             },
         ],
         [
+            // The response cache (ADR 0003 §8) does exact invalidation and LRU eviction with
+            // `set(key, undefined)` — a delete that needs no contract extension. A conforming
+            // store must drop the key, so a later `get` resolves to undefined.
+            'set: set(key, undefined) deletes the entry',
+            async () => {
+                await store.set(k('del'), 'present');
+                expectDeepEqual(
+                    await store.get(k('del')),
+                    'present',
+                    'get before delete',
+                );
+                await store.set(k('del'), undefined);
+                const after = await store.get(k('del'));
+                if (after !== undefined) {
+                    throw new Error(
+                        `set(key, undefined) did not delete: got ${show(after)}`,
+                    );
+                }
+            },
+        ],
+        [
             'set: a ttlMs entry expires',
             async () => {
                 await store.set(k('ttl'), 'soon-gone', ttlMs);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -91,6 +91,56 @@ export interface IdempotencyOptions {
     key?: (input: StitchInput) => string; // stable key per logical call (default: a random uuid)
 }
 
+// ---- Cache (ADR 0003) -----------------------------------------------------
+/**
+ * Transport-level response cache + in-process request coalescing (ADR 0003). The key is
+ * **derived** from the resolved request — no caller-authored keys — so it cannot drift from
+ * what it names. Off by default: no `cache` block ⇒ no caching and no hot-path cost. The engine
+ * ships behind its own `stitchapi/cache` subpath, so `import { stitch }` pulls none of it.
+ *
+ * Every field round-trips as JSON; `key` is **sugar** (a function override) that does not.
+ */
+export interface CacheConfig {
+    /** Time-to-live for a cached entry — `30_000`, `'30s'`, `'5m'`. Bounds staleness/drift. */
+    ttl: number | string;
+    /**
+     * Whose responses an entry may be served to. `'principal'` (default, **fail-closed**) folds
+     * the bound principal into the key so user A can never be served user B's cached response;
+     * `'app'` shares one entry across callers — correct only for public, unauthenticated data.
+     */
+    scope?: 'principal' | 'app';
+    /**
+     * Request headers whose values vary the response and so must be part of the key (e.g.
+     * `['accept-language']`). An explicit allowlist **overrides** the default of honouring the
+     * response's `Vary`. Volatile/secret headers (authorization, cookie, traceparent, …) are
+     * never keyed.
+     */
+    vary?: string[];
+    /**
+     * Cacheable HTTP methods. Default `['GET','HEAD']`. A GraphQL **query** opts in by listing
+     * its method (`['POST']`) — a POST's read-vs-mutate intent cannot be inferred, so it is
+     * explicit. Coalescing applies to exactly this set; mutations are never cached.
+     */
+    methods?: string[];
+    /** In-process LRU cap on live entries (the store stays dumb). Default 1000. */
+    maxEntries?: number;
+    /**
+     * Request coalescing mode. `'process'` (v1 default) collapses concurrent identical in-flight
+     * callers in one process onto a single shared run; `false` disables it. `'cluster'` is
+     * reserved for the deferred cross-process protocol and behaves as `'process'` in v1.
+     */
+    coalesce?: 'process' | 'cluster' | false;
+    /**
+     * Opaque schema/version tag folded into the key. Setting it is the explicit **no-revalidate**
+     * fast path (a promise the `output` schema is unchanged); leaving it unset uses the safe
+     * default — **re-validate on hit** (still skips network/throttle/transform) until schema
+     * fingerprinting (ADR 0004) lands.
+     */
+    version?: string | number;
+    /** Sugar: author the key seed from the input instead of deriving it from the request. */
+    key?: (input: StitchInput) => string;
+}
+
 // ---- Auth -----------------------------------------------------------------
 export interface AuthContext {
     store: StitchStore; // throttle/session state — in-memory by default, shareable when configured
@@ -138,7 +188,8 @@ export type ProgressPhase =
     | 'throttled'
     | 'retry'
     | 'paginate'
-    | 'circuit';
+    | 'circuit'
+    | 'cache';
 export type StitchEvent<T = unknown> =
     | {
           type: 'start';
@@ -245,6 +296,18 @@ export interface StitchConfig {
     /** Inject a stable Idempotency-Key header on writes so safe retries don't duplicate. */
     idempotency?: IdempotencyOptions;
     /**
+     * Read-through response cache + in-process coalescing (ADR 0003). Off unless set; the engine
+     * is loaded lazily from the `stitchapi/cache` subpath only when this block is present.
+     */
+    cache?: CacheConfig;
+    /**
+     * Opt this stitch out of the cache **and** coalescing entirely — never stored, always a live
+     * call. The honest "do not persist this response" hatch for one-time tokens or compliance-
+     * bound data; the opaque key + principal scope already cover leak-protection, so the default
+     * `false` is not fail-open. Only meaningful alongside a `cache` block.
+     */
+    sensitive?: boolean;
+    /**
      * How arrays are serialised in the query string.
      * - `'indices'` (default) — `ids%5B0%5D=1&ids%5B1%5D=2`
      * - `'brackets'`          — `ids%5B%5D=1&ids%5B%5D=2`
@@ -288,6 +351,18 @@ export interface Stitch<TOut = unknown, TIn = StitchInput> {
     with<const P extends Partial<TIn>>(
         partial: P,
     ): Stitch<TOut, RelaxKeys<TIn, keyof P>>;
+    /**
+     * Cache surface (ADR 0003). A no-op unless this stitch has a `cache` block.
+     * - `invalidate(input)` — **exact** eviction of the one entry that `input` would hit.
+     * - `cache.invalidate()` — **bulk** eviction of every entry this stitch produced (a
+     *   per-stitch generation bump; prior entries become unreachable and TTL out).
+     * - `cache.key(input)` — the derived opaque key, for introspection.
+     */
+    invalidate(input?: StitchInput): Promise<void>;
+    readonly cache: {
+        invalidate(): Promise<void>;
+        key(input?: StitchInput): Promise<string | undefined>;
+    };
     readonly __config: StitchConfig;
     readonly __stitch: true;
 }
@@ -371,6 +446,13 @@ export interface Seam {
      * bucket. The principal lives in this closure, never in `StitchInput` (ADR 0002 §2–3).
      */
     as(principal: string): Seam;
+    /**
+     * Bulk cache invalidation (ADR 0003) over the shared store this seam owns. With no argument
+     * it bumps the **cache-wide** generation (every member stitch's entries become unreachable);
+     * pass a member `stitch` to bump just that stitch's generation. A no-op for members without a
+     * `cache` block. Exact, single-entry eviction stays on `stitch.invalidate(input)`.
+     */
+    invalidate(stitch?: Stitch): Promise<void>;
     /** Flush the shared trace sink (drain any buffered exporter). */
     flush(): Promise<void>;
     /** `flush()`, then close the shared store/vault and drop the registry. */

--- a/packages/core/test/cache-internals.spec.ts
+++ b/packages/core/test/cache-internals.spec.ts
@@ -1,0 +1,266 @@
+// Unit tests for the cache engine internals (ADR 0003): the 128-bit hash, the canonicalisation
+// rules that decide when two requests collide, the in-process coalescer primitive, and the
+// generation-bump invalidation helpers. These exercise `src/cache.ts` directly — the engine
+// integration is covered by cache.spec.ts.
+import { memoryStore } from '../src';
+import {
+    InflightCoalescer,
+    type RequestDescriptor,
+    bumpCacheGeneration,
+    cacheStitchId,
+    deriveCacheKey,
+    xxh128,
+} from '../src/cache';
+
+const GET = (extra: Partial<RequestDescriptor> = {}): RequestDescriptor => ({
+    method: 'GET',
+    url: 'https://api.example.test/users',
+    ...extra,
+});
+
+describe('xxh128', () => {
+    test('is deterministic and 128-bit (32 lowercase hex chars)', () => {
+        expect(xxh128('hello')).toBe(xxh128('hello'));
+        expect(xxh128('hello')).toMatch(/^[0-9a-f]{32}$/);
+        expect(xxh128('')).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    test('distinguishes different inputs', () => {
+        expect(xxh128('hello')).not.toBe(xxh128('world'));
+        expect(xxh128('a')).not.toBe(xxh128('b'));
+        // length-sensitive (the avalanche folds the length in)
+        expect(xxh128('abc')).not.toBe(xxh128('abcd'));
+    });
+
+    test('handles inputs spanning the 32-byte stripe boundary', () => {
+        const long = 'x'.repeat(200);
+        expect(xxh128(long)).toBe(xxh128(long));
+        expect(xxh128(long)).not.toBe(xxh128('x'.repeat(201)));
+    });
+});
+
+describe('deriveCacheKey canonicalisation', () => {
+    test('object keys are sorted recursively (order-insensitive)', () => {
+        const a = deriveCacheKey(
+            GET({ body: { a: 1, b: { c: 2, d: 3 } } }),
+            undefined,
+        );
+        const b = deriveCacheKey(
+            GET({ body: { b: { d: 3, c: 2 }, a: 1 } }),
+            undefined,
+        );
+        expect(a).toBe(b);
+    });
+
+    test('array order is preserved (ordered)', () => {
+        const a = deriveCacheKey(GET({ body: { ids: [1, 2, 3] } }), undefined);
+        const b = deriveCacheKey(GET({ body: { ids: [3, 2, 1] } }), undefined);
+        expect(a).not.toBe(b);
+    });
+
+    test('null is kept; undefined is treated as absent', () => {
+        const withNull = deriveCacheKey(GET({ body: { a: null } }), undefined);
+        const empty = deriveCacheKey(GET({ body: {} }), undefined);
+        const withUndef = deriveCacheKey(
+            GET({ body: { a: undefined } }),
+            undefined,
+        );
+        expect(withNull).not.toBe(empty); // null is an explicit value
+        expect(withUndef).toBe(empty); // undefined ≡ absent
+    });
+
+    test('URL is normalised through the platform URL (host case, default port, dot-segments)', () => {
+        const a = deriveCacheKey(
+            { method: 'GET', url: 'https://API.example.test:443/a/../b' },
+            undefined,
+        );
+        const b = deriveCacheKey(
+            { method: 'GET', url: 'https://api.example.test/b' },
+            undefined,
+        );
+        expect(a).toBe(b);
+    });
+
+    test('query-param order is preserved (we own the query string)', () => {
+        const a = deriveCacheKey(
+            { method: 'GET', url: 'https://x.test/s?a=1&b=2' },
+            undefined,
+        );
+        const b = deriveCacheKey(
+            { method: 'GET', url: 'https://x.test/s?b=2&a=1' },
+            undefined,
+        );
+        expect(a).not.toBe(b);
+    });
+
+    test('method is upper-cased', () => {
+        expect(deriveCacheKey({ ...GET(), method: 'get' }, undefined)).toBe(
+            deriveCacheKey({ ...GET(), method: 'GET' }, undefined),
+        );
+    });
+
+    test('principal is folded in (scope isolation)', () => {
+        const alice = deriveCacheKey(GET({ principal: 'alice' }), undefined);
+        const bob = deriveCacheKey(GET({ principal: 'bob' }), undefined);
+        const none = deriveCacheKey(GET(), undefined);
+        expect(alice).not.toBe(bob);
+        expect(alice).not.toBe(none);
+    });
+
+    test('an unhashable body yields undefined (warn-and-pass-through)', () => {
+        expect(
+            deriveCacheKey(GET({ body: () => 1 }), undefined),
+        ).toBeUndefined();
+        expect(
+            deriveCacheKey(GET({ body: new Map() }), undefined),
+        ).toBeUndefined();
+        expect(
+            deriveCacheKey(GET({ body: new Uint8Array([1, 2]) }), undefined),
+        ).toBeUndefined();
+    });
+
+    test('explicit vary folds the listed request headers; others are ignored', () => {
+        const en = GET({ headers: { 'accept-language': 'en' } });
+        const fr = GET({ headers: { 'accept-language': 'fr' } });
+        expect(deriveCacheKey(en, ['accept-language'])).not.toBe(
+            deriveCacheKey(fr, ['accept-language']),
+        );
+        // not in the vary set → header ignored, keys collide
+        expect(deriveCacheKey(en, undefined)).toBe(
+            deriveCacheKey(fr, undefined),
+        );
+    });
+
+    test('volatile/secret headers never enter the key, even if named in vary', () => {
+        const a = GET({ headers: { authorization: 'Bearer A' } });
+        const b = GET({ headers: { authorization: 'Bearer B' } });
+        expect(deriveCacheKey(a, ['authorization'])).toBe(
+            deriveCacheKey(b, ['authorization']),
+        );
+    });
+
+    test('GraphQL document is opaque; variables are canonicalised', () => {
+        const v1 = deriveCacheKey(
+            {
+                method: 'POST',
+                url: 'https://x.test/graphql',
+                graphql: { query: 'query Q { me }', variables: { a: 1, b: 2 } },
+            },
+            undefined,
+        );
+        const v2 = deriveCacheKey(
+            {
+                method: 'POST',
+                url: 'https://x.test/graphql',
+                graphql: { query: 'query Q { me }', variables: { b: 2, a: 1 } },
+            },
+            undefined,
+        );
+        const v3 = deriveCacheKey(
+            {
+                method: 'POST',
+                url: 'https://x.test/graphql',
+                graphql: {
+                    query: 'query OTHER { me }',
+                    variables: { a: 1, b: 2 },
+                },
+            },
+            undefined,
+        );
+        expect(v1).toBe(v2); // variable key order irrelevant
+        expect(v1).not.toBe(v3); // different document → different key
+    });
+
+    test('the cache.key sugar override replaces the request seed but keeps principal isolation', () => {
+        const alice = deriveCacheKey(
+            GET({ principal: 'alice' }),
+            undefined,
+            'custom',
+        );
+        const bob = deriveCacheKey(
+            GET({ principal: 'bob' }),
+            undefined,
+            'custom',
+        );
+        const sameAlice = deriveCacheKey(
+            GET({ principal: 'alice', url: 'https://other.test/x' }),
+            undefined,
+            'custom',
+        );
+        expect(alice).not.toBe(bob); // principal still isolates
+        expect(alice).toBe(sameAlice); // the request itself no longer matters
+    });
+});
+
+describe('InflightCoalescer', () => {
+    test('the first caller leads; the rest follow one shared promise', async () => {
+        const c = new InflightCoalescer<number>();
+        const a = c.join('k');
+        const b = c.join('k');
+        expect(a.leader).toBe(true);
+        expect(b.leader).toBe(false);
+        expect(c.size).toBe(1);
+        if (a.leader) a.settle(42);
+        expect(await b.promise).toBe(42);
+        expect(c.size).toBe(0); // settle drops the in-flight entry
+    });
+
+    test('a leader failure rejects the shared promise (the engine re-runs followers)', async () => {
+        const c = new InflightCoalescer<number>();
+        const a = c.join('k');
+        const b = c.join('k');
+        if (a.leader) a.fail(new Error('boom'));
+        await expect(b.promise).rejects.toThrow('boom');
+        expect(c.size).toBe(0);
+    });
+
+    test('distinct keys do not coalesce', () => {
+        const c = new InflightCoalescer<number>();
+        expect(c.join('a').leader).toBe(true);
+        expect(c.join('b').leader).toBe(true);
+        expect(c.size).toBe(2);
+    });
+
+    test('aborts are ref-counted: the run drops only when the LAST participant aborts', () => {
+        const c = new InflightCoalescer<number>();
+        let cancelled = 0;
+        const s0 = new AbortController();
+        const s1 = new AbortController();
+        const s2 = new AbortController();
+        c.join('k', { signal: s0.signal, onCancel: () => (cancelled += 1) });
+        c.join('k', { signal: s1.signal });
+        c.join('k', { signal: s2.signal });
+        expect(c.size).toBe(1);
+
+        s1.abort();
+        expect(cancelled).toBe(0);
+        expect(c.size).toBe(1);
+
+        s2.abort();
+        expect(cancelled).toBe(0);
+        expect(c.size).toBe(1);
+
+        s0.abort(); // last waiter
+        expect(cancelled).toBe(1);
+        expect(c.size).toBe(0);
+    });
+});
+
+describe('generation helpers', () => {
+    test('cacheStitchId prefers name, then path, then a fallback', () => {
+        expect(cacheStitchId({ name: 'foo' })).toBe('foo');
+        expect(cacheStitchId({ path: '/bar' })).toBe('/bar');
+        expect(cacheStitchId({})).toBe('stitch');
+    });
+
+    test('bumpCacheGeneration incr-s the cache-wide and per-stitch counters', async () => {
+        const store = memoryStore();
+        await bumpCacheGeneration(store);
+        await bumpCacheGeneration(store);
+        expect(await store.get('cache:gen')).toBe(2);
+
+        await bumpCacheGeneration(store, 'users');
+        expect(await store.get('cache:gen:users')).toBe(1);
+        expect(await store.get('cache:gen')).toBe(2); // untouched
+    });
+});

--- a/packages/core/test/cache.spec.ts
+++ b/packages/core/test/cache.spec.ts
@@ -1,0 +1,431 @@
+// Engine-level cache + coalescing behaviour (ADR 0003) driven through the public `stitch`/`seam`
+// surfaces against a counting adapter — so "served from cache" is observable as "the origin was
+// not called again". Covers hit/miss, TTL, in-process coalescing, exact + bulk invalidation, LRU
+// eviction, the `sensitive` bypass, principal scope isolation, re-validate-on-hit + the
+// `version` fast path, and the cacheable-method gate (GraphQL opt-in).
+import { graphql, memoryStore, seam, stitch } from '../src';
+import type { Adapter } from '../src';
+
+const sleep = (ms: number): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+// An adapter that counts origin calls and returns a JSON body. `body(callNo, req)` defaults to
+// `{ n: callNo }`, so a stable cached response still lets a test prove freshness by call count.
+function counting(opts?: {
+    body?: (callNo: number, req: { url: string; method: string }) => unknown;
+    headers?: Record<string, string>;
+    delayMs?: number;
+    failCall?: number;
+}): { adapter: Adapter; calls: () => number } {
+    let calls = 0;
+    const adapter: Adapter = async (req) => {
+        const n = (calls += 1);
+        if (opts?.delayMs) await sleep(opts.delayMs);
+        if (opts?.failCall === n) throw new Error(`origin failed on call ${n}`);
+        return {
+            status: 200,
+            headers: opts?.headers ?? {},
+            body: opts?.body
+                ? opts.body(n, { url: req.url, method: req.method })
+                : { n },
+        };
+    };
+    return { adapter, calls: () => calls };
+}
+
+const URL = 'https://api.test/resource';
+
+describe('cache — hit / miss', () => {
+    test('a second identical call is served from cache (origin called once)', async () => {
+        const { adapter, calls } = counting();
+        const s = stitch({
+            url: URL,
+            adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app' },
+        });
+        expect(await s()).toEqual({ n: 1 });
+        expect(await s()).toEqual({ n: 1 }); // same value, no second origin call
+        expect(calls()).toBe(1);
+    });
+
+    test('distinct inputs derive distinct keys (separate entries)', async () => {
+        const { adapter, calls } = counting();
+        const s = stitch({
+            url: URL,
+            adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app' },
+        });
+        await s({ query: { id: 1 } });
+        await s({ query: { id: 2 } });
+        expect(calls()).toBe(2);
+        await s({ query: { id: 1 } }); // hit
+        expect(calls()).toBe(2);
+    });
+
+    test('an entry expires after its ttl', async () => {
+        const { adapter, calls } = counting();
+        const s = stitch({
+            url: URL,
+            adapter,
+            trace: false,
+            cache: { ttl: 30, scope: 'app' },
+        });
+        await s();
+        await s();
+        expect(calls()).toBe(1);
+        await sleep(60);
+        await s(); // ttl lapsed → refetch
+        expect(calls()).toBe(2);
+    });
+
+    test('a non-cacheable method (default GET/HEAD set) is never cached', async () => {
+        const { adapter, calls } = counting();
+        const s = stitch({
+            url: URL,
+            method: 'POST',
+            adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app' },
+        });
+        await s();
+        await s();
+        expect(calls()).toBe(2);
+    });
+});
+
+describe('cache — in-process coalescing', () => {
+    test('N concurrent identical callers collapse onto one origin call', async () => {
+        const { adapter, calls } = counting({ delayMs: 40 });
+        const s = stitch({
+            url: URL,
+            adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app' },
+        });
+        const results = await Promise.all([s(), s(), s(), s(), s()]);
+        for (const r of results) expect(r).toEqual({ n: 1 });
+        expect(calls()).toBe(1);
+    });
+
+    test('a leader failure is NOT shared — each waiter re-runs independently', async () => {
+        // Only the first origin call fails; the leader rejects, and the two followers proceed on
+        // their own (each making its own call), so failure never fans out to the waiters.
+        const { adapter, calls } = counting({ delayMs: 30, failCall: 1 });
+        const s = stitch({
+            url: URL,
+            adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app' },
+        });
+        const settled = await Promise.allSettled([s(), s(), s()]);
+        const rejected = settled.filter((r) => r.status === 'rejected');
+        expect(rejected).toHaveLength(1); // exactly the leader
+        expect(calls()).toBe(3); // leader + two independent re-runs
+    });
+
+    test('coalesce:false disables collapsing (still caches)', async () => {
+        const { adapter, calls } = counting({ delayMs: 40 });
+        const s = stitch({
+            url: URL,
+            adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app', coalesce: false },
+        });
+        await Promise.all([s(), s(), s()]); // not collapsed
+        expect(calls()).toBe(3);
+        await s(); // but the cache is warm now
+        expect(calls()).toBe(3);
+    });
+});
+
+describe('cache — invalidation', () => {
+    test('handle.invalidate(input) is an exact eviction', async () => {
+        const { adapter, calls } = counting();
+        const s = stitch({
+            url: URL,
+            adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app' },
+        });
+        await s({ query: { id: 1 } });
+        await s({ query: { id: 2 } });
+        expect(calls()).toBe(2);
+
+        await s.invalidate({ query: { id: 1 } });
+        await s({ query: { id: 1 } }); // evicted → refetch
+        await s({ query: { id: 2 } }); // still cached
+        expect(calls()).toBe(3);
+    });
+
+    test('stitch.cache.invalidate() bulk-evicts every entry (generation bump)', async () => {
+        const { adapter, calls } = counting();
+        const s = stitch({
+            url: URL,
+            adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app' },
+        });
+        await s({ query: { id: 1 } });
+        await s({ query: { id: 2 } });
+        expect(calls()).toBe(2);
+
+        await s.cache.invalidate();
+        await s({ query: { id: 1 } });
+        await s({ query: { id: 2 } });
+        expect(calls()).toBe(4); // both buckets gone
+    });
+
+    test('seam.invalidate() bulk-evicts across the shared store', async () => {
+        const { adapter, calls } = counting();
+        const api = seam({
+            baseUrl: 'https://api.test',
+            adapter,
+            trace: false,
+        });
+        const users = api.stitch({
+            path: '/users',
+            cache: { ttl: '60s', scope: 'app' },
+        });
+        await users();
+        await users();
+        expect(calls()).toBe(1);
+
+        await api.invalidate(); // cache-wide
+        await users();
+        expect(calls()).toBe(2);
+    });
+
+    test('seam.invalidate(stitch) targets one member', async () => {
+        const { adapter, calls } = counting();
+        const api = seam({
+            baseUrl: 'https://api.test',
+            adapter,
+            trace: false,
+        });
+        const users = api.stitch({
+            path: '/users',
+            cache: { ttl: '60s', scope: 'app' },
+        });
+        const orders = api.stitch({
+            path: '/orders',
+            cache: { ttl: '60s', scope: 'app' },
+        });
+        await users();
+        await orders();
+        expect(calls()).toBe(2);
+
+        await api.invalidate(users); // only users
+        await users(); // refetch
+        await orders(); // still cached
+        expect(calls()).toBe(3);
+    });
+
+    test('cache.key(input) exposes the derived opaque key', async () => {
+        const { adapter } = counting();
+        const s = stitch({
+            url: URL,
+            adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app' },
+        });
+        const k1 = await s.cache.key({ query: { id: 1 } });
+        const k2 = await s.cache.key({ query: { id: 1 } });
+        const k3 = await s.cache.key({ query: { id: 2 } });
+        expect(k1).toMatch(/^[0-9a-f]{32}$/);
+        expect(k1).toBe(k2);
+        expect(k1).not.toBe(k3);
+    });
+});
+
+describe('cache — LRU bound', () => {
+    test('maxEntries evicts the least-recently-used entry', async () => {
+        const { adapter, calls } = counting();
+        const s = stitch({
+            url: URL,
+            adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app', maxEntries: 2 },
+        });
+        await s({ query: { id: 1 } }); // 1
+        await s({ query: { id: 2 } }); // 2
+        await s({ query: { id: 3 } }); // 3 → evicts id:1
+        expect(calls()).toBe(3);
+
+        await s({ query: { id: 1 } }); // evicted → refetch
+        expect(calls()).toBe(4);
+        await s({ query: { id: 3 } }); // still resident → hit
+        expect(calls()).toBe(4);
+    });
+});
+
+describe('cache — sensitive bypass', () => {
+    test('sensitive:true never caches and never coalesces', async () => {
+        const { adapter, calls } = counting({ delayMs: 30 });
+        const s = stitch({
+            url: URL,
+            adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app' },
+            sensitive: true,
+        });
+        await Promise.all([s(), s()]); // not coalesced
+        expect(calls()).toBe(2);
+        await s(); // not cached
+        expect(calls()).toBe(3);
+    });
+});
+
+describe('cache — scope isolation', () => {
+    test('principal scope (default) never serves one principal another’s entry', async () => {
+        const { adapter, calls } = counting();
+        const api = seam({
+            baseUrl: 'https://api.test',
+            adapter,
+            trace: false,
+        });
+        const def = { path: '/me', cache: { ttl: '60s' } }; // default scope: 'principal'
+        const alice = api.as('alice').stitch(def);
+        const bob = api.as('bob').stitch(def);
+
+        await alice();
+        await alice();
+        expect(calls()).toBe(1); // alice cached
+        await bob();
+        expect(calls()).toBe(2); // bob is a different key → miss
+        await bob();
+        expect(calls()).toBe(2); // bob now cached too
+    });
+
+    test('scope:"app" shares one entry across principals', async () => {
+        const { adapter, calls } = counting();
+        const api = seam({
+            baseUrl: 'https://api.test',
+            adapter,
+            trace: false,
+        });
+        const def = {
+            path: '/pub',
+            cache: { ttl: '60s', scope: 'app' as const },
+        };
+        const alice = api.as('alice').stitch(def);
+        const bob = api.as('bob').stitch(def);
+
+        await alice();
+        expect(calls()).toBe(1);
+        await bob(); // app scope → shares alice's entry
+        expect(calls()).toBe(1);
+    });
+});
+
+describe('cache — re-validate on hit vs version fast path', () => {
+    test('without a version, a hit is re-validated and a stale-shaped entry self-heals', async () => {
+        // First origin call returns a string `n`; later calls return a number. A loose writer
+        // caches the string; a strict reader (sharing the store + key) re-validates on hit, finds
+        // it stale, evicts, and refetches a conforming value.
+        const { adapter, calls } = counting({
+            body: (n) => ({ n: n === 1 ? 'oops' : 7 }),
+        });
+        const store = memoryStore();
+        const base = {
+            url: URL,
+            name: 'reval',
+            adapter,
+            store,
+            trace: false as const,
+            cache: { ttl: '60s', scope: 'app' as const },
+        };
+        const writer = stitch(base);
+        const reader = stitch({
+            ...base,
+            output: (v: unknown): v is { n: number } =>
+                typeof (v as { n?: unknown }).n === 'number',
+        });
+
+        expect(await writer()).toEqual({ n: 'oops' }); // call 1, cached as-is
+        expect(await reader()).toEqual({ n: 7 }); // hit fails revalidation → refetch (call 2)
+        expect(calls()).toBe(2);
+    });
+
+    test('cache.version pins the schema — a hit is trusted, not re-validated', async () => {
+        const { adapter, calls } = counting({
+            body: (n) => ({ n: n === 1 ? 'oops' : 7 }),
+        });
+        const store = memoryStore();
+        const base = {
+            url: URL,
+            name: 'pinned',
+            adapter,
+            store,
+            trace: false as const,
+            cache: { ttl: '60s', scope: 'app' as const, version: '1' },
+        };
+        const writer = stitch(base);
+        const reader = stitch({
+            ...base,
+            output: (v: unknown): v is { n: number } =>
+                typeof (v as { n?: unknown }).n === 'number',
+        });
+
+        expect(await writer()).toEqual({ n: 'oops' }); // call 1, cached
+        // version set → no re-validation: the stale-shaped value is returned as-is, no refetch.
+        expect(await reader()).toEqual({ n: 'oops' });
+        expect(calls()).toBe(1);
+    });
+});
+
+describe('cache — GraphQL opt-in', () => {
+    test('a GraphQL query caches only when its method opts in', async () => {
+        const { adapter, calls } = counting({
+            body: () => ({ data: { me: { id: 1 } } }),
+        });
+        const q = graphql({
+            url: 'https://api.test/graphql',
+            query: '{ me { id } }',
+            adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app', methods: ['POST'] },
+        });
+        expect(await q()).toEqual({ me: { id: 1 } });
+        await q();
+        expect(calls()).toBe(1); // POST opted in → cached
+    });
+
+    test('a GraphQL query without the opt-in is not cached', async () => {
+        const { adapter, calls } = counting({
+            body: () => ({ data: { me: { id: 1 } } }),
+        });
+        const q = graphql({
+            url: 'https://api.test/graphql',
+            query: '{ me { id } }',
+            adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app' }, // default methods GET/HEAD → POST excluded
+        });
+        await q();
+        await q();
+        expect(calls()).toBe(2);
+    });
+});
+
+describe('cache — non-storable pass-through', () => {
+    test('a binary responseType warns and passes through (never throws)', async () => {
+        const { adapter, calls } = counting();
+        const s = stitch({
+            url: URL,
+            adapter,
+            responseType: 'arrayBuffer',
+            trace: false,
+            cache: { ttl: '60s', scope: 'app' },
+        });
+        let bypass = false;
+        for await (const ev of s.stream()) {
+            if (ev.type === 'progress' && ev.phase === 'cache')
+                bypass = ev.detail?.startsWith('bypass') ?? false;
+        }
+        expect(bypass).toBe(true);
+        await s();
+        expect(calls()).toBe(2); // not cached
+    });
+});

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -2,8 +2,10 @@ import { defineConfig } from 'tsup';
 
 // Two bundles from one source tree:
 //   lib/index.{js,mjs} (+ .d.ts) — the library (function surface), dual-format + types
-//   plus serve/mcp/registry/testing as their own subpath entry points (stitchapi/serve, etc.)
+//   plus serve/mcp/registry/testing/cache as their own subpath entry points (stitchapi/serve, …)
 //   lib/cli.js                   — the `stitch` bin (run/trace/serve/mcp), CJS, no types
+// `cache` is its own entry so `import { stitch }` never pulls the cache engine (ADR 0003 §11):
+// the engine reaches it via a lazy `import('./cache')`, which esm splitting keeps in its chunk.
 export default defineConfig([
     {
         entry: [
@@ -12,6 +14,7 @@ export default defineConfig([
             'src/mcp.ts',
             'src/registry.ts',
             'src/testing.ts',
+            'src/cache.ts',
         ],
         format: ['cjs', 'esm'],
         minify: true,


### PR DESCRIPTION
Implements the **v1 slice of [ADR 0003](docs/adr/0003-derived-key-response-cache-and-coalescing.md)** — a transport-level read-through response cache with a *derived* opaque key, plus in-process request coalescing. The ADR is the source of truth for every decision; this PR is the implementation.

## What's in v1

- **Derived key** — a 128-bit synchronous non-crypto digest (dual-seed XXH64) over the *canonicalised resolved request*: method + URL (normalised via the platform `URL`) + canonical body / GraphQL variables + vary-relevant headers + principal. Sorted object keys, preserved array + query-param order, `null` kept / `undefined` ≡ absent, opaque GraphQL document with canonicalised variables, principal canonicalised like a body. Frozen `k1` key-schema version prefix. `cache.key()` is sugar.
- **TTL read-through** over the existing `StitchStore` get/set/incr under a `cache:` namespace. Only *validated* responses are cached (the resolved `T`). A shared store makes it distributed for free, like throttle/circuit.
- **Lifecycle: outermost, but after input validation** — validate/normalise input → derive key → lookup. A hit short-circuits throttle/circuit/network/transform/output-validation; a miss runs the full chain and writes the cache **last**.
- **In-process coalescing** — a process-local `Map<key, Promise>`; concurrent identical callers await one shared run. Failures are **not** shared (each waiter re-runs); aborts are **ref-counted**. Applies only to the cacheable method set. `coalesce: 'cluster'` is reserved (degrades to `'process'` in v1).
- **Invalidation** — exact = `store.set(key, undefined)`; bulk = generation-counter bump folded into the namespace. Surfaces: `stitch.invalidate(input)` (exact), `stitch.cache.invalidate()` and `seam.invalidate(stitch?)` (bulk).
- **LRU + maxEntries** enforced in the cache layer (the store stays dumb).
- **`sensitive: true`** bypasses cache **and** coalescing entirely.
- **Cacheable methods** GET/HEAD by default; GraphQL queries opt in via `methods`. Non-storable (`responseType` blob/arrayBuffer) and unhashable bodies **warn-and-pass-through**, never throw.
- **Safe default until schema fingerprinting (ADR 0004):** re-validate on hit (still skips network/throttle/transform); `cache.version` is the explicit no-revalidate fast path.

## Architecture & gates

- New `packages/core/src/cache.ts`, exported via its **own `stitchapi/cache` subpath** (package.json + tsup entry). `import { stitch }` pulls none of it — the engine reaches the cache via a lazy `import('./cache')`, which ESM splitting keeps in `lib/cache.mjs` (verified: the hasher lives only there; `index.mjs` reaches it through `import("./cache.mjs")`).
- Config (`cache` + `sensitive`) lives in `types.ts` (type-only, zero bundle cost). Every field round-trips as JSON; functions are sugar. Principal scope is the fail-closed default. Cache hit/miss/coalesced surface on the existing event stream as a `progress` event with phase `cache` (redacted detail only — the stored key stays opaque).
- Holds the project gates: **browser-first** (no `node:*` on the call path; xxh128 is sync, no WebCrypto — uses `TextEncoder`/`BigInt`/`URL`), **bundle-frugal**, **contract-not-dependency** (zero new runtime deps; only get/set/incr), **declarative spelling**, **no side effects by default**.

## Out of scope (deferred per the ADR)

- Cross-process/cluster coalescing (the store-lock protocol) — `'cluster'` reserved.
- Schema fingerprinting (ADR 0004) — re-validate-on-hit + manual `cache.version` stand in.

## Tests

- `test/cache-internals.spec.ts` — hash determinism, canonicalisation edge cases, the coalescer primitive (leader/follower, failure rejection, ref-counted abort), generation helpers.
- `test/cache.spec.ts` — hit/miss, TTL expiry, coalescing (N→1, failure-not-shared, `coalesce:false`), exact + bulk invalidation (incl. `seam.invalidate(stitch?)`), LRU eviction, `sensitive` bypass, principal scope isolation + `scope:'app'` sharing, re-validate-on-hit vs `version` fast path, GraphQL opt-in, non-storable pass-through.
- Conformance kit (`stitchapi/testing`) gains a `set(key, undefined) deletes` rule — the exact-eviction primitive the cache relies on.

**249 tests pass** (40 files). Lint, types (`tsc` ×2 + `tsd`), `attw`, and the full pre-push gate (incl. build-docs) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)