### PR TITLE
feat(nest): @stitchapi/nest — NestJS integration (ADR 0006)

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,6 +5,7 @@
     "singleQuote": true,
     "semi": true,
     "plugins": ["@trivago/prettier-plugin-sort-imports"],
+    "importOrderParserPlugins": ["typescript", "jsx", "decorators-legacy"],
     "importOrder": [
         "^[./]",
         "^@/(.*)$",

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -1,0 +1,122 @@
+# @stitchapi/nest
+
+First-class [NestJS](https://nestjs.com) integration for
+[StitchAPI](https://stitchapi.dev) — design captured in
+[ADR 0006](../../docs/adr/0006-nestjs-integration.md).
+
+It is a **thin** package: `StitchModule` wires StitchAPI's `seam` into Nest's DI
+graph, plus two bridge helpers and a `Logger` sink. It adds **no capability** — every
+piece sits on an existing core extension point, so `stitchapi` stays a peer dependency
+and core is untouched (contract-not-dependency).
+
+```sh
+pnpm add @stitchapi/nest stitchapi
+# peers you already have in a Nest app: @nestjs/common, reflect-metadata
+```
+
+> [!IMPORTANT]
+>
+> Call `app.enableShutdownHooks()` in `main.ts`. Without it Nest never fires
+> `OnApplicationShutdown`, so the seam's trace is not flushed and its store not closed.
+
+## Configure the shared client — `forRoot` / `forRootAsync`
+
+`forRoot` configures the app-wide shared infrastructure (one `store`, one `trace`
+sink) and a default seam carrying your `SeamConfig` defaults (`baseUrl`, `headers`,
+`auth`, `retry`, `throttle`, `cache`, …). Tracing is **off by default**; opt in with the
+`'logger'` sentinel.
+
+```ts
+import { StitchModule, fromConfig } from '@stitchapi/nest';
+import { bearer } from 'stitchapi';
+
+@Module({
+    imports: [
+        StitchModule.forRootAsync({
+            imports: [ConfigModule],
+            inject: [ConfigService],
+            useFactory: (config: ConfigService) => ({
+                baseUrl: config.getOrThrow('API_BASE_URL'),
+                store: new RedisStore(config.getOrThrow('REDIS_URL')), // any StitchStore
+                auth: bearer(fromConfig(config)('API_TOKEN')),
+                trace: 'logger', // → loggerSink(new Logger('Stitch'))
+            }),
+        }),
+    ],
+})
+export class AppModule {}
+```
+
+## Injectable stitches — `forFeature` + `defineStitch`
+
+Declare stitches with `defineStitch(token, build)`; register them per feature module.
+A feature module may also own its **own upstream seam** (its `baseUrl`/`auth`), built
+over the shared store + trace — omit `seam` to attach the stitches to the default seam.
+
+```ts
+// users.stitches.ts
+export const GetUser = defineStitch('GET_USER', (s) =>
+    s.stitch({ name: 'getUser', path: '/users/{id}', output: UserSchema }),
+);
+
+@Module({
+    imports: [
+        StitchModule.forFeature({
+            seam: {
+                baseUrl: 'https://api.example.com',
+                auth: bearer(env('TOKEN')),
+            },
+            stitches: [GetUser],
+        }),
+    ],
+})
+export class UsersModule {}
+
+@Injectable()
+export class UsersService {
+    // Injected<typeof GetUser> keeps the type linked to the definition.
+    constructor(
+        @InjectStitch(GetUser)
+        private readonly getUser: Injected<typeof GetUser>,
+    ) {}
+    find(id: string) {
+        return this.getUser({ params: { id } }); // PromiseLike<User>; .stream() for events
+    }
+}
+```
+
+## Multi-tenant — `seam.as(principal)` in request scope
+
+Multi-tenancy is **principal-scoped over the shared store** (separate sessions/tokens
+per tenant, one connection pool) — never a per-request store. Bind the principal from
+the request:
+
+```ts
+{
+    provide: TENANT_SEAM,
+    scope: Scope.REQUEST,
+    useFactory: (root: Seam, req) => root.as(req.user?.tenantId ?? 'anonymous'),
+    inject: [STITCH_SEAM, REQUEST],
+}
+```
+
+Outside HTTP (BullMQ, `@Cron`, microservices) there is no `REQUEST`: inject the seam and
+bind explicitly — `seam.as(job.data.tenantId)`.
+
+## Bridges
+
+-   **`loggerSink(logger?)`** — a `TraceSink` that forwards the event stream to a Nest
+    `Logger`. It logs only name/method/url/status and strips the URL query: a custom sink
+    receives **un-redacted** events, so never log `event.input`/headers raw.
+-   **`fromConfig(config)(key)`** — a `ConfigService`-backed secret thunk (core's `env()`
+    twin). Synchronous, so it cannot fetch a rotating secret per call — use
+    `oauth2`/`cookieSession` for that.
+
+## Testing
+
+Swap the transport globally with the seam's `adapter`, or override a stitch provider:
+
+```ts
+StitchModule.forRoot({ adapter: mockAdapter }); // every stitch hits the mock
+// or: Test.createTestingModule(...).overrideProvider(GetUser.token).useValue(fakeStitch)
+```

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -1,0 +1,60 @@
+{
+    "name": "@stitchapi/nest",
+    "version": "0.0.0",
+    "description": "First-class NestJS integration for StitchAPI — StitchModule.forRoot/forFeature, injectable stitches, Logger + ConfigService bridges (ADR 0006).",
+    "main": "lib/index.js",
+    "module": "lib/index.mjs",
+    "types": "lib/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./lib/index.d.mts",
+                "default": "./lib/index.mjs"
+            },
+            "require": {
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
+            }
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "lib"
+    ],
+    "scripts": {
+        "build": "tsup",
+        "test": "vitest run",
+        "check:types": "tsc --noEmit"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rejifald/StitchAPI.git",
+        "directory": "packages/nest"
+    },
+    "keywords": [
+        "stitchapi",
+        "nestjs",
+        "nest",
+        "dependency-injection",
+        "module",
+        "adapter",
+        "api-client"
+    ],
+    "author": "Oleksandr Zhuravlov (rejifald@gmail.com)",
+    "license": "Apache-2.0",
+    "homepage": "https://stitchapi.dev",
+    "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "stitchapi": ">=0.7.0"
+    },
+    "devDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@types/node": "^22.10.0",
+        "reflect-metadata": "^0.2.2",
+        "rxjs": "^7.8.1",
+        "stitchapi": "workspace:*",
+        "tsup": "^8.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.8"
+    }
+}

