### PR TITLE
feat(core): sse + stream streaming surfaces (ADR 0005 Decisions 4,5,12; Stage 5)

### DIFF
--- a/docs/adr/0005-surfaces-and-the-authoring-model.md
+++ b/docs/adr/0005-surfaces-and-the-authoring-model.md
@@ -107,6 +107,12 @@ A surface literally named `stream`, reached only by a caller who has opted out o
 
 What the two surfaces _do_ share is the lower-level mechanics that turn a `ReadableStream<Uint8Array>` into UTF-8 lines across chunk boundaries (a single internal `lineReader` helper). `sse`'s frame parser and `stream`'s `'lines'` / `'ndjson'` decoders both sit on top of that one helper. They reuse the **plumbing**, not the **decoder** — which keeps SSE semantics correct without duplicating the byte-handling.
 
+### Q4 — What does the `await` path resolve to for a streaming surface? (Stage 5)
+
+**Resolved:** _the collected array of every `delta` chunk._
+
+A streaming run ends, like every run, `… → result → done`, and `await stitch()` (via `consume()`) returns the terminal `result.value`. For a streaming surface that value is the **ordered collection of everything emitted as a `delta`**: `await` means "give me the whole stream", `.stream()` means "give me it incrementally". The alternatives both lose. Resolving to `undefined` makes streaming the lone surface whose `await` returns no data, forcing `.stream()` even for a bounded stream. Resolving to the **last chunk** silently discards data — catastrophic for `sse`, where every event matters. The array is the only choice that is lossless and consistent with the event spine, and it reads like `Array.fromAsync(stream)`. The trade-off (documented at the call site): `await` buffers the whole stream in memory, so it is for **bounded** streams; an unbounded / long-lived stream is consumed incrementally via `.stream()`, which yields each `delta` as it arrives and buffers nothing. transform / unwrap / `output` validation are buffered-response concepts and are **not** applied to the delta path.
+
 ## Consequences
 
 **Positive**

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -19,6 +19,7 @@ import {
 import { vaultView } from './store';
 import type { SurfaceOutcome } from './surface';
 import type {
+    AcquireOptions,
     Adapter,
     AdapterRequest,
     AdapterResponse,
@@ -59,7 +60,10 @@ export interface Runtime {
     cfg: StitchConfig;
     adapter: Adapter;
     throttle: {
-        acquire(key: string): Promise<{ waitedMs: number }>;
+        acquire(
+            key: string,
+            opts?: AcquireOptions,
+        ): Promise<{ waitedMs: number }>;
         release(key: string): void;
     };
     trace: TraceSink;
@@ -324,22 +328,26 @@ async function acquireWithin(
     throttle: Runtime['throttle'],
     key: string,
     budget?: TotalBudget,
+    opts?: AcquireOptions,
 ): Promise<{ waitedMs: number }> {
-    if (budget == null) return throttle.acquire(key);
+    if (budget == null) return throttle.acquire(key, opts);
     const remaining = budget.deadline - now();
     if (remaining <= 0) throw budgetError(budget);
-    const pending = throttle.acquire(key);
+    const pending = throttle.acquire(key, opts);
     let timer: ReturnType<typeof setTimeout> | undefined;
     const expiry = new Promise<never>((_, reject) => {
         timer = setTimeout(() => {
-            void pending.then(
-                () => {
-                    throttle.release(key);
-                },
-                () => {
-                    /* a rejected acquire holds no slot */
-                },
-            );
+            // A rate-only acquire (streaming, Decision 12) holds no concurrency slot, so there is
+            // nothing to hand back on timeout; only a slot-taking acquire is released here.
+            if (!opts?.rateOnly)
+                void pending.then(
+                    () => {
+                        throttle.release(key);
+                    },
+                    () => {
+                        /* a rejected acquire holds no slot */
+                    },
+                );
             reject(budgetError(budget));
         }, remaining);
     });
@@ -808,6 +816,105 @@ async function* runFrom(
         : { ok: true, value, status: res.status };
 }
 
+// Streaming surfaces (sse/stream): open the LIVE body and decode it into `delta` chunks via the
+// surface's `stream` hook (ADR 0005 Decisions 4-5). Deliberately lean — no retry/circuit/cache:
+// Decision 12 puts broken-stream retry out of scope, and streaming bypasses the cache. It charges
+// the rate gate ONCE at open but takes NO concurrency slot (a rate-only acquire, never released),
+// so a long-lived connection can never pin a seam's concurrency budget (Decision 12). The await/
+// `consume` path resolves to the COLLECTED array of every emitted chunk — the terminal `result`
+// mirrors the delta spine (Stage 5 sub-decision); `.stream()` yields the chunks incrementally and
+// buffers nothing. transform/unwrap/output validation are buffered-response concepts and are not
+// applied to the delta path.
+async function* runStreaming(
+    rt: Runtime,
+    input: StitchInput,
+    name: string,
+    state: { attempts: number },
+    t0: number,
+    budget?: TotalBudget,
+): AsyncGenerator<StitchEvent, void> {
+    const { cfg } = rt;
+    const streamHook = cfg.kind?.stream;
+    if (!streamHook) return; // unreachable: only entered for a streaming surface
+
+    let baseReq: AdapterRequest;
+    try {
+        baseReq = buildRequest(cfg, input);
+    } catch (e) {
+        yield errEvt(e, name, 0);
+        yield doneEvt(false, t0, 0);
+        return;
+    }
+    // Ask the transport for the live body — un-buffered, un-parsed (ADR 0005 Q1).
+    baseReq = { ...baseReq, stream: true };
+    yield startEvt(name, baseReq, input);
+    state.attempts = 1;
+
+    // Charge the rate limiter once at open, but take NO concurrency slot (Decision 12). A rate
+    // wait still surfaces as a `throttled` event.
+    let waitedMs: number;
+    try {
+        ({ waitedMs } = await acquireWithin(
+            rt.throttle,
+            hostKey(baseReq, cfg),
+            budget,
+            { rateOnly: true },
+        ));
+    } catch (e) {
+        yield errEvt(e, name, 1);
+        yield doneEvt(false, t0, 1);
+        return;
+    }
+    if (waitedMs > 0)
+        yield {
+            type: 'progress',
+            phase: 'throttled',
+            attempt: 1,
+            waitedMs,
+            at: now(),
+        };
+
+    let res: AdapterResponse;
+    try {
+        const req = cloneReq(baseReq);
+        if (cfg.auth) await cfg.auth.apply(req, rt.authCtx);
+        await cfg.hooks?.onRequest?.({ name, attempt: 1, req });
+        yield { type: 'progress', phase: 'request', attempt: 1, at: now() };
+        res = await rt.adapter(req);
+        await cfg.hooks?.onResponse?.({ name, attempt: 1, res });
+    } catch (e) {
+        await cfg.hooks?.onError?.({ name, attempt: 1, error: e });
+        yield errEvt(e, name, 1);
+        yield doneEvt(false, t0, 1);
+        return;
+    }
+
+    if (res.status >= 400) {
+        const e = new Error(`HTTP ${res.status}`) as Error & { status: number };
+        e.status = res.status;
+        yield errEvt(e, name, 1);
+        yield doneEvt(false, t0, 1);
+        return;
+    }
+
+    // Decode the live body into `delta` chunks; collect them so the await path resolves to the
+    // whole sequence (Stage 5 sub-decision).
+    const chunks: unknown[] = [];
+    try {
+        for await (const chunk of streamHook(res, cfg)) {
+            chunks.push(chunk);
+            yield { type: 'delta', chunk, at: now() };
+        }
+    } catch (e) {
+        yield errEvt(e, name, 1);
+        yield doneEvt(false, t0, 1);
+        return;
+    }
+
+    yield resultEvt(chunks, res.status, 1);
+    yield doneEvt(true, t0, 1);
+}
+
 // A single uncached run: build the request, emit `start`, then run the chain.
 async function* runOnce(
     rt: Runtime,
@@ -965,6 +1072,14 @@ export async function* execute(
     } catch (e) {
         yield errEvt(e, name, 0);
         yield doneEvt(false, t0, 0);
+        return;
+    }
+
+    // Streaming surfaces (sse/stream) take a dedicated path: open the live body and emit `delta`
+    // chunks (Decisions 4-5). Streaming bypasses pagination and the cache, and is exempt from the
+    // concurrency bucket (Decision 12). Checked before both so neither can wrap a live stream.
+    if (cfg.kind?.stream) {
+        yield* runStreaming(rt, input, name, state, t0, budget);
         return;
     }
 

--- a/packages/core/src/line-reader.ts
+++ b/packages/core/src/line-reader.ts
@@ -1,0 +1,41 @@
+// The shared byte→line plumbing for streaming surfaces (ADR 0005 Decision 5, Q3). Turns a
+// `ReadableStream<Uint8Array>` into UTF-8 text lines, correctly carrying state across chunk
+// boundaries: a multi-byte character split between two chunks (the streaming `TextDecoder`) and a
+// line split between two chunks (the `buf` carry). Lines are split on `\n` only and yielded WITHOUT
+// the terminator; a trailing line with no final newline is yielded at end-of-stream.
+//
+// `stream`'s `'lines'` / `'ndjson'` decoders consume these lines directly; `sse`'s frame parser
+// layers the event-stream grammar on top (stripping a trailing `\r`, grouping by blank lines). They
+// share this plumbing, not a decoder — `text/event-stream` is a protocol, "lines" is not.
+export async function* lineReader(
+    stream: ReadableStream<Uint8Array>,
+): AsyncGenerator<string, void> {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    try {
+        for (;;) {
+            const r = await reader.read();
+            if (r.done) break;
+            buf += decoder.decode(r.value, { stream: true });
+            let nl = buf.indexOf('\n');
+            while (nl >= 0) {
+                yield buf.slice(0, nl);
+                buf = buf.slice(nl + 1);
+                nl = buf.indexOf('\n');
+            }
+        }
+        // Flush any bytes the streaming decoder held back (a split multi-byte char), then drain
+        // any remaining complete lines and finally the unterminated trailing line, if any.
+        buf += decoder.decode();
+        let nl = buf.indexOf('\n');
+        while (nl >= 0) {
+            yield buf.slice(0, nl);
+            buf = buf.slice(nl + 1);
+            nl = buf.indexOf('\n');
+        }
+        if (buf.length > 0) yield buf;
+    } finally {
+        reader.releaseLock();
+    }
+}

--- a/packages/core/src/resilience.ts
+++ b/packages/core/src/resilience.ts
@@ -2,6 +2,7 @@
 // throttle (rate + concurrency, per key), and a timeout wrapper. Dependency-free;
 // pacing/cancellation go through the shared `sleep`/`now` helpers from `./util`.
 import type {
+    AcquireOptions,
     CircuitOptions,
     RetryOptions,
     StitchStore,
@@ -66,7 +67,7 @@ const hostStates = new Map<string, KeyState>();
  * keeps state closure-local to this limiter.
  */
 export function createThrottle(opts?: ThrottleOptions): {
-    acquire(key: string): Promise<{ waitedMs: number }>;
+    acquire(key: string, opts?: AcquireOptions): Promise<{ waitedMs: number }>;
     release(key: string): void;
 } {
     const limit = opts?.concurrency;
@@ -95,14 +96,23 @@ export function createThrottle(opts?: ThrottleOptions): {
         return new Promise<void>((resolve) => s.waiters.push(resolve));
     };
 
-    async function acquire(key: string): Promise<{ waitedMs: number }> {
+    async function acquire(
+        key: string,
+        acqOpts?: AcquireOptions,
+    ): Promise<{ waitedMs: number }> {
         const s = stateFor(key);
-        // Only a real concurrency block counts as "waited" — not incidental scheduling
-        // jitter — so waitedMs (and the 'throttled' event) is deterministic.
-        const blocked = limit != null && s.inFlight >= limit;
-        const blockStart = now();
-        await takeSlot(s); // gate entry on concurrency first
-        let waitedMs = blocked ? now() - blockStart : 0;
+        let waitedMs = 0;
+        // A rate-only acquire (a streaming surface — ADR 0005 Decision 12) skips the concurrency
+        // slot entirely: it never takes (or, lacking a paired release, holds) one. It still paces
+        // on the rate budget below, so opening a stream is counted against the rate limiter.
+        if (!acqOpts?.rateOnly) {
+            // Only a real concurrency block counts as "waited" — not incidental scheduling
+            // jitter — so waitedMs (and the 'throttled' event) is deterministic.
+            const blocked = limit != null && s.inFlight >= limit;
+            const blockStart = now();
+            await takeSlot(s); // gate entry on concurrency first
+            if (blocked) waitedMs = now() - blockStart;
+        }
         if (spacing > 0) {
             // Then pace within the held slot: reserve the next grant time and wait for it.
             const at = Math.max(now(), s.nextGrantAt);

--- a/packages/core/src/seam.ts
+++ b/packages/core/src/seam.ts
@@ -47,7 +47,10 @@ function seamBucket(
     if (opts?.scope === 'host') return inner; // the host key already pools across the seam
     const key = `seam:${seamId}`;
     return {
-        acquire: () => inner.acquire(key),
+        // Re-key every acquire onto the one seam-stable key, forwarding the acquire options (e.g.
+        // `rateOnly` for streaming members — ADR 0005 Decision 12) so the bucket charges rate
+        // without taking a concurrency slot for a stream.
+        acquire: (_key, opts) => inner.acquire(key, opts),
         release: () => {
             inner.release(key);
         },

--- a/packages/core/src/sse.ts
+++ b/packages/core/src/sse.ts
@@ -1,0 +1,148 @@
+// The `stitchapi/sse` surface subpath (ADR 0005 Decision 4): Server-Sent Events over `fetch` +
+// Web Streams — never `EventSource` (GET-only, no custom headers, Node-absent — fails all three
+// gates). The `stream` hook parses the `text/event-stream` wire format off the response's
+// `ReadableStream` and yields one parsed event per `delta` chunk. SSE rides the same auth / retry /
+// headers spine as every other surface. Auto-reconnection / `Last-Event-ID` is out (issue #71).
+//
+// Bundle-frugal (Decision 10): this module — and the frame parser — is reached only through the
+// `sse` subpath, never from the root entry; `import { stitch }` pulls in no SSE code.
+import type { InputOf } from './infer';
+import { lineReader } from './line-reader';
+import { seam as makeSeam } from './seam';
+import { makeStitch } from './stitch';
+import type { Surface } from './surface';
+import {
+    type AdapterResponse,
+    type Seam,
+    type SeamOptions,
+    type Stitch,
+    type StitchConfig,
+    type StitchInput,
+    isSeam,
+} from './types';
+
+/**
+ * One Server-Sent Event. `data` is JSON-parsed when it parses, else the raw string. `event` (the
+ * type), `id` (last-event id), and `retry` (reconnect ms) are present only when the event carried
+ * them. An event is only produced when at least one `data:` field was seen (the SSE spec).
+ */
+export interface SseEvent {
+    event?: string;
+    data: unknown;
+    id?: string;
+    retry?: number;
+}
+
+// JSON-parse the data payload, falling back to the raw string when it is not JSON (a bare word, a
+// log line, …). `JSON.parse` returns `any`; the function's `unknown` return keeps callers honest.
+function parseData(raw: string): unknown {
+    try {
+        return JSON.parse(raw);
+    } catch {
+        return raw;
+    }
+}
+
+// Parse the `text/event-stream` grammar off a byte stream: events are separated by blank lines;
+// `event:` / `data:` / `id:` / `retry:` fields accumulate (multiple `data:` lines join with `\n`);
+// `:`-prefixed lines are comments; exactly one leading space after the field colon is stripped. A
+// trailing event with no terminating blank line is discarded (spec), as is a block with no `data:`.
+async function* parseEventStream(
+    body: ReadableStream<Uint8Array>,
+): AsyncGenerator<SseEvent, void> {
+    let event: string | undefined;
+    let id: string | undefined;
+    let retry: number | undefined;
+    let dataLines: string[] = [];
+
+    for await (const raw of lineReader(body)) {
+        // lineReader splits on `\n`; strip a trailing `\r` so CRLF streams parse (the SSE plumbing
+        // shared with `stream`'s `'lines'` stays a literal `\n` split — Q3).
+        const line = raw.endsWith('\r') ? raw.slice(0, -1) : raw;
+
+        if (line === '') {
+            // Blank line dispatches the event — but only if a `data:` field was seen. An id/retry/
+            // event-only block sets no data and is not dispatched (SSE spec dispatch step 2).
+            if (dataLines.length > 0) {
+                const ev: SseEvent = { data: parseData(dataLines.join('\n')) };
+                if (event !== undefined) ev.event = event;
+                if (id !== undefined) ev.id = id;
+                if (retry !== undefined) ev.retry = retry;
+                yield ev;
+            }
+            event = undefined;
+            id = undefined;
+            retry = undefined;
+            dataLines = [];
+            continue;
+        }
+        if (line.startsWith(':')) continue; // comment
+
+        const colon = line.indexOf(':');
+        const field = colon === -1 ? line : line.slice(0, colon);
+        let value = colon === -1 ? '' : line.slice(colon + 1);
+        if (value.startsWith(' ')) value = value.slice(1); // strip ONE leading space
+
+        if (field === 'event') event = value;
+        else if (field === 'data') dataLines.push(value);
+        else if (field === 'id') {
+            if (!value.includes('\0')) id = value; // SSE: ignore an id containing NUL
+        } else if (field === 'retry') {
+            if (/^\d+$/.test(value)) retry = Number(value);
+        }
+        // any other field name is ignored
+    }
+}
+
+/**
+ * The SSE surface. Its `stream` hook marks it streaming (Decision 12): the engine opens the live
+ * body, feeds it here, and emits each parsed {@link SseEvent} as a `delta` chunk.
+ */
+export const sseSurface: Surface<StitchInput, SseEvent[]> = {
+    id: 'sse',
+    async *stream(res: AdapterResponse) {
+        const body = res.body;
+        if (body instanceof ReadableStream)
+            yield* parseEventStream(body as ReadableStream<Uint8Array>);
+    },
+};
+
+/** sse members bound to a seam. `stitch(config)` creates an sse member of `seam`; `seam` is the
+ *  underlying handle for lifecycle/principal (`.as`/`.flush`/`.close`). */
+export interface SseSeamApi {
+    readonly stitch: <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+        config: C,
+    ) => Stitch<SseEvent[], InputOf<C>>;
+    readonly seam: Seam;
+}
+
+// Standalone sse stitch: the call argument is inferred from `config.input`, the result fixed to the
+// collected event array (a streaming await resolves to all of its `delta` chunks — Stage 5).
+const sseStitch = <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+    config: C,
+): Stitch<SseEvent[], InputOf<C>> =>
+    makeStitch<SseEvent[]>({ ...config, kind: sseSurface });
+
+// Bind sse members to a seam through the seam's surface-agnostic `stitch({ kind })` (Decision 3) —
+// no per-surface seam method; one shared runtime / principal boundary.
+function bindSeam(s: Seam): SseSeamApi {
+    const stitch = <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+        config: C,
+    ): Stitch<SseEvent[], InputOf<C>> =>
+        s.stitch<SseEvent[]>({ ...config, kind: sseSurface });
+    return { stitch, seam: s };
+}
+
+/**
+ * The sse surface's authoring helper — callable for the terse form (`sse(config)`) plus:
+ * - `sse.stitch(config)` — a standalone sse stitch (alias of the callable).
+ * - `sse.seam(existingSeam)` — bind sse members to an existing seam.
+ * - `sse.seam(options)` — a new seam whose members default to sse.
+ * - `sse.surface` — the sse {@link Surface} identity.
+ */
+export const sse = Object.assign(sseStitch, {
+    surface: sseSurface,
+    stitch: sseStitch,
+    seam: (arg: Seam | SeamOptions): SseSeamApi =>
+        bindSeam(isSeam(arg) ? arg : makeSeam(arg)),
+});

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -1,7 +1,7 @@
 // The default in-memory state store + a store-backed throttle. Swapping the store for a
 // Redis/Postgres adapter makes throttle distributed and sessions persistent/shared across
 // workers, with no change to the call site (DESIGN.md §13).
-import type { StitchStore, ThrottleOptions } from './types';
+import type { AcquireOptions, StitchStore, ThrottleOptions } from './types';
 import { now, parseRate, sleep } from './util';
 
 /** Default store: in-memory, single process, with TTL + atomic incr. */
@@ -66,10 +66,13 @@ export function vaultView(store: StitchStore, prefix = 'vault:'): StitchStore {
  */
 export function chainThrottle(throttles: Throttle[]): Throttle {
     return {
-        async acquire(key) {
+        async acquire(key, opts) {
             let waitedMs = 0;
+            // Thread the acquire options (e.g. `rateOnly` for streaming) to EVERY gate, so a
+            // streaming member skips the concurrency slot on both the seam bucket and its own
+            // local throttle while still charging each rate gate (ADR 0005 Decision 12).
             for (const t of throttles)
-                waitedMs += (await t.acquire(key)).waitedMs;
+                waitedMs += (await t.acquire(key, opts)).waitedMs;
             return { waitedMs };
         },
         release(key) {
@@ -80,7 +83,7 @@ export function chainThrottle(throttles: Throttle[]): Throttle {
 }
 
 export interface Throttle {
-    acquire(key: string): Promise<{ waitedMs: number }>;
+    acquire(key: string, opts?: AcquireOptions): Promise<{ waitedMs: number }>;
     release(key: string): void;
 }
 
@@ -118,13 +121,21 @@ export function createStoreThrottle(
         return new Promise<void>((resolve) => s.waiters.push(resolve));
     };
 
-    async function acquire(key: string): Promise<{ waitedMs: number }> {
-        // Only a real concurrency block counts as "waited" — not incidental store or
-        // scheduling time — so waitedMs (and the 'throttled' event) is deterministic.
-        const blocked = limit != null && stateFor(key).inFlight >= limit;
-        const blockStart = now();
-        await takeSlot(key);
-        let waitedMs = blocked ? now() - blockStart : 0;
+    async function acquire(
+        key: string,
+        acqOpts?: AcquireOptions,
+    ): Promise<{ waitedMs: number }> {
+        let waitedMs = 0;
+        // A rate-only acquire (a streaming surface — ADR 0005 Decision 12) takes no concurrency
+        // slot (and so is never released); it still charges the rate window below.
+        if (!acqOpts?.rateOnly) {
+            // Only a real concurrency block counts as "waited" — not incidental store or
+            // scheduling time — so waitedMs (and the 'throttled' event) is deterministic.
+            const blocked = limit != null && stateFor(key).inFlight >= limit;
+            const blockStart = now();
+            await takeSlot(key);
+            if (blocked) waitedMs = now() - blockStart;
+        }
         if (rate) {
             // At most rate.count grants per rate.perMs window. If we land over the limit,
             // wait for the next window boundary and re-check.

--- a/packages/core/src/stream.ts
+++ b/packages/core/src/stream.ts
@@ -1,0 +1,108 @@
+// The `stitchapi/stream` surface subpath (ADR 0005 Decision 5): raw response streaming with a
+// configurable decoder. Its `stream` hook reads the response's `ReadableStream` and emits each
+// decoded item as a `delta` chunk, per `stream.decode`:
+//   - `'bytes'`  (default) — raw `Uint8Array` chunks, lossless, no encoding assumed (Q2).
+//   - `'lines'`  — UTF-8 lines (split on `\n`).
+//   - `'ndjson'` — `'lines'` + `JSON.parse` per non-blank line.
+// The `'lines'`/`'ndjson'` decoders share the byte→line plumbing with `sse` (the `lineReader`), but
+// `sse` layers its own event-stream frame parser on top — they share plumbing, not a decoder (Q3).
+//
+// Bundle-frugal (Decision 10): reached only through the `stream` subpath; `import { stitch }` pulls
+// in none of it.
+import type { InputOf } from './infer';
+import { lineReader } from './line-reader';
+import { seam as makeSeam } from './seam';
+import { makeStitch } from './stitch';
+import type { Surface } from './surface';
+import {
+    type AdapterResponse,
+    type Seam,
+    type SeamOptions,
+    type Stitch,
+    type StitchConfig,
+    type StitchInput,
+    isSeam,
+} from './types';
+
+// Decode the live body into `delta` items per `cfg.stream.decode` (default `'bytes'`).
+async function* decodeStream(
+    res: AdapterResponse,
+    cfg: StitchConfig,
+): AsyncGenerator<unknown, void> {
+    const body = res.body;
+    if (!(body instanceof ReadableStream)) return;
+    const stream = body as ReadableStream<Uint8Array>;
+    const decode = cfg.stream?.decode ?? 'bytes';
+
+    if (decode === 'lines') {
+        yield* lineReader(stream);
+        return;
+    }
+    if (decode === 'ndjson') {
+        for await (const line of lineReader(stream)) {
+            if (line.trim() === '') continue; // tolerate blank lines between records
+            const parsed: unknown = JSON.parse(line);
+            yield parsed;
+        }
+        return;
+    }
+    // 'bytes' (default): hand back raw chunks exactly as they arrive on the wire.
+    const reader = stream.getReader();
+    try {
+        for (;;) {
+            const r = await reader.read();
+            if (r.done) break;
+            yield r.value;
+        }
+    } finally {
+        reader.releaseLock();
+    }
+}
+
+/**
+ * The raw streaming surface. Its `stream` hook marks it streaming (Decision 12): the engine opens
+ * the live body, feeds it here, and emits each decoded chunk as a `delta`.
+ */
+export const streamSurface: Surface<StitchInput, unknown[]> = {
+    id: 'stream',
+    stream: (res, cfg) => decodeStream(res, cfg),
+};
+
+/** stream members bound to a seam. `stitch(config)` creates a stream member of `seam`; `seam` is
+ *  the underlying handle for lifecycle/principal (`.as`/`.flush`/`.close`). */
+export interface StreamSeamApi {
+    readonly stitch: <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+        config: C,
+    ) => Stitch<unknown[], InputOf<C>>;
+    readonly seam: Seam;
+}
+
+// Standalone stream stitch: the call argument is inferred from `config.input`, the result fixed to
+// the collected chunk array (a streaming await resolves to all of its `delta` chunks — Stage 5).
+const streamStitch = <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+    config: C,
+): Stitch<unknown[], InputOf<C>> =>
+    makeStitch<unknown[]>({ ...config, kind: streamSurface });
+
+// Bind stream members to a seam through the seam's surface-agnostic `stitch({ kind })` (Decision 3).
+function bindSeam(s: Seam): StreamSeamApi {
+    const stitch = <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+        config: C,
+    ): Stitch<unknown[], InputOf<C>> =>
+        s.stitch<unknown[]>({ ...config, kind: streamSurface });
+    return { stitch, seam: s };
+}
+
+/**
+ * The stream surface's authoring helper — callable for the terse form (`stream(config)`) plus:
+ * - `stream.stitch(config)` — a standalone stream stitch (alias of the callable).
+ * - `stream.seam(existingSeam)` — bind stream members to an existing seam.
+ * - `stream.seam(options)` — a new seam whose members default to stream.
+ * - `stream.surface` — the stream {@link Surface} identity.
+ */
+export const stream = Object.assign(streamStitch, {
+    surface: streamSurface,
+    stitch: streamStitch,
+    seam: (arg: Seam | SeamOptions): StreamSeamApi =>
+        bindSeam(isSeam(arg) ? arg : makeSeam(arg)),
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -60,6 +60,17 @@ export interface MultipartOptions {
     nesting?: MultipartNesting;
 }
 /**
+ * How the `stream` surface decodes each chunk of a live response body (ADR 0005 Decision 5).
+ * - `'bytes'` (default) — raw `Uint8Array` chunks, lossless, no encoding assumed.
+ * - `'lines'` — UTF-8, split on `\n`; each `delta` chunk is a `string`.
+ * - `'ndjson'` — `'lines'` + `JSON.parse` per non-blank line; each chunk a parsed value.
+ */
+export type StreamDecode = 'bytes' | 'lines' | 'ndjson';
+export interface StreamOptions {
+    /** Decoder for a `stream` surface body. Default `'bytes'` (total + lossless). */
+    decode?: StreamDecode;
+}
+/**
  * Byte-transfer progress for a single request (ADR 0005 Decision 9). Reported through
  * {@link AdapterRequest.onProgress}, tagged by direction: `'upload'` as the request body is
  * sent, `'download'` as the response body arrives. `total` is the content length when known.
@@ -114,6 +125,14 @@ export interface ThrottleOptions {
     rate?: string; // "2/s"
     concurrency?: number;
     scope?: 'stitch' | 'host';
+}
+/**
+ * Options for one throttle `acquire`. `rateOnly` charges the rate limiter but takes NO concurrency
+ * slot — for streaming surfaces (`sse`/`stream`), whose long-lived connection must not pin a slot
+ * (ADR 0005 Decision 12). A rate-only acquire is NOT paired with a `release` (nothing was held).
+ */
+export interface AcquireOptions {
+    rateOnly?: boolean;
 }
 export interface TimeoutOptions {
     total?: number | string;
@@ -310,6 +329,11 @@ export interface StitchConfig {
      * field names. Only meaningful with `bodyType: 'multipart'`. Default nesting `'bracket'`.
      */
     multipart?: MultipartOptions;
+    /**
+     * Streaming options (ADR 0005 Decision 5) — how a `stream` surface decodes the live body
+     * (`'bytes'` default / `'lines'` / `'ndjson'`). Only meaningful for the `stream` surface.
+     */
+    stream?: StreamOptions;
     /** How to read the response body. Default: auto by content-type. */
     responseType?: ResponseType;
     /**

--- a/packages/core/test/gaps/browser-bundle.spec.ts
+++ b/packages/core/test/gaps/browser-bundle.spec.ts
@@ -1,4 +1,5 @@
 // Pins docs/GAP-AUDIT.md §1.5: The core entry must bundle for the browser — no node:* imports or unguarded process.env on the call path
+import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
 
@@ -76,4 +77,61 @@ describe('browser bundle (GAP-AUDIT §1.5)', () => {
         expect(outcome.output).not.toMatch(NODE_SPECIFIER);
         expect(outcome.output.length).toBeGreaterThan(0);
     }, 15_000);
+});
+
+// ---------------------------------------------------------------------------
+// ADR 0005 Stage 5 — streaming surfaces hold the browser-first + bundle-frugal gates
+// ---------------------------------------------------------------------------
+
+describe('streaming surfaces are browser-first (ADR 0005 Decisions 4-5)', () => {
+    // Each surface subpath must bundle for the browser on fetch + Web Streams alone — no node:*
+    // dep transitively, and never `EventSource` (Decision 4 rejects it: GET-only, no headers,
+    // Node-absent).
+    test.each(['src/sse.ts', 'src/stream.ts'])(
+        '%s bundles for "browser" with no node:* specifiers and no EventSource',
+        async (entry) => {
+            const { build } = loadEsbuild();
+            const outcome = await build({
+                entryPoints: [join(ROOT, entry)],
+                bundle: true,
+                platform: 'browser',
+                format: 'esm',
+                write: false,
+                logLevel: 'silent',
+            }).then(
+                (result) => ({
+                    errorTexts: result.errors.map((e) => e.text),
+                    output: result.outputFiles?.[0]?.text ?? '',
+                }),
+                (error: unknown) => {
+                    const failed = error as { errors?: EsbuildMessage[] };
+                    return {
+                        errorTexts: (
+                            failed.errors ?? [{ text: String(error) }]
+                        ).map((e) => e.text),
+                        output: '',
+                    };
+                },
+            );
+
+            expect(outcome.errorTexts).toEqual([]);
+            expect(outcome.output).not.toMatch(NODE_SPECIFIER);
+            expect(outcome.output).not.toMatch(/\bEventSource\b/);
+            expect(outcome.output.length).toBeGreaterThan(0);
+        },
+        15_000,
+    );
+});
+
+describe('streaming surfaces are bundle-frugal (ADR 0005 Decision 10)', () => {
+    // `import { stitch }` must pull in NO streaming code: the root entry and the engine reach a
+    // streaming surface only through `cfg.kind.stream` at runtime, never a static import of the
+    // surface modules or the shared line reader. (The parser/decoders live behind the subpaths.)
+    test.each(['src/index.ts', 'src/engine.ts'])(
+        '%s does not statically import a streaming surface module',
+        (rel) => {
+            const src = readFileSync(join(ROOT, rel), 'utf8');
+            expect(src).not.toMatch(/['"]\.\/(sse|stream|line-reader)['"]/);
+        },
+    );
 });

--- a/packages/core/test/sse.spec.ts
+++ b/packages/core/test/sse.spec.ts
@@ -1,0 +1,187 @@
+// The `sse` surface (ADR 0005 Decision 4): Server-Sent Events over fetch + Web Streams (never
+// EventSource). The stream hook parses the text/event-stream wire format off the ReadableStream
+// and yields one parsed event per `delta` chunk. Most cases drive the frame parser directly over a
+// fake stream (precise chunk boundaries); the engine spine + a real-fetch case round it out.
+import { seam, stitch } from '../src';
+import { sse, sseSurface } from '../src/sse';
+import type { SseEvent } from '../src/sse';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+import { collectEvents, streamAdapter, streamOf } from './support/streams';
+
+// Run the SSE frame parser over the given chunk boundaries and collect the parsed events.
+async function parse(chunks: string[]): Promise<SseEvent[]> {
+    const res = { status: 200, headers: {}, body: streamOf(chunks) };
+    const out: SseEvent[] = [];
+    // `stream` is defined on a streaming surface; tests may assert non-null.
+    for await (const ev of sseSurface.stream!(res, {}))
+        out.push(ev as SseEvent);
+    return out;
+}
+
+describe('sse surface identity (Decisions 4, 11)', () => {
+    test('sseSurface has the stable id "sse" and a stream hook', () => {
+        expect(sseSurface.id).toBe('sse');
+        expect(typeof sseSurface.stream).toBe('function');
+    });
+
+    test('kind round-trips through __config as the id string "sse"', () => {
+        const s = sse({ url: 'https://x.test/e' });
+        const json = JSON.parse(JSON.stringify(s.__config)) as {
+            kind?: unknown;
+        };
+        expect(json.kind).toBe('sse');
+    });
+});
+
+describe('sse frame parser (Decision 4)', () => {
+    test('a single data event', async () => {
+        expect(await parse(['data: hello\n\n'])).toEqual([{ data: 'hello' }]);
+    });
+
+    test('data is JSON-parsed when it parses, else the raw string', async () => {
+        expect(await parse(['data: {"x":1}\n\n'])).toEqual([
+            { data: { x: 1 } },
+        ]);
+        expect(await parse(['data: plain text\n\n'])).toEqual([
+            { data: 'plain text' },
+        ]);
+        expect(await parse(['data: 42\n\n'])).toEqual([{ data: 42 }]);
+    });
+
+    test('multiple data: lines join with \\n', async () => {
+        expect(await parse(['data: a\ndata: b\n\n'])).toEqual([
+            { data: 'a\nb' },
+        ]);
+    });
+
+    test('event / id / retry fields are captured; retry must be an integer', async () => {
+        expect(
+            await parse(['event: ping\nid: 7\nretry: 1500\ndata: hi\n\n']),
+        ).toEqual([{ event: 'ping', id: '7', retry: 1500, data: 'hi' }]);
+        // a non-integer retry is ignored
+        expect(await parse(['retry: soon\ndata: x\n\n'])).toEqual([
+            { data: 'x' },
+        ]);
+    });
+
+    test('comments (":"-prefixed) are ignored; exactly one leading space is stripped', async () => {
+        expect(await parse([': keep-alive\ndata:  x\n\n'])).toEqual([
+            { data: ' x' }, // two spaces after colon, one stripped → leading space kept
+        ]);
+    });
+
+    test('CRLF line endings are handled', async () => {
+        expect(await parse(['data: a\r\n\r\n'])).toEqual([{ data: 'a' }]);
+    });
+
+    test('a block with no data: line dispatches nothing', async () => {
+        // an id-only block sets no data → not dispatched (SSE spec); only the real event yields
+        expect(await parse(['id: 1\n\ndata: y\n\n'])).toEqual([{ data: 'y' }]);
+    });
+
+    test('an incomplete trailing event (no terminating blank line) is discarded', async () => {
+        expect(await parse(['data: full\n\ndata: partial'])).toEqual([
+            { data: 'full' },
+        ]);
+    });
+
+    test('events split across chunk boundaries still parse', async () => {
+        expect(
+            await parse(['da', 'ta: spl', 'it\n', '\ndata: two', '\n\n']),
+        ).toEqual([{ data: 'split' }, { data: 'two' }]);
+    });
+
+    test('a field with no value (no colon) is read with an empty value', async () => {
+        // `data` alone → one empty data line → data buffer "" → dispatched with empty data
+        expect(await parse(['data\n\n'])).toEqual([{ data: '' }]);
+    });
+});
+
+describe('sse over the engine (event spine + await)', () => {
+    test('emits start → request → delta-per-event → result (collected) → done', async () => {
+        const s = sse({
+            url: 'https://x.test/e',
+            adapter: streamAdapter(
+                streamOf(['data: 1\n\n', 'data: 2\n\n', 'data: 3\n\n']),
+            ),
+        });
+
+        const ev = await collectEvents(s.stream());
+        expect(ev.types).toEqual([
+            'start',
+            'progress',
+            'delta',
+            'delta',
+            'delta',
+            'result',
+            'done',
+        ]);
+        expect(ev.deltas).toEqual([{ data: 1 }, { data: 2 }, { data: 3 }]);
+        expect(ev.result).toEqual([{ data: 1 }, { data: 2 }, { data: 3 }]);
+    });
+
+    test('await resolves to the collected array of events', async () => {
+        const s = sse({
+            url: 'https://x.test/e',
+            adapter: streamAdapter(streamOf(['data: a\n\n', 'data: b\n\n'])),
+        });
+        expect(await s()).toEqual([{ data: 'a' }, { data: 'b' }]);
+    });
+});
+
+describe('sse over real fetch + Web Streams (browser-first gate)', () => {
+    let server: MockServer;
+    beforeAll(async () => {
+        server = await startMockServer();
+    });
+    afterAll(async () => {
+        await server.close();
+    });
+    beforeEach(() => {
+        server.reset();
+    });
+
+    test('parses an event-stream served over HTTP (no EventSource)', async () => {
+        const wire = 'event: tick\ndata: {"n":1}\n\ndata: {"n":2}\n\n';
+        server.route('GET', '/events', {
+            body: Buffer.from(wire),
+            headers: { 'content-type': 'text/event-stream' },
+        });
+
+        const events = sse({ baseUrl: server.url, path: '/events' });
+        expect(await events()).toEqual([
+            { event: 'tick', data: { n: 1 } },
+            { data: { n: 2 } },
+        ]);
+        expect(server.calls('/events')[0]?.method).toBe('GET');
+    });
+});
+
+describe('sse authoring helpers (Decision 3)', () => {
+    test('sse.surface is the sse Surface; sse.stitch aliases the callable', () => {
+        expect(sse.surface).toBe(sseSurface);
+        const a = sse({ url: 'https://x.test/e' });
+        const b = sse.stitch({ url: 'https://x.test/e' });
+        expect(a.__config.kind).toBe(b.__config.kind);
+    });
+
+    test('sse.seam(existingSeam).stitch(...) creates an sse member of that seam', async () => {
+        const api = seam({ baseUrl: 'https://x.test' });
+        const events = sse.seam(api).stitch({
+            path: '/e',
+            adapter: streamAdapter(streamOf(['data: ok\n\n'])),
+        });
+        expect(await events()).toEqual([{ data: 'ok' }]);
+    });
+
+    test('a generic stitch({ kind: sseSurface }) streams the same way', async () => {
+        const s = stitch({
+            kind: sseSurface,
+            url: 'https://x.test/e',
+            adapter: streamAdapter(streamOf(['data: via-kind\n\n'])),
+        });
+        const ev = await collectEvents(s.stream());
+        expect(ev.deltas).toEqual([{ data: 'via-kind' }]);
+    });
+});

--- a/packages/core/test/stream.spec.ts
+++ b/packages/core/test/stream.spec.ts
@@ -1,0 +1,205 @@
+// The `stream` surface (ADR 0005 Decision 5): raw response streaming with a configurable
+// decoder (`bytes` default / `lines` / `ndjson`), emitting one `delta` chunk per decoded item.
+// Plus Decision 12: a streaming member is exempt from the seam concurrency bucket but still
+// charges the rate gate at open. Streams are driven by a fake adapter over Web Streams, so chunk
+// boundaries are fully controlled (no socket).
+import { createThrottle } from '../src/resilience';
+import { chainThrottle, createStoreThrottle, memoryStore } from '../src/store';
+import { stream, streamSurface } from '../src/stream';
+import { now } from '../src/util';
+import {
+    collectEvents,
+    gatedStream,
+    streamAdapter,
+    streamOf,
+} from './support/streams';
+
+const td = new TextDecoder();
+
+describe('stream surface identity (Decisions 5, 11)', () => {
+    test('streamSurface has the stable id "stream" and a stream hook', () => {
+        expect(streamSurface.id).toBe('stream');
+        expect(typeof streamSurface.stream).toBe('function');
+    });
+
+    test('kind round-trips through __config as the id string "stream"', () => {
+        const s = stream({ url: 'https://x.test/s' });
+        const json = JSON.parse(JSON.stringify(s.__config)) as {
+            kind?: unknown;
+        };
+        expect(json.kind).toBe('stream');
+    });
+});
+
+describe('stream decoders (Decision 5)', () => {
+    test('default decode is "bytes": delta chunks are Uint8Array, await collects them', async () => {
+        const s = stream({
+            url: 'https://x.test/b',
+            adapter: streamAdapter(streamOf(['ab', 'cd'])),
+        });
+
+        const chunks = await s();
+        expect(chunks.every((c) => c instanceof Uint8Array)).toBe(true);
+        const joined = chunks.map((c) => td.decode(c as Uint8Array)).join('');
+        expect(joined).toBe('abcd');
+    });
+
+    test('decode "lines": UTF-8 split on \\n, one string per line, across chunk boundaries', async () => {
+        const s = stream({
+            url: 'https://x.test/l',
+            stream: { decode: 'lines' },
+            // a line ("hello") is split across two chunks; the last line has no trailing \n
+            adapter: streamAdapter(streamOf(['he', 'llo\nwor', 'ld'])),
+        });
+
+        expect(await s()).toEqual(['hello', 'world']);
+    });
+
+    test('decode "ndjson": each non-blank line is JSON.parsed', async () => {
+        const s = stream({
+            url: 'https://x.test/n',
+            stream: { decode: 'ndjson' },
+            adapter: streamAdapter(
+                streamOf(['{"a":1}\n', '\n', '{"b":', '2}\n']),
+            ),
+        });
+
+        expect(await s()).toEqual([{ a: 1 }, { b: 2 }]);
+    });
+});
+
+describe('stream event spine (Decisions 5, 12)', () => {
+    test('emits start → request → delta* → result → done; result is the collected array', async () => {
+        const s = stream({
+            url: 'https://x.test/e',
+            stream: { decode: 'lines' },
+            adapter: streamAdapter(streamOf(['one\n', 'two\n', 'three\n'])),
+        });
+
+        const ev = await collectEvents(s.stream());
+        expect(ev.types).toEqual([
+            'start',
+            'progress', // request
+            'delta',
+            'delta',
+            'delta',
+            'result',
+            'done',
+        ]);
+        expect(ev.deltas).toEqual(['one', 'two', 'three']);
+        expect(ev.result).toEqual(['one', 'two', 'three']); // await resolves to the collection
+        expect(ev.done?.ok).toBe(true);
+    });
+
+    test('the engine asks the transport for the live body (req.stream = true)', async () => {
+        let sawStream: boolean | undefined;
+        const s = stream({
+            url: 'https://x.test/f',
+            adapter: (req) => {
+                sawStream = req.stream;
+                return Promise.resolve({
+                    status: 200,
+                    headers: {},
+                    body: streamOf(['x']),
+                });
+            },
+        });
+
+        await s();
+        expect(sawStream).toBe(true);
+    });
+
+    test('a >=400 status fails the call (the stream opened with an error status)', async () => {
+        const s = stream({
+            url: 'https://x.test/err',
+            adapter: streamAdapter(streamOf(['nope']), { status: 503 }),
+        });
+
+        await expect(s()).rejects.toThrow(/503/);
+    });
+});
+
+describe('Decision 12 — streaming is concurrency-exempt but rate-charged', () => {
+    test('a long-lived stream does NOT pin the concurrency slot', async () => {
+        // concurrency: 1. Stream 1 opens and stays open (gated). If a streaming open held the
+        // single slot for the connection's life, stream 2 could never acquire it and would hang.
+        let release1!: () => void;
+        const gate = new Promise<void>((r) => {
+            release1 = r;
+        });
+        let opened1!: () => void;
+        const stream1Open = new Promise<void>((r) => {
+            opened1 = r;
+        });
+
+        let opens = 0;
+        const s = stream({
+            url: 'https://x.test/c',
+            stream: { decode: 'lines' },
+            throttle: { concurrency: 1 },
+            adapter: (req) => {
+                if (!req.stream) throw new Error('expected stream');
+                const n = ++opens;
+                if (n === 1) {
+                    opened1();
+                    return Promise.resolve({
+                        status: 200,
+                        headers: {},
+                        body: gatedStream('hold\n', gate),
+                    });
+                }
+                return Promise.resolve({
+                    status: 200,
+                    headers: {},
+                    body: streamOf(['second\n']),
+                });
+            },
+        });
+
+        // Pump stream 1 in the background; it parks reading the open (gated) body.
+        const pump1 = collectEvents(s.stream());
+        await stream1Open;
+
+        // Stream 2 must fully open + complete despite the single concurrency slot.
+        expect(await s()).toEqual(['second']);
+        expect(opens).toBe(2);
+
+        release1();
+        const ev1 = await pump1;
+        expect(ev1.result).toEqual(['hold']);
+    });
+
+    test('createThrottle: a rateOnly acquire takes NO concurrency slot (never released)', async () => {
+        const t = createThrottle({ concurrency: 1 });
+        // Two rate-only acquires with concurrency:1 and no release: if either took the slot the
+        // second (or the normal acquire below) would block forever.
+        await t.acquire('k', { rateOnly: true });
+        await t.acquire('k', { rateOnly: true });
+        // The slot was never consumed, so a normal acquire still proceeds immediately.
+        const r = await t.acquire('k');
+        expect(r.waitedMs).toBe(0);
+    });
+
+    test('createStoreThrottle: rateOnly skips concurrency but DOES charge the rate window', async () => {
+        const store = memoryStore();
+        const t = createStoreThrottle({ concurrency: 1, rate: '100/s' }, store);
+        await t.acquire('svc', { rateOnly: true });
+        await t.acquire('svc', { rateOnly: true });
+        // The fixed-window counter records BOTH opens (Decision 12: charge the rate gate at open).
+        const windowStart = Math.floor(now() / 1000) * 1000;
+        expect(await store.get(`rl:svc:${windowStart}`)).toBe(2);
+    });
+
+    test('chainThrottle forwards rateOnly to every gate (seam bucket + member)', async () => {
+        const t = chainThrottle([
+            createThrottle({ concurrency: 1 }),
+            createThrottle({ concurrency: 1 }),
+        ]);
+        // Both gates are concurrency:1; a rate-only acquire must skip BOTH, so repeated
+        // un-released acquires never deadlock.
+        await t.acquire('k', { rateOnly: true });
+        await t.acquire('k', { rateOnly: true });
+        const r = await t.acquire('k', { rateOnly: true });
+        expect(r.waitedMs).toBe(0);
+    });
+});

--- a/packages/core/test/support/streams.ts
+++ b/packages/core/test/support/streams.ts
@@ -1,0 +1,99 @@
+// Test helpers for driving Web Streams without a socket: build a `ReadableStream` from
+// string/byte chunks, an adapter that hands one back as a live (`req.stream`) body, and a
+// collector that drains a stitch event generator into its parts. Lets sse/stream specs assert
+// the streaming execution path deterministically, with full control over chunk boundaries.
+import type {
+    Adapter,
+    AdapterRequest,
+    AdapterResponse,
+    StitchEvent,
+} from '../../src/types';
+
+const enc = new TextEncoder();
+
+/**
+ * A `ReadableStream` that emits each of `chunks` as a separate read (strings are UTF-8 encoded),
+ * then closes. One chunk per `pull`, so a test can place chunk boundaries anywhere — e.g. split a
+ * single SSE line across two chunks to exercise cross-chunk buffering.
+ */
+export function streamOf(
+    chunks: (string | Uint8Array)[],
+): ReadableStream<Uint8Array> {
+    let i = 0;
+    return new ReadableStream<Uint8Array>({
+        pull(controller) {
+            if (i >= chunks.length) {
+                controller.close();
+                return;
+            }
+            const c = chunks[i++] as string | Uint8Array;
+            controller.enqueue(typeof c === 'string' ? enc.encode(c) : c);
+        },
+    });
+}
+
+/**
+ * A `ReadableStream` that emits `first`, then stays OPEN until `gate` resolves, then closes —
+ * the long-lived-connection shape the concurrency-exemption test (Decision 12) needs.
+ */
+export function gatedStream(
+    first: string,
+    gate: Promise<void>,
+): ReadableStream<Uint8Array> {
+    let sent = false;
+    return new ReadableStream<Uint8Array>({
+        async pull(controller) {
+            if (!sent) {
+                sent = true;
+                controller.enqueue(enc.encode(first));
+                return;
+            }
+            await gate;
+            controller.close();
+        },
+    });
+}
+
+/** An adapter that requires a streaming request and returns `body` as the live response body. */
+export function streamAdapter(
+    body: ReadableStream<Uint8Array>,
+    init: { status?: number; headers?: Record<string, string> } = {},
+): Adapter {
+    return (req: AdapterRequest): Promise<AdapterResponse> => {
+        if (!req.stream)
+            return Promise.reject(new Error('expected req.stream to be set'));
+        return Promise.resolve({
+            status: init.status ?? 200,
+            headers: init.headers ?? {},
+            body,
+        });
+    };
+}
+
+export interface CollectedEvents<T> {
+    types: string[];
+    deltas: unknown[];
+    result: T | undefined;
+    error: { message: string; status: number | undefined } | undefined;
+    done: { ok: boolean } | undefined;
+}
+
+/** Drain a stitch event generator into its parts: every delta chunk, the terminal result/error/done. */
+export async function collectEvents<T>(
+    gen: AsyncGenerator<StitchEvent<T>, void>,
+): Promise<CollectedEvents<T>> {
+    const types: string[] = [];
+    const deltas: unknown[] = [];
+    let result: T | undefined;
+    let error: { message: string; status: number | undefined } | undefined;
+    let done: { ok: boolean } | undefined;
+    for await (const ev of gen) {
+        types.push(ev.type);
+        if (ev.type === 'delta') deltas.push(ev.chunk);
+        else if (ev.type === 'result') result = ev.value;
+        else if (ev.type === 'error')
+            error = { message: ev.message, status: ev.status };
+        else if (ev.type === 'done') done = { ok: ev.ok };
+    }
+    return { types, deltas, result, error, done };
+}


### PR DESCRIPTION
## ADR 0005 Stage 5 — the `sse` + `stream` surfaces (Decisions 4, 5, 12)

Stages 0–4 introduced the surface plugin model and moved `graphql` behind it. This stage adds the two **streaming** surfaces and the engine's streaming execution path, finally giving the dormant `delta` `StitchEvent` its emitters.

### What's here

- **`stream` surface** (`src/stream.ts`, Decision 5) — raw response streaming with a `stream.decode` option: `'bytes'` (default — total + lossless `Uint8Array` chunks), `'lines'` (UTF-8 split on `\n`), `'ndjson'` (lines + `JSON.parse`). Monomorphic helper `stream.stitch` / `stream.seam` / `stream.surface`, mirroring `graphql.ts`.
- **`sse` surface** (`src/sse.ts`, Decision 4) — a `text/event-stream` frame parser over **fetch + Web Streams, never `EventSource`**. Yields one `{ event?, data, id?, retry? }` per `delta` (`data` JSON-parsed when it parses, else the raw string; multi-line `data:` joined with `\n`; comments + one leading space handled; an event with no `data:` and an incomplete trailing event are not dispatched, per spec).
- **Shared `lineReader`** (`src/line-reader.ts`) — the byte→UTF-8-line plumbing both surfaces sit on (handles multi-byte chars and lines split across chunk boundaries). `sse`'s frame parser and `stream`'s `lines`/`ndjson` decoders share the *plumbing*, not a *decoder* (Q3).
- **Engine streaming path** (`engine.ts` `runStreaming`) — when `cfg.kind.stream` is present, set `AdapterRequest.stream = true`, open the live `ReadableStream`, and yield each decoded item as a `delta`, then a terminal `result`/`done`. Bypasses cache + pagination; no retry/circuit (broken-stream retry is out of scope, issue #71).
- **Decision 12 — concurrency-exempt, rate-charged.** A streaming open charges the rate gate **once** but takes **no** concurrency slot (a long-lived stream must never pin one). New `rateOnly` `AcquireOptions` threaded through `createThrottle` / `createStoreThrottle` / `chainThrottle` / the seam bucket and the engine's `acquireWithin` (which also skips the release-on-timeout for a rate-only acquire — there is no slot to hand back).

### Sub-decision the ADR left open: what does `await` resolve to for a streaming surface?

**Resolved → the collected array of every `delta` chunk** (recorded as ADR **Q4**).

A streaming run ends `… → result → done` like every run, and `await stitch()` returns the terminal `result.value`. For a streaming surface that is the **ordered collection of everything emitted as a `delta`** — `await` is "give me the whole stream", `.stream()` is "give me it incrementally". The alternatives lose: `undefined` makes streaming the lone surface whose `await` returns no data; the **last chunk** silently discards data (catastrophic for SSE, where every event matters). The array is the only lossless, spine-consistent choice and reads like `Array.fromAsync(stream)`. Documented trade-off: `await` buffers the whole stream, so it is for **bounded** streams; unbounded/long-lived streams use `.stream()`, which buffers nothing. (transform/unwrap/`output` validation are buffered-response concepts and are not applied to the delta path.)

### Gates re-checked (new tests in `gaps/browser-bundle.spec.ts`)

- **Browser-first** — `src/sse.ts` and `src/stream.ts` bundle for `platform: 'browser'` with no `node:*` specifier and no `EventSource`.
- **Bundle-frugal** — `src/index.ts` and `src/engine.ts` never statically import `sse`/`stream`/`line-reader`; the engine reaches a streaming surface only through `cfg.kind.stream` at runtime. `import { stitch }` pulls in zero streaming code.
- **Contract-not-dependency** — `kind` round-trips through `__config` as the id string (`'sse'` / `'stream'`).

### Scope / out of scope

- Per-stage rule honoured: **one** stage, stop for review. Packaging the subpath `exports` (`./sse`, `./stream`) + docs reframe is **Stage 7** (the surfaces are reached via their `src/*` modules and fully tested here, exactly as the `graphql` helper skeleton was staged ahead of its packaging).
- SSE auto-reconnection / `Last-Event-ID` is **out** (issue #71).

### Tests

`sse.spec.ts` (frame parser incl. cross-chunk boundaries, CRLF, JSON-vs-raw data, event spine, **a real fetch + mock-server round-trip**, helpers) and `stream.spec.ts` (the three decoders, event spine, the collected-array `await`, and Decision 12 — a long-lived stream not pinning the single concurrency slot + throttle-primitive rate-only unit tests). Full suite green: **339 tests**, typecheck (src+test) + tsd + eslint + prettier + attw + build-docs all clean.
