### PR TITLE
feat(cache): fold the ADR 0004 schema fingerprint into the response cache

### DIFF
--- a/docs/adr/0003-derived-key-response-cache-and-coalescing.md
+++ b/docs/adr/0003-derived-key-response-cache-and-coalescing.md
@@ -1,6 +1,6 @@
 # ADR 0003 — Derived-key response cache & request coalescing
 
--   **Status:** Proposed (decisions firm; implementation pending — tracked in [`IDEAS.md`](../IDEAS.md))
+-   **Status:** Accepted & implemented — the derived-key cache, in-process coalescing, generation-based invalidation, and LRU bound ship behind the `stitchapi/cache` subpath, and the [ADR 0004](0004-standard-schema-fingerprint-for-cache-invalidation.md) schema fingerprint is now folded into the generation (decisions 2 & 8). The cross-process coalescing protocol (decision 6) remains deferred to its own grill.
 -   **Date:** 2026-06-14
 -   **Tags:** caching, performance, resilience, runtime, multi-tenant, agents
 
@@ -256,9 +256,13 @@ round-trips as JSON; functions are sugar).
     prefix; any change to it is itself a generation bump (mass self-healing miss, never a
     stale-key collision). Oversized / stream / `FormData` bodies skip hashing and fall to
     warn-and-pass-through (decision 3).
--   **Schema-fingerprinting (ADR 0004).** How to fingerprint a Standard Schema so an `output`
-    change invalidates cached values (decision 2): per-validator strategies behind a contract, a
-    manual `cache.version` fallback, and re-validate-on-hit when un-fingerprintable.
+-   **Schema-fingerprinting (ADR 0004).** ✅ _Resolved & wired._ A Standard Schema fingerprint folds
+    into the generation so an `output`/`unwrap`/versioned-`transform` change invalidates cached
+    values (decision 2): per-validator strategies behind a contract, a manual `cache.version`
+    fallback, refuse-to-cache by default when un-fingerprintable, and `onUnfingerprintable:
+'revalidate'` for opt-in re-validate-on-hit. `resolveFingerprint` is computed once per stitch in
+    `createCache`; its `policy` drives fast / revalidate / refuse and its `reason` rides the cache
+    trace.
 -   **Cross-process coalescing protocol (deferred — own grill).** The cluster mode of decision 6,
     saved for a dedicated session: the `incr` + lease lock and **leader election / re-election**;
     the **stranded-waiter signal** (cache-present ⇒ take it / lock-gone + cache-empty ⇒ re-elect)

--- a/docs/adr/0004-standard-schema-fingerprint-for-cache-invalidation.md
+++ b/docs/adr/0004-standard-schema-fingerprint-for-cache-invalidation.md
@@ -1,6 +1,6 @@
 # ADR 0004 — Standard Schema fingerprint for cache invalidation
 
--   **Status:** Accepted (contract + kit + vendor packages implemented; cache wiring folds into [ADR 0003](0003-derived-key-response-cache-and-coalescing.md) when its response cache lands)
+-   **Status:** Accepted & implemented — the contract, conformance kit, and five vendor packages ship, and `resolveFingerprint` is now **folded into [ADR 0003](0003-derived-key-response-cache-and-coalescing.md)'s response cache**: it is resolved once per stitch and its `generation` folds into the cache generation namespace, its `policy` drives fast / re-validate-on-hit / refuse, and its `reason` is surfaced on the cache trace.
 -   **Date:** 2026-06-14
 -   **Tags:** caching, validation, schema, standard-schema, contract-not-dependency, runtime
 
@@ -426,13 +426,26 @@ assertConformance(
 
 ## Implementation status
 
-Shipped on this branch (the cache wiring itself waits on ADR 0003's response
-cache; everything below is standalone and unit-/conformance-tested):
+Shipped and **wired into the ADR 0003 response cache** (each piece unit- and
+conformance-tested):
 
 -   **`stitchapi/fingerprint`** — the contract: `SchemaFingerprinter` /
     `SchemaFingerprint`, the registry (`registerFingerprinter` /
-    `getFingerprinter`), the synchronous FNV-1a `hash`, and `resolveFingerprint`
-    (the ladder). Browser-safe, synchronous, no new core dependency.
+    `getFingerprinter`), the synchronous `hash`, and `resolveFingerprint`
+    (the ladder). Browser-safe, synchronous, no new core dependency. `hash` now
+    rides the **same 128-bit `xxh128`** the cache key uses (the shared `src/hash.ts`
+    primitive) — the swap this module always anticipated, a one-time safe
+    over-invalidation of the opaque token.
+-   **The fold (`stitchapi/cache`)** — `createCache` calls `resolveFingerprint`
+    once per stitch from its `output`/`transform`/`unwrap` + the `cache` options
+    (`version`, `transformVersion`, `trustTransform`, `onUnfingerprintable`). The
+    `generation` token folds into the cache namespace **alongside** the per-stitch
+    generation counter (so a schema/unwrap/versioned-transform change moves the
+    bucket while bulk-invalidate still bumps the counter); the `policy` selects
+    fast / re-validate-on-hit / refuse; the `reason` is surfaced on the cache
+    trace. The raw schema reaches the resolver because `toValidator` keeps a
+    non-enumerable `source` back-reference (the Validator wrapper otherwise hides
+    `~standard`).
 -   **`stitchapi/testing` → `verifyFingerprintContract`** — the conformance kit
     (vendor agreement, sync result-shape, determinism + stability, sensitivity,
     soundness-or-abstain, committed snapshots).

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -7,115 +7,16 @@
 // hash is bundle weight). The key is a 128-bit SYNCHRONOUS non-cryptographic digest. It reuses
 // the `StitchStore` get/set/incr contract — no new vendor surface — exactly like throttle and
 // the circuit breaker, so a shared store makes the cache distributed for free.
+import { resolveFingerprint } from './fingerprint';
+import type { CachePolicy } from './fingerprint';
+import { xxh128 } from './hash';
 import type { CacheConfig, StitchInput, StitchStore } from './types';
 import { parseDuration } from './util';
 
