### PR TITLE
docs(core): README — tracing is off by default, not on

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -76,7 +76,7 @@ There are plenty of ways to get a typed API client — spec-based generators, ha
 
 -   **Agents are first-class callers.** Typed clients were designed for humans writing app code. A stitch is also designed to be invoked by an agent: one definition is callable as an in-process function and as a CLI command (`stitch run`) today, with HTTP and MCP surfaces on the roadmap — returning structured, schema-validated, traceable results instead of opaque bytes.
 
--   **Observability with zero infrastructure.** Every call emits a typed event stream, traced to the console and a local JSONL log by default (`stitch trace` to inspect) — no collector, no dashboard, nothing to deploy. Exporters become opt-in when you do have infrastructure.
+-   **Observability with zero infrastructure.** Every call emits a typed event stream, but tracing is **off by default** — a stitch's only effect is its call, writing and printing nothing until you opt in (per stitch with `trace: 'console'` / `fileSink(path)` / a `TraceSink`, or globally with `STITCH_TRACE_CONSOLE=1` / `STITCH_TRACE_FILE=<path>` / `STITCH_EXPORT=otlp`). Then it's the console and a local JSONL log (`stitch trace` to inspect) — no collector, no dashboard, nothing to deploy.
 
 -   **A library, not a platform.** Zero runtime dependencies, embeds in your project, nothing to operate. Workflow platforms (Windmill, n8n, …) solve integration with a server and a visual builder; StitchAPI keeps it a code primitive — stitches compose in plain TypeScript.
 
@@ -102,7 +102,7 @@ For the full competitive landscape and positioning, see the [Overview](docs/OVER
 -   **Data shaping** - `unwrap` dot-paths, `transform` (e.g. scrape HTML into structure), auto-looping pagination, and `json` / `form` / `multipart` request bodies.
 -   **Any request style** - `http` is the default; `graphql`, `sse`, `stream`, and `download` are peer **surfaces**, each a subpath import (`stitchapi/sse`, …) on the same engine — so `import { stitch }` bundles `http` alone.
 -   **Pluggable state store** - throttle counters and sessions/tokens live behind a 3-method store; in-memory by default, a shared store makes throttling distributed and sessions shared across workers.
--   **Zero-infra observability** - every event is appended to a local JSONL trace by default; `stitch trace` summarizes runs, retries, drift, and latency percentiles.
+-   **Zero-infra observability** - tracing is **off by default** (a stitch's only effect is its call); opt in per stitch with `trace: 'console'` / `fileSink(path)` / a `TraceSink`, or globally with `STITCH_TRACE_CONSOLE=1` / `STITCH_TRACE_FILE=<path>` / `STITCH_EXPORT=otlp`. `stitch trace` then summarizes runs, retries, drift, and latency percentiles.
 -   **CLI surface** - the definition your code imports is also runnable from the shell: `stitch run <name>` streams JSONL events (HTTP and MCP surfaces are on the roadmap).
 -   **Typed URLs** - full [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) URI templates (`{id}`, `{+path}`, `{?q,sort}`, explode `*`, prefix `:n`), and a `qs`-style query builder that serializes nested objects (`a[b]=c`) and arrays — both dependency-free.
 -   **Pluggable transport** - `fetch` by default; drop in the shipped `axiosAdapter`, or any `Adapter` function, to route requests through axios or another HTTP client.
@@ -601,17 +601,20 @@ Pair it with `drift` and a renamed HTML selector that silently drops a field bec
 
 ## Zero-infra observability
 
-Observability is a consumer of the event stream, not a separate system. Every event of every call is appended as JSONL to `~/.stitch/runs/proto.jsonl` by default — no collector, no dashboard, nothing to deploy:
+Observability is a consumer of the event stream, not a separate system — and it's **off by default**: a stitch's only effect is its call, writing and printing nothing until you opt in. Turn tracing on per stitch with the `trace` field (`'console'` for a colored stderr stream, `fileSink(path)` for JSONL on disk, or any `TraceSink`), or globally with the `STITCH_TRACE_*` / `STITCH_EXPORT` env vars — no collector, no dashboard, nothing to deploy:
 
 ```bash
-# choose where the JSONL goes (default: ~/.stitch/runs/proto.jsonl)
+# append JSONL to a path (off unless set; fileSink() defaults to ~/.stitch/runs/proto.jsonl)
 STITCH_TRACE_FILE=./run.jsonl node app.js
 
 # opt into a live, colored, one-line-per-event view on stderr
 STITCH_TRACE_CONSOLE=1 node app.js
+
+# ALSO fan the same events to an OTLP collector
+STITCH_EXPORT=otlp node app.js
 ```
 
-That is per-call latency, status, attempts, throttle waits, and drift findings — recorded for free, inspectable with [`stitch trace`](#the-stitch-cli) or plain `jq`. Drift rides the same events, so a leveled drift signal shows up in the trace with no extra wiring. Need a custom sink? Consume `.stream()` yourself — the built-in trace is just one consumer of the same events. (OTLP export is on the roadmap.)
+That is per-call latency, status, attempts, throttle waits, and drift findings — recorded for free once you opt in, inspectable with [`stitch trace`](#the-stitch-cli) or plain `jq`. Drift rides the same events, so a leveled drift signal shows up in the trace with no extra wiring. The built-in JSONL and console sinks are safe by default: header values on a fixed secret denylist (`authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-api-key`) are replaced with `[REDACTED]` at the sink boundary, so the live request still carries the real header but the trace copy never does. Need a custom sink? Consume `.stream()` yourself — the built-in trace is just one consumer of the same events.
 
 ## The stitch CLI
 


### PR DESCRIPTION
## What

`packages/core/README.md` described tracing as happening **by default** in three places, but tracing has been **off by default** since #58 (no-side-effects-by-default) — a stitch's only effect is its call until you opt in. This ports the off-by-default reality (already correct on the docs site) into the package README.

## Changes

- **Off-by-default + opt-in** in all three stale spots (the "why" bullet, the features bullet, the *Zero-infra observability* prose): opt in per-stitch with `trace: 'console'` / `fileSink(path)` / a `TraceSink`, or globally with `STITCH_TRACE_CONSOLE=1` / `STITCH_TRACE_FILE=<path>` / `STITCH_EXPORT=otlp`.
- **Consistency fixes in the same section** (else it would contradict itself): the code-block comment no longer implies file tracing writes by default and gains a `STITCH_EXPORT=otlp` example; dropped the stale "(OTLP export is on the roadmap.)" note — OTLP ships (`otlp.ts`, `otlpTrace`, `STITCH_EXPORT` parsing, tests, `otlp.mdx`).
- **Safe-by-default privacy**: documented the real header-denylist redaction (`authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-api-key` → `[REDACTED]` at the sink boundary), matching `apps/docs/.../trace-sinks.mdx`.

## Deliberately *not* documented

The original ask also mentioned "scrubs URL credentials" and "truncates bodies to 2048 chars (`STITCH_TRACE_MAX_BODY=full`)" as documented in `trace-sinks.mdx`. **Neither exists** — zero matches in code or docs; `trace.ts` only redacts the 5-header denylist. I left these out rather than write false security guarantees into the README. If they're intended features, that's a separate code/doc gap.

## Out of scope (flagging)

`README.md` "Scope & roadmap" still lists **OTLP export** and **binary/blob responses** as "Next up," though both shipped. Not a tracing "by default" claim, so untouched here.

## Verification

Pre-push gate green: format, lint, typecheck, typecheck-d, test, exports, build-docs all ✔️.

🤖 Generated with [Claude Code](https://claude.com/claude-code)