### PR TITLE
chore(docs): regen playground completions for ADR 0005 surfaces

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -14,8 +14,8 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
         {
             label: "kind",
             type: "property",
-            detail: "'http' | 'graphql'",
-            info: "Request kind. `'http'` (default) or `'graphql'` for a POST `{ query, variables }`.",
+            detail: "Surface",
+            info: "Request style — a  plugin (ADR 0005 Decisions 1-2). Omitted = the built-in `http` surface. The public `__config` exposes only the surface's `id` string (so a stitch's declaration round-trips as JSON — Decision 11); the live object stays on `__rawConfig`.",
         },
         {
             label: "method",
@@ -28,6 +28,18 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             type: "property",
             detail: "'json' | 'form' | 'multipart'",
             info: "Request body encoding. Default `'json'`.",
+        },
+        {
+            label: "multipart",
+            type: "property",
+            detail: "MultipartOptions",
+            info: "Multipart serialisation options (ADR 0005 Decision 6) — how nested objects/arrays become field names. Only meaningful with `bodyType: 'multipart'`. Default nesting `'bracket'`.",
+        },
+        {
+            label: "stream",
+            type: "property",
+            detail: "StreamOptions",
+            info: "Streaming options (ADR 0005 Decision 5) — how a `stream` surface decodes the live body (`'bytes'` default / `'lines'` / `'ndjson'`). Only meaningful for the `stream` surface.",
         },
         {
             label: "responseType",


### PR DESCRIPTION
## What

Regenerates the docs-playground CodeMirror completions map, which had drifted from the core `StitchConfig` types after the ADR 0005 surface work (PRs #93–#101, already merged to `main`).

`apps/docs/app/(home)/playground/playground-completions.generated.ts` is a **generated** file (header: `// @generated — do not edit by hand`). The committed copy predated those PRs, so the playground showed stale autocompletion.

## Diff (generated-only, +14/−2)

- **`kind`** — `detail` `'http' | 'graphql'` → `Surface`; `info` updated to the ADR 0005 _"Request style — a Surface plugin (Decisions 1-2)"_ description.
- **`multipart`** (`MultipartOptions`) and **`stream`** (`StreamOptions`) — added; these config properties now exist on `StitchConfig`.

No other entries changed.

## How

```
pnpm --filter @stitchapi/docs run gen:completions
```

(Equivalent to what `next build` runs via the `PlaygroundCompletionsPlugin` in `apps/docs/next.config.mjs`.) The generator parses `packages/core/src/**/*.ts` directly, so no core build was needed. Output verified to faithfully match the merged `StitchConfig` source at `packages/core/src/types.ts:332+`.

## Notes

- Surfaced incidentally while working on the oauth2 `clientAuth` PR; **not** caused by that change — the file regenerates purely from the already-merged surface types.
- The file is `.prettierignore`d (`**/*.generated.ts`; raw `JSON.stringify` output), so there's no formatting drift — the committed copy now matches exactly what `next build` would emit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)