### PR TITLE
build(hooks): auto-regenerate playground completions on pre-commit

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -81,7 +81,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "input",
             type: "property",
             detail: "InputSchemas",
-            info: "Schemas validating params, query, body, and headers before the request.",
+            info: "Schemas validating params, query, body, headers, and (GraphQL) variables before the request.",
         },
         {
             label: "output",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,6 +4,15 @@
 pre-commit:
     parallel: false
     jobs:
+        # Regenerate the playground autocomplete maps when the core source that
+        # feeds the generator changes, then stage the result so the committed
+        # *.generated.ts never drifts from the types it mirrors. The generator
+        # reads packages/core/src directly (no build step), so this stays cheap.
+        # Keep this glob in sync with the `packages` list in
+        # apps/docs/scripts/gen-stitch-completions.mjs.
+        - name: completions
+          glob: 'packages/core/src/**/*.ts'
+          run: pnpm --filter @stitchapi/docs run gen:completions && git add "apps/docs/app/(home)/playground/playground-completions.generated.ts"
         - name: format
           # Keep in sync with CI's `prettier --check .` (verify.yml) — cover every
           # extension Prettier handles here so committed files are never left unformatted


### PR DESCRIPTION
## What

Adds a lefthook `pre-commit` job that regenerates the playground CodeMirror autocomplete map (`apps/docs/app/(home)/playground/playground-completions.generated.ts`) and stages it whenever `packages/core/src` changes — so the committed map never drifts from the core `*Config` types it mirrors.

## Why

The map is generated from core's `*Config` JSDoc/interfaces but was only regenerated manually (or as a side effect of a full docs build), so it silently went stale. This PR caught exactly that: the `input` JSDoc gained `(GraphQL) variables` in #117, but the committed file still read *"…body, and headers"* — now regenerated.

## How it works

```yaml
- name: completions
  glob: 'packages/core/src/**/*.ts'
  run: pnpm --filter @stitchapi/docs run gen:completions && git add "apps/docs/app/(home)/playground/playground-completions.generated.ts"
```

- **Glob-scoped** so unrelated commits skip it (negative-tested: `completions (skip) no matching staged files`).
- **No build step** — the generator reads core source directly via the TS compiler API, so the job runs in ~0.9s.
- Placed first so the regenerated file is staged before the format/lint/typecheck jobs validate it.

> [!NOTE]
> The glob mirrors the generator's hardcoded `packages` list in `apps/docs/scripts/gen-stitch-completions.mjs`. If an adapter package is ever added there, widen this glob too, or adapter-config drift won't be caught.

## Verification

- `lefthook dump` — job parses and registers correctly.
- **Negative:** no core source staged → job skips.
- **Positive:** core source in scope → generator runs end-to-end (~0.9s), output staged, idempotent (empty diff after).
- Full local pre-push gate green: format / lint / typecheck / typecheck-d / test / exports / build-docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)