### PR TITLE
feat(playground): console-as-editor + knob-chip and drift polish

### DIFF
--- a/apps/docs/app/(home)/playground/ConsoleEditor.tsx
+++ b/apps/docs/app/(home)/playground/ConsoleEditor.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { signalConsoleTheme } from './codemirror-theme';
+
+import { javascript } from '@codemirror/lang-javascript';
+import CodeMirror, {
+    Decoration,
+    EditorState,
+    EditorView,
+    RangeSetBuilder,
+    type ReactCodeMirrorRef,
+    StateField,
+    lineNumbers,
+} from '@uiw/react-codemirror';
+import { useEffect, useMemo, useRef } from 'react';
+
+/** One formatted console line plus the level of the entry it belongs to. */
+export interface ConsoleLine {
+    text: string;
+    level: string;
+}
+
+/* Cached per-level line decorations — a multi-line entry shares one object for
+   every line it spans. `log` (and unknown levels) are left to the highlighter. */
+const LINE_DECO: Record<string, Decoration> = {
+    info: Decoration.line({ class: 'cm-log-line cm-log-info' }),
+    warn: Decoration.line({ class: 'cm-log-line cm-log-warn' }),
+    error: Decoration.line({ class: 'cm-log-line cm-log-error' }),
+    debug: Decoration.line({ class: 'cm-log-line cm-log-debug' }),
+};
+
+/**
+ * A StateField that paints each document line with its log level's color, so the
+ * per-level colors of the structured console survive in the editor view.
+ * `levelsPerLine` is indexed by document line (0-based). Decorations are rebuilt
+ * on every doc change so they track a growing/streamed log buffer; the field is
+ * re-created (fresh closure) whenever the levels change — see the useMemo below.
+ */
+function lineLevelField(levelsPerLine: string[]) {
+    const build = (state: EditorState) => {
+        const builder = new RangeSetBuilder<Decoration>();
+        const n = Math.min(state.doc.lines, levelsPerLine.length);
+        for (let i = 0; i < n; i++) {
+            const deco = LINE_DECO[levelsPerLine[i]];
+            if (deco) {
+                const from = state.doc.line(i + 1).from;
+                builder.add(from, from, deco);
+            }
+        }
+        return builder.finish();
+    };
+    return StateField.define({
+        create: build,
+        update: (deco, tr) =>
+            tr.docChanged ? build(tr.state) : deco.map(tr.changes),
+        provide: (f) => EditorView.decorations.from(f),
+    });
+}
+
+/**
+ * Readonly CodeMirror rendering the console log stream with per-entry line
+ * numbers and a conservative JSON-friendly highlight (see {@link
+ * signalConsoleTheme}). Per-line info/warn/error/debug colors are applied via
+ * {@link lineLevelField}. Errors, notices, and the trace DAG are rendered by the
+ * shell beneath this editor.
+ */
+export function ConsoleEditor({ lines }: { lines: ConsoleLine[] }) {
+    const value = useMemo(() => lines.map((l) => l.text).join('\n'), [lines]);
+
+    // Expand entry-levels to DOC-line levels: a multi-line entry (e.g. a
+    // pretty-printed object) paints every one of its lines with the entry level.
+    const levelsPerLine = useMemo(() => {
+        const out: string[] = [];
+        for (const l of lines) {
+            const count = l.text.split('\n').length;
+            for (let i = 0; i < count; i++) out.push(l.level);
+        }
+        return out;
+    }, [lines]);
+
+    // Per-entry gutter labels: number each log ENTRY (one console.* call), not
+    // each physical row. A multi-line entry (e.g. a pretty-printed object) shows
+    // its number on the first row and a blank gutter on its continuation rows, so
+    // an object reads as one entry instead of inflating the line count.
+    const gutterLabels = useMemo(() => {
+        const labels: string[] = [];
+        let entryNo = 0;
+        for (const l of lines) {
+            const rows = l.text.split('\n').length;
+            entryNo += 1;
+            labels.push(String(entryNo));
+            for (let i = 1; i < rows; i++) labels.push('');
+        }
+        return labels;
+    }, [lines]);
+
+    // Auto-scroll: keep the newest line in view as output arrives, but only while
+    // the viewer is already near the bottom — a manual scroll up to read earlier
+    // output is not yanked back down on the next log line.
+    const editorRef = useRef<ReactCodeMirrorRef>(null);
+    const stickToBottom = useRef(true);
+    // Set true around our own pin so the resulting scroll event doesn't get
+    // mistaken for the user scrolling away (which would wrongly un-stick).
+    const selfScroll = useRef(false);
+
+    const extensions = useMemo(
+        () => [
+            javascript({ typescript: true }),
+            EditorView.lineWrapping,
+            lineNumbers({
+                formatNumber: (lineNo) => gutterLabels[lineNo - 1] ?? '',
+            }),
+            lineLevelField(levelsPerLine),
+        ],
+        [levelsPerLine, gutterLabels],
+    );
+
+    // Re-evaluate "parked at the bottom" only on USER scrolls, so auto-scroll
+    // pauses when they scroll up to read earlier output and resumes when they
+    // return to the bottom.
+    useEffect(() => {
+        const view = editorRef.current?.view;
+        if (!view) return;
+        const sd = view.scrollDOM;
+        const onScroll = () => {
+            if (selfScroll.current) {
+                selfScroll.current = false;
+                return;
+            }
+            stickToBottom.current =
+                sd.scrollHeight - sd.scrollTop - sd.clientHeight < 32;
+        };
+        sd.addEventListener('scroll', onScroll, { passive: true });
+        return () => sd.removeEventListener('scroll', onScroll);
+    }, []);
+
+    // After the doc grows, pin to the newest line when stuck to bottom. The rAF
+    // lets CodeMirror measure the new content height before we scroll.
+    useEffect(() => {
+        if (!stickToBottom.current || value.length === 0) return;
+        const view = editorRef.current?.view;
+        if (!view) return;
+        const raf = requestAnimationFrame(() => {
+            const sd = view.scrollDOM;
+            selfScroll.current = true;
+            sd.scrollTop = sd.scrollHeight;
+        });
+        return () => cancelAnimationFrame(raf);
+    }, [value]);
+
+    return (
+        <CodeMirror
+            ref={editorRef}
+            className="stitch-console-editor"
+            value={value}
+            theme={signalConsoleTheme}
+            editable={false}
+            readOnly
+            extensions={extensions}
+            basicSetup={{
+                // Our own per-entry gutter is added via `extensions` above.
+                lineNumbers: false,
+                foldGutter: false,
+                highlightActiveLine: false,
+                highlightActiveLineGutter: false,
+                autocompletion: false,
+                // The buffer is mixed prose + JSON, not a program — the default
+                // highlight would grey out `//` URLs and flag prose as invalid.
+                // We supply our own conservative highlight via `theme` instead.
+                syntaxHighlighting: false,
+                searchKeymap: false,
+                highlightSelectionMatches: false,
+            }}
+        />
+    );
+}
+
+export default ConsoleEditor;

