### PR TITLE
feat(core): safe-by-default tracing — body/result truncation + URL credential scrubbing (GAP-AUDIT §2.3)

### DIFF
--- a/apps/docs/content/docs/guides/observability/otlp.mdx
+++ b/apps/docs/content/docs/guides/observability/otlp.mdx
@@ -48,6 +48,12 @@ OTLP/JSON to `${endpoint}/v1/traces`. `toOtlpJson(spans)` serializes collected
 spans to the OTLP/JSON `ResourceSpans` shape a collector accepts, if you ship
 them some other way.
 
+A span carries method, `url.full`, `server.address`, status, and timings — never
+request headers or bodies. `url.full` is the only attribute that can hold a
+secret, so it is scrubbed before export: userinfo is stripped and the values of
+secret-bearing query params (`api_key`, `access_token`, `signature`, …) become
+`REDACTED`.
+
 See [Reference → Helpers](/docs/reference/helpers) for the helper signatures and
 [Reference → Events](/docs/reference/events) for the event types each span is
 built from.
@@ -58,14 +64,12 @@ built from.
 </Callout>
 
 <Callout type="warn">
-    **Anti-pattern:** don't assume OTLP export inherits the built-in sink's
-    `[REDACTED]` header scrubbing and flip it on for a stitch that carries its
-    secret in the URL query string — each span sets `url.full` to the full
-    resolved URL verbatim, so a token in the query ships to your collector in
-    the clear (the denylist only ever masks header values, and the span never
-    goes through it). Resolve the secret as a header-borne capability instead,
-    so it stays out of the URL the span exports. See [Capability, not
-    credential](/docs/concepts/capability-not-credential).
+    **Defense in depth, not a guarantee:** `url.full` is scrubbed before export
+    — userinfo stripped, secret-bearing query values masked — but that is a
+    best-effort denylist, so an unusually named param can still slip through.
+    Resolve a secret as a header-borne capability so it never enters the URL the
+    span exports in the first place (headers are never exported at all). See
+    [Capability, not credential](/docs/concepts/capability-not-credential).
 </Callout>
 
 ## See also

--- a/apps/docs/content/docs/guides/observability/trace-sinks.mdx
+++ b/apps/docs/content/docs/guides/observability/trace-sinks.mdx
@@ -49,6 +49,9 @@ STITCH_EXPORT=otlp node run.js
 
 # Turn file tracing OFF: 0, false, or an empty value disable it (no file is written).
 STITCH_TRACE_FILE=0 node run.js
+
+# Capture full request/response bodies (the JSONL truncates them to 2048 chars by default).
+STITCH_TRACE_MAX_BODY=full node run.js
 ```
 
 A stitch-local `trace` wins over the environment: `trace: false` forces tracing
@@ -81,11 +84,13 @@ The `trace` field accepts:
 | a `TraceSink` | Any custom sink — e.g. from `createTrace` / `multiplex` / `otlpTrace`. |
 | `false`       | Forces tracing off, even when `STITCH_TRACE_*` is set.                 |
 
-When `trace` is unset, three env vars control the built-in sink:
+When `trace` is unset, four env vars control the built-in sink:
 `STITCH_TRACE_CONSOLE=1` turns on the colored stderr stream;
 `STITCH_TRACE_FILE=<path>` appends JSONL to that path (off when unset, `0`, or
-`false`); and `STITCH_EXPORT=otlp` adds OTLP as one more sink fed from the same
-events — see [OTLP export](/docs/guides/observability/otlp).
+`false`); `STITCH_EXPORT=otlp` adds OTLP as one more sink fed from the same
+events — see [OTLP export](/docs/guides/observability/otlp); and
+`STITCH_TRACE_MAX_BODY` tunes [body truncation](#body-truncation-and-full-capture)
+(`full` to capture whole bodies, or a character cap).
 
 To build sinks in code, `consoleSink()` and `fileSink(path)` return the
 single-purpose sinks, `createTrace({ console, file })` returns one that does
@@ -131,6 +136,29 @@ So a call carrying `authorization: 'Bearer …'` traces as
 happens at the sink boundary, so the live request still sends the real header; only
 the trace copy is scrubbed.
 
+The same boundary scrubs **URLs**: a `start` event's resolved URL has any userinfo
+(`https://user:pass@host`) removed and the values of secret-bearing query params
+(`api_key`, `access_token`, `signature`, …) replaced with `REDACTED` — in both the
+JSONL `url` field and the OTLP [`url.full`](/docs/guides/observability/otlp)
+attribute. The matching keys in the `start` event's structured `input.query` are
+redacted the same way, so the two views can't disagree; benign params (`page`,
+`sort`) survive for observability.
+
+Need to redact a non-standard auth header (say `x-auth-token`)? Widen the
+denylist — you can extend it but never shrink it — with `redactHeaders`:
+
+```ts twoslash
+import { fileSink, stitch } from 'stitchapi';
+
+const search = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/search',
+    trace: fileSink('./runs/today.jsonl', {
+        redactHeaders: ['x-auth-token', 'x-session-id'],
+    }),
+});
+```
+
 A `TraceSink` is just `{ handle(event, ctx), flush?() }` — implement those two
 and you have a custom consumer you can pass to `trace` or `multiplex`. The same
 shape backs the console, JSONL, and OTLP sinks, which is why all three come from
