### PR TITLE
Tier-0 dogfooding batch: oauth2 tenancy, hooks/url-shaping docs, sandbox+e2e CI

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -41,3 +41,39 @@ jobs:
             # generator throw all pass type-check and only fail at build. Building the
             # docs app runs generateStaticParams over every page and surfaces those.
             - run: pnpm --filter @stitchapi/docs build
+
+    # The sandbox simulator + playground smoke suites (docs/sandbox/tests/run-all.mjs) import
+    # the BUILT `stitchapi`, so they are build-dependent integration tests — they run in their
+    # own job that builds core first, not in the src-only `pnpm test` gate above. This is where
+    # the five @stitchapi/sandbox-sim suites (plus the six docs/sandbox suites) land in CI.
+    sandbox:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - uses: actions/checkout@v4
+            - uses: pnpm/action-setup@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version-file: .nvmrc
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile
+            - run: pnpm --filter stitchapi build
+            - run: pnpm --filter @stitchapi/sandbox test:smoke
+
+    # Browser-sandbox security model (§2.13): the Playwright harness proves the real CSP +
+    # Worker egress blocking and that a real RunResult.trace reaches the playground DAG. It
+    # builds the docs app and drives a headless Chromium, so it runs as its own job rather
+    # than inside the `verify` gate. Make it a required check once it has settled in CI.
+    e2e:
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        steps:
+            - uses: actions/checkout@v4
+            - uses: pnpm/action-setup@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version-file: .nvmrc
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile
+            - run: pnpm --filter @stitchapi/docs test:e2e:install
+            - run: pnpm --filter @stitchapi/docs test:e2e

--- a/apps/docs/content/docs/guides/authoring/hooks.mdx
+++ b/apps/docs/content/docs/guides/authoring/hooks.mdx
@@ -1,0 +1,101 @@
+---
+title: 'Hooks'
+description: 'Observe a call as it runs — onRequest, onResponse, onError, onRetry — and where each fires relative to auth, retry, throttle, and timeout.'
+---
+
+Hooks are observation points on a stitch's lifecycle: small callbacks that run as a
+call progresses, for logging, metrics, or tracing. They never change what a stitch
+returns — a call's only result is its response — so reach for a hook when you want
+to _watch_ a call, and for [`transform`](/docs/guides/data/transform) when you want
+to _reshape_ its output.
+
+## Example
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const getUser = stitch({
+    url: 'https://api.example.com/users/{id}',
+    hooks: {
+        onRequest: ({ name, attempt, req }) => {
+            console.log(`→ ${name} #${attempt}: ${req?.method} ${req?.url}`);
+        },
+        onResponse: ({ res }) => {
+            console.log(`← ${res?.status}`);
+        },
+        onRetry: ({ attempt, error, res }) => {
+            console.log(`retrying after #${attempt}`, error ?? res?.status);
+        },
+    },
+});
+```
+
+## The four hooks
+
+Each hook receives a `HookContext` — `{ name, attempt, req?, res?, error? }` — with
+the fields relevant to its moment populated:
+
+| Hook         | Fires when                                  | Populated        |
+| ------------ | ------------------------------------------- | ---------------- |
+| `onRequest`  | just before the request goes out            | `req`            |
+| `onResponse` | a response came back (any status)           | `res`            |
+| `onError`    | the transport threw (network/abort/timeout) | `error`          |
+| `onRetry`    | the engine decided to retry, before backoff | `error` or `res` |
+
+## Firing order
+
+Hooks interleave with the engine's per-attempt pipeline. Within a single attempt, in
+order:
+
+1. **throttle** — wait for a concurrency / rate slot
+2. **`auth.apply`** — credentials are stamped onto the request
+3. **`onRequest`** — the request is fully shaped (auth headers included)
+4. **the network call** (bounded by `timeout.perAttempt`)
+5. on a thrown transport error → **`onError`**, then if another attempt remains →
+   **`onRetry`** → backoff → next attempt
+6. on a response → **`onResponse`**
+7. **`auth.shouldRefresh` / `auth.refresh`** — a token wall (e.g. a 401) refreshes
+   auth and replays the attempt
+8. on a retryable status → **`onRetry`** → backoff → next attempt
+
+So `onRequest` always sees the post-auth request, and `onRetry` fires with `error`
+populated on a network failure or `res` populated on a retryable status.
+
+<Callout type="info">
+    Hooks run on **every attempt**, not once per call: a stitch that retries
+    twice fires `onRequest` three times. Use `attempt` to tell them apart.
+</Callout>
+
+## Order across composed layers
+
+When stitches compose via [`extends`](/docs/guides/authoring/extends), hooks
+**chain** rather than overwrite — every layer's hook runs. They unwind like
+middleware:
+
+-   `onRequest` runs **base → child** (outermost layer first)
+-   `onResponse`, `onError`, `onRetry` run **child → base** (innermost layer first)
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const base = stitch({
+    baseUrl: 'https://api.example.com',
+    hooks: { onRequest: () => console.log('base onRequest') },
+});
+
+const getUser = stitch({
+    extends: [base],
+    path: '/users/{id}',
+    hooks: { onRequest: () => console.log('child onRequest') },
+});
+// Calling getUser logs "base onRequest" then "child onRequest".
+```
+
+## See also
+
+<Cards>
+    <Card title="extends" href="/docs/guides/authoring/extends" />
+    <Card title="Guide: retry" href="/docs/guides/resilience/retry" />
+    <Card title="Guide: transform" href="/docs/guides/data/transform" />
+    <Card title="Reference: config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/guides/authoring/meta.json
+++ b/apps/docs/content/docs/guides/authoring/meta.json
@@ -1,4 +1,4 @@
 {
     "title": "Authoring & composition",
-    "pages": ["stitch", "extends", "with"]
+    "pages": ["stitch", "extends", "with", "hooks"]
 }