-// ---------------------------------------------------------------------------
-// 128-bit synchronous non-cryptographic hash (xxHash family)
-// ---------------------------------------------------------------------------
-// v1 derives the digest from two XXH64 passes (seeds A and B) over the canonical request's
-// UTF-8 bytes — a well-specified, bit-stable xxHash member that needs only 64-bit integer math
-// (BigInt; JS has no native u64) and no async/WebCrypto. 128 bits puts a collision past ~2^64
-// entries — unreachable — so there is no verify-on-read (which would mean storing the plaintext
-// request beside the value, re-introducing the leak the opaque key avoids). The algorithm is
-// frozen behind KEY_VERSION: any change to it is a key-schema bump (mass self-healing miss).
-
-const MASK64 = (1n << 64n) - 1n;
-const P1 = 11400714785074694791n;
-const P2 = 14029467366897019727n;
-const P3 = 1609587929392839161n;
-const P4 = 9650029242287828579n;
-const P5 = 2870177450012600261n;
-const SEED_A = 0n;
-const SEED_B = 0x9e3779b185ebca87n; // a second, independent seed → the high 64 bits
-
-const mul = (a: bigint, b: bigint): bigint => (a * b) & MASK64;
-const rotl = (x: bigint, r: bigint): bigint =>
-    ((x << r) | (x >> (64n - r))) & MASK64;
-const xxhRound = (acc: bigint, input: bigint): bigint =>
-    mul(rotl((acc + mul(input, P2)) & MASK64, 31n), P1);
-const mergeRound = (acc: bigint, val: bigint): bigint =>
-    (mul(acc ^ xxhRound(0n, val), P1) + P4) & MASK64;
-
-// All reads are bounds-guaranteed by the callers' stripe arithmetic; `?? 0` keeps the indexed
-// access total without a non-null assertion (noUncheckedIndexedAccess).
-function read64LE(b: Uint8Array, i: number): bigint {
-    let v = 0n;
-    for (let j = 7; j >= 0; j--) v = (v << 8n) | BigInt(b[i + j] ?? 0);
-    return v;
-}
-function read32LE(b: Uint8Array, i: number): bigint {
-    return BigInt(
-        ((b[i] ?? 0) |
-            ((b[i + 1] ?? 0) << 8) |
-            ((b[i + 2] ?? 0) << 16) |
-            ((b[i + 3] ?? 0) << 24)) >>>
-            0,
-    );
-}
-
-function xxh64(b: Uint8Array, seed: bigint): bigint {
-    const len = b.length;
-    let h: bigint;
-    let p = 0;
-    if (len >= 32) {
-        let v1 = (seed + P1 + P2) & MASK64;
-        let v2 = (seed + P2) & MASK64;
-        let v3 = seed & MASK64;
-        let v4 = (seed - P1) & MASK64;
-        const limit = len - 32;
-        while (p <= limit) {
-            v1 = xxhRound(v1, read64LE(b, p));
-            p += 8;
-            v2 = xxhRound(v2, read64LE(b, p));
-            p += 8;
-            v3 = xxhRound(v3, read64LE(b, p));
-            p += 8;
-            v4 = xxhRound(v4, read64LE(b, p));
-            p += 8;
-        }
-        h =
-            (rotl(v1, 1n) + rotl(v2, 7n) + rotl(v3, 12n) + rotl(v4, 18n)) &
-            MASK64;
-        h = mergeRound(h, v1);
-        h = mergeRound(h, v2);
-        h = mergeRound(h, v3);
-        h = mergeRound(h, v4);
-    } else {
-        h = (seed + P5) & MASK64;
-    }
-    h = (h + BigInt(len)) & MASK64;
-    while (p + 8 <= len) {
-        h ^= xxhRound(0n, read64LE(b, p));
-        h = (mul(rotl(h, 27n), P1) + P4) & MASK64;
-        p += 8;
-    }
-    if (p + 4 <= len) {
-        h ^= mul(read32LE(b, p), P1);
-        h = (mul(rotl(h, 23n), P2) + P3) & MASK64;
-        p += 4;
-    }
-    while (p < len) {
-        h ^= mul(BigInt(b[p] ?? 0), P5);
-        h = mul(rotl(h, 11n), P1);
-        p += 1;
-    }
-    h ^= h >> 33n;
-    h = mul(h, P2);
-    h ^= h >> 29n;
-    h = mul(h, P3);
-    h ^= h >> 32n;
-    return h & MASK64;
-}
-
-const encoder = new TextEncoder();
-const toHex16 = (v: bigint): string => v.toString(16).padStart(16, '0');
-
-/** A 128-bit synchronous non-cryptographic digest of `input` as a 32-char hex string. */
-export function xxh128(input: string): string {
-    const bytes = encoder.encode(input);
-    return toHex16(xxh64(bytes, SEED_A)) + toHex16(xxh64(bytes, SEED_B));
-}
+// The 128-bit synchronous non-crypto key hash now lives in the shared `./hash` module so the cache
+// key (ADR 0003) and the schema fingerprint (ADR 0004) ride one well-tested primitive. Re-exported
+// here to keep the `stitchapi/cache` surface (and `cache-internals.spec`) importing it from `cache`.
+export { xxh128 } from './hash';
 
 // ---------------------------------------------------------------------------
 // canonicalisation
