### PR TITLE
docs(adr): 0006 — first-class NestJS integration (@stitchapi/nest)

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,6 +5,7 @@
     "singleQuote": true,
     "semi": true,
     "plugins": ["@trivago/prettier-plugin-sort-imports"],
+    "importOrderParserPlugins": ["typescript", "jsx", "decorators-legacy"],
     "importOrder": [
         "^[./]",
         "^@/(.*)$",

--- a/docs/adr/0006-nestjs-integration.md
+++ b/docs/adr/0006-nestjs-integration.md
@@ -57,7 +57,8 @@ There is precedent for "host integration as a thin, framework-free adapter over 
         static forRoot(options: StitchModuleOptions = {}): DynamicModule {
             const { isGlobal, store, trace, ...defaults } = options;
             const sharedStore = store ? borrowStore(store) : memoryStore(); // app owns a store it passes
-            const sharedTrace = trace === 'logger' ? loggerSink(new Logger('Stitch')) : trace; // off (Q2)
+            const sharedTrace =
+                trace === 'logger' ? loggerSink(new Logger('Stitch')) : trace; // off (Q2)
             return {
                 module: StitchModule,
                 global: isGlobal ?? true,
@@ -68,12 +69,25 @@ There is precedent for "host integration as a thin, framework-free adapter over 
                     {
                         provide: STITCH_SEAM,
                         useFactory: (reg: SeamRegistry): Seam =>
-                            reg.track(seam({ ...defaults, store: sharedStore, ...(sharedTrace ? { trace: sharedTrace } : {}) })),
+                            reg.track(
+                                seam({
+                                    ...defaults,
+                                    store: sharedStore,
+                                    ...(sharedTrace
+                                        ? { trace: sharedTrace }
+                                        : {}),
+                                }),
+                            ),
                         inject: [SeamRegistry],
                     },
                     StitchLifecycle,
                 ],
-                exports: [STITCH_SEAM, STITCH_STORE, STITCH_TRACE, SeamRegistry],
+                exports: [
+                    STITCH_SEAM,
+                    STITCH_STORE,
+                    STITCH_TRACE,
+                    SeamRegistry,
+                ],
             };
         }
 
