### PR TITLE
feat(core): infer params from RFC 6570 path-template vars in path/url (#114)

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -32,8 +32,10 @@ function coerce(raw: string): unknown {
 
 // Template parameter names (`/users/{id}` → ["id"]) so a bare `--id` routes to params,
 // matching the engine's RFC 6570 expansion — operator prefixes (`{+id}`, `{?q,sort}`) and
-// `*`/`:n` modifiers are stripped to the bare names.
-export function paramNamesOf(stitch: Stitch): string[] {
+// `*`/`:n` modifiers are stripped to the bare names. Accepts an any-input `Stitch<unknown, never>`
+// (it only reads `__config`), so a templated-path stitch — whose call argument now requires `params`
+// (Phase 2c) — is still a valid argument.
+export function paramNamesOf(stitch: Stitch<unknown, never>): string[] {
     const { path, url } = stitch.__config;
     const tpl = (path ?? '') + ' ' + (typeof url === 'string' ? url : '');
     const names: string[] = [];

--- a/packages/core/src/download.ts
+++ b/packages/core/src/download.ts
@@ -87,7 +87,9 @@ export const downloadSurface: Surface<StitchInput, DownloadResult> = {
 /** download members bound to a seam. `stitch(config)` creates a download member of `seam`; `seam`
  *  is the underlying handle for lifecycle/principal (`.as`/`.flush`/`.close`). */
 export interface DownloadSeamApi {
-    readonly stitch: <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+    readonly stitch: <
+        const C extends Partial<StitchConfig> = Partial<StitchConfig>,
+    >(
         config: C,
     ) => Stitch<DownloadResult, InputOf<C>>;
     readonly seam: Seam;
@@ -96,7 +98,7 @@ export interface DownloadSeamApi {
 // Standalone download stitch: the call argument is inferred from `config.input`, the result fixed
 // to `{ blob, filename }`.
 const downloadStitch = <
-    C extends Partial<StitchConfig> = Partial<StitchConfig>,
+    const C extends Partial<StitchConfig> = Partial<StitchConfig>,
 >(
     config: C,
 ): Stitch<DownloadResult, InputOf<C>> =>
@@ -104,7 +106,9 @@ const downloadStitch = <
 
 // Bind download members to a seam through the seam's surface-agnostic `stitch({ kind })`.
 function bindSeam(s: Seam): DownloadSeamApi {
-    const stitch = <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+    const stitch = <
+        const C extends Partial<StitchConfig> = Partial<StitchConfig>,
+    >(
         config: C,
     ): Stitch<DownloadResult, InputOf<C>> =>
         s.stitch<DownloadResult>({ ...config, kind: downloadSurface });

--- a/packages/core/src/infer.ts
+++ b/packages/core/src/infer.ts
@@ -135,15 +135,112 @@ type CallInput<I> = Prettify<
             : { variables?: Record<string, unknown> })
 >;
 
+// ---- Path-template variables (Phase 2c) -----------------------------------
+// A templated endpoint contributes required input that the `input` schemas don't name: the engine
+// expands the path against `input.params` (`expandPath(tpl, input.params ?? {})`, engine.ts), so a
+// `{id}` slot needs `params.id` at call time even with no `input.params` schema. These types read
+// the variable NAMES off a string-literal `path`/`url` and fold them into the `params` slot, mirroring
+// the runtime grammar (`expandPath` in util.ts) at the type level. Pure types — zero runtime: the
+// engine already does the expansion. A non-literal endpoint (a `${base}/…` template-literal type, or a
+// thunk `url`) has no literal to walk, so it yields `never` and adds nothing — fail open, never closed.
+
+/** RFC 6570 expression operators (`{+id}`, `{?q}`, …) — the leading char `expandPath` strips. */
+type TplOp = '+' | '#' | '.' | '/' | ';' | '?' | '&';
+/** Drop a leading {@link TplOp} from one `{…}` expression body, matching `expandPath`'s operator slice. */
+type StripOp<S extends string> = S extends `${TplOp}${infer R}` ? R : S;
 /**
- * Map a config object's `input` slot to the typed call argument. No `input` key → the loose
- * {@link StitchInput} (the historical default), so a stitch with no input schemas is unchanged and
- * its argument stays fully optional. Like {@link OutputOf}, this reads only the top-level `input`
- * key, not `extends` fragments.
+ * Drop a varspec's modifier — prefix (`id:2`) or explode (`id*`) — leaving the bare name. Mirrors the
+ * runtime varspec regex `([^:*]*)(?::(\d+)|(\*))?`: the name is everything up to the first `:` or `*`.
+ * The `:` case is tested first so `id:2` stops at the colon rather than the (absent) star.
+ */
+type StripMod<S extends string> = S extends `${infer N}:${string}`
+    ? N
+    : S extends `${infer N}*`
+      ? N
+      : S;
+/** Split one expression body on commas (`{?q,sort}` → `q | sort`), stripping each varspec's modifier. */
+type SplitVars<S extends string> = S extends `${infer H},${infer T}`
+    ? StripMod<H> | SplitVars<T>
+    : StripMod<S>;
+/**
+ * Every variable name in a template literal: walk each `{…}` expression, strip its operator, split its
+ * comma-separated varspecs, strip each modifier → a union of names. A string with no `{` (a plain path,
+ * or a literal `?page=1` query — which lives outside any brace) yields `never`. Recursion is bounded by
+ * the number of `{…}` groups, well within TS's instantiation budget for realistic endpoints.
+ */
+type PathVars<S extends string> = S extends `${string}{${infer E}}${infer Rest}`
+    ? SplitVars<StripOp<E>> | PathVars<Rest>
+    : never;
+/**
+ * The path-template variables a config declares: from a string-literal `path`, else a string-literal
+ * `url` (host included — `url` is templated too). The `infer P extends string` guard matches a literal
+ * only — a thunk `url` (`() => string`) and a widened `string` both fail the constraint and fall through
+ * to `never`, so a non-literal endpoint adds no params (fail open). `path` wins when both are literals,
+ * matching the engine's `usingUrl ? url : path` precedence is irrelevant here (a config rarely sets both,
+ * and either spelling's vars are equally required); reading `path` first is the simple, stable choice.
+ */
+type PathVarsOf<C> = C extends { path: infer P extends string }
+    ? PathVars<P>
+    : C extends { url: infer U extends string }
+      ? PathVars<U>
+      : never;
+
+/**
+ * The `params` shape a config's `input.params` schema declares, or the empty object when it declares
+ * none. Read straight off `C['input']['params']` via {@link InferInput} (NOT off the computed `Base`):
+ * the loose {@link StitchInput} fallback carries `params?: Record<string, unknown>`, whose index
+ * signature would otherwise make EVERY name look schema-provided and swallow the path-only fold. With no
+ * `input.params` schema this is `Record<never, never>` (the empty object, spelled to avoid a bare `{}`),
+ * so the path vars alone shape `params`. `NonNullable` unwraps the optional slot; a non-object inferred
+ * shape (degenerate) intersects harmlessly with the path-only keys.
+ */
+type SchemaParams<C> = C extends { input: { params: infer P } }
+    ? NonNullable<InferInput<P>>
+    : Record<never, never>;
+/**
+ * The folded `params` slot: the schema-declared shape ({@link SchemaParams}) intersected with the
+ * path-only var names typed `string | number` (what `expandPath` ultimately stringifies). Path-only
+ * keys are `Exclude`d of the schema's keys, so a key the schema already names KEEPS its schema type —
+ * schema wins. Placed as a REQUIRED property, so `HasRequired`/`Args` make the call argument required —
+ * the correctness win. {@link Prettify} flattens the intersection for clean errors and tsd identity.
+ */
+type PathParams<C> = Prettify<
+    SchemaParams<C> &
+        Record<Exclude<PathVarsOf<C>, keyof SchemaParams<C>>, string | number>
+>;
+
+/**
+ * Map a config object's `input` slot to the typed call argument, then fold in any RFC 6570
+ * path-template vars (from a string-literal `path`/`url`). No `input` key → the loose
+ * {@link StitchInput} (the historical default), so a stitch with no input schemas and no template stays
+ * fully optional. Like {@link OutputOf}, this reads only the top-level `input`/`path`/`url`, not
+ * `extends` fragments. No path vars in a branch (`PathVarsOf<C>` is `never`, tuple-wrapped to stop
+ * distribution) → the base is returned byte-for-byte, so a non-templated stitch is exactly Phase 2.
+ *
+ * The two `input` branches fold path vars DIFFERENTLY on purpose — both must keep the result assignable
+ * to {@link StitchInput}, because every surface helper assigns the engine's loose
+ * `Stitch<TOut, StitchInput>` to its declared `Stitch<TOut, InputOf<C>>` and the call argument sits
+ * contravariantly in that signature (so `InputOf<C>` must flow *back* into `StitchInput`):
+ *
+ * - **With an `input` schema** (`Base = CallInput<I>`, a deferred mapped type for a generic `C`): fold by
+ *   INTERSECTION (`CallInput<I> & { params }`). The base is left structurally untouched — its `query?` /
+ *   `body?` modifiers stay exactly as Phase 2 emitted them; an `Omit<…>`-re-wrap would, under
+ *   `exactOptionalPropertyTypes`, widen those optional slots to `T | undefined` and break that boundary
+ *   assignment. Intersecting only narrows/adds `params`: a `params` schema key keeps its schema type,
+ *   path-only keys are added required.
+ * - **Without an `input` schema** (`Base = StitchInput`, a CONCRETE interface): build `params` purely from
+ *   the path vars via `Omit<StitchInput, 'params'> & { params }`. `Omit` over a concrete type resolves
+ *   immediately (no deferral → no boundary break) and DROPS `StitchInput`'s loose
+ *   `params?: Record<string, unknown>`, so the slot is exactly `{ id: string | number }` rather than that
+ *   intersected with the catch-all index signature.
  */
 export type InputOf<C> = C extends { input: infer I }
-    ? CallInput<I>
-    : StitchInput;
+    ? [PathVarsOf<C>] extends [never]
+        ? CallInput<I>
+        : CallInput<I> & { params: PathParams<C> }
+    : [PathVarsOf<C>] extends [never]
+      ? StitchInput
+      : Prettify<Omit<StitchInput, 'params'> & { params: PathParams<C> }>;
 
 /** The required (non-optional) keys of `T`. (`Record<never, never>` is the empty object `{}` — the
  * standard "is this key optional?" probe — spelled to avoid a bare `{}` type.) */

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -8,7 +8,17 @@ import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-export type StitchRegistry = Record<string, Stitch>;
+/**
+ * A bag of stitches keyed by name, holding stitches of **any** call-argument shape. The element is
+ * `Stitch<unknown, never>` — `never` in the contravariant `TIn` slot makes every concrete stitch
+ * (including a templated-path stitch whose call argument now *requires* `params`, Phase 2c, or one with
+ * a required `body`) assignable into the registry. A plain `Stitch` (= `Stitch<unknown, StitchInput>`)
+ * would reject those, since a required-input call signature is narrower than the loose one. The surfaces
+ * over a registry (CLI `run`, HTTP `serve`, MCP) build the input dynamically at call time, so the
+ * static argument type is intentionally erased here; {@link selectStitch} re-widens to an invokable
+ * `Stitch` at the one dynamic-dispatch boundary.
+ */
+export type StitchRegistry = Record<string, Stitch<unknown, never>>;
 
 // Module names probed (in order) when no explicit module path is given.
 export const DEFAULT_MODULES = [
@@ -54,10 +64,14 @@ export function collectStitches(mod: unknown): StitchRegistry {
 // Resolve a stitch by name: exact export-key match first, then a stitch whose
 // configured `name` matches. Throws a helpful, listing error when absent.
 export function selectStitch(registry: StitchRegistry, name: string): Stitch {
-    const direct = registry[name];
+    // Re-widen the input-erased registry element (`Stitch<unknown, never>`) to an invokable `Stitch`:
+    // the surfaces call it with a `StitchInput` built at runtime from CLI flags / the request body /
+    // the MCP argument, and the engine reads that input by field name regardless of its static type.
+    // This is the single dynamic-dispatch boundary the registry's type erasure is designed around.
+    const direct = registry[name] as Stitch | undefined;
     if (direct) return direct;
     for (const s of Object.values(registry))
-        if (s.__config.name === name) return s;
+        if (s.__config.name === name) return s as Stitch;
 
     const available = Object.keys(registry).sort();
     const err = new Error(

--- a/packages/core/src/sse.ts
+++ b/packages/core/src/sse.ts
@@ -113,7 +113,9 @@ export const sseSurface: Surface<StitchInput, SseEvent[]> = {
 /** sse members bound to a seam. `stitch(config)` creates an sse member of `seam`; `seam` is the
  *  underlying handle for lifecycle/principal (`.as`/`.flush`/`.close`). */
 export interface SseSeamApi {
-    readonly stitch: <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+    readonly stitch: <
+        const C extends Partial<StitchConfig> = Partial<StitchConfig>,
+    >(
         config: C,
     ) => Stitch<SseEvent[], InputOf<C>>;
     readonly seam: Seam;
@@ -121,7 +123,9 @@ export interface SseSeamApi {
 
 // Standalone sse stitch: the call argument is inferred from `config.input`, the result fixed to the
 // collected event array (a streaming await resolves to all of its `delta` chunks — Stage 5).
-const sseStitch = <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+const sseStitch = <
+    const C extends Partial<StitchConfig> = Partial<StitchConfig>,
+>(
     config: C,
 ): Stitch<SseEvent[], InputOf<C>> =>
     makeStitch<SseEvent[]>({ ...config, kind: sseSurface });
@@ -129,7 +133,9 @@ const sseStitch = <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
 // Bind sse members to a seam through the seam's surface-agnostic `stitch({ kind })` (Decision 3) —
 // no per-surface seam method; one shared runtime / principal boundary.
 function bindSeam(s: Seam): SseSeamApi {
-    const stitch = <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+    const stitch = <
+        const C extends Partial<StitchConfig> = Partial<StitchConfig>,
+    >(
         config: C,
     ): Stitch<SseEvent[], InputOf<C>> =>
         s.stitch<SseEvent[]>({ ...config, kind: sseSurface });

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -399,10 +399,15 @@ export interface StitchFn {
      * generic always wins. Note: passing the explicit generic stops TypeScript from inferring the
      * config type, so the call argument falls back to the loose `StitchInput` in that form (a
      * limitation of partial type-argument inference — never worse than pre-inference).
+     *
+     * `const C` captures string-literal `path` / `url` (and other literals) instead of widening them to
+     * `string`, so {@link InputOf} can read the RFC 6570 path-template vars off the literal and require
+     * the matching `params` (Phase 2c). Schema *values* (Zod/Standard Schema) are reference types and so
+     * are unaffected by the `const` modifier.
      */
     <
         TExplicit = never,
-        C extends Partial<StitchConfig> = Partial<StitchConfig>,
+        const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
         config: C,
     ): Stitch<ResolveOutput<TExplicit, C>, InputOf<C>>;
@@ -440,7 +445,7 @@ export function drift<S>(
 /** graphql(): a stitch preset for GraphQL-over-HTTP — POST { query, variables }, unwrap `data`. */
 export function graphql<
     TExplicit = never,
-    C extends Partial<StitchConfig> & {
+    const C extends Partial<StitchConfig> & {
         query: string;
     } = Partial<StitchConfig> & {
         query: string;

--- a/packages/core/src/stream.ts
+++ b/packages/core/src/stream.ts
@@ -71,7 +71,9 @@ export const streamSurface: Surface<StitchInput, unknown[]> = {
 /** stream members bound to a seam. `stitch(config)` creates a stream member of `seam`; `seam` is
  *  the underlying handle for lifecycle/principal (`.as`/`.flush`/`.close`). */
 export interface StreamSeamApi {
-    readonly stitch: <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+    readonly stitch: <
+        const C extends Partial<StitchConfig> = Partial<StitchConfig>,
+    >(
         config: C,
     ) => Stitch<unknown[], InputOf<C>>;
     readonly seam: Seam;
@@ -79,14 +81,18 @@ export interface StreamSeamApi {
 
 // Standalone stream stitch: the call argument is inferred from `config.input`, the result fixed to
 // the collected chunk array (a streaming await resolves to all of its `delta` chunks — Stage 5).
-const streamStitch = <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+const streamStitch = <
+    const C extends Partial<StitchConfig> = Partial<StitchConfig>,
+>(
     config: C,
 ): Stitch<unknown[], InputOf<C>> =>
     makeStitch<unknown[]>({ ...config, kind: streamSurface });
 
 // Bind stream members to a seam through the seam's surface-agnostic `stitch({ kind })` (Decision 3).
 function bindSeam(s: Seam): StreamSeamApi {
-    const stitch = <C extends Partial<StitchConfig> = Partial<StitchConfig>>(
+    const stitch = <
+        const C extends Partial<StitchConfig> = Partial<StitchConfig>,
+    >(
         config: C,
     ): Stitch<unknown[], InputOf<C>> =>
         s.stitch<unknown[]>({ ...config, kind: streamSurface });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -579,7 +579,7 @@ export interface Seam {
      */
     stitch<
         TExplicit = never,
-        C extends Partial<StitchConfig> = Partial<StitchConfig>,
+        const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
         config: C,
     ): Stitch<ResolveOutput<TExplicit, C>, InputOf<C>>;
@@ -588,7 +588,7 @@ export interface Seam {
     /** GraphQL-over-HTTP member stitch (POST `{ query, variables }`, unwrap `data`). */
     graphql<
         TExplicit = never,
-        C extends Partial<StitchConfig> & {
+        const C extends Partial<StitchConfig> & {
             query: string;
         } = Partial<StitchConfig> & {
             query: string;

--- a/packages/core/test-d/path-vars.test-d.ts
+++ b/packages/core/test-d/path-vars.test-d.ts
@@ -1,0 +1,128 @@
+// `stitch()` reads RFC 6570 path-template vars off a string-literal `path` / `url` and folds them into
+// the `params` slot of the inferred call argument (Phase 2c) — so a templated endpoint, whose engine
+// expands `path` against `input.params`, has a correctly *required* call argument. We assert on the
+// call-argument type via `CallArg` (a `Stitch<…>` bound can't see required-arg stitches, and
+// `expectType<Stitch<…>>` is broken by the recursive `with()`); positive "this call compiles" cases live
+// in the runtime spec (test/path-vars.spec.ts) with `await`, so they aren't floating promises here.
+//
+// `const C` on the inferring overloads is what preserves the string LITERAL of `path` / `url` for the
+// extractor — without it the literal widens to `string` and no vars are read — so these plain
+// `stitch({ path: '…' })` forms (no `as const`) exercise that capture too.
+import { seam, stitch } from '..';
+import type { StitchInput } from '..';
+import { type CallArg } from './_util';
+
+import { expectAssignable, expectError, expectType } from 'tsd';
+import { z } from 'zod';
+
+// 1) bare `{id}`: params is present, required, and typed `string | number`; the arg is required.
+const u = stitch({ path: '/users/{id}' });
+expectType<{ id: string | number }>(
+    null as unknown as NonNullable<CallArg<typeof u>>['params'],
+);
+expectError(u()); // params required → no-arg call is an error
+expectError(u({})); // params still required
+expectError(u({ query: { page: 1 } })); // params still required
+
+// 2) path var + `input.params` schema for a SHARED key: the schema type wins for `id`, the path adds
+//    the rest (`postId`) as required `string | number`.
+const post = stitch({
+    path: '/u/{id}/p/{postId}',
+    input: { params: z.object({ id: z.string() }) },
+});
+expectType<string>(
+    null as unknown as NonNullable<CallArg<typeof post>>['params']['id'], // schema wins (not string|number)
+);
+expectType<string | number>(
+    null as unknown as NonNullable<CallArg<typeof post>>['params']['postId'], // path-only → string|number
+);
+expectError(post()); // params required
+expectError(post({ params: { id: 'a' } })); // missing the path-only `postId`
+
+// 3) operators and modifiers are stripped to bare names (mirrors `expandPath`'s varspec parse):
+//    `{?q,sort}` → `q | sort`; `{id*}` (explode) → `id`; `{id:2}` (prefix) → `id`.
+const query = stitch({ path: '/search{?q,sort}' });
+expectType<{ q: string | number; sort: string | number }>(
+    null as unknown as NonNullable<CallArg<typeof query>>['params'],
+);
+const explode = stitch({ url: 'https://api.example.com/files/{id*}' });
+expectType<{ id: string | number }>(
+    null as unknown as NonNullable<CallArg<typeof explode>>['params'],
+);
+const prefix = stitch({ url: 'https://api.example.com/u/{id:2}' });
+expectType<{ id: string | number }>(
+    null as unknown as NonNullable<CallArg<typeof prefix>>['params'],
+);
+
+// 4) a literal `?page=1` after the path is a query default, NOT a template var (it lives outside any
+//    `{…}` brace) — so no params are required and the argument stays optional.
+const literalQuery = stitch({ path: '/items?page=1' });
+expectType<StitchInput | undefined>(
+    null as unknown as CallArg<typeof literalQuery>,
+);
+expectAssignable<CallArg<typeof literalQuery>>(undefined);
+
+// 5) a thunk `url` has no string literal to walk → no path params (fail open); the argument is optional.
+const thunk = stitch({ url: () => 'https://api.example.com/ping' });
+expectType<StitchInput | undefined>(null as unknown as CallArg<typeof thunk>);
+expectAssignable<CallArg<typeof thunk>>(undefined);
+
+// 6) `.with({ params })` relaxes the whole `params` slot (per-key partial binding is out of scope), so a
+//    previously-required templated arg becomes optional once params are bound.
+const bound = u.with({ params: { id: 1 } });
+expectAssignable<CallArg<typeof bound>>(undefined);
+
+// 7) `url` (host included) is templated too: a `{tenant}` in the host is a required param.
+const host = stitch({ url: 'https://{tenant}.example.com/v1/ping' });
+expectType<{ tenant: string | number }>(
+    null as unknown as NonNullable<CallArg<typeof host>>['params'],
+);
+expectError(host());
+
+// 8) `path` wins the var source when both `path` and `url` are literals (the engine never expands both;
+//    reading `path` first is the stable choice).
+const both = stitch({ path: '/p/{p}', url: 'https://x/u/{u}' });
+expectType<{ p: string | number }>(
+    null as unknown as NonNullable<CallArg<typeof both>>['params'],
+);
+
+// 9) a non-templated stitch is byte-for-byte Phase 2: no `{…}` → loose, OPTIONAL argument (backward compat).
+const plain = stitch({ path: '/ping' });
+expectType<StitchInput | undefined>(null as unknown as CallArg<typeof plain>);
+expectAssignable<CallArg<typeof plain>>(undefined);
+
+// 10) other input slots keep their own shape/required-ness alongside a folded `params`. A required `body`
+//     schema stays required; `params` is added required from the path var.
+const withBody = stitch({
+    path: '/u/{id}',
+    input: { body: z.object({ name: z.string() }) },
+});
+expectType<{ name: string }>(
+    null as unknown as NonNullable<CallArg<typeof withBody>>['body'],
+);
+expectType<{ id: string | number }>(
+    null as unknown as NonNullable<CallArg<typeof withBody>>['params'],
+);
+expectError(withBody({ body: { name: 'Ada' } })); // params still required
+expectError(withBody({ params: { id: 1 } })); // body still required
+
+// 11) seam members (root, principal-bound, and graphql) fold path vars identically.
+const api = seam({ baseUrl: 'https://x' });
+const member = api.stitch({ path: '/users/{id}' });
+expectType<{ id: string | number }>(
+    null as unknown as NonNullable<CallArg<typeof member>>['params'],
+);
+expectError(member());
+const asMember = api.as('u1').stitch({ path: '/orgs/{org}' });
+expectType<{ org: string | number }>(
+    null as unknown as NonNullable<CallArg<typeof asMember>>['params'],
+);
+expectError(asMember());
+const gqlMember = api.graphql({
+    query: 'query { ok }',
+    path: '/gql/{region}',
+});
+expectType<{ region: string | number }>(
+    null as unknown as NonNullable<CallArg<typeof gqlMember>>['params'],
+);
+expectError(gqlMember());

--- a/packages/core/test/input-inference.spec.ts
+++ b/packages/core/test/input-inference.spec.ts
@@ -87,6 +87,26 @@ test('params + query schemas validate and the typed call expands them', async ()
     expect(server.calls('/users/1')[0]?.query).toEqual({ trace: 'on' });
 });
 
+test('an RFC 6570 path var with NO input schema requires params (Phase 2c)', async () => {
+    server.route('GET', '/users/7', { body: { id: 7, name: 'Bo' } });
+    // No `input.params` schema: the `{id}` template alone makes `params` a required call argument,
+    // typed `string | number`. This call is itself a compile-time assertion (tsconfig.test.json
+    // typechecks this file) — it only compiles because the path var is folded into the argument.
+    const getUser = stitch({
+        baseUrl: server.url,
+        path: '/users/{id}',
+        output: userSchema,
+    });
+    const user = await getUser({ params: { id: 7 } });
+    expect(user).toEqual({ id: 7, name: 'Bo' });
+    expect(server.callCount('/users/7')).toBe(1);
+
+    // `.with({ params })` relaxes the slot: the pre-bound stitch takes no further argument.
+    const bound = getUser.with({ params: { id: 7 } });
+    const same = await bound();
+    expect(same.name).toBe('Bo');
+});
+
 test('seam members infer and validate input identically', async () => {
     server.route('POST', '/users', { body: { id: 3, name: 'Cy' } });
     const api = seam({ baseUrl: server.url });

--- a/packages/nest/src/define-stitch.ts
+++ b/packages/nest/src/define-stitch.ts
@@ -14,6 +14,19 @@ export interface StitchDef<TOut = unknown, TIn = StitchInput> {
 }
 
 /**
+ * A def of **any** call-argument shape — `never` in the contravariant `TIn` slot makes every
+ * concrete `StitchDef` assignable, including a templated-path def whose call argument now *requires*
+ * `params` (path-template inference) or one with a required `body`. A plain `StitchDef` (=
+ * `StitchDef<unknown, StitchInput>`) would reject those, since a required-input call signature is
+ * narrower than the loose one. Used wherever defs are held heterogeneously or input-erased — a
+ * feature registry (`forFeature`'s `stitches`) or the `@InjectStitch` token-lookup — where the
+ * static input shape is intentionally widened away; per-def inference (`Injected<typeof Def>`) is
+ * unaffected and still recovers the exact `TIn`. Mirrors core's `StitchRegistry` element
+ * (`Stitch<unknown, never>` in `packages/core/src/registry.ts`).
+ */
+export type AnyStitchDef = StitchDef<unknown, never>;
+
+/**
  * Declare an injectable stitch: an injection token plus a builder that receives the
  * seam (root or principal-bound) the registering module hands it. Prefer a `Symbol`
  * token to avoid string collisions across feature modules.
@@ -33,6 +46,7 @@ export function defineStitch<TOut = unknown, TIn = StitchInput>(
 export type Injected<D> =
     D extends StitchDef<infer TOut, infer TIn> ? Stitch<TOut, TIn> : never;
 
-/** `@InjectStitch(def)` — sugar for `@Inject(def.token)`. */
-export const InjectStitch = (def: StitchDef): ParameterDecorator =>
+/** `@InjectStitch(def)` — sugar for `@Inject(def.token)`. Accepts an any-input
+ *  {@link AnyStitchDef} so a templated-path def (required `params`) injects too. */
+export const InjectStitch = (def: AnyStitchDef): ParameterDecorator =>
     Inject(def.token);

--- a/packages/nest/src/index.ts
+++ b/packages/nest/src/index.ts
@@ -9,6 +9,7 @@ export {
     defineStitch,
     InjectStitch,
     type StitchDef,
+    type AnyStitchDef,
     type StitchHost,
     type Injected,
 } from './define-stitch';

--- a/packages/nest/src/module.ts
+++ b/packages/nest/src/module.ts
@@ -3,7 +3,7 @@
 // registers injectable stitches and, optionally, a per-upstream feature seam built over
 // that shared infrastructure. `SeamRegistry` owns the shutdown lifecycle.
 import { borrowStore, loggerSink } from './bridges';
-import type { StitchDef, StitchHost } from './define-stitch';
+import type { AnyStitchDef, StitchHost } from './define-stitch';
 import { STITCH_SEAM, STITCH_STORE, STITCH_TRACE } from './tokens';
 
 import {
@@ -47,7 +47,9 @@ export interface StitchModuleAsyncOptions {
 
 /** forFeature options — a feature's injectable stitches and, optionally, its own upstream seam. */
 export interface StitchFeatureOptions {
-    stitches: StitchDef[];
+    // Any-input element: a feature registry is heterogeneous, so it must admit templated-path defs
+    // whose call argument *requires* `params` (see `AnyStitchDef`). Per-def inference is unaffected.
+    stitches: AnyStitchDef[];
     /** This feature's own seam (its `baseUrl`/`auth`/…), built over the shared store + trace.
      *  Omit to attach the stitches to the root/default seam. */
     seam?: SeamConfig;
@@ -165,7 +167,9 @@ export class StitchModule {
         };
     }
 
-    static forFeature(opts: StitchFeatureOptions | StitchDef[]): DynamicModule {
+    static forFeature(
+        opts: StitchFeatureOptions | AnyStitchDef[],
+    ): DynamicModule {
         const norm: StitchFeatureOptions = Array.isArray(opts)
             ? { stitches: opts }
             : opts;

--- a/packages/nest/test/module.spec.ts
+++ b/packages/nest/test/module.spec.ts
@@ -120,6 +120,44 @@ describe('StitchModule.forFeature', () => {
         expect(providers).toHaveLength(1);
         expect(providers[0]?.inject).toEqual([STITCH_SEAM]);
     });
+
+    // Regression (path-vars fallout, #114): a templated-path def's call argument now *requires*
+    // `params`, so its `StitchDef` has a narrower (contravariant) input than the loose default.
+    // The feature registry must still admit it — `stitches` is bound to the any-input
+    // `AnyStitchDef`, mirroring core's `StitchRegistry`. This wouldn't compile before the fix.
+    it('accepts a templated-path stitch (required params) in a feature registry', async () => {
+        const calls: string[] = [];
+        const GetUser = defineStitch('GET_USER', (h) =>
+            h.stitch({ path: '/users/{id}' }),
+        );
+        const mixed = [
+            GetUser,
+            defineStitch('LIST', (h) => h.stitch({ path: '/users' })),
+        ];
+        const providers = StitchModule.forFeature({
+            seam: {
+                baseUrl: 'https://feat.test',
+                adapter: recordingAdapter(calls),
+            },
+            stitches: mixed,
+        }).providers as FProv[];
+
+        const userProv = providers.find((p) => p.provide === GetUser.token);
+        const seamProv = providers.find(
+            (p) => p.provide !== GetUser.token && p.provide !== mixed[1]!.token,
+        );
+        const reg = new SeamRegistry();
+        const featSeam = seamProv!.useFactory!(
+            memoryStore(),
+            false,
+            reg,
+        ) as Seam;
+        const getUser = userProv!.useFactory!(featSeam) as ReturnType<
+            typeof GetUser.build
+        >;
+        await getUser({ params: { id: 42 } });
+        expect(calls).toEqual(['GET https://feat.test/users/42']);
+    });
 });
 
 describe('bridges', () => {


### PR DESCRIPTION
Closes #114.

## What

A templated endpoint contributes **required** input that the type couldn't see. The engine expands `path`/`url` against `input.params` (`const path = expandPath(tpl, input.params ?? {})`, `engine.ts`), so `stitch({ path: '/users/{id}' })` needs `params.id` at runtime — yet its call argument was typed as the fully-optional `StitchInput`. This reads the RFC 6570 variable names off a **string-literal** `path`/`url` at the type level and folds them into the `params` slot of `InputOf`.

**Pure types — ZERO runtime change.** The engine already does the expansion; this only tightens the static call-argument type.

### Inferred signature, before → after

```ts
const u = stitch({ path: '/users/{id}' });
// BEFORE:  u(input?: StitchInput) => …            // params optional; u() compiles
// AFTER:   u(input:  { params: { id: string | number }; query?: …; … }) => …
//          u()  // ❌ compile error — params required
```

## `infer.ts` change (additive, append-only)

- `PathVars<S>` walks every `{…}` expression, strips the operator (`+ # . / ; ? &`) and the `*` / `:n` modifiers, splits comma-separated varspecs → a union of names — mirroring `expandPath`'s grammar in `util.ts`.
- `PathVarsOf<C>` reads a string-literal `C['path']` else `C['url']` (host included — `url` is templated too). A thunk `url` (`() => string`) and a widened `string` both fall through to `never` (**fail open**).
- `InputOf<C>` folds the names into `params`: a **schema-typed key wins** (keeps its schema type); a **path-only key** becomes required `string | number`. A non-empty var set makes `params` — and the whole call argument — required via the existing `Args`/`HasRequired`.
  - The two `input` branches fold **differently on purpose** so the result stays assignable to `StitchInput` at the engine boundary under `exactOptionalPropertyTypes`: intersection onto the deferred `CallInput<I>`, `Omit` over the concrete `StitchInput`.

`const C` is added to the inferring `stitch` / `seam.stitch` / `seam.graphql` / `graphql` / surface (`download`/`sse`/`stream`) signatures so the string **literal** of `path`/`url` is captured (otherwise it widens to `string` and no vars are read). Schema values are reference types and are unaffected.

## Acceptance

- `stitch({ path: '/users/{id}' })` → arg `{ params: { id: string \| number } }`, **required**; no-arg call is a compile error. ✅
- `path: '/u/{id}/p/{postId}'` + `input.params` schema for `id`: `id` keeps the schema type, `postId` is required `string \| number`. ✅
- Operators/modifiers: `{?q,sort}` → `q \| sort`; `{id*}` / `{id:2}` → `id`; a literal `?page=1` is **not** a var; a thunk `url` adds no params. ✅
- No regression to non-templated stitches or to the docs twoslash suite. ✅

## ⚠️ Breaking change

Tightens a previously-optional call argument to **required** for a templated path/url with no `input.params` schema — an intended correctness win. `.with({ params })` relaxes the whole slot (per-key partial binding is out of scope).

**Fallout fixed:** the registry surfaces (CLI `run`, HTTP `serve`, MCP) now hold `Stitch<unknown, never>` (an any-input element), so a templated stitch with required `params` — like a required-`body` stitch — registers cleanly; `selectStitch` re-widens to an invokable `Stitch` at the single dynamic-dispatch boundary. This is a genuine user-facing improvement, not just a test fix. The docs twoslash examples already pass `params` where they call a templated stitch, so the docs build is unaffected.

## Tests

- `test-d/path-vars.test-d.ts`: bare `{id}` (required + `expectError(u())`), schema-wins + path-adds for a shared key, operators/modifiers, literal `?page=1` (optional arg), thunk `url` (optional arg), host var, `.with({ params })` relax, and seam / principal-bound / graphql members.
- A positive runtime case in `test/input-inference.spec.ts` constructs a path-only templated stitch and `await`s it with `{ params }` (+ a `.with` no-arg call).

## Gates (all green)

- `check:types-d` (tsup build + tsd), `check:types` (both tsconfigs), `check:lint`, `check:exports`, `test` (393 passed) — for `stitchapi`.
- Whole-repo `check:types` (sandbox-sim, all `fingerprint-*`, `@stitchapi/nest`, **and the docs twoslash build**) all pass.

## Coupling

One of three coupled PRs touching `infer.ts` (path-vars here; **#75** gql variables, **#76** extends/fragment inference). This stays **append-only** — new helper types plus a nested wrap of `InputOf` that preserves its original two-branch structure — for a clean sequential rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)