--- a/packages/nest/src/bridges.ts
+++ b/packages/nest/src/bridges.ts
@@ -1,0 +1,89 @@
+// The three bridges between core primitives and the NestJS world (ADR 0006
+// Decisions 6-8). None of them touches core: a TraceSink, a `Secret` thunk, and a
+// StitchStore are all existing extension points.
+import { Logger } from '@nestjs/common';
+import type { StitchEvent, StitchStore, TraceSink } from 'stitchapi';
+
+/**
+ * A {@link TraceSink} that forwards the stitch event stream to a Nest {@link Logger}.
+ *
+ * SECURITY: a custom sink receives the **raw** event (core only redacts inside its own
+ * built-in sinks), so `event.input.headers` still holds `authorization`/`cookie`. This
+ * sink therefore logs only name/method/url/status — never `JSON.stringify(event)` — and
+ * strips the URL query (it can carry secrets like `?api_key=`).
+ */
+export function loggerSink(logger: Logger = new Logger('Stitch')): TraceSink {
+    return {
+        handle(event: StitchEvent, ctx: { name: string }): void {
+            const name = ctx.name;
+            switch (event.type) {
+                case 'start':
+                    logger.log(
+                        `→ ${name} ${event.method} ${redactUrl(event.url)}`,
+                    );
+                    break;
+                case 'result':
+                    logger.log(
+                        `← ${name} ${event.status} (${event.attempts} attempt(s))`,
+                    );
+                    break;
+                case 'error':
+                    logger.error(
+                        `✗ ${name} ${event.message}${event.status != null ? ` ${event.status}` : ''}`,
+                    );
+                    break;
+                case 'drift':
+                    logger.warn(
+                        `drift ${name} ${event.finding.path} ${event.finding.change}`,
+                    );
+                    break;
+                case 'progress':
+                    logger.debug(`· ${name} ${event.phase}#${event.attempt}`);
+                    break;
+                default:
+                    // 'delta' / 'done': too chatty for a logger — dropped.
+                    break;
+            }
+        },
+    };
+}
+
+// Drop the query string (it may carry secrets, e.g. `?api_key=…`) before logging.
+function redactUrl(url: string): string {
+    const q = url.indexOf('?');
+    return q === -1 ? url : `${url.slice(0, q)}?…`;
+}
+
+/** The minimal slice of Nest's `ConfigService` this package needs — kept structural so
+ * `@nestjs/config` is not even a peer dependency. */
+export interface ConfigServiceLike {
+    getOrThrow<T = string>(key: string): T;
+}
+
+/**
+ * A `ConfigService`-backed secret resolver — core's `env(name)` twin. Returns a
+ * synchronous `Secret` thunk (`() => string`) resolved at call time, so the credential
+ * never lands on `__config` or in a trace. Pass it to any auth strategy:
+ * `bearer(fromConfig(config)('API_TOKEN'))`.
+ *
+ * NOTE: `Secret` is synchronous, so this cannot fetch a rotating secret per call — that
+ * is what `oauth2` / `cookieSession` are for (they refresh asynchronously via the vault).
+ */
+export function fromConfig(
+    config: ConfigServiceLike,
+): (key: string) => () => string {
+    return (key: string) => () => String(config.getOrThrow<string>(key));
+}
+
+/**
+ * Wrap a store the package does **not** own: `get`/`set`/`incr` delegate, but `close` is
+ * omitted, so a seam's `close()` never tears down a store the app passed in (ADR 0006
+ * Decision 8). The app — not the package — disposes a store it provides.
+ */
+export function borrowStore(store: StitchStore): StitchStore {
+    return {
+        get: (key) => store.get(key),
+        set: (key, value, ttlMs) => store.set(key, value, ttlMs),
+        incr: (key, ttlMs) => store.incr(key, ttlMs),
+    };
+}