@@ -161,7 +175,10 @@ There is precedent for "host integration as a thin, framework-free adapter over 
 
     @Injectable()
     export class UsersService {
-        constructor(@InjectStitch(GetUser) private readonly getUser: Injected<typeof GetUser>) {}
+        constructor(
+            @InjectStitch(GetUser)
+            private readonly getUser: Injected<typeof GetUser>,
+        ) {}
         find(id: string) {
             return this.getUser({ params: { id } }); // PromiseLike<User>; .stream() for events
         }
@@ -174,7 +191,10 @@ There is precedent for "host integration as a thin, framework-free adapter over 
     @Module({
         imports: [
             StitchModule.forFeature({
-                seam: { baseUrl: 'https://api.stripe.com', auth: bearer(env('STRIPE_KEY')) },
+                seam: {
+                    baseUrl: 'https://api.stripe.com',
+                    auth: bearer(env('STRIPE_KEY')),
+                },
                 stitches: [CreateCharge, GetCustomer],
             }),
         ],

--- a/docs/adr/0006-nestjs-integration.md
+++ b/docs/adr/0006-nestjs-integration.md
@@ -1,0 +1,352 @@
+# ADR 0006 — NestJS integration (`@stitchapi/nest`)
+
+-   **Status:** Proposed (firm — Q1–Q2 resolved 2026-06-15; see _Resolved questions_). Net-new: not in [`GAP-AUDIT.md`](../GAP-AUDIT.md). Builds only on existing core extension points; **this ADR modifies no core code.**
+-   **Date:** 2026-06-15
+-   **Tags:** integration, nestjs, adapter, packaging, dependency-injection, multi-tenant, peer-dependency, contract-not-dependency
+
+> [!NOTE]
+>
+> The integration is a thin **adapter package**, exactly the class [ADR 0001](./0001-package-naming-and-distribution.md) Decision 2 already anticipated ("framework adapters (e.g. React)… `@stitchapi/<name>`"). It contributes _DI wiring + two bridge helpers + a Logger sink_ over primitives core already exposes — no new capability, so it cannot regress the **contract-not-dependency** gate ([`two-gates`](../DESIGN.md)).
+
+## Context
+
+A stitch is a plain function: `stitch(config)` returns a callable that runs an HTTP/GraphQL/streaming call ([`stitch.ts`](../../packages/core/src/stitch.ts)). That works in any runtime, but it is **unwired** in a NestJS backend — there is no module to import, no provider to inject, no lifecycle hook, and no idiomatic path from Nest's `ConfigService`/`Logger`/request scope into a stitch. Today a Nest user hand-rolls all of that, and gets three things subtly wrong:
+
+1.  **Core identity.** [ADR 0001](./0001-package-naming-and-distribution.md) Decision 4 makes `stitchapi` a **mandatory `peerDependency`** for any plugin host: two physical copies of core split the cache/throttle registries and break seam identity. A hand-rolled integration can silently double-install.
+2.  **Lifecycle.** A long-lived server must `flush()` the trace sink and `close()` the store/vault on shutdown ([`seam.ts:165`](../../packages/core/src/seam.ts)). This is easy to forget.
+3.  **The principal boundary.** Multi-tenant auth rides `seam.as(req.user.tenantId)` ([ADR 0002](./0002-seam-primitive-and-principal-scoped-auth.md) §2) — the closure that makes impersonation impossible. Wiring it to Nest's request scope by hand is the fiddliest and highest-stakes part.
+
+The decisive enabling fact: **every bridge already exists in the core contract**, so the integration is pure wiring.
+
+| Nest need                 | Existing core extension point                                                                                                                  |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Shared client + defaults  | `seam(SeamOptions)` — one store + vault + trace + throttle + principal boundary + lifecycle ([`seam.ts:188`](../../packages/core/src/seam.ts)) |
+| Pluggable `store`         | `StitchStore` (`get`/`set`/`incr`/`close?`) ([`types.ts:508`](../../packages/core/src/types.ts))                                               |
+| `trace` → Nest `Logger`   | `TraceSink { handle(ev, {name}); flush?() }` ([`types.ts:500`](../../packages/core/src/types.ts))                                              |
+| secrets → `ConfigService` | `Secret = string \| (() => string)`, resolved at call time ([`auth.ts:15`](../../packages/core/src/auth.ts))                                   |
+| multi-tenant              | `seam.as(principal)` → `PrincipalSeam` ([`types.ts:555`](../../packages/core/src/types.ts))                                                    |
+| test transport            | `SeamConfig.adapter` (the seam's `adapter` slot is not omitted — [`types.ts:529`](../../packages/core/src/types.ts))                           |
+| shutdown                  | `seam.close()` (flush trace, close store/vault) ([`seam.ts:169`](../../packages/core/src/seam.ts))                                             |
+
+There is precedent for "host integration as a thin, framework-free adapter over the registry/stream" in core itself: [`serve.ts`](../../packages/core/src/serve.ts) (the HTTP front door) reuses `stitch.stream()` with no new dependency. `@stitchapi/nest` is the same philosophy, expressed in Nest's DI vocabulary.
+
+## Decision
+
+1.  **Ship `@stitchapi/nest` (a package), not a recipe-only doc.** Recipe-only would be ~10 lines of provider factory, but it leaves the three correctness items above to the user. The package owns them once. It is a first-party scoped package per [ADR 0001](./0001-package-naming-and-distribution.md) Decisions 2 & 4, mirroring the [`@stitchapi/fingerprint-*`](../../packages/fingerprint-zod/package.json) shape: `peerDependencies` on `stitchapi >=0.7.0` plus `@nestjs/common` and `@nestjs/config`; zero runtime deps of its own; dual CJS/ESM via `tsup`. **The README publishes the recipe as "what the module does under the hood"** — the package _is_ the recipe, frozen and verified. Keep it tiny (~150 LOC): a `DynamicModule`, a stitch-provider helper, two bridge helpers, the Logger sink, and a seam registry for lifecycle.
+
+2.  **Separate app-global _infrastructure_ from per-upstream _surface_.** A real backend integrates several upstreams (Stripe + GitHub + an internal service), each with its own `baseUrl`/`auth`/`throttle`/`retry` — but it wants **one** Redis and **one** Logger. So:
+
+    -   **`forRoot({ store?, trace?, ...defaultSeam? })`** configures shared infrastructure once and exposes it as injectable tokens — `STITCH_STORE` (borrowed if you pass one, else an owned `memoryStore()`) and `STITCH_TRACE` — plus (for the single-upstream common case) an optional **default seam** (`STITCH_SEAM`) carrying app-wide `SeamConfig` defaults.
+    -   **Each additional upstream is its own seam**, created by a feature module via `forFeature({ stitches, seam })` (Decision 4, **Q1**), which builds the seam from the shared `STITCH_STORE`/`STITCH_TRACE` but layers its own surface config. "Which seam does a stitch belong to?" is answered by **which module registered it** — the natural Nest grain (one feature module ≈ one bounded context ≈ one upstream).
+    -   A small **`SeamRegistry`** singleton (provided by `forRoot`) collects every seam created in the app so a single lifecycle guardian can flush their traces and close package-created stores (Decision 8).
+
+3.  **`forRoot` / `forRootAsync` provide the seam(s).** The seam is exposed under a symbol token (`STITCH_SEAM` for the default seam); `forRootAsync` is the path that lets `ConfigService` reach the store, secrets, and `baseUrl`.
+
+    ```ts
+    export const STITCH_SEAM = Symbol('STITCH_SEAM'); // the default seam
+    export const STITCH_STORE = Symbol('STITCH_STORE'); // shared store (borrowed if app-provided)
+    export const STITCH_TRACE = Symbol('STITCH_TRACE'); // shared trace sink (false when off)
+
+    export interface StitchModuleOptions extends Omit<SeamOptions, 'trace'> {
+        trace?: SeamOptions['trace'] | 'logger'; // 'logger' → loggerSink(new Logger('Stitch'))
+        isGlobal?: boolean; // default true — like ConfigModule.forRoot({ isGlobal })
+    }
+
+    @Module({})
+    export class StitchModule {
+        static forRoot(options: StitchModuleOptions = {}): DynamicModule {
+            const { isGlobal, store, trace, ...defaults } = options;
+            const sharedStore = store ? borrowStore(store) : memoryStore(); // app owns a store it passes
+            const sharedTrace = trace === 'logger' ? loggerSink(new Logger('Stitch')) : trace; // off (Q2)
+            return {
+                module: StitchModule,
+                global: isGlobal ?? true,
+                providers: [
+                    SeamRegistry,
+                    { provide: STITCH_STORE, useValue: sharedStore },
+                    { provide: STITCH_TRACE, useValue: sharedTrace ?? false },
+                    {
+                        provide: STITCH_SEAM,
+                        useFactory: (reg: SeamRegistry): Seam =>
+                            reg.track(seam({ ...defaults, store: sharedStore, ...(sharedTrace ? { trace: sharedTrace } : {}) })),
+                        inject: [SeamRegistry],
+                    },
+                    StitchLifecycle,
+                ],
+                exports: [STITCH_SEAM, STITCH_STORE, STITCH_TRACE, SeamRegistry],
+            };
+        }
+
+        // forRootAsync mirrors forRoot but resolves StitchModuleOptions from an async factory (so
+        // ConfigService et al. are injectable), then applies the same borrow + 'logger' normalization
+        // before providing STITCH_STORE / STITCH_TRACE / STITCH_SEAM.
+        static forRootAsync(options: StitchModuleAsyncOptions): DynamicModule {
+            /* … */
+        }
+    }
+    ```
+
+    Usage with `ConfigService` (the secrets + store bridge, Decisions 6–7):
+
+    ```ts
+    StitchModule.forRootAsync({
+        imports: [ConfigModule],
+        inject: [ConfigService],
+        useFactory: (config: ConfigService) => ({
+            baseUrl: config.getOrThrow('API_BASE_URL'),
+            store: new RedisStore(config.getOrThrow('REDIS_URL')), // any StitchStore
+            auth: bearer(fromConfig(config)('API_TOKEN')),
+            retry: { attempts: 3 },
+            trace: 'logger', // sentinel → loggerSink(new Logger('Stitch')) (Q2)
+        }),
+    });
+    ```
+
+4.  **`forFeature` registers injectable stitches via `defineStitch`.** A stitch definition builds against the **common subset of `Seam` and `PrincipalSeam`** (`Pick<Seam, 'stitch' | 'graphql'>`, which both satisfy), so the _same_ definition resolves against the app-wide singleton **or** a request-scoped tenant handle — only the provider's `inject` differs (Decision 5).
+
+    ```ts
+    export type StitchHost = Pick<Seam, 'stitch' | 'graphql'>; // Seam AND PrincipalSeam both satisfy this
+
+    export interface StitchDef<T = unknown, In = StitchInput> {
+        token: InjectionToken;
+        build: (host: StitchHost) => Stitch<T, In>;
+    }
+    export function defineStitch<T, In>(
+        token: InjectionToken,
+        build: (host: StitchHost) => Stitch<T, In>,
+    ): StitchDef<T, In> {
+        return { token, build };
+    }
+
+    export interface StitchFeatureOptions {
+        stitches: StitchDef[];
+        // This feature's own upstream seam (its baseUrl/auth/throttle), built over the shared
+        // STITCH_STORE + STITCH_TRACE. Omit to attach the stitches to the root/default seam.
+        seam?: SeamConfig;
+        // Token to expose the feature seam under, for `.as(principal)` multi-tenant (Decision 5).
+        seamToken?: InjectionToken;
+    }
+
+    // A feature module owns its stitches and, optionally, its own upstream seam (Q1). A bare
+    // StitchDef[] is shorthand for { stitches } on the root/default seam.
+    static forFeature(opts: StitchFeatureOptions | StitchDef[]): DynamicModule {
+        const { stitches, seam: cfg, seamToken } = Array.isArray(opts) ? { stitches: opts } : opts;
+        const token = seamToken ?? STITCH_SEAM;
+        const providers: Provider[] = [];
+        if (cfg) {
+            providers.push({
+                provide: token,
+                useFactory: (store: StitchStore, trace: TraceSink | false, reg: SeamRegistry): Seam =>
+                    reg.track(seam({ ...cfg, store, ...(trace ? { trace } : {}) })),
+                inject: [STITCH_STORE, STITCH_TRACE, SeamRegistry],
+            });
+        }
+        providers.push(
+            ...stitches.map((d) => ({ provide: d.token, useFactory: (s: Seam) => d.build(s), inject: [token] })),
+        );
+        return { module: StitchModule, providers, exports: providers.map((p) => p.provide) };
+    }
+    ```
+
+    Authoring and injection:
+
+    ```ts
+    // users.stitches.ts
+    export const GetUser = defineStitch('GET_USER', (s) =>
+        s.stitch({ name: 'getUser', path: '/users/{id}', output: UserSchema }),
+    );
+
+    @Module({ imports: [StitchModule.forFeature({ stitches: [GetUser] })] }) // bare [GetUser] also works
+    export class UsersModule {}
+
+    @Injectable()
+    export class UsersService {
+        constructor(@InjectStitch(GetUser) private readonly getUser: Injected<typeof GetUser>) {}
+        find(id: string) {
+            return this.getUser({ params: { id } }); // PromiseLike<User>; .stream() for events
+        }
+    }
+    ```
+
+    A feature module with its **own upstream** (its `baseUrl`/`auth`, sharing the app's store + trace via `STITCH_STORE`/`STITCH_TRACE`):
+
+    ```ts
+    @Module({
+        imports: [
+            StitchModule.forFeature({
+                seam: { baseUrl: 'https://api.stripe.com', auth: bearer(env('STRIPE_KEY')) },
+                stitches: [CreateCharge, GetCustomer],
+            }),
+        ],
+    })
+    export class StripeModule {} // a ConfigService-backed seam uses the async factory variant, as in forRootAsync
+    ```
+
+    On **types — the honest story.** A param decorator cannot _synthesize_ the parameter's type; `@InjectStitch(GetUser)` is `@Inject(GetUser.token)` and the developer still annotates the field. To keep that annotation linked to the definition (no hand-retyped `Stitch<User>`), the package exports `Injected<D>`:
+
+    ```ts
+    export type Injected<D> =
+        D extends StitchDef<infer T, infer In> ? Stitch<T, In> : never;
+    // → `@InjectStitch(GetUser) getUser: Injected<typeof GetUser>` tracks GetUser's inferred type.
+    ```
+
+    Building stitches eagerly at DI resolution is cheap: `makeStitch` does no I/O — it composes config and attaches a (lazy) cache surface ([`stitch.ts:312`](../../packages/core/src/stitch.ts)).
+
+5.  **Multi-tenancy is principal-scoped over a _shared_ store, never a per-request store.** `seam.as(tenantId)` keys sessions/tokens/cache by principal in the shared vault ([`auth.ts:256`](../../packages/core/src/auth.ts)), so one OAuth token and one connection pool serve all tenants while cross-tenant bleed is impossible. Swapping the store per request would throw that away and is **rejected**. At the HTTP edge, bind the principal in `REQUEST` scope:
+
+    ```ts
+    export const TENANT_SEAM = Symbol('TENANT_SEAM');
+
+    {
+        provide: TENANT_SEAM,
+        scope: Scope.REQUEST,
+        useFactory: (root: Seam, req: { user?: { tenantId?: string } }) =>
+            root.as(req.user?.tenantId ?? 'anonymous'), // PrincipalSeam — lifecycle-free by design
+        inject: [STITCH_SEAM, REQUEST],
+    }
+    // request-scoped stitches reuse the SAME StitchDef, built from the tenant handle:
+    { provide: GetUser.token, scope: Scope.REQUEST, useFactory: (h: StitchHost) => GetUser.build(h), inject: [TENANT_SEAM] }
+    ```
+
+    Two caveats, both documented:
+
+    -   **Scope bubbling.** A request-scoped provider makes its consumers request-scoped too — a real per-request instantiation cost. Teams that want singleton services can instead keep everything singleton and bind at the edge: `this.api.as(req.user.tenantId).stitch(...)`. The package offers both; the request-scoped wiring is the default convenience.
+    -   **Non-HTTP contexts.** `REQUEST` does not exist in BullMQ processors, `@Cron` jobs, or microservice consumers. There, the principal is **bound explicitly** from job/message metadata: inject the singleton seam and call `seam.as(job.data.tenantId)`. `seam.as` is the primitive; request scope is only an HTTP-edge convenience over it.
+
+6.  **`trace` → Nest `Logger` via `loggerSink()`.** A `TraceSink` whose `handle` forwards the event stream to a framework `Logger`:
+
+    ```ts
+    import { Logger } from '@nestjs/common';
+    import type { StitchEvent, TraceSink } from 'stitchapi';
+
+    export function loggerSink(logger = new Logger('Stitch')): TraceSink {
+        return {
+            handle(ev: StitchEvent, { name }) {
+                switch (ev.type) {
+                    case 'start':
+                        return logger.log(
+                            `→ ${name} ${ev.method} ${redactUrl(ev.url)}`,
+                        );
+                    case 'result':
+                        return logger.log(
+                            `← ${name} ${ev.status} (${ev.attempts} attempt(s))`,
+                        );
+                    case 'error':
+                        return logger.error(
+                            `✗ ${name} ${ev.message}${ev.status ? ` ${ev.status}` : ''}`,
+                        );
+                    case 'drift':
+                        return logger.warn(
+                            `drift ${name} ${ev.finding.path} ${ev.finding.change}`,
+                        );
+                    case 'progress':
+                        return logger.debug?.(
+                            `· ${name} ${ev.phase}#${ev.attempt}`,
+                        );
+                    // 'delta'/'done' → debug or drop
+                }
+            },
+            flush() {}, // Logger writes synchronously
+        };
+    }
+    ```
+
+    > [!WARNING]
+    >
+    > **Redaction is the custom sink's responsibility.** Core's built-in JSONL/console sink redacts secret headers _inside_ `createTrace` ([`trace.ts:26`](../../packages/core/src/trace.ts)); a custom `TraceSink` receives the **raw** event, so `ev.input.headers` on a `start` event still contains `authorization`/`cookie`, and `ev.url` may carry a secret query string. `loggerSink` therefore logs only `name`/`method`/`url`/`status` (never `JSON.stringify(ev)`) and ships a `redactUrl()` that strips the query string. This is the one place a naive Nest recipe leaks credentials — another reason the package owns it.
+
+7.  **secrets → `ConfigService` via `fromConfig()`.** Because `Secret = string | (() => string)` is already a call-time thunk and `env(name)` ([`auth.ts:19`](../../packages/core/src/auth.ts)) is exactly this shape, the bridge is a one-liner — `fromConfig` is `env`'s `ConfigService` twin:
+
+    ```ts
+    export const fromConfig =
+        (config: ConfigService) =>
+        (key: string): (() => string) =>
+        () =>
+            config.getOrThrow<string>(key); // resolved per call; never lands on __config or in traces
+    // usage: auth: bearer(fromConfig(config)('API_TOKEN'))
+    ```
+
+    > [!IMPORTANT]
+    >
+    > **Secrets resolve _synchronously_.** `resolve(s)` calls `s()` expecting a `string`, not a `Promise` ([`auth.ts:16`](../../packages/core/src/auth.ts)). `fromConfig` is sound because `ConfigService` loads config asynchronously at bootstrap and then serves it synchronously. **Per-call async secret fetch** (e.g. pulling a rotating short-lived credential from Vault on every request) is _not_ expressible through `Secret`. The supported async-credential path is `oauth2` / `cookieSession`, which refresh **asynchronously** through the vault/store on a `401` wall ([`auth.ts:135`](../../packages/core/src/auth.ts)). This is a core constraint, not a Nest one; calling it out here corrects an earlier overstatement that "Vault/SSM async work unchanged."
+
+8.  **Lifecycle: `StitchLifecycle` + the app owns the shared store.** A guardian provider closes every tracked seam on shutdown:
+
+    ```ts
+    @Injectable()
+    class StitchLifecycle implements OnApplicationShutdown {
+        constructor(private readonly registry: SeamRegistry) {}
+        async onApplicationShutdown() {
+            await this.registry.closeAll(); // flush each trace, then close the (single) real store once
+        }
+    }
+    ```
+
+    Two correctness points:
+
+    -   **`seam.close()` always closes its store** ([`seam.ts:171`](../../packages/core/src/seam.ts)). With many seams sharing one store, that would close it N times (the second close disconnects a pool the others still need). So the package wraps any **app-provided** store in a **borrowed view** (below) before handing it to each seam: a seam never tears down a store it did not create, and an app-provided store stays the **app's** to dispose. `SeamRegistry.closeAll()` flushes every seam's trace and closes only the stores the package itself created.
+
+        ```ts
+        // `close` intentionally omitted → a seam's `store.close?.()` becomes a no-op.
+        function borrowStore(store: StitchStore): StitchStore {
+            return {
+                get: (k) => store.get(k),
+                set: (k, v, t) => store.set(k, v, t),
+                incr: (k, t) => store.incr(k, t),
+            };
+        }
+        ```
+
+        When `forRoot` is given no `store`, the package creates and **owns** one `memoryStore()` (shared via `STITCH_STORE`), and `closeAll()` closes it — the simple case stays simple. Borrowing applies only to a store the app passed in.
+
+    -   **`enableShutdownHooks()` is required.** Nest does not invoke `OnApplicationShutdown` unless the app calls `app.enableShutdownHooks()`. Without it, `seam.close()` never runs (trace unflushed, store unclosed). A library cannot force this; the README's first setup step states it prominently.
+
+9.  **Testing: swap the transport, or override the provider.** Two clean paths, both first-class:
+
+    -   **Globally** — `forRoot({ adapter: mockAdapter })` (or a `forRootAsync` test factory) routes every stitch through a mock transport; the seam's `adapter` slot is part of `SeamConfig` for exactly this.
+    -   **Per stitch** — `Test.createTestingModule(...).overrideProvider(GetUser.token).useValue(fakeStitch)`.
+
+    Pair with `stitchapi/testing` (the conformance kit) for adapter-level assertions.
+
+10. **Non-goals for this version (anticipated, not built).** Kept out to stay thin; each is a clean follow-up:
+
+    -   **Exception mapping** — a `StitchExceptionFilter` mapping `StitchError.status` ([`stitch.ts:209`](../../packages/core/src/stitch.ts)) → Nest `HttpException`. Opt-in; today the app writes its own filter.
+    -   **SSE controller bridge** — `stitch.stream()` is an `AsyncGenerator`; Nest's `@Sse()` wants an RxJS `Observable`. A `from()` interop is ~3 lines but pulls `rxjs` (an optional peer); documented as a snippet for now.
+    -   **Terminus health indicator** — a `StitchHealthIndicator` that pings a stitch.
+    -   **Nest GraphQL (server) disambiguation** — StitchAPI's `graphql()` is a _client_ surface (calling an upstream GraphQL API); it does not interact with `@nestjs/graphql` (a server). A one-paragraph README note prevents the confusion.
+
+## Resolved questions
+
+Both resolved 2026-06-15 (the recommended option chosen for each); folded into the Decisions above.
+
+-   **Q1 — Feature-seam ergonomics → `forFeature({ stitches, seam? })` (Decision 4).** The feature module owns one seam, the most idiomatic Nest grain; lifecycle stays in `SeamRegistry`. The feature seam is built over the shared `STITCH_STORE`/`STITCH_TRACE` tokens `forRoot` exposes (Decision 3). A bare `StitchDef[]` is shorthand for `{ stitches }` on the default seam. Rejected: a dedicated `forSeam(token, opts)` (a non-standard fourth static) and a `forRoot({ seams })` map (couples every upstream to root config, scales poorly).
+
+-   **Q2 — `trace` default → OFF (Decisions 3 & 6).** Honors **"no side effects by default"** ([`no-side-effects-default`](../OVERVIEW.md)): a stitch's only effect is its call. The friendly opt-in is the string sentinel **`trace: 'logger'`**, which `forRoot`/`forRootAsync` expand to `loggerSink(new Logger('Stitch'))` — one word, no import. Any `TraceSink` / `'console'` / `false` still passes straight through to core. (My first sketch defaulted it on; this corrected it.)
+
+## Consequences
+
+**Positive**
+
+-   **No core change.** Every bridge rides an existing extension point; core stays at its current surface, and the contract-not-dependency gate is green by construction (the package adds no capability, declares `stitchapi` as a peer).
+-   **One mental model:** the root/feature seam is a provider; a stitch is a provider built from it; a tenant is `seam.as()` in request scope. Nothing new to learn beyond core + Nest DI.
+-   **Correctness the recipe can't guarantee:** single core instance (peer dep), lifecycle (`SeamRegistry.closeAll`), the principal boundary, and credential-safe logging are owned once.
+-   **Idiomatic Nest:** `forRoot`/`forRootAsync`/`forFeature`, `ConfigService` and `Logger` bridges, request-scoped multi-tenant, and a clean testing override story.
+
+**Accepted trade-offs**
+
+-   **Request-scoped multi-tenant bubbles scope** to consumers (per-request instantiation). Mitigated by offering the singleton + edge-binding alternative.
+-   **Synchronous secrets** (Decision 7): per-call async secret fetch is unsupported; rotating credentials go through `oauth2`/`cookieSession`.
+-   **In-process concurrency is per-instance.** Horizontally scaled (multi-pod) deployments share _rate_ limits only through a shared store; concurrency caps stay per-pod ([`store.ts:96`](../../packages/core/src/store.ts)). Documented, not solved here (a distributed semaphore is out of scope, same as core).
+
+**Required follow-ups**
+
+-   Resolve Q1 + Q2, then scaffold `packages/nest` (package.json mirroring `fingerprint-*`; `DynamicModule`, `defineStitch`/`forFeature`, `loggerSink`, `fromConfig`, `borrowStore`, `SeamRegistry`, `StitchLifecycle`).
+-   Confirm npm scope ownership before publishing the first `@stitchapi/*` package ([ADR 0001](./0001-package-naming-and-distribution.md) follow-up — still open).
+-   A docs guide under `apps/docs` (the recipe + the bridges), and an end-to-end vitest against a real Nest test module + the mock server.
+
+## Alternatives considered
+
+-   **A. Recipe-only, no package.** A documented `useFactory: () => seam({...})` provider. Cheapest, and stays valid as the package's own internals doc. Rejected as the _primary_ answer because it cannot enforce the three correctness items (peer-dep single instance, lifecycle, credential-safe logging) and re-litigates the principal wiring in every app. **Kept as the package README's "under the hood."**
+-   **B. Single global seam only** (the brief's literal `forRoot({ store, trace, preset })`). Simplest, but a real backend integrates multiple upstreams with different `baseUrl`/`auth`; one seam cannot model that. Rejected in favour of the infra-vs-surface split (Decision 2), which keeps the single-upstream case a one-liner (the default seam) while supporting many.
+-   **C. Per-stitch, no seam** (plain `stitch()` + a shared config fragment via `extends`). Avoids the seam abstraction, but each stitch then builds its _own_ store/throttle/trace runtime — losing the shared throttle bucket, the shared vault, the principal boundary, and a single lifecycle. The seam exists precisely for a long-lived shared surface; a server is the canonical case. Rejected.
+-   **D. Fold Nest support into core** (a `stitchapi/nest` subpath). Violates [ADR 0001](./0001-package-naming-and-distribution.md) Decisions 4 & 6 (a framework peer dep does not belong in lean core; subpaths are for dependency-free in-package code) and would put `@nestjs/*` in core's dependency graph. Rejected.

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -1,0 +1,122 @@
+# @stitchapi/nest
+
+First-class [NestJS](https://nestjs.com) integration for
+[StitchAPI](https://stitchapi.dev) — design captured in
+[ADR 0006](../../docs/adr/0006-nestjs-integration.md).
+
+It is a **thin** package: `StitchModule` wires StitchAPI's `seam` into Nest's DI
+graph, plus two bridge helpers and a `Logger` sink. It adds **no capability** — every
+piece sits on an existing core extension point, so `stitchapi` stays a peer dependency
+and core is untouched (contract-not-dependency).
+
+```sh
+pnpm add @stitchapi/nest stitchapi
+# peers you already have in a Nest app: @nestjs/common, reflect-metadata
+```
+
+> [!IMPORTANT]
+>
+> Call `app.enableShutdownHooks()` in `main.ts`. Without it Nest never fires
+> `OnApplicationShutdown`, so the seam's trace is not flushed and its store not closed.
+
+## Configure the shared client — `forRoot` / `forRootAsync`
+
+`forRoot` configures the app-wide shared infrastructure (one `store`, one `trace`
+sink) and a default seam carrying your `SeamConfig` defaults (`baseUrl`, `headers`,
+`auth`, `retry`, `throttle`, `cache`, …). Tracing is **off by default**; opt in with the
+`'logger'` sentinel.
+
+```ts
+import { StitchModule, fromConfig } from '@stitchapi/nest';
+import { bearer } from 'stitchapi';
+
+@Module({
+    imports: [
+        StitchModule.forRootAsync({
+            imports: [ConfigModule],
+            inject: [ConfigService],
+            useFactory: (config: ConfigService) => ({
+                baseUrl: config.getOrThrow('API_BASE_URL'),
+                store: new RedisStore(config.getOrThrow('REDIS_URL')), // any StitchStore
+                auth: bearer(fromConfig(config)('API_TOKEN')),
+                trace: 'logger', // → loggerSink(new Logger('Stitch'))
+            }),
+        }),
+    ],
+})
+export class AppModule {}
+```
+
+## Injectable stitches — `forFeature` + `defineStitch`
+
+Declare stitches with `defineStitch(token, build)`; register them per feature module.
+A feature module may also own its **own upstream seam** (its `baseUrl`/`auth`), built
+over the shared store + trace — omit `seam` to attach the stitches to the default seam.
+
+```ts
+// users.stitches.ts
+export const GetUser = defineStitch('GET_USER', (s) =>
+    s.stitch({ name: 'getUser', path: '/users/{id}', output: UserSchema }),
+);
+
+@Module({
+    imports: [
+        StitchModule.forFeature({
+            seam: {
+                baseUrl: 'https://api.example.com',
+                auth: bearer(env('TOKEN')),
+            },
+            stitches: [GetUser],
+        }),
+    ],
+})
+export class UsersModule {}
+
+@Injectable()
+export class UsersService {
+    // Injected<typeof GetUser> keeps the type linked to the definition.
+    constructor(
+        @InjectStitch(GetUser)
+        private readonly getUser: Injected<typeof GetUser>,
+    ) {}
+    find(id: string) {
+        return this.getUser({ params: { id } }); // PromiseLike<User>; .stream() for events
+    }
+}
+```
+
+## Multi-tenant — `seam.as(principal)` in request scope
+
+Multi-tenancy is **principal-scoped over the shared store** (separate sessions/tokens
+per tenant, one connection pool) — never a per-request store. Bind the principal from
+the request:
+
+```ts
+{
+    provide: TENANT_SEAM,
+    scope: Scope.REQUEST,
+    useFactory: (root: Seam, req) => root.as(req.user?.tenantId ?? 'anonymous'),
+    inject: [STITCH_SEAM, REQUEST],
+}
+```
+
+Outside HTTP (BullMQ, `@Cron`, microservices) there is no `REQUEST`: inject the seam and
+bind explicitly — `seam.as(job.data.tenantId)`.
+
+## Bridges
+
+-   **`loggerSink(logger?)`** — a `TraceSink` that forwards the event stream to a Nest
+    `Logger`. It logs only name/method/url/status and strips the URL query: a custom sink
+    receives **un-redacted** events, so never log `event.input`/headers raw.
+-   **`fromConfig(config)(key)`** — a `ConfigService`-backed secret thunk (core's `env()`
+    twin). Synchronous, so it cannot fetch a rotating secret per call — use
+    `oauth2`/`cookieSession` for that.
+
+## Testing
+
+Swap the transport globally with the seam's `adapter`, or override a stitch provider:
+
+```ts
+StitchModule.forRoot({ adapter: mockAdapter }); // every stitch hits the mock
+// or: Test.createTestingModule(...).overrideProvider(GetUser.token).useValue(fakeStitch)
+```

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -1,0 +1,60 @@
+{
+    "name": "@stitchapi/nest",
+    "version": "0.0.0",
+    "description": "First-class NestJS integration for StitchAPI — StitchModule.forRoot/forFeature, injectable stitches, Logger + ConfigService bridges (ADR 0006).",
+    "main": "lib/index.js",
+    "module": "lib/index.mjs",
+    "types": "lib/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./lib/index.d.mts",
+                "default": "./lib/index.mjs"
+            },
+            "require": {
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
+            }
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "lib"
+    ],
+    "scripts": {
+        "build": "tsup",
+        "test": "vitest run",
+        "check:types": "tsc --noEmit"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rejifald/StitchAPI.git",
+        "directory": "packages/nest"
+    },
+    "keywords": [
+        "stitchapi",
+        "nestjs",
+        "nest",
+        "dependency-injection",
+        "module",
+        "adapter",
+        "api-client"
+    ],
+    "author": "Oleksandr Zhuravlov (rejifald@gmail.com)",
+    "license": "Apache-2.0",
+    "homepage": "https://stitchapi.dev",
+    "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "stitchapi": ">=0.7.0"
+    },
+    "devDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@types/node": "^22.10.0",
+        "reflect-metadata": "^0.2.2",
+        "rxjs": "^7.8.1",
+        "stitchapi": "workspace:*",
+        "tsup": "^8.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.8"
+    }
+}

--- a/packages/nest/src/bridges.ts
+++ b/packages/nest/src/bridges.ts
@@ -1,0 +1,89 @@
+// The three bridges between core primitives and the NestJS world (ADR 0006
+// Decisions 6-8). None of them touches core: a TraceSink, a `Secret` thunk, and a
+// StitchStore are all existing extension points.
+import { Logger } from '@nestjs/common';
+import type { StitchEvent, StitchStore, TraceSink } from 'stitchapi';
+
+/**
+ * A {@link TraceSink} that forwards the stitch event stream to a Nest {@link Logger}.
+ *
+ * SECURITY: a custom sink receives the **raw** event (core only redacts inside its own
+ * built-in sinks), so `event.input.headers` still holds `authorization`/`cookie`. This
+ * sink therefore logs only name/method/url/status — never `JSON.stringify(event)` — and
+ * strips the URL query (it can carry secrets like `?api_key=`).
+ */
+export function loggerSink(logger: Logger = new Logger('Stitch')): TraceSink {
+    return {
+        handle(event: StitchEvent, ctx: { name: string }): void {
+            const name = ctx.name;
+            switch (event.type) {
+                case 'start':
+                    logger.log(
+                        `→ ${name} ${event.method} ${redactUrl(event.url)}`,
+                    );
+                    break;
+                case 'result':
+                    logger.log(
+                        `← ${name} ${event.status} (${event.attempts} attempt(s))`,
+                    );
+                    break;
+                case 'error':
+                    logger.error(
+                        `✗ ${name} ${event.message}${event.status != null ? ` ${event.status}` : ''}`,
+                    );
+                    break;
+                case 'drift':
+                    logger.warn(
+                        `drift ${name} ${event.finding.path} ${event.finding.change}`,
+                    );
+                    break;
+                case 'progress':
+                    logger.debug(`· ${name} ${event.phase}#${event.attempt}`);
+                    break;
+                default:
+                    // 'delta' / 'done': too chatty for a logger — dropped.
+                    break;
+            }
+        },
+    };
+}
+
+// Drop the query string (it may carry secrets, e.g. `?api_key=…`) before logging.
+function redactUrl(url: string): string {
+    const q = url.indexOf('?');
+    return q === -1 ? url : `${url.slice(0, q)}?…`;
+}
+
+/** The minimal slice of Nest's `ConfigService` this package needs — kept structural so
+ * `@nestjs/config` is not even a peer dependency. */
+export interface ConfigServiceLike {
+    getOrThrow<T = string>(key: string): T;
+}
+
+/**
+ * A `ConfigService`-backed secret resolver — core's `env(name)` twin. Returns a
+ * synchronous `Secret` thunk (`() => string`) resolved at call time, so the credential
+ * never lands on `__config` or in a trace. Pass it to any auth strategy:
+ * `bearer(fromConfig(config)('API_TOKEN'))`.
+ *
+ * NOTE: `Secret` is synchronous, so this cannot fetch a rotating secret per call — that
+ * is what `oauth2` / `cookieSession` are for (they refresh asynchronously via the vault).
+ */
+export function fromConfig(
+    config: ConfigServiceLike,
+): (key: string) => () => string {
+    return (key: string) => () => String(config.getOrThrow<string>(key));
+}
+
+/**
+ * Wrap a store the package does **not** own: `get`/`set`/`incr` delegate, but `close` is
+ * omitted, so a seam's `close()` never tears down a store the app passed in (ADR 0006
+ * Decision 8). The app — not the package — disposes a store it provides.
+ */
+export function borrowStore(store: StitchStore): StitchStore {
+    return {
+        get: (key) => store.get(key),
+        set: (key, value, ttlMs) => store.set(key, value, ttlMs),
+        incr: (key, ttlMs) => store.incr(key, ttlMs),
+    };
+}

