### PR TITLE
feat(http): nested multipart via multipart.nesting (ADR 0005 Decision 6, Stage 1)

### DIFF
--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -190,6 +190,7 @@ function buildRequest(cfg: StitchConfig, input: StitchInput): AdapterRequest {
               }
             : input.body,
         ...(bodyType !== undefined ? { bodyType } : {}),
+        ...(cfg.multipart !== undefined ? { multipart: cfg.multipart } : {}),
         ...(cfg.responseType !== undefined
             ? { responseType: cfg.responseType }
             : {}),

--- a/packages/core/src/http-adapter.ts
+++ b/packages/core/src/http-adapter.ts
@@ -2,6 +2,7 @@ import type {
     Adapter,
     AdapterRequest,
     AdapterResponse,
+    MultipartNesting,
     ResponseType,
 } from './types';
 
@@ -107,11 +108,11 @@ export function encodeRequestBody(req: AdapterRequest): {
     }
     if (req.bodyType === 'multipart') {
         const form = new FormData();
-        for (const [k, v] of Object.entries(
+        encodeMultipart(
+            form,
             req.body as Record<string, unknown>,
-        )) {
-            appendForm(form, k, v);
-        }
+            req.multipart?.nesting ?? 'bracket',
+        );
         return { body: form };
     }
     return { body: JSON.stringify(req.body), contentType: 'application/json' };
@@ -143,9 +144,21 @@ export function decodeResponseBody(
     return text;
 }
 