@@ -155,6 +183,61 @@ union a sink receives.
     `--trace`, which records the JSONL file (at `~/.stitch/runs/proto.jsonl`, or
     wherever `STITCH_TRACE_FILE` points) so [`stitch trace`](/docs/surfaces/cli)
     has a log to summarize. Use `--trace=console` to stream to stderr instead.
+</Callout>
+
+## Body truncation and full capture
+
+To keep one large response from bloating the log — and to limit how much payload
+is persisted by default — the built-in JSONL sink **truncates** the request body
+(the `start` event) and the response value (the `result` event) once their JSON
+encoding passes a character cap. The oversized value is replaced with a compact
+marker:
+
+```json
+{ "truncated": true, "bytes": 51234, "preview": "{\"items\":[{\"id\":1,…" }
+```
+
+`preview` is the first `maxBodyBytes` characters of the (already header-redacted)
+JSON, so you keep a readable head of the payload without storing all of it. The
+default cap is **2048 characters**; `0` keeps only the marker, no preview.
+
+Truncation bounds _size_ — it is not field-level redaction, and a preview can
+still contain a body-embedded secret. Header and URL secrets are redacted (above)
+regardless of the cap.
+
+Opt into **full capture** — the whole body, untruncated — when you need it, with
+`maxBodyBytes: false` on the file sink:
+
+```ts twoslash
+import { fileSink, stitch } from 'stitchapi';
+
+const report = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/report',
+    // false = capture the whole body; a number sets a custom character cap.
+    trace: fileSink('./runs/today.jsonl', { maxBodyBytes: false }),
+});
+```
+
+Or globally, without touching code, via the env knob the built-in sink reads:
+
+```bash
+# Whole bodies, no truncation.
+STITCH_TRACE_MAX_BODY=full node run.js
+
+# A custom character cap (here 8 KB).
+STITCH_TRACE_MAX_BODY=8192 node run.js
+```
+
+<Callout type="warn">
+    **Migration:** earlier releases stored every request and response body in the
+    JSONL trace in full. The built-in file sink now truncates them to 2048
+    characters by default, and resolved URLs have their userinfo and secret query
+    values scrubbed. No API changed shape and nothing was removed — if a tool or
+    `stitch trace` workflow relied on whole bodies on disk, restore the old
+    behaviour with `STITCH_TRACE_MAX_BODY=full` (or
+    `fileSink(path, { maxBodyBytes: false })`). A custom `TraceSink` is unaffected:
+    it receives the live events and decides for itself.
 </Callout>
 
 ## See also

--- a/apps/docs/content/docs/reference/helpers.mdx
+++ b/apps/docs/content/docs/reference/helpers.mdx
@@ -43,19 +43,25 @@ const sink = consoleSink();
 
 A file-only sink: append every event as JSONL to `path` (defaults to
 `~/.stitch/runs/proto.jsonl`). Writing to disk is a side effect, so you pass it
