### PR TITLE
feat(core): download surface — buffered binary GET → { blob, filename } (ADR 0005 Decision 8; Stage 6)

### DIFF
--- a/packages/core/src/download.ts
+++ b/packages/core/src/download.ts
@@ -1,0 +1,126 @@
+// The `stitchapi/download` surface subpath (ADR 0005 Decision 8): a buffered binary GET that
+// resolves to `{ blob, filename }`. The surface forces `GET` + `responseType: 'blob'`, buffers the
+// whole body into a `Blob` (reporting byte progress as it arrives when a caller passes
+// `onProgress` — Decision 9), and names it from `Content-Disposition` (`filename*` preferred, then
+// `filename`), falling back to the response URL's last path segment. It NEVER writes to disk —
+// returning a `Blob` keeps it browser-first; saving is the caller's choice. Distinct from `stream`:
+// `download` buffers; `stream` hands back live chunks.
+//
+// Bundle-frugal (Decision 10): reached only through the `download` subpath; `import { stitch }`
+// pulls in none of it.
+import type { InputOf } from './infer';
+import { seam as makeSeam } from './seam';
+import { makeStitch } from './stitch';
+import type { Surface, SurfaceOutcome } from './surface';
+import {
+    type Seam,
+    type SeamOptions,
+    type Stitch,
+    type StitchConfig,
+    type StitchInput,
+    isSeam,
+} from './types';
+
+/** What a `download` stitch resolves to: the buffered body and its parsed filename (when known). */
+export interface DownloadResult {
+    blob: Blob;
+    filename?: string;
+}
+
+// Parse a filename from a `Content-Disposition` header. RFC 5987 `filename*` (percent-encoded, with
+// a charset) is preferred over a plain `filename` (quoted or a bare token).
+function filenameFromDisposition(cd: string | undefined): string | undefined {
+    if (cd === undefined) return undefined;
+    const ext = /filename\*\s*=\s*[^']*'[^']*'([^;]+)/i.exec(cd)?.[1]?.trim();
+    if (ext !== undefined && ext !== '') {
+        try {
+            return decodeURIComponent(ext);
+        } catch {
+            return ext; // malformed percent-encoding: hand back the raw value
+        }
+    }
+    const m = /filename\s*=\s*(?:"([^"]*)"|([^;]+))/i.exec(cd);
+    const plain = (m?.[1] ?? m?.[2])?.trim();
+    return plain !== undefined && plain !== '' ? plain : undefined;
+}
+
+// Fall back to the last path segment of the (final, post-redirect) response URL.
+function filenameFromUrl(url: string | undefined): string | undefined {
+    if (url === undefined) return undefined;
+    let pathname: string;
+    try {
+        pathname = new URL(url).pathname;
+    } catch {
+        return undefined; // not an absolute URL
+    }
+    const segments = pathname.split('/').filter((s) => s !== '');
+    const last = segments[segments.length - 1];
+    if (last === undefined) return undefined;
+    try {
+        return decodeURIComponent(last);
+    } catch {
+        return last;
+    }
+}
+
+/**
+ * The download surface. No `stream` hook → it is a BUFFERED surface (rides the normal engine path,
+ * not concurrency-exempt). `buildRequest` forces a blob GET; `interpret` names the buffered Blob.
+ */
+export const downloadSurface: Surface<StitchInput, DownloadResult> = {
+    id: 'download',
+    buildRequest: (_cfg, _input, base) => ({
+        ...base,
+        method: 'GET',
+        responseType: 'blob',
+    }),
+    interpret: (res): SurfaceOutcome<DownloadResult> => {
+        const value: DownloadResult = { blob: res.body as Blob };
+        const filename =
+            filenameFromDisposition(res.headers['content-disposition']) ??
+            filenameFromUrl(res.url);
+        if (filename !== undefined) value.filename = filename;
+        return { ok: true, value };
+    },
+};
+
+/** download members bound to a seam. `stitch(config)` creates a download member of `seam`; `seam`
+ *  is the underlying handle for lifecycle/principal (`.as`/`.flush`/`.close`). */
+export interface DownloadSeamApi {
+    readonly stitch: <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+        config: C,
+    ) => Stitch<DownloadResult, InputOf<C>>;
+    readonly seam: Seam;
+}
+
+// Standalone download stitch: the call argument is inferred from `config.input`, the result fixed
+// to `{ blob, filename }`.
+const downloadStitch = <
+    C extends Partial<StitchConfig> = Partial<StitchConfig>,
+>(
+    config: C,
+): Stitch<DownloadResult, InputOf<C>> =>
+    makeStitch<DownloadResult>({ ...config, kind: downloadSurface });
+
+// Bind download members to a seam through the seam's surface-agnostic `stitch({ kind })`.
+function bindSeam(s: Seam): DownloadSeamApi {
+    const stitch = <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+        config: C,
+    ): Stitch<DownloadResult, InputOf<C>> =>
+        s.stitch<DownloadResult>({ ...config, kind: downloadSurface });
+    return { stitch, seam: s };
+}
+
+/**
+ * The download surface's authoring helper — callable for the terse form (`download(config)`) plus:
+ * - `download.stitch(config)` — a standalone download stitch (alias of the callable).
+ * - `download.seam(existingSeam)` — bind download members to an existing seam.
+ * - `download.seam(options)` — a new seam whose members default to download.
+ * - `download.surface` — the download {@link Surface} identity.
+ */
+export const download = Object.assign(downloadStitch, {
+    surface: downloadSurface,
+    stitch: downloadStitch,
+    seam: (arg: Seam | SeamOptions): DownloadSeamApi =>
+        bindSeam(isSeam(arg) ? arg : makeSeam(arg)),
+});

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -187,6 +187,11 @@ function buildRequest(cfg: StitchConfig, input: StitchInput): AdapterRequest {
             ? { responseType: cfg.responseType }
             : {}),
     };
