### PR TITLE
docs(site): add Docs link to header navbar

### DIFF
--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -12,6 +12,10 @@ export function baseOptions(): BaseLayoutProps {
         },
         links: [
             {
+                text: 'Docs',
+                url: '/docs',
+            },
+            {
                 text: 'Playground',
                 url: '/playground',
             },


### PR DESCRIPTION
## Summary

- Adds a **Docs** link (`/docs`) to the site header, sitting before the existing Playground link
- One-line change to `apps/docs/lib/layout.shared.tsx`

## Test plan

- [x] Dev server started, header visually verified — both Docs and Playground links render correctly
- [x] Pre-push gate passed (format, lint, typecheck, tsd, 416 tests, exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)