### PR TITLE
feat(core): infer GraphQL variables from an input.variables schema (#75)

### DIFF
--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -243,9 +243,17 @@ async function validateInput(
     cfg: StitchConfig,
     input: StitchInput,
 ): Promise<void> {
-    for (const part of ['params', 'query', 'body', 'headers'] as const) {
+    for (const part of [
+        'params',
+        'query',
+        'body',
+        'headers',
+        'variables',
+    ] as const) {
         // `input.*` is widened to SchemaLike for authoring ergonomics, but `compose` →
         // `normalizeInput` has already coerced every present slot to a Validator by now.
+        // `variables` (the graphql surface's primary input) validates here too; the validated
+        // value still flows untouched into the `{ query, variables }` body the surface packs.
         const v = cfg.input?.[part] as Validator | undefined;
         if (!v) continue;
         const r = await v.validate((input as Record<string, unknown>)[part]);

--- a/packages/core/src/infer.ts
+++ b/packages/core/src/infer.ts
@@ -85,9 +85,9 @@ export type ResolveOutput<TExplicit, C> = [TExplicit] extends [never]
  */
 type Prettify<T> = { [K in keyof T]: T[K] } & {};
 
-/** The slots an `input` schema can validate (see {@link InputSchemas}): params, query, body, headers. */
+/** The slots an `input` schema can validate (see {@link InputSchemas}): params, query, body, headers, variables. */
 type SchemaSlots = keyof InputSchemas;
-/** {@link StitchInput} keys with no schema slot — `variables` (GraphQL). Carried through untyped. */
+/** {@link StitchInput} keys with no schema slot — the runtime-only `signal` / `onProgress` controls. Carried through untyped. */
 type ExtraSlots = Exclude<keyof StitchInput, SchemaSlots>;
 /**
  * The pre-coercion input type a declared slot accepts. `NonNullable` keeps it sound when `I` is the
@@ -111,8 +111,16 @@ type RequiredSchemaKeys<I> = {
 
 /**
  * The typed call argument for a config whose `input` is `I`: required schema slots, optional schema
- * slots, and the untyped `variables` passthrough (always optional). {@link Prettify} collapses the
- * required∩optional split into one flat object.
+ * slots, the runtime-only `signal`/`onProgress` passthrough, and — when no `variables` schema is
+ * declared — the untyped `variables` passthrough. {@link Prettify} collapses the required∩optional
+ * split into one flat object.
+ *
+ * The trailing conditional restores backward compatibility: `variables` is now an {@link InputSchemas}
+ * slot, so it falls OUT of {@link ExtraSlots}. A graphql config that declares a `variables` schema
+ * types it through the slot machinery above; one that declares NONE (`I` has no `variables` key) would
+ * otherwise lose the optional `variables?` it used to carry — so re-add it here as the loose
+ * passthrough. The `I extends { variables: unknown }` probe is true only when a `variables` key was
+ * actually written, so the two branches never overlap (no typed-vs-loose clash on the same key).
  */
 type CallInput<I> = Prettify<
     { [K in RequiredSchemaKeys<I> & keyof I]: SlotInput<I, K> } & {
@@ -120,7 +128,11 @@ type CallInput<I> = Prettify<
             SlotInput<I, K>,
             undefined
         >;
-    } & { [K in ExtraSlots]?: StitchInput[K] }
+    } & { [K in ExtraSlots]?: StitchInput[K] } & (I extends {
+            variables: unknown;
+        }
+            ? Record<never, never>
+            : { variables?: Record<string, unknown> })
 >;
 
 /**

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -96,7 +96,13 @@ function normalizeInput(
 ): InputSchemas | undefined {
     if (!input) return undefined;
     const out: InputSchemas = {};
-    for (const k of ['params', 'query', 'body', 'headers'] as const) {
+    for (const k of [
+        'params',
+        'query',
+        'body',
+        'headers',
+        'variables',
+    ] as const) {
         const schema = input[k];
         if (!schema) continue;
         const v = toValidator(schema);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -328,6 +328,10 @@ export interface InputSchemas {
     query?: SchemaLike;
     body?: SchemaLike;
     headers?: SchemaLike;
+    // GraphQL variables (the `graphql` surface's primary input). Declaring a schema here types the
+    // call arg's `variables` (see `CallInput`) and validates them at runtime alongside the other
+    // slots; left undeclared, `variables` stays the loose untyped passthrough it has always been.
+    variables?: SchemaLike;
 }
 export interface StitchConfig {
     /** Label used in events and traces; defaults to `path` or `'stitch'`. */
@@ -370,7 +374,7 @@ export interface StitchConfig {
     headers?: Record<string, string>;
     /** GraphQL query string (`kind: 'graphql'`). */
     query?: string;
-    /** Schemas validating params, query, body, and headers before the request. */
+    /** Schemas validating params, query, body, headers, and (GraphQL) variables before the request. */
     input?: InputSchemas;
     /**
      * Response schema, or a {@link DriftSpec} for leveled drift detection. Accepts any

--- a/packages/core/test-d/graphql-variables.test-d.ts
+++ b/packages/core/test-d/graphql-variables.test-d.ts
@@ -1,0 +1,55 @@
+// Phase 2b (issue #75): a graphql stitch infers its `variables` CALL ARGUMENT from an
+// `input.variables` schema — the slot that Phase 2 left as an untyped passthrough. Same tsd idioms
+// as input-inference.test-d.ts: assert on `CallArg` (not `expectType<Stitch<…>>`), and use
+// `expectError` for the missing/ill-typed cases. Positive "this call compiles" cases live in the
+// runtime spec (test/graphql-and-headers.spec.ts) with `await`.
+import { graphql, seam } from '..';
+import { type CallArg } from './_util';
+
+import { expectAssignable, expectError, expectType } from 'tsd';
+import { z } from 'zod';
+
+// 1) a declared `input.variables` schema types the call arg's `variables` and makes it required.
+const getThing = graphql({
+    query: 'query($id: ID!) { thing(id: $id) { name } }',
+    input: { variables: z.object({ id: z.string() }) },
+});
+expectType<{ id: string }>(
+    null as unknown as CallArg<typeof getThing>['variables'],
+);
+expectError(getThing()); // variables required → no-arg call is an error
+expectError(getThing({ variables: {} })); // missing `id`
+expectError(getThing({ variables: { id: 1 } })); // `id` is a string, not a number
+
+// 2) an `.optional()` variables schema yields an OPTIONAL slot — the whole call arg becomes optional
+//    (so a no-arg call stays legal, asserted via `{}` below), yet a present `variables` is still
+//    type-checked: a bad shape is rejected.
+const maybeVars = graphql({
+    query: 'query { ok }',
+    input: { variables: z.object({ region: z.string() }).optional() },
+});
+expectAssignable<CallArg<typeof maybeVars>>({}); // optional slot → empty arg is valid
+expectAssignable<CallArg<typeof maybeVars>>({ variables: { region: 'eu' } });
+expectError(maybeVars({ variables: { region: 1 } })); // region must be a string
+
+// 3) a graphql stitch with NO variables schema keeps `variables` optional + a loose passthrough —
+//    the pre-#75 behaviour, preserved now that `variables` is an InputSchemas slot. Any shape goes.
+const loose = graphql({ query: 'query { ok }' });
+expectAssignable<CallArg<typeof loose>>({ variables: { anything: 1 } });
+expectAssignable<CallArg<typeof loose>>({}); // and the arg stays fully optional
+
+// 4) `seam.graphql(...)` infers `variables` identically (it routes through the same `InputOf<C>`).
+const api = seam({ baseUrl: 'https://api.example.com' });
+const memberTyped = api.graphql({
+    query: 'query($id: ID!) { thing(id: $id) { name } }',
+    input: { variables: z.object({ id: z.string() }) },
+});
+expectType<{ id: string }>(
+    null as unknown as CallArg<typeof memberTyped>['variables'],
+);
+expectError(memberTyped()); // required on a seam member too
+expectError(memberTyped({ variables: { id: 1 } })); // wrong type on a seam member too
+
+// a schema-less seam graphql member also keeps the loose passthrough.
+const memberLoose = api.graphql({ query: 'query { ok }' });
+expectAssignable<CallArg<typeof memberLoose>>({ variables: { anything: 1 } });

--- a/packages/core/test-d/input-inference.test-d.ts
+++ b/packages/core/test-d/input-inference.test-d.ts
@@ -92,7 +92,9 @@ const gqlTyped = api.graphql({
 expectType<{ region: string }>(
     null as unknown as CallArg<typeof gqlTyped>['params'],
 );
-// GraphQL `variables` stay an untyped passthrough (typing them is deferred — see follow-up issue).
+// A graphql stitch with NO `input.variables` schema keeps `variables` as a loose untyped
+// passthrough. (Issue #75 makes a DECLARED `input.variables` schema type them — covered in
+// graphql-variables.test-d.ts; this case pins the schema-less behaviour stays unchanged.)
 const gqlLoose = api.graphql({ query: 'query { ok }', output: userSchema });
 expectAssignable<CallArg<typeof gqlLoose>>({ variables: { region: 'eu' } });
 

--- a/packages/core/test/graphql-and-headers.spec.ts
+++ b/packages/core/test/graphql-and-headers.spec.ts
@@ -10,6 +10,7 @@ import type { MockServer } from './support/mock-server';
 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { z } from 'zod';
 
 process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
@@ -75,6 +76,61 @@ describe('GraphQL kind', () => {
         });
         const query = graphql({ baseUrl: server.url, query: '{ thing }' });
         await expect(query()).rejects.toThrow(/thing.*not found/);
+    });
+});
+
+// Issue #75: `input.variables` is now a validated slot (it used to be an untyped passthrough).
+// The compile-time half is graphql-variables.test-d.ts; this is the runtime half.
+describe('GraphQL input.variables validation', () => {
+    test('rejects bad variables BEFORE hitting the wire', async () => {
+        server.route('POST', '/graphql', { body: { data: { ok: true } } });
+        const query = graphql({
+            baseUrl: server.url,
+            query: 'query($id: ID!) { thing(id: $id) { name } }',
+            input: { variables: z.object({ id: z.string() }) },
+        });
+
+        // `id` must be a string — a number fails the variables schema.
+        await expect(
+            query({ variables: { id: 1 as unknown as string } }),
+        ).rejects.toThrow(/invalid variables/);
+        // validation runs before the request, so the server never saw the call.
+        expect(server.calls('/graphql')).toHaveLength(0);
+    });
+
+    test('accepts good variables and packs them into { query, variables }', async () => {
+        server.route('POST', '/graphql', {
+            body: { data: { thing: { name: 'Ada' } } },
+        });
+        const query = graphql({
+            baseUrl: server.url,
+            query: 'query($id: ID!) { thing(id: $id) { name } }',
+            input: { variables: z.object({ id: z.string() }) },
+        });
+
+        const out = await query({ variables: { id: 'abc' } });
+        expect(out).toEqual({ thing: { name: 'Ada' } });
+        const call = server.calls('/graphql')[0]!;
+        expect((call.body as { variables: unknown }).variables).toEqual({
+            id: 'abc',
+        });
+    });
+
+    test('a graphql call with NO variables schema still works (untyped passthrough)', async () => {
+        server.route('POST', '/graphql', { body: { data: { ok: true } } });
+        const query = graphql({
+            baseUrl: server.url,
+            query: 'query($id: ID) { thing(id: $id) { name } }',
+        });
+
+        // No `input.variables` → no validation; any variables flow straight through.
+        const out = await query({ variables: { id: 42, extra: 'anything' } });
+        expect(out).toEqual({ ok: true });
+        const call = server.calls('/graphql')[0]!;
+        expect((call.body as { variables: unknown }).variables).toEqual({
+            id: 42,
+            extra: 'anything',
+        });
     });
 });
 


### PR DESCRIPTION
Closes #75.

Phase 2 typed `params` / `query` / `body` / `headers` from their `input` schemas but left GraphQL `variables` an untyped `Record<string, unknown>` passthrough — read only at one runtime site. This closes that gap: a declared `input.variables` schema now **types** the call argument and **validates** it at runtime, while a graphql stitch that declares no `variables` schema keeps the loose passthrough exactly as before.

> [!NOTE]
> Unlike its two sibling `infer.ts` PRs (path-vars, extends — type-only), this PR includes a **small additive runtime change** (validate the new slot). The runtime change is a no-op when `input.variables` is undefined.

### Inferred signature — before / after

`graphql({ query, input: { variables: z.object({ id: z.string() }) } })`

- **Before:** call arg `{ variables?: Record<string, unknown>; … }` — the schema was ignored at the type level (untyped, optional).
- **After:** call arg `{ variables: { id: string }; signal?: …; onProgress?: … }` — `variables` is **required and typed**; a missing or ill-typed `id` is a compile error, and the runtime validator rejects bad variables before the request.

A schema-less `graphql({ query })` resolves to `StitchInput | undefined` — the loose `variables?: Record<string, unknown>` passthrough is **preserved**.

### Type-level

- **types.ts** — add `variables?: SchemaLike` to `InputSchemas`, making it a first-class schema slot (`SchemaSlots` picks it up; it leaves `ExtraSlots`).
- **infer.ts** — `CallInput` types a declared `variables` through the existing required/optional slot machinery. A trailing conditional re-adds the loose `variables?: Record<string, unknown>` **only when no `variables` schema is declared** (`I extends { variables: unknown } ? Record<never, never> : { variables?: … }`), so the typed and loose branches never overlap. The `signal` / `onProgress` passthrough (the remaining `ExtraSlots`) is unaffected. This is the single, localized `infer.ts` edit — minimal for the coupled rebase chain.

### Runtime (additive)

- **stitch.ts `normalizeInput`** — coerce a declared `input.variables` via `toValidator`, alongside the other slots.
- **engine.ts `validateInput`** — validate `variables` too; the validated value still flows untouched into the `{ query, variables }` body the graphql surface packs. `mergeInput` already folds `variables`, so `.with({ variables })` / pagination are unaffected (no change there).

### Tests

- **test-d/graphql-variables.test-d.ts** (new) — a declared schema makes `variables` required + typed (`expectError` on missing / ill-typed); a schema-less graphql stitch keeps the optional passthrough; `seam.graphql(...)` infers identically.
- **input-inference.test-d.ts** — refresh the now-stale "variables typing is deferred" comment.
- **graphql-and-headers.spec.ts** — runtime rejects bad variables *before* the wire, accepts good ones into the POST body, and an undeclared-variables call still passes anything through.

### Gates

`check:types-d`, `check:types`, `check:lint` all green; `test` → 395 passed (50 files). Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)