+    // Per-call execution controls (ADR 0005 Decisions 8-9): cancellation + byte progress, threaded
+    // BEFORE the surface shapes the request so a surface that spreads `base` (e.g. `download`)
+    // keeps them. Runtime-only — they never came from `__config`.
+    if (input.signal) req.signal = input.signal;
+    if (input.onProgress) req.onProgress = input.onProgress;
     // The surface shapes the request (graphql packs { query, variables } + forces POST, …);
     // absent, the http identity above stands.
     if (cfg.kind?.buildRequest) req = cfg.kind.buildRequest(cfg, input, req);
@@ -393,6 +398,7 @@ async function* attemptLoop(
                 res = await withTimeout(
                     (signal) => rt.adapter({ ...req, signal }),
                     attemptMs,
+                    req.signal, // link a caller's AbortSignal (e.g. a download's) to this attempt
                 );
             } catch (err) {
                 await cfg.hooks?.onError?.({
@@ -867,8 +873,12 @@ async function* runCached(
         return;
     }
     // A non-storable response (binary read straight into the store) warns and passes through —
-    // configuring `cache` here is a no-op-with-warning, never a crash (ADR 0003 §3).
-    if (cfg.responseType === 'blob' || cfg.responseType === 'arrayBuffer') {
+    // configuring `cache` here is a no-op-with-warning, never a crash (ADR 0003 §3). Read the
+    // RESOLVED request's responseType so a surface that forces blob (`download`) is caught too.
+    if (
+        baseReq.responseType === 'blob' ||
+        baseReq.responseType === 'arrayBuffer'
+    ) {
         yield cacheEvt('bypass: non-storable responseType');
         yield* runFrom(rt, baseReq, name, state, t0, budget);
         return;

--- a/packages/core/src/http-adapter.ts
+++ b/packages/core/src/http-adapter.ts
@@ -57,6 +57,7 @@ export function fetchAdapter(): Adapter {
                 status: response.status,
                 headers: resHeaders,
                 body: response.body,
+                url: response.url,
             };
         }
 
@@ -69,6 +70,7 @@ export function fetchAdapter(): Adapter {
                 status: response.status,
                 headers: resHeaders,
                 body: decodeResponseBody(req.responseType, contentType, bytes),
+                url: response.url,
             };
         }
 
@@ -98,7 +100,12 @@ export function fetchAdapter(): Adapter {
             }
         }
 
-        return { status: response.status, headers: resHeaders, body: parsed };
+        return {
+            status: response.status,
+            headers: resHeaders,
+            body: parsed,
+            url: response.url,
+        };
     };
 }
 