--- a/apps/docs/app/(home)/playground/KnobsBuilder.tsx
+++ b/apps/docs/app/(home)/playground/KnobsBuilder.tsx
@@ -48,14 +48,30 @@ function toSimKnobs(s: KnobsState): SimKnobs {
     return knobs;
 }
 
-/** Short header chips for the active knobs (in panel order). */
-function activeChips(knobs: SimKnobs): string[] {
-    const chips: string[] = [];
-    if (knobs.status !== undefined) chips.push(`status ${knobs.status}`);
-    if (knobs.latencyMs !== undefined) chips.push(`${knobs.latencyMs}ms`);
-    if (knobs.stream !== undefined) chips.push(knobs.stream);
-    if (knobs.flaky !== undefined) chips.push(`flaky ${knobs.flaky}`);
-    if (knobs.drift) chips.push('drift');
+/** A header chip for one active knob: the raw `state` field it maps to (so the
+ *  × can reset just that field) plus its display label. */
+interface ActiveChip {
+    field: keyof KnobsState;
+    label: string;
+}
+
+/** Header chips for the active knobs (in panel order). Each carries the raw
+ *  `state` field so a per-chip × can reset only that knob. Labels use a
+ *  `key: value` delimiter; the boolean drift knob has no value. */
+function activeChips(knobs: SimKnobs): ActiveChip[] {
+    const chips: ActiveChip[] = [];
+    if (knobs.status !== undefined)
+        chips.push({ field: 'status', label: `status: ${knobs.status}` });
+    if (knobs.latencyMs !== undefined)
+        chips.push({
+            field: 'latencyMs',
+            label: `latency: ${knobs.latencyMs}ms`,
+        });
+    if (knobs.stream !== undefined)
+        chips.push({ field: 'stream', label: `stream: ${knobs.stream}` });
+    if (knobs.flaky !== undefined)
+        chips.push({ field: 'flaky', label: `flaky: ${knobs.flaky}` });
+    if (knobs.drift) chips.push({ field: 'drift', label: 'drift' });
     return chips;
 }
 
@@ -75,6 +91,10 @@ export function KnobsBuilder({
         onChange(toSimKnobs(next));
     };
 
+    // Reset a single knob to its initial value and re-emit — backs each chip's ×.
+    const clearField = <K extends keyof KnobsState>(field: K) =>
+        update({ [field]: INITIAL[field] } as Partial<KnobsState>);
+
     const clear = () => {
         setState(INITIAL);
         onChange({});
@@ -92,8 +112,17 @@ export function KnobsBuilder({
                 {chips.length > 0 && (
                     <span className="stitch-knobs__chips">
                         {chips.map((c) => (
-                            <span key={c} className="stitch-knobs__chip">
-                                {c}
+                            <span key={c.field} className="stitch-knobs__chip">
+                                {c.label}
+                                <button
+                                    type="button"
+                                    className="stitch-knobs__chip-remove"
+                                    aria-label={`Clear ${c.label}`}
+                                    title={`Clear ${c.label}`}
+                                    onClick={() => clearField(c.field)}
+                                >
+                                    ×
+                                </button>
                             </span>
                         ))}
                     </span>
@@ -198,9 +227,11 @@ export function KnobsBuilder({
 
                     <div
                         className="stitch-knobs__field stitch-knobs__field--switch"
-                        title="Return a body that fails validation"
+                        title="Return a response body that fails schema validation"
                     >
-                        <span className="stitch-knobs__label">Drift</span>
+                        <span className="stitch-knobs__label">
+                            Schema drift
+                        </span>
                         <button
                             type="button"
                             role="switch"

--- a/apps/docs/app/(home)/playground/PlaygroundClient.tsx
+++ b/apps/docs/app/(home)/playground/PlaygroundClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { CodeEditor } from './CodeEditor';
+import { ConsoleEditor } from './ConsoleEditor';
 import { KnobsBuilder } from './KnobsBuilder';
 import { PLAYGROUND_EXAMPLES } from './playground-examples';
 
@@ -11,31 +12,17 @@ import {
     type WorkerLike,
     makeBrowserWorkerRunner,
 } from '@stitchapi/sandbox/runtime/browser-runner';
-import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock';
 import { useMemo, useState } from 'react';
 
 /** Same-origin module Worker emitted by `build:sandbox` into /public/sandbox. */
 const WORKER_URL = '/sandbox/sandbox-worker.mjs';
 
-/** True when a formatted log line is a pretty-printed object/array, so it can be
- *  highlighted as JSON; prose logs stay plain text. */
-function jsonLog(text: string): boolean {
-    const t = text.trim();
-    if (t[0] !== '{' && t[0] !== '[') return false;
-    try {
-        JSON.parse(t);
-        return true;
-    } catch {
-        return false;
-    }
-}
-
 /**
  * Client wrapper that wires the in-house sandbox engine into the UI shell, plus
- * a CodeMirror editor (`renderEditor`), Fumadocs `DynamicCodeBlock` highlighting
- * for JSON console lines (`renderLog`), and the interactive Server-knobs panel
- * (`aside`). The heavy lifting lives in the engine; the shell only knows the
- * `CodeRunner` contract + the render hooks.
+ * a CodeMirror editor (`renderEditor`), a readonly CodeMirror console with line
+ * numbers + per-level colors (`renderLogs` → {@link ConsoleEditor}), and the
+ * interactive Server-knobs panel (`aside`). The heavy lifting lives in the
+ * engine; the shell only knows the `CodeRunner` contract + the render hooks.
  */
 export function PlaygroundClient() {
     // Build the runner once, on the client. A fresh Worker per run is what gives
@@ -100,13 +87,7 @@ export function PlaygroundClient() {
             knobs={knobs}
             tabs={exampleTabs}
             renderEditor={(props) => <CodeEditor {...props} />}
-            renderLog={(text) =>
-                jsonLog(text) ? (
-                    <DynamicCodeBlock lang="json" code={text} />
-                ) : (
-                    text
-                )
-            }
+            renderLogs={(entries) => <ConsoleEditor lines={entries} />}
             asideLabel="Server knobs"
             aside={<KnobsBuilder onChange={setKnobs} />}
         />

--- a/apps/docs/app/(home)/playground/codemirror-theme.ts
+++ b/apps/docs/app/(home)/playground/codemirror-theme.ts
@@ -125,3 +125,51 @@ export const signalCodeMirrorTheme = [
     editorChrome,
     syntaxHighlighting(signalHighlight),
 ];
+
+/* ── Console variant (readonly log view) ──────────────────────────────────
+   The console buffer is a mix of prose log lines and pretty-printed JSON, NOT a
+   valid program, so the JS parser flags prose as `invalid` and treats `//` in a
+   URL as a comment. This chrome + highlight is deliberately conservative: it
+   only colors the tokens that read well in JSON output (strings, numbers,
+   booleans, keys, punctuation) and leaves comments, invalid regions, and bare
+   identifiers as plain foreground — so prose stays calm and JSON stays legible.
+   Per-line log-level colors are layered on top via CodeMirror line decorations
+   (see ConsoleEditor.tsx + playground.css `.cm-log-*`). */
+const consoleChrome = EditorView.theme({
+    '&': {
+        color: 'var(--color-fd-foreground)',
+        backgroundColor: 'var(--color-fd-secondary)',
+    },
+    '.cm-content': { fontFamily: 'var(--font-mono)' },
+    '.cm-gutters': {
+        backgroundColor: 'var(--color-fd-secondary)',
+        color: 'var(--text-faint)',
+        border: 'none',
+    },
+    '.cm-activeLine': { backgroundColor: 'transparent' },
+    '.cm-activeLineGutter': {
+        backgroundColor: 'transparent',
+        color: 'var(--text-faint)',
+    },
+});
+
+const consoleHighlight = HighlightStyle.define([
+    {
+        tag: [t.string, t.special(t.string), t.regexp],
+        color: 'var(--syn-string)',
+    },
+    {
+        tag: [t.number, t.integer, t.float, t.bool, t.atom, t.null],
+        color: 'var(--syn-keyword)',
+    },
+    { tag: [t.propertyName], color: 'var(--syn-name)' },
+    {
+        tag: [t.punctuation, t.separator, t.bracket, t.squareBracket, t.brace],
+        color: 'var(--syn-punct)',
+    },
+]);
+
+export const signalConsoleTheme = [
+    consoleChrome,
+    syntaxHighlighting(consoleHighlight),
+];

--- a/apps/docs/app/(home)/playground/playground.css
+++ b/apps/docs/app/(home)/playground/playground.css
@@ -244,6 +244,15 @@
     .stitch-playground__pane--console .stitch-playground__output {
         max-height: 18rem;
     }
+    /* Editor-console needs a definite height for the flex log editor to resolve
+       (the pane is auto-height when stacked). `flex: none` so this height wins
+       over the base `.stitch-playground__output { flex: 1 }` (whose flex-basis
+       0% would otherwise collapse it / let it grow to fit all output). */
+    .stitch-playground__pane--console .stitch-playground__output--editor {
+        flex: none;
+        height: 20rem;
+        max-height: none;
+    }
 }
 
 /* ── Editor ─────────────────────────────────────────────────────────────── */
@@ -386,6 +395,70 @@
     display: none !important;
 }
 
+/* ── Console as a readonly editor (renderLogs → ConsoleEditor) ───────────── */
+/* The log stream fills most of the pane and scrolls internally; the error /
+   notices / DAG sit in their own strip beneath it. */
+.stitch-playground__output--editor {
+    display: flex;
+    flex-direction: column;
+    padding: 0;
+    overflow: hidden;
+}
+.stitch-playground__logs-editor {
+    flex: 1 1 auto;
+    min-height: 6rem;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+.stitch-playground__logs-editor .stitch-console-editor,
+.stitch-playground__logs-editor .cm-editor {
+    flex: 1;
+    min-height: 0;
+}
+/* The extras strip keeps the existing block styles but is capped so the log
+   editor keeps the bulk of the pane. */
+.stitch-playground__output-extras {
+    flex: none;
+    max-height: 45%;
+    overflow: auto;
+    padding: 0.6rem 1rem 0.7rem;
+    border-top: 1px solid var(--color-fd-border);
+    background: var(--color-fd-secondary);
+}
+.stitch-playground__output-extras > :first-child {
+    margin-top: 0;
+}
+
+/* Per-line log-level colors, re-applied over the syntax tokens via CodeMirror
+   line decorations (cm-log-* classes from ConsoleEditor.tsx). The descendant
+   `*` + !important wins over the highlight spans so a whole warn/error line
+   reads in its level color; plain `log` lines keep their JSON highlight. */
+.stitch-console-editor .cm-line.cm-log-info,
+.stitch-console-editor .cm-line.cm-log-info * {
+    color: var(--stitch-strong) !important;
+}
+.stitch-console-editor .cm-line.cm-log-warn,
+.stitch-console-editor .cm-line.cm-log-warn * {
+    color: #b45309 !important;
+}
+.dark .stitch-console-editor .cm-line.cm-log-warn,
+.dark .stitch-console-editor .cm-line.cm-log-warn * {
+    color: #fbbf24 !important;
+}
+.stitch-console-editor .cm-line.cm-log-error,
+.stitch-console-editor .cm-line.cm-log-error * {
+    color: #dc2626 !important;
+}
+.dark .stitch-console-editor .cm-line.cm-log-error,
+.dark .stitch-console-editor .cm-line.cm-log-error * {
+    color: #f87171 !important;
+}
+.stitch-console-editor .cm-line.cm-log-debug,
+.stitch-console-editor .cm-line.cm-log-debug * {
+    color: var(--color-fd-muted-foreground) !important;
+}
+
 /* ── Server-knobs builder — fills the aside pane: own header bar + control row */
 .stitch-knobs {
     display: flex;
@@ -423,7 +496,11 @@
     gap: 0.25rem;
 }
 .stitch-knobs__chip {
-    padding: 0.02rem 0.4rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.15rem;
+    /* tighter on the × side so the button hugs the label */
+    padding: 0.02rem 0.2rem 0.02rem 0.4rem;
     border-radius: 0.3rem;
     border: 1px solid var(--stitch-border);
     background: color-mix(in srgb, var(--stitch) 14%, transparent);
@@ -431,6 +508,34 @@
     font-weight: 600;
     color: var(--color-fd-foreground);
     white-space: nowrap;
+}
+/* Per-chip × — clears just that knob. */
+.stitch-knobs__chip-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: none;
+    width: 0.85rem;
+    height: 0.85rem;
+    padding: 0;
+    border: 0;
+    border-radius: 0.25rem;
+    background: transparent;
+    color: var(--color-fd-muted-foreground);
+    font-size: 0.85rem;
+    line-height: 1;
+    cursor: pointer;
+    transition:
+        background 0.15s ease,
+        color 0.15s ease;
+}
+.stitch-knobs__chip-remove:hover {
+    color: var(--color-fd-foreground);
+    background: color-mix(in srgb, var(--color-fd-foreground) 14%, transparent);
+}
+.stitch-knobs__chip-remove:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--stitch) 45%, transparent);
+    outline-offset: 1px;
 }
 .stitch-knobs__clear {
     flex: none;
@@ -510,8 +615,11 @@
 }
 
 /* ── Drift: an on/off switch (the sandbox's drift is binary) ──────────────── */
-.stitch-knobs__field--switch {
-    padding-bottom: 0.3rem; /* lift the switch to line up with the inputs */
+/* Center the short switch in a control slot the same height as the text inputs
+   (1.9rem) so its label lines up with the other fields' labels. The 0.375rem
+   block margin = (1.9rem − 1.15rem switch) / 2. */
+.stitch-knobs__field--switch .stitch-knobs__switch {
+    margin-block: 0.375rem;
 }
 .stitch-knobs__switch {
     /* The thumb is a flex item positioned by justify-content (flow layout) — a

--- a/docs/sandbox/component/StitchPlayground.tsx
+++ b/docs/sandbox/component/StitchPlayground.tsx
@@ -92,6 +92,14 @@ export interface StitchPlaygroundProps {
      */
     renderLog?: (text: string, level: string) => ReactNode;
     /**
+     * Custom renderer for the WHOLE log stream as one block (e.g. a readonly
+     * code editor with line numbers). Receives each formatted line plus the
+     * level of the entry it belongs to. Takes precedence over {@link renderLog}
+     * for the logs section; the error block, notices strip, and trace DAG stay
+     * as their own styled blocks beneath it. Absent → per-line {@link renderLog}.
+     */
+    renderLogs?: (entries: { text: string; level: string }[]) => ReactNode;
+    /**
      * Optional panel rendered in the bottom-right slot, beside the editor and
      * below the console (e.g. the docs "Server knobs"). When provided, the body
      * becomes a three-pane grid; when omitted, the console spans the full right
@@ -150,6 +158,7 @@ export function StitchPlayground({
     readOnly = false,
     renderEditor,
     renderLog,
+    renderLogs,
     aside,
     asideLabel = 'Server knobs',
 }: StitchPlaygroundProps) {
@@ -309,6 +318,7 @@ export function StitchPlayground({
                     deferred={isDeferred}
                     running={running}
                     renderLog={renderLog}
+                    renderLogs={renderLogs}
                 />
 
                 {/* The aside owns its full chrome (header bar + body), so it can
@@ -351,12 +361,14 @@ function StitchOutput({
     deferred,
     running,
     renderLog,
+    renderLogs,
 }: {
     view: RunView | null;
     result: RunResult | null;
     deferred: boolean;
     running: boolean;
     renderLog?: (text: string, level: string) => ReactNode;
+    renderLogs?: (entries: { text: string; level: string }[]) => ReactNode;
 }) {
     let body: ReactNode;
     if (deferred) {
@@ -380,22 +392,42 @@ function StitchOutput({
             </div>
         );
     } else {
-        body = (
-            <div className="stitch-playground__output">
-                {/* ── Logs ───────────────────────────────────────────── */}
-                {view.logs.map((line, i) => {
-                    const level = result?.logs[i]?.level ?? 'log';
-                    return (
-                        <div
-                            key={i}
-                            data-level={result?.logs[i]?.level}
-                            className="stitch-playground__log"
-                        >
-                            {renderLog ? renderLog(line, level) : line}
-                        </div>
-                    );
-                })}
+        // When `renderLogs` is supplied the whole log stream renders as one block
+        // (e.g. a readonly editor with line numbers); the error / notices / DAG
+        // then sit in their own scrollable strip beneath it. Otherwise the logs
+        // render per-line and everything flows in one scroll surface.
+        const useEditor = !!renderLogs && view.logs.length > 0;
 
+        const logsBlock = useEditor ? (
+            <div className="stitch-playground__logs-editor">
+                {renderLogs(
+                    view.logs.map((text, i) => ({
+                        text,
+                        level: result?.logs[i]?.level ?? 'log',
+                    })),
+                )}
+            </div>
+        ) : (
+            view.logs.map((line, i) => {
+                const level = result?.logs[i]?.level ?? 'log';
+                return (
+                    <div
+                        key={i}
+                        data-level={result?.logs[i]?.level}
+                        className="stitch-playground__log"
+                    >
+                        {renderLog ? renderLog(line, level) : line}
+                    </div>
+                );
+            })
+        );
+
+        const hasDag = !!view.mermaid && !view.mermaid.includes('_empty');
+        const hasExtras =
+            view.errorText !== null || view.notices.length > 0 || hasDag;
+
+        const extras = (
+            <>
                 {/* ── Error ──────────────────────────────────────────── */}
                 {view.errorText !== null && (
                     <pre className="stitch-playground__error">
@@ -416,7 +448,7 @@ function StitchOutput({
 
                 {/* ── Mermaid DAG ────────────────────────────────────── */}
                 {/* Show the DAG as soon as any trace event has been folded in. */}
-                {view.mermaid && !view.mermaid.includes('_empty') && (
+                {hasDag && (
                     <div className="stitch-playground__dag">
                         {/* Streaming badge: shown when any chunk event arrived or any
                             trace entry carries `.stream`. Active during and after the run. */}
@@ -437,6 +469,27 @@ function StitchOutput({
                         </pre>
                     </div>
                 )}
+            </>
+        );
+
+        body = (
+            <div
+                className={
+                    'stitch-playground__output' +
+                    (useEditor ? ' stitch-playground__output--editor' : '')
+                }
+            >
+                {logsBlock}
+                {/* In editor mode the extras get their own scrollable strip so the
+                    log editor keeps the bulk of the pane; otherwise they flow inline. */}
+                {hasExtras &&
+                    (useEditor ? (
+                        <div className="stitch-playground__output-extras">
+                            {extras}
+                        </div>
+                    ) : (
+                        extras
+                    ))}
             </div>
         );
     }


### PR DESCRIPTION
Builds on the playground work from #78. UI-only; no core/runtime changes.

## Console pane → readonly CodeMirror editor
- **Per-entry line numbers** — one number per `console.*` call; a multi-line value (pretty-printed object/array) shows its number on the first row and a **blank gutter** on continuation rows, so an object reads as one entry instead of inflating the count.
- **Per-line level colors** (info/warn/error/debug) via CodeMirror line decorations, preserving the structured console's color affordance.
- **Conservative JSON-friendly highlight** — the buffer is mixed prose + JSON, not a program, so a dedicated highlight colors JSON tokens but leaves comments/`invalid`/identifiers plain (no `//`-URLs-as-comments, no orange prose).
- **Line wrapping** and **stick-to-bottom auto-scroll** (only when already parked at the bottom, so a manual scroll-up isn't yanked).
- Error / notices / trace DAG stay as separate styled blocks below the editor.

## Server-knobs panel
- Each active-knob chip gets a **× to clear just that knob**; chip labels use a clearer `key: value` form (`status: 503`, `latency: 800ms`, …).
- **"Drift" → "Schema drift"**, with the switch aligned to the other field labels (centered in an input-height slot).

## Shared shell
- `StitchPlayground` gains an additive `renderLogs` prop (the docs app supplies the editor); the default per-line `renderLog` path is unchanged.

## Verification
Verified in-browser in light/dark/mobile (375px). Full pre-push gate green: format, lint, typecheck, typecheck-d, test, exports, build-docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)