--- a/packages/nest/src/define-stitch.ts
+++ b/packages/nest/src/define-stitch.ts
@@ -1,0 +1,38 @@
+// Injectable stitch definitions (ADR 0006 Decision 4). A definition builds against
+// the common subset of `Seam` and `PrincipalSeam`, so the SAME definition resolves
+// against the app-wide singleton seam OR a request-scoped principal handle — only the
+// provider's `inject` differs.
+import { Inject, type InjectionToken } from '@nestjs/common';
+import type { Seam, Stitch, StitchInput } from 'stitchapi';
+
+/** Both `Seam` and `PrincipalSeam` satisfy this — the host a stitch is built from. */
+export type StitchHost = Pick<Seam, 'stitch' | 'graphql'>;
+
+export interface StitchDef<TOut = unknown, TIn = StitchInput> {
+    token: InjectionToken;
+    build: (host: StitchHost) => Stitch<TOut, TIn>;
+}
+
+/**
+ * Declare an injectable stitch: an injection token plus a builder that receives the
+ * seam (root or principal-bound) the registering module hands it. Prefer a `Symbol`
+ * token to avoid string collisions across feature modules.
+ */
+export function defineStitch<TOut = unknown, TIn = StitchInput>(
+    token: InjectionToken,
+    build: (host: StitchHost) => Stitch<TOut, TIn>,
+): StitchDef<TOut, TIn> {
+    return { token, build };
+}
+
+/**
+ * The injected stitch's type, derived from its definition — keeps the injection-site
+ * annotation linked to the def (no hand-retyped `Stitch<T>`):
+ * `@InjectStitch(GetUser) getUser: Injected<typeof GetUser>`.
+ */
+export type Injected<D> =
+    D extends StitchDef<infer TOut, infer TIn> ? Stitch<TOut, TIn> : never;
+
+/** `@InjectStitch(def)` — sugar for `@Inject(def.token)`. */
+export const InjectStitch = (def: StitchDef): ParameterDecorator =>
+    Inject(def.token);

