### PR TITLE
feat(playground): render the DAG from real runs (populate RunResult.trace)

### DIFF
--- a/apps/docs/e2e/sandbox-trace.spec.ts
+++ b/apps/docs/e2e/sandbox-trace.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * A2 end-to-end — the REAL worker bundle produces a stitch trace from a REAL run
+ * (RELEASE.md → Go/no-go gate #3: "the Mermaid DAG renders from a real run's
+ * trace"). This drives the actual `/sandbox/sandbox-worker.mjs` (worker-main →
+ * trace-collector → stitch-browser → sandbox-sim) in a real browser, bypassing
+ * the playground chrome so it proves the data pipeline, not the UI.
+ */
+
+test.describe('playground sandbox trace', () => {
+    test('a real stitch run yields a trace entry (progress + final result)', async ({
+        page,
+    }) => {
+        await page.goto('/playground');
+
+        const outcome = await page.evaluate(async () => {
+            // Run a plain-JS snippet (the worker does not transpile) that makes a
+            // real stitch call against the in-Worker sandbox simulator.
+            const js =
+                "const r = await stitch('https://demo.stitchapi.dev/users/2')(); return r;";
+            const worker = new Worker('/sandbox/sandbox-worker.mjs', {
+                type: 'module',
+            });
+            const progressTraceIds: string[] = [];
+            try {
+                return await new Promise<{
+                    finalTrace: unknown;
+                    sawProgressTrace: boolean;
+                }>((resolve, reject) => {
+                    const timer = setTimeout(
+                        () => reject(new Error('worker run timed out')),
+                        15000,
+                    );
+                    worker.onmessage = (ev: MessageEvent) => {
+                        const d = ev.data as {
+                            type: string;
+                            event?: { type: string; entry?: { id: string } };
+                            trace?: unknown;
+                        };
+                        if (
+                            d.type === 'progress' &&
+                            d.event?.type === 'trace'
+                        ) {
+                            progressTraceIds.push(d.event.entry?.id ?? '');
+                            return;
+                        }
+                        if (d.type === 'result') {
+                            clearTimeout(timer);
+                            resolve({
+                                finalTrace: d.trace,
+                                sawProgressTrace: progressTraceIds.length > 0,
+                            });
+                        }
+                    };
+                    worker.onerror = (e: ErrorEvent) =>
+                        reject(new Error(e.message || 'worker error'));
+                    worker.postMessage({
+                        type: 'run',
+                        js,
+                        extraScopeNames: [],
+                    });
+                });
+            } finally {
+                worker.terminate();
+            }
+        });
+
+        // The progressive trace event fired during the run (incremental DAG).
+        expect(
+            outcome.sawProgressTrace,
+            'a {type:"trace"} progress event should fire during the run',
+        ).toBe(true);
+
+        // The final result carries the structured trace → RunResult.trace → DAG.
+        const trace = outcome.finalTrace as
+            | Array<{
+                  id: string;
+                  request: { method: string; url: string };
+                  response?: { status: number; ok: boolean };
+              }>
+            | undefined;
+        expect(
+            Array.isArray(trace) && trace.length >= 1,
+            'trace populated',
+        ).toBe(true);
+        const entry = trace![0];
+        expect(entry.request.method).toBe('GET');
+        expect(entry.request.url).toContain('users/2');
+        // A response (or error) was recorded — the call actually completed.
+        expect(
+            entry.response !== undefined || 'error' in entry,
+            'entry has a response or error outcome',
+        ).toBe(true);
+    });
+});