--- a/packages/core/src/resilience.ts
+++ b/packages/core/src/resilience.ts
@@ -128,17 +128,43 @@ export function createThrottle(opts?: ThrottleOptions): {
     return { acquire, release };
 }
 
+// The Error to reject with when a linked signal is already aborted — its own `reason` when that is
+// an Error (the default AbortError, or a caller-supplied one), else a generic abort Error.
+function abortError(signal: AbortSignal): Error {
+    const reason: unknown = signal.reason;
+    return reason instanceof Error
+        ? reason
+        : new Error('the operation was aborted');
+}
+
 /**
- * Run `fn` with an AbortSignal that aborts after `ms`. On timeout, reject with
- * TimeoutError and ensure the signal is aborted. If `ms` is undefined, just run
- * `fn` with a non-aborting signal.
+ * Run `fn` with an AbortSignal that aborts after `ms`. On timeout, reject with TimeoutError and
+ * ensure the signal is aborted. If `ms` is undefined, just run `fn` with a non-aborting signal.
+ * An optional `linkSignal` (a caller's `AbortSignal`, e.g. on a `download` — ADR 0005 Decision 8)
+ * is mirrored onto this attempt: aborting it cancels the call. The listener is cleaned up when `fn`
+ * settles; an already-aborted `linkSignal` rejects before `fn` runs.
  */
 export function withTimeout<T>(
     fn: (signal: AbortSignal) => Promise<T>,
     ms?: number,
+    linkSignal?: AbortSignal,
 ): Promise<T> {
     const controller = new AbortController();
-    if (ms == null) return fn(controller.signal);
+    let unlink: (() => void) | undefined;
+    if (linkSignal) {
+        if (linkSignal.aborted) return Promise.reject(abortError(linkSignal));
+        const onAbort = () => {
+            controller.abort(linkSignal.reason);
+        };
+        linkSignal.addEventListener('abort', onAbort, { once: true });
+        unlink = () => {
+            linkSignal.removeEventListener('abort', onAbort);
+        };
+    }
+    if (ms == null) {
+        const out = fn(controller.signal);
+        return unlink ? out.finally(unlink) : out;
+    }
     return new Promise<T>((resolve, reject) => {
         const timer = setTimeout(() => {
             controller.abort();
@@ -147,10 +173,12 @@ export function withTimeout<T>(
         fn(controller.signal).then(
             (value) => {
                 clearTimeout(timer);
+                unlink?.();
                 resolve(value);
             },
             (err) => {
                 clearTimeout(timer);
+                unlink?.();
                 reject(err);
             },
         );

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -243,6 +243,13 @@ function mergeInput(a: StitchInput = {}, b: StitchInput = {}): StitchInput {
     // undefined`).
     if (a.variables ?? b.variables)
         merged.variables = { ...(a.variables ?? {}), ...(b.variables ?? {}) };
+    // Per-call execution controls (signal/onProgress, ADR 0005): the call argument wins over a
+    // bound value, so a `.with(...)`-bound download still honours a signal passed at call time.
+    // Omit the key when neither side sets it (exactOptionalPropertyTypes).
+    const signal = b.signal ?? a.signal;
+    if (signal) merged.signal = signal;
+    const onProgress = b.onProgress ?? a.onProgress;
+    if (onProgress) merged.onProgress = onProgress;
     return merged;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -16,6 +16,18 @@ export interface StitchInput {
     body?: unknown;
     headers?: Record<string, string>;
     variables?: Record<string, unknown>; // GraphQL variables (kind: 'graphql')
+    /**
+     * Per-call cancellation (ADR 0005 Decision 8). The engine threads it onto the request and
+     * links it with the per-attempt timeout, so aborting it cancels the in-flight call. Runtime-
+     * only — never serialised, never on `__config`.
+     */
+    signal?: AbortSignal;
+    /**
+     * Per-call byte-progress callback (ADR 0005 Decision 9), threaded onto the request — fires as
+     * the request body is sent (`'upload'`, needs `xhrAdapter`) / the response arrives
+     * (`'download'`). The `download` surface's natural progress channel. Runtime-only.
+     */
+    onProgress?: (progress: AdapterProgress) => void;
 }
 
 // ---- Drift ----------------------------------------------------------------
@@ -98,6 +110,12 @@ export interface AdapterResponse {
     headers: Record<string, string>;
     // Parsed JSON when possible, else text — OR a `ReadableStream<Uint8Array>` when `stream` was set.
     body: unknown;
+    /**
+     * The final response URL (after redirects), when the transport exposes it (`fetchAdapter` sets
+     * it from `response.url`). The `download` surface uses it for the filename fallback (ADR 0005
+     * Decision 8); other readers may ignore it.
+     */
+    url?: string;
 }
 export type Adapter = (req: AdapterRequest) => Promise<AdapterResponse>;
 

--- a/packages/core/test/download.spec.ts
+++ b/packages/core/test/download.spec.ts
@@ -1,0 +1,308 @@
+// The `download` surface (ADR 0005 Decision 8): a buffered binary GET → `{ blob, filename }`.
+// GET + responseType:'blob' (forced by the surface), byte progress (Decision 9 `onProgress`),
+// `Content-Disposition` filename (filename* / filename) with a URL-last-segment fallback, and a
+// per-call `AbortSignal`. Never writes to disk — it returns a Blob. Tests drive a fake adapter for
+// the unit cases and the real fetch + mock server for the round-trip (browser-first).
+import { seam, stitch } from '../src';
+import { download, downloadSurface } from '../src/download';
+import type { DownloadResult } from '../src/download';
+import type { Adapter, AdapterProgress, AdapterResponse } from '../src/types';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const CORE = join(import.meta.dirname, '..');
+
+// A fake adapter that hands back a Blob body (as the blob responseType would decode to), plus
+// optional response headers / final url. Records the last request it saw.
+function blobAdapter(
+    bytes: string,
+    init: {
+        headers?: Record<string, string>;
+        url?: string;
+        status?: number;
+    } = {},
+): Adapter & { last?: Parameters<Adapter>[0] } {
+    const fn = ((req) => {
+        fn.last = req;
+        const res: AdapterResponse = {
+            status: init.status ?? 200,
+            headers: init.headers ?? {},
+            body: new Blob([bytes]),
+        };
+        if (init.url !== undefined) res.url = init.url;
+        return Promise.resolve(res);
+    }) as Adapter & { last?: Parameters<Adapter>[0] };
+    return fn;
+}
+
+const bytesOf = (blob: Blob): Promise<Uint8Array> =>
+    blob.arrayBuffer().then((ab) => new Uint8Array(ab));
+
+describe('download surface identity (Decisions 8, 11)', () => {
+    test('downloadSurface has id "download", buildRequest + interpret, and NO stream hook', () => {
+        expect(downloadSurface.id).toBe('download');
+        expect(typeof downloadSurface.buildRequest).toBe('function');
+        expect(typeof downloadSurface.interpret).toBe('function');
+        expect(downloadSurface.stream).toBeUndefined(); // buffered, not a streaming surface
+    });
+
+    test('kind round-trips through __config as the id string "download"', () => {
+        const d = download({ url: 'https://x.test/f' });
+        const json = JSON.parse(JSON.stringify(d.__config)) as {
+            kind?: unknown;
+        };
+        expect(json.kind).toBe('download');
+    });
+});
+
+describe('download shaping (Decision 8)', () => {
+    test('forces GET + responseType "blob" regardless of config', async () => {
+        const adapter = blobAdapter('x');
+        const d = download({
+            url: 'https://x.test/f',
+            method: 'POST',
+            adapter,
+        });
+        await d();
+        expect(adapter.last?.method).toBe('GET');
+        expect(adapter.last?.responseType).toBe('blob');
+    });
+
+    test('resolves to { blob, filename }; the blob carries the bytes', async () => {
+        const adapter = blobAdapter('hello bytes', {
+            headers: {
+                'content-disposition': 'attachment; filename="report.pdf"',
+            },
+        });
+        const d = download({ url: 'https://x.test/f', adapter });
+
+        const out: DownloadResult = await d();
+        expect(out.filename).toBe('report.pdf');
+        expect(out.blob).toBeInstanceOf(Blob);
+        expect(new TextDecoder().decode(await bytesOf(out.blob))).toBe(
+            'hello bytes',
+        );
+    });
+});
+
+describe('filename parsing (Decision 8)', () => {
+    const filenameFor = async (
+        cd: string | undefined,
+        url?: string,
+    ): Promise<string | undefined> => {
+        const headers = cd ? { 'content-disposition': cd } : {};
+        const adapter = url
+            ? blobAdapter('x', { headers, url })
+            : blobAdapter('x', { headers });
+        const d = download({ url: 'https://x.test/f', adapter });
+        return (await d()).filename;
+    };
+
+    test('quoted filename', async () => {
+        expect(await filenameFor('attachment; filename="a b.pdf"')).toBe(
+            'a b.pdf',
+        );
+    });
+
+    test('unquoted token filename', async () => {
+        expect(await filenameFor('attachment; filename=report.csv')).toBe(
+            'report.csv',
+        );
+    });
+
+    test('RFC 5987 filename* is percent-decoded', async () => {
+        expect(
+            await filenameFor(
+                "attachment; filename*=UTF-8''r%C3%A9sum%C3%A9.pdf",
+            ),
+        ).toBe('résumé.pdf');
+    });
+
+    test('filename* is preferred over a plain filename', async () => {
+        expect(
+            await filenameFor(
+                'attachment; filename="fallback.txt"; filename*=UTF-8\'\'real.txt',
+            ),
+        ).toBe('real.txt');
+    });
+
+    test('falls back to the URL last path segment when no Content-Disposition', async () => {
+        expect(
+            await filenameFor(undefined, 'https://h.test/a/b/file.zip'),
+        ).toBe('file.zip');
+    });
+
+    test('filename is undefined when neither header nor URL yields one', async () => {
+        expect(await filenameFor(undefined)).toBeUndefined();
+    });
+});
+
+describe('byte progress (Decision 9, threaded per-call)', () => {
+    test('input.onProgress is threaded into the request and fired', async () => {
+        const adapter: Adapter = (req) => {
+            req.onProgress?.({ phase: 'download', loaded: 5, total: 10 });
+            req.onProgress?.({ phase: 'download', loaded: 10, total: 10 });
+            return Promise.resolve({
+                status: 200,
+                headers: {},
+                body: new Blob(['x']),
+            });
+        };
+        const d = download({ url: 'https://x.test/f', adapter });
+
+        const seen: AdapterProgress[] = [];
+        await d({
+            onProgress: (p) => {
+                seen.push(p);
+            },
+        });
+        expect(seen).toEqual([
+            { phase: 'download', loaded: 5, total: 10 },
+            { phase: 'download', loaded: 10, total: 10 },
+        ]);
+    });
+});
+
+describe('AbortSignal (Decision 8, per-call)', () => {
+    test('an already-aborted signal rejects the call', async () => {
+        const adapter = blobAdapter('x');
+        const d = download({ url: 'https://x.test/f', adapter });
+        const ctrl = new AbortController();
+        ctrl.abort();
+        await expect(d({ signal: ctrl.signal })).rejects.toThrow();
+    });
+
+    test('aborting in flight rejects the call (the signal reaches the adapter)', async () => {
+        // The adapter parks until its (combined) signal aborts — proving the caller's signal is
+        // threaded through the engine + timeout link to the transport.
+        const adapter: Adapter = (req) =>
+            new Promise((_, reject) => {
+                req.signal?.addEventListener(
+                    'abort',
+                    () => {
+                        reject(new Error('aborted by signal'));
+                    },
+                    { once: true },
+                );
+            });
+        const d = download({ url: 'https://x.test/f', adapter });
+        const ctrl = new AbortController();
+        const p = d({ signal: ctrl.signal });
+        ctrl.abort();
+        await expect(p).rejects.toThrow(/aborted/);
+    });
+});
+
+describe('download over real fetch + mock server (browser-first)', () => {
+    let server: MockServer;
+    beforeAll(async () => {
+        server = await startMockServer();
+    });
+    afterAll(async () => {
+        await server.close();
+    });
+    beforeEach(() => {
+        server.reset();
+    });
+
+    // every byte value 0..255 — catches any text-coercion corruption on the blob path
+    const payload = Buffer.from(Array.from({ length: 256 }, (_, i) => i));
+
+    test('downloads a binary body to a Blob with the Content-Disposition filename; bytes round-trip', async () => {
+        server.route('GET', '/file', {
+            body: payload,
+            headers: {
+                'content-disposition': 'attachment; filename="data.bin"',
+            },
+        });
+        const seen: AdapterProgress[] = [];
+        const getFile = download({ baseUrl: server.url, path: '/file' });
+
+        const out = await getFile({
+            onProgress: (p) => {
+                seen.push(p);
+            },
+        });
+        expect(out.filename).toBe('data.bin');
+        expect(out.blob).toBeInstanceOf(Blob);
+        expect(Buffer.from(await out.blob.arrayBuffer()).equals(payload)).toBe(
+            true,
+        );
+        // progress fired for the download phase
+        expect(seen.length).toBeGreaterThan(0);
+        expect(seen.every((p) => p.phase === 'download')).toBe(true);
+        expect(server.calls('/file')[0]?.method).toBe('GET');
+    });
+
+    test('filename falls back to the URL last segment when the server sends no Content-Disposition', async () => {
+        server.route('GET', '/reports/q3.csv', {
+            body: Buffer.from('a,b\n1,2'),
+        });
+        const getCsv = download({
+            baseUrl: server.url,
+            path: '/reports/q3.csv',
+        });
+        expect((await getCsv()).filename).toBe('q3.csv');
+    });
+});
+
+describe('download authoring helpers (Decision 3)', () => {
+    test('download.surface is the Surface; download.stitch aliases the callable', () => {
+        expect(download.surface).toBe(downloadSurface);
+        const a = download({ url: 'https://x.test/f' });
+        const b = download.stitch({ url: 'https://x.test/f' });
+        expect(a.__config.kind).toBe(b.__config.kind);
+    });
+
+    test('download.seam(existingSeam).stitch(...) creates a download member of that seam', async () => {
+        const api = seam({ baseUrl: 'https://x.test' });
+        const getThing = download.seam(api).stitch({
+            path: '/thing',
+            adapter: blobAdapter('thing-bytes', {
+                headers: {
+                    'content-disposition': 'attachment; filename=thing.bin',
+                },
+            }),
+        });
+        const out = await getThing();
+        expect(out.filename).toBe('thing.bin');
+        expect(new TextDecoder().decode(await bytesOf(out.blob))).toBe(
+            'thing-bytes',
+        );
+    });
+
+    test('a generic stitch({ kind: downloadSurface }) downloads the same way', async () => {
+        const d = stitch({
+            kind: downloadSurface,
+            url: 'https://x.test/f',
+            adapter: blobAdapter('z', {
+                headers: {
+                    'content-disposition': 'attachment; filename=z.bin',
+                },
+            }),
+        });
+        // the generic stitch({ kind }) overload stays Stitch<unknown> (surface-driven result
+        // typing is the monomorphic helper's job) — cast to assert the runtime shape
+        const out = (await d()) as DownloadResult;
+        expect(out.filename).toBe('z.bin');
+    });
+});
+
+describe('download holds the browser-first + bundle-frugal gates (ADR 0005)', () => {
+    test('src/download.ts uses no node:* / fs / EventSource (browser-first)', () => {
+        const src = readFileSync(join(CORE, 'src/download.ts'), 'utf8');
+        expect(src).not.toMatch(/from\s*['"]node:/);
+        expect(src).not.toMatch(/\bEventSource\b/);
+        expect(src).not.toMatch(/\bfs\b/);
+    });
+
+    test('src/index.ts and src/engine.ts never statically import ./download (bundle-frugal)', () => {
+        for (const rel of ['src/index.ts', 'src/engine.ts']) {
+            const src = readFileSync(join(CORE, rel), 'utf8');
+            expect(src).not.toMatch(/['"]\.\/download['"]/);
+        }
+    });
+});


### PR DESCRIPTION
## ADR 0005 Stage 6 — the `download` surface (Decision 8)

A non-streaming surface for "fetch a file": **GET + `responseType:'blob'`** (forced by the surface), **byte progress** (Decision 9 `onProgress`), a **`Content-Disposition` filename** with a URL-last-segment fallback, and a per-call **`AbortSignal`** — resolving to **`{ blob, filename }`**. It **never writes to disk** (returns a `Blob`; saving is the caller's choice). Distinct from `stream`: `download` *buffers* the whole body.

### What's here

- **`download` surface** ([download.ts](packages/core/src/download.ts)) — `buildRequest` forces a blob GET; `interpret` buffers `res.body` into a `Blob` and names it from `Content-Disposition` (`filename*` RFC 5987 preferred, then `filename`, quoted or token), falling back to the response URL's last path segment. **No `stream` hook** → it's a *buffered* surface (rides the normal engine path; not concurrency-exempt). Monomorphic helper `download.stitch` / `.seam` / `.surface`, mirroring `graphql`/`sse`/`stream`. **Not re-exported from the root** (bundle-frugal).
- **Per-call execution controls** on `StitchInput` — `signal?: AbortSignal` and `onProgress?` (Decision 9), runtime-only (never serialised, never on `__config`). They **auto-flow into the typed call argument** through `InputOf`'s `ExtraSlots`, so no `infer.ts` change. The engine threads them onto the request in `buildRequest`; `mergeInput` carries them through `.with()` (call arg wins).
- **`AbortSignal` wiring** — `withTimeout` gains an optional `linkSignal` that mirrors a caller's signal onto the per-attempt controller (already-aborted rejects up front; the listener is cleaned up when `fn` settles). `attemptLoop` passes `req.signal`. The no-link path is byte-identical to before, so every existing timeout/retry test is unaffected.
- **`AdapterResponse.url`** (`fetchAdapter` sets it from `response.url`) backs the filename URL fallback. `runCached`'s blob/arrayBuffer cache-bypass now reads the **resolved request's** `responseType`, so a surface-forced blob (download) bypasses the cache too.

### Sub-decisions resolved (noted for review)

1. **How are `onProgress` / `signal` supplied?** → **per-call, via `StitchInput`**. They're per-invocation execution controls (a signal cancels *this* download; progress tracks *this* download's bytes), runtime-only, and the call argument is the natural carrier. Because they live on `StitchInput`, `InputOf`'s `ExtraSlots` clause carries them into typed stitches automatically.
2. **filename source** → **`Content-Disposition` (`filename*` then `filename`), then the response URL's last path segment.** `filename*` is preferred (it carries an explicit charset and percent-encoding for non-ASCII names).

### Gates (in `download.spec.ts`)

- **Browser-first** — `download.ts` uses only `Blob` / `URL` / `fetch`; the test asserts no `node:` / `fs` / `EventSource`.
- **Bundle-frugal** — `index.ts` and `engine.ts` never statically import `./download`.
- **Contract-not-dependency** — `kind` round-trips through `__config` as `'download'`.

### Independence + scope

- **Functionally independent of Stage 5 (#99).** `download` is a *buffered* surface using only Stage 2's `onProgress` and Stage 3's surface hooks — it does **not** touch the streaming path. So it's branched fresh off `main` and is green on its own; it can merge in any order relative to [#99](https://github.com/rejifald/StitchAPI/pull/99). (Both touch `engine.ts`/`types.ts`/`resilience.ts` in different regions; the second to merge resolves a trivial overlap.)
- Packaging the subpath `export` (`./download`) + docs is **Stage 7**.

### Verification

TDD RED→green. Full pre-push gate green: **325 tests**, typecheck (src+test), tsd, eslint, prettier, attw exports, build-docs.