@@ -419,7 +320,15 @@ export interface CacheController {
     key(d: RequestDescriptor, input: StitchInput): string | undefined;
     /** Open a cache operation for `baseKey` (reads the live generation prefix once). */
     open(baseKey: string, d: RequestDescriptor): Promise<CacheOp>;
-    /** Should a hit be re-validated against the output schema? True unless `cache.version` pins it. */
+    /**
+     * The fingerprint-resolved caching policy (ADR 0004), computed once at controller creation:
+     * `'fast'` (serve a hit without re-validating), `'revalidate'` (cache, but re-validate the
+     * stored value on each hit), or `'refuse'` (do not cache — the engine passes through).
+     */
+    readonly policy: CachePolicy;
+    /** Why {@link policy} was chosen — surfaced as a trace `reason` (observability, not swallowed). */
+    readonly reason: string;
+    /** Should a hit be re-validated against the output schema? True exactly when policy is 'revalidate'. */
     readonly revalidateOnHit: boolean;
     /** Join (or start) the in-process coalesced run for `key`. */
     join(key: string): LeaderClaim<CacheHit> | FollowerClaim<CacheHit>;
@@ -434,6 +343,12 @@ export interface CacheControllerOptions {
     store: StitchStore;
     stitchId: string;
     principal?: string;
+    /** The stitch's raw `output` schema (un-wrapped from the Validator), for fingerprinting. */
+    output?: unknown;
+    /** The stitch's `transform` closure — opaque, so it forces a version/trust decision (ADR 0004). */
+    transform?: ((body: unknown) => unknown) | undefined;
+    /** The stitch's `unwrap` dot-path — serialisable, always folds soundly into the generation. */
+    unwrap?: string | undefined;
 }
 
 export function createCache(opts: CacheControllerOptions): CacheController {
@@ -449,7 +364,23 @@ export function createCache(opts: CacheControllerOptions): CacheController {
               .map((n) => n.toLowerCase())
               .filter((n) => !NEVER_VARY.has(n))
         : undefined;
-    const versionTag = config.version != null ? `u${config.version}:` : '';
+    // Fold the Standard Schema fingerprint (ADR 0004) ONCE, here at controller creation (which is
+    // once per stitch — `ensureCache` memoises it). It resolves three things from the stitch's
+    // output/transform/unwrap + cache options: the GENERATION token (a changed output schema /
+    // unwrap / versioned transform yields a new token → a new bucket → old entries unreachable),
+    // the POLICY (fast / revalidate / refuse), and a human-readable REASON for traces. The token is
+    // folded into the namespace ALONGSIDE the per-stitch generation counter (decision 8) — it does
+    // not replace it: bulk-invalidate bumps the counter, a schema change bumps this token.
+    const fp = resolveFingerprint({
+        output: opts.output,
+        transform: opts.transform,
+        unwrap: opts.unwrap,
+        version: config.version,
+        transformVersion: config.transformVersion,
+        trustTransform: config.trustTransform,
+        onUnfingerprintable: config.onUnfingerprintable,
+    });
+    const fpTag = `f${fp.generation}:`;
     // 'cluster' is reserved for the deferred cross-process protocol; v1 degrades it to process.
     const coalesce: 'process' | false =
         config.coalesce === false ? false : 'process';
@@ -492,7 +423,9 @@ export function createCache(opts: CacheControllerOptions): CacheController {
     };
 
     return {
-        revalidateOnHit: config.version == null,
+        policy: fp.policy,
+        reason: fp.reason,
+        revalidateOnHit: fp.policy === 'revalidate',
         coalesce,
 
         cacheableMethod(method) {
@@ -520,10 +453,13 @@ export function createCache(opts: CacheControllerOptions): CacheController {
 
         async open(baseKey, d) {
             const prefix = await genPrefix();
-            // The stored key is prefixed with the frozen key-schema version, so a derivation
-            // change is a mass self-healing miss, never a stale-key hit (ADR 0003 follow-up).
+            // The stored key is prefixed with the frozen key-schema version (a derivation change is
+            // a mass self-healing miss, never a stale-key hit — ADR 0003 follow-up) and the
+            // fingerprint generation token `fpTag` (an output-schema/unwrap/transform change moves
+            // the bucket — ADR 0004). For the 'revalidate' policy the token is empty and freshness
+            // comes from re-validation on the hit path instead.
             const valueKey = (suffix = ''): string =>
-                `${NS}${KEY_VERSION}:${prefix}${versionTag}${baseKey}${suffix}`;
+                `${NS}${KEY_VERSION}:${prefix}${fpTag}${baseKey}${suffix}`;
 
             const hitFrom = (
                 entry: StoredEntry,

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -660,12 +660,32 @@ async function ensureCache(rt: Runtime): Promise<CacheController | null> {
             config,
             store: rt.store,
             stitchId: m.cacheStitchId(cfg),
+            // The RAW output schema (not the Validator wrapper) so the fingerprinter can read its
+            // `~standard.vendor`; transform/unwrap are already raw on the config (ADR 0004 fold).
+            output: outputSchemaSource(cfg),
+            transform: cfg.transform,
+            unwrap: cfg.unwrap,
             ...(rt.authCtx.principal !== undefined
                 ? { principal: rt.authCtx.principal }
                 : {}),
         }),
     );
     return rt.cacheInit;
+}
+
+// `normalizeOutput`/`drift()` wrap `output` through `toValidator`, which hides the original
+// `~standard`. The wrapper keeps a non-enumerable `source` back-reference to the raw schema; unwrap
+// it (and the `DriftSpec.schema` layer) so the fingerprinter sees the real Zod/Valibot/… instance.
+// Falls back to the wrapper itself when no source was recorded — that is simply un-fingerprintable
+// (a custom Validator/predicate), which the resolver handles by refusing or re-validating.
+function outputSchemaSource(cfg: StitchConfig): unknown {
+    const out = cfg.output;
+    if (!out) return undefined;
+    // Cast to a probe shape (not `DriftSpec`) so `__kind` stays `unknown` — a real comparison, not
+    // an always-true one against the `'drift'` literal.
+    const isDrift = (out as { __kind?: unknown }).__kind === 'drift';
+    const validator = isDrift ? (out as DriftSpec).schema : out;
+    return (validator as { source?: unknown }).source ?? validator;
 }
 
 // The resolved request the cache key is derived from. The principal it scopes by is sourced from
@@ -834,6 +854,15 @@ async function* runCached(
     }
     yield startEvt(name, baseReq, input);
 
+    // 'refuse' (ADR 0004): the output contract can't be soundly fingerprinted (no strategy for the
+    // vendor / a non-Standard-Schema validator / an opaque un-versioned transform) and the caller
+    // did not opt into re-validate-on-hit — fail closed, never store, and surface WHY for traces.
+    if (ctl.policy === 'refuse') {
+        yield cacheEvt(`bypass: ${ctl.reason}`);
+        yield* runFrom(rt, baseReq, name, state, t0, budget);
+        return;
+    }
+
     // A non-cacheable method (a mutation sharing a fragment) runs normally, uncached.
     if (!ctl.cacheableMethod(baseReq.method)) {
         yield* runFrom(rt, baseReq, name, state, t0, budget);
@@ -858,9 +887,11 @@ async function* runCached(
     const op = await ctl.open(key, d);
     const found = await op.get();
     if (found) {
-        // Re-validate on hit unless `cache.version` pins the schema (the safe default until
-        // schema fingerprinting, ADR 0004): still skips network/throttle/transform. A fatal
-        // mismatch means the stored value is stale-shaped → evict and fall through to a miss.
+        // policy 'revalidate' (ADR 0004): the schema couldn't be fingerprinted but the caller opted
+        // in, so re-validate the stored value against the current output before serving — a fatal
+        // mismatch means it is stale-shaped → evict and fall through to a miss. policy 'fast' skips
+        // this (the value is bound to a known fingerprint, or there is no output schema). Either way
+        // a hit still short-circuits network/throttle/transform.
         let stale = false;
         if (ctl.revalidateOnHit && cfg.output) {
             for (const finding of await validateOutput(cfg, found.value)) {
@@ -869,7 +900,7 @@ async function* runCached(
             }
         }
         if (!stale) {
-            yield cacheEvt('hit');
+            yield cacheEvt(ctl.revalidateOnHit ? 'hit (revalidated)' : 'hit');
             yield resultEvt(found.value, found.status, 0);
             yield doneEvt(true, t0, 0);
             return;

--- a/packages/core/src/fingerprint.ts
+++ b/packages/core/src/fingerprint.ts
@@ -15,34 +15,25 @@
 // their own packages (`@stitchapi/fingerprint-*`) with the validator as a peer
 // dependency, each proving compliance via `verifyFingerprintContract`
 // (`stitchapi/testing`). No validator ever enters core's dependency graph.
+import { xxh128 } from './hash';
 import { type StandardSchemaV1, isStandardSchema } from './standard-schema';
 
 // ---------------------------------------------------------------------------
 // hash primitive — synchronous, browser-safe, non-crypto, no dependency
 // ---------------------------------------------------------------------------
 
-// FNV-1a over UTF-16 code units, 64-bit, rendered base36. Computed once at
-// stitch-definition time, never on the hot path, so a non-crypto hash is fine.
-// A COLLISION (two different contracts → same token) is the only unsafe failure,
-// because it would under-invalidate; 64 bits keeps that probability negligible
-// for any realistic number of distinct schemas. WebCrypto is async + Node `crypto`
-// is not browser-safe, so neither is usable here (browser-first gate). The token
-// is opaque: ADR 0003 may later swap this for the shared xxh128 key primitive — a
-// one-time, safe over-invalidation — without changing this contract.
-const FNV_OFFSET = 0xcbf29ce484222325n;
-const FNV_PRIME = 0x100000001b3n;
-const MASK64 = 0xffffffffffffffffn;
+// The fingerprint token rides the SAME 128-bit xxh128 the cache key uses — the swap this module's
+// FNV-1a placeholder always anticipated, now that ADR 0003's cache is wired. One well-tested
+// primitive: computed once at stitch-definition time, never on the hot path. A COLLISION (two
+// different contracts → same token) is the only unsafe failure — it would under-invalidate — and
+// 128 bits puts that past ~2^64 distinct schemas, unreachable. WebCrypto is async and Node `crypto`
+// is not browser-safe, so neither is usable here (browser-first gate). The token is opaque, so the
+// one-time change in its bytes from the old FNV form is a safe over-invalidation (no production
+// users; any cached values self-heal under TTL).
 
-/** Stable non-crypto hash of a string → a short opaque token. */
+/** Stable non-crypto hash of a string → an opaque 128-bit token (32-char hex). */
 export function hash(input: string): string {
-    let h = FNV_OFFSET;
-    for (let i = 0; i < input.length; i++) {
-        const c = input.charCodeAt(i);
-        h = ((h ^ BigInt(c & 0xff)) * FNV_PRIME) & MASK64;
-        h = ((h ^ BigInt((c >> 8) & 0xff)) * FNV_PRIME) & MASK64;
-    }
-    // Length-prefix adds a cheap extra discriminator against collisions.
-    return `${input.length.toString(36)}_${h.toString(36)}`;
+    return xxh128(input);
 }
 
 // ---------------------------------------------------------------------------
@@ -157,7 +148,7 @@ export interface FingerprintInput {
      * caches but re-validates on every hit (network savings, but only sound for
      * pure validators — see {@link CachePolicy}).
      */
-    readonly onUnfingerprintable?: 'refuse' | 'revalidate';
+    readonly onUnfingerprintable?: 'refuse' | 'revalidate' | undefined;
 }
 
 export interface FingerprintResolution {

--- a/packages/core/src/hash.ts
+++ b/packages/core/src/hash.ts
@@ -1,0 +1,113 @@
+// 128-bit synchronous non-cryptographic hash (xxHash family) — the ONE key/fingerprint primitive.
+//
+// Shared by the response cache (ADR 0003: the derived opaque request key) and the Standard Schema
+// fingerprint (ADR 0004: the cache-generation token). It lives in its own tiny module — NOT in
+// `util.ts`, which the engine/stitch hot path imports, because a BigInt hash there would tax every
+// cache-free stitch (bundle-frugal gate). Both importers (`cache.ts`, `fingerprint.ts`) are
+// off-the-hot-path subpaths reached only when a `cache` block is present, so this code never lands
+// in the main bundle.
+//
+// The digest is two XXH64 passes (seeds A and B) over the canonical string's UTF-8 bytes — a
+// well-specified, bit-stable xxHash member needing only 64-bit integer math (BigInt; JS has no
+// native u64) and no async/WebCrypto (`crypto.subtle.digest` is async and a JS crypto hash is
+// bundle weight). 128 bits puts a collision past ~2^64 entries — unreachable — so the cache needs
+// no verify-on-read (which would mean storing the plaintext request beside the value, re-introducing
+// the leak the opaque key avoids). The algorithm is frozen behind the cache's KEY_VERSION: any
+// change to it is a key-schema bump (a mass self-healing miss, never a stale-key hit).
+
+const MASK64 = (1n << 64n) - 1n;
+const P1 = 11400714785074694791n;
+const P2 = 14029467366897019727n;
+const P3 = 1609587929392839161n;
+const P4 = 9650029242287828579n;
+const P5 = 2870177450012600261n;
+const SEED_A = 0n;
+const SEED_B = 0x9e3779b185ebca87n; // a second, independent seed → the high 64 bits
+
+const mul = (a: bigint, b: bigint): bigint => (a * b) & MASK64;
+const rotl = (x: bigint, r: bigint): bigint =>
+    ((x << r) | (x >> (64n - r))) & MASK64;
+const xxhRound = (acc: bigint, input: bigint): bigint =>
+    mul(rotl((acc + mul(input, P2)) & MASK64, 31n), P1);
+const mergeRound = (acc: bigint, val: bigint): bigint =>
+    (mul(acc ^ xxhRound(0n, val), P1) + P4) & MASK64;
+
+// All reads are bounds-guaranteed by the callers' stripe arithmetic; `?? 0` keeps the indexed
+// access total without a non-null assertion (noUncheckedIndexedAccess).
+function read64LE(b: Uint8Array, i: number): bigint {
+    let v = 0n;
+    for (let j = 7; j >= 0; j--) v = (v << 8n) | BigInt(b[i + j] ?? 0);
+    return v;
+}
+function read32LE(b: Uint8Array, i: number): bigint {
+    return BigInt(
+        ((b[i] ?? 0) |
+            ((b[i + 1] ?? 0) << 8) |
+            ((b[i + 2] ?? 0) << 16) |
+            ((b[i + 3] ?? 0) << 24)) >>>
+            0,
+    );
+}
+
+function xxh64(b: Uint8Array, seed: bigint): bigint {
+    const len = b.length;
+    let h: bigint;
+    let p = 0;
+    if (len >= 32) {
+        let v1 = (seed + P1 + P2) & MASK64;
+        let v2 = (seed + P2) & MASK64;
+        let v3 = seed & MASK64;
+        let v4 = (seed - P1) & MASK64;
+        const limit = len - 32;
+        while (p <= limit) {
+            v1 = xxhRound(v1, read64LE(b, p));
+            p += 8;
+            v2 = xxhRound(v2, read64LE(b, p));
+            p += 8;
+            v3 = xxhRound(v3, read64LE(b, p));
+            p += 8;
+            v4 = xxhRound(v4, read64LE(b, p));
+            p += 8;
+        }
+        h =
+            (rotl(v1, 1n) + rotl(v2, 7n) + rotl(v3, 12n) + rotl(v4, 18n)) &
+            MASK64;
+        h = mergeRound(h, v1);
+        h = mergeRound(h, v2);
+        h = mergeRound(h, v3);
+        h = mergeRound(h, v4);
+    } else {
+        h = (seed + P5) & MASK64;
+    }
+    h = (h + BigInt(len)) & MASK64;
+    while (p + 8 <= len) {
+        h ^= xxhRound(0n, read64LE(b, p));
+        h = (mul(rotl(h, 27n), P1) + P4) & MASK64;
+        p += 8;
+    }
+    if (p + 4 <= len) {
+        h ^= mul(read32LE(b, p), P1);
+        h = (mul(rotl(h, 23n), P2) + P3) & MASK64;
+        p += 4;
+    }
+    while (p < len) {
+        h ^= mul(BigInt(b[p] ?? 0), P5);
+        h = mul(rotl(h, 11n), P1);
+        p += 1;
+    }
+    h ^= h >> 33n;
+    h = mul(h, P2);
+    h ^= h >> 29n;
+    h = mul(h, P3);
+    h ^= h >> 32n;
+    return h & MASK64;
+}
+
+const encoder = new TextEncoder();
+const toHex16 = (v: bigint): string => v.toString(16).padStart(16, '0');
+
+/** A 128-bit synchronous non-cryptographic digest of `input` as a 32-char hex string. */
+export function xxh128(input: string): string {
+    const bytes = encoder.encode(input);
+    return toHex16(xxh64(bytes, SEED_A)) + toHex16(xxh64(bytes, SEED_B));
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -131,12 +131,36 @@ export interface CacheConfig {
      */
     coalesce?: 'process' | 'cluster' | false;
     /**
-     * Opaque schema/version tag folded into the key. Setting it is the explicit **no-revalidate**
-     * fast path (a promise the `output` schema is unchanged); leaving it unset uses the safe
-     * default — **re-validate on hit** (still skips network/throttle/transform) until schema
-     * fingerprinting (ADR 0004) lands.
+     * Opaque schema/version tag — the **authoritative** rung of the fingerprint ladder (ADR 0004):
+     * setting it pins the contract and takes the **no-revalidate** fast path (you promise the
+     * `output`/`transform`/`unwrap` are unchanged for this tag). Leaving it unset hands off to the
+     * automatic fingerprint: a registered `@stitchapi/fingerprint-*` strategy makes `output`
+     * changes self-invalidate on the fast path; an un-fingerprintable schema falls to
+     * {@link CacheConfig.onUnfingerprintable} (default **refuse-to-cache**, fail-closed).
      */
     version?: string | number;
+    /**
+     * Version tag for an opaque `transform` (ADR 0004). A `transform` is a closure that cannot be
+     * soundly hashed, so by default a stitch that has one **refuses to cache** (re-validation can't
+     * detect a transform change). Set this to make the transform sound and re-enable caching; bump
+     * it whenever the transform's behaviour changes. See also {@link CacheConfig.trustTransform}.
+     */
+    transformVersion?: string | number;
+    /**
+     * Opt in to caching despite an un-versioned `transform`, trusting that its output is stable for
+     * the `ttl`. Weaker than {@link CacheConfig.transformVersion} (a transform change is invisible,
+     * bounded only by TTL); prefer `transformVersion` when you can name a version.
+     */
+    trustTransform?: boolean;
+    /**
+     * Policy when an `output` schema is present but cannot be soundly fingerprinted (no
+     * `@stitchapi/fingerprint-*` registered for its vendor, a non-Standard-Schema validator, or the
+     * strategy abstained). `'refuse'` (default, **fail-closed**) does not cache — and nudges you to
+     * register the vendor package or set `version`. `'revalidate'` caches but **re-validates the
+     * stored value on every hit** against the current schema (saves the network, still safe; sound
+     * only for pure validators with no coercion/transform inside the schema).
+     */
+    onUnfingerprintable?: 'refuse' | 'revalidate';
     /** Sugar: author the key seed from the input instead of deriving it from the request. */
     key?: (input: StitchInput) => string;
 }

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -14,6 +14,23 @@ export type ValidationResult<T> =
 
 export interface Validator<T = unknown> {
     validate(value: unknown): Promise<ValidationResult<T>>;
+    /**
+     * The raw schema this validator wraps (Zod / Valibot / ArkType / any Standard Schema /
+     * predicate), attached non-enumerably by {@link toValidator}. The response cache reads it to
+     * fingerprint the output contract (ADR 0004): the wrapper itself hides the original
+     * `~standard.vendor` the fingerprint strategy dispatches on. Non-enumerable, so it never lands
+     * in `__config`, JSON, or trace payloads.
+     */
+    readonly source?: unknown;
+}
+
+// Attach the raw schema to a wrapper non-enumerably, so the cache can fingerprint the output
+// contract (ADR 0004) without the schema leaking through enumerable copies into `__config`/traces.
+function withSource(validator: Validator, source: unknown): Validator {
+    return Object.defineProperty(validator, 'source', {
+        value: source,
+        enumerable: false,
+    });
 }
 
 /** Coerce a Zod schema | Standard Schema | Validator | undefined into a Validator. */
@@ -36,56 +53,67 @@ export function toValidator(schema: unknown): Validator | undefined {
     // Zod (v3): has safeParse
     const zodLike = schema as { safeParse?: (v: unknown) => ZodResult };
     if (typeof zodLike.safeParse === 'function') {
-        return {
-            async validate(value) {
-                const r = zodLike.safeParse!(value);
-                if (r.success) return { ok: true, value: r.data };
-                return {
-                    ok: false,
-                    issues: (r.error?.issues ?? []).map((i) => ({
-                        path: i.path ?? [],
-                        message: i.message,
-                    })),
-                };
+        return withSource(
+            {
+                async validate(value) {
+                    const r = zodLike.safeParse!(value);
+                    if (r.success) return { ok: true, value: r.data };
+                    return {
+                        ok: false,
+                        issues: (r.error?.issues ?? []).map((i) => ({
+                            path: i.path ?? [],
+                            message: i.message,
+                        })),
+                    };
+                },
             },
-        };
+            schema,
+        );
     }
 
     // Standard Schema
     if (isStandardSchema(schema)) {
-        return {
-            async validate(value) {
-                const r = await schema['~standard'].validate(value);
-                if ('issues' in r && r.issues) {
-                    return {
-                        ok: false,
-                        issues: r.issues.map((i) => ({
-                            path: (i.path ?? []).map((p) =>
-                                typeof p === 'object'
-                                    ? (p.key as string | number)
-                                    : (p as string | number),
-                            ),
-                            message: i.message,
-                        })),
-                    };
-                }
-                return { ok: true, value: (r as { value: unknown }).value };
+        return withSource(
+            {
+                async validate(value) {
+                    const r = await schema['~standard'].validate(value);
+                    if ('issues' in r && r.issues) {
+                        return {
+                            ok: false,
+                            issues: r.issues.map((i) => ({
+                                path: (i.path ?? []).map((p) =>
+                                    typeof p === 'object'
+                                        ? (p.key as string | number)
+                                        : (p as string | number),
+                                ),
+                                message: i.message,
+                            })),
+                        };
+                    }
+                    return { ok: true, value: (r as { value: unknown }).value };
+                },
             },
-        };
+            schema,
+        );
     }
 
     // Plain predicate: (value: unknown) => boolean
     if (typeof schema === 'function') {
         const predicate = schema as (v: unknown) => boolean;
-        return {
-            async validate(value) {
-                if (predicate(value)) return { ok: true, value };
-                return {
-                    ok: false,
-                    issues: [{ path: [], message: 'Predicate returned false' }],
-                };
+        return withSource(
+            {
+                async validate(value) {
+                    if (predicate(value)) return { ok: true, value };
+                    return {
+                        ok: false,
+                        issues: [
+                            { path: [], message: 'Predicate returned false' },
+                        ],
+                    };
+                },
             },
-        };
+            schema,
+        );
     }
 
     throw new Error(

--- a/packages/core/test/cache.spec.ts
+++ b/packages/core/test/cache.spec.ts
@@ -5,9 +5,52 @@
 // `version` fast path, and the cacheable-method gate (GraphQL opt-in).
 import { graphql, memoryStore, seam, stitch } from '../src';
 import type { Adapter } from '../src';
+import { clearFingerprinters, registerFingerprinter } from '../src/fingerprint';
+import type { SchemaFingerprinter } from '../src/fingerprint';
+import type { StandardSchemaV1 } from '../src/standard-schema';
 
 const sleep = (ms: number): Promise<void> =>
     new Promise((resolve) => setTimeout(resolve, ms));
+
+// A minimal Standard Schema carrying an inspectable `__desc` (mirrors fingerprint.spec). It rides
+// through `toValidator`, which preserves it as the Validator's non-enumerable `source` so the cache
+// can fingerprint it; `~standard.validate` accepts the value unchanged.
+function fpSchema(
+    desc: unknown,
+    vendor = 'test',
+): StandardSchemaV1 & { __desc: unknown } {
+    return {
+        '~standard': {
+            version: 1,
+            vendor,
+            validate: (value: unknown) => ({ value }),
+        },
+        __desc: desc,
+    };
+}
+
+// Reference strategy: distinct `__desc` → distinct token; ABSTAINS (value null) on `{ opaque }`.
+const testFingerprinter: SchemaFingerprinter = {
+    vendor: 'test',
+    supports: '*',
+    fingerprint(schema) {
+        const desc = (schema as { __desc?: unknown }).__desc;
+        if (desc && typeof desc === 'object' && 'opaque' in desc)
+            return { value: null, strength: 'strong' };
+        return { value: JSON.stringify(desc), strength: 'strong' };
+    },
+};
+
+// Drain a stitch's event stream and collect the `cache`-phase trace details (hit/miss/bypass/…).
+async function cacheTrace(
+    run: AsyncIterable<{ type: string; phase?: string; detail?: string }>,
+): Promise<string[]> {
+    const details: string[] = [];
+    for await (const ev of run)
+        if (ev.type === 'progress' && ev.phase === 'cache' && ev.detail)
+            details.push(ev.detail);
+    return details;
+}
 
 // An adapter that counts origin calls and returns a JSON body. `body(callNo, req)` defaults to
 // `{ n: callNo }`, so a stable cached response still lets a test prove freshness by call count.
@@ -320,10 +363,12 @@ describe('cache — scope isolation', () => {
 });
 
 describe('cache — re-validate on hit vs version fast path', () => {
-    test('without a version, a hit is re-validated and a stale-shaped entry self-heals', async () => {
+    test('onUnfingerprintable:"revalidate" self-heals a stale-shaped hit', async () => {
         // First origin call returns a string `n`; later calls return a number. A loose writer
-        // caches the string; a strict reader (sharing the store + key) re-validates on hit, finds
-        // it stale, evicts, and refetches a conforming value.
+        // (accept-anything predicate) caches the string; a strict reader (number predicate) sharing
+        // the store + key re-validates on hit, finds it stale, evicts, and refetches a conforming
+        // value. Both outputs are predicates — un-fingerprintable — so with onUnfingerprintable:
+        // 'revalidate' both take policy 'revalidate' and share one (empty-fingerprint) bucket.
         const { adapter, calls } = counting({
             body: (n) => ({ n: n === 1 ? 'oops' : 7 }),
         });
@@ -334,9 +379,16 @@ describe('cache — re-validate on hit vs version fast path', () => {
             adapter,
             store,
             trace: false as const,
-            cache: { ttl: '60s', scope: 'app' as const },
+            cache: {
+                ttl: '60s',
+                scope: 'app' as const,
+                onUnfingerprintable: 'revalidate' as const,
+            },
         };
-        const writer = stitch(base);
+        const writer = stitch({
+            ...base,
+            output: (v: unknown): v is object => typeof v === 'object',
+        });
         const reader = stitch({
             ...base,
             output: (v: unknown): v is { n: number } =>
@@ -372,6 +424,121 @@ describe('cache — re-validate on hit vs version fast path', () => {
         // version set → no re-validation: the stale-shaped value is returned as-is, no refetch.
         expect(await reader()).toEqual({ n: 'oops' });
         expect(calls()).toBe(1);
+    });
+});
+
+describe('cache — schema fingerprint fold (ADR 0004)', () => {
+    afterEach(() => {
+        clearFingerprinters();
+    });
+
+    test('a no-output stitch caches fast — a hit is served without re-validation', async () => {
+        const { adapter, calls } = counting();
+        const s = stitch({
+            url: URL,
+            adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app' },
+        });
+        expect(await s()).toEqual({ n: 1 });
+        const trace = await cacheTrace(s.stream());
+        expect(trace).toContain('hit'); // policy 'fast' → plain 'hit', not 'hit (revalidated)'
+        expect(trace).not.toContain('hit (revalidated)');
+        expect(calls()).toBe(1);
+    });
+
+    test('a registered fingerprinter takes the fast path; a changed schema is a new generation → miss', async () => {
+        registerFingerprinter(testFingerprinter);
+        const { adapter, calls } = counting();
+        const store = memoryStore();
+        const base = {
+            url: URL,
+            name: 'fp',
+            adapter,
+            store,
+            trace: false as const,
+            cache: { ttl: '60s', scope: 'app' as const },
+        };
+        const v1 = stitch({ ...base, output: fpSchema('v1') });
+        expect(await v1()).toEqual({ n: 1 });
+        expect(await v1()).toEqual({ n: 1 }); // sound fingerprint → fast hit
+        expect(calls()).toBe(1);
+
+        // Ship a changed output schema (new __desc → new fingerprint token) → new bucket → miss.
+        const v2 = stitch({ ...base, output: fpSchema('v2') });
+        expect(await v2()).toEqual({ n: 2 });
+        expect(calls()).toBe(2);
+
+        // The old schema's entry lives in its own bucket — still a hit, not clobbered.
+        expect(await v1()).toEqual({ n: 1 });
+        expect(calls()).toBe(2);
+    });
+
+    test('an un-fingerprintable schema is refused by default (fail-closed) and surfaces why', async () => {
+        registerFingerprinter(testFingerprinter); // registered, but ABSTAINS on { opaque }
+        const { adapter, calls } = counting();
+        const s = stitch({
+            url: URL,
+            adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app' },
+            output: fpSchema({ opaque: true }),
+        });
+        const trace = await cacheTrace(s.stream());
+        expect(trace.some((d) => d.startsWith('bypass:'))).toBe(true);
+        expect(trace.join(' ')).toContain('abstained'); // the reason is not swallowed
+        await s();
+        expect(calls()).toBe(2); // never cached — each call is live
+    });
+
+    test('onUnfingerprintable:"revalidate" caches and re-validates the stored value on each hit', async () => {
+        registerFingerprinter(testFingerprinter);
+        const { adapter, calls } = counting();
+        const s = stitch({
+            url: URL,
+            adapter,
+            trace: false,
+            cache: {
+                ttl: '60s',
+                scope: 'app',
+                onUnfingerprintable: 'revalidate',
+            },
+            output: fpSchema({ opaque: true }), // abstains → policy 'revalidate'
+        });
+        expect(await s()).toEqual({ n: 1 });
+        const trace = await cacheTrace(s.stream());
+        expect(trace).toContain('hit (revalidated)'); // re-validated, then served
+        expect(calls()).toBe(1); // value re-validates fine → still cached
+    });
+
+    test('an opaque transform refuses to cache unless a transformVersion makes it sound', async () => {
+        const refused = counting();
+        const r = stitch({
+            url: URL,
+            name: 'tx',
+            adapter: refused.adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app' },
+            transform: (b) => b, // opaque closure, no transformVersion/trustTransform → refuse
+        });
+        const trace = await cacheTrace(r.stream());
+        expect(trace.some((d) => d.startsWith('bypass:'))).toBe(true);
+        expect(trace.join(' ')).toContain('transform'); // reason names the transform
+        await r();
+        expect(refused.calls()).toBe(2); // not cached
+
+        const versioned = counting();
+        const v = stitch({
+            url: URL,
+            name: 'txv',
+            adapter: versioned.adapter,
+            trace: false,
+            cache: { ttl: '60s', scope: 'app', transformVersion: '1' },
+            transform: (b) => b, // now sound (version named) → fast
+        });
+        await v();
+        await v();
+        expect(versioned.calls()).toBe(1); // second call is a hit
     });
 });
 

--- a/packages/core/test/fingerprint.spec.ts
+++ b/packages/core/test/fingerprint.spec.ts
@@ -70,10 +70,9 @@ describe('hash', () => {
         expect(hash('user|v1')).not.toBe(hash('user|v2'));
     });
 
-    it('returns a short non-empty token', () => {
+    it('returns an opaque 128-bit token (32-char hex)', () => {
         const h = hash('the quick brown fox');
-        expect(h.length).toBeGreaterThan(0);
-        expect(h).toMatch(/^[0-9a-z]+_[0-9a-z]+$/);
+        expect(h).toMatch(/^[0-9a-f]{32}$/);
     });
 });
 


### PR DESCRIPTION
## What

Wires **`resolveFingerprint` (ADR 0004)** into the **ADR 0003 response cache** so a changed `output` schema / `unwrap` / versioned `transform` invalidates cached values — closing the hazard in [ADR 0003 Decision 2](https://github.com/rejifald/StitchAPI/blob/main/docs/adr/0003-derived-key-response-cache-and-coalescing.md) (the cache stores the post-validation value and skips re-validation on a hit, so a shipped schema change would otherwise serve stale-shaped values for the whole TTL).

> [!NOTE]
> Rebased onto current `main` after [#81](https://github.com/rejifald/StitchAPI/pull/81) (the fingerprint contract + kit + 5 vendor packages) and [#84](https://github.com/rejifald/StitchAPI/pull/84) merged. This PR is now **just the fold** — 10 files, no new vendor packages — and is mergeable.

## The fold (core of the change)

`createCache` calls `resolveFingerprint` **once per stitch** (it is memoised, so once per lifetime) from its `output`/`transform`/`unwrap` + the `cache` options, then:

- **`generation`** folds into the cache key namespace **alongside** the per-stitch generation counter — a schema/unwrap/versioned-transform change moves the bucket (old entries unreachable), while `invalidate()` still bumps the counter. They compose; one does not replace the other. Namespace: `cache:k1:g{cacheGen}.{stitchGen}.{stitchId}.f{fpGeneration}:{requestKey}{varySuffix}` (`fpGeneration` replaces the old `versionTag`, which it subsumes).
- **`policy`** drives the hit path: `fast` (serve without re-validating), `revalidate` (re-validate the stored value against the current schema on each hit, via the engine's `validateOutput`), `refuse` (never cache — pass through, uncached).
- **`reason`** is surfaced on the cache trace (e.g. `bypass: <reason>`), not swallowed.

## Three design decisions

1. **One shared hash primitive.** Extracted `xxh128` into a new tiny `src/hash.ts` (off the main bundle — deliberately **not** `util.ts`, which the engine/stitch hot path imports, so a cache-free stitch pays nothing). Both the cache key (ADR 0003) and the fingerprint token (ADR 0004) ride it; `fingerprint.hash()` now delegates to `xxh128` — the swap `fingerprint.ts` always anticipated, a one-time safe over-invalidation of the opaque token. `cache.ts` re-exports `xxh128` to keep the `stitchapi/cache` surface stable.
2. **Config shape.** `CacheConfig` gains `transformVersion`, `trustTransform`, `onUnfingerprintable`; `version` now feeds the ladder's authoritative rung. Each maps 1:1 onto `resolveFingerprint`'s input.
3. **Namespace composition.** Per-stitch generation counter (bulk-invalidate) + static fingerprint token (schema change) coexist in the key, as above.

### One integration subtlety

`normalizeOutput`/`drift()` wrap `output` through `toValidator`, which hides the original `~standard`, so the fingerprinter could never dispatch on the vendor. Fix: `toValidator` keeps a **non-enumerable `source`** back-reference to the raw schema; `ensureCache` un-wraps it (and the `DriftSpec.schema` layer) to feed the resolver. Non-enumerable ⇒ never leaks into `__config`/JSON/traces.

## Behaviour change

A stitch with an `output` schema + `cache` but **no registered fingerprinter and no `version`** now **refuses to cache by default** (fail-closed, ADR 0004) instead of the old "cache + re-validate-on-hit" placeholder. Opt back in with `onUnfingerprintable: 'revalidate'`, a `version`, or a registered `@stitchapi/fingerprint-*`. The existing self-heal test was updated to opt in explicitly.

## Tests

New `cache — schema fingerprint fold (ADR 0004)` suite (engine-level, through the public `stitch`/`seam` surface, via a registered test-double fingerprinter mirroring `fingerprint.spec`):

- no-output stitch → caches fast (plain `hit`, no re-validation)
- registered fingerprinter → fast path; **changing the schema → new generation → miss** (other bucket stays live)
- un-fingerprintable schema → **refused by default**, reason surfaced on the trace
- `onUnfingerprintable: 'revalidate'` → caches + re-validates on each hit
- opaque `transform` → refused; `transformVersion` → fast

Plus `fingerprint.hash` asserts the 32-char hex token.

## Gate

`format`, `lint`, `typecheck`, `typecheck-d`, `test` (core **277** + 5 vendor suites), `check:exports` (`stitchapi/cache` + `stitchapi/fingerprint` both 🟢), and `build-docs` all green. ADRs 0003 & 0004 marked **implemented** (the "cache wiring pending" caveat removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)