--- a/apps/docs/playwright.config.ts
+++ b/apps/docs/playwright.config.ts
@@ -18,7 +18,11 @@ export default defineConfig({
     testDir: './e2e',
     timeout: 30_000,
     expect: { timeout: 10_000 },
-    fullyParallel: true,
+    // One worker: the specs share a single Next dev/prod server that compiles
+    // routes on demand and runs the sandbox Worker — parallel browser workers
+    // overwhelm it (a real run can starve an on-demand compile past the timeout).
+    fullyParallel: false,
+    workers: 1,
     reporter: process.env.CI ? 'github' : 'list',
     use: {
         baseURL: 'http://localhost:3000',

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -56,9 +56,14 @@ The entire core library (`stitchapi`, currently `0.7.0`), verified against
         confined to the worker via a per-route policy on `/sandbox/*`. Lives in
         [`apps/docs/lib/security-headers.mjs`](../apps/docs/lib/security-headers.mjs);
         served headers verified, egress block proven in a real browser.
--   [ ] **Populate `RunResult.trace` from the real Worker** — emit
-        `StitchTraceEntry` chunks from `stitch-browser.ts` so the Mermaid DAG
-        renders from real runs, not test fixtures
+-   [x] **Populate `RunResult.trace` from the real Worker** — a traced `stitch`
+        ([`docs/sandbox/runtime/trace-collector.ts`](../docs/sandbox/runtime/trace-collector.ts))
+        injects a core trace sink per call and emits `StitchTraceEntry`s through
+        the worker progress relay → `ResultMessage.trace` → `RunResult.trace`, so
+        the Mermaid DAG renders from real runs. Proven end-to-end in a real
+        browser ([`e2e/sandbox-trace.spec.ts`](../apps/docs/e2e/sandbox-trace.spec.ts)) + unit ([`trace-collector.test.ts`](../docs/sandbox/runtime/trace-collector.test.ts)).
+        Follow-ups: dependency EDGES (`dependsOn`, needs the composition graph)
+        and `seam`-created stitches.
 -   [ ] **Playwright harness** ([`apps/docs/e2e/`](../apps/docs/e2e/)) — egress
         confinement + CSP enforcement (SEC-10..13) **proven** (4/4 green). Broaden
         to SEC-04 (non-HTTP egress), Worker isolation / no state-bleed (SEC-36/37),

--- a/docs/sandbox/runtime/browser-runner.ts
+++ b/docs/sandbox/runtime/browser-runner.ts
@@ -289,12 +289,18 @@ class BrowserWorkerRunner implements CodeRunner {
 function mapResult(msg: ResultMessage, durationMs: number): RunResult {
     const logs = msg.logs.map(toLogEntry);
     const notices = msg.notices.map(toNotice);
+    // A2: the worker's structured stitch trace → RunResult.trace, so the output
+    // panel's Mermaid DAG renders from the real run. Already StitchTraceEntry[]
+    // (structured-cloneable), so it passes through verbatim.
+    const trace = msg.trace && msg.trace.length ? msg.trace : undefined;
     if (msg.error) {
-        // The snippet itself threw/rejected → reason:'throw' (SEC-39a).
+        // The snippet itself threw/rejected → reason:'throw' (SEC-39a). Partial
+        // trace (stitches that completed before the throw) is still surfaced.
         return {
             logs,
             durationMs,
             notices: notices.length ? notices : undefined,
+            trace,
             error: throwError(msg.error),
         };
     }
@@ -303,6 +309,7 @@ function mapResult(msg: ResultMessage, durationMs: number): RunResult {
         durationMs,
         value: msg.value,
         notices: notices.length ? notices : undefined,
+        trace,
     };
 }
 

--- a/docs/sandbox/runtime/trace-collector.test.ts
+++ b/docs/sandbox/runtime/trace-collector.test.ts
@@ -1,0 +1,386 @@
+/**
+ * A2 — trace-collector unit proofs (no browser, no installed deps).
+ *
+ * Drives `createTraceCollector` with a FAKE core `stitch` that pumps synthetic
+ * `StitchEvent`s through the injected trace sink — exactly what the real engine's
+ * `tee` does on the await/.stream() paths. Proves real lifecycle events become
+ * `StitchTraceEntry` DAG nodes + stream `chunk` events on the progress sink.
+ *
+ * Run with:  npx -y tsx docs/sandbox/runtime/trace-collector.test.ts
+ */
+import type { RunEvent } from '../component/runner';
+import { createTraceCollector } from './trace-collector';
+import type { ProgressSink } from './worker-entry';
+
+let passed = 0;
+let failed = 0;
+
+function assert(label: string, condition: boolean, detail?: unknown): void {
+    if (condition) {
+        console.log(`  PASS  ${label}`);
+        passed++;
+    } else {
+        console.error(`  FAIL  ${label}`, detail ?? '');
+        failed++;
+    }
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * A fake core `stitch`: returns a callable that, when invoked, drives the given
+ * synthetic events through the trace sink the collector injected into `config`,
+ * then resolves `value`. `onConfig` captures the config the collector passed.
+ */
+function fakeCore(opts: {
+    events: () => any[];
+    value?: unknown;
+    onConfig?: (config: any) => void;
+}): (config: unknown) => unknown {
+    return (config: any) => {
+        opts.onConfig?.(config);
+        const sink = config.trace as {
+            handle: (e: any, ctx: { name: string }) => void;
+        };
+        const name = config.name ?? config.path ?? 'stitch';
+        return (_input?: unknown) => {
+            for (const ev of opts.events()) sink.handle(ev, { name });
+            return Promise.resolve(opts.value ?? { ok: true });
+        };
+    };
+}
+
+const startEv = (over: any = {}) => ({
+    type: 'start',
+    name: 'getUser',
+    method: 'GET',
+    url: 'https://demo/users/2',
+    input: {},
+    at: 0,
+    ...over,
+});
+
+async function runTests(): Promise<void> {
+    console.log('\n--- A2 trace-collector: real events → DAG entries ---\n');
+
+    /* 1 — a successful call → one trace entry with request + response ------- */
+    {
+        const events: RunEvent[] = [];
+        const collector = createTraceCollector(
+            fakeCore({
+                events: () => [
+                    startEv(),
+                    {
+                        type: 'result',
+                        value: {},
+                        status: 200,
+                        attempts: 1,
+                        at: 3,
+                    },
+                    { type: 'done', ok: true, ms: 12, attempts: 1, at: 12 },
+                ],
+            }),
+        );
+        collector.bindProgress((e) => events.push(e));
+        const s = collector.stitch({
+            name: 'getUser',
+        }) as () => Promise<unknown>;
+        await s();
+
+        const traceEvents = events.filter((e) => e.type === 'trace');
+        assert('1 emitted exactly one trace event', traceEvents.length === 1);
+        const entry = (traceEvents[0] as Extract<RunEvent, { type: 'trace' }>)
+            ?.entry;
+        assert(
+            '1 entry has id, label, request method/url',
+            entry?.id === 'stitch-1' &&
+                entry?.label === 'getUser' &&
+                entry?.request.method === 'GET' &&
+                entry?.request.url === 'https://demo/users/2',
+            entry,
+        );
+        assert(
+            '1 entry response is ok with status + duration',
+            entry?.response?.status === 200 &&
+                entry?.response?.ok === true &&
+                entry?.response?.durationMs === 12,
+            entry?.response,
+        );
+        assert(
+            '1 no error, no stream on success',
+            !entry?.error && !entry?.stream,
+        );
+    }
+
+    /* 2 — an HTTP error (status known) → error + response(ok:false) --------- */
+    {
+        const events: RunEvent[] = [];
+        const collector = createTraceCollector(
+            fakeCore({
+                events: () => [
+                    startEv(),
+                    {
+                        type: 'error',
+                        name: 'StitchHTTP',
+                        message: 'gateway timeout',
+                        status: 504,
+                        attempts: 1,
+                        at: 5,
+                    },
+                    { type: 'done', ok: false, ms: 30, attempts: 1, at: 30 },
+                ],
+            }),
+        );
+        collector.bindProgress((e) => events.push(e));
+        const s = collector.stitch({ name: 'x' }) as () => Promise<unknown>;
+        await s();
+        const entry = (
+            events.find((e) => e.type === 'trace') as
+                | Extract<RunEvent, { type: 'trace' }>
+                | undefined
+        )?.entry;
+        assert(
+            '2 entry carries the error name/message',
+            entry?.error?.name === 'StitchHTTP' &&
+                entry?.error?.message === 'gateway timeout',
+            entry?.error,
+        );
+        assert(
+            '2 entry response is not-ok with the error status',
+            entry?.response?.status === 504 && entry?.response?.ok === false,
+            entry?.response,
+        );
+    }
+
+    /* 3 — a transport error (no status) → error, no response ---------------- */
+    {
+        const events: RunEvent[] = [];
+        const collector = createTraceCollector(
+            fakeCore({
+                events: () => [
+                    startEv(),
+                    {
+                        type: 'error',
+                        name: 'StitchError',
+                        message: 'network down',
+                        attempts: 1,
+                        at: 2,
+                    },
+                    { type: 'done', ok: false, ms: 8, attempts: 1, at: 8 },
+                ],
+            }),
+        );
+        collector.bindProgress((e) => events.push(e));
+        await (collector.stitch({ name: 'x' }) as () => Promise<unknown>)();
+        const entry = (
+            events.find((e) => e.type === 'trace') as
+                | Extract<RunEvent, { type: 'trace' }>
+                | undefined
+        )?.entry;
+        assert(
+            '3 error entry has no response when status is unknown',
+            !!entry?.error && entry?.response === undefined,
+            entry,
+        );
+    }
+
+    /* 4 — streaming deltas → chunk events then a trace with stream count ---- */
+    {
+        const events: RunEvent[] = [];
+        const collector = createTraceCollector(
+            fakeCore({
+                events: () => [
+                    startEv(),
+                    { type: 'delta', chunk: 'Hel', at: 1 },
+                    { type: 'delta', chunk: 'lo', at: 2 },
+                    { type: 'done', ok: true, ms: 5, attempts: 1, at: 5 },
+                ],
+            }),
+        );
+        collector.bindProgress((e) => events.push(e));
+        await (collector.stitch({ name: 'x' }) as () => Promise<unknown>)();
+        const types = events.map((e) => e.type);
+        assert(
+            '4 order is chunk, chunk, trace',
+            JSON.stringify(types) ===
+                JSON.stringify(['chunk', 'chunk', 'trace']),
+            types,
+        );
+        const chunks = events.filter((e) => e.type === 'chunk') as Extract<
+            RunEvent,
+            { type: 'chunk' }
+        >[];
+        assert(
+            '4 chunks carry the entry id + ordered text',
+            chunks[0]?.traceId === 'stitch-1' &&
+                chunks[0]?.text === 'Hel' &&
+                chunks[1]?.text === 'lo',
+            chunks,
+        );
+        const entry = (
+            events.find((e) => e.type === 'trace') as
+                | Extract<RunEvent, { type: 'trace' }>
+                | undefined
+        )?.entry;
+        assert(
+            '4 trace entry records stream chunk count',
+            entry?.stream?.chunks === 2,
+            entry,
+        );
+    }
+
+    /* 5 — sensitive request headers surface as headersRedacted -------------- */
+    {
+        const events: RunEvent[] = [];
+        const collector = createTraceCollector(
+            fakeCore({
+                events: () => [
+                    startEv({
+                        input: {
+                            headers: {
+                                Authorization: 'Bearer s3cret',
+                                'content-type': 'application/json',
+                            },
+                        },
+                    }),
+                    {
+                        type: 'result',
+                        value: {},
+                        status: 200,
+                        attempts: 1,
+                        at: 1,
+                    },
+                    { type: 'done', ok: true, ms: 4, attempts: 1, at: 4 },
+                ],
+            }),
+        );
+        collector.bindProgress((e) => events.push(e));
+        await (collector.stitch({ name: 'x' }) as () => Promise<unknown>)();
+        const entry = (
+            events.find((e) => e.type === 'trace') as
+                | Extract<RunEvent, { type: 'trace' }>
+                | undefined
+        )?.entry;
+        assert(
+            '5 only the sensitive header name is flagged',
+            JSON.stringify(entry?.request.headersRedacted) ===
+                JSON.stringify(['Authorization']),
+            entry?.request.headersRedacted,
+        );
+    }
+
+    /* 6 — a user-supplied trace sink is preserved (multiplexed) ------------- */
+    {
+        const events: RunEvent[] = [];
+        const userSeen: string[] = [];
+        const userSink = {
+            handle: (e: any) => userSeen.push(e.type as string),
+        };
+        const collector = createTraceCollector(
+            fakeCore({
+                events: () => [
+                    startEv(),
+                    {
+                        type: 'result',
+                        value: {},
+                        status: 200,
+                        attempts: 1,
+                        at: 1,
+                    },
+                    { type: 'done', ok: true, ms: 6, attempts: 1, at: 6 },
+                ],
+            }),
+        );
+        collector.bindProgress((e) => events.push(e));
+        await (
+            collector.stitch({
+                name: 'x',
+                trace: userSink,
+            }) as () => Promise<unknown>
+        )();
+        assert(
+            '6 user sink still received the raw lifecycle events',
+            userSeen.includes('start') && userSeen.includes('done'),
+            userSeen,
+        );
+        assert(
+            '6 DAG trace still emitted alongside the user sink',
+            events.some((e) => e.type === 'trace'),
+            events,
+        );
+    }
+
+    /* 7 — string shorthand is normalised to a path, not shattered ---------- */
+    {
+        let received: any;
+        const collector = createTraceCollector(
+            fakeCore({
+                events: () => [],
+                onConfig: (c) => {
+                    received = c;
+                },
+            }),
+        );
+        collector.bindProgress(() => {});
+        await (
+            collector.stitch('https://demo/users/2') as () => Promise<unknown>
+        )();
+        assert(
+            '7 string config became { path } with an injected trace sink',
+            received?.path === 'https://demo/users/2' &&
+                typeof received?.trace === 'object' &&
+                received['0'] === undefined,
+            received,
+        );
+    }
+
+    /* 8 — no bound sink → no emit, no throw, value still returned ----------- */
+    {
+        const collector = createTraceCollector(
+            fakeCore({
+                events: () => [
+                    startEv(),
+                    { type: 'done', ok: true, ms: 1, attempts: 1, at: 1 },
+                ],
+                value: { ok: true, id: 2 },
+            }),
+        );
+        // deliberately NOT binding a progress sink (or unbind immediately):
+        const unbind = collector.bindProgress((_e: RunEvent) => {
+            throw new Error('should not be called after unbind');
+        });
+        unbind();
+        let threw = false;
+        let value: unknown;
+        try {
+            value = await (
+                collector.stitch({ name: 'x' }) as () => Promise<unknown>
+            )();
+        } catch {
+            threw = true;
+        }
+        assert('8 no throw when no active sink', !threw);
+        assert(
+            '8 value still returned with the sink unbound',
+            !!value && (value as { id: number }).id === 2,
+            value,
+        );
+    }
+
+    console.log(`\n${passed} passed, ${failed} failed\n`);
+    if (failed === 0) {
+        console.log('A2 OK');
+    } else {
+        console.error('A2 FAILED');
+        process.exit(1);
+    }
+}
+
+// satisfy the ProgressSink type import (documents the bound-sink shape).
+const _typecheck: ProgressSink = () => {};
+void _typecheck;
+
+runTests().catch((err) => {
+    console.error('Unexpected test runner error:', err);
+    process.exit(1);
+});

--- a/docs/sandbox/runtime/trace-collector.ts
+++ b/docs/sandbox/runtime/trace-collector.ts
@@ -1,0 +1,199 @@
+/**
+ * A2 — real-run trace collector for the playground DAG.
+ *
+ * Wraps the browser `stitch` build so every `stitch()` call a snippet makes
+ * surfaces as a {@link StitchTraceEntry} — the shape the output panel's Mermaid
+ * DAG renders (`output-format.ts#traceToMermaid`). Without this, `RunResult.trace`
+ * is always empty and the DAG only ever shows "(no trace)".
+ *
+ * How it works (NO fork of packages/core): each `stitch(config)` gets a core
+ * `TraceSink` injected into its config. The engine `tee`s every lifecycle event
+ * (`start → … → done`) through that sink on BOTH the `await` and `.stream()`
+ * paths (stitch.ts), so the sink sees one start/done pair per call. We translate
+ * each pair into a `StitchTraceEntry` and emit it (plus stream `chunk`s) through
+ * the run's progress sink — the SAME channel the worker body already relays to
+ * the host and accumulates into the final result.
+ *
+ * Correlation: a stitch instance's calls are tracked in a FIFO of open entries
+ * (`start` opens, `done` closes-and-emits). Sequential snippet code — the common
+ * case — is exact; concurrent calls on one instance degrade gracefully (entries
+ * still emit; timing may attribute to a sibling) and NEVER throw.
+ *
+ * Scope (A2): nodes render from real runs. Dependency EDGES (`dependsOn`) need
+ * the composition graph core doesn't emit, and `seam`-created stitches aren't
+ * wrapped yet — both are tracked as follow-ups in RELEASE.md.
+ */
+import type { StitchTraceEntry } from '../component/runner';
+import type { ProgressSink } from './worker-entry';
+
+import { multiplex } from 'stitchapi';
+import type { StitchEvent, TraceSink } from 'stitchapi';
+
+/** Header names whose presence we surface as redacted in the trace entry. */
+const SECRET_HEADERS = new Set([
+    'authorization',
+    'cookie',
+    'set-cookie',
+    'x-api-key',
+    'proxy-authorization',
+]);
+
+/** Mutable state for one in-flight stitch call (between `start` and `done`). */
+interface OpenEntry {
+    id: string;
+    label: string;
+    method: string;
+    url: string;
+    headersRedacted?: string[];
+    status?: number;
+    error?: { name: string; message: string };
+    chunks: number;
+}
+
+export interface TraceCollector {
+    /** Drop-in replacement for the build's `stitch`, exposed to the snippet. */
+    stitch: (config: unknown) => unknown;
+    /**
+     * The {@link WorkerEnv.bindProgress} hook: bind the run's progress sink so
+     * trace/chunk events can flow. Returns a teardown that unbinds it.
+     */
+    bindProgress: (sink: ProgressSink) => () => void;
+}
+
+/** Sensitive header names present on a stitch input's headers, if any. */
+function redactedNames(headers: unknown): string[] | undefined {
+    if (!headers || typeof headers !== 'object') return undefined;
+    const names = Object.keys(headers as Record<string, unknown>).filter((h) =>
+        SECRET_HEADERS.has(h.toLowerCase()),
+    );
+    return names.length ? names : undefined;
+}
+
+/** Best-effort stringify of a stream chunk for the `chunk` event's `text`. */
+function chunkText(chunk: unknown): string {
+    if (typeof chunk === 'string') return chunk;
+    try {
+        return JSON.stringify(chunk) ?? String(chunk);
+    } catch {
+        return String(chunk);
+    }
+}
+
+/** Build the final {@link StitchTraceEntry} from a completed open entry. */
+function finalize(
+    e: OpenEntry,
+    ok: boolean,
+    durationMs: number,
+): StitchTraceEntry {
+    const entry: StitchTraceEntry = {
+        id: e.id,
+        label: e.label,
+        request: { method: e.method, url: e.url },
+    };
+    if (e.headersRedacted) entry.request.headersRedacted = e.headersRedacted;
+    if (e.status !== undefined)
+        entry.response = { status: e.status, ok, durationMs };
+    if (e.error) entry.error = e.error;
+    if (e.chunks > 0) entry.stream = { chunks: e.chunks };
+    return entry;
+}
+
+/**
+ * Create a trace collector around a core `stitch`. `coreStitch` is the browser
+ * build's `stitch` (re-exported from `stitchapi`); the returned `stitch` injects
+ * the DAG trace sink and is otherwise identical (same call / `.stream()` /
+ * `.with()` behaviour — the runtime is unchanged).
+ */
+export function createTraceCollector(
+    coreStitch: (config: unknown) => unknown,
+): TraceCollector {
+    let activeSink: ProgressSink | undefined;
+    let counter = 0;
+
+    // One DAG sink per stitch INSTANCE, so each instance's calls correlate in
+    // their own FIFO. All instances emit to the single run-scoped `activeSink`.
+    const makeDagSink = (): TraceSink => {
+        const open: OpenEntry[] = [];
+        return {
+            handle(event: StitchEvent, ctx: { name: string }): void {
+                switch (event.type) {
+                    case 'start':
+                        open.push({
+                            id: `stitch-${(counter += 1)}`,
+                            label: ctx.name,
+                            method: event.method,
+                            url: event.url,
+                            headersRedacted: redactedNames(
+                                event.input?.headers,
+                            ),
+                            chunks: 0,
+                        });
+                        break;
+                    case 'result':
+                        if (open[0]) open[0].status = event.status;
+                        break;
+                    case 'error':
+                        if (open[0]) {
+                            open[0].error = {
+                                name: event.name,
+                                message: event.message,
+                            };
+                            if (event.status !== undefined)
+                                open[0].status = event.status;
+                        }
+                        break;
+                    case 'delta':
+                        if (open[0]) {
+                            open[0].chunks += 1;
+                            activeSink?.({
+                                type: 'chunk',
+                                traceId: open[0].id,
+                                text: chunkText(event.chunk),
+                            });
+                        }
+                        break;
+                    case 'done': {
+                        const e = open.shift();
+                        if (e)
+                            activeSink?.({
+                                type: 'trace',
+                                entry: finalize(e, event.ok, event.ms),
+                            });
+                        break;
+                    }
+                    // 'progress' / 'drift' carry no DAG-node data — ignored.
+                }
+            },
+        };
+    };
+
+    const stitch = (config: unknown): unknown => {
+        // Mirror core's string-shorthand normalisation (`asConfig`: a string is
+        // a `path`) so `stitch('https://…')` still gets a trace sink. Spreading a
+        // raw string would shatter it into char-indexed keys.
+        const base: Record<string, unknown> =
+            typeof config === 'string'
+                ? { path: config }
+                : { ...((config as Record<string, unknown>) ?? {}) };
+        const dag = makeDagSink();
+        const userTrace = base.trace;
+        // Compose with a user-supplied sink; otherwise the DAG sink alone. This
+        // also neutralises `trace:'console'` (writes to an absent stderr in the
+        // browser); `trace:false` is overridden only for the DAG, which never
+        // writes console/JSONL, so the "no side effects by default" intent holds.
+        base.trace =
+            userTrace && typeof userTrace === 'object'
+                ? multiplex(userTrace as TraceSink, dag)
+                : dag;
+        return coreStitch(base);
+    };
+
+    const bindProgress = (sink: ProgressSink): (() => void) => {
+        activeSink = sink;
+        return () => {
+            if (activeSink === sink) activeSink = undefined;
+        };
+    };
+
+    return { stitch, bindProgress };
+}

--- a/docs/sandbox/runtime/worker-entry.ts
+++ b/docs/sandbox/runtime/worker-entry.ts
@@ -36,7 +36,12 @@
  *   - A snippet throw/reject is reported as `error` on the result; the main
  *     thread classifies timeout/abort/internal — see worker-protocol.ts.
  */
-import type { LogEntry, LogLevel, RunEvent } from '../component/runner';
+import type {
+    LogEntry,
+    LogLevel,
+    RunEvent,
+    StitchTraceEntry,
+} from '../component/runner';
 import type { SimKnobs } from '../contracts/sim';
 import type {
     ProgressMessage,
@@ -259,23 +264,32 @@ export async function runSnippetInWorker(
         }
     }
 
-    // A1: wrap the host sink so a throwing onEvent/relay can never derail the
-    // snippet, and so a `log` emitted by the console capture and a chunk/trace/
-    // notice emitted by the env both funnel through ONE ordered relay.
-    const emit: ProgressSink | undefined = onProgress
-        ? (event: RunEvent): void => {
-              try {
-                  onProgress(event);
-              } catch {
-                  /* swallow — observation must never break the run */
-              }
-          }
-        : undefined;
+    // A2: accumulate every stitch trace entry the env emits, so the FINAL result
+    // carries the full DAG even when the host wants no progressive events.
+    const traceEntries: StitchTraceEntry[] = [];
+
+    // ONE ordered relay (A1 + A2). It (1) accumulates trace entries for the final
+    // result and (2) forwards every event to the host `onProgress` IF it asked
+    // for live updates. A throwing host callback can never derail the run. The
+    // relay is ALWAYS wired so trace collection doesn't depend on the host
+    // opting into progress — but it stays pure observation: with no producer (an
+    // env without `bindProgress`) `traceEntries` is empty and the result is
+    // byte-for-byte unchanged.
+    const emit: ProgressSink = (event: RunEvent): void => {
+        if (event.type === 'trace') traceEntries.push(event.entry);
+        if (onProgress) {
+            try {
+                onProgress(event);
+            } catch {
+                /* swallow — observation must never break the run */
+            }
+        }
+    };
 
     // Let the env wire its chunk/trace/notice producers to the progress relay
     // (optional + best-effort). Returns a teardown we run once the snippet ends.
     let unbindProgress: (() => void) | void = undefined;
-    if (emit && env.bindProgress) {
+    if (env.bindProgress) {
         try {
             unbindProgress = env.bindProgress(emit);
         } catch {
@@ -285,7 +299,7 @@ export async function runSnippetInWorker(
 
     const { console, logs } = makeCapturingConsole(
         () => Date.now() - t0,
-        emit ? (entry: LogEntry) => emit({ type: 'log', entry }) : undefined,
+        (entry: LogEntry) => emit({ type: 'log', entry }),
     );
 
     // Build the allow-listed scope (SEC-34). These are the ONLY names a snippet
@@ -350,6 +364,7 @@ export async function runSnippetInWorker(
             logs,
             notices: drainSafely(env),
             error: toWireError(buildErr),
+            trace: traceEntries.length ? traceEntries : undefined,
         };
     }
 
@@ -361,6 +376,7 @@ export async function runSnippetInWorker(
             logs,
             notices: drainSafely(env),
             value: safeClone(value),
+            trace: traceEntries.length ? traceEntries : undefined,
         };
     } catch (runErr) {
         teardownProgress(unbindProgress);
@@ -369,6 +385,7 @@ export async function runSnippetInWorker(
             logs,
             notices: drainSafely(env),
             error: toWireError(runErr),
+            trace: traceEntries.length ? traceEntries : undefined,
         };
     }
 }

--- a/docs/sandbox/runtime/worker-main.ts
+++ b/docs/sandbox/runtime/worker-main.ts
@@ -24,6 +24,7 @@ import { allHandlers } from '../../../packages/sandbox-sim/src/handlers';
 import type { SimKnobs } from '../contracts/sim';
 import { browserProcess } from './shims/process';
 import * as stitchBuild from './stitch-browser';
+import { createTraceCollector } from './trace-collector';
 import {
     type WorkerEnv,
     type WorkerGlobal,
@@ -46,9 +47,20 @@ const simFetch = createFetchShim(allHandlers, () => currentKnobs);
 // "no real network" real: the sole reachable fetch IS the sim shim.
 (globalThis as { fetch?: unknown }).fetch = simFetch;
 
+// A2: wrap the build's `stitch` so each call a snippet makes surfaces as a
+// StitchTraceEntry, and expose the matching `bindProgress` hook so those entries
+// flow to the result/DAG. Other build exports pass through untouched.
+const traceCollector = createTraceCollector(
+    stitchBuild.stitch as unknown as (config: unknown) => unknown,
+);
+
 const env: WorkerEnv = {
-    // The whole B1 stitch build, exposed name-by-name into the snippet scope.
-    stitchBuild: stitchBuild as unknown as Record<string, unknown>,
+    // The whole B1 stitch build, exposed name-by-name into the snippet scope,
+    // with the traced `stitch` overriding the raw re-export.
+    stitchBuild: {
+        ...stitchBuild,
+        stitch: traceCollector.stitch,
+    } as unknown as Record<string, unknown>,
     // The snippet's `fetch` (cast: createFetchShim is precisely `fetch`-typed,
     // WorkerEnv.fetch is the loose (unknown, unknown) wire shape).
     fetch: simFetch as unknown as WorkerEnv['fetch'],
@@ -64,6 +76,8 @@ const env: WorkerEnv = {
     applyKnobs: (knobs) => {
         currentKnobs = knobs;
     },
+    // Bind the run's progress sink so traced `stitch` calls reach the DAG (A2).
+    bindProgress: traceCollector.bindProgress,
 };
 
 // `self` is the Worker global; the only WebWorker-touching line in the build.

--- a/docs/sandbox/runtime/worker-protocol.ts
+++ b/docs/sandbox/runtime/worker-protocol.ts
@@ -20,7 +20,7 @@
  * Like everything here, the payload is pure data / structured-cloneable — the
  * `RunEvent` shapes mirror the frozen `runner.ts` union, carried by value.
  */
-import type { LogLevel, RunEvent } from '../component/runner';
+import type { LogLevel, RunEvent, StitchTraceEntry } from '../component/runner';
 import type { SimKnobs } from '../contracts/sim';
 
 /* -------------------------------------------------------------------------- */
@@ -101,6 +101,14 @@ export interface ResultMessage {
      * the terminate), never reported through this field.
      */
     error?: WireError;
+    /**
+     * Structured trace of the `stitch()` calls made during the run, in
+     * completion order (A2). Assembled by the worker body from the env's trace
+     * producers (the B1 build's traced `stitch`); absent when the run made no
+     * observable stitch calls. The main thread maps it to `RunResult.trace` so
+     * the playground's Mermaid DAG renders from the REAL run, not a fixture.
+     */
+    trace?: StitchTraceEntry[];
 }
 
 /**

--- a/docs/sandbox/tests/run-all.mjs
+++ b/docs/sandbox/tests/run-all.mjs
@@ -36,6 +36,8 @@ const SUITES = [
     'docs/sandbox/runtime/transpile.test.ts',
     // R1 — browser-worker runner harness (worker_threads proofs)
     'docs/sandbox/runtime/browser-runner.test.ts',
+    // A2 — trace-collector: real stitch events → DAG entries
+    'docs/sandbox/runtime/trace-collector.test.ts',
     // U1 — output-format helpers
     'docs/sandbox/component/output-format.test.ts',
     // T-α — integration over REAL sim + dispatch


### PR DESCRIPTION
Closes RELEASE.md → Playground browser Phase-2 item **A2**. The sandbox Worker never populated `RunResult.trace`, so the playground's Mermaid DAG only ever showed "(no trace)". This closes the loop — **without forking `packages/core`**.

## How
- **`docs/sandbox/runtime/trace-collector.ts`** (new) wraps the browser build's `stitch` so each call injects a core `TraceSink` into its config. The engine `tee`s every lifecycle event through it on **both** the `await` and `.stream()` paths, so the sink sees one `start → done` pair per call and translates it into a `StitchTraceEntry` (+ stream `chunk` events), emitted through the run's progress relay. Mirrors core's string-shorthand normalisation (`stitch('https://…')`) and composes with a user-supplied trace sink.
- **`worker-main`** wires the traced `stitch` + the `bindProgress` hook into the env.
- **`worker-entry`** always wires the relay and accumulates trace entries into the final `ResultMessage.trace`, so the DAG renders even when the host wants no progressive events (preserves the "identical RunResult with/without onEvent" invariant).
- **`worker-protocol`** carries the new `trace` field; **`browser-runner.mapResult`** passes it through to `RunResult.trace`.

## Verification
- **Unit** — `trace-collector.test.ts`: 16 assertions over success / HTTP-error / transport-error / streaming / multiplex / string-shorthand / unbound-sink paths.
- **E2E (real browser)** — `e2e/sandbox-trace.spec.ts`: drives the actual `/sandbox/sandbox-worker.mjs` bundle; a real stitch run yields a `{type:'trace'}` progress event **and** a populated `RunResult.trace`.
- Existing `browser-runner` (40/40) + `integration` (24/24) + `output-format` suites stay green; worker bundle builds; docs typecheck + eslint + prettier clean. Playwright pinned to one worker (single dev server).

## Follow-ups (tracked in RELEASE.md)
Dependency **edges** (`dependsOn`, needs the composition graph core doesn't emit) and `seam`-created stitches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)