### PR TITLE
fix(playground): unwedge Run/Stop after an explicit Stop

### DIFF
--- a/docs/sandbox/component/StitchPlayground.tsx
+++ b/docs/sandbox/component/StitchPlayground.tsx
@@ -196,7 +196,17 @@ export function StitchPlayground({
                 setView(buildRunView(res));
             }
         } finally {
-            if (!ac.signal.aborted) setRunning(false);
+            // Only the *current* run owns the button state. Keying off
+            // `abortRef.current === ac` (not `ac.signal.aborted`) distinguishes
+            // the two ways this run can end aborted: an explicit Stop leaves
+            // `abortRef.current` pointing at `ac`, so we flip `running` off and
+            // return the button to "Run" / re-enable Reset; a *superseding* run
+            // has already replaced `abortRef.current` with its own controller
+            // and set `running` true again, so we must leave it alone.
+            if (abortRef.current === ac) {
+                abortRef.current = null;
+                setRunning(false);
+            }
         }
     }, [code, runner, scope, knobs]);
 


### PR DESCRIPTION
## Problem

In the docs playground shell, clicking **Stop** during a run left the UI permanently wedged: the button stayed on "Stop" and **Reset** stayed disabled, so the user could neither re-run nor reset without reloading the page.

## Root cause

The `run` callback's `finally` cleared `running` only when the run *wasn't* aborted:

```ts
} finally {
    if (!ac.signal.aborted) setRunning(false);
}
```

`stop` aborts the **current** controller, so on an explicit Stop `ac.signal.aborted` is `true` and `setRunning(false)` is skipped — `running` stays `true` forever. The button renders "Stop" while `running`, and Reset is `disabled={running}`, so both stick.

## Fix

Key the reset off **ownership** rather than abortedness — `abortRef.current === ac`:

- **Stop**: the ref still points at this controller → reset the button to "Run", re-enable Reset.
- **Superseding run**: a newer run already swapped in its own controller and set `running` true again → leave it alone (no flicker to "Run").
- **Normal completion**: not superseded → reset as before, and clear the now-stale `abortRef.current`.

## Verification

Ran the docs dev server against `/playground` (Complete example):

| Scenario | Result |
|---|---|
| Stop mid-run | Button → **Run**, Reset **enabled** ✅ |
| Re-run after Stop (Run→Stop→Run→Stop) | Clean each time; re-runnable without reload ✅ |
| Normal completion | Full output, button → Run, Reset enabled ✅ |
| Superseding run | In-flight run continues; no flicker to "Run" ✅ |

Gates: `tsc --noEmit` ✅, `eslint .` ✅, `prettier --check` ✅ (plus the full pre-push suite: lint, typecheck, typecheck-d, test, exports, build-docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)