### PR TITLE
feat(playground): bring back the trace DAG as Mermaid SVG, wired to ADR 0007/0008 causality

### DIFF
--- a/apps/docs/app/(home)/playground/playground.css
+++ b/apps/docs/app/(home)/playground/playground.css
@@ -347,6 +347,34 @@
     background: color-mix(in srgb, var(--stitch) 10%, transparent);
     color: var(--color-fd-foreground);
 }
+.stitch-playground__dag {
+    margin-top: 0.75rem;
+}
+.stitch-playground__dag-streaming-badge {
+    display: inline-block;
+    margin-bottom: 0.25rem;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--stitch-strong);
+}
+.stitch-playground__mermaid {
+    margin: 0;
+    white-space: pre-wrap;
+    color: var(--color-fd-muted-foreground);
+}
+/* Client-rendered Mermaid SVG (MermaidDiagram). Center the diagram and let the
+   <svg> scale down to the pane width instead of overflowing / fixing its
+   intrinsic size. */
+.stitch-playground__mermaid-svg {
+    display: flex;
+    justify-content: center;
+}
+.stitch-playground__mermaid-svg svg {
+    max-width: 100%;
+    height: auto;
+}
+
 /* ── CodeMirror editor (renderEditor) ───────────────────────────────────── */
 .stitch-playground .cm-editor {
     font-size: 0.875rem;

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -134,3 +134,40 @@ cache signal); GraphQL query-vs-mutation opt-in classification; conformance-kit 
 `incr`-as-lock correctness; `__config`/trace redaction of cached values + lock keys (extends ADR
 0002 §6). Dropped: hierarchy, SWR/background refresh, mutation-driven cross-stitch invalidation
 (= app-level cache policy, out of scope — see ADR 0003 §12).
+
+---
+
+## Playground trace DAG — dependency / derivation edges
+
+-   **Status:** idea
+-   **Date:** 2026-06
+-   **Tags:** playground, visual, observability, DX, trace
+-   **Gates:** browser-first ✅ (renders client-side in the existing playground; mermaid is
+    lazy-loaded, off the SSR / initial-bundle path) · bundle-frugal — stays inside the
+    `docs/sandbox` playground surface, never pulled into the core `stitch()` import.
+
+**Problem / why** — The playground DAG now renders one node per executed `stitch()` call,
+labelled `METHOD /path` (shipped 2026-06: client-side Mermaid SVG + distinguishing labels). But
+the graph has **no edges** — every node is a disconnected box. The runtime trace
+(`runtime/trace-collector.ts`) emits per-call nodes with no composition graph, and a snippet's
+calls are often genuinely independent, so there is no honest _data-dependency_ edge to draw. The
+DAG therefore reads as a list, not a graph.
+
+**Sketch** — Render the **`extends` derivation tree** instead of (or alongside) the flat call
+list: `api → getUser`, `api → listNames`, `api → flaky`, … — the real structural relationship a
+config-object author expresses. Base stitches that are never called directly still appear as
+parent nodes. The flat `METHOD /path` labels stay on the leaf (call) nodes. True data-dependency
+edges (one call's output feeding another's input) remain a later layer, gated on the engine
+emitting a composition graph.
+
+**Backed by / builds on** — the just-shipped client-side Mermaid rendering + `traceToMermaid`
+(`component/output-format.ts`), the `StitchTraceEntry.dependsOn` field already consumed to draw
+edges, and `extends`/`flatten` composition metadata. Net-new is surfacing the derivation
+relationship (parent identity) into the trace / entry shape.
+
+**Open questions** — Where does the derivation graph come from — does `stitch()`/`seam` emit
+parent identity into the trace (the collector can't see `extends` today), or is it inferred
+statically from the snippet? Do base (never-called) stitches get nodes, and how are they de-duped
+across calls? Derivation tree vs. true data-dependency edges — show one, both, or a toggle?
+(Down-payment on the Studio "Mermaid-from-definition" line; see the `docs/sandbox` A2 trace
+follow-up noted in `RELEASE.md`.)

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -137,7 +137,7 @@ cache signal); GraphQL query-vs-mutation opt-in classification; conformance-kit 
 
 ---
 
-## Playground trace DAG — dependency / derivation edges
+## Playground trace DAG — `extends` derivation overlay
 
 -   **Status:** idea
 -   **Date:** 2026-06
@@ -146,28 +146,28 @@ cache signal); GraphQL query-vs-mutation opt-in classification; conformance-kit 
     lazy-loaded, off the SSR / initial-bundle path) · bundle-frugal — stays inside the
     `docs/sandbox` playground surface, never pulled into the core `stitch()` import.
 
-**Problem / why** — The playground DAG now renders one node per executed `stitch()` call,
-labelled `METHOD /path` (shipped 2026-06: client-side Mermaid SVG + distinguishing labels). But
-the graph has **no edges** — every node is a disconnected box. The runtime trace
-(`runtime/trace-collector.ts`) emits per-call nodes with no composition graph, and a snippet's
-calls are often genuinely independent, so there is no honest _data-dependency_ edge to draw. The
-DAG therefore reads as a list, not a graph.
+**Problem / why** — The playground DAG now renders one node per executed `stitch()` call
+(labelled `METHOD /path`, or `$ command` for a `shell` surface), **with real edges**: ADR 0007's
+run-identity span tree means a child run carries its parent's id, so the collector draws true
+**runtime-causality** edges — a `cookieSession` login → the call that triggered it, a `pipe()`
+`stepA → stepB → stepC` chain — plus per-iteration annotations (`↻` retries, `⊞` pages). What the
+DAG still **cannot** show is the **static `extends` derivation** — _which fragment a stitch was
+composed from_. That is a different axis the runtime collector can't see (ADR 0007 Q4 scoped it
+out), so siblings derived from one base still appear as independent call nodes.
 
