### PR TITLE
feat(cli): stitch diagram — Mermaid flowchart of a stitch's pipeline

### DIFF
--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -4,6 +4,7 @@
 // Flags map onto a stitch's single input object ({ params, query, body, headers });
 // every event the stitch emits is written to stdout as one line of JSON, so the
 // output pipes straight into jq and friends. No app boot required.
+import { toMermaid } from './diagram';
 import { serveStdio } from './mcp';
 import {
     type StitchRegistry,
@@ -392,6 +393,7 @@ usage:
   stitch trace [--file <path>] [--since 1h] [--name <x>] [--json]
   stitch serve [--module <path>] [--port <n>] [--host <h>]   HTTP: POST /stitch/:name
   stitch mcp [--module <path>]                               MCP over stdio (run_stitch)
+  stitch diagram [--module <path>] [--name <name>]           Mermaid flowchart of the stitches
 
 run:
   --module, -m <path>   stitches module to load (default: ./stitches.{ts,js,…})
@@ -404,6 +406,12 @@ run:
 
 Every event the stitch emits is printed as one line of JSON on stdout. Tracing is off
 by default (no side effects) — opt in with --trace or the STITCH_TRACE_* env vars.
+
+diagram:
+  --name <name>   diagram only this stitch (by export name or configured name)
+  Emits a Mermaid flowchart of each stitch's configured pipeline (throttle, request,
+  retry, surface, pagination, validation, transform, unwrap, cache). Auth is redacted
+  from a stitch's public config, so it is not shown.
 `;
 
 async function runCommand(args: string[], io: CliIO): Promise<number> {
@@ -579,6 +587,33 @@ async function mcpCommand(args: string[], io: CliIO): Promise<number> {
     return 0;
 }
 
+// stitch diagram [--module <path>] [--name <name>] — render a Mermaid flowchart of each stitch's
+// configured pipeline (from its definition, not a run) to stdout. See src/diagram.ts.
+async function diagramCommand(args: string[], io: CliIO): Promise<number> {
+    let modulePath: string | undefined;
+    let name: string | undefined;
+    for (let i = 0; i < args.length; i++) {
+        const a = args[i];
+        if (a === '--module' || a === '-m') modulePath = args[++i];
+        else if (a === '--name') name = args[++i];
+    }
+
+    let registry: StitchRegistry;
+    try {
+        registry = await io.load(resolveModulePath(modulePath, io.cwd));
+    } catch (e) {
+        io.writeErr(`${(e as Error).message}\n`);
+        return 1;
+    }
+
+    const { diagram, warnings } = toMermaid(registry, {
+        ...(name !== undefined ? { name } : {}),
+    });
+    for (const w of warnings) io.writeErr(`warning: ${w}\n`);
+    io.write(diagram);
+    return 0;
+}
+
 // Entry point. Returns the process exit code; the bin shim calls process.exit.
 export async function main(
     argv: string[],
@@ -595,6 +630,8 @@ export async function main(
             return serveCommand(rest, io);
         case 'mcp':
             return mcpCommand(rest, io);
+        case 'diagram':
+            return diagramCommand(rest, io);
         case undefined:
         case '-h':
         case '--help':

--- a/packages/core/src/diagram.ts
+++ b/packages/core/src/diagram.ts
@@ -1,0 +1,97 @@
+// `stitch diagram` — render a Mermaid flowchart of each stitch's SHAPE from its definition
+// (`__config`), not from a run. A glance-able "what does this stitch do": the configured request
+// pipeline — throttle, the request, retry, a non-http surface's interpret step, pagination,
+// validation, transform, unwrap, cache — in engine order. A trace-driven DAG of what actually ran
+// is a separate, future capability (it needs composition causality the flat event stream does not
+// yet emit). Auth is intentionally absent: it is redacted from `__config` (ADR 0002), so a stitch
+// cannot leak which credential it holds — not even its scheme — through this view.
+import type { StitchRegistry } from './registry';
+import type { StitchConfig } from './types';
+
+export interface MermaidExportResult {
+    diagram: string;
+    warnings: string[];
+}
+
+// A compact "METHOD endpoint" label for the request node.
+function endpointLabel(cfg: StitchConfig): string {
+    const method = (cfg.method ?? 'GET').toUpperCase();
+    let where: string;
+    if (typeof cfg.url === 'string') where = cfg.url;
+    else if (typeof cfg.url === 'function') where = '(dynamic url)';
+    else {
+        const base =
+            typeof cfg.baseUrl === 'string'
+                ? cfg.baseUrl
+                : cfg.baseUrl
+                  ? '(dynamic)'
+                  : '';
+        where = base + (cfg.path ?? '');
+    }
+    return `${method} ${where || '(no endpoint)'}`;
+}
+
+// The configured pipeline stages, in engine order. `call`/`result` always bookend; the middle
+// stages appear only when configured. Auth is redacted from __config, so it never appears.
+function stagesFor(cfg: StitchConfig): string[] {
+    const kindRaw: unknown = cfg.kind; // __config.kind is the surface id string
+    const kind = typeof kindRaw === 'string' ? kindRaw : 'http';
+    const stages: string[] = ['call'];
+    if (cfg.throttle) stages.push('throttle');
+    stages.push(endpointLabel(cfg));
+    if (cfg.retry) stages.push(`retry ×${cfg.retry.attempts ?? 1}`);
+    if (kind !== 'http') stages.push(`${kind} interpret`);
+    if (cfg.paginate) stages.push(`paginate (max ${cfg.paginate.max ?? 50})`);
+    if (cfg.output) stages.push('validate');
+    if (cfg.transform) stages.push('transform');
+    if (cfg.unwrap) stages.push(`unwrap: ${cfg.unwrap}`);
+    if (cfg.cache) stages.push('cache');
+    stages.push('result');
+    return stages;
+}
+
+// Mermaid node ids must be identifier-safe; labels ride in quotes (double-quotes swapped out).
+function safeId(key: string, i: number): string {
+    return `s${i}_${key.replace(/[^A-Za-z0-9]/g, '_')}`;
+}
+function label(text: string): string {
+    return text.replace(/"/g, "'");
+}
+
+/**
+ * Build a Mermaid `flowchart` of the registry: one subgraph per stitch, each a left-to-right chain
+ * of its configured pipeline stages. Pure (no I/O). `opts.name` filters to a single stitch (by
+ * registry key or configured `name`). Returns the diagram text plus warnings (e.g. an unknown name).
+ */
+export function toMermaid(
+    registry: StitchRegistry,
+    opts: { name?: string } = {},
+): MermaidExportResult {
+    const warnings: string[] = [];
+    const entries = Object.entries(registry).filter(
+        ([key, s]) =>
+            opts.name === undefined ||
+            key === opts.name ||
+            s.__config.name === opts.name,
+    );
+    if (opts.name !== undefined && entries.length === 0)
+        warnings.push(`no stitch named "${opts.name}"`);
+
+    const lines: string[] = ['flowchart TD'];
+    entries.forEach(([key, stitch], i) => {
+        const id = safeId(key, i);
+        const chain = stagesFor(stitch.__config)
+            .map((text, j, all) => {
+                const terminal = j === 0 || j === all.length - 1;
+                return terminal
+                    ? `${id}_${j}(["${label(text)}"])`
+                    : `${id}_${j}["${label(text)}"]`;
+            })
+            .join(' --> ');
+        lines.push(`  subgraph ${id}["${label(key)}"]`);
+        lines.push('    direction LR');
+        lines.push(`    ${chain}`);
+        lines.push('  end');
+    });
+    return { diagram: `${lines.join('\n')}\n`, warnings };
+}

--- a/packages/core/test/diagram.spec.ts
+++ b/packages/core/test/diagram.spec.ts
@@ -1,0 +1,86 @@
+// `stitch diagram` — render a Mermaid flowchart of each stitch's configured pipeline from its
+// definition (not a run). The pure `toMermaid` is asserted directly; the `diagram` command is
+// driven through `main` with an injected registry loader.
+import { stitch } from '../src';
+import { main } from '../src/cli';
+import { toMermaid } from '../src/diagram';
+import type { StitchRegistry } from '../src/registry';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { z } from 'zod';
+
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-diagram-${process.pid}.jsonl`,
+);
+
+const sampleRegistry = (): StitchRegistry => ({
+    getUser: stitch({
+        baseUrl: 'https://api.example.com',
+        path: '/users/{id}',
+        retry: { attempts: 3 },
+        output: z.object({ id: z.number() }),
+        unwrap: 'data',
+    }),
+    ping: stitch('https://api.example.com/ping'),
+});
+
+describe('toMermaid', () => {
+    test('emits a flowchart with one subgraph per stitch', () => {
+        const { diagram } = toMermaid(sampleRegistry());
+        expect(diagram.startsWith('flowchart TD')).toBe(true);
+        expect(diagram).toContain('subgraph s0_getUser["getUser"]');
+        expect(diagram).toContain('subgraph s1_ping["ping"]');
+    });
+
+    test('a stitch chains its configured pipeline stages in order', () => {
+        const { diagram } = toMermaid(sampleRegistry());
+        // getUser: call -> request -> retry -> validate -> unwrap -> result (no throttle/cache).
+        expect(diagram).toContain('(["call"]) -->');
+        expect(diagram).toContain('GET https://api.example.com/users/{id}');
+        expect(diagram).toContain('retry');
+        expect(diagram).toContain('validate');
+        expect(diagram).toContain('unwrap: data');
+        expect(diagram).toContain('(["result"])');
+    });
+
+    test('a bare stitch is just call -> request -> result', () => {
+        const { diagram } = toMermaid({
+            ping: stitch('https://api.example.com/ping'),
+        });
+        expect(diagram).not.toContain('retry');
+        expect(diagram).not.toContain('validate');
+        expect(diagram).toContain('GET https://api.example.com/ping');
+    });
+
+    test('--name filters to one stitch; an unknown name warns', () => {
+        const only = toMermaid(sampleRegistry(), { name: 'ping' });
+        expect(only.diagram).toContain('s0_ping["ping"]');
+        expect(only.diagram).not.toContain('getUser');
+        expect(only.warnings).toEqual([]);
+
+        const missing = toMermaid(sampleRegistry(), { name: 'nope' });
+        expect(missing.warnings.some((w) => w.includes('nope'))).toBe(true);
+    });
+});
+
+describe('stitch diagram (CLI)', () => {
+    test('writes a Mermaid flowchart to stdout', async () => {
+        const registry: StitchRegistry = {
+            getUser: stitch('https://api.example.com/users/{id}'),
+        };
+        let out = '';
+        const code = await main(['diagram', '--module', 'x'], {
+            cwd: '/',
+            load: async () => registry,
+            write: (s) => {
+                out += s;
+            },
+            writeErr: () => undefined,
+        });
+        expect(code).toBe(0);
+        expect(out.startsWith('flowchart TD')).toBe(true);
+        expect(out).toContain('GET https://api.example.com/users/{id}');
+    });
+});