--- a/packages/nest/src/define-stitch.ts
+++ b/packages/nest/src/define-stitch.ts
@@ -1,0 +1,38 @@
+// Injectable stitch definitions (ADR 0006 Decision 4). A definition builds against
+// the common subset of `Seam` and `PrincipalSeam`, so the SAME definition resolves
+// against the app-wide singleton seam OR a request-scoped principal handle — only the
+// provider's `inject` differs.
+import { Inject, type InjectionToken } from '@nestjs/common';
+import type { Seam, Stitch, StitchInput } from 'stitchapi';
+
+/** Both `Seam` and `PrincipalSeam` satisfy this — the host a stitch is built from. */
+export type StitchHost = Pick<Seam, 'stitch' | 'graphql'>;
+
+export interface StitchDef<TOut = unknown, TIn = StitchInput> {
+    token: InjectionToken;
+    build: (host: StitchHost) => Stitch<TOut, TIn>;
+}
+
+/**
+ * Declare an injectable stitch: an injection token plus a builder that receives the
+ * seam (root or principal-bound) the registering module hands it. Prefer a `Symbol`
+ * token to avoid string collisions across feature modules.
+ */
+export function defineStitch<TOut = unknown, TIn = StitchInput>(
+    token: InjectionToken,
+    build: (host: StitchHost) => Stitch<TOut, TIn>,
+): StitchDef<TOut, TIn> {
+    return { token, build };
+}
+
+/**
+ * The injected stitch's type, derived from its definition — keeps the injection-site
+ * annotation linked to the def (no hand-retyped `Stitch<T>`):
+ * `@InjectStitch(GetUser) getUser: Injected<typeof GetUser>`.
+ */
+export type Injected<D> =
+    D extends StitchDef<infer TOut, infer TIn> ? Stitch<TOut, TIn> : never;
+
+/** `@InjectStitch(def)` — sugar for `@Inject(def.token)`. */
+export const InjectStitch = (def: StitchDef): ParameterDecorator =>
+    Inject(def.token);

--- a/packages/nest/src/index.ts
+++ b/packages/nest/src/index.ts
@@ -1,0 +1,21 @@
+export {
+    StitchModule,
+    SeamRegistry,
+    type StitchModuleOptions,
+    type StitchModuleAsyncOptions,
+    type StitchFeatureOptions,
+} from './module';
+export {
+    defineStitch,
+    InjectStitch,
+    type StitchDef,
+    type StitchHost,
+    type Injected,
+} from './define-stitch';
+export {
+    loggerSink,
+    fromConfig,
+    borrowStore,
+    type ConfigServiceLike,
+} from './bridges';
+export { STITCH_SEAM, STITCH_STORE, STITCH_TRACE } from './tokens';

