### PR TITLE
chore(playground): regenerate stale stitch completions

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -81,7 +81,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "input",
             type: "property",
             detail: "InputSchemas",
-            info: "Schemas validating params, query, body, and headers before the request.",
+            info: "Schemas validating params, query, body, headers, and (GraphQL) variables before the request.",
         },
         {
             label: "output",


### PR DESCRIPTION
## What

Regenerates the committed playground completions file
`apps/docs/app/(home)/playground/playground-completions.generated.ts`, which was
stale relative to `packages/core/src/types.ts`.

## Why

[#117](https://github.com/rejifald/StitchAPI/pull/117) added the GraphQL
`variables?: SchemaLike` slot to `InputSchemas` and updated the JSDoc on
`StitchConfig.input` accordingly. The generated completions map carried the
pre-#117 doc text, so the playground autocomplete still described `input` as
validating only "params, query, body, and headers."

## Diff

A single content line — the `info` string on the `input` config completion:

```diff
-            info: "Schemas validating params, query, body, and headers before the request.",
+            info: "Schemas validating params, query, body, headers, and (GraphQL) variables before the request.",
```

Note: the generator (`@stitchapi/completions-plugin`) surfaces only top-level
`StitchConfig` keys and does **not** recurse into `InputSchemas`, so `variables`
correctly appears as updated doc text on the existing `input` entry rather than
as a standalone completion. No new entry is expected.

## How it was regenerated

`pnpm --filter @stitchapi/docs run gen:completions` (the same generator that runs
inside `build:sandbox`).

## Verification

- `pnpm --filter @stitchapi/docs build` passes (exit 0). The build re-runs the
  generator via `build:sandbox`; the file is **idempotent** (no further change).
- Diff is limited to the one genuine content line above — no formatting churn
  (the file is `**/*.generated.ts`, prettier-ignored, and passes `prettier --check`).
- Working tree shows only this one file modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
