### PR TITLE
feat(core): graphql as a surface — move its engine logic behind the surface hooks (ADR 0005 Stage 4)

### DIFF
--- a/packages/core/eslint-suppressions.json
+++ b/packages/core/eslint-suppressions.json
@@ -23,7 +23,7 @@
       "count": 1
     },
     "@typescript-eslint/no-unnecessary-condition": {
-      "count": 5
+      "count": 4
     },
     "@typescript-eslint/no-unnecessary-type-conversion": {
       "count": 1

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -113,7 +113,6 @@ export interface RequestDescriptor {
     method: string;
     url: string;
     body?: unknown;
-    graphql?: { query: string; variables: unknown };
     headers?: Record<string, string>;
     principal?: string;
 }
@@ -131,12 +130,9 @@ function canonicalRequest(
         m: d.method.toUpperCase(),
         u: normalizeUrl(d.url),
     };
-    if (d.graphql) {
-        parts['q'] = d.graphql.query; // document opaque; no GraphQL parser pulled in
-        parts['gv'] = d.graphql.variables; // variables canonicalised by stable()
-    } else if (d.body !== undefined) {
-        parts['b'] = d.body;
-    }
+    // The body is the resolved request payload (for graphql, the { query, variables } the surface
+    // packed) — keyed uniformly; canonicalised by stable().
+    if (d.body !== undefined) parts['b'] = d.body;
     if (varyNames?.length) {
         const h = varyHeaderObject(d.headers, varyNames);
         if (Object.keys(h).length) parts['h'] = h;

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -17,6 +17,7 @@ import {
     withTimeout,
 } from './resilience';
 import { vaultView } from './store';
+import type { SurfaceOutcome } from './surface';
 import type {
     Adapter,
     AdapterRequest,
@@ -137,14 +138,12 @@ const resolveStr = (v: string | (() => string) | undefined): string =>
     typeof v === 'function' ? v() : (v ?? '');
 
 function buildRequest(cfg: StitchConfig, input: StitchInput): AdapterRequest {
-    const isGql = cfg.kind?.id === 'graphql';
     // Endpoint resolution: when `url` is set it IS the whole endpoint (no base), but still
-    // templated + query-split like a path. Otherwise join `baseUrl` + `path`.
+    // templated + query-split like a path. Otherwise join `baseUrl` + `path`. (Surface-specific
+    // shaping — graphql's body/method/`/graphql` default — is applied below / by its helper.)
     const usingUrl = cfg.url !== undefined;
     const base = usingUrl ? '' : resolveStr(cfg.baseUrl);
-    const raw = usingUrl
-        ? resolveStr(cfg.url)
-        : (cfg.path ?? (isGql ? '/graphql' : ''));
+    const raw = usingUrl ? resolveStr(cfg.url) : (cfg.path ?? '');
     // Split off a literal `?predefined=query` (brace-aware, so a `{?x}` template operator
     // isn't mistaken for it); the template part is expanded, the rest are query defaults.
     const qIdx = topLevelQueryIndex(raw);
@@ -175,26 +174,25 @@ function buildRequest(cfg: StitchConfig, input: StitchInput): AdapterRequest {
         e.name = 'StitchConfigError';
         throw e;
     }
-    const method = (cfg.method ?? (isGql ? 'POST' : 'GET')).toUpperCase();
+    const method = (cfg.method ?? 'GET').toUpperCase();
     const headers = { ...(cfg.headers ?? {}), ...(input.headers ?? {}) };
-    applyIdempotency(cfg, input, method, headers);
-    const bodyType = isGql ? 'json' : cfg.bodyType;
-    return {
+    let req: AdapterRequest = {
         url,
         method,
         headers,
-        body: isGql
-            ? {
-                  query: cfg.query,
-                  variables: input.variables ?? input.body ?? {},
-              }
-            : input.body,
-        ...(bodyType !== undefined ? { bodyType } : {}),
+        body: input.body,
+        ...(cfg.bodyType !== undefined ? { bodyType: cfg.bodyType } : {}),
         ...(cfg.multipart !== undefined ? { multipart: cfg.multipart } : {}),
         ...(cfg.responseType !== undefined
             ? { responseType: cfg.responseType }
             : {}),
     };
+    // The surface shapes the request (graphql packs { query, variables } + forces POST, …);
+    // absent, the http identity above stands.
+    if (cfg.kind?.buildRequest) req = cfg.kind.buildRequest(cfg, input, req);
+    // Idempotency runs AFTER surface shaping so a surface that forces a write still gets a key.
+    applyIdempotency(cfg, input, req.method, req.headers);
+    return req;
 }
 
 const cloneReq = (r: AdapterRequest): AdapterRequest => ({
@@ -574,28 +572,16 @@ async function* paginated(
         }
         lastStatus = res.status;
 
-        // GraphQL: a 200 response carrying `errors` is a failure — same as the non-paginated path.
-        if (cfg.kind?.id === 'graphql') {
-            const body = res.body as
-                | { errors?: { message?: string }[] }
-                | null
-                | undefined;
-            const errs = body?.errors;
-            if (errs?.length) {
-                yield {
-                    type: 'error',
-                    name,
-                    message: `GraphQL: ${errs.map((e) => e.message ?? 'error').join('; ')}`,
-                    status: res.status,
-                    attempts: state.attempts,
-                    at: now(),
-                };
-                yield doneEvt(false, t0, state.attempts);
-                return;
-            }
+        // The surface interprets each page (graphql's "200-with-`errors`" failure) — same as the
+        // non-paginated path.
+        const outcome = interpretResponse(cfg, res);
+        if (!outcome.ok) {
+            yield surfaceErrEvt(outcome, name, state.attempts);
+            yield doneEvt(false, t0, state.attempts);
+            return;
         }
 
-        let value: unknown = res.body;
+        let value: unknown = outcome.value;
         if (cfg.transform) value = await cfg.transform(value);
         if (cfg.unwrap) value = getPath(value, cfg.unwrap);
         const items = pg.items
@@ -692,22 +678,15 @@ function outputSchemaSource(cfg: StitchConfig): unknown {
 // The resolved request the cache key is derived from. The principal it scopes by is sourced from
 // the trusted AuthContext at controller creation, never from StitchInput (ADR 0002 §2), so the
 // descriptor itself stays principal-free; folding + scope are the controller's job.
-function describe(
-    cfg: StitchConfig,
-    input: StitchInput,
-    baseReq: AdapterRequest,
-): RequestDescriptor {
+function describe(baseReq: AdapterRequest): RequestDescriptor {
     const d: RequestDescriptor = {
         method: baseReq.method,
         url: baseReq.url,
         headers: baseReq.headers,
     };
-    if (cfg.kind?.id === 'graphql')
-        d.graphql = {
-            query: cfg.query ?? '',
-            variables: input.variables ?? input.body ?? {},
-        };
-    else if (baseReq.body !== undefined) d.body = baseReq.body;
+    // The surface has already shaped the body (graphql's { query, variables } IS baseReq.body),
+    // so the cache keys on the resolved request uniformly — no surface-specific branch.
+    if (baseReq.body !== undefined) d.body = baseReq.body;
     return d;
 }
 
@@ -742,6 +721,34 @@ const resultEvt = (
     attempts: number,
 ): StitchEvent => ({ type: 'result', value, status, attempts, at: now() });
 
+// Interpret a buffered response into a result value via the surface's `interpret` hook (graphql's
+// "200-with-`errors`" failure lives there). No surface / no hook → the body is the value.
+function interpretResponse(
+    cfg: StitchConfig,
+    res: AdapterResponse,
+): SurfaceOutcome {
+    return cfg.kind?.interpret
+        ? cfg.kind.interpret(res, cfg)
+        : { ok: true, value: res.body };
+}
+
+// Build the `error` event for a surface that interpreted the response as a failure.
+function surfaceErrEvt(
+    outcome: Extract<SurfaceOutcome, { ok: false }>,
+    name: string,
+    attempts: number,
+): StitchEvent {
+    const evt: Extract<StitchEvent, { type: 'error' }> = {
+        type: 'error',
+        name,
+        message: outcome.message,
+        attempts,
+        at: now(),
+    };
+    if (outcome.status !== undefined) evt.status = outcome.status;
+    return evt;
+}
+
 // The resilience chain from the request onward (no `start` event — the caller emits it). Returns
 // the validated outcome so the cache layer can store/share it; on any failure it yields the
 // error/done events and returns `{ ok: false }`.
@@ -763,25 +770,15 @@ async function* runFrom(
         return { ok: false };
     }
 
-    // GraphQL: a 200 response carrying `errors` is a failure.
-    if (cfg.kind?.id === 'graphql') {
-        const errs = (res.body as { errors?: { message?: string }[] })?.errors;
-        if (errs?.length) {
-            yield {
-                type: 'error',
-                name,
-                message: `GraphQL: ${errs.map((e) => e.message ?? 'error').join('; ')}`,
-                status: res.status,
-                attempts: state.attempts,
-                at: now(),
-            };
-            yield doneEvt(false, t0, state.attempts);
-            return { ok: false };
-        }
+    // The surface interprets the response (graphql's "200-with-`errors`-is-a-failure" lives in
+    // its interpret hook); with no hook the body is the value. Then transform → unwrap → validate.
+    const outcome = interpretResponse(cfg, res);
+    if (!outcome.ok) {
+        yield surfaceErrEvt(outcome, name, state.attempts);
+        yield doneEvt(false, t0, state.attempts);
+        return { ok: false };
     }
-
-    // transform (e.g. scrape HTML -> structured), then unwrap, then validate/drift the result.
-    let value: unknown = res.body;
+    let value: unknown = outcome.value;
     if (cfg.transform) value = await cfg.transform(value);
     if (cfg.unwrap) value = getPath(value, cfg.unwrap);
     const findings = await validateOutput(cfg, value);
@@ -877,7 +874,7 @@ async function* runCached(
         return;
     }
 
-    const d = describe(cfg, input, baseReq);
+    const d = describe(baseReq);
     const key = ctl.key(d, input);
     if (key === undefined) {
         yield cacheEvt('bypass: unhashable request');
@@ -1003,7 +1000,7 @@ export async function cacheInvalidateExact(
         return;
     }
     if (!ctl.cacheableMethod(baseReq.method)) return;
-    const d = describe(rt.cfg, input, baseReq);
+    const d = describe(baseReq);
     const key = ctl.key(d, input);
     if (key === undefined) return;
     await (await ctl.open(key, d)).delete();
@@ -1030,7 +1027,7 @@ export async function cacheKeyOf(
     } catch {
         return undefined;
     }
-    return ctl.key(describe(rt.cfg, input, baseReq), input);
+    return ctl.key(describe(baseReq), input);
 }
 
 export async function executeRaw(

--- a/packages/core/src/seam.ts
+++ b/packages/core/src/seam.ts
@@ -91,8 +91,11 @@ function makeBuild(shared: SharedSeam, principal: string | undefined) {
         };
         if (isGql) {
             cfg.kind = graphqlSurface;
-            cfg.method = 'POST';
             cfg.unwrap = own.unwrap ?? 'data';
+            // Default the endpoint to `/graphql` when the member gives neither `url` nor `path`
+            // (method/body shaping is the surface's).
+            if (own.url === undefined && own.path === undefined)
+                cfg.path = '/graphql';
         }
 
         const runtime: SharedRuntime = {

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -420,10 +420,13 @@ export function graphql<
         query: string;
     },
 >(config: C): Stitch<ResolveOutput<TExplicit, C>, InputOf<C>> {
+    // Default the endpoint to `/graphql` only when neither `url` nor `path` is given (preserves the
+    // convenience without clobbering an explicit endpoint). Method/body shaping is the surface's.
+    const endpointless = config.url === undefined && config.path === undefined;
     return makeStitch<ResolveOutput<TExplicit, C>>({
         ...config,
+        ...(endpointless ? { path: '/graphql' } : {}),
         kind: graphqlSurface,
-        method: 'POST',
         unwrap: config.unwrap ?? 'data',
     });
 }

--- a/packages/core/src/surface.ts
+++ b/packages/core/src/surface.ts
@@ -61,6 +61,33 @@ export interface Surface<TInput = StitchInput, TResult = unknown> {
 /** The default surface: a plain JSON-over-HTTP call. Selected whenever `kind` is omitted. */
 export const httpSurface: Surface = { id: 'http' };
 
-/** GraphQL-over-HTTP. Its behaviour is wired into the surface hooks in Stage 4; for now the
- *  engine keys its built-in handling on this id and the `graphql(...)` helper sets the shape. */
-export const graphqlSurface: Surface = { id: 'graphql' };
+/**
+ * GraphQL-over-HTTP. Its behaviour lives entirely in these hooks (ADR 0005 Stage 4): `buildRequest`
+ * packs `{ query, variables }` as JSON and forces POST; `interpret` treats a 200 carrying `errors`
+ * as a failure. The `data` unwrap is a plain config key the `graphql(...)` helper / `seam.graphql()`
+ * set (the engine applies it after `interpret`), as is the `/graphql` default path.
+ */
+export const graphqlSurface: Surface = {
+    id: 'graphql',
+    buildRequest: (cfg, input, base) => ({
+        ...base,
+        method: (cfg.method ?? 'POST').toUpperCase(),
+        bodyType: 'json',
+        body: {
+            query: cfg.query ?? '',
+            variables: input.variables ?? input.body ?? {},
+        },
+    }),
+    interpret: (res) => {
+        const errs = (
+            res.body as { errors?: { message?: string }[] } | null | undefined
+        )?.errors;
+        if (errs?.length)
+            return {
+                ok: false,
+                message: `GraphQL: ${errs.map((e) => e.message ?? 'error').join('; ')}`,
+                status: res.status,
+            };
+        return { ok: true, value: res.body };
+    },
+};

--- a/packages/core/test/cache-internals.spec.ts
+++ b/packages/core/test/cache-internals.spec.ts
@@ -139,12 +139,14 @@ describe('deriveCacheKey canonicalisation', () => {
         );
     });
 
-    test('GraphQL document is opaque; variables are canonicalised', () => {
+    test('GraphQL body { query, variables } is canonicalised (document opaque)', () => {
+        // The graphql surface packs { query, variables } into the request body, so the cache keys
+        // on it uniformly (no separate graphql descriptor) — still order-independent in variables.
         const v1 = deriveCacheKey(
             {
                 method: 'POST',
                 url: 'https://x.test/graphql',
-                graphql: { query: 'query Q { me }', variables: { a: 1, b: 2 } },
+                body: { query: 'query Q { me }', variables: { a: 1, b: 2 } },
             },
             undefined,
         );
@@ -152,7 +154,7 @@ describe('deriveCacheKey canonicalisation', () => {
             {
                 method: 'POST',
                 url: 'https://x.test/graphql',
-                graphql: { query: 'query Q { me }', variables: { b: 2, a: 1 } },
+                body: { query: 'query Q { me }', variables: { b: 2, a: 1 } },
             },
             undefined,
         );
@@ -160,7 +162,7 @@ describe('deriveCacheKey canonicalisation', () => {
             {
                 method: 'POST',
                 url: 'https://x.test/graphql',
-                graphql: {
+                body: {
                     query: 'query OTHER { me }',
                     variables: { a: 1, b: 2 },
                 },

--- a/packages/core/test/graphql-and-headers.spec.ts
+++ b/packages/core/test/graphql-and-headers.spec.ts
@@ -1,6 +1,10 @@
-// Closes the last two gaps: a real `graphql` kind (proving the kind abstraction) and a
-// static `headers` config field.
+// graphql as a Surface (ADR 0005 Stage 4): graphql's request shaping + "200-with-errors is a
+// failure" now live in the graphql surface's hooks, and the engine dispatches to those hooks
+// GENERICALLY — it no longer special-cases `kind === 'graphql'`. Proven below by the graphql
+// behaviour (unchanged) plus custom surfaces routed through the same engine. Plus a static
+// `headers` config field.
 import { apiKey, env, graphql, stitch } from '../src';
+import type { Surface } from '../src';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
 
@@ -71,6 +75,49 @@ describe('GraphQL kind', () => {
         });
         const query = graphql({ baseUrl: server.url, query: '{ thing }' });
         await expect(query()).rejects.toThrow(/thing.*not found/);
+    });
+});
+
+describe('Surface dispatch — graphql is no longer special-cased', () => {
+    test('a surface buildRequest hook shapes the outgoing request', async () => {
+        server.route('PUT', '/x', { body: { ok: true } });
+        const put: Surface = {
+            id: 'put',
+            buildRequest: (_cfg, _input, base) => ({ ...base, method: 'PUT' }),
+        };
+        const s = stitch({ kind: put, url: server.url + '/x' });
+
+        // pre-refactor sends GET → 404; only the recorded wire method matters here
+        await s().then(
+            () => undefined,
+            () => undefined,
+        );
+        expect(server.calls('/x')[0]?.method).toBe('PUT');
+    });
+
+    test('a surface interpret hook produces the result value', async () => {
+        server.route('GET', '/u', { body: { msg: 'hi' } });
+        const upper: Surface = {
+            id: 'upper',
+            interpret: (res) => ({
+                ok: true,
+                value: (res.body as { msg: string }).msg.toUpperCase(),
+            }),
+        };
+        const s = stitch({ kind: upper, url: server.url + '/u' });
+
+        expect(await s()).toBe('HI');
+    });
+
+    test('a surface interpret hook can fail the call (like graphql errors)', async () => {
+        server.route('GET', '/r', { body: {} });
+        const reject: Surface = {
+            id: 'reject',
+            interpret: () => ({ ok: false, message: 'nope', status: 422 }),
+        };
+        const s = stitch({ kind: reject, url: server.url + '/r' });
+
+        await expect(s()).rejects.toThrow(/nope/);
     });
 });
 


### PR DESCRIPTION
**Stage 4** of the surfaces rollout ([ADR 0005](https://github.com/rejifald/StitchAPI/blob/main/docs/adr/0005-surfaces-and-the-authoring-model.md)). **Stacked on Stage 3 (#97)** — base is `feat/surface-plugin-model`; retarget to `main` once #97 merges. The engine stops special-casing `kind === 'graphql'`; graphql's behaviour moves into the surface hooks and the engine dispatches to them **generically**.

### What moved
- **`graphqlSurface.buildRequest`** packs `{ query, variables }` as JSON and forces POST (`cfg.method` still overrides). **`graphqlSurface.interpret`** treats a 200 carrying `errors` as a failure.
- **`engine.buildRequest`** builds the http request generically, then applies `cfg.kind?.buildRequest` (the surface patch), then idempotency (so a surface that forces a write still gets a key).
- **`runFrom` + `paginated`** run the response through a shared `interpretResponse` / `surfaceErrEvt` — no graphql branch.
- **`describe()`** keys the cache on the resolved `body` uniformly (graphql's body *is* `{ query, variables }`), so `RequestDescriptor.graphql` + its key branch are deleted from `cache.ts`.
- The `/graphql` default path + the `data` unwrap stay plain config keys the `graphql()` helper / `seam.graphql()` set.

**Net:** all four `cfg.kind?.id === 'graphql'` sites are gone — the engine is surface-agnostic (only comments mention graphql). One now-unused eslint suppression pruned (`no-unnecessary-condition` 5→4).

### Verification (RED → green)
- **Behaviour unchanged:** the three existing graphql tests pass as-is (POST `{query,variables}` + auth + unwrap `data`; `.with({variables})`; 200-with-`errors` → reject).
- **New (proving the abstraction):** a custom surface's `buildRequest` shapes the request, its `interpret` produces the value, and its `interpret` can fail the call — the *same* generic path graphql now uses. (These were RED before this stage: Stage 3's engine ignored the hooks.)
- `cache-internals` graphql-key test now keys via `body`.

Full core suite (298), typecheck (src + test), eslint, prettier — all green.

Stops here per the staged plan; Stage 5 (`sse` + `stream` surfaces, the `delta` event, the concurrency/rate split) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)