--- a/packages/nest/src/index.ts
+++ b/packages/nest/src/index.ts
@@ -1,0 +1,21 @@
+export {
+    StitchModule,
+    SeamRegistry,
+    type StitchModuleOptions,
+    type StitchModuleAsyncOptions,
+    type StitchFeatureOptions,
+} from './module';
+export {
+    defineStitch,
+    InjectStitch,
+    type StitchDef,
+    type StitchHost,
+    type Injected,
+} from './define-stitch';
+export {
+    loggerSink,
+    fromConfig,
+    borrowStore,
+    type ConfigServiceLike,
+} from './bridges';
+export { STITCH_SEAM, STITCH_STORE, STITCH_TRACE } from './tokens';

--- a/packages/nest/src/module.ts
+++ b/packages/nest/src/module.ts
@@ -1,0 +1,202 @@
+// `StitchModule` — the DynamicModule (ADR 0006 Decisions 2-4 & 8). forRoot/forRootAsync
+// configure shared infrastructure (store + trace) and a default seam; forFeature
+// registers injectable stitches and, optionally, a per-upstream feature seam built over
+// that shared infrastructure. `SeamRegistry` owns the shutdown lifecycle.
+import { borrowStore, loggerSink } from './bridges';
+import type { StitchDef, StitchHost } from './define-stitch';
+import { STITCH_SEAM, STITCH_STORE, STITCH_TRACE } from './tokens';
+
+import {
+    type DynamicModule,
+    type FactoryProvider,
+    Injectable,
+    type InjectionToken,
+    Logger,
+    Module,
+    type OnApplicationShutdown,
+    type Provider,
+} from '@nestjs/common';
+import {
+    type Seam,
+    type SeamConfig,
+    type SeamOptions,
+    type StitchStore,
+    type TraceSink,
+    memoryStore,
+    seam,
+} from 'stitchapi';
+
+/** forRoot options: the shared `SeamConfig` defaults + infra, plus the `'logger'` trace sentinel. */
+export interface StitchModuleOptions extends Omit<SeamOptions, 'trace'> {
+    /** A `TraceSink`, `'console'`, `false`, or the `'logger'` sentinel (→ Nest Logger). Default: off. */
+    trace?: SeamOptions['trace'] | 'logger';
+    /** Register as a global module (default `true`). */
+    isGlobal?: boolean;
+}
+
+/** forRootAsync options — resolve {@link StitchModuleOptions} from an injected factory. */
+export interface StitchModuleAsyncOptions {
+    imports?: DynamicModule['imports'];
+    inject?: FactoryProvider['inject'];
+    // Matches Nest's own factory typing so any typed factory (e.g. `(c: ConfigService) => …`) fits.
+    useFactory: (
+        ...args: any[]
+    ) => StitchModuleOptions | Promise<StitchModuleOptions>;
+    isGlobal?: boolean;
+}
+
+/** forFeature options — a feature's injectable stitches and, optionally, its own upstream seam. */
+export interface StitchFeatureOptions {
+    stitches: StitchDef[];
+    /** This feature's own seam (its `baseUrl`/`auth`/…), built over the shared store + trace.
+     *  Omit to attach the stitches to the root/default seam. */
+    seam?: SeamConfig;
+    /** Token to expose the feature seam under, for `.as(principal)` multi-tenant. */
+    seamToken?: InjectionToken;
+}
+
+interface Infra {
+    store: StitchStore;
+    trace: TraceSink | 'console' | false;
+    defaults: Omit<SeamOptions, 'store' | 'trace'>;
+}
+
+// Normalise module options into shared infra: borrow an app-provided store (else own a
+// memoryStore), expand the `'logger'` trace sentinel, default tracing OFF.
+function resolveInfra(options: StitchModuleOptions): Infra {
+    const { store, trace } = options;
+    const defaults: Record<string, unknown> = { ...options };
+    delete defaults['store'];
+    delete defaults['trace'];
+    delete defaults['isGlobal'];
+    return {
+        store: store ? borrowStore(store) : memoryStore(),
+        trace:
+            trace === 'logger'
+                ? loggerSink(new Logger('Stitch'))
+                : (trace ?? false),
+        defaults: defaults as Omit<SeamOptions, 'store' | 'trace'>,
+    };
+}
+
+function buildSeam(infra: Infra): Seam {
+    return seam({ ...infra.defaults, store: infra.store, trace: infra.trace });
+}
+
+/**
+ * Tracks every seam the module creates so a single shutdown hook can flush each trace
+ * and close each seam. A borrowed (app-provided) store no-ops on close; an owned
+ * `memoryStore` clears. Implements the lifecycle directly (no separate provider) so the
+ * package never relies on `emitDecoratorMetadata` for constructor injection.
+ */
+@Injectable()
+export class SeamRegistry implements OnApplicationShutdown {
+    private readonly seams: Seam[] = [];
+
+    track(s: Seam): Seam {
+        this.seams.push(s);
+        return s;
+    }
+
+    async closeAll(): Promise<void> {
+        for (const s of this.seams) await s.close();
+        this.seams.length = 0;
+    }
+
+    onApplicationShutdown(): Promise<void> {
+        return this.closeAll();
+    }
+}
+
+@Module({})
+export class StitchModule {
+    static forRoot(options: StitchModuleOptions = {}): DynamicModule {
+        const infra = resolveInfra(options);
+        return {
+            module: StitchModule,
+            global: options.isGlobal ?? true,
+            providers: [
+                SeamRegistry,
+                { provide: STITCH_STORE, useValue: infra.store },
+                { provide: STITCH_TRACE, useValue: infra.trace },
+                {
+                    provide: STITCH_SEAM,
+                    useFactory: (reg: SeamRegistry): Seam =>
+                        reg.track(buildSeam(infra)),
+                    inject: [SeamRegistry],
+                },
+            ],
+            exports: [STITCH_SEAM, STITCH_STORE, STITCH_TRACE, SeamRegistry],
+        };
+    }
+
+    static forRootAsync(options: StitchModuleAsyncOptions): DynamicModule {
+        const RESOLVED: InjectionToken = Symbol('stitch-resolved-infra');
+        return {
+            module: StitchModule,
+            global: options.isGlobal ?? true,
+            imports: options.imports ?? [],
+            providers: [
+                SeamRegistry,
+                {
+                    provide: RESOLVED,
+                    useFactory: async (...deps: any[]): Promise<Infra> =>
+                        resolveInfra(await options.useFactory(...deps)),
+                    inject: options.inject ?? [],
+                },
+                {
+                    provide: STITCH_STORE,
+                    useFactory: (i: Infra) => i.store,
+                    inject: [RESOLVED],
+                },
+                {
+                    provide: STITCH_TRACE,
+                    useFactory: (i: Infra) => i.trace,
+                    inject: [RESOLVED],
+                },
+                {
+                    provide: STITCH_SEAM,
+                    useFactory: (i: Infra, reg: SeamRegistry): Seam =>
+                        reg.track(buildSeam(i)),
+                    inject: [RESOLVED, SeamRegistry],
+                },
+            ],
+            exports: [STITCH_SEAM, STITCH_STORE, STITCH_TRACE, SeamRegistry],
+        };
+    }
+
+    static forFeature(opts: StitchFeatureOptions | StitchDef[]): DynamicModule {
+        const norm: StitchFeatureOptions = Array.isArray(opts)
+            ? { stitches: opts }
+            : opts;
+        const cfg = norm.seam;
+        // A feature seam gets its own token (or the caller's, for multi-tenant `.as()`);
+        // with no feature seam, stitches bind to the root/default seam.
+        const token: InjectionToken =
+            norm.seamToken ??
+            (cfg ? Symbol('stitch-feature-seam') : STITCH_SEAM);
+        const providers: Provider[] = [];
+        const exported: InjectionToken[] = [];
+        if (cfg) {
+            providers.push({
+                provide: token,
+                useFactory: (
+                    store: StitchStore,
+                    trace: TraceSink | 'console' | false,
+                    reg: SeamRegistry,
+                ): Seam => reg.track(seam({ ...cfg, store, trace })),
+                inject: [STITCH_STORE, STITCH_TRACE, SeamRegistry],
+            });
+            exported.push(token);
+        }
+        for (const d of norm.stitches) {
+            providers.push({
+                provide: d.token,
+                useFactory: (host: StitchHost) => d.build(host),
+                inject: [token],
+            });
+            exported.push(d.token);
+        }
+        return { module: StitchModule, providers, exports: exported };
+    }
+}

