### PR TITLE
test(core): pin timeout.total budget across throttle, pagination, and executeRaw (GAP-AUDIT §1.1)

### DIFF
--- a/packages/core/test/gaps/timeout-total.spec.ts
+++ b/packages/core/test/gaps/timeout-total.spec.ts
@@ -88,3 +88,81 @@ test('timeout.total is enforced alongside timeout.perAttempt across retries', as
     // total: 400 must bound the whole call — not 5 × perAttempt + backoffs.
     expect(elapsed).toBeLessThan(1500);
 }, 10000);
+
+// ── C. total caps a throttle/rate wait, not just request + backoff ──────────
+// `throttle.rate` paces successive acquires for a key: the first call is granted
+// immediately and arms the limiter's next-grant clock, so the next call must wait
+// ~1000ms for its rate slot. That wait is part of the call and must count against
+// `total` — a 300ms budget has to cut a call stuck behind the limiter short rather
+// than let it block for the full rate spacing (acquireWithin, engine.ts).
+test('timeout.total caps a throttle (rate) wait', async () => {
+    server.route('GET', '/rate-limited', { body: { ok: true } }); // instant 200
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/rate-limited',
+        throttle: { rate: '1/s' }, // 1000ms minimum spacing between grants
+        timeout: { total: 300 },
+    });
+
+    // First call grants immediately (reserving the next grant ~1s out); the runtime
+    // — and its limiter state — is reused by the second call.
+    await call();
+    // Second call is stuck behind the ~1000ms rate spacing; the 300ms budget must
+    // abort the throttle wait and surface a timeout.
+    const { err, elapsed } = await rejectionOf(call());
+
+    expect(err).toBeDefined();
+    expect(err?.message ?? '').toMatch(/timed?\s?out|timeout/i);
+    expect(elapsed).toBeLessThan(900); // budget (300) ≪ rate spacing (1000)
+}, 10000);
+
+// ── D. total spans a paginated call, capping the page loop ──────────────────
+// Pagination follows pages until `next` returns undefined; each page is a full
+// request, and every page's time (here a 150ms server delay) draws down one shared
+// budget. With `next` always advancing, only `total` can stop the loop — a 400ms
+// budget must cut it to a few pages instead of grinding through `max` (50) pages.
+test('timeout.total bounds a paginated call across pages', async () => {
+    server.route('GET', '/feed', {
+        delayMs: 150, // each page costs ~150ms
+        body: (i: number) => ({ items: [i], cursor: i + 1 }),
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/feed',
+        paginate: {
+            items: (v) => (v as { items: unknown[] }).items,
+            next: (body) => ({
+                query: { cursor: String((body as { cursor: number }).cursor) },
+            }),
+            max: 50,
+        },
+        timeout: { total: 400 },
+    });
+
+    const { err, elapsed } = await rejectionOf(call());
+
+    expect(err).toBeDefined();
+    expect(err?.message ?? '').toMatch(/timed?\s?out|timeout/i);
+    // 50 pages × 150ms ≈ 7.5s unbounded; the 400ms total must stop it far sooner.
+    expect(elapsed).toBeLessThan(2000);
+}, 10000);
+
+// ── E. total bounds executeRaw (the raw login path) ─────────────────────────
+// `executeRaw` (exposed as `stitch.__raw`, used by cookieSession to read Set-Cookie
+// from a login stitch) drives the same attempt loop and must honour `total` too —
+// otherwise a hung login would block the whole session setup. A glacial endpoint
+// under a 300ms total must reject promptly, not hang for the server's 5s.
+test('timeout.total bounds executeRaw', async () => {
+    server.route('GET', '/raw-glacial', { delayMs: 5000, body: { ok: true } });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/raw-glacial',
+        timeout: { total: 300 },
+    }) as unknown as { __raw: (input?: unknown) => Promise<unknown> };
+
+    const { err, elapsed } = await rejectionOf(call.__raw());
+
+    expect(err).toBeDefined();
+    expect(err?.message ?? '').toMatch(/timed?\s?out|timeout/i);
+    expect(elapsed).toBeLessThan(2000); // the 300ms budget, not the 5s server delay
+}, 10000);


### PR DESCRIPTION
## What

Closes the **spec-coverage gap** for `timeout.total` as a cross-retry wall-clock deadline (GAP-AUDIT §1.1).

The implementation itself already shipped in #50 (`dcc811c`): each attempt is clamped to `min(perAttempt, remaining)`, and backoff (`sleepWithin`) + throttle (`acquireWithin`) waits draw down one shared budget, covering `paginated()` and `executeRaw()`. But the gap spec only pinned two of the cases the audit names.

## Why

`test/gaps/timeout-total.spec.ts` pinned only:
- **A** — `total` caps the retry/backoff loop
- **B** — `total` enforced even when `perAttempt` is *also* set (the dead-config regression)

The three other budget-draws the audit calls out were unpinned, so a regression in any of them would pass CI silently. This adds them.

## Changes

Tests only — **no engine change**. Three new cases in `test/gaps/timeout-total.spec.ts`:

| | Pins |
|---|---|
| **C** | a throttle (rate) wait is capped by `total` (`acquireWithin`) |
| **D** | a paginated call is bounded across pages (`paginated()`) |
| **E** | `executeRaw` (the cookieSession raw-login path) honours `total` |

Each asserts a `/timed out/i` rejection, so it fails if the budget isn't enforced (the throttled call would otherwise resolve after ~1s, pagination would run all 50 pages ~7.5s, `__raw` would hang for the server's 5s).

## Verification

Full local pre-push gate (mirrors CI) green: format, lint, typecheck, tsd, **test (full suite)**, exports, build-docs. The timeout spec is 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