--- a/packages/nest/src/module.ts
+++ b/packages/nest/src/module.ts
@@ -1,0 +1,202 @@
+// `StitchModule` — the DynamicModule (ADR 0006 Decisions 2-4 & 8). forRoot/forRootAsync
+// configure shared infrastructure (store + trace) and a default seam; forFeature
+// registers injectable stitches and, optionally, a per-upstream feature seam built over
+// that shared infrastructure. `SeamRegistry` owns the shutdown lifecycle.
+import { borrowStore, loggerSink } from './bridges';
+import type { StitchDef, StitchHost } from './define-stitch';
+import { STITCH_SEAM, STITCH_STORE, STITCH_TRACE } from './tokens';
+
+import {
+    type DynamicModule,
+    type FactoryProvider,
+    Injectable,
+    type InjectionToken,
+    Logger,
+    Module,
+    type OnApplicationShutdown,
+    type Provider,
+} from '@nestjs/common';
+import {
+    type Seam,
+    type SeamConfig,
+    type SeamOptions,
+    type StitchStore,
+    type TraceSink,
+    memoryStore,
+    seam,
+} from 'stitchapi';
+
+/** forRoot options: the shared `SeamConfig` defaults + infra, plus the `'logger'` trace sentinel. */
+export interface StitchModuleOptions extends Omit<SeamOptions, 'trace'> {
+    /** A `TraceSink`, `'console'`, `false`, or the `'logger'` sentinel (→ Nest Logger). Default: off. */
+    trace?: SeamOptions['trace'] | 'logger';
+    /** Register as a global module (default `true`). */
+    isGlobal?: boolean;
+}
+
+/** forRootAsync options — resolve {@link StitchModuleOptions} from an injected factory. */
+export interface StitchModuleAsyncOptions {
+    imports?: DynamicModule['imports'];
+    inject?: FactoryProvider['inject'];
+    // Matches Nest's own factory typing so any typed factory (e.g. `(c: ConfigService) => …`) fits.
+    useFactory: (
+        ...args: any[]
+    ) => StitchModuleOptions | Promise<StitchModuleOptions>;
+    isGlobal?: boolean;
+}
+
+/** forFeature options — a feature's injectable stitches and, optionally, its own upstream seam. */
+export interface StitchFeatureOptions {
+    stitches: StitchDef[];
+    /** This feature's own seam (its `baseUrl`/`auth`/…), built over the shared store + trace.
+     *  Omit to attach the stitches to the root/default seam. */
+    seam?: SeamConfig;
+    /** Token to expose the feature seam under, for `.as(principal)` multi-tenant. */
+    seamToken?: InjectionToken;
+}
+
+interface Infra {
+    store: StitchStore;
+    trace: TraceSink | 'console' | false;
+    defaults: Omit<SeamOptions, 'store' | 'trace'>;
+}
+
+// Normalise module options into shared infra: borrow an app-provided store (else own a
+// memoryStore), expand the `'logger'` trace sentinel, default tracing OFF.
+function resolveInfra(options: StitchModuleOptions): Infra {
+    const { store, trace } = options;
+    const defaults: Record<string, unknown> = { ...options };
+    delete defaults['store'];
+    delete defaults['trace'];
+    delete defaults['isGlobal'];
+    return {
+        store: store ? borrowStore(store) : memoryStore(),
+        trace:
+            trace === 'logger'
+                ? loggerSink(new Logger('Stitch'))
+                : (trace ?? false),
+        defaults: defaults as Omit<SeamOptions, 'store' | 'trace'>,
+    };
+}
+
+function buildSeam(infra: Infra): Seam {
+    return seam({ ...infra.defaults, store: infra.store, trace: infra.trace });
+}
+
+/**
+ * Tracks every seam the module creates so a single shutdown hook can flush each trace
+ * and close each seam. A borrowed (app-provided) store no-ops on close; an owned
+ * `memoryStore` clears. Implements the lifecycle directly (no separate provider) so the
+ * package never relies on `emitDecoratorMetadata` for constructor injection.
+ */
+@Injectable()
+export class SeamRegistry implements OnApplicationShutdown {
+    private readonly seams: Seam[] = [];
+
+    track(s: Seam): Seam {
+        this.seams.push(s);
+        return s;
+    }
+
+    async closeAll(): Promise<void> {
+        for (const s of this.seams) await s.close();
+        this.seams.length = 0;
+    }
+
+    onApplicationShutdown(): Promise<void> {
+        return this.closeAll();
+    }
+}
+
+@Module({})
+export class StitchModule {
+    static forRoot(options: StitchModuleOptions = {}): DynamicModule {
+        const infra = resolveInfra(options);
+        return {
+            module: StitchModule,
+            global: options.isGlobal ?? true,
+            providers: [
+                SeamRegistry,
+                { provide: STITCH_STORE, useValue: infra.store },
+                { provide: STITCH_TRACE, useValue: infra.trace },
+                {
+                    provide: STITCH_SEAM,
+                    useFactory: (reg: SeamRegistry): Seam =>
+                        reg.track(buildSeam(infra)),
+                    inject: [SeamRegistry],
+                },
+            ],
+            exports: [STITCH_SEAM, STITCH_STORE, STITCH_TRACE, SeamRegistry],
+        };
+    }
+
+    static forRootAsync(options: StitchModuleAsyncOptions): DynamicModule {
+        const RESOLVED: InjectionToken = Symbol('stitch-resolved-infra');
+        return {
+            module: StitchModule,
+            global: options.isGlobal ?? true,
+            imports: options.imports ?? [],
+            providers: [
+                SeamRegistry,
+                {
+                    provide: RESOLVED,
+                    useFactory: async (...deps: any[]): Promise<Infra> =>
+                        resolveInfra(await options.useFactory(...deps)),
+                    inject: options.inject ?? [],
+                },
+                {
+                    provide: STITCH_STORE,
+                    useFactory: (i: Infra) => i.store,
+                    inject: [RESOLVED],
+                },
+                {
+                    provide: STITCH_TRACE,
+                    useFactory: (i: Infra) => i.trace,
+                    inject: [RESOLVED],
+                },
+                {
+                    provide: STITCH_SEAM,
+                    useFactory: (i: Infra, reg: SeamRegistry): Seam =>
+                        reg.track(buildSeam(i)),
+                    inject: [RESOLVED, SeamRegistry],
+                },
+            ],
+            exports: [STITCH_SEAM, STITCH_STORE, STITCH_TRACE, SeamRegistry],
+        };
+    }
+
+    static forFeature(opts: StitchFeatureOptions | StitchDef[]): DynamicModule {
+        const norm: StitchFeatureOptions = Array.isArray(opts)
+            ? { stitches: opts }
+            : opts;
+        const cfg = norm.seam;
+        // A feature seam gets its own token (or the caller's, for multi-tenant `.as()`);
+        // with no feature seam, stitches bind to the root/default seam.
+        const token: InjectionToken =
+            norm.seamToken ??
+            (cfg ? Symbol('stitch-feature-seam') : STITCH_SEAM);
+        const providers: Provider[] = [];
+        const exported: InjectionToken[] = [];
+        if (cfg) {
+            providers.push({
+                provide: token,
+                useFactory: (
+                    store: StitchStore,
+                    trace: TraceSink | 'console' | false,
+                    reg: SeamRegistry,
+                ): Seam => reg.track(seam({ ...cfg, store, trace })),
+                inject: [STITCH_STORE, STITCH_TRACE, SeamRegistry],
+            });
+            exported.push(token);
+        }
+        for (const d of norm.stitches) {
+            providers.push({
+                provide: d.token,
+                useFactory: (host: StitchHost) => d.build(host),
+                inject: [token],
+            });
+            exported.push(d.token);
+        }
+        return { module: StitchModule, providers, exports: exported };
+    }
+}