--- a/packages/nest/src/tokens.ts
+++ b/packages/nest/src/tokens.ts
@@ -1,0 +1,12 @@
+// Injection tokens. `STITCH_SEAM` is the default seam (forRoot's shared-defaults
+// seam); `STITCH_STORE` / `STITCH_TRACE` expose the app-wide shared infrastructure
+// so feature modules (forFeature) can build their own seam over it.
+
+/** The default seam — the shared-defaults seam created by `forRoot`/`forRootAsync`. */
+export const STITCH_SEAM = Symbol('STITCH_SEAM');
+
+/** The app-wide shared store (a borrowed view when you pass one; else an owned `memoryStore`). */
+export const STITCH_STORE = Symbol('STITCH_STORE');
+
+/** The app-wide shared trace sink, or `false` when tracing is off (the default). */
+export const STITCH_TRACE = Symbol('STITCH_TRACE');

--- a/packages/nest/test/module.spec.ts
+++ b/packages/nest/test/module.spec.ts
@@ -1,0 +1,197 @@
+// Wiring proof for @stitchapi/nest. We resolve the DynamicModule's provider factories
+// directly (no Nest DI container needed) and run the resulting stitches against a mock
+// adapter, asserting wire-level effects — the same style as core's tests.
+import {
+    type ConfigServiceLike,
+    STITCH_SEAM,
+    STITCH_STORE,
+    STITCH_TRACE,
+    SeamRegistry,
+    StitchModule,
+    borrowStore,
+    defineStitch,
+    fromConfig,
+    loggerSink,
+} from '../src';
+
+import { Logger } from '@nestjs/common';
+import type { Adapter, Seam, StitchStore } from 'stitchapi';
+import { memoryStore } from 'stitchapi';
+import { describe, expect, it } from 'vitest';
+
+// Minimal view of a provider object literal, for poking at the factories.
+type FProv = {
+    provide: unknown;
+    useFactory?: (...args: any[]) => unknown;
+    useValue?: unknown;
+    inject?: unknown[];
+};
+
+const recordingAdapter = (sink: string[]): Adapter => {
+    return async (req) => {
+        sink.push(`${req.method} ${req.url}`);
+        return { status: 200, headers: {}, body: { ok: true } };
+    };
+};
+
+describe('StitchModule.forRoot', () => {
+    it('wires a seam over the configured adapter; store is a value; lifecycle closes', async () => {
+        const calls: string[] = [];
+        const mod = StitchModule.forRoot({
+            baseUrl: 'https://api.test',
+            adapter: recordingAdapter(calls),
+        });
+        expect(mod.global).toBe(true);
+
+        const providers = mod.providers as FProv[];
+        const seamProv = providers.find((p) => p.provide === STITCH_SEAM);
+        const storeProv = providers.find((p) => p.provide === STITCH_STORE);
+        expect(seamProv?.inject).toEqual([SeamRegistry]);
+        expect(storeProv?.useValue).toBeDefined();
+
+        const reg = new SeamRegistry();
+        const api = seamProv!.useFactory!(reg) as Seam;
+        await api.stitch({ path: '/thing' })();
+        expect(calls).toEqual(['GET https://api.test/thing']);
+
+        await reg.closeAll(); // must not throw
+    });
+
+    it('defaults tracing OFF (no STITCH_TRACE sink)', () => {
+        const providers = StitchModule.forRoot().providers as FProv[];
+        const traceProv = providers.find((p) => p.provide === STITCH_TRACE);
+        expect(traceProv?.useValue).toBe(false);
+    });
+
+    it("expands the 'logger' trace sentinel to a sink", () => {
+        const providers = StitchModule.forRoot({ trace: 'logger' })
+            .providers as FProv[];
+        const traceProv = providers.find((p) => p.provide === STITCH_TRACE);
+        expect(
+            typeof (traceProv?.useValue as { handle?: unknown }).handle,
+        ).toBe('function');
+    });
+});
+
+describe('StitchModule.forFeature', () => {
+    it('builds a feature seam over shared store/trace and binds stitches to it', async () => {
+        const calls: string[] = [];
+        const GetThing = defineStitch('GET_THING', (h) =>
+            h.stitch({ path: '/thing' }),
+        );
+        const mod = StitchModule.forFeature({
+            seam: {
+                baseUrl: 'https://feat.test',
+                adapter: recordingAdapter(calls),
+            },
+            stitches: [GetThing],
+        });
+
+        const providers = mod.providers as FProv[];
+        const stitchProv = providers.find((p) => p.provide === GetThing.token);
+        const seamProv = providers.find((p) => p.provide !== GetThing.token);
+        expect(seamProv?.inject).toEqual([
+            STITCH_STORE,
+            STITCH_TRACE,
+            SeamRegistry,
+        ]);
+        // the stitch binds to the feature seam's token, not the root seam
+        expect(stitchProv?.inject?.[0]).toBe(seamProv?.provide);
+
+        const reg = new SeamRegistry();
+        const featSeam = seamProv!.useFactory!(
+            memoryStore(),
+            false,
+            reg,
+        ) as Seam;
+        const stitch = stitchProv!.useFactory!(featSeam) as ReturnType<
+            typeof GetThing.build
+        >;
+        await stitch();
+        expect(calls).toEqual(['GET https://feat.test/thing']);
+    });
+
+    it('attaches stitches to the root seam when no feature seam is given', () => {
+        const GetThing = defineStitch('GET_THING_2', (h) =>
+            h.stitch({ path: '/thing' }),
+        );
+        const providers = StitchModule.forFeature([GetThing])
+            .providers as FProv[];
+        expect(providers).toHaveLength(1);
+        expect(providers[0]?.inject).toEqual([STITCH_SEAM]);
+    });
+});
+
+describe('bridges', () => {
+    it('borrowStore delegates get/set/incr but omits close', async () => {
+        const calls: string[] = [];
+        const backing: StitchStore = {
+            get: async () => {
+                calls.push('get');
+                return 1;
+            },
+            set: async () => {
+                calls.push('set');
+            },
+            incr: async () => {
+                calls.push('incr');
+                return 2;
+            },
+            close: async () => {
+                calls.push('close');
+            },
+        };
+        const borrowed = borrowStore(backing);
+        expect(borrowed.close).toBeUndefined();
+        expect(await borrowed.get('k')).toBe(1);
+        await borrowed.set('k', 'v');
+        expect(await borrowed.incr('k', 1)).toBe(2);
+        expect(calls).toEqual(['get', 'set', 'incr']); // close is never delegated
+    });
+
+    it('loggerSink logs lifecycle lines and redacts the URL query', () => {
+        const logs: string[] = [];
+        const errs: string[] = [];
+        const fake = {
+            log: (m: string) => logs.push(m),
+            error: (m: string) => errs.push(m),
+            warn: () => {},
+            debug: () => {},
+        } as unknown as Logger;
+        const sink = loggerSink(fake);
+        sink.handle(
+            {
+                type: 'start',
+                name: 'x',
+                method: 'GET',
+                url: 'https://h/p?token=secret',
+                input: {},
+                at: 0,
+            },
+            { name: 'x' },
+        );
+        sink.handle(
+            {
+                type: 'error',
+                name: 'x',
+                message: 'boom',
+                status: 500,
+                attempts: 1,
+                at: 0,
+            },
+            { name: 'x' },
+        );
+        expect(logs[0]).toContain('GET https://h/p?…');
+        expect(logs[0]).not.toContain('secret');
+        expect(errs[0]).toContain('boom');
+    });
+
+    it('fromConfig resolves a synchronous secret thunk from a ConfigService-like', () => {
+        const config: ConfigServiceLike = {
+            getOrThrow<T = string>(key: string): T {
+                return `val:${key}` as T;
+            },
+        };
+        expect(fromConfig(config)('API_TOKEN')()).toBe('val:API_TOKEN');
+    });
+});

