### PR TITLE
feat(core): Surface plugin model — kind is a pluggable surface (ADR 0005 Decisions 1-3,10,11; Stage 3)

### DIFF
--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -137,7 +137,7 @@ const resolveStr = (v: string | (() => string) | undefined): string =>
     typeof v === 'function' ? v() : (v ?? '');
 
 function buildRequest(cfg: StitchConfig, input: StitchInput): AdapterRequest {
-    const isGql = cfg.kind === 'graphql';
+    const isGql = cfg.kind?.id === 'graphql';
     // Endpoint resolution: when `url` is set it IS the whole endpoint (no base), but still
     // templated + query-split like a path. Otherwise join `baseUrl` + `path`.
     const usingUrl = cfg.url !== undefined;
@@ -575,7 +575,7 @@ async function* paginated(
         lastStatus = res.status;
 
         // GraphQL: a 200 response carrying `errors` is a failure — same as the non-paginated path.
-        if (cfg.kind === 'graphql') {
+        if (cfg.kind?.id === 'graphql') {
             const body = res.body as
                 | { errors?: { message?: string }[] }
                 | null
@@ -702,7 +702,7 @@ function describe(
         url: baseReq.url,
         headers: baseReq.headers,
     };
-    if (cfg.kind === 'graphql')
+    if (cfg.kind?.id === 'graphql')
         d.graphql = {
             query: cfg.query ?? '',
             variables: input.variables ?? input.body ?? {},
@@ -764,7 +764,7 @@ async function* runFrom(
     }
 
     // GraphQL: a 200 response carrying `errors` is a failure.
-    if (cfg.kind === 'graphql') {
+    if (cfg.kind?.id === 'graphql') {
         const errs = (res.body as { errors?: { message?: string }[] })?.errors;
         if (errs?.length) {
             yield {

--- a/packages/core/src/graphql.ts
+++ b/packages/core/src/graphql.ts
@@ -1,0 +1,37 @@
+// The `stitchapi/graphql` surface subpath (ADR 0005 Decisions 3, 10): the graphql surface's
+// monomorphic authoring helpers. `graphql(config)` stays the terse callable form; `graphql.stitch`
+// is its alias, `graphql.seam(...)` binds graphql members to a seam, and `graphql.surface` is the
+// Surface identity. The seam stays surface-agnostic — graphql members are created through the
+// seam's own `graphql()` method (in Stage 4 graphql's shaping/unwrap move behind the surface
+// hooks; today they ride the engine's id-keyed handling + this helper).
+import { seam as makeSeam } from './seam';
+import { graphql as graphqlStitch } from './stitch';
+import { graphqlSurface } from './surface';
+import { isSeam } from './types';
+import type { Seam, SeamOptions } from './types';
+
+/** graphql members bound to a seam. `stitch(config)` creates a graphql member of `seam`; `seam`
+ *  is the underlying handle for lifecycle/principal (`.as`/`.flush`/`.close`). */
+export interface GraphqlSeamApi {
+    readonly stitch: Seam['graphql'];
+    readonly seam: Seam;
+}
+
+const bind = (s: Seam): GraphqlSeamApi => ({
+    stitch: s.graphql.bind(s),
+    seam: s,
+});
+
+/**
+ * The graphql surface's authoring helper — callable for the terse form (`graphql(config)`) plus:
+ * - `graphql.stitch(config)` — a standalone graphql stitch (alias of the callable).
+ * - `graphql.seam(existingSeam)` — bind graphql members to an existing seam.
+ * - `graphql.seam(options)` — a new seam whose members default to graphql.
+ * - `graphql.surface` — the graphql {@link Surface} identity.
+ */
+export const graphql = Object.assign(graphqlStitch, {
+    surface: graphqlSurface,
+    stitch: graphqlStitch,
+    seam: (arg: Seam | SeamOptions): GraphqlSeamApi =>
+        bind(isSeam(arg) ? arg : makeSeam(arg)),
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,8 @@
-export { stitch, drift, graphql } from './stitch';
+export { stitch, drift } from './stitch';
+export { graphql } from './graphql';
 export { seam } from './seam';
+export { httpSurface, graphqlSurface } from './surface';
+export type { Surface, SurfaceOutcome } from './surface';
 export {
     bearer,
     apiKey,

--- a/packages/core/src/seam.ts
+++ b/packages/core/src/seam.ts
@@ -18,6 +18,7 @@ import {
     memoryStore,
     vaultView,
 } from './store';
+import { graphqlSurface } from './surface';
 import type {
     PrincipalSeam,
     Seam,
@@ -89,7 +90,7 @@ function makeBuild(shared: SharedSeam, principal: string | undefined) {
             extends: [shared.fragment, ...(own.extends ?? [])],
         };
         if (isGql) {
-            cfg.kind = 'graphql';
+            cfg.kind = graphqlSurface;
             cfg.method = 'POST';
             cfg.unwrap = own.unwrap ?? 'data';
         }

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -14,6 +14,7 @@ import type { InferOutput, InputOf, ResolveOutput } from './infer';
 import { otlpTrace } from './otlp';
 import { createThrottle } from './resilience';
 import { createStoreThrottle, memoryStore } from './store';
+import { graphqlSurface } from './surface';
 import { consoleSink, createTrace, exportsFromEnv, multiplex } from './trace';
 import {
     type DriftOptions,
@@ -109,14 +110,19 @@ export function compose(config: Fragment): StitchConfig {
     let merged: Partial<StitchConfig> = {};
     const hookLayers: Hooks[] = [];
     let store: StitchStore | undefined;
+    let kind: StitchConfig['kind'];
     for (const layer of layers) {
         if (layer.hooks) hookLayers.push(layer.hooks);
         if (layer.store) store = layer.store;
-        // hooks/store are accumulated above; strip them so deepMerge only folds the rest
+        // The surface is an atomic value (last-writer-wins), never deep-merged — merging two
+        // Surface objects would corrupt their hooks/identity (ADR 0005 Decision 2).
+        if (layer.kind) kind = layer.kind;
+        // hooks/store/kind are accumulated above; strip them so deepMerge only folds the rest
         // (exactOptionalPropertyTypes forbids spreading them back in as `undefined`).
         const rest = { ...layer };
         delete rest.hooks;
         delete rest.store;
+        delete rest.kind;
         merged = deepMerge(merged, rest);
         // Endpoint slot: `url` and `baseUrl`/`path` are two spellings of the same target, and
         // deepMerge keeps them as separate keys. Reconcile so the last fragment to write either
@@ -132,6 +138,7 @@ export function compose(config: Fragment): StitchConfig {
     const hooks = chainHooks(hookLayers);
     if (hooks) merged.hooks = hooks;
     if (store) merged.store = store;
+    if (kind) merged.kind = kind;
     const output = normalizeOutput(merged.output);
     if (output !== undefined) merged.output = output;
     const input = normalizeInput(merged.input);
@@ -262,6 +269,9 @@ export function redactConfig(cfg: StitchConfig): StitchConfig {
     delete rest.store;
     delete rest.auth;
     delete rest.adapter;
+    // Normalise the surface to its id string so __config round-trips as JSON (ADR 0005
+    // Decision 11): never expose the live Surface (its hooks don't serialise), only its identity.
+    if (rest.kind) (rest as { kind?: unknown }).kind = rest.kind.id;
     return rest;
 }
 
@@ -412,7 +422,7 @@ export function graphql<
 >(config: C): Stitch<ResolveOutput<TExplicit, C>, InputOf<C>> {
     return makeStitch<ResolveOutput<TExplicit, C>>({
         ...config,
-        kind: 'graphql',
+        kind: graphqlSurface,
         method: 'POST',
         unwrap: config.unwrap ?? 'data',
     });

--- a/packages/core/src/surface.ts
+++ b/packages/core/src/surface.ts
@@ -1,0 +1,66 @@
+// Surfaces — the pluggable request-style model (ADR 0005 Decisions 1–3, 10, 11). A surface is a
+// small unit (a stable string `id` + behaviour hooks) that the engine asks "how is this call
+// shaped / interpreted / streamed" instead of branching on a closed `kind` union. `http` is the
+// default surface; `graphql` (and later `sse`/`stream`/`download`) are peers on the same engine.
+//
+// Stage 3 introduces the MODEL and carries each surface's identity through `kind` (redacted to the
+// `id` string in `__config` so it round-trips as JSON — Decision 11). The behaviour hooks below
+// are the contract later stages fill in (Stage 4 moves graphql's shaping/interpretation here;
+// Stage 5 the streaming `stream` hook). Until then the engine keys its built-in graphql handling
+// on `kind.id`.
+import type {
+    AdapterRequest,
+    AdapterResponse,
+    StitchConfig,
+    StitchInput,
+} from './types';
+
+/** The result a surface's {@link Surface.interpret} produces from a buffered response. */
+export type SurfaceOutcome<T = unknown> =
+    | { ok: true; value: T }
+    | { ok: false; message: string; status?: number };
+
+/**
+ * A pluggable request style. `TInput` is the call-argument type a typed surface narrows to;
+ * `TResult` the value it yields. Both default to the http surface's (loose `StitchInput`, `unknown`)
+ * and are recovered by `stitch<S>` / the per-surface helpers for surfaces that specialise them
+ * (e.g. `download` → `{ blob, filename }`).
+ */
+export interface Surface<TInput = StitchInput, TResult = unknown> {
+    /** Stable identifier — the only part that round-trips into `__config` (Decision 11). */
+    readonly id: string;
+    /**
+     * Shape the outgoing request: receives the engine's default http-built request and returns a
+     * (possibly patched) one. Omitted = the http identity. (Wired for graphql in Stage 4.)
+     */
+    readonly buildRequest?: (
+        cfg: StitchConfig,
+        input: StitchInput,
+        base: AdapterRequest,
+    ) => AdapterRequest;
+    /**
+     * Interpret a buffered response into a result or a failure — e.g. graphql's
+     * "200-with-`errors` is an error". Omitted = the engine default (the body is the value).
+     */
+    readonly interpret?: (
+        res: AdapterResponse,
+        cfg: StitchConfig,
+    ) => SurfaceOutcome<TResult>;
+    /**
+     * Decode a live response body into `delta` chunks. Its presence marks a surface as
+     * **streaming** (ADR 0005 Decision 12). Omitted = a buffered surface. (Wired in Stage 5.)
+     */
+    readonly stream?: (
+        res: AdapterResponse,
+        cfg: StitchConfig,
+    ) => AsyncIterable<unknown>;
+    /** Phantom carrier so `stitch<S>` can recover a surface's call-argument type. Never read. */
+    readonly __input?: (input: TInput) => void;
+}
+
+/** The default surface: a plain JSON-over-HTTP call. Selected whenever `kind` is omitted. */
+export const httpSurface: Surface = { id: 'http' };
+
+/** GraphQL-over-HTTP. Its behaviour is wired into the surface hooks in Stage 4; for now the
+ *  engine keys its built-in handling on this id and the `graphql(...)` helper sets the shape. */
+export const graphqlSurface: Surface = { id: 'graphql' };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,6 +7,7 @@ import type {
     ResolveOutput,
     SchemaLike,
 } from './infer';
+import type { Surface } from './surface';
 import type { Validator } from './validator';
 
 export interface StitchInput {
@@ -294,8 +295,12 @@ export interface InputSchemas {
 export interface StitchConfig {
     /** Label used in events and traces; defaults to `path` or `'stitch'`. */
     name?: string;
-    /** Request kind. `'http'` (default) or `'graphql'` for a POST `{ query, variables }`. */
-    kind?: 'http' | 'graphql';
+    /**
+     * Request style — a {@link Surface} plugin (ADR 0005 Decisions 1-2). Omitted = the built-in
+     * `http` surface. The public `__config` exposes only the surface's `id` string (so a stitch's
+     * declaration round-trips as JSON — Decision 11); the live object stays on `__rawConfig`.
+     */
+    kind?: Surface;
     /** HTTP method; defaults to `GET`. */
     method?: string;
     /** Request body encoding. Default `'json'`. */
@@ -438,6 +443,14 @@ export function isStitch(x: unknown): x is Stitch {
     return (
         typeof x === 'function' &&
         (x as { __stitch?: boolean }).__stitch === true
+    );
+}
+
+export function isSeam(x: unknown): x is Seam {
+    return (
+        typeof x === 'object' &&
+        x !== null &&
+        (x as { __seam?: boolean }).__seam === true
     );
 }
 

--- a/packages/core/test/surface.spec.ts
+++ b/packages/core/test/surface.spec.ts
@@ -1,0 +1,100 @@
+// The Surface plugin model (ADR 0005 Decisions 1-3, 10, 11): `kind` is a pluggable Surface
+// (not a closed string union), normalised to its id string in __config (JSON round-trip), and
+// each surface exposes monomorphic `.stitch()` / `.seam()` helpers. The seam stays
+// surface-agnostic. graphql's behaviour still rides the engine's id-keyed handling here (it
+// moves behind the surface hooks in Stage 4).
+import { graphql, httpSurface, seam, stitch } from '../src';
+import { graphqlSurface } from '../src/surface';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+describe('Surface model (ADR 0005 Decisions 1-2, 11)', () => {
+    test('built-in surfaces carry stable ids', () => {
+        expect(httpSurface.id).toBe('http');
+        expect(graphqlSurface.id).toBe('graphql');
+    });
+
+    test('kind round-trips through __config as the id STRING, never the live object', () => {
+        const g = graphql({ baseUrl: 'https://x.test', query: '{ a }' });
+        const json = JSON.parse(JSON.stringify(g.__config)) as {
+            kind?: unknown;
+        };
+        expect(json.kind).toBe('graphql');
+
+        const h = stitch({ kind: httpSurface, url: 'https://x.test/a' });
+        const hjson = JSON.parse(JSON.stringify(h.__config)) as {
+            kind?: unknown;
+        };
+        expect(hjson.kind).toBe('http');
+    });
+
+    test('a plain stitch has no kind (http is the implicit default)', () => {
+        const h = stitch({ url: 'https://x.test/a' });
+        expect(h.__config.kind).toBeUndefined();
+    });
+});
+
+describe('generic stitch({ kind }) accepts a Surface (Decision 3)', () => {
+    test('kind: graphqlSurface shapes the request as graphql (POST { query, variables })', async () => {
+        server.route('POST', '/gql', { body: { data: { ok: 1 } } });
+        const q = stitch({
+            kind: graphqlSurface,
+            baseUrl: server.url,
+            path: '/gql',
+            query: '{ ok }',
+        });
+
+        await q({ variables: { x: 1 } });
+
+        const call = server.calls('/gql')[0];
+        expect(call?.method).toBe('POST');
+        expect(call?.body).toEqual({ query: '{ ok }', variables: { x: 1 } });
+    });
+});
+
+describe('graphql surface helper (Decision 3/10)', () => {
+    test('graphql.surface is the graphql Surface', () => {
+        expect(graphql.surface).toBe(graphqlSurface);
+    });
+
+    test('graphql.stitch(...) behaves like graphql(...) — POST, unwrap data', async () => {
+        server.route('POST', '/g', { body: { data: { me: { id: 7 } } } });
+        const q = graphql.stitch({
+            baseUrl: server.url,
+            path: '/g',
+            query: '{ me { id } }',
+            unwrap: 'data.me',
+        });
+        expect(await q()).toEqual({ id: 7 });
+    });
+
+    test('graphql.seam(existingSeam).stitch(...) creates a graphql member of that seam', async () => {
+        server.route('POST', '/api', { body: { data: { ping: 'pong' } } });
+        const api = seam({ baseUrl: server.url });
+        const ping = graphql.seam(api).stitch({
+            path: '/api',
+            query: '{ ping }',
+            unwrap: 'data.ping',
+        });
+        expect(await ping()).toBe('pong');
+    });
+
+    test('graphql.seam(options) makes a new seam whose members are graphql', async () => {
+        server.route('POST', '/s', { body: { data: { v: 42 } } });
+        const g = graphql.seam({ baseUrl: server.url });
+        expect(g.seam.__seam).toBe(true);
+        const v = g.stitch({ path: '/s', query: '{ v }', unwrap: 'data.v' });
+        expect(await v()).toBe(42);
+    });
+});


### PR DESCRIPTION
**Stage 3** of the surfaces rollout ([ADR 0005](https://github.com/rejifald/StitchAPI/blob/main/docs/adr/0005-surfaces-and-the-authoring-model.md) Decisions 1-3, 10, 11). Off latest `main`. Replaces the closed `kind` string union with a pluggable **Surface**, so new request styles stop being baked into the engine.

### The model (`src/surface.ts`)
`Surface<TInput, TResult>` = a stable string `id` + behaviour hooks (`buildRequest` / `interpret` / `stream?`) — the contract later stages fill in. Built-in `httpSurface` / `graphqlSurface` constants (id-only for now; graphql's behaviour moves behind the hooks in **Stage 4**).

### `kind` becomes the surface (Decisions 2, 11)
- `StitchConfig.kind?: Surface` — the `'http' | 'graphql'` union is gone.
- `compose` treats the surface as **atomic** (last-writer-wins; never deep-merged — merging two `Surface` objects would corrupt their hooks/identity).
- `redactConfig` normalises `kind` → its **`id` string** in the public `__config` (exactly as it strips `store`/`auth`/`adapter`), so a stitch still serialises to `{ "kind": "graphql" }` for MCP/playground/`llms.txt`. `__rawConfig` keeps the live object.
- The engine keys its built-in graphql handling on `cfg.kind?.id === 'graphql'` (4 sites) — behaviour identical; the inline logic moves into the surface hooks in Stage 4.

### Authoring (Decision 3)
- Generic `stitch({ kind: someSurface, … })` is accepted by the existing inferring overload (result from `output`, arg from `input`); `http` is the implicit default (omit `kind`). Surface-**specialised** result typing (e.g. download's `{ blob, filename }`) is delivered by the monomorphic helpers / later stages — no speculative generics added here that nothing exercises yet.
- Per-surface subpath helper (`src/graphql.ts` → `stitchapi/graphql`): `graphql` stays **callable**, plus `graphql.stitch` (alias), `graphql.seam(existingSeam)` / `graphql.seam(options)`, and `graphql.surface`. **The seam stays surface-agnostic** — members are created through the seam's own `graphql()`; the helper only binds. (`package.json` `exports` wiring is Stage 7.)

### Gates
- **Browser-first:** pure types/data, no runtime deps.
- **Bundle-frugal:** `surface.ts` is tiny; graphql lives behind its own module.
- **Contract-not-dependency:** `kind` round-trips through `__config` as the id string (asserted).

### Verification
RED → green TDD. `surface.spec.ts` (8). **No existing test changed** — graphql-and-headers / cache / gaps specs use the `graphql()` helper, which now carries `graphqlSurface`. Full core suite (295), typecheck (src + test), eslint, prettier — all green.

Stops here per the staged plan; Stage 4 (move graphql's engine logic behind the surface hooks) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)