--- a/packages/nest/src/tokens.ts
+++ b/packages/nest/src/tokens.ts
@@ -1,0 +1,12 @@
+// Injection tokens. `STITCH_SEAM` is the default seam (forRoot's shared-defaults
+// seam); `STITCH_STORE` / `STITCH_TRACE` expose the app-wide shared infrastructure
+// so feature modules (forFeature) can build their own seam over it.
+
+/** The default seam — the shared-defaults seam created by `forRoot`/`forRootAsync`. */
+export const STITCH_SEAM = Symbol('STITCH_SEAM');
+
+/** The app-wide shared store (a borrowed view when you pass one; else an owned `memoryStore`). */
+export const STITCH_STORE = Symbol('STITCH_STORE');
+
+/** The app-wide shared trace sink, or `false` when tracing is off (the default). */
+export const STITCH_TRACE = Symbol('STITCH_TRACE');

--- a/packages/nest/test/module.spec.ts
+++ b/packages/nest/test/module.spec.ts
@@ -1,0 +1,197 @@
+// Wiring proof for @stitchapi/nest. We resolve the DynamicModule's provider factories
+// directly (no Nest DI container needed) and run the resulting stitches against a mock
+// adapter, asserting wire-level effects — the same style as core's tests.
+import {
+    type ConfigServiceLike,
+    STITCH_SEAM,
+    STITCH_STORE,
+    STITCH_TRACE,
+    SeamRegistry,
+    StitchModule,
+    borrowStore,
+    defineStitch,
+    fromConfig,
+    loggerSink,
+} from '../src';
+
+import { Logger } from '@nestjs/common';
+import type { Adapter, Seam, StitchStore } from 'stitchapi';
+import { memoryStore } from 'stitchapi';
+import { describe, expect, it } from 'vitest';
+
+// Minimal view of a provider object literal, for poking at the factories.
+type FProv = {
+    provide: unknown;
+    useFactory?: (...args: any[]) => unknown;
+    useValue?: unknown;
+    inject?: unknown[];
+};
+
+const recordingAdapter = (sink: string[]): Adapter => {
+    return async (req) => {
+        sink.push(`${req.method} ${req.url}`);
+        return { status: 200, headers: {}, body: { ok: true } };
+    };
+};
+
+describe('StitchModule.forRoot', () => {
+    it('wires a seam over the configured adapter; store is a value; lifecycle closes', async () => {
+        const calls: string[] = [];
+        const mod = StitchModule.forRoot({
+            baseUrl: 'https://api.test',
+            adapter: recordingAdapter(calls),
+        });
+        expect(mod.global).toBe(true);
+
+        const providers = mod.providers as FProv[];
+        const seamProv = providers.find((p) => p.provide === STITCH_SEAM);
+        const storeProv = providers.find((p) => p.provide === STITCH_STORE);
+        expect(seamProv?.inject).toEqual([SeamRegistry]);
+        expect(storeProv?.useValue).toBeDefined();
+
+        const reg = new SeamRegistry();
+        const api = seamProv!.useFactory!(reg) as Seam;
+        await api.stitch({ path: '/thing' })();
+        expect(calls).toEqual(['GET https://api.test/thing']);
+
+        await reg.closeAll(); // must not throw
+    });
+
+    it('defaults tracing OFF (no STITCH_TRACE sink)', () => {
+        const providers = StitchModule.forRoot().providers as FProv[];
+        const traceProv = providers.find((p) => p.provide === STITCH_TRACE);
+        expect(traceProv?.useValue).toBe(false);
+    });
+
+    it("expands the 'logger' trace sentinel to a sink", () => {
+        const providers = StitchModule.forRoot({ trace: 'logger' })
+            .providers as FProv[];
+        const traceProv = providers.find((p) => p.provide === STITCH_TRACE);
+        expect(
+            typeof (traceProv?.useValue as { handle?: unknown }).handle,
+        ).toBe('function');
+    });
+});
+
+describe('StitchModule.forFeature', () => {
+    it('builds a feature seam over shared store/trace and binds stitches to it', async () => {
+        const calls: string[] = [];
+        const GetThing = defineStitch('GET_THING', (h) =>
+            h.stitch({ path: '/thing' }),
+        );
+        const mod = StitchModule.forFeature({
+            seam: {
+                baseUrl: 'https://feat.test',
+                adapter: recordingAdapter(calls),
+            },
+            stitches: [GetThing],
+        });
+
+        const providers = mod.providers as FProv[];
+        const stitchProv = providers.find((p) => p.provide === GetThing.token);
+        const seamProv = providers.find((p) => p.provide !== GetThing.token);
+        expect(seamProv?.inject).toEqual([
+            STITCH_STORE,
+            STITCH_TRACE,
+            SeamRegistry,
+        ]);
+        // the stitch binds to the feature seam's token, not the root seam
+        expect(stitchProv?.inject?.[0]).toBe(seamProv?.provide);
+
+        const reg = new SeamRegistry();
+        const featSeam = seamProv!.useFactory!(
+            memoryStore(),
+            false,
+            reg,
+        ) as Seam;
+        const stitch = stitchProv!.useFactory!(featSeam) as ReturnType<
+            typeof GetThing.build
+        >;
+        await stitch();
+        expect(calls).toEqual(['GET https://feat.test/thing']);
+    });
+
+    it('attaches stitches to the root seam when no feature seam is given', () => {
+        const GetThing = defineStitch('GET_THING_2', (h) =>
+            h.stitch({ path: '/thing' }),
+        );
+        const providers = StitchModule.forFeature([GetThing])
+            .providers as FProv[];
+        expect(providers).toHaveLength(1);
+        expect(providers[0]?.inject).toEqual([STITCH_SEAM]);
+    });
+});
+
+describe('bridges', () => {
+    it('borrowStore delegates get/set/incr but omits close', async () => {
+        const calls: string[] = [];
+        const backing: StitchStore = {
+            get: async () => {
+                calls.push('get');
+                return 1;
+            },
+            set: async () => {
+                calls.push('set');
+            },
+            incr: async () => {
+                calls.push('incr');
+                return 2;
+            },
+            close: async () => {
+                calls.push('close');
+            },
+        };
+        const borrowed = borrowStore(backing);
+        expect(borrowed.close).toBeUndefined();
+        expect(await borrowed.get('k')).toBe(1);
+        await borrowed.set('k', 'v');
+        expect(await borrowed.incr('k', 1)).toBe(2);
+        expect(calls).toEqual(['get', 'set', 'incr']); // close is never delegated
+    });
+
+    it('loggerSink logs lifecycle lines and redacts the URL query', () => {
+        const logs: string[] = [];
+        const errs: string[] = [];
+        const fake = {
+            log: (m: string) => logs.push(m),
+            error: (m: string) => errs.push(m),
+            warn: () => {},
+            debug: () => {},
+        } as unknown as Logger;
+        const sink = loggerSink(fake);
+        sink.handle(
+            {
+                type: 'start',
+                name: 'x',
+                method: 'GET',
+                url: 'https://h/p?token=secret',
+                input: {},
+                at: 0,
+            },
+            { name: 'x' },
+        );
+        sink.handle(
+            {
+                type: 'error',
+                name: 'x',
+                message: 'boom',
+                status: 500,
+                attempts: 1,
+                at: 0,
+            },
+            { name: 'x' },
+        );
+        expect(logs[0]).toContain('GET https://h/p?…');
+        expect(logs[0]).not.toContain('secret');
+        expect(errs[0]).toContain('boom');
+    });
+
+    it('fromConfig resolves a synchronous secret thunk from a ConfigService-like', () => {
+        const config: ConfigServiceLike = {
+            getOrThrow<T = string>(key: string): T {
+                return `val:${key}` as T;
+            },
+        };
+        expect(fromConfig(config)('API_TOKEN')()).toBe('val:API_TOKEN');
+    });
+});