-**Sketch** — Render the **`extends` derivation tree** instead of (or alongside) the flat call
-list: `api → getUser`, `api → listNames`, `api → flaky`, … — the real structural relationship a
-config-object author expresses. Base stitches that are never called directly still appear as
-parent nodes. The flat `METHOD /path` labels stay on the leaf (call) nodes. True data-dependency
-edges (one call's output feeding another's input) remain a later layer, gated on the engine
-emitting a composition graph.
+**Sketch** — A derivation **overlay**: render the `extends` tree alongside (or as a toggle on) the
+runtime-causality DAG — `api → getUser`, `api → listNames`, `api → flaky`, … — the structural
+relationship a config-object author expresses. Base stitches never called directly still appear as
+parent nodes; the `METHOD /path` labels stay on the leaf (call) nodes. A distinct edge style keeps
+derivation edges visually separate from the runtime-causality edges this PR already draws.
 
-**Backed by / builds on** — the just-shipped client-side Mermaid rendering + `traceToMermaid`
-(`component/output-format.ts`), the `StitchTraceEntry.dependsOn` field already consumed to draw
-edges, and `extends`/`flatten` composition metadata. Net-new is surfacing the derivation
-relationship (parent identity) into the trace / entry shape.
+**Backed by / builds on** — the shipped client-side Mermaid rendering + `traceToMermaid`
+(`component/output-format.ts`) and the now-real `StitchTraceEntry.dependsOn` causality edges. Net-new
+is surfacing the **static** derivation relationship (which fragment, via `extends`/`flatten`), which
+the runtime trace deliberately does not carry.
 
