### PR TITLE
feat(core): oauth2 clientAuth — client_secret_basic + token-request extras

### DIFF
--- a/apps/docs/content/docs/guides/auth/oauth2.mdx
+++ b/apps/docs/content/docs/guides/auth/oauth2.mdx
@@ -45,6 +45,35 @@ Give two stitches the same `key` plus a shared `store` and one token serves them
 all — across stitches and across workers, surviving restarts. See
 [Reference → Auth strategies](/docs/reference/auth-strategies) for every field.
 
+## Client authentication
+
+By default the client authenticates with `client_secret_post`: `client_id` and
+`client_secret` ride in the form body. Some providers require
+`client_secret_basic` instead — the credentials as an HTTP Basic header, with
+only `grant_type` in the body. Set `clientAuth: 'basic'` for those:
+
+```ts twoslash
+import { env, oauth2, stitch } from 'stitchapi';
+
+const messages = stitch({
+    baseUrl: 'https://sms.example.com',
+    path: '/messages',
+    auth: oauth2({
+        tokenUrl: 'https://sms.example.com/oauth/token',
+        clientId: env('CLIENT_ID'),
+        clientSecret: env('CLIENT_SECRET'),
+        clientAuth: 'basic',
+    }),
+});
+```
+
+The Basic header is Base64 of `id:secret`, encoded without Node's `Buffer` so it
+works in a browser bundle too. For provider-specific extras on the token request,
+`audience` sets the OAuth2 `audience` field, `params` merges arbitrary fields into
+the token-request body (e.g. `resource`, or a custom `grant_type`), and `headers`
+adds headers to it. The client credentials are always applied last, so `params`
+can never shadow them.
+
 <Callout type="warn">
     **Anti-pattern:** don't rely on the default token cache across multiple
     workers — it lives in memory, process-local, so every worker fetches and

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -15,6 +15,19 @@ import { nodeFs, now, readEnv } from './util';
 export type Secret = string | (() => string);
 const resolve = (s: Secret): string => (typeof s === 'function' ? s() : s);
 
