### PR TITLE
feat(core): infer input/output across `extends` fragments (#76)

### DIFF
--- a/packages/core/src/download.ts
+++ b/packages/core/src/download.ts
@@ -96,13 +96,21 @@ export interface DownloadSeamApi {
 }
 
 // Standalone download stitch: the call argument is inferred from `config.input`, the result fixed
-// to `{ blob, filename }`.
+// to `{ blob, filename }`. The `as` retypes the loose `makeStitch` result (`Stitch<…, StitchInput>`)
+// to the declared `InputOf<C>` call-arg type: now that `InputOf` reads `extends`-fragment schemas
+// (#76) it is no longer a clean supertype of `StitchInput` under an unresolved `C`, so this loose
+// body needs the same retype `stitch()`/`seam` get for free from their inferring overloads. Sound —
+// the runtime stitch is byte-identical; only the static call-arg richness is restored (the type
+// tests check every concrete config).
 const downloadStitch = <
     const C extends Partial<StitchConfig> = Partial<StitchConfig>,
 >(
     config: C,
 ): Stitch<DownloadResult, InputOf<C>> =>
-    makeStitch<DownloadResult>({ ...config, kind: downloadSurface });
+    makeStitch<DownloadResult>({
+        ...config,
+        kind: downloadSurface,
+    }) as unknown as Stitch<DownloadResult, InputOf<C>>;
 
 // Bind download members to a seam through the seam's surface-agnostic `stitch({ kind })`.
 function bindSeam(s: Seam): DownloadSeamApi {
@@ -111,7 +119,10 @@ function bindSeam(s: Seam): DownloadSeamApi {
     >(
         config: C,
     ): Stitch<DownloadResult, InputOf<C>> =>
-        s.stitch<DownloadResult>({ ...config, kind: downloadSurface });
+        s.stitch<DownloadResult>({
+            ...config,
+            kind: downloadSurface,
+        }) as unknown as Stitch<DownloadResult, InputOf<C>>;
     return { stitch, seam: s };
 }
 

--- a/packages/core/src/infer.ts
+++ b/packages/core/src/infer.ts
@@ -54,13 +54,166 @@ export type InferInput<S> =
               ? G
               : unknown;
 
+// ---- extends/fragment flattening (the type-level image of `flatten` + `deepMerge`) --------
+// `OutputOf`/`InputOf` historically read ONLY the top-level `output`/`input` of the directly-passed
+// config, ignoring schemas a fragment contributes through `extends`. At runtime `compose()` in
+// stitch.ts deep-merges `input`/`output` across every fragment (depth-first, base→child, last-wins
+// per key) and `validateInput` validates the merged result — so the static type was blind to a
+// fragment-supplied slot (issue #76). The machinery below mirrors that runtime merge at the type
+// level: it expands `extends` into a flat, ordered layer list, then folds the `input` slots
+// (key-union, last-wins per slot) and picks the last-written `output`.
+//
+// ENGAGEMENT (tuple-only, by design): the merge engages ONLY when `extends` is a concrete TUPLE —
+// `[C] extends [{ extends: readonly [unknown, ...unknown[]] }]`. `stitch`/`seam`/`graphql` capture
+// their config with a `const` type parameter, so an INLINE `extends: [base, …]` is inferred as a
+// tuple and each fragment's literal slot types survive. A pre-widened `extends` (e.g. built up in a
+// mutable variable, inferred as the loose `Fragment[]` array) is NOT a tuple → the guard's false
+// branch → the historical top-level-only read. Two payoffs: (1) the no-`extends` (and array-
+// `extends`) path is byte-identical to before, so existing inference and compile cost are unchanged;
+// (2) for an unresolved type parameter `C` (the surface helpers' generic), `InputOf<C>`/`OutputOf<C>`
+// collapse to the loose `StitchInput`/`unknown`, which the loose-implementation bodies depend on
+// (they retype with a documented `as` — see download/sse/stream/seam/graphql).
+//
+// Scope note (the seam shared fragment): a seam contributes its config as one more `extends`
+// fragment, but `SeamConfig = Omit<StitchConfig, …|'input'|'output'|…>` (types.ts) STRUCTURALLY
+// cannot carry `input`/`output` — so #76's "apply to the seam fragment" is a no-op for these two
+// slots by construction, and only the explicit `extends:[…]` array can contribute schemas. We do
+// not widen `SeamConfig`; the type tests pin that a seam can't declare `input`/`output`.
+
 /**
- * Map a config object's `output` slot to the stitch result type. No `output` key → `unknown`
- * (the historical default), so a stitch with no response schema is unchanged.
+ * Normalise one `extends` member to a config-shaped object. A bare path STRING contributes only
+ * `path` (no `input`/`output`), exactly like `asConfig` in stitch.ts — so a string fragment narrows
+ * nothing. A {@link Stitch} used as a fragment is left as-is: it has no top-level `input`/`output`
+ * key (those live, loosely typed, under `__rawConfig`), so it too contributes nothing narrowing.
+ * That stitch-as-fragment limitation is accepted and deliberate (#76): a stitch erases its literal
+ * slot types behind the loose `InputSchemas`/`SchemaLike` of `StitchConfig`, so digging into it
+ * would only yield `unknown`-ish inference — we leave its runtime merge intact and infer nothing
+ * extra from it.
  */
-export type OutputOf<C> = C extends { output: infer O }
-    ? InferOutput<O>
-    : unknown;
+type AsFrag<F> = F extends string ? { path: F } : F;
+
+/**
+ * The fragment-tree depth cap. `extends` can nest (a fragment that itself `extends`), and the
+ * flattening below is recursive — an unbounded walk would blow up compile time / hit the recursion
+ * limiter on a pathological config. We bound the DEPTH of `extends` nesting at 8: deeper than that,
+ * `ExpandFrag` stops descending and treats the over-deep fragment as a leaf (its own slots still
+ * count; only its further-nested `extends` is ignored). Eight is far beyond any realistic preset
+ * chain — typical use is one or two layers — and keeps the docs twoslash suite fast. The countdown
+ * is a tuple whose length is the remaining budget; `[unknown, ...D]` would grow it, `D extends
+ * [unknown, ...infer R]` spends one.
+ */
+type FragDepth = [
+    unknown,
+    unknown,
+    unknown,
+    unknown,
+    unknown,
+    unknown,
+    unknown,
+    unknown,
+];
+
+/**
+ * Expand one already-`AsFrag`-normalised config into the ordered list of layers it stands for:
+ * its own `extends` fragments first (base, recursively), then the config itself minus `extends`
+ * — the depth-first, base→child order of `flatten`. When the depth budget `D` is exhausted we stop
+ * recursing and keep the config as a single leaf, so a too-deep chain degrades to the top-level
+ * read rather than failing.
+ */
+type ExpandFrag<C, D extends readonly unknown[]> = D extends [
+    unknown,
+    ...infer Rest,
+]
+    ? C extends { extends: infer E extends readonly unknown[] }
+        ? [...Flatten<E, Rest>, Omit<C, 'extends'>]
+        : [C]
+    : [C];
+
+/**
+ * Flatten a `readonly` fragment array into a single ordered layer list (base→child, last-wins),
+ * recursing through each member's own `extends`. The head/tail split walks the array; `AsFrag`
+ * normalises strings/stitches before expansion. `D` is the shared depth budget threaded down.
+ */
+type Flatten<
+    Fs extends readonly unknown[],
+    D extends readonly unknown[],
+> = Fs extends readonly [infer H, ...infer T]
+    ? [...ExpandFrag<AsFrag<H>, D>, ...Flatten<T, D>]
+    : [];
+
+/**
+ * The full ordered layer list for a config `C` (the config itself last). `C` is fed through the
+ * same `ExpandFrag` so its own `extends` is expanded ahead of it — identical to `flatten([config])`
+ * at runtime. The result is base→child, so a left-to-right fold gives last-wins semantics.
+ */
+type Layers<C> = ExpandFrag<C, FragDepth>;
+
+/**
+ * Fold the layer list to the merged `output` slot: the LAST layer that declares `output` wins the
+ * whole slot (an atomic schema is never structurally merged — mirroring how a child `output`
+ * dominates the validated result). Walk from the tail so the first hit IS the last writer.
+ */
+type MergeOutput<Ls extends readonly unknown[]> = Ls extends readonly [
+    ...infer Rest,
+    infer Last,
+]
+    ? Last extends { output: infer O }
+        ? O
+        : MergeOutput<Rest>
+    : never;
+
+/** Whether any layer in the list declares an `output` slot. */
+type HasOutput<Ls extends readonly unknown[]> = Ls extends readonly [
+    infer H,
+    ...infer T,
+]
+    ? H extends { output: unknown }
+        ? true
+        : HasOutput<T>
+    : false;
+
+/**
+ * Fold the layer list to the merged `input` schemas: union the slot keys across every layer's
+ * `input`, with the LAST layer to declare a given slot winning it (key-union + last-wins per slot —
+ * the type-level image of `deepMerge` folding each layer's `input` object). Walk base→child and let
+ * later writes overwrite; `Acc` carries the running merge.
+ */
+type MergeInputSlots<
+    Ls extends readonly unknown[],
+    Acc = Record<never, never>,
+> = Ls extends readonly [infer H, ...infer T]
+    ? MergeInputSlots<
+          T,
+          H extends { input: infer I } ? Omit<Acc, keyof I> & I : Acc
+      >
+    : Acc;
+
+/** Whether any layer in the list declares an `input` slot (drives the no-input fallback). */
+type HasInput<Ls extends readonly unknown[]> = Ls extends readonly [
+    infer H,
+    ...infer T,
+]
+    ? H extends { input: unknown }
+        ? true
+        : HasInput<T>
+    : false;
+
+/**
+ * Map a config object's `output` slot to the stitch result type, now reading the merged `output`
+ * across `extends` fragments. No `extends` → the historical, byte-identical top-level read
+ * (`C extends { output } ? InferOutput : unknown`), so every existing stitch is unchanged and pays
+ * no extra type work. With `extends`, the last fragment (or the config) to declare `output` wins;
+ * if none do, the result stays `unknown`.
+ */
+export type OutputOf<C> = [C] extends [
+    { extends: readonly [unknown, ...unknown[]] },
+]
+    ? HasOutput<Layers<C>> extends true
+        ? InferOutput<MergeOutput<Layers<C>>>
+        : unknown
+    : C extends { output: infer O }
+      ? InferOutput<O>
+      : unknown;
 
 /**
  * Resolve a stitch's result type at the call boundary: an explicitly supplied generic always
@@ -187,16 +340,19 @@ type PathVarsOf<C> = C extends { path: infer P extends string }
 
 /**
  * The `params` shape a config's `input.params` schema declares, or the empty object when it declares
- * none. Read straight off `C['input']['params']` via {@link InferInput} (NOT off the computed `Base`):
- * the loose {@link StitchInput} fallback carries `params?: Record<string, unknown>`, whose index
- * signature would otherwise make EVERY name look schema-provided and swallow the path-only fold. With no
+ * none. Read off the {@link MergedInput} of `C` (the `extends`-folded `input`) — NOT the bare
+ * top-level `C['input']`: that is what lets a `params` schema contributed by an `extends` fragment win
+ * its keys over the path-only fold. Read via {@link InferInput} (NOT off the computed `Base`): the
+ * loose {@link StitchInput} fallback carries `params?: Record<string, unknown>`, whose index signature
+ * would otherwise make EVERY name look schema-provided and swallow the path-only fold. With no
  * `input.params` schema this is `Record<never, never>` (the empty object, spelled to avoid a bare `{}`),
  * so the path vars alone shape `params`. `NonNullable` unwraps the optional slot; a non-object inferred
  * shape (degenerate) intersects harmlessly with the path-only keys.
  */
-type SchemaParams<C> = C extends { input: { params: infer P } }
-    ? NonNullable<InferInput<P>>
-    : Record<never, never>;
+type SchemaParams<C> =
+    MergedInput<C> extends { params: infer P }
+        ? NonNullable<InferInput<P>>
+        : Record<never, never>;
 /**
  * The folded `params` slot: the schema-declared shape ({@link SchemaParams}) intersected with the
  * path-only var names typed `string | number` (what `expandPath` ultimately stringifies). Path-only
@@ -210,37 +366,75 @@ type PathParams<C> = Prettify<
 >;
 
 /**
- * Map a config object's `input` slot to the typed call argument, then fold in any RFC 6570
- * path-template vars (from a string-literal `path`/`url`). No `input` key → the loose
- * {@link StitchInput} (the historical default), so a stitch with no input schemas and no template stays
- * fully optional. Like {@link OutputOf}, this reads only the top-level `input`/`path`/`url`, not
- * `extends` fragments. No path vars in a branch (`PathVarsOf<C>` is `never`, tuple-wrapped to stop
- * distribution) → the base is returned byte-for-byte, so a non-templated stitch is exactly Phase 2.
+ * The merged `input` schema object a config resolves to once `extends` fragments are folded — the
+ * SOURCE OF TRUTH that {@link SchemaParams} reads `params` off. With an `extends` array, fold the
+ * layers key-union/last-wins via {@link MergeInputSlots} (or `Record<never, never>` when no layer
+ * declares `input`); without `extends`, the directly-written top-level `input` (or empty). Reading
+ * `params` off THIS — not off `C['input']` — is what lets a `params` schema contributed by an
+ * `extends` fragment win its keys over the bare path-only fold.
+ */
+type MergedInput<C> = [C] extends [
+    { extends: readonly [unknown, ...unknown[]] },
+]
+    ? HasInput<Layers<C>> extends true
+        ? MergeInputSlots<Layers<C>>
+        : Record<never, never>
+    : C extends { input: infer I }
+      ? I
+      : Record<never, never>;
+
+/**
+ * Fold the RFC 6570 path-template vars onto an already-computed call-argument `Base`. No path vars
+ * (`PathVarsOf<C>` is `never`, tuple-wrapped to stop distribution) → `Base` is returned byte-for-byte,
+ * so a non-templated stitch is exactly its Phase-2 base. Otherwise intersect a required `params`
+ * slot ({@link PathParams}) — schema-named keys keep their schema type, path-only names are added
+ * required. Used for the `CallInput<…>` arms; the no-input arms build `params` via `Omit` instead
+ * (see {@link InputOf}).
+ */
+type FoldPathParams<C, Base> = [PathVarsOf<C>] extends [never]
+    ? Base
+    : Base & { params: PathParams<C> };
+
+/**
+ * Map a config object's `input` slot to the typed call argument, reading the `extends`-merged `input`
+ * schemas (Gap B) and then folding in any RFC 6570 path-template vars from a string-literal
+ * `path`/`url` (Gap A). No `input`/`extends` and no path vars → the loose {@link StitchInput} (the
+ * historical default), so a stitch with no input schemas and no template stays fully optional.
  *
- * The two `input` branches fold path vars DIFFERENTLY on purpose — both must keep the result assignable
- * to {@link StitchInput}, because every surface helper assigns the engine's loose
+ * The merged base comes first: with an `extends` array we key-union the layers' `input` slots
+ * (last-wins, via {@link MergeInputSlots}) so a `headers` schema from a base fragment or a `body` the
+ * child adds both surface; without `extends` we read the top-level `input`. Path vars are then folded
+ * over that base. The two families of branches fold DIFFERENTLY on purpose — both must keep the result
+ * assignable to {@link StitchInput}, because every surface helper assigns the engine's loose
  * `Stitch<TOut, StitchInput>` to its declared `Stitch<TOut, InputOf<C>>` and the call argument sits
  * contravariantly in that signature (so `InputOf<C>` must flow *back* into `StitchInput`):
  *
- * - **With an `input` schema** (`Base = CallInput<I>`, a deferred mapped type for a generic `C`): fold by
- *   INTERSECTION (`CallInput<I> & { params }`). The base is left structurally untouched — its `query?` /
- *   `body?` modifiers stay exactly as Phase 2 emitted them; an `Omit<…>`-re-wrap would, under
- *   `exactOptionalPropertyTypes`, widen those optional slots to `T | undefined` and break that boundary
- *   assignment. Intersecting only narrows/adds `params`: a `params` schema key keeps its schema type,
- *   path-only keys are added required.
- * - **Without an `input` schema** (`Base = StitchInput`, a CONCRETE interface): build `params` purely from
+ * - **With input schemas** (`Base = CallInput<…>`, a deferred mapped type for a generic `C`): fold by
+ *   INTERSECTION (`CallInput<…> & { params }`, via {@link FoldPathParams}). The base is left
+ *   structurally untouched — its `query?` / `body?` modifiers stay exactly as Phase 2 emitted them; an
+ *   `Omit<…>`-re-wrap would, under `exactOptionalPropertyTypes`, widen those optional slots to
+ *   `T | undefined` and break that boundary assignment. Intersecting only narrows/adds `params`: a
+ *   `params` schema key (now also one a fragment contributed) keeps its schema type, path-only keys
+ *   are added required.
+ * - **Without input schemas** (`Base = StitchInput`, a CONCRETE interface): build `params` purely from
  *   the path vars via `Omit<StitchInput, 'params'> & { params }`. `Omit` over a concrete type resolves
  *   immediately (no deferral → no boundary break) and DROPS `StitchInput`'s loose
- *   `params?: Record<string, unknown>`, so the slot is exactly `{ id: string | number }` rather than that
- *   intersected with the catch-all index signature.
+ *   `params?: Record<string, unknown>`, so the slot is exactly `{ id: string | number }` rather than
+ *   that intersected with the catch-all index signature.
  */
-export type InputOf<C> = C extends { input: infer I }
-    ? [PathVarsOf<C>] extends [never]
-        ? CallInput<I>
-        : CallInput<I> & { params: PathParams<C> }
-    : [PathVarsOf<C>] extends [never]
-      ? StitchInput
-      : Prettify<Omit<StitchInput, 'params'> & { params: PathParams<C> }>;
+export type InputOf<C> = [C] extends [
+    { extends: readonly [unknown, ...unknown[]] },
+]
+    ? HasInput<Layers<C>> extends true
+        ? FoldPathParams<C, CallInput<MergeInputSlots<Layers<C>>>>
+        : [PathVarsOf<C>] extends [never]
+          ? StitchInput
+          : Prettify<Omit<StitchInput, 'params'> & { params: PathParams<C> }>
+    : C extends { input: infer I }
+      ? FoldPathParams<C, CallInput<I>>
+      : [PathVarsOf<C>] extends [never]
+        ? StitchInput
+        : Prettify<Omit<StitchInput, 'params'> & { params: PathParams<C> }>;
 
 /** The required (non-optional) keys of `T`. (`Record<never, never>` is the empty object `{}` — the
  * standard "is this key optional?" probe — spelled to avoid a bare `{}` type.) */

--- a/packages/core/src/seam.ts
+++ b/packages/core/src/seam.ts
@@ -130,11 +130,16 @@ function sharedConfig(shared: SharedSeam): StitchConfig {
 function principalHandle(shared: SharedSeam, principal: string): PrincipalSeam {
     const build = makeBuild(shared, principal);
     return {
-        // `build` is generic at runtime; the inferring overloads come from the interface the
-        // object literal is checked against (the function return type).
+        // `build` is generic at runtime; the inferring overloads come from the interface the object
+        // literal is checked against (the function return type). `stitch` satisfies its loose
+        // fallback overload (`stitch<T>(config: string | Partial<StitchConfig>)`) as-is. `graphql`
+        // has ONLY the single inferring `InputOf<C>` overload, and after #76 widened `InputOf` (it
+        // now reads `extends`-fragment schemas) the loose `build` body is no longer a clean supertype
+        // of that return under an unresolved `C` — so `graphql` needs the `as`. Sound — runtime is
+        // identical; only the static call-arg richness is restored.
         stitch: (config: string | Partial<StitchConfig>) => build(config),
-        graphql: (config: Partial<StitchConfig> & { query: string }) =>
-            build(config, true),
+        graphql: ((config: Partial<StitchConfig> & { query: string }) =>
+            build(config, true)) as PrincipalSeam['graphql'],
         as: (p) => principalHandle(shared, p),
         get __config() {
             return sharedConfig(shared);
@@ -148,9 +153,12 @@ function principalHandle(shared: SharedSeam, principal: string): PrincipalSeam {
 function rootHandle(shared: SharedSeam): Seam {
     const build = makeBuild(shared, undefined);
     return {
+        // See `principalHandle`: only `graphql` (single inferring overload) needs the `as` to
+        // restore its rich `InputOf<C>` return after #76 widened `InputOf`; `stitch` satisfies its
+        // loose fallback overload as-is.
         stitch: (config: string | Partial<StitchConfig>) => build(config),
-        graphql: (config: Partial<StitchConfig> & { query: string }) =>
-            build(config, true),
+        graphql: ((config: Partial<StitchConfig> & { query: string }) =>
+            build(config, true)) as Seam['graphql'],
         as: (p) => principalHandle(shared, p),
         // Bulk cache invalidation over the seam's shared store (ADR 0003 §8). No argument bumps
         // the cache-wide generation; a member `stitch` bumps just that stitch's generation. The

--- a/packages/core/src/sse.ts
+++ b/packages/core/src/sse.ts
@@ -122,13 +122,20 @@ export interface SseSeamApi {
 }
 
 // Standalone sse stitch: the call argument is inferred from `config.input`, the result fixed to the
-// collected event array (a streaming await resolves to all of its `delta` chunks — Stage 5).
+// collected event array (a streaming await resolves to all of its `delta` chunks — Stage 5). The
+// `as` retypes the loose `makeStitch` result to the declared `InputOf<C>`: now that `InputOf` reads
+// `extends`-fragment schemas (#76) it is no longer a clean supertype of `StitchInput` under an
+// unresolved `C`, so this loose body needs the same retype `stitch()`/`seam` get from their
+// inferring overloads. Sound — the runtime stitch is byte-identical (the type tests cover it).
 const sseStitch = <
     const C extends Partial<StitchConfig> = Partial<StitchConfig>,
 >(
     config: C,
 ): Stitch<SseEvent[], InputOf<C>> =>
-    makeStitch<SseEvent[]>({ ...config, kind: sseSurface });
+    makeStitch<SseEvent[]>({
+        ...config,
+        kind: sseSurface,
+    }) as unknown as Stitch<SseEvent[], InputOf<C>>;
 
 // Bind sse members to a seam through the seam's surface-agnostic `stitch({ kind })` (Decision 3) —
 // no per-surface seam method; one shared runtime / principal boundary.
@@ -138,7 +145,10 @@ function bindSeam(s: Seam): SseSeamApi {
     >(
         config: C,
     ): Stitch<SseEvent[], InputOf<C>> =>
-        s.stitch<SseEvent[]>({ ...config, kind: sseSurface });
+        s.stitch<SseEvent[]>({
+            ...config,
+            kind: sseSurface,
+        }) as unknown as Stitch<SseEvent[], InputOf<C>>;
     return { stitch, seam: s };
 }
 

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -454,10 +454,15 @@ export function graphql<
     // Default the endpoint to `/graphql` only when neither `url` nor `path` is given (preserves the
     // convenience without clobbering an explicit endpoint). Method/body shaping is the surface's.
     const endpointless = config.url === undefined && config.path === undefined;
+    // The `as` retypes the loose `makeStitch` result (`Stitch<…, StitchInput>`) to the declared
+    // `InputOf<C>` call-arg type. Now that `InputOf` reads `extends`-fragment schemas (#76) it is no
+    // longer a clean supertype of `StitchInput` under an unresolved `C`, so this body needs the same
+    // retype the inferring `stitch`/`seam` overloads get for free. Sound: the runtime stitch is
+    // byte-identical; only the static call-arg richness is restored.
     return makeStitch<ResolveOutput<TExplicit, C>>({
         ...config,
         ...(endpointless ? { path: '/graphql' } : {}),
         kind: graphqlSurface,
         unwrap: config.unwrap ?? 'data',
-    });
+    }) as unknown as Stitch<ResolveOutput<TExplicit, C>, InputOf<C>>;
 }

--- a/packages/core/src/stream.ts
+++ b/packages/core/src/stream.ts
@@ -80,13 +80,20 @@ export interface StreamSeamApi {
 }
 
 // Standalone stream stitch: the call argument is inferred from `config.input`, the result fixed to
-// the collected chunk array (a streaming await resolves to all of its `delta` chunks — Stage 5).
+// the collected chunk array (a streaming await resolves to all of its `delta` chunks — Stage 5). The
+// `as` retypes the loose `makeStitch` result to the declared `InputOf<C>`: now that `InputOf` reads
+// `extends`-fragment schemas (#76) it is no longer a clean supertype of `StitchInput` under an
+// unresolved `C`, so this loose body needs the same retype `stitch()`/`seam` get from their
+// inferring overloads. Sound — the runtime stitch is byte-identical (the type tests cover it).
 const streamStitch = <
     const C extends Partial<StitchConfig> = Partial<StitchConfig>,
 >(
     config: C,
 ): Stitch<unknown[], InputOf<C>> =>
-    makeStitch<unknown[]>({ ...config, kind: streamSurface });
+    makeStitch<unknown[]>({
+        ...config,
+        kind: streamSurface,
+    }) as unknown as Stitch<unknown[], InputOf<C>>;
 
 // Bind stream members to a seam through the seam's surface-agnostic `stitch({ kind })` (Decision 3).
 function bindSeam(s: Seam): StreamSeamApi {
@@ -95,7 +102,10 @@ function bindSeam(s: Seam): StreamSeamApi {
     >(
         config: C,
     ): Stitch<unknown[], InputOf<C>> =>
-        s.stitch<unknown[]>({ ...config, kind: streamSurface });
+        s.stitch<unknown[]>({
+            ...config,
+            kind: streamSurface,
+        }) as unknown as Stitch<unknown[], InputOf<C>>;
     return { stitch, seam: s };
 }
 

--- a/packages/core/test-d/extends-inference.test-d.ts
+++ b/packages/core/test-d/extends-inference.test-d.ts
@@ -1,0 +1,133 @@
+// `stitch()` / `seam` infer the CALL-ARGUMENT (and result) type from `input`/`output` schemas a
+// fragment contributes through `extends` — not just the top-level config (issue #76). The runtime
+// `compose()` already deep-merges these slots; these tests pin the STATIC type now mirrors it.
+//
+// Assertions follow input-inference.test-d.ts: `CallArg<typeof s>` for the call-argument type (a
+// `Stitch<…>` bound can't see required-arg stitches and `expectType<Stitch<…>>` is broken by the
+// recursive `with()`), `output(s)` for the resolved result, and `expectError` / `@ts-expect-error`
+// for the negative cases. The merge engages only for an INLINE `extends` tuple — `stitch`/`seam`
+// capture config with a `const` type parameter, so the literal array's per-fragment slot types
+// survive (a pre-widened `Fragment[]` array would fall back to the top-level read).
+import { seam, stitch } from '..';
+import { output } from './_util';
+import { type CallArg } from './_util';
+
+import { expectError, expectType } from 'tsd';
+import { z } from 'zod';
+
+const userSchema = z.object({ id: z.number(), name: z.string() });
+type User = z.infer<typeof userSchema>;
+
+// 1) a `headers` schema contributed PURELY by an `extends` fragment shows up in the call argument —
+//    the headline of #76. The child declares no `headers`; it comes entirely from `base`.
+const base = { input: { headers: z.object({ 'x-tenant': z.string() }) } };
+const fromFragment = stitch({
+    extends: [base],
+    input: { body: z.object({ name: z.string() }) },
+});
+expectType<{ 'x-tenant': string }>(
+    null as unknown as CallArg<typeof fromFragment>['headers'],
+);
+// 1b) and the child's own `body` MERGES with the fragment's `headers` (key-union across layers).
+expectType<{ name: string }>(
+    null as unknown as CallArg<typeof fromFragment>['body'],
+);
+// both slots are required → a no-arg call (and a call missing `headers`) is an error.
+expectError(fromFragment());
+expectError(fromFragment({ body: { name: 'Ada' } })); // missing the fragment's `headers`
+
+// 2) LAST-WINS per slot across fragments: two fragments both declare `body`; the later one (closer
+//    to the child) wins the whole slot. `base1.body` is `{ a }`, `base2.body` is `{ b: number }` —
+//    the merged call arg must require `{ b: number }`, not `{ a: string }`.
+const base1 = { input: { body: z.object({ a: z.string() }) } };
+const base2 = { input: { body: z.object({ b: z.number() }) } };
+const lastWins = stitch({ extends: [base1, base2] });
+expectType<{ b: number }>(null as unknown as CallArg<typeof lastWins>['body']);
+
+// 3) NESTED extends: a fragment that itself `extends` another. The depth-first walk surfaces the
+//    innermost `params`, the middle `query`, and the child's `body`, all merged. The nesting is
+//    written INLINE so every `extends` is captured as a tuple (a fragment pulled from a `const`
+//    variable would widen its own `extends` to a `Fragment[]` array, and the deeper layer would
+//    fall back to the top-level read — the documented tuple-only engagement).
+const nested = stitch({
+    extends: [
+        {
+            extends: [{ input: { params: z.object({ id: z.string() }) } }],
+            input: { query: z.object({ page: z.number() }) },
+        },
+    ],
+    input: { body: z.object({ x: z.number() }) },
+});
+expectType<{ id: string }>(null as unknown as CallArg<typeof nested>['params']);
+expectType<{ page: number }>(
+    null as unknown as CallArg<typeof nested>['query'],
+);
+expectType<{ x: number }>(null as unknown as CallArg<typeof nested>['body']);
+
+// 4) OUTPUT via a fragment: an `output` schema declared only on a fragment infers the result type
+//    (the parallel #76 fix for Phase-1 output inference). The child declares no `output`.
+const outFrag = { output: userSchema };
+const outFromFragment = stitch({ extends: [outFrag], path: '/users' });
+expectType<User>(output(outFromFragment));
+// 4b) the CHILD's `output` wins over a fragment's (last writer of the whole slot).
+const childWins = stitch({
+    extends: [{ output: z.object({ a: z.string() }) }],
+    output: userSchema,
+});
+expectType<User>(output(childWins));
+
+// 5) STITCH-as-fragment is an accepted limitation (finding #2): a `Stitch` used in `extends`
+//    contributes nothing NARROWING. It carries no top-level `input`/`output` key (its config lives,
+//    loosely typed, under `__rawConfig`), so the merge reads nothing extra from it — the runtime
+//    still composes its config, only the static narrowing is dropped. A LOOSE stitch (no input
+//    schemas) is what fits the `Fragment` union here: a typed stitch's narrowed call arg is not
+//    assignable to the loose `Stitch` member of `extends` (a pre-existing `Stitch`-variance limit,
+//    independent of #76 — `with()` makes `TIn` appear contravariantly), so it can't be a fragment.
+const looseStitch = stitch({ path: '/dep' });
+const fromStitchFrag = stitch({
+    extends: [looseStitch],
+    input: { body: z.object({ name: z.string() }) },
+});
+// the stitch fragment narrows nothing; only the child's own `body` shapes the argument.
+expectType<{ name: string }>(
+    null as unknown as CallArg<typeof fromStitchFrag>['body'],
+);
+expectError(fromStitchFrag()); // the child's `body` is still required
+
+// 6) a bare STRING fragment contributes only `path` — nothing that narrows the call argument.
+const fromStringFrag = stitch({
+    extends: ['/from-string'],
+    input: { body: z.object({ name: z.string() }) },
+});
+expectType<{ name: string }>(
+    null as unknown as CallArg<typeof fromStringFrag>['body'],
+);
+
+// 7) a SEAM contributes its fragment too, and a member merges the seam's defaults with its own
+//    `extends` + top-level `input`. A `params` schema from the member's `extends` fragment surfaces.
+const api = seam({ baseUrl: 'https://x' });
+const member = api.stitch({
+    extends: [{ input: { params: z.object({ region: z.string() }) } }],
+    input: { body: z.object({ name: z.string() }) },
+});
+expectType<{ region: string }>(
+    null as unknown as CallArg<typeof member>['params'],
+);
+expectType<{ name: string }>(null as unknown as CallArg<typeof member>['body']);
+
+// 8) the SEAM shared fragment STRUCTURALLY cannot carry `input`/`output` — `SeamConfig` Omits both
+//    (types.ts), so #76's "apply to the seam fragment" is a no-op for these two slots BY
+//    CONSTRUCTION (we never widen `SeamConfig`). A seam that tries to declare either is a type
+//    error: only the member's `extends:[…]` array can contribute schemas.
+// @ts-expect-error — a seam fragment cannot declare `input` (SeamConfig omits it).
+seam({ baseUrl: 'https://x', input: { body: z.object({ name: z.string() }) } });
+// @ts-expect-error — a seam fragment cannot declare `output` (SeamConfig omits it).
+seam({ baseUrl: 'https://x', output: userSchema });
+
+// 9) REGRESSION GUARD: a config with NO `extends` is byte-identical to the top-level-only read.
+//    A required top-level `body` stays required; no `extends` machinery changes its inference.
+const noExtends = stitch({ input: { body: z.object({ name: z.string() }) } });
+expectType<{ name: string }>(
+    null as unknown as CallArg<typeof noExtends>['body'],
+);
+expectError(noExtends());

--- a/packages/core/test/composition.spec.ts
+++ b/packages/core/test/composition.spec.ts
@@ -86,6 +86,91 @@ test('a seam member is equivalent to the extends facade', async () => {
     expect(server.callCount('/items')).toBe(2);
 });
 
+// 1c) #76 — an `input` schema contributed PURELY by an `extends` fragment is merged and VALIDATED
+// at runtime (the static call-arg type now reflects this too — see test-d/extends-inference). The
+// fragment declares `headers`; the child declares `body`; both are validated and sent. This call is
+// itself a compile-time assertion (tsconfig.test.json typechecks this file), so it only compiles if
+// the merged call-arg type surfaces the fragment's `headers` slot.
+test('extends fragment contributes an input schema that is merged + validated', async () => {
+    server.route('POST', '/orders', { body: { ok: true } });
+
+    const tenantFragment = {
+        input: { headers: z.object({ 'x-tenant': z.string() }) },
+    };
+    const createOrder = stitch({
+        baseUrl: server.url,
+        path: '/orders',
+        method: 'POST',
+        extends: [tenantFragment],
+        input: { body: z.object({ sku: z.string() }) },
+    });
+
+    await expect(
+        createOrder({ headers: { 'x-tenant': 'acme' }, body: { sku: 'A1' } }),
+    ).resolves.toEqual({ ok: true });
+
+    const call = server.calls('/orders')[0];
+    expect(call?.headers['x-tenant']).toBe('acme');
+    expect(call?.body).toEqual({ sku: 'A1' });
+});
+
+// 1d) The merged input is actually VALIDATED: a bad value for the slot a FRAGMENT contributed is
+// rejected before the request leaves the client (the value is unchanged; only the static check is
+// bypassed with `as never` to reach the runtime path).
+test('a fragment-contributed input schema still rejects bad input at runtime', async () => {
+    server.route('POST', '/orders', { body: { ok: true } });
+
+    const tenantFragment = {
+        input: { headers: z.object({ 'x-tenant': z.string() }) },
+    };
+    const createOrder = stitch({
+        baseUrl: server.url,
+        path: '/orders',
+        method: 'POST',
+        extends: [tenantFragment],
+        input: { body: z.object({ sku: z.string() }) },
+    });
+
+    // `x-tenant` must be a string — a number fails the fragment's headers schema.
+    await expect(
+        createOrder({
+            headers: { 'x-tenant': 123 },
+            body: { sku: 'A1' },
+        } as never),
+    ).rejects.toThrow(/invalid headers/i);
+    expect(server.callCount('/orders')).toBe(0); // never left the client
+});
+
+// 1e) LAST-WINS per slot across fragments: two fragments both declare a `body` schema; the later one
+// validates. The earlier schema's constraint no longer applies (the static type agrees — the last
+// writer wins the whole slot).
+test('last fragment wins a slot both fragments declare (body schema)', async () => {
+    server.route('POST', '/orders', { body: { ok: true } });
+
+    const looseBody = { input: { body: z.object({ a: z.string() }) } };
+    const strictBody = {
+        input: { body: z.object({ sku: z.string(), qty: z.number() }) },
+    };
+    const createOrder = stitch({
+        baseUrl: server.url,
+        path: '/orders',
+        method: 'POST',
+        extends: [looseBody, strictBody],
+    });
+
+    // The SECOND fragment's schema is in force: `{ sku, qty }` passes; `{ a }` (the first
+    // fragment's shape) would fail it. The valid call needs NO cast — last-wins gave the call arg
+    // the strict `{ sku, qty }` shape, so this line is itself a compile-time merge assertion.
+    await expect(createOrder({ body: { sku: 'A1', qty: 2 } })).resolves.toEqual(
+        { ok: true },
+    );
+    await expect(createOrder({ body: { a: 'x' } } as never)).rejects.toThrow(
+        /invalid body/i,
+    );
+
+    expect(server.callCount('/orders')).toBe(1); // only the valid call left the client
+});
+
 // 2) Predefined query in the path merges with call-time query; input wins on conflict.
 test('predefined query merges with call-time query (input wins on conflict)', async () => {
     server.route('GET', '/items', { body: { ok: true } });


### PR DESCRIPTION
Closes #76.

## What

`OutputOf<C>` / `InputOf<C>` (`packages/core/src/infer.ts`) read only the **top-level** `output`/`input` of the directly-passed config — they ignored schemas a fragment contributed through `extends`. At runtime `compose()` + `flatten()` + `deepMerge()` (`stitch.ts`) already deep-merge `input`/`output` across every fragment (depth-first, base→child, last-wins per key) and `validateInput` validates the merged result; only the **static** call-arg/result type was blind to fragment-supplied schemas.

This mirrors that runtime merge at the type level so a `headers`/`params`/`body`/`output` schema contributed purely by an `extends` fragment is now reflected in the inferred type.

## How

- **Type-level flatten + merge** in `infer.ts` (heavy WHY-comments, additive):
  - `AsFrag` (string ⟹ `{ path }`), `Flatten` / `ExpandFrag` expand `extends` into a flat, ordered layer list (depth-first, base→child).
  - `MergeInputSlots` folds each layer's `input` (key-union, **last-wins per slot**); `MergeOutput` picks the **last-written** `output` (whole-slot).
  - `OutputOf` / `InputOf` route through the merged layers. `InputOf` still terminates in `CallInput<…>` / `StitchInput` so the parallel path-vars work can wrap its slot shape.
- **No-`extends` path is byte-identical** to before (pure top-level read), so existing inference and compile cost are unchanged.
- **Recursion bound = fragment-tree depth 8** (`FragDepth`); deeper than that it falls back to the top-level read — protects the docs twoslash compile budget.
- **Engagement is tuple-only by design**: the merge fires only when `extends` is a concrete tuple. `stitch` / `seam.stitch` / `graphql` gain a `const` type parameter so an *inline* `extends: [...]` is captured as a tuple; a pre-widened `Fragment[]` array falls back to the top-level read. For an unresolved type parameter `C` (the surface helpers' generic) the guard collapses to the loose `StitchInput`/`unknown`, which the loose-implementation bodies require — `download`/`sse`/`stream` and `graphql`/`seam.graphql` retype their loose result with a documented `as`.

### Inferred signature, before → after

```ts
const base = { input: { headers: z.object({ 'x-tenant': z.string() }) } };
const s = stitch({ extends: [base], input: { body: z.object({ name: z.string() }) } });
```

- **Before:** call arg `{ body: { name: string }; variables?; signal?; onProgress? }` — the fragment's `headers` was validated at runtime but **missing** from the type.
- **After:** call arg `{ body: { name: string }; headers: { 'x-tenant': string }; variables?; signal?; onProgress? }` — `headers` is now required, matching the runtime merge.

## Two sharp findings honored

1. **The seam shared fragment STRUCTURALLY cannot carry `input`/`output`** — `SeamConfig = Omit<StitchConfig, …|'input'|'output'|…>`. So #76's "apply to the seam fragment" is a no-op for these two slots **by construction**. `SeamConfig` is **not** widened; a test pins that a seam can't declare `input`/`output` (`@ts-expect-error`). Only the member's `extends:[…]` array contributes schemas.
2. **A `Stitch` used as a fragment contributes nothing narrowing** — its slots erase behind `StitchConfig`'s loose `InputSchemas`/`SchemaLike` (it has no top-level `input`/`output` key). A `string` fragment contributes only `path`. Both are left working and documented. (A *typed* stitch was already not assignable to the loose `Stitch` member of `extends` — a pre-existing `Stitch`-variance limit under `exactOptionalPropertyTypes`, independent of this change.)

## Tests

- `packages/core/test-d/extends-inference.test-d.ts`: headers-from-fragment in the call arg; body-from-child merges with it; last-wins per slot across fragments; inline-nested `extends`; `output` via a fragment; child-wins-output; loose-stitch / string fragments contribute nothing narrowing; the seam-can't-carry-input/output `@ts-expect-error`; a no-`extends` regression guard.
- `packages/core/test/composition.spec.ts`: runtime cases confirming the merged `input` is actually validated (a fragment-contributed `headers` schema is merged + sent; a bad value rejects before the request leaves the client; last-wins across two fragments declaring the same slot).

## Coupling

One of three coupled PRs touching `infer.ts` (this = `extends`; plus path-vars and gql-vars). Edits are additive/localized; `InputOf` still ends in a `CallInput<…>` / `StitchInput` shape the path-vars PR can wrap.

## Gates (all green)

`check:lint`, `check:types` (both projects), `check:types-d` (build + tsd, ~9s), `test` (50 files / 395 tests), `check:exports` (attw all 🟢), and `build-docs` — full Next.js docs render, twoslash **Compiled successfully in 25.2s**, 222/222 static pages, no twoslash errors (~40s wall). Compile perf is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)