--- a/packages/nest/tsconfig.json
+++ b/packages/nest/tsconfig.json
@@ -1,0 +1,39 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM"],
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "esModuleInterop": true,
+        "experimentalDecorators": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "exactOptionalPropertyTypes": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "verbatimModuleSyntax": true,
+        "isolatedModules": true,
+
+        "types": ["node", "vitest/globals"],
+
+        // Resolve the workspace package to its SOURCE so typecheck + tests don't
+        // depend on `stitchapi` being built first (the pre-push gate typechecks
+        // before it builds). The published `exports` map still points at `lib/`.
+        "baseUrl": ".",
+        "paths": {
+            "stitchapi": ["../core/src/index.ts"]
+        }
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts",
+        "tsup.config.ts",
+        "vitest.config.ts"
+    ]
+}

--- a/packages/nest/tsup.config.ts
+++ b/packages/nest/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+// Single dual-format entry. `stitchapi` and `@nestjs/common` are peer deps,
+// externalised by tsup, so the bundle is just the wiring. Not minified — class
+// names (e.g. SeamRegistry) show up in Nest's DI errors and logs.
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    minify: false,
+    outDir: 'lib',
+    clean: true,
+});

--- a/packages/nest/vitest.config.ts
+++ b/packages/nest/vitest.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+// Alias the workspace package to core SOURCE, so tests run without `stitchapi`
+// being built first. Mirrors tsconfig `paths`.
+const src = (p: string): string =>
+    fileURLToPath(new URL(`../core/src/${p}`, import.meta.url));
+
+export default defineConfig({
+    resolve: {
+        alias: [{ find: /^stitchapi$/, replacement: src('index.ts') }],
+    },
+    test: {
+        globals: true,
+        environment: 'node',
+        // Load the metadata polyfill before any test module, so importing the module
+        // (which runs @Module/@Injectable at load) never depends on import ordering.
+        setupFiles: ['reflect-metadata'],
+        include: ['test/**/*.spec.ts'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,7 +186,7 @@ importers:
         version: 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -210,7 +210,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
   packages/fingerprint-effect:
     devDependencies:
@@ -295,6 +295,33 @@ importers:
       zod:
         specifier: ^3.23.8
         version: 3.25.76
+
+  packages/nest:
+    devDependencies:
+      '@nestjs/common':
+        specifier: ^11.0.0
+        version: 11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.21
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
+      stitchapi:
+        specifier: workspace:*
+        version: link:../core
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
   packages/sandbox-sim:
     devDependencies:
@@ -431,6 +458,9 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
   '@braidai/lang@1.1.2':
     resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
@@ -1069,6 +1099,10 @@ packages:
   '@loaderkit/resolve@1.0.6':
     resolution: {integrity: sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==}
 
+  '@lukeed/csprng@1.1.0':
+    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
+    engines: {node: '>=8'}
+
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
@@ -1080,6 +1114,19 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@nestjs/common@11.1.27':
+    resolution: {integrity: sha512-kEGSzqM2lWr4whh4Ubflw+oPZSEzxvRMu9WL+LveZploJWTjec5bBlCiRVlVzTPg2kIwBiLwWSvCCW7Wnin1gg==}
+    peerDependencies:
+      class-transformer: '>=0.4.1'
+      class-validator: '>=0.13.2'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
 
   '@next/env@16.2.7':
     resolution: {integrity: sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==}
@@ -1906,6 +1953,13 @@ packages:
 
   '@tailwindcss/postcss@4.3.0':
     resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
+
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
   '@trivago/prettier-plugin-sort-imports@4.3.0':
     resolution: {integrity: sha512-r3n0onD3BTOVUNPhR4lhVK4/pABGpbA7bW3eumZnYdKaHkf1qEC+Mag6DPbGNuuh0eG8AaYj+YqmVHSiGslaTQ==}
@@ -2940,6 +2994,10 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -3295,6 +3353,9 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -3477,6 +3538,10 @@ packages:
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
+
+  iterare@1.2.1:
+    resolution: {integrity: sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==}
+    engines: {node: '>=6'}
 
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
@@ -3698,6 +3763,10 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-esm@1.0.3:
+    resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
+    engines: {node: '>=13.2.0'}
 
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
@@ -4339,6 +4408,9 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -4421,6 +4493,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
@@ -4594,6 +4669,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
@@ -4679,6 +4758,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -4809,6 +4892,14 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  uid@2.0.2:
+    resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
+    engines: {node: '>=8'}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -5244,6 +5335,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@braidai/lang@1.1.2': {}
 
@@ -5716,6 +5809,8 @@ snapshots:
     dependencies:
       '@braidai/lang': 1.1.2
 
+  '@lukeed/csprng@1.1.0': {}
+
   '@marijn/find-cluster-break@1.0.2': {}
 
   '@mdx-js/mdx@3.1.1':
@@ -5754,6 +5849,18 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
+
+  '@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      file-type: 21.3.4
+      iterare: 1.2.1
+      load-esm: 1.0.3
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@next/env@16.2.7': {}
 
@@ -6413,6 +6520,15 @@ snapshots:
       postcss: 8.5.15
       tailwindcss: 4.3.0
 
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
   '@trivago/prettier-plugin-sort-imports@4.3.0(prettier@3.3.3)':
     dependencies:
       '@babel/generator': 7.17.7
@@ -6788,7 +6904,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
 
   '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.8)':
     dependencies:
@@ -6798,7 +6914,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
     transitivePeerDependencies:
       - supports-color
 
@@ -7744,6 +7860,15 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -8168,6 +8293,8 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -8341,6 +8468,8 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  iterare@1.2.1: {}
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -8510,6 +8639,8 @@ snapshots:
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  load-esm@1.0.3: {}
 
   load-tsconfig@0.2.5: {}
 
@@ -9436,6 +9567,8 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  reflect-metadata@0.2.2: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -9611,6 +9744,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   safe-array-concat@1.1.4:
     dependencies:
@@ -9857,6 +9994,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   style-mod@4.1.3: {}
 
   style-to-js@1.1.21:
@@ -9932,6 +10073,12 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
 
   tree-kill@1.2.2: {}
 
@@ -10094,6 +10241,12 @@ snapshots:
   typescript@6.0.3: {}
 
   ufo@1.6.4: {}
+
+  uid@2.0.2:
+    dependencies:
+      '@lukeed/csprng': 1.1.0
+
+  uint8array-extras@1.5.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
Captures the design for a first-class NestJS integration as **ADR 0006**. **Docs-only** (one ADR file); no code change. The implementation (`packages/nest`) lands in a follow-up PR, per the ADR-then-implementation pattern.

## Recommendation

A thin first-party `@stitchapi/nest` peer-dep package (not a recipe-only doc), because core needs **zero changes** — every bridge already exists as an extension point:

- `seam(...)` — the DI-shaped primitive (shared store/vault/trace/throttle + principal boundary + lifecycle)
- `TraceSink` → Nest `Logger` (`loggerSink()`)
- `Secret` call-time thunk → `ConfigService` (`fromConfig()`)
- `seam.as(principal)` → request-scoped multi-tenant
- `SeamConfig.adapter` → test transport

The package earns its keep on three correctness items a hand-rolled recipe gets wrong: single core instance (peer dep — ADR 0001 Decision 4), lifecycle (`seam.close()` ↔ shutdown hooks), and the principal boundary.

## API

- `forRoot` / `forRootAsync` — shared infra (`STITCH_STORE` / `STITCH_TRACE`) + an optional default seam
- `forFeature({ stitches, seam? })` — injectable stitches + a per-upstream feature seam
- `loggerSink()` and `fromConfig()` bridges; `Injected<typeof Def>` for the injection-site type

## Resolved questions

- **Q1** feature-seam ergonomics → `forFeature({ stitches, seam? })` owns it (over shared `STITCH_STORE`/`STITCH_TRACE`)
- **Q2** trace default → OFF (honors "no side effects by default"); opt in with `trace: 'logger'`

## Grill notes (hardened in the ADR)

Multi-upstream seam model, borrowed-store lifecycle (no double-close), non-HTTP principal binding, **synchronous** secret thunks (per-call async not supported — use `oauth2`/`cookieSession`), `enableShutdownHooks()` requirement, manual injection-type annotation, and the testing override story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)