-explicitly — a stitch never opens a trace file on its own.
+explicitly — a stitch never opens a trace file on its own. An optional second
+argument tunes privacy: `maxBodyBytes` (default `2048`; `false` for full capture)
+caps body/result [truncation](/docs/guides/observability/trace-sinks#body-truncation-and-full-capture),
+and `redactHeaders` widens the redaction denylist.
 
 ```ts twoslash
 import { fileSink } from 'stitchapi';
 
-const sink = fileSink('./runs/today.jsonl');
+const sink = fileSink('./runs/today.jsonl', { maxBodyBytes: false });
 ```
 
 ### createTrace
 
 Build a zero-infra trace sink: a compact one-line-per-event summary on the
 console and/or an appended JSONL record per event. `console` defaults to `true`;
-`file` defaults to a path under `$HOME`, or `false` to disable the JSONL stream.
+`file` defaults to a path under `$HOME`, or `false` to disable the JSONL stream;
+`maxBodyBytes` and `redactHeaders` tune the JSONL sink's
+[privacy defaults](/docs/guides/observability/trace-sinks#default-secret-redaction)
+(header/URL redaction and body truncation are always applied to the file stream).
 (This is the low-level builder behind `consoleSink`/`fileSink`; the off-by-default
 behavior lives at the stitch's `trace` field, not here.)
 

--- a/packages/core/src/otlp.ts
+++ b/packages/core/src/otlp.ts
@@ -3,7 +3,7 @@
 // SpanExporter. The default exporter POSTs OTLP/JSON to a collector; tests inject a stub
 // exporter (no running collector). It is a normal TraceSink, so it tees alongside console/JSONL.
 import type { StitchEvent, TraceSink } from './types';
-import { readEnv } from './util';
+import { readEnv, scrubUrl } from './util';
 
 export type SpanAttributes = Record<string, string | number | boolean>;
 
@@ -98,9 +98,11 @@ export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
             const name = ctx.name;
             switch (event.type) {
                 case 'start': {
+                    // url.full is OTLP's only secret-bearing attribute (it never exports
+                    // headers/bodies): scrub userinfo + secret query values before export.
                     const attributes: SpanAttributes = {
                         'http.request.method': event.method,
-                        'url.full': event.url,
+                        'url.full': scrubUrl(event.url),
                     };
                     const host = serverAddress(event.url);
                     if (host) attributes['server.address'] = host;

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -163,11 +163,24 @@ function fileFromEnv(value: string | undefined): string | false {
     return value;
 }
 
+// `STITCH_TRACE_MAX_BODY` tunes JSONL body/result truncation: unset → the built-in
+// default cap; `full` → full capture (no truncation); a non-negative integer → that
+// character cap (`0` keeps only the marker). Anything else falls back to the default.
+function maxBodyFromEnv(value: string | undefined): number | false | undefined {
+    if (value === undefined) return undefined;
+    const trimmed = value.trim().toLowerCase();
+    if (trimmed === 'full') return false;
+    const n = Number(trimmed);
+    return Number.isInteger(n) && n >= 0 ? n : undefined;
+}
+
 function getTrace(): TraceSink {
     const file = fileFromEnv(readEnv('STITCH_TRACE_FILE'));
+    const maxBodyBytes = maxBodyFromEnv(readEnv('STITCH_TRACE_MAX_BODY'));
     const base = createTrace({
         console: readEnv('STITCH_TRACE_CONSOLE') === '1',
         file,
+        ...(maxBodyBytes !== undefined ? { maxBodyBytes } : {}),
     });
     if (!exportsFromEnv(readEnv('STITCH_EXPORT')).includes('otlp')) return base;
     return multiplex(base, otlpTrace());

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -1,38 +1,129 @@
 // Zero-infra observability sink: append every StitchEvent as a JSONL record and,
 // optionally, print a compact colored one-line-per-event summary to stderr. No deps.
 import type { DriftLevel, StitchEvent, TraceSink } from './types';
-import { dirnameOf, nodeFs, readEnv } from './util';
+import { dirnameOf, isSecretQueryKey, nodeFs, readEnv, scrubUrl } from './util';
 
 export interface TraceOptions {
     console?: boolean; // pretty one-line-per-event to stderr (default true)
     file?: string | false; // JSONL path; default `${process.env.HOME}/.stitch/runs/proto.jsonl`; false disables
+    /**
+     * Max length (in characters of the JSON encoding) of the request body and the
+     * response value persisted to the JSONL sink. Anything larger is replaced with a
+     * `{ truncated, bytes, preview }` marker, so a multi-MB response never bloats the
+     * log or persists a payload in full. Default {@link DEFAULT_MAX_BODY_BYTES}; pass
+     * `false` for full capture (the pre-1.0 behaviour); `0` keeps only the marker.
+     */
+    maxBodyBytes?: number | false;
+    /**
+     * Extra header names (case-insensitive) to redact on top of the built-in
+     * denylist. Additive — you can widen the denylist but never shrink it, so a
+     * custom value can't accidentally un-redact `authorization`/`cookie`/…
+     */
+    redactHeaders?: readonly string[];
 }
 
 // Header names whose values are secrets: redacted before any event leaves for a
 // built-in sink (JSONL/console). Matched case-insensitively wherever headers appear
 // in an event payload (start input.headers, result/response headers, etc.).
-const SECRET_HEADERS = new Set([
+const SECRET_HEADERS = [
     'authorization',
     'proxy-authorization',
     'cookie',
     'set-cookie',
     'x-api-key',
-]);
+];
 const REDACTED = '[REDACTED]';
 
-// Deep-clone `value`, replacing any object property whose key is a secret header
-// name (case-insensitive) with '[REDACTED]'. Non-mutating: the engine keeps the
-// real headers; only the trace copy is scrubbed.
-function redact(value: unknown): unknown {
-    if (Array.isArray(value)) return value.map(redact);
+// Default body/result truncation cap: large enough to keep a small JSON response or
+// error body fully readable, small enough to bound on-disk growth and limit how much
+// payload is persisted by default. Opt into full capture with `maxBodyBytes: false`.
+const DEFAULT_MAX_BODY_BYTES = 2048;
+
+// Deep-clone `value`, replacing any object property whose key is in `denylist`
+// (lowercased secret header names) with '[REDACTED]'. Non-mutating: the engine keeps
+// the real headers; only the trace copy is scrubbed.
+function redact(value: unknown, denylist: Set<string>): unknown {
+    if (Array.isArray(value)) return value.map((v) => redact(v, denylist));
     if (value !== null && typeof value === 'object') {
         const out: Record<string, unknown> = {};
         for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-            out[k] = SECRET_HEADERS.has(k.toLowerCase()) ? REDACTED : redact(v);
+            out[k] = denylist.has(k.toLowerCase())
+                ? REDACTED
+                : redact(v, denylist);
         }
         return out;
     }
     return value;
+}
+
+// Replace a request body / response value with a compact marker once its JSON
+// encoding exceeds `max` characters; `false` disables truncation (full capture).
+// The preview is the JSON prefix of the ALREADY-REDACTED value, so header secrets
+// never reach it (body-field secrets can — full capture is opt-in, not the default).
+function capBody(value: unknown, max: number | false): unknown {
+    if (max === false || value === undefined || value === null) return value;
+    try {
+        const json = JSON.stringify(value);
+        if (json.length <= max) return value;
+        return {
+            truncated: true,
+            bytes: json.length,
+            preview: json.slice(0, max),
+        };
+    } catch {
+        // Unserializable (a cycle, or a value that stringifies to undefined) —
+        // leave it to the outer writer, which already JSON.stringifies the record.
+        return value;
+    }
+}
+
+// Replace the values of secret-bearing query params (api_key, access_token, …) with
+// '[REDACTED]', the same denylist scrubUrl applies to the URL. Shallow: query slots
+// are flat name → string | string[]; a whole secret value is dropped wholesale.
+function redactSecretQuery(
+    query: Record<string, unknown>,
+): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(query))
+        out[k] = isSecretQueryKey(k) ? REDACTED : v;
+    return out;
+}
+
+// Build the final JSONL record for one event: header redaction everywhere, URL
+// credential-scrubbing on `start`, and body/result truncation. Operates on a fresh
+// clone — the live event the engine emitted is untouched.
+function prepareRecord(
+    name: string,
+    event: StitchEvent,
+    denylist: Set<string>,
+    maxBody: number | false,
+): unknown {
+    const record = redact({ name, ...event }, denylist) as Record<
+        string,
+        unknown
+    >;
+    if (event.type === 'start') {
+        if (typeof record['url'] === 'string')
+            record['url'] = scrubUrl(record['url']);
+        const input = record['input'];
+        if (input !== null && typeof input === 'object') {
+            const i = input as Record<string, unknown>;
+            // Body: size-bound it. Query: redact secret param values so the
+            // structured input can't leak what scrubUrl already stripped from `url`.
+            if ('body' in i) i['body'] = capBody(i['body'], maxBody);
+            const query = i['query'];
+            if (query !== null && typeof query === 'object')
+                i['query'] = redactSecretQuery(
+                    query as Record<string, unknown>,
+                );
+        }
+    } else if (event.type === 'result') {
+        record['value'] = capBody(record['value'], maxBody);
+    } else if (event.type === 'delta') {
+        // A streamed chunk is response-body data too — cap it like `result.value`.
+        record['chunk'] = capBody(record['chunk'], maxBody);
+    }
+    return record;
 }
 
 const RESET = '\x1b[0m';
@@ -57,7 +148,7 @@ function paint(color: string, text: string): string {
 function format(name: string, event: StitchEvent): string | null {
     switch (event.type) {
         case 'start':
-            return `${paint(CYAN, '→')} ${name} ${event.method} ${event.url}`;
+            return `${paint(CYAN, '→')} ${name} ${event.method} ${scrubUrl(event.url)}`;
         case 'progress': {
             const waited =
                 event.waitedMs != null ? ` waited ${event.waitedMs}ms` : '';
@@ -114,6 +205,14 @@ export function createTrace(
     const fs = nodeFs();
     const path = fs ? resolvePath(opts?.file) : null;
     let dirReady = false;
+    // Privacy policy resolved once: the denylist is the built-ins WIDENED by any
+    // caller-supplied names (never shrunk), and bodies truncate at the cap unless
+    // full capture is requested.
+    const denylist = new Set([
+        ...SECRET_HEADERS,
+        ...(opts?.redactHeaders ?? []).map((h) => h.toLowerCase()),
+    ]);
+    const maxBody = opts?.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
 
     return {
         path,
@@ -125,7 +224,7 @@ export function createTrace(
                 }
                 fs.appendFileSync(
                     path,
-                    `${JSON.stringify(redact({ name: ctx.name, ...event }))}\n`,
+                    `${JSON.stringify(prepareRecord(ctx.name, event, denylist, maxBody))}\n`,
                 );
             }
             if (toConsole) {
@@ -150,10 +249,14 @@ export function consoleSink(): TraceSink {
  * `~/.stitch/runs/proto.jsonl`). Writing to disk is a side effect, so you reach
  * for this explicitly — a stitch never opens a trace file on its own.
  */
-export function fileSink(path?: string): TraceSink {
+export function fileSink(
+    path?: string,
+    opts?: Omit<TraceOptions, 'console' | 'file'>,
+): TraceSink {
     return createTrace({
         console: false,
         ...(path !== undefined ? { file: path } : {}),
+        ...opts,
     });
 }
 

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -392,3 +392,74 @@ export function dirnameOf(path: string): string {
     if (i < 0) return '.';
     return i === 0 ? path.slice(0, 1) : path.slice(0, i);
 }
+
+// Query keys whose values are secrets when they ride in a URL: redacted before a
+// URL reaches a trace sink (OTLP `url.full`, the JSONL `start.url`). A key matches
+// if (case-insensitively) it is one of these names …
+const SECRET_QUERY_KEYS = new Set([
+    'key',
+    'sig',
+    'auth',
+    'pwd',
+    'code',
+    'sas',
+    'access_key',
+]);
+// … or if it CONTAINS one of these stems — so `access_token`, `refresh_token`,
+// `client_secret`, `x-amz-signature`, and `apikey` are all caught without listing
+// every vendor spelling. Over-matching a benign param is the safe direction here.
+const SECRET_QUERY_STEMS = [
+    'token',
+    'secret',
+    'password',
+    'passwd',
+    'signature',
+    'credential',
+    'apikey',
+    'api_key',
+];
+const URL_REDACTED = 'REDACTED';
+
+/**
+ * True when a query-param name (or any key in the same family — a `start` event's
+ * `input.query`) carries a secret value: matched case-insensitively against the
+ * secret key set above, or by containing one of the secret stems.
+ */
+export function isSecretQueryKey(key: string): boolean {
+    const k = key.toLowerCase();
+    return (
+        SECRET_QUERY_KEYS.has(k) ||
+        SECRET_QUERY_STEMS.some((s) => k.includes(s))
+    );
+}
+
+/**
+ * Strip credentials from a URL before it reaches a trace sink: removes userinfo
+ * (`https://user:pass@host` → `https://host`) and replaces the values of
+ * secret-bearing query params (`api_key`, `access_token`, `signature`, …) with
+ * `REDACTED`, while keeping benign params (`page`, `sort`) intact for observability.
+ * Returns the original string unchanged when there is nothing to scrub (so a clean
+ * URL is never reformatted) or when it is not an absolute URL we can parse.
+ */
+export function scrubUrl(url: string): string {
+    let u: URL;
+    try {
+        u = new URL(url);
+    } catch {
+        return url; // relative/opaque/malformed — no structured parts to scrub
+    }
+    const hadUserinfo = u.username !== '' || u.password !== '';
+    u.username = '';
+    u.password = '';
+    const secretKeys = [...new Set(u.searchParams.keys())].filter(
+        isSecretQueryKey,
+    );
+    for (const key of secretKeys) {
+        // Preserve a repeated key's arity (e.g. `?k=a&k=b` → two REDACTED values).
+        const count = u.searchParams.getAll(key).length;
+        u.searchParams.delete(key);
+        for (let i = 0; i < count; i++)
+            u.searchParams.append(key, URL_REDACTED);
+    }
+    return hadUserinfo || secretKeys.length > 0 ? u.toString() : url;
+}

--- a/packages/core/test/gaps/trace-controls.spec.ts
+++ b/packages/core/test/gaps/trace-controls.spec.ts
@@ -1,5 +1,7 @@
-// Pins docs/GAP-AUDIT.md §2.3: Tracing needs an off switch and default secret redaction
-import { stitch } from '../../src';
+// Pins docs/GAP-AUDIT.md §2.3: safe-by-default tracing — an off switch (config +
+// env), default header redaction, body/result truncation with opt-in full capture,
+// and URL credential-scrubbing in the JSONL `start` record.
+import { fileSink, stitch } from '../../src';
 import { startMockServer } from '../support/mock-server';
 import type { MockServer } from '../support/mock-server';
 
@@ -122,4 +124,109 @@ test('JSONL trace redacts authorization and x-api-key header values by default',
     expect(jsonl).not.toContain('supersecret123');
     expect(jsonl).not.toContain('sk-redact-me');
     expect(jsonl).toContain('[REDACTED]');
+});
+
+// Read the JSONL trace back as parsed records (skipping blank/partial lines).
+function readRecords(file: string): Record<string, unknown>[] {
+    return readFileSync(file, 'utf8')
+        .split('\n')
+        .filter((l) => l.trim() !== '')
+        .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+// A body whose JSON encoding comfortably exceeds the 2048-char default cap.
+const BIG = 'x'.repeat(5000);
+
+// (d) Default truncation: a request body / response value larger than the cap is
+// replaced with a compact `{ truncated, bytes, preview }` marker — the multi-KB
+// payload never lands on disk in full.
+test('JSONL truncates request body and response value past the default cap', async () => {
+    const traceFile = join(tmpdir(), `stitch-trace-trunc-${process.pid}.jsonl`);
+    rmSync(traceFile, { force: true });
+    cleanupPaths.push(traceFile);
+    process.env['STITCH_TRACE_FILE'] = traceFile;
+
+    server.route('POST', '/big', { body: { blob: BIG } });
+    const call = stitch({
+        name: 'big',
+        method: 'POST',
+        baseUrl: server.url,
+        path: '/big',
+    });
+    await expect(call({ body: { blob: BIG } })).resolves.toEqual({ blob: BIG });
+
+    const records = readRecords(traceFile);
+    const start = records.find((r) => r['type'] === 'start')!;
+    const result = records.find((r) => r['type'] === 'result')!;
+
+    const reqBody = (start['input'] as { body: Record<string, unknown> }).body;
+    expect(reqBody['truncated']).toBe(true);
+    expect(reqBody['bytes']).toBeGreaterThanOrEqual(2048);
+    expect((reqBody['preview'] as string).length).toBeLessThanOrEqual(2048);
+
+    const value = result['value'] as Record<string, unknown>;
+    expect(value['truncated']).toBe(true);
+    expect(value['blob']).toBeUndefined(); // the original shape is gone
+
+    // The full 5000-char payload is nowhere on disk — only a ≤2048-char preview.
+    expect(readFileSync(traceFile, 'utf8')).not.toContain(BIG);
+});
+
+// (e) Opt-in full capture (env): STITCH_TRACE_MAX_BODY=full disables truncation,
+// restoring the pre-1.0 behaviour of persisting the whole body.
+test('STITCH_TRACE_MAX_BODY=full captures the whole body (no truncation)', async () => {
+    const traceFile = join(tmpdir(), `stitch-trace-full-${process.pid}.jsonl`);
+    rmSync(traceFile, { force: true });
+    cleanupPaths.push(traceFile);
+    process.env['STITCH_TRACE_FILE'] = traceFile;
+    process.env['STITCH_TRACE_MAX_BODY'] = 'full';
+
+    server.route('GET', '/full', { body: { blob: BIG } });
+    const call = stitch({ name: 'full', baseUrl: server.url, path: '/full' });
+    await expect(call()).resolves.toEqual({ blob: BIG });
+
+    const result = readRecords(traceFile).find((r) => r['type'] === 'result')!;
+    expect((result['value'] as { blob: string }).blob).toBe(BIG);
+});
+
+// (f) Opt-in full capture (code): fileSink(path, { maxBodyBytes: false }) is the
+// in-code equivalent of the env switch.
+test('fileSink({ maxBodyBytes: false }) captures the whole body', async () => {
+    const traceFile = join(tmpdir(), `stitch-trace-cap-${process.pid}.jsonl`);
+    rmSync(traceFile, { force: true });
+    cleanupPaths.push(traceFile);
+
+    server.route('GET', '/cap', { body: { blob: BIG } });
+    const call = stitch({
+        name: 'cap',
+        baseUrl: server.url,
+        path: '/cap',
+        trace: fileSink(traceFile, { maxBodyBytes: false }),
+    });
+    await expect(call()).resolves.toEqual({ blob: BIG });
+
+    const result = readRecords(traceFile).find((r) => r['type'] === 'result')!;
+    expect((result['value'] as { blob: string }).blob).toBe(BIG);
+});
+
+// (g) URL credential-scrub: a secret-bearing query param is REDACTED in the
+// `start` record's resolved URL, while benign params survive.
+test('JSONL start.url redacts secret query params, keeps benign ones', async () => {
+    const traceFile = join(tmpdir(), `stitch-trace-url-${process.pid}.jsonl`);
+    rmSync(traceFile, { force: true });
+    cleanupPaths.push(traceFile);
+    process.env['STITCH_TRACE_FILE'] = traceFile;
+
+    server.route('GET', '/scrub', { body: { ok: true } });
+    const call = stitch({ name: 'scrub', baseUrl: server.url, path: '/scrub' });
+    await expect(
+        call({ query: { api_key: 'sk-url-leak', page: '2' } }),
+    ).resolves.toEqual({ ok: true });
+
+    const start = readRecords(traceFile).find((r) => r['type'] === 'start')!;
+    const url = start['url'] as string;
+    expect(url).not.toContain('sk-url-leak');
+    expect(url).toContain('api_key=REDACTED');
+    expect(url).toContain('page=2');
+    expect(readFileSync(traceFile, 'utf8')).not.toContain('sk-url-leak');
 });

--- a/packages/core/test/otlp-export.spec.ts
+++ b/packages/core/test/otlp-export.spec.ts
@@ -4,6 +4,7 @@
 import { otlpTrace, stitch } from '../src';
 import type { OtelSpan, SpanExporter, StitchEvent } from '../src';
 import { exportsFromEnv, multiplex } from '../src/trace';
+import { scrubUrl } from '../src/util';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
 
@@ -142,4 +143,66 @@ test('STITCH_EXPORT parses to a list and multiplex fans out to every sink', () =
     );
     expect(seenA).toEqual(['done']);
     expect(seenB).toEqual(['done']);
+});
+
+// url.full is OTLP's only secret-bearing attribute (it never exports headers or
+// bodies), so it must be scrubbed before a span leaves for a collector.
+test('url.full strips userinfo and redacts secret query params before export', () => {
+    const { exporter, spans } = stubExporter();
+    const sink = otlpTrace({ exporter });
+    const name = 'fetchThing';
+    const events: StitchEvent[] = [
+        {
+            type: 'start',
+            name,
+            method: 'GET',
+            url: 'https://user:pass@api.example.com/data?access_token=sk-otlp-leak&page=2',
+            input: {},
+            at: 1000,
+        },
+        { type: 'result', value: {}, status: 200, attempts: 1, at: 1050 },
+        { type: 'done', ok: true, ms: 50, attempts: 1, at: 1050 },
+    ];
+    for (const ev of events) sink.handle(ev, { name });
+
+    const full = String(spans[0]!.attributes['url.full']);
+    expect(full).not.toContain('sk-otlp-leak');
+    expect(full).not.toContain('user:pass');
+    expect(full).toContain('access_token=REDACTED');
+    expect(full).toContain('page=2'); // benign params survive
+    expect(spans[0]!.attributes['server.address']).toBe('api.example.com');
+});
+
+test('scrubUrl: clean URLs pass through, credentials are redacted', () => {
+    // Nothing to scrub → returned byte-for-byte (a clean URL is never reformatted).
+    expect(scrubUrl('http://api.example.com/x')).toBe(
+        'http://api.example.com/x',
+    );
+    expect(scrubUrl('https://api.example.com/x?page=2&sort=name')).toBe(
+        'https://api.example.com/x?page=2&sort=name',
+    );
+
+    // Userinfo is stripped.
+    expect(scrubUrl('https://u:p@h.example.com/x')).toBe(
+        'https://h.example.com/x',
+    );
+
+    // Secret keys — exact-match and substring-stem — are redacted; benign survive.
+    for (const key of [
+        'api_key',
+        'access_token',
+        'X-Amz-Signature',
+        'sig',
+        'password',
+    ]) {
+        const out = scrubUrl(`https://h.example.com/x?${key}=shh&page=2`);
+        expect(out).not.toContain('shh');
+        expect(out).toContain(`${key}=REDACTED`);
+        expect(out).toContain('page=2');
+    }
+
+    // Non-absolute / unparseable strings are returned unchanged.
+    expect(scrubUrl('/relative/path?token=abc')).toBe(
+        '/relative/path?token=abc',
+    );
 });


### PR DESCRIPTION
Completes **GAP-AUDIT §2.3** (safe-by-default tracing). Verifying against `main` first showed the task/audit were stale — **3 of the 4 "Build" items had already shipped**, so this PR adds only the two genuinely-missing pieces and closes their edges.

| §2.3 "Build" item | Status |
| --- | --- |
| Header denylist redaction | ✅ already shipped (#50) |
| `trace: false` + real env off-switch (`STITCH_TRACE_FILE=0` no longer writes a file named `0`) + off-by-default | ✅ already shipped (#58) |
| **Body/result truncation + opt-in full capture** | ✅ this PR |
| **OTLP `url.full` scrubbing** | ✅ this PR |

## What changed

- **Body truncation** (`trace.ts`) — the built-in JSONL sink now caps `start.input.body`, `result.value`, and `delta.chunk` at **2048 chars** by default, replacing oversized payloads with a `{ truncated, bytes, preview }` marker (the preview is a prefix of the already-redacted JSON). Opt into full capture with `STITCH_TRACE_MAX_BODY=full` (env) or `fileSink(path, { maxBodyBytes: false })` (code); `0` keeps only the marker.
- **`scrubUrl`** (`util.ts`) — strips userinfo (`https://user:pass@host`) and redacts secret query values (`api_key`, `access_token`, `signature`, …) by denylist, keeping benign params (`page`, `sort`). Applied to OTLP `url.full` — its only secret-bearing attribute — and, for coherence, the JSONL/console `start.url`.
- **`input.query` redaction** — a test caught that scrubbing the URL while leaving the same secret in the structured `input.query` is incoherent; the query twin is now redacted with the same denylist.
- **`redactHeaders`** option widens (never shrinks) the header denylist for non-standard auth headers.

## Deliverable: design + defaults + migration

- **Design / defaults**: documented in `trace-sinks.mdx` (new "Body truncation and full capture" section) and `helpers.mdx` (the new `fileSink`/`createTrace` options). Defaults: header denylist + URL scrub on; bodies truncate at 2048 chars.
- **Migration note**: bodies now truncate and URLs are scrubbed by default — no API removed, nothing changed shape. Restore the old behavior with `STITCH_TRACE_MAX_BODY=full` or `fileSink(path, { maxBodyBytes: false })`. A custom `TraceSink` is unaffected (it receives the live events).
- Corrected a **now-false anti-pattern callout** in `otlp.mdx` that claimed `url.full` shipped verbatim.

## Testing

Extends the §2.3 acceptance spec `test/gaps/trace-controls.spec.ts` (default truncation, full capture via env and code, URL/query scrub) and `test/otlp-export.spec.ts` (`url.full` scrub end-to-end + `scrubUrl` units). Full local gate green: types, lint, `tsd`, **370 tests**, exports, prettier, and the docs render build.

> [!NOTE]
> Out of scope but flagged separately: `packages/core/README.md` still says tracing is on "by default" (stale since #58 made it off-by-default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)