### PR TITLE
feat(core): packaging — every surface is a subpath export + "any surface" docs (ADR 0005 Decisions 7,10; Stage 7)

### DIFF
--- a/apps/docs/content/docs/reference/meta.json
+++ b/apps/docs/content/docs/reference/meta.json
@@ -5,6 +5,7 @@
         "stitch",
         "auth-strategies",
         "config-types",
+        "surfaces",
         "helpers",
         "conformance-kits",
         "events"

--- a/apps/docs/content/docs/reference/surfaces.mdx
+++ b/apps/docs/content/docs/reference/surfaces.mdx
@@ -1,0 +1,147 @@
+---
+title: 'Request surfaces'
+description: 'http, graphql, sse, stream, and download — the request styles a stitch can speak, each a subpath import riding one engine.'
+---
+
+A **surface** is the request _style_ a stitch speaks. `http` is the default — a
+plain JSON-over-HTTP call, what most of these docs use. GraphQL, Server-Sent
+Events, a raw byte stream, and a file download are **peer surfaces**: each shapes
+and interprets its own request, but they all ride the same engine, so `auth`,
+`retry`, `throttle`, `timeout`, validation, and the [event
+stream](/docs/concepts/event-stream) compose with every one.
+
+> A request surface is how a stitch shapes its _request_. Don't confuse it with
+> the four [invocation surfaces](/docs/surfaces/function) — function, CLI, HTTP,
+> MCP — which are how you _call_ a stitch. The two are orthogonal: any request
+> surface is reachable through any invocation surface.
+
+Every non-`http` surface ships as its own **subpath import**, so
+`import { stitch }` from the root pulls in only the `http` engine — a surface's
+code (and its parser/decoder) loads only when you import it.
+
+| Surface    | Import               | Shapes                                     | `await` resolves to            |
+| ---------- | -------------------- | ------------------------------------------ | ------------------------------ |
+| `http`     | `stitch` (default)   | a JSON-over-HTTP call                      | the validated body             |
+| `graphql`  | `stitchapi/graphql`  | POST `{ query, variables }`, unwrap `data` | the `data` payload             |
+| `sse`      | `stitchapi/sse`      | a `text/event-stream` reader (over fetch)  | every parsed event, collected  |
+| `stream`   | `stitchapi/stream`   | a raw `ReadableStream` reader              | every decoded chunk, collected |
+| `download` | `stitchapi/download` | a buffered binary GET                      | `{ blob, filename }`           |
+
+## http — the default
+
+`stitch(...)` with no `kind` is the `http` surface: send the request, parse JSON
+when the response is JSON-ish, validate, return. Nothing to import.
+
+```ts
+import { stitch } from 'stitchapi';
+
+const getUser = stitch('https://api.example.com/users/{id}');
+```
+
+## graphql
+
+`graphql()` POSTs `{ query, variables }` and unwraps `data`; a `200` carrying
+`errors[]` is treated as a failure, never silently passed.
+
+```ts
+import { graphql } from 'stitchapi/graphql';
+
+const getThing = graphql({
+    baseUrl: 'https://api.example.com',
+    query: 'query ($id: ID) { thing(id: $id) { name } }',
+});
+
+const thing = await getThing({ variables: { id: 1 } });
+```
+
+## sse
+
+`sse` parses the `text/event-stream` wire format over `fetch` + Web Streams —
+never `EventSource`, so it keeps your `auth`, headers, and retries. Each event
+becomes a `delta` chunk; `await` collects them, `.stream()` yields them live.
+
+```ts
+import { sse } from 'stitchapi/sse';
+
+const ticks = sse({ url: 'https://api.example.com/ticks' });
+
+for await (const ev of ticks.stream()) {
+    if (ev.type === 'delta') handle(ev.chunk); // a parsed SseEvent
+}
+```
+
+`data` is JSON-parsed when it parses, else kept as the raw string:
+
+<AutoTypeTable path="../../packages/core/src/sse.ts" name="SseEvent" />
+
+## stream
+
+`stream` is the raw streaming sibling — it hands back the response body decoded
+per `stream.decode`: `'bytes'` (the default, lossless `Uint8Array` chunks),
+`'lines'` (UTF-8 lines), or `'ndjson'` (a parsed value per line).
+
+```ts
+import { stream } from 'stitchapi/stream';
+
+const logs = stream({
+    url: 'https://api.example.com/logs',
+    stream: { decode: 'ndjson' },
+});
+
+for await (const ev of logs.stream()) {
+    if (ev.type === 'delta') console.log(ev.chunk); // one parsed JSON value per line
+}
+```
+
+<AutoTypeTable path="../../packages/core/src/types.ts" name="StreamOptions" />
+
+Streaming members open on the same auth/retry/throttle spine, with one twist:
+opening a stream **charges the rate limiter once** but **never holds a
+concurrency slot**, so a long-lived connection can't pin a [seam](/docs/concepts/the-stitch)'s
+concurrency budget.
+
+## download
+
+`download` fetches a file: a `GET` buffered into a `Blob`, with byte progress,
+a `Content-Disposition` filename (with a URL-last-segment fallback), and a
+per-call `AbortSignal`. It **never writes to disk** — saving the `Blob` is your
+call, which keeps it browser-first.
+
+```ts
+import { download } from 'stitchapi/download';
+
+const getReport = download({ url: 'https://api.example.com/report.pdf' });
+
+const { blob, filename } = await getReport({
+    signal: controller.signal,
+    onProgress: (p) => console.log(p.loaded, '/', p.total),
+});
+```
+
+<AutoTypeTable
+    path="../../packages/core/src/download.ts"
+    name="DownloadResult"
+/>
+
+## Both spellings, one engine
+
+Every surface has two co-existing spellings. The monomorphic helper above
+(`sse(...)`, `download(...)`, …) is pre-bound to its surface and gives
+surface-specific types. The generic form passes the surface as `kind` on the
+core `stitch`, so a `seam` can mint members of any surface without forking:
+
+```ts
+import { seam, stitch } from 'stitchapi';
+import { downloadSurface } from 'stitchapi/download';
+
+const file = stitch({ kind: downloadSurface, url: 'https://x/report.pdf' });
+
+const api = seam({ baseUrl: 'https://api.example.com' });
+const member = api.stitch({ kind: downloadSurface, path: '/report.pdf' });
+```
+
+Either way the surface is named in `__config` by a stable string `id`
+(`'sse'`, `'download'`, …), so a stitch's declaration still round-trips to JSON
+for MCP, the playground, and `llms.txt` — the behaviour hooks stay a runtime
+detail. An `id` a consumer doesn't recognise degrades to "an http-shaped call of
+unknown style", never a crash.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -46,7 +46,7 @@ The name StitchAPI combines the words “stitch” and “API,” reflecting its
 -   [Pluggable state store](#pluggable-state-store)
 -   [Request body encoding](#request-body-encoding)
 -   [HTTP transport (adapters)](#http-transport-adapters)
--   [GraphQL](#graphql)
+-   [Surfaces: any request style](#surfaces-any-request-style)
 -   [Pagination](#pagination)
 -   [Transform](#transform)
 -   [Zero-infra observability](#zero-infra-observability)
@@ -99,7 +99,8 @@ For the full competitive landscape and positioning, see the [Overview](docs/OVER
 -   **Leveled drift detection** - live responses are diffed against a committed contract snapshot; changes surface as `error` / `warn` / `info` findings instead of a silent `undefined`.
 -   **Declared resilience** - retry with backoff and `Retry-After`, proactive throttle (rate + concurrency, per stitch or per host), and total / per-attempt timeouts with real aborts.
 -   **Auth as a boundary** - `bearer`, `apiKey`, `basic`, `cookieSession` (auto-login and re-login), and `oauth2` client credentials; secrets resolve at call time via `env()` / `secretsFile()` and never reach the caller.
--   **Data shaping** - `unwrap` dot-paths, `transform` (e.g. scrape HTML into structure), auto-looping pagination, `json` / `form` / `multipart` request bodies, and a `graphql()` helper.
+-   **Data shaping** - `unwrap` dot-paths, `transform` (e.g. scrape HTML into structure), auto-looping pagination, and `json` / `form` / `multipart` request bodies.
+-   **Any request style** - `http` is the default; `graphql`, `sse`, `stream`, and `download` are peer **surfaces**, each a subpath import (`stitchapi/sse`, …) on the same engine — so `import { stitch }` bundles `http` alone.
 -   **Pluggable state store** - throttle counters and sessions/tokens live behind a 3-method store; in-memory by default, a shared store makes throttling distributed and sessions shared across workers.
 -   **Zero-infra observability** - every event is appended to a local JSONL trace by default; `stitch trace` summarizes runs, retries, drift, and latency percentiles.
 -   **CLI surface** - the definition your code imports is also runnable from the shell: `stitch run <name>` streams JSONL events (HTTP and MCP surfaces are on the roadmap).
@@ -484,9 +485,25 @@ const echo: Adapter = async (req) => ({
 });
 ```
 
-## GraphQL
+## Surfaces: any request style
 
-`graphql()` is a stitch preset for GraphQL-over-HTTP: it POSTs `{ query, variables }` and unwraps `data`. A `200` carrying `errors[]` is treated as a failure — it will not silently pass:
+A **surface** is the request _style_ a stitch speaks. `http` is the default — the plain JSON-over-HTTP call every example above uses. GraphQL, Server-Sent Events, a raw byte stream, and a file download are **peer surfaces**: each shapes and interprets its own request, but they all ride the same engine — `auth`, `retry`, `throttle`, `timeout`, validation, and the event stream compose with every one.
+
+Every non-`http` surface ships as its own **subpath import**, so `import { stitch }` from the root pulls in only the `http` engine; a surface's code loads only when you import it.
+
+| Surface    | Import               | Shapes                                     | `await` resolves to            |
+| ---------- | -------------------- | ------------------------------------------ | ------------------------------ |
+| `http`     | `stitch` (default)   | a JSON-over-HTTP call                      | the validated body             |
+| `graphql`  | `stitchapi/graphql`  | POST `{ query, variables }`, unwrap `data` | the `data` payload             |
+| `sse`      | `stitchapi/sse`      | a `text/event-stream` reader (over fetch)  | every parsed event, collected  |
+| `stream`   | `stitchapi/stream`   | a raw `ReadableStream` reader              | every decoded chunk, collected |
+| `download` | `stitchapi/download` | a buffered binary GET                      | `{ blob, filename }`           |
+
+(Distinct from the four _invocation_ surfaces — function, CLI, HTTP, MCP — which are how you _call_ a stitch. A request surface is how a stitch shapes its _request_.)
+
+### GraphQL
+
+`graphql()` POSTs `{ query, variables }` and unwraps `data`. A `200` carrying `errors[]` is a failure — it will not silently pass:
 
 ```ts
 import { graphql } from 'stitchapi';
@@ -499,7 +516,52 @@ const getThing = graphql({
 const thing = await getThing({ variables: { id: 1 } });
 ```
 
-Because it is just a stitch underneath, `auth`, `retry`, `throttle`, and `output` / `drift` all compose with it.
+### Streaming: `sse` and `stream`
+
+A streaming surface decodes a live response body into `delta` events. `await` collects every chunk into an array; `.stream()` yields them as they arrive and buffers nothing — for an unbounded stream, prefer `.stream()`. `sse` parses the `text/event-stream` wire format over `fetch` + Web Streams (never `EventSource`), yielding one `{ event?, data, id?, retry? }` per event:
+
+```ts
+import { sse } from 'stitchapi/sse';
+
+const ticks = sse({ url: 'https://api.example.com/ticks' });
+
+for await (const ev of ticks.stream()) {
+    if (ev.type === 'delta') handle(ev.chunk); // a parsed SSE event
+}
+```
+
+`stream` is the raw sibling — `decode: 'bytes'` (default), `'lines'`, or `'ndjson'`:
+
+```ts
+import { stream } from 'stitchapi/stream';
+
+const logs = stream({
+    url: 'https://api.example.com/logs',
+    stream: { decode: 'ndjson' },
+});
+
+for await (const ev of logs.stream()) {
+    if (ev.type === 'delta') console.log(ev.chunk); // one parsed JSON value per line
+}
+```
+
+Opening a stream charges the rate limiter once but never holds a concurrency slot, so a long-lived connection can't pin a seam's budget.
+
+### Download
+
+`download` fetches a file: GET + a buffered `Blob`, with byte progress, a `Content-Disposition` filename, and a per-call `AbortSignal`. It never writes to disk — saving the `Blob` is your call:
+
+```ts
+import { download } from 'stitchapi/download';
+
+const getReport = download({ url: 'https://api.example.com/report.pdf' });
+
+const { blob, filename } = await getReport({
+    onProgress: (p) => console.log(p.loaded, '/', p.total),
+});
+```
+
+Because every surface is just a stitch underneath, `auth`, `retry`, `throttle`, and `output` / `drift` compose with all of them.
 
 ## Pagination
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,6 +75,56 @@
                 "types": "./lib/cache.d.ts",
                 "default": "./lib/cache.js"
             }
+        },
+        "./graphql": {
+            "import": {
+                "types": "./lib/graphql.d.mts",
+                "default": "./lib/graphql.mjs"
+            },
+            "require": {
+                "types": "./lib/graphql.d.ts",
+                "default": "./lib/graphql.js"
+            }
+        },
+        "./sse": {
+            "import": {
+                "types": "./lib/sse.d.mts",
+                "default": "./lib/sse.mjs"
+            },
+            "require": {
+                "types": "./lib/sse.d.ts",
+                "default": "./lib/sse.js"
+            }
+        },
+        "./stream": {
+            "import": {
+                "types": "./lib/stream.d.mts",
+                "default": "./lib/stream.mjs"
+            },
+            "require": {
+                "types": "./lib/stream.d.ts",
+                "default": "./lib/stream.js"
+            }
+        },
+        "./download": {
+            "import": {
+                "types": "./lib/download.d.mts",
+                "default": "./lib/download.mjs"
+            },
+            "require": {
+                "types": "./lib/download.d.ts",
+                "default": "./lib/download.js"
+            }
+        },
+        "./xhr": {
+            "import": {
+                "types": "./lib/xhr-adapter.d.mts",
+                "default": "./lib/xhr-adapter.mjs"
+            },
+            "require": {
+                "types": "./lib/xhr-adapter.d.ts",
+                "default": "./lib/xhr-adapter.js"
+            }
         }
     },
     "sideEffects": false,

--- a/packages/core/test/gaps/subpath-exports.spec.ts
+++ b/packages/core/test/gaps/subpath-exports.spec.ts
@@ -87,3 +87,42 @@ describe('tsup.config.ts entry points', () => {
         expect(tsupText).toContain(entry);
     });
 });
+
+// ---------------------------------------------------------------------------
+// ADR 0005 Decision 10 — every non-http surface + the xhr adapter is a subpath
+// export, built by tsup, so `import { stitch }` bundles http alone while each
+// surface is reached only when used.
+// ---------------------------------------------------------------------------
+
+describe('surface + adapter subpath exports (ADR 0005 Decision 10)', () => {
+    const exports = readJson('package.json')['exports'] as Record<
+        string,
+        {
+            import?: { types?: string; default?: string };
+            require?: { types?: string; default?: string };
+        }
+    >;
+    const tsupText = readText('tsup.config.ts');
+
+    // subpath → its `src` entry (the `xhr` subpath maps to `xhr-adapter`, not its own name)
+    const SURFACES = [
+        ['./graphql', 'src/graphql.ts'],
+        ['./sse', 'src/sse.ts'],
+        ['./stream', 'src/stream.ts'],
+        ['./download', 'src/download.ts'],
+        ['./xhr', 'src/xhr-adapter.ts'],
+    ] as const;
+
+    test.each(SURFACES)(
+        'exports["%s"] maps to its lib/ artifact and tsup builds the entry',
+        (subpath, entry) => {
+            const base = entry.replace(/^src\//, '').replace(/\.ts$/, '');
+            const e = exports[subpath];
+            expect(e?.import?.types).toBe(`./lib/${base}.d.mts`);
+            expect(e?.import?.default).toBe(`./lib/${base}.mjs`);
+            expect(e?.require?.types).toBe(`./lib/${base}.d.ts`);
+            expect(e?.require?.default).toBe(`./lib/${base}.js`);
+            expect(tsupText).toContain(entry);
+        },
+    );
+});

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from 'tsup';
 // Two bundles from one source tree:
 //   lib/index.{js,mjs} (+ .d.ts) — the library (function surface), dual-format + types
 //   plus serve/mcp/registry/testing/fingerprint/cache as their own subpath entry points (stitchapi/serve, etc.)
+//   plus each non-http surface (graphql/sse/stream/download) and the xhr adapter as their own
+//   subpath entries (ADR 0005 Decision 10) — `import { stitch }` bundles `http` only; every other
+//   surface is reached through its subpath, exactly like the cache engine.
 //   lib/cli.js                   — the `stitch` bin (run/trace/serve/mcp), CJS, no types
 // `cache` is its own entry so `import { stitch }` never pulls the cache engine (ADR 0003 §11):
 // the engine reaches it via a lazy `import('./cache')`, which esm splitting keeps in its chunk.
@@ -16,6 +19,13 @@ export default defineConfig([
             'src/testing.ts',
             'src/fingerprint.ts',
             'src/cache.ts',
+            // surfaces (ADR 0005 Decision 10) — subpath-only; the root entry bundles http alone
+            'src/graphql.ts',
+            'src/sse.ts',
+            'src/stream.ts',
+            'src/download.ts',
+            // the browser-only xhr adapter (upload progress) → stitchapi/xhr
+            'src/xhr-adapter.ts',
         ],
         format: ['cjs', 'esm'],
         minify: true,


### PR DESCRIPTION
## ADR 0005 Stage 7 — packaging & the "any surface" reframe (Decisions 10, 7) — the finale

> **Stacked on Stages 5 (#99) and 6 (#100).** Packaging the `./sse` / `./stream` / `./download` subpaths needs those stages' source, so this branch merges both (no conflicts — they touch disjoint regions) and adds Stage 7 on top. **The new work is the single Stage 7 commit `47042e5`**; the rest is #99 + #100. Once they merge to `main`, rebasing shrinks this PR to just that commit. Merge order: #99 and #100 first, then this.

### Decision 10 — every surface + adapter is a subpath export

- `package.json` `exports` and the `tsup` entry list gain **`./graphql`, `./sse`, `./stream`, `./download`, `./xhr`** (the xhr adapter) alongside the existing `./cache` / `./fingerprint` / etc.
- `import { stitch }` from the root bundles **`http` only**; every other surface is reached through its subpath, exactly like the cache engine. ESM code-splitting shares one engine chunk, so each surface's `.mjs` is **~1 KB** (its parser/decoder only) — `lib/sse.mjs` 1.04 KB, `lib/stream.mjs` 800 B, `lib/download.mjs` 1.05 KB.
- **`attw` is green for all 13 subpaths** across node10 / node16 (CJS+ESM) / bundler. A new gap test (`subpath-exports.spec.ts`) pins each new subpath → its `lib/` artifact + `tsup` entry (incl. `./xhr` → `xhr-adapter`).

### Decision 7 — positioning: "fits any style" → "any surface"

- **Published README reframed** around *one model, any request style*: a Surfaces section + table (`http` default; `graphql`/`sse`/`stream`/`download` as subpath peers on the same engine), a Features bullet, and per-surface examples.
- **New docs page** [`reference/surfaces.mdx`](apps/docs/content/docs/reference/surfaces.mdx) ("Request surfaces") introduces the request styles with their subpath imports + examples, and `AutoTypeTable`s for `SseEvent` / `StreamOptions` / `DownloadResult`.
- **Terminology note:** the docs already use "Surfaces" for the four *invocation* channels (function/CLI/HTTP/MCP). The new content is explicitly disambiguated — a *request* surface is how a stitch shapes its **request**; an *invocation* surface is how you **call** it. (Per the chosen "focused reframe" scope; deeper per-surface guide pages can follow.)

### Verification

`next build` runs clean (222 static pages, `AutoTypeTable` resolves). Full pre-push gate green: **364 tests**, typecheck (src+test), tsd, eslint, prettier, **attw exports**, **build-docs**.

### Rollout status

This is the **final stage** — Stages 0–7 complete the ADR 0005 surface model. After 5/6/7 merge, all four non-http surfaces (`graphql`, `sse`, `stream`, `download`) and the `xhr` adapter are publicly importable, and the engine stays surface-agnostic.
