### PR TITLE
feat(adapter): streaming body + onProgress contract; fetch streaming/progress + xhrAdapter (ADR 0005 Decision 9, Stage 2)

### DIFF
--- a/packages/core/src/axios-adapter.ts
+++ b/packages/core/src/axios-adapter.ts
@@ -44,6 +44,14 @@ export function axiosAdapter(
     return async function axiosAdapterRequest(
         req: AdapterRequest,
     ): Promise<AdapterResponse> {
+        // Buffered-only transport (ADR 0005 Decision 9): a streaming surface must use
+        // fetchAdapter. Fail loudly rather than silently buffering a stream. `onProgress` is
+        // simply ignored (not wired) — axios stays the zero-config buffered option.
+        if (req.stream) {
+            throw new Error(
+                'axiosAdapter does not support streaming responses; use fetchAdapter for `stream`.',
+            );
+        }
         const headers: Record<string, string> = {
             ...defaults.headers,
             ...req.headers,

--- a/packages/core/src/http-adapter.ts
+++ b/packages/core/src/http-adapter.ts
@@ -1,5 +1,6 @@
 import type {
     Adapter,
+    AdapterProgress,
     AdapterRequest,
     AdapterResponse,
     MultipartNesting,
@@ -49,6 +50,28 @@ export function fetchAdapter(): Adapter {
             }
         }
 
+        // Streaming surfaces (sse/stream) ask for the live body: hand back the ReadableStream
+        // unparsed (ADR 0005 Q1 — `body` carries the stream when `req.stream` is set).
+        if (req.stream) {
+            return {
+                status: response.status,
+                headers: resHeaders,
+                body: response.body,
+            };
+        }
+
+        // Download progress: read the body in chunks, reporting bytes as they arrive, then
+        // decode the assembled bytes exactly as the buffered path would (ADR 0005 Decision 9).
+        if (req.onProgress) {
+            const bytes = await readWithProgress(response, req.onProgress);
+            const contentType = resHeaders['content-type'] ?? '';
+            return {
+                status: response.status,
+                headers: resHeaders,
+                body: decodeResponseBody(req.responseType, contentType, bytes),
+            };
+        }
+
         // Read the body. An explicit responseType wins (arrayBuffer/blob for binary
         // downloads, text/json to force a shape); otherwise auto-detect by content-type.
         let parsed: unknown;
@@ -77,6 +100,47 @@ export function fetchAdapter(): Adapter {
 
         return { status: response.status, headers: resHeaders, body: parsed };
     };
+}
+
+// Read a response body to completion, reporting download progress per chunk (ADR 0005
+// Decision 9). Returns the full bytes so the caller decodes them per responseType — the same
+// `decodeResponseBody` the buffered path uses, so a progress read parses identically.
+async function readWithProgress(
+    response: Response,
+    onProgress: (p: AdapterProgress) => void,
+): Promise<ArrayBuffer> {
+    const lenHeader = response.headers.get('content-length');
+    const parsedLen = lenHeader != null ? Number(lenHeader) : NaN;
+    const total = Number.isFinite(parsedLen) ? parsedLen : undefined;
+    const reader = response.body?.getReader();
+    if (!reader) {
+        onProgress(
+            total !== undefined
+                ? { phase: 'download', loaded: 0, total }
+                : { phase: 'download', loaded: 0 },
+        );
+        return new ArrayBuffer(0);
+    }
+    const chunks: Uint8Array[] = [];
+    let loaded = 0;
+    for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+        loaded += value.byteLength;
+        onProgress(
+            total !== undefined
+                ? { phase: 'download', loaded, total }
+                : { phase: 'download', loaded },
+        );
+    }
+    const out = new Uint8Array(loaded);
+    let offset = 0;
+    for (const c of chunks) {
+        out.set(c, offset);
+        offset += c.byteLength;
+    }
+    return out.buffer;
 }
 
 const hasHeader = (headers: Record<string, string>, name: string): boolean =>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,8 @@ export type {
     AxiosLikeConfig,
     AxiosLikeResponse,
 } from './axios-adapter';
+export { xhrAdapter } from './xhr-adapter';
+export type { XhrLike, XhrLikeCtor, XhrProgress } from './xhr-adapter';
 export { createTrace, consoleSink, fileSink, multiplex } from './trace';
 export { otlpTrace, otlpHttpExporter, toOtlpJson } from './otlp';
 export type {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -58,6 +58,16 @@ export interface MultipartOptions {
     /** Nesting strategy for nested objects/arrays in a multipart body. Default `'bracket'`. */
     nesting?: MultipartNesting;
 }
+/**
+ * Byte-transfer progress for a single request (ADR 0005 Decision 9). Reported through
+ * {@link AdapterRequest.onProgress}, tagged by direction: `'upload'` as the request body is
+ * sent, `'download'` as the response body arrives. `total` is the content length when known.
+ */
+export interface AdapterProgress {
+    phase: 'upload' | 'download';
+    loaded: number;
+    total?: number;
+}
 export interface AdapterRequest {
     url: string;
     method: string;
@@ -67,12 +77,26 @@ export interface AdapterRequest {
     /** Multipart serialisation options (nesting); only read when `bodyType: 'multipart'`. */
     multipart?: MultipartOptions;
     responseType?: ResponseType;
+    /**
+     * Ask the transport NOT to buffer/parse the response — hand back the live body instead
+     * (ADR 0005 Decision 9 / Q1). When set, {@link AdapterResponse.body} is a
+     * `ReadableStream<Uint8Array>`. Only `fetch` honours it; buffered-only adapters (axios, xhr)
+     * reject the request.
+     */
+    stream?: boolean;
+    /**
+     * Byte-progress callback (ADR 0005 Decision 9). Fires with `phase: 'download'` as the
+     * response is read, and `phase: 'upload'` as the request body is sent (upload progress needs
+     * `xhrAdapter` — `fetch` cannot report it). Orthogonal to {@link AdapterRequest.stream}.
+     */
+    onProgress?: (progress: AdapterProgress) => void;
     signal?: AbortSignal;
 }
 export interface AdapterResponse {
     status: number;
     headers: Record<string, string>;
-    body: unknown; // parsed JSON when possible, else text
+    // Parsed JSON when possible, else text — OR a `ReadableStream<Uint8Array>` when `stream` was set.
+    body: unknown;
 }
 export type Adapter = (req: AdapterRequest) => Promise<AdapterResponse>;
 

--- a/packages/core/src/xhr-adapter.ts
+++ b/packages/core/src/xhr-adapter.ts
@@ -1,0 +1,150 @@
+// A browser-only Adapter backed by XMLHttpRequest. Its reason to exist over fetchAdapter is
+// UPLOAD progress: `fetch` cannot report bytes sent, but `xhr.upload` can (ADR 0005 Decision 9).
+// Zero-dependency; it reuses the shared body-encoding / response-decoding helpers so its wire
+// behaviour matches fetchAdapter exactly. It is buffered-only — it rejects `req.stream` (use
+// fetchAdapter to stream). Like axiosAdapter takes its client, this takes an optional XHR
+// constructor (default `globalThis.XMLHttpRequest`) so it is testable off-browser.
+import { decodeResponseBody, encodeRequestBody } from './http-adapter';
+import type { Adapter, AdapterRequest, AdapterResponse } from './types';
+
+/** The byte-progress shape XHR emits (a structural subset of the DOM `ProgressEvent`). */
+export interface XhrProgress {
+    lengthComputable: boolean;
+    loaded: number;
+    total: number;
+}
+
+/** The minimal surface of an XMLHttpRequest the adapter needs — structurally satisfied by the
+ *  browser global. Mirrors the `AxiosLike` pattern so the transport stays dependency-injectable. */
+export interface XhrLike {
+    responseType: string;
+    readonly status: number;
+    readonly response: unknown;
+    readonly upload: { onprogress: ((e: XhrProgress) => void) | null };
+    onload: (() => void) | null;
+    onerror: (() => void) | null;
+    onabort: (() => void) | null;
+    onprogress: ((e: XhrProgress) => void) | null;
+    open(method: string, url: string, async: boolean): void;
+    setRequestHeader(name: string, value: string): void;
+    getAllResponseHeaders(): string;
+    send(body: string | FormData | null): void;
+    abort(): void;
+}
+export type XhrLikeCtor = new () => XhrLike;
+
+/**
+ * Wrap `XMLHttpRequest` as a stitch {@link Adapter} with upload + download progress. Pass a
+ * constructor to inject a custom/fake XHR (testing, non-browser polyfills); defaults to the
+ * browser global. Throws if no constructor is available, and rejects `stream` (buffered-only).
+ */
+export function xhrAdapter(XHR?: XhrLikeCtor): Adapter {
+    return function xhrAdapterRequest(
+        req: AdapterRequest,
+    ): Promise<AdapterResponse> {
+        if (req.stream) {
+            return Promise.reject(
+                new Error(
+                    'xhrAdapter does not support streaming responses; use fetchAdapter for `stream`.',
+                ),
+            );
+        }
+        const Ctor =
+            XHR ?? (globalThis.XMLHttpRequest as XhrLikeCtor | undefined);
+        if (!Ctor) {
+            return Promise.reject(
+                new Error(
+                    'xhrAdapter requires XMLHttpRequest (browser only). Pass a constructor for other runtimes.',
+                ),
+            );
+        }
+
+        return new Promise<AdapterResponse>((resolve, reject) => {
+            const xhr = new Ctor();
+            xhr.open(req.method.toUpperCase(), req.url, true);
+            xhr.responseType = 'arraybuffer';
+
+            // Encode the body with the shared helper so json/form/multipart match fetchAdapter.
+            const { body, contentType } = encodeRequestBody(req);
+            const headers = { ...req.headers };
+            if (contentType && !hasHeader(headers, 'content-type'))
+                headers['content-type'] = contentType;
+            for (const [k, v] of Object.entries(headers))
+                xhr.setRequestHeader(k, v);
+
+            const onProgress = req.onProgress;
+            if (onProgress) {
+                xhr.upload.onprogress = (e) => {
+                    onProgress(
+                        e.lengthComputable
+                            ? {
+                                  phase: 'upload',
+                                  loaded: e.loaded,
+                                  total: e.total,
+                              }
+                            : { phase: 'upload', loaded: e.loaded },
+                    );
+                };
+                xhr.onprogress = (e) => {
+                    onProgress(
+                        e.lengthComputable
+                            ? {
+                                  phase: 'download',
+                                  loaded: e.loaded,
+                                  total: e.total,
+                              }
+                            : { phase: 'download', loaded: e.loaded },
+                    );
+                };
+            }
+
+            xhr.onload = () => {
+                const resHeaders = parseHeaders(xhr.getAllResponseHeaders());
+                const contentTypeResp = resHeaders['content-type'] ?? '';
+                const bytes =
+                    (xhr.response as ArrayBuffer | null) ?? new ArrayBuffer(0);
+                resolve({
+                    status: xhr.status,
+                    headers: resHeaders,
+                    body: decodeResponseBody(
+                        req.responseType,
+                        contentTypeResp,
+                        bytes,
+                    ),
+                });
+            };
+            xhr.onerror = () => {
+                reject(new Error('xhrAdapter: network error'));
+            };
+            xhr.onabort = () => {
+                reject(new Error('xhrAdapter: aborted'));
+            };
+
+            if (req.signal) {
+                if (req.signal.aborted) xhr.abort();
+                else
+                    req.signal.addEventListener('abort', () => {
+                        xhr.abort();
+                    });
+            }
+
+            xhr.send(body ?? null);
+        });
+    };
+}
+
+const hasHeader = (headers: Record<string, string>, name: string): boolean =>
+    Object.keys(headers).some((k) => k.toLowerCase() === name.toLowerCase());
+
+// Parse the raw CRLF-joined header block from getAllResponseHeaders() into a lowercased map.
+function parseHeaders(raw: string): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const line of raw.trim().split(/[\r\n]+/)) {
+        const idx = line.indexOf(':');
+        if (idx === -1) continue;
+        out[line.slice(0, idx).trim().toLowerCase()] = line
+            .slice(idx + 1)
+            .trim();
+    }
+    return out;
+}

--- a/packages/core/test/adapter-streaming.spec.ts
+++ b/packages/core/test/adapter-streaming.spec.ts
@@ -1,0 +1,121 @@
+// Adapter contract extension (ADR 0005 Decision 9): a streaming response body + byte-progress.
+// fetchAdapter returns the live ReadableStream when `stream` is set, and reports download
+// progress (then decodes as usual) when `onProgress` is set. axios stays buffered-only and
+// throws on `stream`.
+import { axiosAdapter, fetchAdapter } from '../src';
+import type { AdapterProgress } from '../src/types';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+    const reader = stream.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+        total += value.byteLength;
+    }
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const c of chunks) {
+        out.set(c, offset);
+        offset += c.byteLength;
+    }
+    return out;
+}
+
+describe('fetchAdapter streaming (ADR 0005 Decision 9)', () => {
+    test('stream:true hands back the live ReadableStream body, unparsed', async () => {
+        server.route('GET', '/s', { body: { hello: 'world' } });
+
+        const res = await fetchAdapter()({
+            url: server.url + '/s',
+            method: 'GET',
+            headers: {},
+            stream: true,
+        });
+
+        expect(res.body).toBeInstanceOf(ReadableStream);
+        const bytes = await drain(res.body as ReadableStream<Uint8Array>);
+        expect(JSON.parse(new TextDecoder().decode(bytes))).toEqual({
+            hello: 'world',
+        });
+    });
+
+    test('onProgress reports download bytes (total from content-length); body still decodes', async () => {
+        const payload = { items: Array.from({ length: 50 }, (_, i) => i) };
+        const len = new TextEncoder().encode(JSON.stringify(payload)).length;
+        // pin a content-length so the `total` path is exercised (the mock server is otherwise chunked)
+        server.route('GET', '/d', {
+            body: payload,
+            headers: { 'content-length': String(len) },
+        });
+
+        const events: AdapterProgress[] = [];
+        const res = await fetchAdapter()({
+            url: server.url + '/d',
+            method: 'GET',
+            headers: {},
+            onProgress: (p) => events.push(p),
+        });
+
+        // buffered path: the body is still decoded to JSON
+        expect(res.body).toEqual(payload);
+        expect(events.length).toBeGreaterThan(0);
+        expect(events.every((e) => e.phase === 'download')).toBe(true);
+        const last = events[events.length - 1];
+        expect(last?.loaded).toBe(len);
+        expect(last?.total).toBe(len);
+    });
+
+    test('onProgress still reports loaded when content-length is absent (chunked)', async () => {
+        server.route('GET', '/c', { body: { ok: true } });
+
+        const events: AdapterProgress[] = [];
+        await fetchAdapter()({
+            url: server.url + '/c',
+            method: 'GET',
+            headers: {},
+            onProgress: (p) => events.push(p),
+        });
+
+        expect(events.length).toBeGreaterThan(0);
+        const last = events[events.length - 1];
+        expect(last?.phase).toBe('download');
+        expect(last?.loaded).toBeGreaterThan(0);
+        expect(last?.total).toBeUndefined(); // omitted, never guessed
+    });
+});
+
+describe('axiosAdapter rejects streaming (ADR 0005 Decision 9)', () => {
+    test('throws a clear error when stream:true is requested', async () => {
+        const client = {
+            request: async () => ({
+                status: 200,
+                headers: {},
+                data: new ArrayBuffer(0),
+            }),
+        };
+        await expect(
+            axiosAdapter(client)({
+                url: 'http://h/x',
+                method: 'GET',
+                headers: {},
+                stream: true,
+            }),
+        ).rejects.toThrow(/stream/i);
+    });
+});