--- a/packages/nest/tsconfig.json
+++ b/packages/nest/tsconfig.json
@@ -1,0 +1,39 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM"],
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "esModuleInterop": true,
+        "experimentalDecorators": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "exactOptionalPropertyTypes": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "verbatimModuleSyntax": true,
+        "isolatedModules": true,
+
+        "types": ["node", "vitest/globals"],
+
+        // Resolve the workspace package to its SOURCE so typecheck + tests don't
+        // depend on `stitchapi` being built first (the pre-push gate typechecks
+        // before it builds). The published `exports` map still points at `lib/`.
+        "baseUrl": ".",
+        "paths": {
+            "stitchapi": ["../core/src/index.ts"]
+        }
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts",
+        "tsup.config.ts",
+        "vitest.config.ts"
+    ]
+}

--- a/packages/nest/tsup.config.ts
+++ b/packages/nest/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+// Single dual-format entry. `stitchapi` and `@nestjs/common` are peer deps,
+// externalised by tsup, so the bundle is just the wiring. Not minified — class
+// names (e.g. SeamRegistry) show up in Nest's DI errors and logs.
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    minify: false,
+    outDir: 'lib',
+    clean: true,
+});

--- a/packages/nest/vitest.config.ts
+++ b/packages/nest/vitest.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+// Alias the workspace package to core SOURCE, so tests run without `stitchapi`
+// being built first. Mirrors tsconfig `paths`.
+const src = (p: string): string =>
+    fileURLToPath(new URL(`../core/src/${p}`, import.meta.url));
+
+export default defineConfig({
+    resolve: {
+        alias: [{ find: /^stitchapi$/, replacement: src('index.ts') }],
+    },
+    test: {
+        globals: true,
+        environment: 'node',
+        // Load the metadata polyfill before any test module, so importing the module
+        // (which runs @Module/@Injectable at load) never depends on import ordering.
+        setupFiles: ['reflect-metadata'],
+        include: ['test/**/*.spec.ts'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,7 +186,7 @@ importers:
         version: 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -210,7 +210,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
   packages/fingerprint-effect:
     devDependencies:
@@ -295,6 +295,33 @@ importers:
       zod:
         specifier: ^3.23.8
         version: 3.25.76
+
+  packages/nest:
+    devDependencies:
+      '@nestjs/common':
+        specifier: ^11.0.0
+        version: 11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.21
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      rxjs:
+        specifier: ^7.8.1
+        version: 7.8.2
+      stitchapi:
+        specifier: workspace:*
+        version: link:../core
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
   packages/sandbox-sim:
     devDependencies:
@@ -431,6 +458,9 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
   '@braidai/lang@1.1.2':
     resolution: {integrity: sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA==}
@@ -1069,6 +1099,10 @@ packages:
   '@loaderkit/resolve@1.0.6':
     resolution: {integrity: sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg==}
 
+  '@lukeed/csprng@1.1.0':
+    resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
+    engines: {node: '>=8'}
+
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
@@ -1080,6 +1114,19 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@nestjs/common@11.1.27':
+    resolution: {integrity: sha512-kEGSzqM2lWr4whh4Ubflw+oPZSEzxvRMu9WL+LveZploJWTjec5bBlCiRVlVzTPg2kIwBiLwWSvCCW7Wnin1gg==}
+    peerDependencies:
+      class-transformer: '>=0.4.1'
+      class-validator: '>=0.13.2'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+      rxjs: ^7.1.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
 
   '@next/env@16.2.7':
     resolution: {integrity: sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==}
@@ -1906,6 +1953,13 @@ packages:
 
   '@tailwindcss/postcss@4.3.0':
     resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
+
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
   '@trivago/prettier-plugin-sort-imports@4.3.0':
     resolution: {integrity: sha512-r3n0onD3BTOVUNPhR4lhVK4/pABGpbA7bW3eumZnYdKaHkf1qEC+Mag6DPbGNuuh0eG8AaYj+YqmVHSiGslaTQ==}
@@ -2940,6 +2994,10 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -3295,6 +3353,9 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -3477,6 +3538,10 @@ packages:
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
+
+  iterare@1.2.1:
+    resolution: {integrity: sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==}
+    engines: {node: '>=6'}
 
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
@@ -3698,6 +3763,10 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-esm@1.0.3:
+    resolution: {integrity: sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==}
+    engines: {node: '>=13.2.0'}
 
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
@@ -4339,6 +4408,9 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -4421,6 +4493,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
@@ -4594,6 +4669,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
@@ -4679,6 +4758,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -4809,6 +4892,14 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  uid@2.0.2:
+    resolution: {integrity: sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==}
+    engines: {node: '>=8'}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -5244,6 +5335,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@braidai/lang@1.1.2': {}
 
@@ -5716,6 +5809,8 @@ snapshots:
     dependencies:
       '@braidai/lang': 1.1.2
 
+  '@lukeed/csprng@1.1.0': {}
+
   '@marijn/find-cluster-break@1.0.2': {}
 
   '@mdx-js/mdx@3.1.1':
@@ -5754,6 +5849,18 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
+
+  '@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+    dependencies:
+      file-type: 21.3.4
+      iterare: 1.2.1
+      load-esm: 1.0.3
+      reflect-metadata: 0.2.2
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      uid: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@next/env@16.2.7': {}
 
@@ -6413,6 +6520,15 @@ snapshots:
       postcss: 8.5.15
       tailwindcss: 4.3.0
 
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
   '@trivago/prettier-plugin-sort-imports@4.3.0(prettier@3.3.3)':
     dependencies:
       '@babel/generator': 7.17.7
@@ -6788,7 +6904,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
 
   '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.8)':
     dependencies:
@@ -6798,7 +6914,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
     transitivePeerDependencies:
       - supports-color
 
@@ -7744,6 +7860,15 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -8168,6 +8293,8 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -8341,6 +8468,8 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  iterare@1.2.1: {}
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -8510,6 +8639,8 @@ snapshots:
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
+
+  load-esm@1.0.3: {}
 
   load-tsconfig@0.2.5: {}
 
@@ -9436,6 +9567,8 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  reflect-metadata@0.2.2: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -9611,6 +9744,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
 
   safe-array-concat@1.1.4:
     dependencies:
@@ -9857,6 +9994,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   style-mod@4.1.3: {}
 
   style-to-js@1.1.21:
@@ -9932,6 +10073,12 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
 
   tree-kill@1.2.2: {}
 
@@ -10094,6 +10241,12 @@ snapshots:
   typescript@6.0.3: {}
 
   ufo@1.6.4: {}
+
+  uid@2.0.2:
+    dependencies:
+      '@lukeed/csprng': 1.1.0
+
+  uint8array-extras@1.5.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:


### PR DESCRIPTION
Implements **ADR 0006** (#103) — a thin first-party `@stitchapi/nest` package.

> **Stacked on #103** — base is the ADR branch (`claude/hungry-newton-2a0b0d`), so the diff here is **package-only**. Retarget the base to `main` once #103 merges.

## What it adds

- `StitchModule.forRoot` / `forRootAsync` — shared infra (`STITCH_STORE` / `STITCH_TRACE`) + a default seam; one-word `trace: 'logger'` sentinel
- `forFeature({ stitches, seam? })` — injectable stitches + per-upstream feature seams built over the shared infra (bare `StitchDef[]` = shorthand on the default seam)
- `defineStitch` / `InjectStitch` / `Injected<typeof Def>` — typed injection
- Bridges: `loggerSink` (→ Nest `Logger`, query-redacted), `fromConfig` (→ `ConfigService`, synchronous secret thunk), `borrowStore`
- `SeamRegistry` — `OnApplicationShutdown` flush + close (borrowed app-store is never closed by the package)

**Zero core change** — every piece rides an existing extension point; `stitchapi` is a peer dependency (contract-not-dependency holds). Uses explicit `@Inject` tokens only (no `emitDecoratorMetadata` reliance → the tsup/esbuild build is sound).

## Notable inclusions

- **`.prettierrc.json`** gains `decorators-legacy` in `importOrderParserPlugins` — these are the repo's **first decorator files**, which the `@trivago` sort-imports plugin (Babel) could not otherwise parse. No existing file was reformatted.
- **`pnpm-lock.yaml` +161** — `@nestjs/common` + `rxjs` + `reflect-metadata` as devDeps (peers in a real Nest app).

## Verification

Full pre-push gate green: lint · typecheck · tsd · **test** · exports · **build-docs (`next build`)** · format. The 8 specs build real stitches *through the module* and assert wire-level calls against a mock adapter; monorepo `pnpm -r test` = core 364 + 5 fingerprint + nest 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)