-// Append a value to multipart FormData: a Blob/Uint8Array becomes a file part; a
-// { value, filename?, type? } wrapper becomes a named file; everything else a string field.
-function appendForm(form: FormData, key: string, v: unknown): void {
+// ---- multipart encoding (ADR 0005 Decision 6) -----------------------------
+// A value that becomes a binary file part: a Blob, a raw byte view, or a
+// { value, filename?, type? } wrapper. Anything else is a scalar field.
+function isFileLeaf(v: unknown): boolean {
+    return (
+        v instanceof Blob ||
+        v instanceof Uint8Array ||
+        (typeof v === 'object' &&
+            v !== null &&
+            'value' in (v as Record<string, unknown>))
+    );
+}
+
+// Append one file leaf as a multipart file part (named, when a filename is given).
+function appendFilePart(form: FormData, key: string, v: unknown): void {
     if (v instanceof Blob) {
         form.append(key, v);
         return;
@@ -158,22 +171,121 @@ function appendForm(form: FormData, key: string, v: unknown): void {
         form.append(key, new Blob([v as BlobPart]));
         return;
     }
-    if (
-        v &&
-        typeof v === 'object' &&
-        'value' in (v as Record<string, unknown>)
-    ) {
-        const f = v as { value: unknown; filename?: string; type?: string };
-        const blob =
-            f.value instanceof Blob
-                ? f.value
-                : new Blob(
-                      [f.value as BlobPart],
-                      f.type ? { type: f.type } : undefined,
-                  );
-        if (f.filename) form.append(key, blob, f.filename);
-        else form.append(key, blob);
+    const f = v as { value: unknown; filename?: string; type?: string };
+    const blob =
+        f.value instanceof Blob
+            ? f.value
+            : new Blob(
+                  [f.value as BlobPart],
+                  f.type ? { type: f.type } : undefined,
+              );
+    if (f.filename) form.append(key, blob, f.filename);
+    else form.append(key, blob);
+}
+
+// Legacy 'none' nesting: top-level keys only — a file leaf becomes a file part, anything
+// else is stringified (so a nested object becomes the literal "[object Object]").
+function appendForm(form: FormData, key: string, v: unknown): void {
+    if (isFileLeaf(v)) {
+        appendFilePart(form, key, v);
         return;
     }
     form.append(key, String(v));
+}
+
+// Compose a child field name under a parent. Root keys (no parent) are bare; nested keys
+// are `parent[child]` (bracket) or `parent.child` (dot).
+function joinKey(parent: string, child: string | number, dot: boolean): string {
+    if (parent === '') return String(child);
+    return dot ? `${parent}.${child}` : `${parent}[${child}]`;
+}
+
+// Recursive flatten for 'bracket'/'dot': a file leaf becomes a binary part at its flattened
+// key, a scalar a string part, and nested objects/arrays recurse with composed keys.
+// null/undefined are skipped so no empty parts are emitted.
+function flattenInto(
+    form: FormData,
+    value: unknown,
+    key: string,
+    dot: boolean,
+): void {
+    if (value === undefined || value === null) return;
+    if (isFileLeaf(value)) {
+        appendFilePart(form, key, value);
+        return;
+    }
+    if (Array.isArray(value)) {
+        value.forEach((item, i) => {
+            flattenInto(form, item, joinKey(key, i, dot), dot);
+        });
+        return;
+    }
+    if (typeof value === 'object') {
+        for (const [k, v] of Object.entries(value as Record<string, unknown>))
+            flattenInto(form, v, joinKey(key, k, dot), dot);
+        return;
+    }
+    if (typeof value === 'string') {
+        form.append(key, value);
+        return;
+    }
+    if (
+        typeof value === 'number' ||
+        typeof value === 'bigint' ||
+        typeof value === 'boolean'
+    )
+        form.append(key, String(value));
+}
+
+// 'json' nesting: pull every file leaf out into its own bracket-path-keyed part (collected in
+// `files`) and return the remaining structure (files removed) to be JSON-encoded as one part.
+function stripFiles(
+    value: unknown,
+    key: string,
+    files: [string, unknown][],
+): unknown {
+    if (isFileLeaf(value)) {
+        files.push([key, value]);
+        return undefined;
+    }
+    if (Array.isArray(value)) {
+        const out: unknown[] = [];
+        value.forEach((item, i) => {
+            const kept = stripFiles(item, joinKey(key, i, false), files);
+            if (kept !== undefined) out.push(kept);
+        });
+        return out;
+    }
+    if (typeof value === 'object' && value !== null) {
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+            const kept = stripFiles(v, joinKey(key, k, false), files);
+            if (kept !== undefined) out[k] = kept;
+        }
+        return out;
+    }
+    return value;
+}
+
+// Encode a multipart body per `nesting` (ADR 0005 Decision 6). Default 'bracket'.
+function encodeMultipart(
+    form: FormData,
+    body: Record<string, unknown>,
+    nesting: MultipartNesting,
+): void {
+    if (nesting === 'none') {
+        for (const [k, v] of Object.entries(body)) appendForm(form, k, v);
+        return;
+    }
+    if (nesting === 'json') {
+        const files: [string, unknown][] = [];
+        const json = stripFiles(body, '', files);
+        // One JSON part (the `payload` field) carries all non-file data; each hoisted file
+        // rides as a binary part keyed by its bracket path so the server can correlate it.
+        form.append('payload', JSON.stringify(json));
+        for (const [k, v] of files) appendFilePart(form, k, v);
+        return;
+    }
+    const dot = nesting === 'dot';
+    for (const [k, v] of Object.entries(body)) flattenInto(form, v, k, dot);
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -46,12 +46,26 @@ export interface DriftSpec<T = unknown> {
 // ---- Adapter (HTTP kind) --------------------------------------------------
 /** How to read the response body. Default (unset) = auto: JSON when the content-type is json-ish, else text. */
 export type ResponseType = 'json' | 'text' | 'arrayBuffer' | 'blob';
+/**
+ * How a multipart body serialises nested objects/arrays into field names (ADR 0005 Decision 6).
+ * - `'bracket'` (default) — `parent[child][0]` keys (PHP/Rails convention; broadest compatibility).
+ * - `'dot'` — `parent.child.0` keys.
+ * - `'json'` — non-file data is one JSON part; each file leaf is hoisted to its own path-keyed part.
+ * - `'none'` — top-level keys only (legacy; a nested object stringifies to `[object Object]`).
+ */
+export type MultipartNesting = 'bracket' | 'dot' | 'json' | 'none';
+export interface MultipartOptions {
+    /** Nesting strategy for nested objects/arrays in a multipart body. Default `'bracket'`. */
+    nesting?: MultipartNesting;
+}
 export interface AdapterRequest {
     url: string;
     method: string;
     headers: Record<string, string>;
     body?: unknown;
     bodyType?: 'json' | 'form' | 'multipart';
+    /** Multipart serialisation options (nesting); only read when `bodyType: 'multipart'`. */
+    multipart?: MultipartOptions;
     responseType?: ResponseType;
     signal?: AbortSignal;
 }
@@ -262,6 +276,11 @@ export interface StitchConfig {
     method?: string;
     /** Request body encoding. Default `'json'`. */
     bodyType?: 'json' | 'form' | 'multipart';
+    /**
+     * Multipart serialisation options (ADR 0005 Decision 6) — how nested objects/arrays become
+     * field names. Only meaningful with `bodyType: 'multipart'`. Default nesting `'bracket'`.
+     */
+    multipart?: MultipartOptions;
     /** How to read the response body. Default: auto by content-type. */
     responseType?: ResponseType;
     /**

--- a/packages/core/test/multipart-nesting.spec.ts
+++ b/packages/core/test/multipart-nesting.spec.ts
@@ -1,0 +1,169 @@
+// Nested multipart bodies (ADR 0005 Decision 6): `multipart.nesting` controls how a nested
+// object/array becomes form-field names. Default `bracket` flattens to parent[child][i] keys;
+// `dot` to parent.child.i; `json` rides one JSON part alongside hoisted file parts; `none` is
+// the legacy top-level-only behaviour. File leaves (Blob / Uint8Array / { value, filename?,
+// type? }) always become binary parts. Asserted end-to-end against the raw multipart body the
+// mock server records.
+import { stitch } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+const bytes = new Uint8Array([1, 2, 3, 4]);
+const rawOf = (path: string): string => String(server.calls(path)[0]?.body);
+
+describe('multipart nesting (ADR 0005 Decision 6)', () => {
+    test("'bracket' is the default: nested objects/arrays flatten to parent[child] keys", async () => {
+        server.route('POST', '/upload', { body: { ok: true } });
+        const upload = stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/upload',
+            bodyType: 'multipart',
+        });
+
+        await upload({
+            body: {
+                user: { name: 'Ada', roles: ['admin', 'dev'] },
+                file: { value: bytes, filename: 'a.bin' },
+            },
+        });
+
+        const raw = rawOf('/upload');
+        expect(raw).toContain('name="user[name]"');
+        expect(raw).toContain('Ada');
+        expect(raw).toContain('name="user[roles][0]"');
+        expect(raw).toContain('name="user[roles][1]"');
+        expect(raw).toContain('admin');
+        expect(raw).toContain('dev');
+        // file leaf stays a binary part at its flattened key
+        expect(raw).toContain('name="file"');
+        expect(raw).toContain('filename="a.bin"');
+        // the broken legacy shape must NOT appear
+        expect(raw).not.toContain('[object Object]');
+    });
+
+    test("'dot' nesting uses parent.child keys", async () => {
+        server.route('POST', '/u', { body: { ok: true } });
+        const upload = stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/u',
+            bodyType: 'multipart',
+            multipart: { nesting: 'dot' },
+        });
+
+        await upload({ body: { user: { name: 'Ada', roles: ['x'] } } });
+
+        const raw = rawOf('/u');
+        expect(raw).toContain('name="user.name"');
+        expect(raw).toContain('name="user.roles.0"');
+        expect(raw).not.toContain('user[name]');
+    });
+
+    test("'json': non-file data is one JSON part; file leaves hoist to path-keyed parts", async () => {
+        server.route('POST', '/u', { body: { ok: true } });
+        const upload = stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/u',
+            bodyType: 'multipart',
+            multipart: { nesting: 'json' },
+        });
+
+        await upload({
+            body: {
+                meta: { a: 1 },
+                file: { value: bytes, filename: 'a.bin' },
+                post: { image: bytes },
+            },
+        });
+
+        const raw = rawOf('/u');
+        // one JSON part carries the non-file data, files stripped out of it
+        expect(raw).toContain('name="payload"');
+        expect(raw).toContain('"meta":{"a":1}');
+        // top-level file leaf hoisted to its own part
+        expect(raw).toContain('name="file"');
+        expect(raw).toContain('filename="a.bin"');
+        // nested file leaf hoisted with its bracket path as the key
+        expect(raw).toContain('name="post[image]"');
+    });
+
+    test("'none' preserves the legacy top-level-only behaviour", async () => {
+        server.route('POST', '/u', { body: { ok: true } });
+        const upload = stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/u',
+            bodyType: 'multipart',
+            multipart: { nesting: 'none' },
+        });
+
+        await upload({ body: { user: { name: 'Ada' }, category: 'movies' } });
+
+        const raw = rawOf('/u');
+        expect(raw).toContain('name="category"');
+        expect(raw).toContain('movies');
+        // a nested object is NOT flattened — it stringifies to [object Object]
+        expect(raw).toContain('name="user"');
+        expect(raw).toContain('[object Object]');
+        expect(raw).not.toContain('user[name]');
+    });
+
+    test('a flat body is unchanged under the new default', async () => {
+        server.route('POST', '/u', { body: { ok: true } });
+        const upload = stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/u',
+            bodyType: 'multipart',
+        });
+
+        await upload({
+            body: {
+                category: 'movies',
+                file: {
+                    value: bytes,
+                    filename: 'a.bin',
+                    type: 'application/octet-stream',
+                },
+            },
+        });
+
+        const raw = rawOf('/u');
+        expect(raw).toContain('name="category"');
+        expect(raw).toContain('movies');
+        expect(raw).toContain('name="file"');
+        expect(raw).toContain('filename="a.bin"');
+    });
+
+    // contract-not-dependency gate: the capability is a plain config key (not a closure), so a
+    // stitch's declaration still serialises losslessly to JSON.
+    test('contract gate: multipart.nesting round-trips through __config as JSON', () => {
+        const upload = stitch({
+            method: 'POST',
+            baseUrl: 'https://example.test',
+            path: '/u',
+            bodyType: 'multipart',
+            multipart: { nesting: 'dot' },
+        });
+
+        const json = JSON.parse(JSON.stringify(upload.__config)) as {
+            bodyType?: string;
+            multipart?: { nesting?: string };
+        };
+        expect(json.bodyType).toBe('multipart');
+        expect(json.multipart).toEqual({ nesting: 'dot' });
+    });
+});


### PR DESCRIPTION
**Stage 1** of the surfaces rollout ([ADR 0005](https://github.com/rejifald/StitchAPI/blob/main/docs/adr/0005-surfaces-and-the-authoring-model.md) Decision 6). Branches off latest `main` (incl. #92).

Multipart bodies only iterated top-level keys, so a nested object serialised to the literal `[object Object]`. This adds **`multipart.nesting`** to `StitchConfig` (threaded onto `AdapterRequest`), implemented in `http-adapter.ts`:

| mode | result | notes |
|---|---|---|
| `bracket` **(default)** | `parent[child][0]` | PHP/Rails convention; broadest server compatibility |
| `dot` | `parent.child.0` | |
| `json` | one `payload` JSON part + hoisted file parts | non-file data is `JSON.stringify`-ed into one part; each **file leaf** is hoisted out into its own bracket-path-keyed part, so a JSON metadata blob can still carry binary siblings |
| `none` | top-level keys only | the legacy behaviour, kept as an escape hatch |

A **file leaf** is a `Blob` / `Uint8Array` / `{ value, filename?, type? }` wrapper (detection unchanged, now shared via `isFileLeaf`/`appendFilePart`). A **flat body is byte-identical** under the new `bracket` default, so the existing `body-encoding` suite is untouched. **No new dependencies** — recursion + the existing `FormData`.

### Gates re-checked
- **Browser-first:** `FormData`/`Blob`/`Uint8Array` only; no Node deps, no `fs`.
- **Bundle-frugal:** no new deps, no new subpath — pure recursion in the already-loaded http adapter.
- **Contract-not-dependency:** `multipart.nesting` is a plain config key, not a closure — round-trips through `__config` as JSON (asserted in the spec).

### Verification
RED → green TDD. `multipart-nesting.spec.ts` (6 tests). Full core suite (287), typecheck (src + test), eslint (suppressions intact), and prettier all green.

Review stops here per the staged plan; Stage 2 (adapter contract: `stream` + `onProgress`) follows in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)