--- a/apps/docs/content/docs/guides/data/meta.json
+++ b/apps/docs/content/docs/guides/data/meta.json
@@ -1,4 +1,11 @@
 {
     "title": "Data shaping",
-    "pages": ["unwrap", "transform", "pagination", "body-encoding", "graphql"]
+    "pages": [
+        "unwrap",
+        "transform",
+        "pagination",
+        "body-encoding",
+        "url-shaping",
+        "graphql"
+    ]
 }

--- a/apps/docs/content/docs/guides/data/url-shaping.mdx
+++ b/apps/docs/content/docs/guides/data/url-shaping.mdx
@@ -1,0 +1,71 @@
+---
+title: 'URL shaping'
+description: 'RFC 6570 path templates and qs-style nested query serialization — how params and query become the URL.'
+---
+
+A stitch builds its URL from an
+[RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) URI template plus the
+`params` and `query` you pass at call time. Simple `{id}` interpolation is the
+common case; the full operator set is there when you need it.
+
+## Path templates
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const getUser = stitch('https://api.example.com/users/{id}');
+
+await getUser({ params: { id: 1 }, query: { expand: 'roles' } });
+// → GET https://api.example.com/users/1?expand=roles
+```
+
+Template variables are filled from `params`; `params`, `query`, `headers`, and
+`body` all travel in one input object. The RFC 6570 operators:
+
+| Operator | Template     | Role                                        |
+| -------- | ------------ | ------------------------------------------- |
+| simple   | `{id}`       | percent-encoded interpolation (the default) |
+| reserved | `{+path}`    | keep reserved chars (`/`, `?`) unencoded    |
+| path     | `{/id}`      | prefix the value with `/`                   |
+| query    | `{?id,sort}` | append `?id=…&sort=…`                       |
+| explode  | `{list*}`    | one `key=value` pair per array/object entry |
+| prefix   | `{id:1}`     | take only the first _n_ characters          |
+
+## Query serialization
+
+The query builder serializes nested objects and arrays `qs`-style:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const search = stitch('https://api.example.com/users');
+
+await search({ query: { filter: { type: 'admin' }, ids: [1, 2] } });
+// → /users?filter[type]=admin&ids[0]=1&ids[1]=2
+```
+
+Array encoding is configurable with
+[`arrayFormat`](/docs/reference/config-types) — `indices` (the default shown
+above), `brackets`, or `repeat`.
+
+## Query defaults in the path
+
+Query keys can be baked into the path string; call-time `query` merges over them,
+so a stitch can carry sensible defaults that each call selectively overrides:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const findUsers = stitch('https://api.example.com/users?sort=name&type=admin');
+
+await findUsers({ query: { type: 'user' } });
+// → /users?sort=name&type=user
+```
+
+## See also
+
+<Cards>
+    <Card title="stitch()" href="/docs/guides/authoring/stitch" />
+    <Card title="Body encoding" href="/docs/guides/data/body-encoding" />
+    <Card title="Reference: config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/reference/helpers.mdx
+++ b/apps/docs/content/docs/reference/helpers.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Helpers'
-description: 'fetchAdapter, consoleSink, fileSink, createTrace, multiplex, the OTLP exporters, memoryStore, and toValidator.'
+description: 'fetchAdapter, axiosAdapter, xhrAdapter, consoleSink, fileSink, createTrace, multiplex, the OTLP exporters, memoryStore, and toValidator.'
 ---
 
 The exported helper functions you wire into a stitch: the default transport, the
@@ -20,6 +20,43 @@ propagate, leaving the engine to decide what a status means.
 import { fetchAdapter } from 'stitchapi';
 
 const adapter = fetchAdapter();
+```
+
+### axiosAdapter
+
+Route a stitch through a caller-supplied axios instance instead of `fetch`. The
+runtime stays zero-dependency, so you pass _your_ axios (or an `axios.create()`)
+rather than an import inside StitchAPI; body encoding, headers, and parsing match
+`fetchAdapter`, so swapping transports never changes behavior. It is
+**buffered-only** — it throws on a `stream`/`sse` surface; use `fetchAdapter` to
+stream.
+
+```ts twoslash
+import { type AxiosLike, axiosAdapter, stitch } from 'stitchapi';
+
+// Your real axios instance is structurally an AxiosLike — no axios import needed here.
+declare const axios: AxiosLike;
+
+const getUser = stitch({
+    url: 'https://api.example.com/users/{id}',
+    adapter: axiosAdapter(axios),
+});
+```
+
+### xhrAdapter
+
+An `XMLHttpRequest`-backed transport whose reason to exist is **upload progress**
+(`fetch` cannot report bytes sent). Browser-only by default; pass a constructor to
+inject a polyfill or a fake. Buffered-only, like `axiosAdapter`.
+
+```ts twoslash
+import { stitch, xhrAdapter } from 'stitchapi';
+
+const upload = stitch({
+    method: 'POST',
+    url: 'https://api.example.com/files',
+    adapter: xhrAdapter(), // defaults to globalThis.XMLHttpRequest
+});
 ```
 
 ## Tracing & OTLP