+/**
+ * Base64-encode a UTF-8 string without Node's `Buffer`, so HTTP Basic credentials work in a
+ * browser bundle too (the browser-first gate — `Buffer` is absent there). The bytes match
+ * `Buffer.from(s, 'utf8').toString('base64')` exactly, non-ASCII included: `TextEncoder` emits
+ * the same UTF-8 bytes, mapped 1:1 to a binary string for `btoa` (a DOM/Node global).
+ */
+function base64(s: string): string {
+    const bytes = new TextEncoder().encode(s);
+    let bin = '';
+    for (const b of bytes) bin += String.fromCharCode(b);
+    return btoa(bin);
+}
+
 /** Resolve a secret from an environment variable at call time. */
 export function env(name: string): () => string {
     return () => {
@@ -77,9 +90,7 @@ export function basic(opts: { user: Secret; pass: Secret }): AuthStrategy {
     return {
         name: 'basic',
         apply(req) {
-            const token = Buffer.from(
-                `${resolve(opts.user)}:${resolve(opts.pass)}`,
-            ).toString('base64');
+            const token = base64(`${resolve(opts.user)}:${resolve(opts.pass)}`);
             req.headers['authorization'] = `Basic ${token}`;
         },
     };
@@ -94,6 +105,28 @@ export interface OAuth2Opts {
     clientSecret: Secret;
     /** Optional space-delimited scopes. */
     scope?: string;
+    /**
+     * How the client authenticates to the token endpoint (RFC 6749 §2.3.1). Default `'post'`
+     * (`client_secret_post`) puts `client_id`/`client_secret` in the form body. `'basic'`
+     * (`client_secret_basic`) sends them as an HTTP Basic `Authorization` header and keeps only
+     * `grant_type` (plus `scope`/`audience`/`params`) in the body — what providers like Kyivstar
+     * SMS require. The header is Base64 of `id:secret`, encoded browser-safe (no `Buffer`).
+     */
+    clientAuth?: 'post' | 'basic';
+    /** OAuth2 `audience` (Auth0 / RFC 8693); added to the token-request body when set. */
+    audience?: string;
+    /**
+     * Extra fields merged into the token-request form body — an escape hatch for provider-specific
+     * params (`resource`, a custom `grant_type`, …). Merged over the built-ins, so it can override
+     * `grant_type`/`scope`/`audience`; the client credentials are always applied last and can never
+     * be overridden here.
+     */
+    params?: Record<string, string>;
+    /**
+     * Extra headers on the token request (e.g. a provider-required header). Keys are lower-cased;
+     * cannot override the `Authorization` header that `clientAuth: 'basic'` sets.
+     */
+    headers?: Record<string, string>;
     /** Statuses that mean the token was rejected and should force a refresh. Default [401]. */
     refreshOn?: number[];
     /** Refresh this many ms BEFORE the token's expiry, so it is never used mid-flight. Default 30_000. */
@@ -137,6 +170,7 @@ export function oauth2(opts: OAuth2Opts): AuthStrategy {
     const skew = opts.refreshSkewMs ?? 30_000;
     const nsKey = 'oauth2:' + (opts.key ?? opts.tokenUrl);
     const adapter = opts.adapter ?? fetchAdapter();
+    const clientAuth = opts.clientAuth ?? 'post';
     const flight = singleFlight<string>();
 
     const isFresh = (t: CachedToken | undefined): boolean =>
@@ -148,15 +182,34 @@ export function oauth2(opts: OAuth2Opts): AuthStrategy {
         ctx.emit('auth', 'token');
         const body: Record<string, string> = {
             grant_type: 'client_credentials',
-            client_id: resolve(opts.clientId),
-            client_secret: resolve(opts.clientSecret),
         };
         if (opts.scope) body['scope'] = opts.scope;
+        if (opts.audience) body['audience'] = opts.audience;
+        // Escape-hatch params first, so they can set grant_type/resource/etc. — but BEFORE the
+        // credentials below, which are applied last and can never be shadowed by `params`.
+        if (opts.params) Object.assign(body, opts.params);
+
+        const headers: Record<string, string> = { accept: 'application/json' };
+        for (const [k, v] of Object.entries(opts.headers ?? {}))
+            headers[k.toLowerCase()] = v;
+
+        if (clientAuth === 'basic') {
+            // client_secret_basic: credentials ride in an HTTP Basic header (set last, so a
+            // caller-supplied header can't clobber it) and stay OUT of the body.
+            const creds = base64(
+                `${resolve(opts.clientId)}:${resolve(opts.clientSecret)}`,
+            );
+            headers['authorization'] = `Basic ${creds}`;
+        } else {
+            // client_secret_post: credentials in the form body, applied last so `params` can't shadow them.
+            body['client_id'] = resolve(opts.clientId);
+            body['client_secret'] = resolve(opts.clientSecret);
+        }
 
         const res = await adapter({
             url: opts.tokenUrl,
             method: 'POST',
-            headers: { accept: 'application/json' },
+            headers,
             body,
             bodyType: 'form',
         });

--- a/packages/core/test/oauth2-client-auth.spec.ts
+++ b/packages/core/test/oauth2-client-auth.spec.ts
@@ -1,0 +1,173 @@
+// oauth2 `clientAuth`: how the client authenticates to the token endpoint (RFC 6749 §2.3.1).
+// Default 'post' (client_secret_post) keeps id/secret in the form body; 'basic'
+// (client_secret_basic) moves them into an HTTP Basic header — what providers like Kyivstar SMS
+// require. Also covers the token-request escape hatches: `audience`, `params`, and `headers`.
+import { env, oauth2, stitch } from '../src';
+import type { Stitch } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-oauth2-clientauth-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+    process.env['OAUTH_CLIENT_ID'] = 'cid';
+    process.env['OAUTH_CLIENT_SECRET'] = 'csecret';
+});
+
+// A stitch protected by an oauth2 token, with per-test knobs spread onto the strategy.
+const protectedStitch = (
+    path: string,
+    extra: Record<string, unknown> = {},
+): Stitch =>
+    stitch({
+        baseUrl: server.url,
+        path,
+        auth: oauth2({
+            tokenUrl: `${server.url}/token`,
+            clientId: env('OAUTH_CLIENT_ID'),
+            clientSecret: env('OAUTH_CLIENT_SECRET'),
+            ...extra,
+        }),
+    });
+
+// The token POST body is form-encoded; parse it back into params for assertions.
+const tokenBody = (i = 0): URLSearchParams =>
+    new URLSearchParams(String(server.calls('/token')[i]!.body));
+const tokenHeaders = (i = 0): Record<string, string> =>
+    server.calls('/token')[i]!.headers;
+
+const okToken = { access_token: 'T1', token_type: 'Bearer', expires_in: 3600 };
+
+test("clientAuth: 'basic' sends Basic <base64(id:secret)> and keeps creds out of the body", async () => {
+    server.route('POST', '/token', { body: okToken });
+    server.route('GET', '/data', {
+        requireHeader: { name: 'authorization', value: 'Bearer T1' },
+        body: { ok: true },
+    });
+
+    const data = protectedStitch('/data', { clientAuth: 'basic' });
+    await expect(data()).resolves.toEqual({ ok: true });
+    await expect(data()).resolves.toEqual({ ok: true }); // reuse the cached token
+
+    expect(server.callCount('/token')).toBe(1);
+
+    // The token request authenticates with an HTTP Basic header...
+    const expected = `Basic ${Buffer.from('cid:csecret').toString('base64')}`;
+    expect(tokenHeaders()['authorization']).toBe(expected);
+    // ...and the body carries grant_type/scope only — never the credentials.
+    const body = tokenBody();
+    expect(body.get('grant_type')).toBe('client_credentials');
+    expect(body.get('client_id')).toBeNull();
+    expect(body.get('client_secret')).toBeNull();
+});
+
+test("default clientAuth is 'post': creds in the body, no Authorization header on the token request", async () => {
+    server.route('POST', '/token', { body: okToken });
+    server.route('GET', '/data', {
+        requireHeader: { name: 'authorization' },
+        body: { ok: true },
+    });
+
+    const data = protectedStitch('/data'); // no clientAuth → 'post'
+    await expect(data()).resolves.toEqual({ ok: true });
+
+    const body = tokenBody();
+    expect(body.get('grant_type')).toBe('client_credentials');
+    expect(body.get('client_id')).toBe('cid');
+    expect(body.get('client_secret')).toBe('csecret');
+    expect(tokenHeaders()['authorization']).toBeUndefined();
+});
+
+test("clientAuth: 'basic' refreshes on a 401 like the post flow does", async () => {
+    server.route('POST', '/token', {
+        body: (i: number) => ({
+            access_token: i === 0 ? 'STALE' : 'FRESH',
+            token_type: 'Bearer',
+            expires_in: 3600,
+        }),
+    });
+    // First hit 401s (token rejected); after the forced refresh the retry succeeds.
+    server.route('GET', '/data', { statuses: [401, 200], body: { ok: true } });
+
+    const data = protectedStitch('/data', { clientAuth: 'basic' });
+    await expect(data()).resolves.toEqual({ ok: true });
+
+    expect(server.callCount('/token')).toBe(2); // initial fetch + forced refresh on 401
+    // Both token requests use Basic auth.
+    const expected = `Basic ${Buffer.from('cid:csecret').toString('base64')}`;
+    expect(tokenHeaders(0)['authorization']).toBe(expected);
+    expect(tokenHeaders(1)['authorization']).toBe(expected);
+    const calls = server.calls('/data');
+    expect(calls[0]!.headers['authorization']).toBe('Bearer STALE');
+    expect(calls[1]!.headers['authorization']).toBe('Bearer FRESH');
+});
+
+test('audience is added to the token-request body', async () => {
+    server.route('POST', '/token', { body: okToken });
+    server.route('GET', '/data', { body: { ok: true } });
+
+    const data = protectedStitch('/data', { audience: 'urn:my-api' });
+    await data();
+
+    expect(tokenBody().get('audience')).toBe('urn:my-api');
+});
+
+test('params merge into the body and can override grant_type', async () => {
+    server.route('POST', '/token', { body: okToken });
+    server.route('GET', '/data', { body: { ok: true } });
+
+    const data = protectedStitch('/data', {
+        params: { grant_type: 'urn:custom:grant', resource: 'urn:my:res' },
+    });
+    await data();
+
+    const body = tokenBody();
+    expect(body.get('grant_type')).toBe('urn:custom:grant'); // overrode the default
+    expect(body.get('resource')).toBe('urn:my:res');
+});
+
+test('params can never shadow the resolved client_secret (post mode)', async () => {
+    server.route('POST', '/token', { body: okToken });
+    server.route('GET', '/data', { body: { ok: true } });
+
+    const data = protectedStitch('/data', {
+        params: { client_secret: 'HACKED', client_id: 'HACKED' },
+    });
+    await data();
+
+    const body = tokenBody();
+    expect(body.get('client_secret')).toBe('csecret'); // resolved creds applied last
+    expect(body.get('client_id')).toBe('cid');
+});
+
+test('headers add to the token request but cannot clobber the basic Authorization header', async () => {
+    server.route('POST', '/token', { body: okToken });
+    server.route('GET', '/data', { body: { ok: true } });
+
+    const data = protectedStitch('/data', {
+        clientAuth: 'basic',
+        headers: { 'X-Tenant': 'acme', authorization: 'must-not-win' },
+    });
+    await data();
+
+    const headers = tokenHeaders();
+    expect(headers['x-tenant']).toBe('acme');
+    // The Basic credentials win — the caller header can't displace the client auth.
+    expect(headers['authorization']).toBe(
+        `Basic ${Buffer.from('cid:csecret').toString('base64')}`,
+    );
+});


### PR DESCRIPTION
## What & why

`oauth2()` only supported `client_secret_post` — `client_id`/`client_secret` in the form body. Real providers (e.g. **Kyivstar SMS**, gap 8 from the POC backlog) require `client_secret_basic`: credentials in an HTTP Basic header, only `grant_type` in the body. This adds `clientAuth: 'post' | 'basic'` (**default `'post'`**, so existing behaviour is unchanged), plus the token-request extras the same POC surfaced.

## API

```ts
oauth2({
  tokenUrl, clientId, clientSecret,
  clientAuth: 'post' | 'basic',     // NEW — default 'post'
  audience?: string,                // NEW — OAuth2 `audience` body field
  params?: Record<string, string>,  // NEW — extra token-request body fields (resource, custom grant_type, …)
  headers?: Record<string, string>, // NEW — extra token-request headers
});
```

- **`'post'`** (default): `client_id`/`client_secret` in the form body — unchanged.
- **`'basic'`**: `Authorization: Basic base64(id:secret)`; only `grant_type` (+ `scope`/`audience`/`params`) in the body.
- **Precedence is safety-first**: `params` merges _over_ the built-in body fields (so it can set `grant_type`/`resource`), but the resolved client credentials are applied **last** and can never be shadowed; likewise a caller `headers['authorization']` can't displace the Basic header. Both invariants are tested.

## Browser-safe base64 (gap 3)

Extracted a shared `base64()` helper (`TextEncoder` + `btoa`, no `Buffer`) and routed **both** the new basic mode and the existing `basic()` strategy through it. Output is byte-identical to the old `Buffer.from(...).toString('base64')` (the existing `basic()` test still passes), so `auth.ts` no longer depends on `Buffer` and works in a browser bundle.

## Tests

7 new cases in `oauth2-client-auth.spec.ts` against the mock token endpoint:

- basic mode sends the Basic header and keeps creds out of the body
- default-`post` unchanged (creds in body, no auth header on the token request)
- the 401 refresh lifecycle works in basic mode
- `audience`, `params` (merge + override `grant_type`), `headers`
- the no-shadow-credentials invariant (`params`/caller headers can't displace the real creds)

## Verification

`check:types` (strict src+test), full core suite (**371 passing**), `check:lint`, `prettier --check`, and the docs render gate (`build-docs` — exercises the `AutoTypeTable` reference table + the new twoslash snippet) all pass. The pre-commit and pre-push lefthook gates ran clean.

## Docs

- `oauth2.mdx` gains a "Client authentication" section with a `clientAuth: 'basic'` example.
- The reference table (`auth-strategies.mdx`) auto-updates from the new JSDoc via `AutoTypeTable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
