### PR TITLE
fix(core)!: harden principal boundary, fix .with() variables, narrow SeamConfig

### DIFF
--- a/packages/core/src/seam.ts
+++ b/packages/core/src/seam.ts
@@ -19,6 +19,7 @@ import {
     vaultView,
 } from './store';
 import type {
+    PrincipalSeam,
     Seam,
     SeamOptions,
     Stitch,
@@ -63,8 +64,11 @@ interface SharedSeam {
     stitches: Stitch[]; // registry of root-created stitches (lifecycle/introspection)
 }
 
-function makeHandle(shared: SharedSeam, principal: string | undefined): Seam {
-    const build = <T>(
+// The member-builder, closed over the seam's shared runtime and the bound `principal` (undefined
+// for the root). Shared by the root and every principal handle so a member is constructed the same
+// way regardless of which handle created it.
+function makeBuild(shared: SharedSeam, principal: string | undefined) {
+    return <T>(
         config: string | Partial<StitchConfig>,
         isGql = false,
     ): Stitch<T> => {
@@ -105,14 +109,42 @@ function makeHandle(shared: SharedSeam, principal: string | undefined): Seam {
             };
         return makeStitch<T>(cfg, runtime);
     };
+}
 
+// The shared fragment, redacted (no live store/vault/auth/adapter) — exfil-at-rest (§4/§6).
+function sharedConfig(shared: SharedSeam): StitchConfig {
+    return redactConfig(compose(shared.fragment));
+}
+
+// A principal-bound handle: creates members carrying the principal, can re-bind via `as`, but is
+// deliberately **lifecycle-free**. `flush` / `close` / `invalidate` act on the runtime EVERY
+// principal shares, so they belong to the root seam alone — handing them on a per-request handle
+// would let the least-trusted caller tear down (or cache-bust) the shared surface (ADR 0002 §2).
+function principalHandle(shared: SharedSeam, principal: string): PrincipalSeam {
+    const build = makeBuild(shared, principal);
     return {
-        // `build` is generic at runtime; the inferring overloads come from the `Seam` interface,
-        // which the object literal is checked against (function return type).
+        // `build` is generic at runtime; the inferring overloads come from the interface the
+        // object literal is checked against (the function return type).
         stitch: (config: string | Partial<StitchConfig>) => build(config),
         graphql: (config: Partial<StitchConfig> & { query: string }) =>
             build(config, true),
-        as: (p) => makeHandle(shared, p),
+        as: (p) => principalHandle(shared, p),
+        get __config() {
+            return sharedConfig(shared);
+        },
+        __seam: true,
+    };
+}
+
+// The root seam: the member-builder PLUS the shared-runtime levers (`invalidate` / `flush` /
+// `close`) over the runtime it owns.
+function rootHandle(shared: SharedSeam): Seam {
+    const build = makeBuild(shared, undefined);
+    return {
+        stitch: (config: string | Partial<StitchConfig>) => build(config),
+        graphql: (config: Partial<StitchConfig> & { query: string }) =>
+            build(config, true),
+        as: (p) => principalHandle(shared, p),
         // Bulk cache invalidation over the seam's shared store (ADR 0003 §8). No argument bumps
         // the cache-wide generation; a member `stitch` bumps just that stitch's generation. The
         // cache engine is reached lazily — a seam with no cached members never loads it.
@@ -133,9 +165,8 @@ function makeHandle(shared: SharedSeam, principal: string | undefined): Seam {
                 await shared.secretStore.close?.();
             shared.stitches.length = 0;
         },
-        // The shared fragment, redacted (no live store/vault/auth/adapter) — exfil-at-rest (§4/§6).
         get __config() {
-            return redactConfig(compose(shared.fragment));
+            return sharedConfig(shared);
         },
         __seam: true,
     };
@@ -163,5 +194,5 @@ export function seam(options: SeamOptions = {}): Seam {
         stitches: [],
         ...(secretStore ? { secretStore } : {}),
     };
-    return makeHandle(shared, undefined);
+    return rootHandle(shared);
 }

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -224,12 +224,19 @@ function tee<T>(
 }
 
 function mergeInput(a: StitchInput = {}, b: StitchInput = {}): StitchInput {
-    return {
+    const merged: StitchInput = {
         params: { ...(a.params ?? {}), ...(b.params ?? {}) },
         query: { ...(a.query ?? {}), ...(b.query ?? {}) },
         headers: { ...(a.headers ?? {}), ...(b.headers ?? {}) },
         body: b.body !== undefined ? b.body : a.body,
     };
+    // `variables` is a first-class StitchInput field (GraphQL's primary input). It was dropped
+    // here, so `.with({ variables })` silently lost them; merge it like the rest. Omit the key
+    // entirely when neither side sets it (exactOptionalPropertyTypes forbids `variables:
+    // undefined`).
+    if (a.variables ?? b.variables)
+        merged.variables = { ...(a.variables ?? {}), ...(b.variables ?? {}) };
+    return merged;
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -420,16 +420,46 @@ export interface StitchStore {
 
 // ---- Seam (a primitive stitches belong to) --------------------------------
 /**
- * Options for {@link Seam} — every {@link StitchConfig} key (shared by the seam's stitches as a
- * fragment) plus an optional hardened `secretStore` backing the vault.
+ * The config a seam shares with every member as a fragment — {@link StitchConfig} minus the keys
+ * that are intrinsically **per-endpoint**: the address (`path` / `url` / `method` / `query`) and
+ * the request/response shape (`name` / `input` / `output` / `kind`). Everything cross-cutting —
+ * `baseUrl`, `headers`, `auth`, `retry`, `throttle`, `timeout`, `circuit`, `idempotency`,
+ * `paginate`, `unwrap`, `transform`, `arrayFormat`, `hooks`, `trace`, `store`, `cache`, `adapter`
+ * — belongs here, so the type itself answers "what belongs at the seam". Members set the endpoint
+ * keys.
  */
-export type SeamOptions = Partial<StitchConfig> & {
+export type SeamConfig = Omit<
+    StitchConfig,
+    'path' | 'url' | 'method' | 'query' | 'name' | 'input' | 'output' | 'kind'
+>;
+
+/**
+ * Options for {@link Seam} — the shared {@link SeamConfig} plus an optional hardened `secretStore`
+ * backing the vault.
+ */
+export type SeamOptions = SeamConfig & {
     /**
      * Backend for the vault (auth tokens/sessions). Defaults to a reserved, redacted namespace
      * over the seam's `store`; supply a KMS/Vault-backed store here for a hardened vault. Split
      * is by **visibility**, not backend — both store and vault may be distributed (ADR 0002 §4).
      */
     secretStore?: StitchStore;
+};
+
+/**
+ * A principal-bound seam handle — what `seam.as(id)` returns, and the object trusted code hands to
+ * the least-trusted caller (the agent). It creates member stitches and can re-bind the principal,
+ * but deliberately **lacks the shared-runtime levers** (`flush` / `close` / `invalidate`): tearing
+ * down, or invalidating the cache of, the runtime every other principal depends on is a *root-seam*
+ * authority, never a per-principal one. The boundary that prevents impersonation must not also be a
+ * teardown lever (ADR 0002 §2).
+ */
+export type PrincipalSeam = Omit<
+    Seam,
+    'as' | 'flush' | 'close' | 'invalidate'
+> & {
+    /** Re-bind to another principal — last binding wins. Still lifecycle-free. */
+    as(principal: string): PrincipalSeam;
 };
 
 /**
@@ -465,11 +495,13 @@ export interface Seam {
         config: C,
     ): Stitch<ResolveOutput<TExplicit, C>, InputOf<C>>;
     /**
-     * A principal-bound handle reusing the same shared runtime, but whose stitches carry
-     * `principal` in their AuthContext: separate sessions per principal, one shared throttle
-     * bucket. The principal lives in this closure, never in `StitchInput` (ADR 0002 §2–3).
+     * Derive a principal-bound {@link PrincipalSeam} reusing the same shared runtime, but whose
+     * stitches carry `principal` in their AuthContext: separate sessions per principal, one shared
+     * throttle bucket. The principal lives in the returned closure, never in `StitchInput`
+     * (ADR 0002 §2–3). The handle is **lifecycle-free** — only the root seam may `flush` / `close`
+     * / `invalidate` the shared runtime.
      */
-    as(principal: string): Seam;
+    as(principal: string): PrincipalSeam;
     /**
      * Bulk cache invalidation (ADR 0003) over the shared store this seam owns. With no argument
      * it bumps the **cache-wide** generation (every member stitch's entries become unreachable);

--- a/packages/core/test/graphql-and-headers.spec.ts
+++ b/packages/core/test/graphql-and-headers.spec.ts
@@ -47,6 +47,24 @@ describe('GraphQL kind', () => {
         expect((call?.body as { query: string })?.query).toMatch(/thing/);
     });
 
+    test('.with({ variables }) carries GraphQL variables into the request', async () => {
+        server.route('POST', '/graphql', { body: { data: { ok: true } } });
+        const query = graphql({
+            baseUrl: server.url,
+            query: 'query($id: ID) { thing(id: $id) { name } }',
+        });
+
+        // Partial application must preserve EVERY StitchInput field. `variables` is the primary
+        // input for a GraphQL stitch; mergeInput() now folds it alongside params/query/headers/body.
+        const bound = query.with({ variables: { id: 7 } });
+        await bound();
+
+        const call = server.calls('/graphql')[0]!;
+        expect((call.body as { variables: unknown }).variables).toEqual({
+            id: 7,
+        });
+    });
+
     test('surfaces GraphQL errors (a 200 carrying `errors`) as a failure', async () => {
         server.route('POST', '/graphql', {
             body: { errors: [{ message: 'field "thing" not found' }] },

--- a/packages/core/test/principal.spec.ts
+++ b/packages/core/test/principal.spec.ts
@@ -1,0 +1,138 @@
+// The trusted principal boundary (`seam.as(principal)`, ADR 0002 §2–3). A per-principal handle
+// is the object trusted server code hands to the LEAST-trusted caller (the agent): it binds one
+// identity in the closure so the caller can never name another principal. This suite owns the
+// boundary's integrity guarantees — chiefly that a principal handle gets the principal's *use* of
+// the shared runtime without the *authority* to tear that runtime down. `seam.as(id)` therefore
+// returns a lifecycle-free `PrincipalSeam` (no `flush` / `close` / `invalidate`); only the root
+// seam can tear down (or cache-bust) the runtime every other principal shares.
+import { cookieSession, memoryStore, seam, stitch } from '../src';
+import type { Seam, StitchStore } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-principal-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+// A login stitch standing in for "exchange credentials for a Set-Cookie session".
+const loginStitch = () =>
+    stitch({ method: 'POST', baseUrl: server.url, path: '/login' });
+
+// A store that records whether close() was ever called, delegating everything else to memory.
+function spyStore(): { store: StitchStore; closed: () => boolean } {
+    const base = memoryStore();
+    let didClose = false;
+    return {
+        closed: () => didClose,
+        store: {
+            get: (k) => base.get(k),
+            set: (k, v, ttl) => base.set(k, v, ttl),
+            incr: (k, ttl) => base.incr(k, ttl),
+            close: async () => {
+                didClose = true;
+                await base.close?.();
+            },
+        },
+    };
+}
+
+describe('seam.as(principal) — the trusted principal boundary', () => {
+    test('a principal handle cannot tear down the shared runtime — close/invalidate are root-only', async () => {
+        server.route('GET', '/p', { body: { ok: true } });
+        const spy = spyStore();
+        const api = seam({ baseUrl: server.url, store: spy.store });
+
+        // The handle trusted code derives per request and hands to the agent/caller.
+        const userApi = api.as('req-user-1');
+        await userApi.stitch('/p')();
+
+        // The shared-runtime levers are absent on the type AND at runtime — a per-request handle
+        // can neither close the store every other principal shares nor cache-bust them.
+        const probe = userApi as {
+            close?: () => Promise<void>;
+            invalidate?: () => Promise<void>;
+        };
+        expect(probe.close).toBeUndefined();
+        expect(probe.invalidate).toBeUndefined();
+        await probe.close?.();
+        expect(spy.closed()).toBe(false);
+
+        // The shared surface is still alive for other principals after the agent "closed" its handle.
+        await expect(api.as('req-user-2').stitch('/p')()).resolves.toEqual({
+            ok: true,
+        });
+
+        // Only the ROOT seam owns the lifecycle.
+        await api.close();
+        expect(spy.closed()).toBe(true);
+    });
+
+    test('each principal gets its OWN session — no cross-principal bleed', async () => {
+        server.route('POST', '/login', {
+            setCookie: { name: 'sid', value: 'OK' },
+            body: { ok: true },
+        });
+        server.route('GET', '/data', {
+            requireCookie: { name: 'sid' },
+            body: { ok: true },
+        });
+
+        const api = seam({
+            baseUrl: server.url,
+            auth: cookieSession({
+                login: loginStitch(),
+                cookie: 'sid',
+                loginInput: (principal) => ({ body: { u: principal } }),
+            }),
+        });
+
+        await api.as('A').stitch('/data')();
+        await api.as('B').stitch('/data')();
+
+        expect(server.callCount('/login')).toBe(2); // one session per principal, never shared
+        const logins = server.calls('/login');
+        expect((logins[0]!.body as { u: string }).u).toBe('A');
+        expect((logins[1]!.body as { u: string }).u).toBe('B');
+    });
+
+    test('as() chaining rebinds the principal — the innermost binding wins', async () => {
+        server.route('POST', '/login', {
+            setCookie: { name: 'sid', value: 'OK' },
+            body: { ok: true },
+        });
+        server.route('GET', '/data', {
+            requireCookie: { name: 'sid' },
+            body: { ok: true },
+        });
+
+        const api: Seam = seam({
+            baseUrl: server.url,
+            auth: cookieSession({
+                login: loginStitch(),
+                cookie: 'sid',
+                loginInput: (principal) => ({ body: { u: principal } }),
+            }),
+        });
+
+        // `.as('A').as('B')` is last-writer-wins: the request runs as B, not A.
+        await api.as('A').as('B').stitch('/data')();
+
+        expect(server.callCount('/login')).toBe(1);
+        expect((server.calls('/login')[0]!.body as { u: string }).u).toBe('B');
+    });
+});


### PR DESCRIPTION
Three correctness/safety fixes from a grilling pass over the public `stitch` / `seam` API. Rebased onto current `main` — the surfaces ADR and the Builder removal from the same session already landed independently (ADR 0005 #89, Builder removal #90), so this PR is **just the three bug fixes** that were *not* on main.

| Fix | What |
| --- | --- |
| **Principal boundary** | `seam.as(id)` now returns a lifecycle-free `PrincipalSeam` (no `flush` / `close` / **`invalidate`**). A per-request handle — the thing you hand to least-trusted agent code — could previously `close()` the shared store/vault *or* `invalidate()` the shared cache for **every** principal: a one-line DoS / cache-bust from inside the very boundary ADR 0002 hardens. `seam.ts` split into `makeBuild` / `principalHandle` / `rootHandle`. |
| **`.with({ variables })`** | `mergeInput` dropped GraphQL `variables`, so partial application silently lost a stitch's primary input. Now merged like the other input fields. |
| **`SeamConfig`** | `SeamOptions` narrowed to `Omit<StitchConfig, endpoint-only keys>` — per-endpoint keys (`path`/`url`/`method`/`query`/`name`/`input`/`output`/`kind`) can no longer be set on a seam. The type now answers "what belongs at the seam". |

New dedicated [`test/principal.spec.ts`](packages/core/test/principal.spec.ts) (boundary-integrity suite — asserts `close`/`invalidate` are absent on a principal handle, the no-bleed guarantee, and `as()` re-binding) + a `.with({ variables })` regression test.

**Verification:** 281/281 tests, `tsc` (src + test), eslint exit 0, Prettier clean — and the lefthook pre-commit/pre-push gate (format + lint + typecheck + docs build) passed on commit and push.

> ⚠️ **BREAKING** (pre-1.0, no production users, no migration path): `seam.as(id)` no longer exposes `flush` / `close` / `invalidate`; `SeamOptions` rejects endpoint-only keys.

_Supersedes the code portion of #91 (closed — its ADR 0003 collided with the already-merged ADR 0005, and its `__rawConfig`→WeakMap change conflicts with ADR 0005's decision to keep `__rawConfig` for surface composition; that redaction question can be reopened separately)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)