-**Open questions** — Where does the derivation graph come from — does `stitch()`/`seam` emit
-parent identity into the trace (the collector can't see `extends` today), or is it inferred
-statically from the snippet? Do base (never-called) stitches get nodes, and how are they de-duped
-across calls? Derivation tree vs. true data-dependency edges — show one, both, or a toggle?
-(Down-payment on the Studio "Mermaid-from-definition" line; see the `docs/sandbox` A2 trace
-follow-up noted in `RELEASE.md`.)
+**Open questions** — Where does the derivation graph come from — does `stitch()`/`seam` emit parent
+identity statically, or is it inferred from the snippet AST? Do base (never-called) stitches get
+nodes, and how are they de-duped across calls? Overlay vs. toggle vs. a separate panel relative to
+the runtime-causality edges? (Down-payment on the Studio "Mermaid-from-definition" line; see the
+`docs/sandbox` A2 trace follow-up noted in `RELEASE.md`.)

--- a/docs/sandbox/component/StitchPlayground.tsx
+++ b/docs/sandbox/component/StitchPlayground.tsx
@@ -457,6 +457,12 @@ function StitchOutput({
                 {/* Show the DAG as soon as any trace event has been folded in. */}
                 {hasDag && (
                     <div className="stitch-playground__dag">
+                        {/* Section header, styled like the Console / Server-knobs
+                            pane heads (same .stitch-playground__pane-head: uppercased,
+                            muted, subtle bar). */}
+                        <div className="stitch-playground__pane-head">
+                            Call graph
+                        </div>
                         {/* Streaming badge: shown when any chunk event arrived or any
                             trace entry carries `.stream`. Active during and after the run. */}
                         {view.isStreaming && (

--- a/docs/sandbox/component/StitchPlayground.tsx
+++ b/docs/sandbox/component/StitchPlayground.tsx
@@ -29,7 +29,14 @@ import {
     mockRunner,
 } from './runner';
 
-import { type ReactNode, useCallback, useRef, useState } from 'react';
+import {
+    type ReactNode,
+    useCallback,
+    useEffect,
+    useId,
+    useRef,
+    useState,
+} from 'react';
 
 /**
  * Props passed to a custom editor (the EDITOR INTEGRATION POINT). A renderer
@@ -422,7 +429,9 @@ function StitchOutput({
             })
         );
 
-        const hasExtras = view.errorText !== null || view.notices.length > 0;
+        const hasDag = !!view.mermaid && !view.mermaid.includes('_empty');
+        const hasExtras =
+            view.errorText !== null || view.notices.length > 0 || hasDag;
 
         const extras = (
             <>
@@ -441,6 +450,25 @@ function StitchOutput({
                                 ⚠ {n}
                             </div>
                         ))}
+                    </div>
+                )}
+
+                {/* ── Mermaid DAG ────────────────────────────────────── */}
+                {/* Show the DAG as soon as any trace event has been folded in. */}
+                {hasDag && (
+                    <div className="stitch-playground__dag">
+                        {/* Streaming badge: shown when any chunk event arrived or any
+                            trace entry carries `.stream`. Active during and after the run. */}
+                        {view.isStreaming && (
+                            <span className="stitch-playground__dag-streaming-badge">
+                                streaming
+                            </span>
+                        )}
+                        {/* The Mermaid flowchart is rendered to an inline SVG on the
+                            client by <MermaidDiagram> (mermaid is loaded lazily inside
+                            its effect so nothing touches `document` during SSR). On a
+                            parse/render failure it falls back to the raw graph string. */}
+                        <MermaidDiagram chart={view.mermaid} />
                     </div>
                 )}
             </>
@@ -476,6 +504,102 @@ function StitchOutput({
             <div className="stitch-playground__pane-head">Console</div>
             {body}
         </section>
+    );
+}
+
+/**
+ * Renders a Mermaid `flowchart TD` string to an inline SVG, entirely on the
+ * client. `mermaid` reaches for `document`/`window`, so it is NEVER imported at
+ * module scope — it is loaded lazily with `await import('mermaid')` *inside* the
+ * effect, which only runs in the browser. That keeps the component SSR-safe (the
+ * server render emits the empty container) and keeps mermaid out of the initial
+ * bundle until a DAG actually needs drawing.
+ *
+ * Robustness contract:
+ *   · Each render gets a DOM-id-safe, unique `renderId` (a stripped `useId()`
+ *     plus a per-render counter) so mermaid's injected temp element never
+ *     collides across re-renders.
+ *   · A `cancelled` flag guards the async result so an unmounted / superseded
+ *     effect can't write a stale SVG into the live container.
+ *   · On any failure we `console.warn`, best-effort remove mermaid's orphaned
+ *     temp node, and fall back to the raw graph string in a styled
+ *     `.stitch-playground__mermaid` <pre> written INTO the same container — so
+ *     the DAG panel can never break a run's output, and a later valid graph
+ *     recovers (the container stays mounted, so the effect's ref is stable).
+ */
+function MermaidDiagram({ chart }: { chart: string }) {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    // useId() is stable across renders and unique per instance, but contains
+    // characters (':') that aren't valid in a DOM id — strip them. The counter
+    // makes each successive render's id unique so mermaid's temp element never
+    // collides with a previous (possibly still-unwinding) render.
+    const uid = useId().replace(/[^a-zA-Z0-9]/g, '');
+    const renderCount = useRef(0);
+
+    useEffect(() => {
+        let cancelled = false;
+        const el = containerRef.current;
+        if (!el) return;
+
+        const n = (renderCount.current += 1);
+        const renderId = `mmd-${uid}-${n}`;
+
+        // Drop to the raw graph string in a styled <pre>, IN PLACE — the
+        // container stays mounted, so a subsequent valid `chart` re-runs the
+        // effect and overwrites this with the SVG (a transient parse failure is
+        // not sticky). `textContent` keeps the untrusted graph string inert.
+        const showFallback = () => {
+            const pre = document.createElement('pre');
+            pre.className = 'stitch-playground__mermaid';
+            pre.textContent = chart;
+            el.replaceChildren(pre);
+        };
+
+        (async () => {
+            // Lazy, browser-only import — keeps mermaid out of SSR and the
+            // initial bundle.
+            const mermaid = (await import('mermaid')).default;
+            try {
+                const isDark =
+                    typeof document !== 'undefined' &&
+                    document.documentElement.classList.contains('dark');
+                mermaid.initialize({
+                    startOnLoad: false,
+                    theme: isDark ? 'dark' : 'default',
+                    securityLevel: 'strict',
+                });
+                const { svg, bindFunctions } = await mermaid.render(
+                    renderId,
+                    chart,
+                );
+                // Bail if the effect was torn down / superseded while awaiting.
+                if (cancelled || containerRef.current !== el) return;
+                el.innerHTML = svg;
+                bindFunctions?.(el);
+            } catch (err) {
+                console.warn('[StitchPlayground] mermaid render failed', err);
+                // mermaid can leave an orphan temp node carrying the render id
+                // when it throws mid-render — best-effort cleanup.
+                document.getElementById(renderId)?.remove();
+                if (cancelled || containerRef.current !== el) return;
+                showFallback();
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [chart, uid]);
+
+    // The container is ALWAYS mounted so the effect's ref stays stable across
+    // re-renders; mermaid writes the SVG (or the fallback <pre>) into it.
+    return (
+        <div
+            ref={containerRef}
+            className="stitch-playground__mermaid-svg"
+            role="img"
+            aria-label="Call graph of the run"
+        />
     );
 }
 

--- a/docs/sandbox/component/StitchPlayground.tsx
+++ b/docs/sandbox/component/StitchPlayground.tsx
@@ -102,8 +102,8 @@ export interface StitchPlaygroundProps {
      * Custom renderer for the WHOLE log stream as one block (e.g. a readonly
      * code editor with line numbers). Receives each formatted line plus the
      * level of the entry it belongs to. Takes precedence over {@link renderLog}
-     * for the logs section; the error block and notices strip stay as their own
-     * styled blocks beneath it. Absent → per-line {@link renderLog}.
+     * for the logs section; the error block, notices strip, and trace DAG stay
+     * as their own styled blocks beneath it. Absent → per-line {@link renderLog}.
      */
     renderLogs?: (entries: { text: string; level: string }[]) => ReactNode;
     /**
@@ -344,7 +344,7 @@ export function StitchPlayground({
 }
 
 /**
- * Console pane — the log stream plus errors and shim notices.
+ * Console pane — the log stream plus errors, shim notices, and the trace DAG.
  * It does NOT render the snippet's return value: the playground is logs-first
  * (snippets `console.log` what they want to show), so a returned value is not
  * surfaced. Renders incrementally as RunEvents arrive via onEvent and reconciles
@@ -352,7 +352,7 @@ export function StitchPlayground({
  *
  * Rendering strategy:
  *   · During a run: `view` is updated by `applyEvent` for every RunEvent the runner
- *     emits, so logs, streamed chunks, and notices appear immediately.
+ *     emits, so logs, streamed chunks, trace DAG, and notices appear immediately.
  *   · After a run: `view` is replaced by `buildRunView(result)` so error/durationMs
  *     always reflect the authoritative final state.
  *   · Runners that do not emit onEvent (e.g. mockRunner, DeferredRunner) never call
@@ -400,7 +400,7 @@ function StitchOutput({
         );
     } else {
         // When `renderLogs` is supplied the whole log stream renders as one block
-        // (e.g. a readonly editor with line numbers); the error / notices
+        // (e.g. a readonly editor with line numbers); the error / notices / DAG
         // then sit in their own scrollable strip beneath it. Otherwise the logs
         // render per-line and everything flows in one scroll surface.
         const useEditor = !!renderLogs && view.logs.length > 0;

--- a/docs/sandbox/component/output-format.test.ts
+++ b/docs/sandbox/component/output-format.test.ts
@@ -41,7 +41,7 @@ import assert from 'node:assert/strict';
     );
 }
 
-// Single node with no edges.
+// Single node with no edges. Label is method + path, NOT the name.
 {
     const trace: StitchTraceEntry[] = [
         {
@@ -53,9 +53,155 @@ import assert from 'node:assert/strict';
     ];
     const result = traceToMermaid(trace);
     assert.ok(result.includes('s1'), 'single node: id must appear');
-    assert.ok(result.includes('getUser'), 'single node: label must appear');
+    assert.ok(
+        result.includes('GET /users/1'),
+        'single node: label is method + path',
+    );
+    assert.ok(
+        !result.includes('getUser'),
+        'single node: name not used as label when a url is present',
+    );
     // No edges when there are no dependsOn.
     assert.ok(!result.includes('-->'), 'single node: no edges expected');
+}
+
+// Full-URL request → label is METHOD + pathname (host stripped).
+{
+    const trace: StitchTraceEntry[] = [
+        {
+            id: 'u2',
+            label: 'demo-api',
+            request: {
+                method: 'GET',
+                url: 'https://demo.stitchapi.dev/users/2',
+            },
+            response: { status: 200, ok: true, durationMs: 70 },
+        },
+    ];
+    const result = traceToMermaid(trace);
+    assert.ok(
+        result.includes('u2["GET /users/2"]'),
+        'full url: node labelled GET /users/2',
+    );
+    assert.ok(
+        !result.includes('demo.stitchapi.dev'),
+        'full url: host stripped from label',
+    );
+}
+
+// Bare-path request url → used as-is (new URL() would throw, so we fall back).
+{
+    const trace: StitchTraceEntry[] = [
+        {
+            id: 'u3',
+            label: 'demo-api',
+            request: { method: 'GET', url: '/users' },
+            response: { status: 200, ok: true, durationMs: 30 },
+        },
+    ];
+    const result = traceToMermaid(trace);
+    assert.ok(
+        result.includes('u3["GET /users"]'),
+        'bare path: node labelled GET /users',
+    );
+}
+
+// Sibling stitches sharing a name still get distinct labels via method + path.
+{
+    const trace: StitchTraceEntry[] = [
+        {
+            id: 'getUserById',
+            label: 'demo-api',
+            request: {
+                method: 'GET',
+                url: 'https://demo.stitchapi.dev/users/1',
+            },
+        },
+        {
+            id: 'listUsers',
+            label: 'demo-api',
+            request: { method: 'GET', url: 'https://demo.stitchapi.dev/users' },
+        },
+        {
+            id: 'authMe',
+            label: 'demo-api',
+            request: {
+                method: 'GET',
+                url: 'https://demo.stitchapi.dev/auth/me',
+            },
+        },
+    ];
+    const result = traceToMermaid(trace);
+    assert.ok(
+        result.includes('GET /users/1') &&
+            result.includes('GET /users') &&
+            result.includes('GET /auth/me'),
+        'shared name: each node labelled by its own method + path',
+    );
+}
+
+// Path-with-query → search string is preserved in the label.
+{
+    const trace: StitchTraceEntry[] = [
+        {
+            id: 'q1',
+            request: {
+                method: 'GET',
+                url: 'https://example.com/search?q=cat',
+            },
+        },
+    ];
+    const result = traceToMermaid(trace);
+    assert.ok(
+        result.includes('GET /search?q=cat'),
+        'query string: search preserved in path label',
+    );
+}
+
+// No request → label falls back to entry.label, then entry.id.
+{
+    const trace: StitchTraceEntry[] = [
+        {
+            id: 'no-req',
+            label: 'composedStep',
+        } as StitchTraceEntry,
+    ];
+    const result = traceToMermaid(trace);
+    assert.ok(
+        result.includes('composedStep'),
+        'no request: falls back to entry.label',
+    );
+}
+
+// Stream marker + dependsOn edge survive the method+path labeling.
+{
+    const trace: StitchTraceEntry[] = [
+        {
+            id: 'fetch-token',
+            label: 'auth',
+            request: { method: 'POST', url: 'https://example.com/token' },
+        },
+        {
+            id: 'chat',
+            label: 'chatStream',
+            request: { method: 'POST', url: 'https://example.com/chat' },
+            stream: { chunks: 9 },
+            dependsOn: ['fetch-token'],
+        },
+    ];
+    const result = traceToMermaid(trace);
+    assert.ok(
+        result.includes('POST /token'),
+        'stream+edge: parent labelled by method + path',
+    );
+    assert.ok(
+        result.includes('POST /chat ⟳9'),
+        'stream+edge: child labelled by method + path with stream marker',
+    );
+    assert.ok(
+        result.includes('fetch_token --> chat'),
+        'stream+edge: dependsOn edge still emitted',
+    );
 }
 
 // Two nodes with a dependsOn edge.
@@ -393,8 +539,8 @@ import assert from 'node:assert/strict';
         'A2 trace: mermaid includes new node id',
     );
     assert.ok(
-        v4.mermaid.includes('fetchUser'),
-        'A2 trace: mermaid includes node label',
+        v4.mermaid.includes('GET /users/1'),
+        'A2 trace: mermaid includes method + path node label',
     );
     // isStreaming should remain true (chunks already set it).
     assert.equal(

--- a/docs/sandbox/component/output-format.test.ts
+++ b/docs/sandbox/component/output-format.test.ts
@@ -204,6 +204,124 @@ import assert from 'node:assert/strict';
     );
 }
 
+// Retry attempts (ADR 0007) → node annotated with ↻N (collector sets it only > 1).
+{
+    const trace: StitchTraceEntry[] = [
+        {
+            id: 'flaky',
+            label: 'demo-api',
+            request: { method: 'GET', url: 'https://example.com/users' },
+            response: { status: 200, ok: true, durationMs: 120 },
+            attempts: 3,
+        },
+    ];
+    const result = traceToMermaid(trace);
+    assert.ok(
+        result.includes('GET /users ↻3'),
+        'attempts: node annotated with ↻3 retry marker',
+    );
+}
+
+// Paginate pages (ADR 0007) → node annotated with ⊞N.
+{
+    const trace: StitchTraceEntry[] = [
+        {
+            id: 'list',
+            label: 'demo-api',
+            request: { method: 'GET', url: 'https://example.com/users' },
+            response: { status: 200, ok: true, durationMs: 200 },
+            pages: 4,
+        },
+    ];
+    const result = traceToMermaid(trace);
+    assert.ok(
+        result.includes('GET /users ⊞4'),
+        'pages: node annotated with ⊞4 page marker',
+    );
+}
+
+// Stream + attempts + pages coexist on one node, in a stable order (⟳ ↻ ⊞).
+{
+    const trace: StitchTraceEntry[] = [
+        {
+            id: 'busy',
+            label: 'demo-api',
+            request: { method: 'GET', url: 'https://example.com/feed' },
+            stream: { chunks: 9 },
+            attempts: 2,
+            pages: 3,
+        },
+    ];
+    const result = traceToMermaid(trace);
+    assert.ok(
+        result.includes('GET /feed ⟳9 ↻2 ⊞3'),
+        'annotations: stream + attempts + pages render together',
+    );
+}
+
+// Shell surface (ADR 0008): a `shell:<command>` url labels as `$ <command>`,
+// NOT a fake `GET command` HTTP path (`new URL('shell:git').pathname` is 'git').
+{
+    const trace: StitchTraceEntry[] = [
+        {
+            id: 'git-status',
+            label: 'git',
+            request: { method: 'GET', url: 'shell:git' },
+            response: { status: 200, ok: true, durationMs: 12 },
+        },
+    ];
+    const result = traceToMermaid(trace);
+    assert.ok(
+        result.includes('git_status["$ git"]'),
+        'shell: node labelled `$ git`',
+    );
+    assert.ok(
+        !result.includes('GET git'),
+        'shell: NOT mislabelled as an HTTP path',
+    );
+}
+
+// pipe() chain (ADR 0007 + 0008): each step is a child run of the previous, so
+// the trace carries dependsOn = [prev] and the DAG draws stepA --> stepB --> stepC.
+{
+    const trace: StitchTraceEntry[] = [
+        {
+            id: 'step-a',
+            label: 'fetchUser',
+            request: { method: 'GET', url: 'https://example.com/users/1' },
+        },
+        {
+            id: 'step-b',
+            label: 'enrich',
+            request: { method: 'POST', url: 'https://example.com/enrich' },
+            dependsOn: ['step-a'],
+        },
+        {
+            id: 'step-c',
+            label: 'summarise',
+            request: {
+                method: 'POST',
+                url: 'https://api.anthropic.com/v1/messages',
+            },
+            dependsOn: ['step-b'],
+        },
+    ];
+    const result = traceToMermaid(trace);
+    assert.ok(
+        result.includes('step_a --> step_b'),
+        'pipe: first chain edge drawn',
+    );
+    assert.ok(
+        result.includes('step_b --> step_c'),
+        'pipe: second chain edge drawn',
+    );
+    // The llm step is HTTP, so it keeps the METHOD /path label.
+    assert.ok(
+        result.includes('POST /v1/messages'),
+        'pipe: llm step labelled by its provider endpoint path',
+    );
+}
+
 // Two nodes with a dependsOn edge.
 {
     const trace: StitchTraceEntry[] = [

--- a/docs/sandbox/component/output-format.ts
+++ b/docs/sandbox/component/output-format.ts
@@ -20,11 +20,19 @@ import type {
 
 /**
  * Build a Mermaid `flowchart TD` string from a stitch trace.
+ *
  * Nodes are labelled by HTTP method + request path (e.g. `GET /users/2`) so
  * stitches that share a `name` (e.g. siblings derived via `extends`) stay
- * distinct and readable; when the request/url is missing, the label falls back
- * to the entry's `label` (name), then its `id`.
- * Edges are derived from `StitchTraceEntry.dependsOn`.
+ * distinct and readable. A non-HTTP `shell` surface (ADR 0008) is labelled
+ * `$ <command>` instead; when no request/url is present the label falls back to
+ * the entry's `label` (name), then its `id`. Per-iteration counts are appended
+ * as node annotations (ADR 0007 Decision 6): `⟳` streamed chunks, `↻` retry
+ * attempts, `⊞` paginate pages.
+ *
+ * Edges are derived from `StitchTraceEntry.dependsOn`, which now carries REAL
+ * runtime causality — the run-identity span tree of ADR 0007 (a `cookieSession`
+ * login, or a `pipe()` step→step chain draws parent → child) — not the old
+ * synthetic FIFO heuristic.
  *
  * Deterministic: entries are iterated in their array order; node ids are
  * sanitised to safe Mermaid identifiers (replacing non-alphanumeric chars
@@ -54,19 +62,41 @@ export function traceToMermaid(trace: StitchTraceEntry[]): string {
         }
     };
 
+    // The readable label fragment for a request. Most surfaces are HTTP, so it's
+    // `METHOD /path` (the `llm` surface included — it POSTs to a provider
+    // endpoint). A `shell` surface (ADR 0008) has a `shell:<command>` pseudo-url
+    // and no HTTP method that means anything, so render it `$ <command>` —
+    // otherwise `new URL('shell:git').pathname` would mislabel a subprocess as
+    // `GET git`.
+    const requestLabel = (req: { method: string; url: string }): string =>
+        req.url.startsWith('shell:')
+            ? `$ ${req.url.slice('shell:'.length)}`
+            : `${req.method} ${urlToPath(req.url)}`;
+
     for (const entry of trace) {
         const nid = safeid(entry.id);
-        // Build a label: prefer "METHOD /path" from the request, falling back
-        // to entry.label (name), then entry.id when no usable url is present.
-        // Annotate streaming entries with a ⟳ marker.
-        const url = entry.request?.url;
+        // Build a label: prefer the request's "METHOD /path" (or "$ command"),
+        // falling back to entry.label (name), then entry.id when no usable url
+        // is present (a composed step that made no HTTP / shell call).
+        const req = entry.request;
         const baseLabel =
-            entry.request && url
-                ? `${entry.request.method} ${urlToPath(url)}`
-                : (entry.label ?? entry.id);
+            req && req.url ? requestLabel(req) : (entry.label ?? entry.id);
+        // Node annotations (ADR 0007 Decision 6): per-iteration counts ride the
+        // label exactly as the stream-chunk count does — the detailed
+        // per-attempt / per-page waterfall lives in the OTLP export, not here.
+        //   ⟳N  N streamed response chunks
+        //   ↻N  N attempts — the call was retried (present only when > 1)
+        //   ⊞N  N pages fetched by `paginate`
         const streamMarker = entry.stream ? ` ⟳${entry.stream.chunks}` : '';
+        const attemptsMarker = entry.attempts ? ` ↻${entry.attempts}` : '';
+        const pagesMarker = entry.pages ? ` ⊞${entry.pages}` : '';
         // Escape quotes inside the label so Mermaid doesn't choke.
-        const escapedLabel = (baseLabel + streamMarker).replace(/"/g, "'");
+        const escapedLabel = (
+            baseLabel +
+            streamMarker +
+            attemptsMarker +
+            pagesMarker
+        ).replace(/"/g, "'");
         lines.push(`  ${nid}["${escapedLabel}"]`);
     }
 

--- a/docs/sandbox/component/output-format.ts
+++ b/docs/sandbox/component/output-format.ts
@@ -20,7 +20,10 @@ import type {
 
 /**
  * Build a Mermaid `flowchart TD` string from a stitch trace.
- * Nodes are labelled with the entry id (and label when present).
+ * Nodes are labelled by HTTP method + request path (e.g. `GET /users/2`) so
+ * stitches that share a `name` (e.g. siblings derived via `extends`) stay
+ * distinct and readable; when the request/url is missing, the label falls back
+ * to the entry's `label` (name), then its `id`.
  * Edges are derived from `StitchTraceEntry.dependsOn`.
  *
  * Deterministic: entries are iterated in their array order; node ids are
@@ -40,11 +43,27 @@ export function traceToMermaid(trace: StitchTraceEntry[]): string {
     // Sanitise an id to a safe Mermaid node identifier.
     const safeid = (raw: string) => raw.replace(/[^A-Za-z0-9_]/g, '_');
 
+    // Reduce a request URL to its path (+ search). Full URLs are parsed; bare
+    // paths (e.g. "/users/2") are used as-is. NEVER throws.
+    const urlToPath = (url: string): string => {
+        try {
+            const u = new URL(url);
+            return u.pathname + u.search;
+        } catch {
+            return url;
+        }
+    };
+
     for (const entry of trace) {
         const nid = safeid(entry.id);
-        // Build a label: prefer entry.label, fall back to entry.id.
+        // Build a label: prefer "METHOD /path" from the request, falling back
+        // to entry.label (name), then entry.id when no usable url is present.
         // Annotate streaming entries with a ⟳ marker.
-        const baseLabel = entry.label ?? entry.id;
+        const url = entry.request?.url;
+        const baseLabel =
+            entry.request && url
+                ? `${entry.request.method} ${urlToPath(url)}`
+                : (entry.label ?? entry.id);
         const streamMarker = entry.stream ? ` ⟳${entry.stream.chunks}` : '';
         // Escape quotes inside the label so Mermaid doesn't choke.
         const escapedLabel = (baseLabel + streamMarker).replace(/"/g, "'");

--- a/docs/sandbox/package.json
+++ b/docs/sandbox/package.json
@@ -18,6 +18,7 @@
         "test:mcp": "pnpm run build:mcp && node mcp/smoke.mjs"
     },
     "dependencies": {
+        "mermaid": "^11.15.0",
         "stitchapi": "workspace:*",
         "sucrase": "^3.35.1"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
 
   docs/sandbox:
     dependencies:
+      mermaid:
+        specifier: ^11.15.0
+        version: 11.15.0
       stitchapi:
         specifier: workspace:*
         version: link:../../packages/core
@@ -204,7 +207,7 @@ importers:
         version: 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -394,7 +397,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
 packages:
 
@@ -404,6 +407,9 @@ packages:
 
   '@andrewbranch/untar.js@1.0.3':
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@arethetypeswrong/cli@0.18.3':
     resolution: {integrity: sha512-GeAlc+lUD4gKHD/LDQNvQY30FfQ+xAXg2inbQKUjFZgTOdI5ygEweaOnGHGBPSKXSLGQC7VLhpXu9zMnYk/4sQ==}
@@ -528,6 +534,12 @@ packages:
 
   '@braidai/lang@1.1.2':
     resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
+
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@codemirror/autocomplete@6.20.3':
     resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
@@ -975,6 +987,12 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -1175,6 +1193,9 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@mermaid-js/parser@1.1.1':
+    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
@@ -2110,6 +2131,99 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -2124,6 +2238,9 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -2162,6 +2279,9 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -2377,6 +2497,9 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitest/coverage-v8@4.1.8':
     resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
@@ -2726,6 +2849,14 @@ packages:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
 
@@ -2742,6 +2873,12 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
@@ -2751,6 +2888,162 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -2766,6 +3059,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -2806,6 +3102,9 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
@@ -2835,6 +3134,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dompurify@3.4.10:
+    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
 
   dotenv-expand@12.0.3:
     resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
@@ -2916,6 +3218,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.47.1:
+    resolution: {integrity: sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -3427,6 +3732,9 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
     engines: {node: '>=6'}
@@ -3507,6 +3815,10 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -3522,6 +3834,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -3536,6 +3851,13 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ioredis@5.11.1:
     resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
@@ -3769,8 +4091,15 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -3782,6 +4111,12 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lefthook-darwin-arm64@2.1.9:
     resolution: {integrity: sha512-119HryNcvr4nqn0wUIrNPgpMEPn9yMQzEcW/lezRsnb56PCJriJB92+MCySPVcWDxJnZef7o0T3jdnPNiSH7Qg==}
@@ -3938,6 +4273,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -4001,6 +4339,11 @@ packages:
     engines: {node: '>=16.0.0'}
     peerDependencies:
       marked: '>=1 <16'
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   marked@9.1.6:
     resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
@@ -4066,6 +4409,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid@11.15.0:
+    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -4352,6 +4698,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4377,6 +4726,9 @@ packages:
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -4430,6 +4782,12 @@ packages:
   plur@4.0.0:
     resolution: {integrity: sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==}
     engines: {node: '>=10'}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4654,6 +5012,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4664,8 +5025,14 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -4681,6 +5048,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -4871,6 +5241,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -4958,6 +5331,10 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -5146,6 +5523,10 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
 
   valibot@1.4.1:
     resolution: {integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==}
@@ -5338,6 +5719,11 @@ snapshots:
 
   '@andrewbranch/untar.js@1.0.3': {}
 
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.2.4
+
   '@arethetypeswrong/cli@0.18.3':
     dependencies:
       '@arethetypeswrong/core': 0.18.3
@@ -5515,6 +5901,10 @@ snapshots:
   '@borewit/text-codec@0.2.2': {}
 
   '@braidai/lang@1.1.2': {}
+
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/types@11.1.2': {}
 
   '@codemirror/autocomplete@6.20.3':
     dependencies:
@@ -5845,6 +6235,14 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -6020,6 +6418,10 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@mermaid-js/parser@1.1.1':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -6776,6 +7178,123 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -6792,6 +7311,8 @@ snapshots:
       '@types/estree': 1.0.9
 
   '@types/estree@1.0.9': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -6828,6 +7349,9 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/unist@2.0.11': {}
 
@@ -7109,6 +7633,11 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
   '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -7121,7 +7650,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
 
   '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.8)':
     dependencies:
@@ -7131,7 +7660,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
     transitivePeerDependencies:
       - supports-color
 
@@ -7483,6 +8012,10 @@ snapshots:
 
   commander@4.1.1: {}
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   compute-scroll-into-view@3.1.1: {}
 
   concat-map@0.0.1: {}
@@ -7493,6 +8026,14 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   crelt@1.0.6: {}
 
   cross-spawn@7.0.6:
@@ -7502,6 +8043,190 @@ snapshots:
       which: 2.0.2
 
   csstype@3.2.3: {}
+
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
 
   damerau-levenshtein@1.0.8: {}
 
@@ -7522,6 +8247,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  dayjs@1.11.21: {}
 
   debug@3.2.7:
     dependencies:
@@ -7556,6 +8283,10 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
   denque@2.1.0: {}
 
   dequal@2.0.3: {}
@@ -7577,6 +8308,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dompurify@3.4.10:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv-expand@12.0.3:
     dependencies:
@@ -7720,6 +8455,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.47.1: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -8376,6 +9113,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  hachure-fill@0.5.2: {}
+
   hard-rejection@2.1.0: {}
 
   has-bigints@1.1.0: {}
@@ -8526,6 +9265,10 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -8536,6 +9279,8 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
 
@@ -8548,6 +9293,10 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.1
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   ioredis@5.11.1:
     dependencies:
@@ -8772,9 +9521,15 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  khroma@2.1.0: {}
 
   kind-of@6.0.3: {}
 
@@ -8783,6 +9538,10 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lefthook-darwin-arm64@2.1.9:
     optional: true
@@ -8897,6 +9656,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1: {}
+
   lodash.merge@4.6.2: {}
 
   lodash@4.18.1: {}
@@ -8958,6 +9719,8 @@ snapshots:
       marked: 9.1.6
       node-emoji: 2.2.0
       supports-hyperlinks: 3.2.0
+
+  marked@16.4.2: {}
 
   marked@9.1.6: {}
 
@@ -9142,6 +9905,30 @@ snapshots:
       yargs-parser: 20.2.9
 
   merge2@1.4.1: {}
+
+  mermaid@11.15.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.3
+      '@mermaid-js/parser': 1.1.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.10
+      es-toolkit: 1.47.1
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.0
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -9610,6 +10397,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-manager-detector@1.6.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -9644,6 +10433,8 @@ snapshots:
       entities: 6.0.1
 
   path-browserify@1.0.1: {}
+
+  path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
 
@@ -9682,6 +10473,13 @@ snapshots:
   plur@4.0.0:
     dependencies:
       irregular-plurals: 3.5.0
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   possible-typed-array-names@1.1.0: {}
 
@@ -9953,6 +10751,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  robust-predicates@3.0.3: {}
+
   rolldown@1.0.3:
     dependencies:
       '@oxc-project/types': 0.133.0
@@ -10005,9 +10805,18 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.61.1
       fsevents: 2.3.3
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   rxjs@7.8.2:
     dependencies:
@@ -10031,6 +10840,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
 
   scheduler@0.27.0: {}
 
@@ -10281,6 +11092,8 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.7
 
+  stylis@4.4.0: {}
+
   sucrase@3.35.1:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -10361,6 +11174,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
+
+  ts-dedent@2.3.0: {}
 
   ts-interface-checker@0.1.13: {}
 
@@ -10619,6 +11434,8 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.17
+
+  uuid@14.0.0: {}
 
   valibot@1.4.1(typescript@5.9.3):
     optionalDependencies:


### PR DESCRIPTION
## What & why

PR #95 removed the playground's trace-DAG panel because it only ever dumped raw Mermaid **source** as text — and explicitly left `traceToMermaid` + the trace collector in place "so the trace plumbing can back a **future, properly-rendered visualisation**." **This is that visualisation** — now rendering on top of trace data that didn't exist when this PR was first opened.

The panel returns as an inline **SVG**, wired to the run-identity span tree from **ADR 0007** (#163) and the new surfaces / `pipe()` from **ADR 0008** (#165): real causality edges, per-iteration annotations, and non-HTTP node labels.

| Before (#95 on main) | After (this PR) |
|---|---|
| no DAG panel | rendered **SVG** flowchart |
| — | `GET /users/2`, `GET /auth/me`, `$ git`, `POST /v1/messages` |
| — | real edges: `login → call`, `stepA → stepB` (pipe) |
| — | annotations: `⟳9` chunks · `↻3` retries · `⊞4` pages |

## Changes

- **Re-introduce + render the panel** (`StitchPlayground.tsx`, `playground.css`): a `MermaidDiagram` component lazily `import('mermaid')`s inside an effect (SSR-safe, off the initial bundle), renders to SVG, follows the docs light/dark theme, and falls back to the raw string in-place on a parse failure. Restores the panel + CSS #95 removed, and the DAG mentions in the `StitchOutput` doc comments.
- **Labels** (`output-format.ts`): `METHOD /path` from the trace's request data. A non-HTTP **`shell`** surface (ADR 0008) has a `shell:<command>` pseudo-url → labelled **`$ <command>`** rather than a fake `GET command` path; the **`llm`** surface stays HTTP (`POST /v1/messages`). Name/id fallback unchanged.
- **Edges are now REAL causality** (ADR 0007): `StitchTraceEntry.dependsOn` carries the parent **run id**, so a `cookieSession` **login → call** and a `pipe()` **stepA → stepB → stepC** chain draw as parent → child edges. The collector on main already populates this; the renderer just draws it.
- **Node annotations** (ADR 0007 Decision 6): `↻N` retry attempts and `⊞N` paginate pages, alongside the existing `⟳N` stream-chunk marker.
- **Dep**: `mermaid@11` added to `@stitchapi/sandbox`.
- **Tests** (`output-format.test.ts`): full-URL / bare-path / query labels, name/id fallback, **shell `$ command`**, **attempt/page annotations**, a **`pipe()` chain** drawing both edges, and stream-marker + edge interplay.

## What changed in this revision

The first version of this PR said dependency edges were **"deliberately not in scope … the runtime trace emits no composition graph."** **ADR 0007 changed exactly that** — there is now a run-identity span tree, so the edges are honest and ship here. The only remaining follow-up is the **static `extends` derivation** overlay (which fragment a stitch was composed from) — a different axis the runtime collector can't see, scoped out by ADR 0007 Q4; `docs/IDEAS.md` is updated accordingly.

> Rebased onto current `main` (was 54 behind). The trace **collector** + `StitchTraceEntry` already carry ADR 0007's `dependsOn` / `attempts` / `pages` — this PR is the renderer + panel that consume them.

## Verification

- `pnpm --filter docs check:types` — **0 errors**; full pre-push gate green (**format · lint · typecheck · typecheck-d · test · exports · build-docs**).
- `output-format` tests (tsx): labels, annotations, shell, pipe chain — **all pass**.
- In-browser (`/playground`): panel renders as **SVG** (no text fallback, no console errors); with the **Flaky** knob the nodes annotate live — `GET /users ↻3` (1 + 2 retries, run recovers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