--- a/docs/sandbox/package.json
+++ b/docs/sandbox/package.json
@@ -14,6 +14,7 @@
     },
     "scripts": {
         "build:mcp": "node runtime/build-sandbox-mcp.mjs",
+        "test:smoke": "node tests/run-all.mjs",
         "test:mcp": "pnpm run build:mcp && node mcp/smoke.mjs"
     },
     "dependencies": {

--- a/docs/sandbox/tests/run-all.mjs
+++ b/docs/sandbox/tests/run-all.mjs
@@ -45,7 +45,9 @@ const SUITES = [
 ];
 
 // ---------------------------------------------------------------------------
-// Run each suite: spawn npx tsx <file>, capture exit code + combined output.
+// Run each suite: spawn `node --import tsx <file>`, capture exit + combined output.
+// tsx is a pinned devDependency (workspace root), so this never reaches the network —
+// `npx tsx` would try to *download* tsx when it isn't hoisted to a runnable bin.
 // ---------------------------------------------------------------------------
 
 let passed = 0;
@@ -58,7 +60,7 @@ for (const relPath of SUITES) {
     const absPath = resolve(root, relPath);
     process.stdout.write(`  running ${relPath} … `);
 
-    const result = spawnSync('npx', ['-y', 'tsx', absPath], {
+    const result = spawnSync('node', ['--import', 'tsx', absPath], {
         encoding: 'utf8',
         cwd: root,
         // Give each suite up to 30 s — browser-runner.test.ts uses real threads

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "lefthook": "^2.1.9",
-        "prettier": "3.3.3"
+        "prettier": "3.3.3",
+        "tsx": "^4.22.4"
     },
     "pnpm": {
         "overrides": {

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -133,6 +133,15 @@ export interface OAuth2Opts {
     refreshSkewMs?: number;
     /** Store namespace — give two stitches the same `key` + a shared `store` to share one token. Default: `tokenUrl`. */
     key?: string;
+    /**
+     * Token tenancy (ADR 0002 §3). Default **`'app'`**: one token serves every caller — the right
+     * model for `client_credentials`, which authenticates the *application*, not a user. Set
+     * `'principal'` to fold the seam-bound principal into the token's cache key (and **throw if no
+     * principal is bound**, mirroring {@link CookieSessionOpts.scope}); each tenant then caches its
+     * own token and one tenant's 401/refresh never disturbs another's in-flight calls. Pair it with
+     * per-tenant `clientId`/`clientSecret`/`scope` for full multi-tenant separation.
+     */
+    tenancy?: 'principal' | 'app';
     /** Test seam / custom transport for the token request (default `fetchAdapter()`). */
     adapter?: Adapter;
 }
@@ -168,17 +177,41 @@ function singleFlight<T>(): (key: string, run: () => Promise<T>) => Promise<T> {
 export function oauth2(opts: OAuth2Opts): AuthStrategy {
     const refreshOn = opts.refreshOn ?? [401];
     const skew = opts.refreshSkewMs ?? 30_000;
-    const nsKey = 'oauth2:' + (opts.key ?? opts.tokenUrl);
+    const baseKey = 'oauth2:' + (opts.key ?? opts.tokenUrl);
+    const tenancy = opts.tenancy ?? 'app';
     const adapter = opts.adapter ?? fetchAdapter();
     const clientAuth = opts.clientAuth ?? 'post';
     const flight = singleFlight<string>();
+
+    // The vault key for THIS call. Default 'app' shares one token across all callers (correct for
+    // client_credentials — the token authenticates the application, not a user). 'principal' folds
+    // the seam-bound principal in (fail-closed if none, mirroring cookieSession's scope), so each
+    // tenant caches its own token and one tenant's 401/refresh never disturbs another's.
+    const keyFor = (ctx: AuthContext): string => {
+        if (tenancy === 'app') return baseKey;
+        const principal = ctx.principal;
+        if (principal == null || principal === '') {
+            const e = new Error(
+                "oauth2 with tenancy 'principal' requires a bound principal: create the stitch " +
+                    'through a seam and call `seam.as(principalId)`, or use the default ' +
+                    "tenancy 'app' to share one token across all callers.",
+            );
+            e.name = 'StitchAuthError';
+            throw e;
+        }
+        // U+0000 can't appear in a principal id or key, so it's a collision-free separator.
+        return `${baseKey}\u0000${principal}`;
+    };
 
     const isFresh = (t: CachedToken | undefined): boolean =>
         !!t && (t.expiresAt === 0 || now() < t.expiresAt - skew);
 
     // Fetch a new token from the endpoint and cache it (with TTL = expires_in). Always hits
     // the network; callers gate on `isFresh` to reuse the cached token instead.
-    const fetchToken = async (ctx: AuthContext): Promise<string> => {
+    const fetchToken = async (
+        ctx: AuthContext,
+        nsKey: string,
+    ): Promise<string> => {
         ctx.emit('auth', 'token');
         const body: Record<string, string> = {
             grant_type: 'client_credentials',
@@ -238,11 +271,12 @@ export function oauth2(opts: OAuth2Opts): AuthStrategy {
     };
 
     const tokenFor = async (ctx: AuthContext): Promise<string> => {
+        const nsKey = keyFor(ctx);
         const cached = (await ctx.vault.get(nsKey)) as CachedToken | undefined;
         // Cache miss/stale: coalesce concurrent callers into ONE in-flight fetch.
         return isFresh(cached)
             ? cached!.token
-            : flight(nsKey, () => fetchToken(ctx));
+            : flight(nsKey, () => fetchToken(ctx, nsKey));
     };
 
     return {
@@ -256,7 +290,8 @@ export function oauth2(opts: OAuth2Opts): AuthStrategy {
         async refresh(ctx) {
             // Force a fresh token, ignoring the cache — but simultaneous 401s
             // still share one fetch (an in-flight fetch IS the freshest token).
-            await flight(nsKey, () => fetchToken(ctx));
+            const nsKey = keyFor(ctx);
+            await flight(nsKey, () => fetchToken(ctx, nsKey));
         },
     };
 }

--- a/packages/core/test/oauth2-tenancy.spec.ts
+++ b/packages/core/test/oauth2-tenancy.spec.ts
@@ -1,0 +1,111 @@
+// OAuth2 token tenancy (ADR 0002 §3). The default `'app'` shares one client_credentials token
+// across every caller — the token is the application's identity, not a user's. Opting into
+// `tenancy: 'principal'` folds the seam-bound principal into the token's vault key, so each tenant
+// caches its own token and a missing principal fails closed (mirroring cookieSession's `scope`).
+import { env, oauth2, seam, stitch } from '../src';
+import type { Seam } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-oauth2-tenancy-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+    process.env['OAUTH_CLIENT_ID'] = 'cid';
+    process.env['OAUTH_CLIENT_SECRET'] = 'csecret';
+});
+
+// A seam whose stitches authenticate with an oauth2 client_credentials token; tenancy per test.
+const protectedSeam = (tenancy?: 'principal' | 'app'): Seam =>
+    seam({
+        baseUrl: server.url,
+        auth: oauth2({
+            tokenUrl: `${server.url}/token`,
+            clientId: env('OAUTH_CLIENT_ID'),
+            clientSecret: env('OAUTH_CLIENT_SECRET'),
+            ...(tenancy ? { tenancy } : {}),
+        }),
+    });
+
+test("default tenancy 'app' shares ONE token across principals", async () => {
+    server.route('POST', '/token', {
+        body: { access_token: 'T1', token_type: 'Bearer', expires_in: 3600 },
+    });
+    server.route('GET', '/data', {
+        requireHeader: { name: 'authorization', value: 'Bearer T1' },
+        body: { ok: true },
+    });
+
+    const api = protectedSeam(); // default 'app'
+    await expect(api.as('tenant-a').stitch('/data')()).resolves.toEqual({
+        ok: true,
+    });
+    await expect(api.as('tenant-b').stitch('/data')()).resolves.toEqual({
+        ok: true,
+    });
+
+    expect(server.callCount('/token')).toBe(1); // one app-wide token, shared across tenants
+});
+
+test("tenancy 'principal' caches a SEPARATE token per principal — no cross-tenant bleed", async () => {
+    // The token endpoint hands out a distinct token per fetch, so we can prove isolation.
+    server.route('POST', '/token', {
+        body: (i: number) => ({
+            access_token: i === 0 ? 'T-A' : 'T-B',
+            token_type: 'Bearer',
+            expires_in: 3600,
+        }),
+    });
+    server.route('GET', '/data', {
+        requireHeader: { name: 'authorization' },
+        body: { ok: true },
+    });
+
+    const api = protectedSeam('principal');
+    await api.as('tenant-a').stitch('/data')();
+    await api.as('tenant-b').stitch('/data')();
+    // tenant-a again: its own token is already cached, so NO new token fetch happens.
+    await api.as('tenant-a').stitch('/data')();
+
+    expect(server.callCount('/token')).toBe(2); // one fetch per principal; A reused on the 3rd call
+    const calls = server.calls('/data');
+    expect(calls[0]!.headers['authorization']).toBe('Bearer T-A');
+    expect(calls[1]!.headers['authorization']).toBe('Bearer T-B');
+    expect(calls[2]!.headers['authorization']).toBe('Bearer T-A'); // A's token, never B's
+});
+
+test("tenancy 'principal' fails closed when no principal is bound", async () => {
+    server.route('POST', '/token', {
+        body: { access_token: 'T1', token_type: 'Bearer', expires_in: 3600 },
+    });
+    server.route('GET', '/data', { body: { ok: true } });
+
+    // A bare stitch (no seam, no principal) must refuse rather than silently share one app-wide
+    // token — per-tenant auth can never quietly collapse to a shared credential.
+    const bare = stitch({
+        baseUrl: server.url,
+        path: '/data',
+        auth: oauth2({
+            tokenUrl: `${server.url}/token`,
+            clientId: env('OAUTH_CLIENT_ID'),
+            clientSecret: env('OAUTH_CLIENT_SECRET'),
+            tenancy: 'principal',
+        }),
+    });
+
+    await expect(bare()).rejects.toThrow(/requires a bound principal/);
+    expect(server.callCount('/token')).toBe(0); // refused before any token request
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       prettier:
         specifier: 3.3.3
         version: 3.3.3
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
 
   apps/docs:
     dependencies:
@@ -201,7 +204,7 @@ importers:
         version: 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -361,7 +364,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
   packages/sandbox-sim:
     devDependencies:
@@ -7097,7 +7100,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
 
   '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.8)':
     dependencies:
@@ -7107,7 +7110,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
     transitivePeerDependencies:
       - supports-color
 
@@ -10397,7 +10400,6 @@ snapshots:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
-    optional: true
 
   twoslash-protocol@0.3.8: {}
 


### PR DESCRIPTION
Implements the four low-risk **Tier-0** items from the dogfooding scoping pass — retire GAP-AUDIT residue and stop orphaned-suite rot, with no public-API risk beyond one additive opt-in field.

## Changes

### `feat(auth)` — per-principal oauth2 token tenancy
- New `OAuth2Opts.tenancy` (`'principal' | 'app'`, default `'app'`). The default is a no-op: one `client_credentials` token serves every caller, which is correct because the token authenticates the *application*, not a user. `'principal'` folds the seam-bound principal into the token's vault key and **fails closed** when no principal is bound, mirroring `cookieSession`.
- Named `tenancy` (not `scope`) because `OAuth2Opts.scope` already means OAuth scopes.
- Per-principal *credential/scope* resolution (varying `clientId`/`scope` by tenant) is the natural follow-up; this lands the isolation primitive.

### `docs(site)` — hooks, URL shaping, adapters
- `guides/authoring/hooks.mdx`: the four hooks, firing order vs auth/retry/throttle/timeout, and `base→child` / `child→base` composition order.
- `guides/data/url-shaping.mdx`: RFC 6570 templates + qs-style nested query.
- `reference/helpers.mdx`: `axiosAdapter` / `xhrAdapter` entries (buffered-only).

### `ci` — sandbox smokes + Playwright e2e
- The 5 `@stitchapi/sandbox-sim` + 6 `docs/sandbox` suites were orphaned (a bespoke runner that downloaded `tsx` at runtime). They are **build-dependent** (they import the built `stitchapi`), so they cannot join the src-only `pnpm test` gate that runs before any build.
- Pinned `tsx` at the workspace root; `run-all.mjs` now uses `node --import tsx`. Renamed the script `test`→`test:smoke`. Added a dedicated **`sandbox`** job (build core → `test:smoke`) and an **`e2e`** job (Playwright CSP/egress/trace).

## Verification
- core: `check:types` ✓ · `check:lint` ✓ · **427 tests** ✓ (3 new in `oauth2-tenancy.spec.ts`)
- sandbox: **11/11** smoke suites ✓
- docs `build` (twoslash + render gate) ✓

## Notes for review
- The `e2e` job is intentionally **not** a required check yet — let it settle in CI first.
- The sandbox suites stay `tsx`+`node:assert`; migrating them to behavioral-vitest is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)