--- a/packages/core/test/xhr-adapter.spec.ts
+++ b/packages/core/test/xhr-adapter.spec.ts
@@ -1,0 +1,144 @@
+// The xhrAdapter (ADR 0005 Decision 9): a browser-only, zero-dep Adapter whose reason to exist
+// over fetchAdapter is UPLOAD progress (fetch can't report bytes sent). Driven here by an
+// injected fake XMLHttpRequest, since vitest runs in node (no XMLHttpRequest global).
+import { xhrAdapter } from '../src';
+import type { AdapterProgress } from '../src/types';
+import type { XhrLikeCtor, XhrProgress } from '../src/xhr-adapter';
+
+// A minimal fake XMLHttpRequest: records open/headers/body, then on `send` fires upload
+// progress, download progress, and onload with a scripted arraybuffer response.
+class FakeXHR {
+    static last: FakeXHR | undefined;
+    static script: { status: number; headers: string; body: ArrayBuffer } = {
+        status: 200,
+        headers: 'content-type: application/json\r\n',
+        body: new ArrayBuffer(0),
+    };
+
+    method = '';
+    url = '';
+    sent: unknown;
+    responseType = '';
+    requestHeaders: Record<string, string> = {};
+    status = 0;
+    response: unknown = null;
+    upload = { onprogress: null as ((e: XhrProgress) => void) | null };
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    onabort: (() => void) | null = null;
+    onprogress: ((e: XhrProgress) => void) | null = null;
+
+    constructor() {
+        FakeXHR.last = this;
+    }
+    open(method: string, url: string): void {
+        this.method = method;
+        this.url = url;
+    }
+    setRequestHeader(name: string, value: string): void {
+        this.requestHeaders[name.toLowerCase()] = value;
+    }
+    getAllResponseHeaders(): string {
+        return FakeXHR.script.headers;
+    }
+    abort(): void {
+        this.onabort?.();
+    }
+    send(body: string | FormData | null): void {
+        this.sent = body;
+        queueMicrotask(() => {
+            this.upload.onprogress?.({
+                lengthComputable: true,
+                loaded: 5,
+                total: 10,
+            });
+            this.upload.onprogress?.({
+                lengthComputable: true,
+                loaded: 10,
+                total: 10,
+            });
+            this.onprogress?.({ lengthComputable: true, loaded: 8, total: 16 });
+            this.onprogress?.({
+                lengthComputable: true,
+                loaded: 16,
+                total: 16,
+            });
+            this.status = FakeXHR.script.status;
+            this.response = FakeXHR.script.body;
+            this.onload?.();
+        });
+    }
+}
+
+const asCtor = FakeXHR as unknown as XhrLikeCtor;
+const jsonBody = (obj: unknown): ArrayBuffer =>
+    new TextEncoder().encode(JSON.stringify(obj)).buffer;
+
+describe('xhrAdapter (ADR 0005 Decision 9)', () => {
+    beforeEach(() => {
+        FakeXHR.last = undefined;
+    });
+
+    test('reports upload AND download progress, tagged by phase (upload first)', async () => {
+        FakeXHR.script = {
+            status: 200,
+            headers: 'content-type: application/json\r\n',
+            body: jsonBody({ ok: true }),
+        };
+        const events: AdapterProgress[] = [];
+
+        const res = await xhrAdapter(asCtor)({
+            url: 'http://h/u',
+            method: 'POST',
+            headers: {},
+            bodyType: 'json',
+            body: { a: 1 },
+            onProgress: (p) => events.push(p),
+        });
+
+        expect(res).toEqual({
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+            body: { ok: true },
+        });
+        const phases = events.map((e) => e.phase);
+        expect(phases).toContain('upload');
+        expect(phases).toContain('download');
+        expect(phases.indexOf('upload')).toBeLessThan(
+            phases.indexOf('download'),
+        );
+        // upload progress carries byte counts (the whole point of this adapter)
+        expect(events.find((e) => e.phase === 'upload')).toMatchObject({
+            loaded: 5,
+            total: 10,
+        });
+    });
+
+    test('encodes the request body via the shared helper + sets content-type', async () => {
+        FakeXHR.script = { status: 200, headers: '', body: jsonBody({}) };
+
+        await xhrAdapter(asCtor)({
+            url: 'http://h/u',
+            method: 'POST',
+            headers: {},
+            bodyType: 'json',
+            body: { a: 1 },
+        });
+
+        expect(FakeXHR.last?.sent).toBe(JSON.stringify({ a: 1 }));
+        expect(FakeXHR.last?.requestHeaders['content-type']).toBe(
+            'application/json',
+        );
+    });
+
+    test('rejects streaming (buffered-only transport)', async () => {
+        await expect(
+            xhrAdapter(asCtor)({
+                url: 'http://h/u',
+                method: 'GET',
+                headers: {},
+                stream: true,
+            }),
+        ).rejects.toThrow(/stream/i);
+    });
+});


