### PR TITLE
docs: fix run_stitch & graphql doc examples (+ drop stale gap-spec comments)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -21,3 +21,10 @@ apps/docs/public/sandbox/
 
 # Generated sandbox MCP bundles (@stitchapi/sandbox, built by build:mcp)
 docs/sandbox/dist/
+
+# Local Claude Code git worktrees. CI checks out clean and never sees these, but
+# `prettier --check .` (the pre-push format gate) would otherwise descend into
+# every nested worktree copy — unformatted files and half-removed ones alike —
+# and fail. The tracked `.claude/launch.json` / `.claude/settings.json` stay in
+# scope. See lefthook.yml's pre-push `format` job.
+.claude/worktrees/

--- a/apps/docs/content/docs/errors/stitch-graphql.mdx
+++ b/apps/docs/content/docs/errors/stitch-graphql.mdx
@@ -21,10 +21,10 @@ const user = graphql({
 });
 
 try {
-    await user({ body: { variables: { id: '42' } } });
+    await user({ variables: { id: '42' } });
 } catch (err) {
     // err.name === 'StitchError'
-    // err.message === 'GraphQL: Variable "$id" of required type "ID!" was not provided.'
+    // err.message === 'GraphQL: Not authorized to view user 42.'
     console.error(err);
 }
 ```

--- a/apps/docs/content/docs/surfaces/mcp.mdx
+++ b/apps/docs/content/docs/surfaces/mcp.mdx
@@ -23,7 +23,10 @@ input. The tool call looks like this:
 ```json
 {
     "name": "run_stitch",
-    "input": { "params": { "id": "42" }, "query": { "expand": "owner" } }
+    "input": {
+        "name": "getUser",
+        "input": { "params": { "id": "42" }, "query": { "expand": "owner" } }
+    }
 }
 ```
 

--- a/packages/core/test/gaps/graphql-paginated-errors.spec.ts
+++ b/packages/core/test/gaps/graphql-paginated-errors.spec.ts
@@ -1,6 +1,6 @@
 // Pins docs/GAP-AUDIT.md §1.6: GraphQL errors[] must fail the call on the paginated path too
 import { graphql } from '../../src';
-import type { StitchConfig, StitchInput } from '../../src/types';
+import type { StitchInput } from '../../src/types';
 import { startMockServer } from '../support/mock-server';
 import type { MockServer } from '../support/mock-server';
 
@@ -29,9 +29,8 @@ beforeEach(() => {
  * must REJECT with a GraphQL-error shaped message — the same way the
  * non-paginated path does (see test/graphql-and-headers.spec.ts:50-56).
  *
- * Today the paginated path in engine.ts never inspects per-page bodies for
- * `errors`, so it silently accumulates items and resolves — this test pins
- * that the desired behaviour is a rejection.
+ * The per-page `errors[]` check lives in engine.ts `paginated()`, mirroring
+ * the non-paginated path.
  */
 test('paginated GraphQL rejects when a page body carries errors[]', async () => {
     // Page 1: valid response with a cursor signalling a next page.
@@ -54,7 +53,6 @@ test('paginated GraphQL rejects when a page body carries errors[]', async () => 
         ],
     });
 
-    // TODO(fixer): remove cast once paginate is accepted by graphql() overload
     const paginateConfig = {
         paginate: {
             next: (body: unknown): StitchInput | undefined => {
@@ -73,7 +71,7 @@ test('paginated GraphQL rejects when a page body carries errors[]', async () => 
                 return { variables: { after: pi.endCursor } };
             },
         },
-    } as Partial<StitchConfig>;
+    };
 
     const query = graphql({
         baseUrl: server.url,
@@ -81,7 +79,6 @@ test('paginated GraphQL rejects when a page body carries errors[]', async () => 
         ...paginateConfig,
     });
 
-    // DESIRED: the call rejects, matching the GraphQL-error message from page 2.
-    // TODAY:   the call resolves (silently ignoring the error on page 2).
+    // The call rejects, matching the GraphQL-error message from page 2.
     await expect(query()).rejects.toThrow(/boom/);
 });

--- a/packages/core/test/gaps/secrets-file-rename.spec.ts
+++ b/packages/core/test/gaps/secrets-file-rename.spec.ts
@@ -1,7 +1,6 @@
 // Pins docs/GAP-AUDIT.md §1.8: keychain() was a plaintext-JSON spike — renamed to secretsFile()
 // (the deprecated `keychain` alias has since been removed entirely).
 import { basic, secretsFile, stitch } from '../../src';
-// TODO(fixer): remove cast once secretsFile is exported
 import { startMockServer } from '../support/mock-server';
 import type { MockServer } from '../support/mock-server';
 
@@ -55,9 +54,7 @@ afterEach(() => {
 // §1.8-A  secretsFile() is exported
 // ---------------------------------------------------------------------------
 
-// RED: secretsFile is not yet exported from src/index.ts — import is `undefined`.
 test('secretsFile is exported from the package (not undefined)', () => {
-    // This is the pinning assertion: it fails today because `secretsFile` is not exported.
     expect(secretsFile).toBeDefined();
     expect(typeof secretsFile).toBe('function');
 });
@@ -67,11 +64,6 @@ test('secretsFile is exported from the package (not undefined)', () => {
 // ---------------------------------------------------------------------------
 
 test('secretsFile() reads a value from ~/.stitch/secrets.json via HOME', () => {
-    // Guard: if secretsFile is not yet exported, skip rather than crash
-    if (typeof secretsFile !== 'function') {
-        // This path should not be reached once the fix lands
-        return;
-    }
     const home = makeTempHome({ MY_SECRET: 'from-file' });
     process.env['HOME'] = home;
     Reflect.deleteProperty(process.env, 'MY_SECRET');
@@ -87,9 +79,6 @@ test('secretsFile() reads a value from ~/.stitch/secrets.json via HOME', () => {
 // ---------------------------------------------------------------------------
 
 test('secretsFile() falls back to env var when secrets file is absent', () => {
-    if (typeof secretsFile !== 'function') {
-        return;
-    }
     // Point HOME somewhere without a .stitch/secrets.json
     const home = join(
         tmpdir(),


### PR DESCRIPTION
## What

Two copy-paste documentation examples surfaced by dogfooding did not match the runtime, plus a follow-on cleanup of stale "RED" comments in two gap specs whose remediations have since landed.

### Doc fixes (the live finding — GAP-AUDIT §1.7)
- **`surfaces/mcp.mdx`** — the `run_stitch` tool-call example omitted the stitch `name`, so taken literally it errors with `run_stitch requires a string "name"` (`mcp.ts`). Switched to the nested `{ name, input }` form already used in `agents/run-stitch-tool.mdx` and both recipes (mcp.mdx was the lone outlier of the four `run_stitch` examples).
- **`errors/stitch-graphql.mdx`** — `user({ body: { variables: {...} } })` double-nests on the wire to `{ query, variables: { variables: {...} } }` (`engine.ts` builds `variables: input.variables ?? input.body`), so `$id` is never sent. Switched to the canonical `variables` field and now illustrate a server-side authorization error, matching `guides/data/graphql.mdx`.

### Spec cleanup
- `graphql-paginated-errors.spec.ts` / `secrets-file-rename.spec.ts` — drop the now-false "today this throws / not yet exported / DESIRED vs TODAY" narration, the dead `typeof secretsFile !== 'function'` guards, and the obsolete `as Partial<StitchConfig>` cast (`paginate` is part of `StitchConfig`, so `graphql()` already accepts it). No behavioral change.

## Why

From dogfooding StitchAPI in a real product. The other audited findings — §1.2 `toValidator` predicate, §1.4 host-scoped throttle pooling, §1.6 paginated graphql `errors[]`, §1.8 `secretsFile` — were verified already-landed and green on `main`, so this PR is only the remaining doc-example fixes (§1.7) plus the spec-comment hygiene that follows from them.

## Verification

- `pnpm -r check:types`, `check:lint` — green
- Full `pnpm test` — green
- `build-docs` (twoslash render gate) — green: the `variables` block compiles, mirroring the already-shipping `guides/data/graphql.mdx` call shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)