### PR DESCRIPTION
`stitch diagram [--module <path>] [--name <name>]` emits a Mermaid flowchart of each stitch's configured request pipeline, read statically from its definition (`__config`) — not from a run.

One subgraph per stitch chains the stages it actually has, in engine order: throttle → request → retry → (non-http surface) interpret → paginate → validate → transform → unwrap → cache. Auth is **redacted** from a stitch's public config (ADR 0002), so it isn't shown.

A trace-driven DAG of what actually *ran* is a separate, future capability — it needs the composition causality the flat `StitchEvent` stream doesn't yet emit (couples with `pipe()`).

## Files
- `src/diagram.ts` — pure `toMermaid(registry, opts) → { diagram, warnings }` (no I/O; round-trips & tests cleanly).
- `src/cli.ts` — the `diagram` command + HELP.
- `test/diagram.spec.ts` — pipeline cases + the command through `main()`.

## Verification
- core: `check:types` ✓ · `check:lint` ✓ · **429 tests** ✓ (5 new)
- End-to-end: built the binary and ran `stitch diagram` against a sample module — valid Mermaid (retry/validate/unwrap chain, a bare stitch, a paginate chain).

## Note
Independent of #126 (`stitch export`); both add distinct CLI subcommands. If #126 merges first this may need a trivial conflict nudge in `cli.ts` (adjacent HELP / switch lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)