### PR TITLE
fix(core)!: harden principal boundary + grill fixes; ADR 0003 (surfaces)

### DIFF
--- a/docs/adr/0003-surfaces-and-the-authoring-model.md
+++ b/docs/adr/0003-surfaces-and-the-authoring-model.md
@@ -1,0 +1,390 @@
+# ADR 0003 — Surfaces: one authoring model across http / graphql / sse / upload
+
+-   **Status:** Proposed (12 decisions firm; adapter-stream shape + stream-decode default open — see §Open questions)
+-   **Date:** 2026-06-14
+-   **Tags:** authoring-surface, surfaces, graphql, sse, file-upload, multipart, bundle
+-   **Supersedes parts of:** the ad-hoc `kind` discriminator and the standalone `graphql()`
+    helper introduced before this ADR.
+
+## Context
+
+A stitch today is "one HTTP request as data". But "HTTP request" is not one shape — REST,
+GraphQL, server-sent events, and file upload each have a different **wire envelope**
+(method/body framing), and some a different **response lifecycle** (one value vs. a stream)
+or **error model** (a 200 carrying `errors`). The library currently expresses that variety
+three inconsistent ways at once:
+
+1.  A user-facing `kind: 'http' | 'graphql'` discriminator on `StitchConfig`, dispatched
+    inside the engine ([`engine.ts`](../../packages/core/src/engine.ts) — `cfg.kind ===
+'graphql'` at the body envelope, the error-model check, and the paginate path).
+2.  A standalone `graphql()` helper and a `seam.graphql()` method that both set that `kind`
+    plus `method: 'POST'` and `unwrap: 'data'`.
+3.  Raw `stitch({ kind: 'graphql' })`, which compiles **without** a `query` — the same
+    concept, a third spelling, with the invariant unenforced.
+
+So GraphQL has three doors with inconsistent guarantees, while two real surfaces have **no**
+door at all:
+
+-   **SSE / streaming.** The event spine already exists — `execute` is an async generator,
+    `StitchResult.stream()` is public, and a `delta` `StitchEvent` is **defined but never
+    emitted** ([`types.ts`](../../packages/core/src/types.ts)). There is no surface that
+    parses `text/event-stream` and turns frames into `delta` events. Native `EventSource`
+    is GET-only and cannot send headers/body, which is exactly why a fetch-based SSE surface
+    is needed (the same gap `@microsoft/fetch-event-source` fills).
+-   **Upload.** `bodyType: 'multipart'` exists, but its encoder is broken for any nested
+    value: [`http-adapter.ts`](../../packages/core/src/http-adapter.ts) `appendForm` falls
+    through to `form.append(key, String(v))`, so a nested object becomes the literal
+    `"[object Object]"`. multipart/form-data (RFC 7578) is a deliberately **flat**
+    `(name) -> bytes` model; any hierarchy must be encoded into the names or into a part's
+    bytes by a convention both client and server agree on. The library gives no such
+    convention, so users hand-roll it (e.g. a `json` string field + separate `files`
+    parts, reassembled server-side).
+
+A survey of modern clients (axios, ky, ofetch, openapi-fetch; graphql-request, urql, Apollo;
+`@microsoft/fetch-event-source`) shows the ecosystem has **settled on keeping protocols
+separate**, exposed as **named entrypoints**, never crammed behind one generic
+`call({ kind })` switch — because a single discriminator forces a lowest-common-denominator
+type signature and loses each protocol's ergonomics (typed `query`/`variables`, the GraphQL
+error array, SSE reconnection). The middle path the strongest libraries use is **one shared
+core (base URL, auth, retry, interceptors) + thin per-surface adapters**. That core already
+exists in this library: it is the **seam** (ADR 0002).
+
+This ADR records the model we converged on. There are **no production users**, so the
+user-facing `kind` discriminator and the standalone `graphql()` spelling are replaced
+outright, with no deprecation window. Every decision is checked against the project's three
+gates: **browser-first**, **bundle-frugal**, **contract-not-dependency** (capabilities
+round-trip as JSON).
+
+## Decision
+
+1.  **A "surface" is an imported plugin value passed as `kind`; the authoring verb stays
+    `stitch` (+ `seam.stitch`).** A surface (`graphql`, `sse`, `stream`, `upload`, `download`)
+    is a typed object imported from its own module and handed to the engine as `kind` — it
+    carries the protocol's envelope / decoder / error-model the way `auth` and `adapter` carry
+    behavior. There is **one** authoring model, not N constructor functions:
+
+    -   `stitch({ kind: graphql, query })` — the underlying generic form (any surface, dynamic
+        kinds, binding onto a seam).
+    -   `graphql.stitch({ query })` — sugar every surface object exposes, with `kind`
+        pre-bound. The **recommended** form: **one import**, and being _monomorphic_ it gives
+        **better types and errors** than the generic `stitch({ kind })` (whose inference is
+        generic over the surface).
+    -   `graphql.seam({ baseUrl })` — a surface-flavoured seam (members default to that kind).
+
+    So `graphql.stitch(cfg)` ≡ `stitch({ kind: graphql, ...cfg })`: one concept, a recommended
+    sugar over a generic base — **not** three independently-maintained spellings. `kind` absent
+    = http (the core base). Surfaces share one authoring _model_ but **not** one return _type_:
+    each resolves `await` to what fits (`graphql` -> `T`, `download` -> `{ blob, filename }`,
+    `stream` -> the collected chunks).
+
+    **Mixed seams.** A seam is surface-agnostic; members pick their kind, all inheriting the
+    shared runtime — auth, **one** rate budget, the principal boundary:
+
+    ```ts
+    const partner = seam({ baseUrl, auth, throttle: '20/s' });
+    partner.stitch({ path: '/users' }); //                       http
+    partner.stitch({ kind: graphql, path: '/graphql', query }); // graphql
+    partner.as(userId).stitch({ kind: sse, path: '/events' }); //  sse + principal
+    ```
+
+    For a seam with many same-surface members, `graphql.seam(existingSeam)` returns a
+    surface-flavoured **view sharing that seam's runtime** — the surface-first dual of
+    `.as(principal)`: `const gql = graphql.seam(partner); gql.stitch({ path, query })`. Both
+    `gql.stitch` and `partner.stitch({ kind })` draw on the same auth + rate budget + principal;
+    that cross-surface sharing is the seam's whole point and the strongest case for the model.
+
+2.  **`kind` is freed of its old string values and repurposed as the typed surface slot.** The
+    `kind: 'http' | 'graphql'` magic-string union is removed; `kind?: Surface<TInput, TResult>`
+    now takes an imported surface value (or is absent, meaning http). This is the opposite of a
+    regression: what we kill is the **unguarded string** (`stitch({ kind: 'graphql' })` compiled
+    with no `query`); what we add is a **typed plugin** that enforces the surface's input
+    (graphql requires `query`) and infers its result. `kind` stays Omitted from `SeamConfig`
+    (it is per-member, not a shared default — ADR 0002 follow-up).
+
+3.  **Surfaces still reduce to declarative config — a surface value is a live handle like
+    `auth` / `adapter`, normalised to its `id` string in `__config`.** The contract gate asks
+    that _capabilities_ round-trip as JSON; `StitchConfig` already carries live,
+    non-serialisable handles (`auth`, `adapter`, `store`) that ADR 0002 **redacts** from the
+    public `__config`. A surface plugin is the same category: `kind: graphql` is a live behavior,
+    and `__config.kind` shows the normalised string `'graphql'` (the surface's `id`). The
+    declarative remainder each surface contributes is plain data:
+
+    -   `graphql` -> `{ method: 'POST', unwrap: 'data' }` (+ the graphql error model)
+    -   `sse` / `stream` -> `{ responseType: 'sse' | 'stream', decode }`
+    -   `upload` -> `{ method: 'POST', bodyType: 'multipart', multipart: { nesting } }`
+    -   `download` -> `{ method: 'GET', responseType: 'blob', progress: true }`
+
+    **A surface whose behavior cannot be carried this way — a live handle plus declarative
+    config, inspectable as an `id` — is out of scope.** That is the test a candidate surface
+    must pass.
+
+4.  **Lifecycle vs. sugar is now an _internal_ distinction, not an authoring one.** Every
+    surface is authored identically (a `kind` plugin); they differ only in what they cost the
+    engine:
+
+    -   **Lifecycle surfaces** (`graphql`, `sse`, `stream`) own a genuinely different
+        request/response shape — graphql's envelope + 200-with-`errors` error model; sse/stream's
+        N-chunk cardinality — so each adds a real engine path.
+    -   **Sugar surfaces** (`upload`, `download`) share the plain HTTP lifecycle and only
+        **preset config** (multipart + nesting; GET + blob + progress). Their capabilities live
+        in config and work on a plain `stitch` too; the surface value exists for discoverability
+        and clean types.
+
+    This keeps us from minting a lifecycle path for every content-type, and marks the line
+    (decision 11): a surface is one request whose (possibly streamed) response reduces to config.
+    WebSocket (bidirectional, stateful) is beyond it — future exploration, not core.
+
+5.  **`sse` and `stream` ride the existing event spine; both emit `delta`.** A streaming
+    surface fetches a long/unbounded body, decodes it into chunks, and emits each as the
+    dormant `delta` `StitchEvent` (these are `delta`'s first producers). The awaited path
+    collects chunks into the final value; `.stream()` yields them live. Parsing is a
+    hand-written reader over `fetch`'s `ReadableStream` (browser-first; no `EventSource`, no
+    dependency). Method may be GET **or** POST with headers/body — the capability native
+    `EventSource` lacks. The two are kept **separate** because they answer different questions:
+
+    -   **`sse`** commits to the **SSE protocol** — `text/event-stream`, the `data:` /
+        `event:` / `id:` / `retry:` line framing, `\n\n` records, UTF-8, and server-driven
+        reconnect. It is `stream` with the event-stream decoder _plus_ the protocol's
+        reconnect/identity semantics, which earn a named surface. (Reconnection /
+        `Last-Event-ID` resume is deferred — [#71](https://github.com/rejifald/StitchAPI/issues/71).)
+    -   **`stream`** is the generic case: a configurable `decode` — `'lines'` (raw text
+        lines), `'ndjson'` (newline-delimited JSON, one record per line), `'bytes'` (raw
+        chunks), or a custom decoder. Use cases that are **not** SSE: NDJSON change-feeds and
+        bulk exports (CouchDB `_changes`, Elasticsearch scroll), log / line tailing
+        (`?follow=true`), non-SSE token streams (e.g. Ollama emits NDJSON, not
+        `text/event-stream`), and incremental parsing of a large body without buffering it
+        whole. `sse` would mis-frame all of these.
+
+6.  **Nested multipart is a declarative `nesting` strategy; default `bracket`, opt-in
+    `json`.** `appendForm` gains a `multipart.nesting` config:
+
+    -   `'bracket'` **(default)** — flatten the object tree into bracketed leaf names
+        (`author[name]`, `tags[0]`, `items[0][id]`); file leaves become parts under the same
+        bracketed name. Server-standard: Express+`qs`, Rails, Laravel, FastAPI parse it
+        natively.
+    -   `'dot'` — the same, dotted (`author.name`).
+    -   `'json'` — all **non-file** fields collapse into one JSON-string part (field name
+        `multipart.jsonField`, default `'json'`); each file is **stripped** out of that JSON
+        and appended as its own part keyed by its path — **no** placeholder or reference is
+        left in the blob (the server re-stitches files to structure by part name / filename).
+        This is the user's existing wire format — "a `json` field + file parts, reassembled
+        server-side" — now first-class, **zero backend change**.
+    -   `'none'` — today's flat behaviour (back-compat / escape hatch).
+
+    File leaves are detected as today (`Blob` / `Uint8Array` / `{ value, filename?, type? }`)
+    in every mode. The flattener is ~30 lines, no `qs` / `object-to-formdata` dependency
+    (bundle-frugal), over the web-standard `FormData` (browser-first), and the whole strategy
+    is config (contract gate).
+
+7.  **Reframe the promise from "any coding _style_" to "any _surface_".** The docs line that
+    the library "fits any style" today implies multiple **authoring syntaxes** for the same
+    request — which this ADR (with the Builder removal, ADR 0003's sibling change) explicitly
+    rejects in favour of **one** config-object authoring model. The defensible, true version
+    of the promise is **one authoring model across many protocols**: REST, GraphQL, SSE,
+    uploads. The "any X" claim moves from syntax variety (a liability) to surface coverage
+    (the feature).
+
+8.  **`download` resolves to `{ blob, filename }` (+ progress) and never _saves_; the download
+    manager is future exploration, not core.** `download` is the response-side counterpart to
+    `upload` — a sugar surface (`GET` + `responseType: 'blob'`) that emits byte-progress
+    (`receivedBytes` / `totalBytes` from `Content-Length`), honours a caller `AbortSignal` for
+    cancel, and reads the `Content-Disposition` filename. Its `await` result is its **own
+    type** — `{ blob, filename }` — not the universal `T` (decision 1: surfaces share an
+    authoring model, not a return type); progress comes via `.stream()`. It does **not** save —
+    saving is a DOM concern in the browser (anchor + `objectURL`) and a filesystem concern in
+    Node, so it stays user-land, keeping core **DOM-free** and browser/Node-symmetric. It is
+    still valuable on the frontend (inline, progress-aware downloads instead of a naked `href`
+    the browser may open inline and whose filename is unreadable cross-origin). A higher-level
+    **download manager** — a queue with concurrency, auto-retry/backoff, and per-item status
+    (`queued` / `downloading` / `retrying` / `completed` / `failed` / `cancelled`) — is **not in
+    this ADR's scope**, but is explicitly kept for **later exploration** (see decision 11),
+    because its hard parts already exist or compose cheaply:
+
+    -   **Concurrency / batching** is the **seam's shared throttle bucket** (ADR 0002 §3):
+        `download.seam({ throttle: { concurrency: 3 } })` pools download capacity (sequential /
+        batched / parallel) — no new queue primitive. (Downloads are finite requests, so they
+        **do** hold concurrency slots — unlike streams, decision 12.)
+    -   **Retry/backoff** is the existing `retry` policy; **cancel** is the `AbortSignal`
+        plumbing; **progress** is the `progress` / `delta` event spine.
+
+    What remains is thin **status aggregation** for a UI — the React `useDownloadManager` shape
+    in `~/Development/strimko`. For **now** that layer stays out: `@tanstack/react-query`
+    already solves request status/queue on the frontend, so core ships the `download` surface
+    plus the primitives a manager composes from, and stops there — no `@stitchapi/react`
+    companion is being built today.
+
+9.  **Extend the `Adapter` contract so every adapter has equal capabilities — streaming and
+    progress, never a built-in-only fast path.** The single `(req) => Promise<AdapterResponse>`
+    shape grows two optional channels rather than being bypassed for streaming surfaces:
+
+    -   a **streaming response body** — `AdapterResponse.body` may be a `ReadableStream` /
+        async-iterable of chunks, so an adapter can feed `sse` / `stream` their N `delta`s;
+        non-streaming surfaces just read it to completion.
+    -   an **`onProgress`** hook on `AdapterRequest` for upload/download byte counts.
+
+    Because these live in the contract, a **BYO adapter** (axios or custom) can implement SSE,
+    streaming, and progress too — not a privilege of the built-ins. Concretely: `fetchAdapter`
+    streams responses natively (and reports download progress by reading the body) but
+    **cannot** report _request_ upload progress portably (a streaming request body needs
+    `duplex: 'half'` + HTTP/2, Chromium-only). `XMLHttpRequest` exposes `upload.onprogress`, so
+    a first-party zero-dep **`xhrAdapter`** (XHR, **browser-only**) is the portable way to get
+    upload + symmetric download progress. In Node, upload progress is unavailable — an accepted,
+    browser-only capability gap. The existing `axiosAdapter` stays BYO; **no axios dependency is
+    ever added**.
+
+10. **Each surface (and each non-default adapter) is a separate entry point; the core stays
+    small.** The package exposes subpath exports — `stitchapi` (core: `stitch`, `seam`,
+    `fetchAdapter`), `stitchapi/graphql`, `stitchapi/sse`, `stitchapi/stream`,
+    `stitchapi/upload`, `stitchapi/download`, `stitchapi/xhr-adapter` — each its own module. Each
+    surface module exports a surface object carrying its `id` + behavior **and** the `.stitch()`
+    / `.seam()` sugar (decision 1); importing `graphql` pulls graphql + core, never `upload`'s
+    multipart code or `sse`'s parser. This is what reconciles a **growing surface set** with the
+    **bundle-frugal gate**: surfaces are pay-for-what-you-import, and the core a user always pays
+    for stays just `stitch` + `seam` + the engine. It is also _why_ the **seam stays
+    surface-agnostic** (no `seam.graphql()` method): a per-surface method on the seam object
+    would drag every surface into the core bundle for everyone.
+
+11. **The surface line is "one request whose (possibly streamed) response reduces to config" —
+    held for now, with WebSocket and a download manager kept as _future exploration_, not
+    rejected.** A candidate surface is in scope when it is a single request whose response (even
+    a stream of deltas) reduces to declarative config (decision 3). That line keeps `graphql` /
+    `sse` / `stream` / `upload` / `download` in, and keeps two things out **for now**:
+    **WebSocket** (bidirectional, long-lived, stateful — not one request → response) and a
+    **download manager** (UI / queue state, not a request). But the project's intent is that
+    _all common communication is handled by one library_, so both are explicitly on the
+    **later-exploration** list — a `ws` connection wrapper and a download-manager primitive —
+    revisited once the surfaces here land. The line is the _current_ boundary, not a permanent
+    doctrine.
+
+12. **Streaming members are exempt from the seam's _concurrency_ budget (but not its rate
+    budget).** A seam's `throttle.concurrency` is throughput fairness — it assumes a request
+    starts and finishes. A long-lived `sse` / `stream` member would hold a slot for its entire
+    lifetime, so on a mixed seam three open streams could park a 4-slot bucket and starve every
+    REST call. Therefore streaming surfaces acquire the **rate** gate on connect (an open is
+    still one request against `N/s`) but do **not** hold a **concurrency** slot — a parked stream
+    is not consuming throughput. This refines ADR 0002 §3's shared-bucket model for the streaming
+    case; finite members (http / graphql / upload / download) are unchanged and still hold slots.
+
+## Consequences
+
+**Positive**
+
+-   GraphQL collapses from three inconsistent spellings to **one** surface with the invariant
+    (`query` required) enforced; the unguarded `kind` door is gone.
+-   Streaming and binary surfaces gain first-class, **discoverable** entrypoints: `sse` and
+    `stream` (finally emitting the dormant `delta` event), `upload` (fixing the
+    `"[object Object]"` bug and making "nested data + files" the happy path), and `download`
+    (progress-aware, cancellable, filename-aware).
+-   Cross-cutting concerns (auth, retry, throttle, trace, the principal boundary) are shared
+    **once** at the seam and inherited by every surface — the seam-as-core payoff.
+-   Every surface stays declarative, so traces/mocks/inspection keep working uniformly across
+    protocols.
+
+**Accepted trade-offs**
+
+-   The surface set grows (`sse`, `stream`, `upload`, `download` + an `xhrAdapter`), but each is
+    a **separate import** (decision 10), so the core a user always pays for stays `stitch` +
+    `seam` + engine — the bundle cost is opt-in per surface. The engine still gains `sse` /
+    `stream` paths and `kind: 'sse' | 'stream'` branches, and the `Adapter` contract gains a
+    streaming body + progress hook (decision 9) that every BYO adapter must tolerate.
+-   `kind` changes from a magic-string union to a typed surface plugin, and GraphQL moves from
+    the old `graphql(cfg)` shape to `graphql.stitch(cfg)` / `stitch({ kind: graphql })` —
+    breaking, with **no migration path** (pre-1.0, no users).
+-   The generic `stitch({ kind })` form has weaker inference / error messages than the
+    monomorphic `surface.stitch()`; the sugar is the recommended front door for that reason
+    (decision 1), with the generic form reserved for binding onto seams and dynamic kinds.
+-   Upload progress is **browser-only** (via `xhrAdapter`); Node uploads report no progress —
+    an accepted capability gap (decision 9).
+-   Per-surface imports (decision 10) genuinely **advance** bundle-frugality — a surface you
+    don't import isn't bundled — but only if backed by real ESM module boundaries +
+    `exports` subpaths, not named exports off one barrel. The shared engine still ships once;
+    `kind`-branch code for unused surfaces should be code-split or kept behind the surface
+    module, not the core.
+
+**Required follow-ups**
+
+-   Engine: `kind: 'sse'` / `kind: 'stream'` branches with a `text/event-stream` frame parser
+    and a configurable chunk decoder (`lines` / `ndjson` / `bytes`) emitting `delta`;
+    `responseType: 'sse' | 'stream'` values in
+    [`http-adapter.ts`](../../packages/core/src/http-adapter.ts); byte-progress emission
+    (`receivedBytes` / `totalBytes`) for `download`.
+-   Adapter contract: add a streaming `body` (`ReadableStream` / async-iterable) to
+    `AdapterResponse` and an optional `onProgress` to `AdapterRequest`; implement both in
+    `fetchAdapter` (response stream + download progress) and the new **`xhrAdapter`** (upload +
+    download progress, browser-only); confirm `axiosAdapter` still satisfies the widened contract.
+-   Types: a `Surface<TInput, TResult>` plugin type; `kind?: Surface` on `StitchConfig`; the
+    generic `stitch<S>({ kind: S } & InputOf<S>): Stitch<ResultOf<S>>` overload + the http
+    default; the monomorphic `surface.stitch` / `surface.seam` / `surface.seam(existingSeam)`
+    signatures.
+-   Packaging: `exports` subpaths (`stitchapi/graphql`, `/sse`, `/stream`, `/upload`,
+    `/download`, `/xhr-adapter`), each a separate build entry exporting a surface object that
+    carries its `id` + behavior and the `.stitch()` / `.seam()` sugar (decision 1).
+-   Throttle: exempt streaming members from the concurrency bucket while still charging the rate
+    gate (decision 12) — a refinement to the seam-bucket / `createStoreThrottle` path.
+-   `appendForm`: implement `nesting` (`bracket` / `dot` / `json` / `none`) + recursive
+    flattener with file-leaf detection; in `json` mode, strip files from the blob (decision 6).
+-   Surface objects: each surface's `id`, behavior hooks (envelope / decode / error-model), and
+    the `.stitch()` / `.seam()` sugar; keep `SeamConfig`'s Omit of `kind` aligned.
+-   Tests: `sse.spec.ts`, `stream.spec.ts` (lines/ndjson/bytes decoders),
+    `multipart-nesting.spec.ts` (bracket/dot/json round-trips, files + nesting),
+    `download.spec.ts` (blob, progress, abort, filename), and an `xhr-adapter.spec.ts`
+    (upload + download progress).
+-   Docs: `sse` / `stream` / `upload` / `download` guides; rewrite the "fits any style" line
+    (decision 7); a surfaces overview; remove the `graphql()`-as-config framing.
+-   Gates re-check per surface: stream parsers browser-first (no `EventSource`); multipart over
+    web `FormData`; download over `fetch` streaming; `xhrAdapter` adds no dependency.
+
+## Alternatives considered
+
+-   **A. Keep one entrypoint with a magic-_string_ `kind: 'graphql' | 'sse'` switch.** Rejected
+    as a string: unguarded (no required `query`), not tree-shakable, stringly-typed. But the
+    _shape_ — one authoring verb + a `kind` discriminator — is **adopted** in its typed-plugin
+    form (`kind: graphql`, an imported value that enforces the surface's input + infers its
+    result), with the monomorphic `surface.stitch()` sugar restoring per-surface types and
+    errors. Decisions 1–3.
+-   **G. Dedicated constructor functions taking a seam (`graphql(api, cfg)`).** Rejected in
+    favour of the `kind`-plugin + `surface.stitch()` model: positional `graphql(api, cfg)`
+    needed an overload (first arg a seam? config?), gave no clean place for `api.stitch({ kind })`
+    on a mixed seam, and split the authoring verb per surface. `kind: Surface` keeps one verb,
+    and `surface.seam(existingSeam)` covers the many-same-surface mixed-seam case.
+-   **B. Make `upload` a full lifecycle surface (its own engine path).** Rejected: upload has
+    the **same** request/response lifecycle as plain HTTP — only the body encoding differs.
+    Modelling it as sugar over `multipart` config (decision 4) keeps the capability in data
+    and avoids a redundant path. The `upload()` helper survives only for discoverability.
+-   **C. Add a `qs` / `object-to-formdata` dependency for nested multipart.** Rejected:
+    breaks bundle-frugality for ~30 lines of flattening, and pulls encoding semantics out of
+    declarative config. A built-in `nesting` strategy keeps it BYO-free and as data.
+-   **D. Use native `EventSource` for SSE.** Rejected: GET-only, cannot send
+    headers/body/auth — useless for an authenticated POST stream. A `fetch` + manual frame
+    parser is browser-first and carries the seam's auth.
+-   **E. Ship WebSocket now as a surface.** Deferred, not rejected: a different lifecycle
+    (bidirectional, long-lived, its own backpressure + reconnect model) that does not reduce
+    cleanly to request config — beyond the current line (decision 11). Kept on the
+    later-exploration list as a `ws` wrapper, since the project wants one library for all
+    common comms.
+-   **F. Bypass the adapter for streaming surfaces (built-in `fetch` only).** Rejected: it
+    would make SSE / `stream` / upload-progress a privilege of the built-in adapters and leave
+    BYO adapters (axios, custom) unable to stream — a silent capability cliff. Extending the
+    `Adapter` contract instead (decision 9) keeps every adapter at parity.
+
+## Open questions (to grill)
+
+_Resolved: surfaces are **imported `kind` plugins** authored via `stitch({ kind })` +
+`surface.stitch()` / `surface.seam()` sugar, the seam stays surface-agnostic (1, 2, 10);
+mixed seams bind via `kind` per member or `surface.seam(existingSeam)` (1); `kind` freed of its
+string union, typed + user-facing, not `@internal` (2); surfaces are live handles normalised to
+an `id` in `__config` (3); `json`-mode strips files (6); SSE reconnection deferred to
+[#71](https://github.com/rejifald/StitchAPI/issues/71) (5); `stream` added, distinct from `sse`
+(1, 5); `download` -> `{ blob, filename }`, never saves (8); download manager + WebSocket are
+future exploration beyond the line (8, 11); the `Adapter` contract is **extended** (streaming
+body + `onProgress`), never bypassed (9, F); streaming members skip the concurrency budget (12);
+per-surface return types are fine (1, 8). What remains:_
+
+-   **The streaming `body` shape on `AdapterResponse`.** `ReadableStream` (web-native,
+    browser-first) vs. a plain async-iterable (smaller contract, easy for custom adapters) —
+    and how `onProgress` coexists with it without double-reporting.
+-   **`stream` default `decode`.** Require it explicitly, or default to `'bytes'` (no parsing
+    assumption) or `'ndjson'` (the most common structured case)?
+-   **Does `sse` reuse `stream`'s decoder internally?** Implementation, not API: `sse` is its
+    own import either way, but should it be _built on_ `stream`'s frame reader (DRY) or carry
+    its own event-stream parser (decoupled)?

--- a/packages/core/src/seam.ts
+++ b/packages/core/src/seam.ts
@@ -19,6 +19,7 @@ import {
     vaultView,
 } from './store';
 import type {
+    PrincipalSeam,
     Seam,
     SeamOptions,
     Stitch,
@@ -63,8 +64,11 @@ interface SharedSeam {
     stitches: Stitch[]; // registry of root-created stitches (lifecycle/introspection)
 }
 
-function makeHandle(shared: SharedSeam, principal: string | undefined): Seam {
-    const build = <T>(
+// The member-builder, closed over the seam's shared runtime and the bound `principal` (undefined
+// for the root). Shared by the root and every principal handle so a member is constructed the same
+// way regardless of which handle created it.
+function makeBuild(shared: SharedSeam, principal: string | undefined) {
+    return <T>(
         config: string | Partial<StitchConfig>,
         isGql = false,
     ): Stitch<T> => {
@@ -105,11 +109,37 @@ function makeHandle(shared: SharedSeam, principal: string | undefined): Seam {
             };
         return makeStitch<T>(cfg, runtime);
     };
+}
 
+// The shared fragment, redacted (no live store/vault/auth/adapter) — exfil-at-rest (§4/§6).
+function sharedConfig(shared: SharedSeam): StitchConfig {
+    return redactConfig(compose(shared.fragment));
+}
+
+// A principal-bound handle: creates members carrying the principal, can re-bind via `as`, but is
+// deliberately **lifecycle-free**. `flush`/`close` act on the runtime EVERY principal shares, so
+// they belong to the root seam alone — handing them on a per-request handle would let the
+// least-trusted caller tear down the shared surface (ADR 0002 §2).
+function principalHandle(shared: SharedSeam, principal: string): PrincipalSeam {
+    const build = makeBuild(shared, principal);
     return {
         stitch: (config) => build(config),
         graphql: (config) => build(config, true),
-        as: (p) => makeHandle(shared, p),
+        as: (p) => principalHandle(shared, p),
+        get __config() {
+            return sharedConfig(shared);
+        },
+        __seam: true,
+    };
+}
+
+// The root seam: the member-builder PLUS the lifecycle (`flush`/`close`) over the shared runtime.
+function rootHandle(shared: SharedSeam): Seam {
+    const build = makeBuild(shared, undefined);
+    return {
+        stitch: (config) => build(config),
+        graphql: (config) => build(config, true),
+        as: (p) => principalHandle(shared, p),
         async flush() {
             await shared.trace.flush?.();
         },
@@ -120,19 +150,20 @@ function makeHandle(shared: SharedSeam, principal: string | undefined): Seam {
                 await shared.secretStore.close?.();
             shared.stitches.length = 0;
         },
-        // The shared fragment, redacted (no live store/vault/auth/adapter) — exfil-at-rest (§4/§6).
         get __config() {
-            return redactConfig(compose(shared.fragment));
+            return sharedConfig(shared);
         },
         __seam: true,
     };
 }
 
 /**
- * Create a seam — the primitive for any **shared surface** (a third-party API, an internal
- * service). Pass the shared defaults its stitches inherit (baseUrl, headers, throttle, retry,
- * auth, sink) and, optionally, a hardened `secretStore` for the vault. Members are created with
- * `.stitch()` / `.graphql()`; bind a principal with `.as(id)`; flush/close via the lifecycle.
+ * Create a seam — the home of your **shared runtime** (one `store`, one throttle budget, one trace
+ * sink, one auth `vault`) and the **trusted principal boundary**. Member stitches don't merely
+ * inherit the config you pass here (baseUrl, headers, auth, retry, throttle, sink); they *run
+ * inside* this runtime. Create members with `.stitch()` / `.graphql()`, derive a lifecycle-free
+ * per-principal handle with `.as(id)`, and `flush()` / `close()` the shared runtime from the root
+ * seam. Reach for `seam` for any shared surface; standalone one-off endpoints stay on `stitch()`.
  */
 export function seam(options: SeamOptions = {}): Seam {
     const { secretStore, ...rest } = options;
@@ -150,5 +181,5 @@ export function seam(options: SeamOptions = {}): Seam {
         stitches: [],
         ...(secretStore ? { secretStore } : {}),
     };
-    return makeHandle(shared, undefined);
+    return rootHandle(shared);
 }

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -26,16 +26,19 @@ import { type Validator, toValidator } from './validator';
 
 export type Fragment = Partial<StitchConfig> | Stitch | string;
 
+// The FULL (unredacted) config of every stitch, kept in a module-private WeakMap rather than on
+// the object itself. The public `__config` is redacted (no store/auth/adapter — exfil-at-rest,
+// ADR 0002 §4/§6); composition still needs the live handles, but that need is internal, so it
+// lives here where no caller can reach it — closing the redaction perimeter structurally instead
+// of by the old `__rawConfig` naming convention.
+const rawConfigs = new WeakMap<object, StitchConfig>();
+
 // ---- composition ----------------------------------------------------------
 function asConfig(f: Fragment): Partial<StitchConfig> {
     if (typeof f === 'string') return { path: f };
-    // Compose from the FULL config (`__rawConfig`), not the redacted public `__config`, so a
-    // stitch used as a fragment still carries its store/auth/adapter into the merge.
-    if (isStitch(f))
-        return (
-            (f as Stitch & { __rawConfig?: StitchConfig }).__rawConfig ??
-            f.__config
-        );
+    // Compose from the FULL config, not the redacted public `__config`, so a stitch used as a
+    // fragment still carries its store/auth/adapter into the merge.
+    if (isStitch(f)) return rawConfigs.get(f) ?? f.__config;
     return f;
 }
 
@@ -215,12 +218,19 @@ function tee<T>(
 }
 
 function mergeInput(a: StitchInput = {}, b: StitchInput = {}): StitchInput {
-    return {
+    const merged: StitchInput = {
         params: { ...(a.params ?? {}), ...(b.params ?? {}) },
         query: { ...(a.query ?? {}), ...(b.query ?? {}) },
         headers: { ...(a.headers ?? {}), ...(b.headers ?? {}) },
         body: b.body !== undefined ? b.body : a.body,
     };
+    // `variables` is a first-class StitchInput field (GraphQL's primary input). It was dropped
+    // here, so `.with({ variables })` silently lost them; merge it like the rest. Omit the key
+    // entirely when neither side sets it (exactOptionalPropertyTypes forbids `variables:
+    // undefined`).
+    if (a.variables ?? b.variables)
+        merged.variables = { ...(a.variables ?? {}), ...(b.variables ?? {}) };
+    return merged;
 }
 
 /**
@@ -240,7 +250,7 @@ export interface SharedRuntime {
 
 // `__config` is the PUBLIC view; strip the live secret-bearing handles so the running store,
 // credential, and transport cannot be read back off a stitch (ADR 0002 §4/§6, exfil-at-rest).
-// The full config lives on `__rawConfig` for fragment composition (see `asConfig`).
+// The full config lives in the private `rawConfigs` WeakMap for fragment composition (see `asConfig`).
 export function redactConfig(cfg: StitchConfig): StitchConfig {
     const rest = { ...cfg };
     delete rest.store;
@@ -249,11 +259,12 @@ export function redactConfig(cfg: StitchConfig): StitchConfig {
     return rest;
 }
 
-// Stamp the stitch identity: redacted public `__config`, full `__rawConfig`, and the `__stitch` brand.
+// Stamp the stitch identity: the redacted public `__config` and the `__stitch` brand are visible
+// properties; the full config goes to the private `rawConfigs` WeakMap (off the object entirely).
 function attachMeta(target: object, cfg: StitchConfig): void {
     Object.defineProperty(target, '__config', { value: redactConfig(cfg) });
-    Object.defineProperty(target, '__rawConfig', { value: cfg });
     Object.defineProperty(target, '__stitch', { value: true });
+    rawConfigs.set(target, cfg);
 }
 
 export function makeStitch<T = unknown>(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -296,12 +296,25 @@ export interface StitchStore {
     close?(): Promise<void>;
 }
 
-// ---- Seam (a primitive stitches belong to) --------------------------------
+// ---- Seam (where shared runtime lives) ------------------------------------
 /**
- * Options for {@link Seam} — every {@link StitchConfig} key (shared by the seam's stitches as a
- * fragment) plus an optional hardened `secretStore` backing the vault.
+ * The config a seam shares with every member as a fragment. It is {@link StitchConfig} minus the
+ * keys that are intrinsically **per-endpoint** — the address (`path`, `url`, `method`, `query`)
+ * and the request/response shape (`name`, `input`, `output`, `kind`). Everything cross-cutting —
+ * `baseUrl`, `headers`, `auth`, `retry`, `throttle`, `timeout`, `circuit`, `idempotency`,
+ * `paginate`, `unwrap`, `transform`, `arrayFormat`, `hooks`, `trace`, `store`, `adapter` — belongs
+ * here, so the type itself answers "what belongs at the seam". Members supply the endpoint keys.
  */
-export type SeamOptions = Partial<StitchConfig> & {
+export type SeamConfig = Omit<
+    StitchConfig,
+    'path' | 'url' | 'method' | 'query' | 'name' | 'input' | 'output' | 'kind'
+>;
+
+/**
+ * Options for {@link Seam} — the shared {@link SeamConfig} plus an optional hardened `secretStore`
+ * backing the vault.
+ */
+export type SeamOptions = SeamConfig & {
     /**
      * Backend for the vault (auth tokens/sessions). Defaults to a reserved, redacted namespace
      * over the seam's `store`; supply a KMS/Vault-backed store here for a hardened vault. Split
@@ -311,11 +324,26 @@ export type SeamOptions = Partial<StitchConfig> & {
 };
 
 /**
- * A long-lived entity that owns a shared config fragment, shared runtime (`store` + `vault` +
- * trace sink), a registry of the stitches it created, and a lifecycle. Its decisive job is the
- * **trusted principal boundary**: `seam.as(req.user.id)` binds identity in the closure, so the
- * caller can never name another principal. Create shared surfaces with `seam`; standalone,
- * one-off endpoints stay on the low-level `stitch()` peer (ADR 0002).
+ * A principal-bound seam handle — what `seam.as(id)` returns, and the object trusted server code
+ * hands to the least-trusted caller (the agent). It creates member stitches and can re-bind the
+ * principal, but it deliberately **lacks the lifecycle** (`flush` / `close`): tearing down the
+ * shared runtime that every other principal depends on is a *root-seam* authority, never a
+ * per-principal one. The boundary that prevents impersonation must not also be a teardown lever
+ * (ADR 0002 §2).
+ */
+export type PrincipalSeam = Omit<Seam, 'as' | 'flush' | 'close'> & {
+    /** Re-bind to another principal — last binding wins. Still lifecycle-free. */
+    as(principal: string): PrincipalSeam;
+};
+
+/**
+ * Where your **shared runtime lives**: one `store`, one throttle budget, one trace sink, and one
+ * auth `vault`, shared by every member stitch — plus the **trusted identity boundary**
+ * (`seam.as(userId)` binds a principal in the closure, so a caller can never name another). A
+ * stitch doesn't merely share config with its seam; it *runs inside* the seam's runtime. The root
+ * seam also owns a registry of the stitches it created and the lifecycle (`flush` / `close`).
+ * Reach for `seam` for any shared surface; standalone, one-off endpoints stay on the low-level
+ * `stitch()` peer (ADR 0002).
  */
 export interface Seam {
     /** Create a stitch belonging to this seam — inherits the shared fragment and shares the runtime. */
@@ -325,14 +353,15 @@ export interface Seam {
         config: Partial<StitchConfig> & { query: string },
     ): Stitch<T>;
     /**
-     * A principal-bound handle reusing the same shared runtime, but whose stitches carry
-     * `principal` in their AuthContext: separate sessions per principal, one shared throttle
-     * bucket. The principal lives in this closure, never in `StitchInput` (ADR 0002 §2–3).
+     * Derive a principal-bound {@link PrincipalSeam} reusing the same shared runtime, but whose
+     * stitches carry `principal` in their AuthContext: separate sessions per principal, one shared
+     * throttle bucket. The principal lives in the returned closure, never in `StitchInput`
+     * (ADR 0002 §2–3). The handle is **lifecycle-free** — only the root seam may `flush` / `close`.
      */
-    as(principal: string): Seam;
-    /** Flush the shared trace sink (drain any buffered exporter). */
+    as(principal: string): PrincipalSeam;
+    /** Flush the shared trace sink (drain any buffered exporter). Root seam only. */
     flush(): Promise<void>;
-    /** `flush()`, then close the shared store/vault and drop the registry. */
+    /** `flush()`, then close the shared store/vault and drop the registry. Root seam only. */
     close(): Promise<void>;
     /** The shared config fragment — redacted (no `store`/`vault`/`auth`/`adapter`). */
     readonly __config: StitchConfig;

--- a/packages/core/test/graphql-and-headers.spec.ts
+++ b/packages/core/test/graphql-and-headers.spec.ts
@@ -47,6 +47,24 @@ describe('GraphQL kind', () => {
         expect((call?.body as { query: string })?.query).toMatch(/thing/);
     });
 
+    test('.with({ variables }) carries GraphQL variables into the request', async () => {
+        server.route('POST', '/graphql', { body: { data: { ok: true } } });
+        const query = graphql({
+            baseUrl: server.url,
+            query: 'query($id: ID) { thing(id: $id) { name } }',
+        });
+
+        // Partial application must preserve EVERY StitchInput field. `variables` is the primary
+        // input for a GraphQL stitch; mergeInput() now folds it alongside params/query/headers/body.
+        const bound = query.with({ variables: { id: 7 } });
+        await bound();
+
+        const call = server.calls('/graphql')[0]!;
+        expect((call.body as { variables: unknown }).variables).toEqual({
+            id: 7,
+        });
+    });
+
     test('surfaces GraphQL errors (a 200 carrying `errors`) as a failure', async () => {
         server.route('POST', '/graphql', {
             body: { errors: [{ message: 'field "thing" not found' }] },

--- a/packages/core/test/principal.spec.ts
+++ b/packages/core/test/principal.spec.ts
@@ -1,0 +1,133 @@
+// The trusted principal boundary (`seam.as(principal)`, ADR 0002 §2–3). A per-principal handle
+// is the object trusted server code hands to the LEAST-trusted caller (the agent): it binds one
+// identity in the closure so the caller can never name another principal. This suite owns the
+// boundary's integrity guarantees — chiefly that a principal handle gets the principal's *use* of
+// the shared runtime without the *authority* to tear that runtime down. `seam.as(id)` therefore
+// returns a lifecycle-narrowed `PrincipalSeam` (no `flush`/`close`); only the root seam can tear
+// down the runtime every other principal shares (ADR 0002 §2).
+import { cookieSession, memoryStore, seam, stitch } from '../src';
+import type { Seam, StitchStore } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-principal-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+// A login stitch standing in for "exchange credentials for a Set-Cookie session".
+const loginStitch = () =>
+    stitch({ method: 'POST', baseUrl: server.url, path: '/login' });
+
+// A store that records whether close() was ever called, delegating everything else to memory.
+function spyStore(): { store: StitchStore; closed: () => boolean } {
+    const base = memoryStore();
+    let didClose = false;
+    return {
+        closed: () => didClose,
+        store: {
+            get: (k) => base.get(k),
+            set: (k, v, ttl) => base.set(k, v, ttl),
+            incr: (k, ttl) => base.incr(k, ttl),
+            close: async () => {
+                didClose = true;
+                await base.close?.();
+            },
+        },
+    };
+}
+
+describe('seam.as(principal) — the trusted principal boundary', () => {
+    test('a principal handle cannot tear down the shared runtime — close() is root-only', async () => {
+        server.route('GET', '/p', { body: { ok: true } });
+        const spy = spyStore();
+        const api = seam({ baseUrl: server.url, store: spy.store });
+
+        // The handle trusted code derives per request and hands to the agent/caller.
+        const userApi = api.as('req-user-1');
+        await userApi.stitch('/p')();
+
+        // It must NOT be able to close the store every OTHER principal shares. `as()` returns a
+        // lifecycle-narrowed PrincipalSeam, so `close` isn't on the type — the cast probes that no
+        // such method is reachable at runtime either.
+        await (userApi as { close?: () => Promise<void> }).close?.();
+        expect(spy.closed()).toBe(false); // the principal handle has no teardown authority
+
+        // The shared surface is still alive for other principals after the agent "closed" its handle.
+        await expect(api.as('req-user-2').stitch('/p')()).resolves.toEqual({
+            ok: true,
+        });
+
+        // Only the ROOT seam owns the lifecycle.
+        await api.close();
+        expect(spy.closed()).toBe(true);
+    });
+
+    test('each principal gets its OWN session — no cross-principal bleed', async () => {
+        server.route('POST', '/login', {
+            setCookie: { name: 'sid', value: 'OK' },
+            body: { ok: true },
+        });
+        server.route('GET', '/data', {
+            requireCookie: { name: 'sid' },
+            body: { ok: true },
+        });
+
+        const api = seam({
+            baseUrl: server.url,
+            auth: cookieSession({
+                login: loginStitch(),
+                cookie: 'sid',
+                loginInput: (principal) => ({ body: { u: principal } }),
+            }),
+        });
+
+        await api.as('A').stitch('/data')();
+        await api.as('B').stitch('/data')();
+
+        expect(server.callCount('/login')).toBe(2); // one session per principal, never shared
+        const logins = server.calls('/login');
+        expect((logins[0]!.body as { u: string }).u).toBe('A');
+        expect((logins[1]!.body as { u: string }).u).toBe('B');
+    });
+
+    test('as() chaining rebinds the principal — the innermost binding wins', async () => {
+        server.route('POST', '/login', {
+            setCookie: { name: 'sid', value: 'OK' },
+            body: { ok: true },
+        });
+        server.route('GET', '/data', {
+            requireCookie: { name: 'sid' },
+            body: { ok: true },
+        });
+
+        const api: Seam = seam({
+            baseUrl: server.url,
+            auth: cookieSession({
+                login: loginStitch(),
+                cookie: 'sid',
+                loginInput: (principal) => ({ body: { u: principal } }),
+            }),
+        });
+
+        // `.as('A').as('B')` is last-writer-wins: the request runs as B, not A.
+        await api.as('A').as('B').stitch('/data')();
+
+        expect(server.callCount('/login')).toBe(1);
+        expect((server.calls('/login')[0]!.body as { u: string }).u).toBe('B');
+    });
+});


### PR DESCRIPTION
Outcome of a grilling pass over the public `stitch` / `seam` API. Two parts: shippable Round-1 fixes, and the design record (ADR 0003) for the surfaces work that follows.

## Round 1 — code fixes (tested)

| Fix | What |
| --- | --- |
| **Principal boundary** | `seam.as(id)` now returns a lifecycle-free `PrincipalSeam` (no `flush`/`close`). Previously a per-request handle could `close()` the shared store/vault for **every** principal — a one-line DoS from inside the very boundary ADR 0002 hardens. `seam.ts` split into `makeBuild` / `principalHandle` / `rootHandle`. |
| **`.with({ variables })`** | `mergeInput` dropped GraphQL `variables`, so partial application silently lost a stitch's primary input. Now merged like the other input fields. |
| **`SeamConfig`** | `SeamOptions` narrowed to `Omit<StitchConfig, endpoint-only keys>` — per-endpoint keys (`path`/`url`/`method`/`query`/`name`/`input`/`output`/`kind`) can no longer be set on a seam. The type now answers "what belongs at the seam". |
| **`__rawConfig`** | Moved off the stitch object into a module-private `WeakMap`, closing the `__config` redaction bypass structurally — only the redacted `__config` stays reachable. |

New dedicated [`test/principal.spec.ts`](packages/core/test/principal.spec.ts) (boundary-integrity suite) + a `.with({ variables })` regression test.

**Verification:** 202/202 tests, `tsc` (src + test), eslint exit 0, Prettier clean — and the lefthook pre-commit/pre-push gate (format + lint + typecheck + docs build) passed on push.

> ⚠️ **BREAKING** (pre-1.0, no production users, no migration path): `seam.as(id)` no longer exposes `flush`/`close`; `SeamOptions` rejects endpoint-only keys; `__rawConfig` is no longer a property on a stitch.

## ADR 0003 — surfaces and the authoring model (Proposed)

[docs/adr/0003-…](docs/adr/0003-surfaces-and-the-authoring-model.md) — 12 decisions converged during the grilling:

- Surfaces are imported **`kind` plugin values** (typed objects like `auth`/`adapter`) with monomorphic `surface.stitch()` / `surface.seam()` sugar — one authoring verb, not N constructors; `kind` freed of its string union.
- The `Adapter` contract is **extended** (streaming body + `onProgress`), not bypassed, so BYO adapters keep parity.
- Each surface ships as its **own subpath import**; the seam stays surface-agnostic.
- **Mixed seams** share one auth + rate budget + principal across surfaces; **streaming members** are exempt from the concurrency budget but charge the rate gate.
- Nested multipart via a declarative `nesting` strategy (`bracket` | `dot` | `json` | `none`), fixing the current `"[object Object]"` bug.
- The line: *one request whose possibly-streamed response reduces to config*; WebSocket and a download manager are explicit future exploration beyond it.

No implementation yet — the ADR is the spec for the staged surfaces build. SSE reconnection is tracked in #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)