### PR DESCRIPTION
**Stage 2** of the surfaces rollout ([ADR 0005](https://github.com/rejifald/StitchAPI/blob/main/docs/adr/0005-surfaces-and-the-authoring-model.md) Decision 9). Off latest `main`. The transport widening every streaming/progress surface (Stages 5/6) will ride on.

### Contract (`types.ts`)
- `AdapterRequest.stream?: boolean` — ask the transport **not** to buffer; return the live body.
- `AdapterRequest.onProgress?: (p: AdapterProgress) => void` where `AdapterProgress = { phase: 'upload' | 'download'; loaded; total? }` — **one callback tagged by direction** (the spelling ratified in review).
- `AdapterResponse.body` is **reused** as the stream slot (already `unknown`): a `ReadableStream<Uint8Array>` when `stream` was set, else the parsed value. No new field, no type break (Stage 0 Q1).

### Adapters
| adapter | `stream` | download progress | upload progress |
|---|---|---|---|
| `fetchAdapter` | ✅ returns `response.body` | ✅ chunked read → `decodeResponseBody` | ❌ (fetch can't) |
| **`xhrAdapter`** *(new, zero-dep, browser-only)* | ❌ rejects | ✅ | ✅ `xhr.upload` |
| `axiosAdapter` | ❌ throws clearly | ❌ (ignored) | ❌ (ignored) |

- **fetch**: streaming returns the raw `ReadableStream`; progress reads in chunks then decodes via the **shared** `decodeResponseBody` so a progress read parses identically. `total` comes from `content-length` and is **omitted when absent** (chunked) — never guessed.
- **xhr** (`src/xhr-adapter.ts`): exists **for upload progress** — the only browser-native way to observe bytes sent. Takes an optional XHR constructor (default the browser global) so it's dependency-injectable for tests, mirroring `axiosAdapter`'s client. Reuses `encodeRequestBody`/`decodeResponseBody`.
- **axios "compile-check"**: axios stays buffered-only — it **throws** on `stream` (no silent buffering) and ignores `onProgress`, and **compiles unchanged** against the widened contract (the new fields are optional). That type guarantee is the "compile-check."

### Gates
- **Browser-first:** `fetch` + Web Streams; `xhr` is browser-native; no Node deps, no `fs`.
- **Bundle-frugal:** `xhrAdapter` is its own tree-shakeable module; no new deps. (The dedicated `./xhr` subpath export is Stage 7.)
- **Contract-not-dependency:** runtime adapter contract only — no `__config` serialization surface here.

### Verification
RED → green TDD. `adapter-streaming.spec.ts` (fetch stream + download progress incl. the no-content-length path; axios rejects stream) and `xhr-adapter.spec.ts` (upload + download progress via injected fake XHR; shared body encoding; rejects stream). Full core suite (288), typecheck (src + test, incl. axios compile-check), eslint, prettier — all green.

Stops here per the staged plan; Stage 3 (the `Surface` plugin model) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)