### PR TITLE
feat(nest): reduce NestJS integration boilerplate (logger sink, optional tokens, exception filter, SSE, multi-tenant)

### DIFF
--- a/docs/adr/0006-nestjs-integration.md
+++ b/docs/adr/0006-nestjs-integration.md
@@ -370,3 +370,15 @@ Both resolved 2026-06-15 (the recommended option chosen for each); folded into t
 -   **B. Single global seam only** (the brief's literal `forRoot({ store, trace, preset })`). Simplest, but a real backend integrates multiple upstreams with different `baseUrl`/`auth`; one seam cannot model that. Rejected in favour of the infra-vs-surface split (Decision 2), which keeps the single-upstream case a one-liner (the default seam) while supporting many.
 -   **C. Per-stitch, no seam** (plain `stitch()` + a shared config fragment via `extends`). Avoids the seam abstraction, but each stitch then builds its _own_ store/throttle/trace runtime — losing the shared throttle bucket, the shared vault, the principal boundary, and a single lifecycle. The seam exists precisely for a long-lived shared surface; a server is the canonical case. Rejected.
 -   **D. Fold Nest support into core** (a `stitchapi/nest` subpath). Violates [ADR 0001](./0001-package-naming-and-distribution.md) Decisions 4 & 6 (a framework peer dep does not belong in lean core; subpaths are for dependency-free in-package code) and would put `@nestjs/*` in core's dependency graph. Rejected.
+
+## Addendum (2026-06-16) — boilerplate-reduction follow-ups delivered
+
+Layered on the original decisions to cut per-consumer boilerplate. All additive, **no core change**:
+
+-   **`defineStitch` token is now optional** — `defineStitch(build)` generates a unique `Symbol`; the `(token, build)` form still works. You reference the def object everywhere anyway (`forFeature({ stitches: [GetUser] })`, `@InjectStitch(GetUser)`, `overrideProvider(GetUser.token)`), so the hand-picked token was ceremony.
+-   **`loggerSink` mapping refined** — lifecycle events (`start`/`result`/`done`) moved off the happy-path info level to `debug`/`verbose` (opt out with `{ lifecycle: false }`), `drift` routed by `finding.level`, and `retry`/`circuit` progress surfaced at `warn`. Still payload-free (metadata only), so it stays safe on a secret-bearing seam.
+-   **Exception mapping delivered** (was Decision 10 non-goal) — `StitchExceptionFilter` plus `toHttpException()` / `isStitchError()` map a `StitchError` to an `HttpException`. Status is **`502 Bad Gateway` by default** (never leaks an upstream's status to the client); configurable via `status: number | (err) => number` (propagate, fix, or remap).
+-   **SSE bridge delivered** (was Decision 10 non-goal) — `stitchSse()` adapts `stitch.stream()` to an `Observable<MessageEvent>` for `@Sse()`. Adds `rxjs` as a peer (always present in a Nest app).
+-   **Multi-tenant wiring packaged** — `StitchModule.forFeatureScoped({ stitches, principal })` replaces the hand-rolled request-scoped `TENANT_SEAM` recipe (Decision 5). Adds `@nestjs/core` as a peer (for `REQUEST`; always present in a Nest app).
+
+Peer-dependency policy unchanged in spirit: peer-depend on what a Nest app **always** has (`@nestjs/common`, now `@nestjs/core` + `rxjs`); keep **optional** deps structural (`@nestjs/config` → `ConfigServiceLike`). Still non-goals: the Terminus health indicator and the Nest-GraphQL disambiguation note.

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -5,13 +5,14 @@ First-class [NestJS](https://nestjs.com) integration for
 [ADR 0006](../../docs/adr/0006-nestjs-integration.md).
 
 It is a **thin** package: `StitchModule` wires StitchAPI's `seam` into Nest's DI
-graph, plus two bridge helpers and a `Logger` sink. It adds **no capability** — every
-piece sits on an existing core extension point, so `stitchapi` stays a peer dependency
-and core is untouched (contract-not-dependency).
+graph, plus bridge helpers (a `Logger` sink, `ConfigService` secrets), an exception
+filter, and an SSE bridge. It adds **no capability** — every piece sits on an existing
+core extension point, so `stitchapi` stays a peer dependency and core is untouched
+(contract-not-dependency).
 
 ```sh
 pnpm add @stitchapi/nest stitchapi
-# peers you already have in a Nest app: @nestjs/common, reflect-metadata
+# peers you already have in a Nest app: @nestjs/common, @nestjs/core, rxjs, reflect-metadata
 ```
 
 > [!IMPORTANT]
@@ -49,13 +50,15 @@ export class AppModule {}
 
 ## Injectable stitches — `forFeature` + `defineStitch`
 
-Declare stitches with `defineStitch(token, build)`; register them per feature module.
-A feature module may also own its **own upstream seam** (its `baseUrl`/`auth`), built
-over the shared store + trace — omit `seam` to attach the stitches to the default seam.
+Declare stitches with `defineStitch(build)` — the injection **token is optional** (a
+unique `Symbol` is generated; pass `defineStitch(token, build)` only when you need a
+stable, well-known token). Register them per feature module, which may also own its
+**own upstream seam** (its `baseUrl`/`auth`), built over the shared store + trace — omit
+`seam` to attach the stitches to the default seam.
 
 ```ts
 // users.stitches.ts
-export const GetUser = defineStitch('GET_USER', (s) =>
+export const GetUser = defineStitch((s) =>
     s.stitch({ name: 'getUser', path: '/users/{id}', output: UserSchema }),
 );
 
@@ -85,32 +88,78 @@ export class UsersService {
 }
 ```
 
-## Multi-tenant — `seam.as(principal)` in request scope
+## Multi-tenant — `forFeatureScoped` (principal in request scope)
 
 Multi-tenancy is **principal-scoped over the shared store** (separate sessions/tokens
-per tenant, one connection pool) — never a per-request store. Bind the principal from
-the request:
+per tenant, one connection pool) — never a per-request store. `forFeatureScoped` wires
+the request-scoped `seam.as(principal)` handle and the request-scoped stitches for you:
 
 ```ts
-{
-    provide: TENANT_SEAM,
-    scope: Scope.REQUEST,
-    useFactory: (root: Seam, req) => root.as(req.user?.tenantId ?? 'anonymous'),
-    inject: [STITCH_SEAM, REQUEST],
-}
+@Module({
+    imports: [
+        StitchModule.forFeatureScoped({
+            seam: {
+                baseUrl: 'https://api.example.com',
+                auth: bearer(env('TOKEN')),
+            },
+            stitches: [GetUser],
+            principal: (req) => req.user?.tenantId ?? 'anonymous',
+        }),
+    ],
+})
+export class UsersModule {}
 ```
 
-Outside HTTP (BullMQ, `@Cron`, microservices) there is no `REQUEST`: inject the seam and
-bind explicitly — `seam.as(job.data.tenantId)`.
+Each request resolves `GetUser` from `seam.as(tenantId)`. Note a request-scoped provider
+makes its consumers request-scoped too (a per-request instantiation cost).
+
+Outside HTTP (BullMQ, `@Cron`, microservices) there is no `REQUEST`: inject the singleton
+seam and bind explicitly — `seam.as(job.data.tenantId)`.
 
 ## Bridges
 
--   **`loggerSink(logger?)`** — a `TraceSink` that forwards the event stream to a Nest
-    `Logger`. It logs only name/method/url/status and strips the URL query: a custom sink
-    receives **un-redacted** events, so never log `event.input`/headers raw.
+-   **`loggerSink(logger?, { lifecycle? })`** — a `TraceSink` that forwards the event
+    stream to a Nest `Logger`, by level: `error` → `error`; `drift` → `error`/`warn`/`debug`
+    by the finding's level; a `retry`/`circuit` `progress` → `warn`; `start`/`result`/`done`
+    → `debug`/`verbose` (the happy path, hidden at Nest's default level — `lifecycle: false`
+    drops them). It logs **only metadata** and strips the URL query, so it is safe on a
+    secret-bearing seam: a custom sink receives **un-redacted** events, so never log
+    `event.input`/headers or a `delta` chunk raw.
 -   **`fromConfig(config)(key)`** — a `ConfigService`-backed secret thunk (core's `env()`
     twin). Synchronous, so it cannot fetch a rotating secret per call — use
     `oauth2`/`cookieSession` for that.
+
+## Errors → HTTP — `StitchExceptionFilter`
+
+A failed stitch throws a `StitchError` (a branded `Error` carrying the upstream `status`).
+Register `StitchExceptionFilter` globally to turn it into an `HttpException` — **`502 Bad
+Gateway` by default** (every upstream failure is a gateway error; it never leaks an
+upstream's `401`/`404` to your client), so controllers calling stitches need no try/catch:
+
+```ts
+// main.ts — needs the HTTP adapter, like any BaseExceptionFilter subclass:
+app.useGlobalFilters(new StitchExceptionFilter(app.getHttpAdapter()));
+// configure the status (e.g. propagate the upstream status instead of 502):
+//   new StitchExceptionFilter(app.getHttpAdapter(), { status: (e) => e.status ?? 502 })
+// …or as a provider: { provide: APP_FILTER, useClass: StitchExceptionFilter }
+```
+
+`status` takes a fixed number or a `(err) => number` function. Outside a filter, use
+`toHttpException(err, { status })` / `isStitchError(err)` directly.
+
+## Streaming → SSE — `stitchSse`
+
+Return a stitch's `stream()` from a Nest `@Sse()` endpoint: `delta` chunks become messages,
+an `error` event errors the stream, and a client disconnect aborts the upstream generator.
+
+```ts
+@Sse('chat')
+chat(@Query('q') q: string) {
+    return stitchSse(this.complete.stream({ body: { prompt: q } }), {
+        data: (c: any) => c.text, // map a delta chunk → message data
+    });
+}
+```
 
 ## Testing
 

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@stitchapi/nest",
     "version": "0.0.0",
-    "description": "First-class NestJS integration for StitchAPI — StitchModule.forRoot/forFeature, injectable stitches, Logger + ConfigService bridges (ADR 0006).",
+    "description": "First-class NestJS integration for StitchAPI — StitchModule.forRoot/forFeature/forFeatureScoped, injectable stitches, Logger + ConfigService bridges, an exception filter and an SSE bridge (ADR 0006).",
     "main": "lib/index.js",
     "module": "lib/index.mjs",
     "types": "lib/index.d.ts",
@@ -45,10 +45,13 @@
     "homepage": "https://stitchapi.dev",
     "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "rxjs": "^7.8.1",
         "stitchapi": ">=0.7.0"
     },
     "devDependencies": {
         "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0",
         "@types/node": "^22.10.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",

--- a/packages/nest/src/bridges.ts
+++ b/packages/nest/src/bridges.ts
@@ -5,44 +5,105 @@ import { Logger } from '@nestjs/common';
 import type { StitchEvent, StitchStore, TraceSink } from 'stitchapi';
 
 /**
- * A {@link TraceSink} that forwards the stitch event stream to a Nest {@link Logger}.
+ * The minimal logger surface this sink calls — declared structurally so Nest's
+ * `Logger` satisfies it and a plain `{ log, warn, error, debug, verbose }` test
+ * double works too. `debug`/`verbose` are optional and guarded at the call site,
+ * so a partial logger (or one whose level hides them) is fine.
+ */
+export interface LoggerLike {
+    log(message: string): void;
+    warn(message: string): void;
+    error(message: string): void;
+    debug?(message: string): void;
+    verbose?(message: string): void;
+}
+
+/** Options for {@link loggerSink}. */
+export interface NestLoggerSinkOptions {
+    /**
+     * Emit the happy-path lifecycle events: `start` → `debug`, `result` → `verbose`,
+     * `done` → `debug`. Default `true`. They sit at `debug`/`verbose` precisely so
+     * Nest's default log level hides them in production — raise the level to see them,
+     * or set `false` to drop them and log only retries, drift findings, and errors.
+     */
+    lifecycle?: boolean;
+}
+
+/**
+ * A {@link TraceSink} that forwards the stitch event stream to a Nest {@link Logger}
+ * (or any {@link LoggerLike}), mapping each {@link StitchEvent} to a log level:
+ *
+ * - `error` → `error`
+ * - `drift` → `error` / `warn` / `debug`, following the finding's `level`
+ * - `progress` → `warn` when the phase is `retry` or `circuit` (the upstream is flaky
+ *   or the breaker tripped), else `debug` (routine throttle / paginate / cache waits)
+ * - `start` → `debug`, `result` → `verbose`, `done` → `debug` (only when `lifecycle`)
+ * - `delta` → dropped (per-chunk streaming output — it is raw response data)
  *
  * SECURITY: a custom sink receives the **raw** event (core only redacts inside its own
- * built-in sinks), so `event.input.headers` still holds `authorization`/`cookie`. This
- * sink therefore logs only name/method/url/status — never `JSON.stringify(event)` — and
- * strips the URL query (it can carry secrets like `?api_key=`).
+ * built-in sinks), so a `start` event's `input.headers` still holds `authorization` /
+ * `cookie` and a `delta`'s `chunk` is raw response data. This sink therefore logs
+ * **only metadata** — name, method, redacted URL, status, attempt counts, drift
+ * path/level, timing — never `event.input`, `event.value`, a `delta` chunk, or
+ * `JSON.stringify(event)`, and it strips the URL query (it can carry `?api_key=…`).
+ * That keeps it safe on a secret-bearing seam independent of core's trace redaction.
  */
-export function loggerSink(logger: Logger = new Logger('Stitch')): TraceSink {
+export function loggerSink(
+    logger: LoggerLike = new Logger('Stitch'),
+    options: NestLoggerSinkOptions = {},
+): TraceSink {
+    const lifecycle = options.lifecycle ?? true;
     return {
         handle(event: StitchEvent, ctx: { name: string }): void {
             const name = ctx.name;
             switch (event.type) {
                 case 'start':
-                    logger.log(
-                        `→ ${name} ${event.method} ${redactUrl(event.url)}`,
-                    );
-                    break;
+                    if (lifecycle)
+                        logger.debug?.(
+                            `→ ${name} ${event.method} ${redactUrl(event.url)}`,
+                        );
+                    return;
+                case 'progress': {
+                    const line = `· ${name} ${event.phase}#${event.attempt}${
+                        event.waitedMs !== undefined
+                            ? ` waited ${event.waitedMs}ms`
+                            : ''
+                    }`;
+                    // A retry or a tripped circuit means the upstream is misbehaving —
+                    // surface it at warn; throttle/paginate/cache waits are routine.
+                    if (event.phase === 'retry' || event.phase === 'circuit')
+                        logger.warn(line);
+                    else logger.debug?.(line);
+                    return;
+                }
+                case 'drift': {
+                    const f = event.finding;
+                    const line = `drift ${name} ${f.path} ${f.change}${f.detail ? ` (${f.detail})` : ''}`;
+                    if (f.level === 'error') logger.error(line);
+                    else if (f.level === 'warn') logger.warn(line);
+                    else logger.debug?.(line);
+                    return;
+                }
                 case 'result':
-                    logger.log(
-                        `← ${name} ${event.status} (${event.attempts} attempt(s))`,
-                    );
-                    break;
+                    if (lifecycle)
+                        logger.verbose?.(
+                            `← ${name} ${event.status} (${event.attempts} attempt(s))`,
+                        );
+                    return;
                 case 'error':
                     logger.error(
-                        `✗ ${name} ${event.message}${event.status != null ? ` ${event.status}` : ''}`,
+                        `✗ ${name} ${event.message}${event.status != null ? ` ${event.status}` : ''} (${event.attempts} attempt(s))`,
                     );
-                    break;
-                case 'drift':
-                    logger.warn(
-                        `drift ${name} ${event.finding.path} ${event.finding.change}`,
-                    );
-                    break;
-                case 'progress':
-                    logger.debug(`· ${name} ${event.phase}#${event.attempt}`);
-                    break;
+                    return;
+                case 'done':
+                    if (lifecycle)
+                        logger.debug?.(
+                            `${name} done ${event.ok ? 'ok' : 'failed'} in ${event.ms}ms (${event.attempts} attempt(s))`,
+                        );
+                    return;
                 default:
-                    // 'delta' / 'done': too chatty for a logger — dropped.
-                    break;
+                    // 'delta' — per-chunk streaming output; never logged (raw data).
+                    return;
             }
         },
     };

--- a/packages/nest/src/define-stitch.ts
+++ b/packages/nest/src/define-stitch.ts
@@ -27,14 +27,35 @@ export interface StitchDef<TOut = unknown, TIn = StitchInput> {
 export type AnyStitchDef = StitchDef<unknown, never>;
 
 /**
- * Declare an injectable stitch: an injection token plus a builder that receives the
- * seam (root or principal-bound) the registering module hands it. Prefer a `Symbol`
- * token to avoid string collisions across feature modules.
+ * Declare an injectable stitch: a builder that receives the seam (root or
+ * principal-bound) the registering module hands it. The injection **token is
+ * optional** — omit it and a unique `Symbol` is generated, since you reference the
+ * stitch by its definition object everywhere anyway (`forFeature({ stitches: [GetUser] })`,
+ * `@InjectStitch(GetUser)`, `overrideProvider(GetUser.token)`). Pass an explicit
+ * `InjectionToken` first only when you need a stable, well-known token (e.g. to
+ * override it from a module that does not import the def).
+ *
+ * ```ts
+ * export const GetUser = defineStitch((s) => s.stitch({ path: '/users/{id}' }));
+ * export const GetUser = defineStitch('GET_USER', (s) => s.stitch({ path: '/users/{id}' }));
+ * ```
  */
+export function defineStitch<TOut = unknown, TIn = StitchInput>(
+    build: (host: StitchHost) => Stitch<TOut, TIn>,
+): StitchDef<TOut, TIn>;
 export function defineStitch<TOut = unknown, TIn = StitchInput>(
     token: InjectionToken,
     build: (host: StitchHost) => Stitch<TOut, TIn>,
+): StitchDef<TOut, TIn>;
+export function defineStitch<TOut = unknown, TIn = StitchInput>(
+    a: InjectionToken | ((host: StitchHost) => Stitch<TOut, TIn>),
+    b?: (host: StitchHost) => Stitch<TOut, TIn>,
 ): StitchDef<TOut, TIn> {
+    // Disambiguate on whether a second arg was passed — NOT `typeof a`, because an
+    // InjectionToken can itself be a function (a class token), which would misread as
+    // the builder. Two args → (token, build); one arg → (build) with a generated token.
+    const build = (b ?? a) as (host: StitchHost) => Stitch<TOut, TIn>;
+    const token: InjectionToken = b ? (a as InjectionToken) : Symbol('stitch');
     return { token, build };
 }
 

--- a/packages/nest/src/exception-filter.ts
+++ b/packages/nest/src/exception-filter.ts
@@ -1,0 +1,79 @@
+// StitchError → Nest HttpException (ADR 0006 Decision 10 follow-up). A failed stitch
+// throws a plain `Error` branded `name === 'StitchError'` carrying the upstream `status`
+// (packages/core/src/stitch.ts). This bridges it to Nest's HTTP layer so a controller
+// calling a stitch needs no per-handler try/catch and no hand-rolled @Catch filter.
+import {
+    type ArgumentsHost,
+    Catch,
+    HttpException,
+    type HttpServer,
+    HttpStatus,
+} from '@nestjs/common';
+import { BaseExceptionFilter } from '@nestjs/core';
+
+/** The error a stitch throws on failure: a branded `Error` with the upstream status. */
+export type StitchError = Error & { status?: number };
+
+/** True when `err` is the error a stitch throws on failure (`name === 'StitchError'`). */
+export function isStitchError(err: unknown): err is StitchError {
+    return err instanceof Error && err.name === 'StitchError';
+}
+
+export interface ToHttpExceptionOptions {
+    /**
+     * The HTTP status for the mapped exception. Default `502 Bad Gateway` — **every**
+     * upstream failure is reported as a gateway error, regardless of the upstream's own
+     * status. This is the safe default: it never leaks an upstream's `401`/`404`/etc.
+     * semantics to your client. Override per call — a fixed number, or a function for
+     * full control: propagate the upstream status with `(e) => e.status ?? 502`, or remap
+     * specific codes (`(e) => (e.status === 429 ? 429 : 502)`).
+     */
+    status?: number | ((err: StitchError) => number);
+}
+
+/**
+ * Map a thrown stitch failure to a Nest {@link HttpException}, or `undefined` when `err`
+ * is not a {@link StitchError} (so a caller can rethrow it untouched). The status is
+ * `502` by default; override it via {@link ToHttpExceptionOptions.status}.
+ */
+export function toHttpException(
+    err: unknown,
+    options: ToHttpExceptionOptions = {},
+): HttpException | undefined {
+    if (!isStitchError(err)) return undefined;
+    const { status = HttpStatus.BAD_GATEWAY } = options;
+    const code = typeof status === 'function' ? status(err) : status;
+    return new HttpException(err.message || 'Upstream request failed', code);
+}
+
+/**
+ * A global exception filter that converts a {@link StitchError} into an
+ * {@link HttpException} (via {@link toHttpException} — `502` by default) and lets Nest
+ * render it; every other exception is delegated to Nest's default handling, unchanged.
+ * Register it globally so controllers calling stitches need no try/catch:
+ *
+ * ```ts
+ * // main.ts — like any BaseExceptionFilter subclass, it needs the HTTP adapter:
+ * app.useGlobalFilters(new StitchExceptionFilter(app.getHttpAdapter()));
+ * // configure the status (e.g. propagate the upstream status instead of 502):
+ * //   new StitchExceptionFilter(app.getHttpAdapter(), { status: (e) => e.status ?? 502 })
+ * // …or as a provider (the adapter is resolved for you):
+ * //   { provide: APP_FILTER, useClass: StitchExceptionFilter }
+ * ```
+ */
+@Catch()
+export class StitchExceptionFilter extends BaseExceptionFilter {
+    constructor(
+        applicationRef?: HttpServer,
+        private readonly options: ToHttpExceptionOptions = {},
+    ) {
+        super(applicationRef);
+    }
+
+    override catch(exception: unknown, host: ArgumentsHost): void {
+        super.catch(
+            toHttpException(exception, this.options) ?? exception,
+            host,
+        );
+    }
+}

--- a/packages/nest/src/index.ts
+++ b/packages/nest/src/index.ts
@@ -4,6 +4,7 @@ export {
     type StitchModuleOptions,
     type StitchModuleAsyncOptions,
     type StitchFeatureOptions,
+    type StitchScopedFeatureOptions,
 } from './module';
 export {
     defineStitch,
@@ -18,5 +19,15 @@ export {
     fromConfig,
     borrowStore,
     type ConfigServiceLike,
+    type LoggerLike,
+    type NestLoggerSinkOptions,
 } from './bridges';
 export { STITCH_SEAM, STITCH_STORE, STITCH_TRACE } from './tokens';
+export {
+    StitchExceptionFilter,
+    toHttpException,
+    isStitchError,
+    type StitchError,
+    type ToHttpExceptionOptions,
+} from './exception-filter';
+export { stitchSse, type MessageEventLike, type StitchSseOptions } from './sse';

--- a/packages/nest/src/module.ts
+++ b/packages/nest/src/module.ts
@@ -15,7 +15,9 @@ import {
     Module,
     type OnApplicationShutdown,
     type Provider,
+    Scope,
 } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
 import {
     type Seam,
     type SeamConfig,
@@ -55,6 +57,14 @@ export interface StitchFeatureOptions {
     seam?: SeamConfig;
     /** Token to expose the feature seam under, for `.as(principal)` multi-tenant. */
     seamToken?: InjectionToken;
+}
+
+/** forFeatureScoped options — {@link StitchFeatureOptions} plus a `principal` derived
+ *  from the request, so each tenant gets its own session/token over the shared store. */
+export interface StitchScopedFeatureOptions extends StitchFeatureOptions {
+    // Derive the principal id (e.g. a tenant) from the incoming request. `any` because the
+    // request type is platform-specific (express/fastify) — the caller narrows it.
+    principal: (req: any) => string;
 }
 
 interface Infra {
@@ -198,6 +208,63 @@ export class StitchModule {
                 provide: d.token,
                 useFactory: (host: StitchHost) => d.build(host),
                 inject: [token],
+            });
+            exported.push(d.token);
+        }
+        return { module: StitchModule, providers, exports: exported };
+    }
+
+    /**
+     * Like {@link forFeature}, but **request-scoped per principal**: each request gets a
+     * `seam.as(principal(req))` handle — a separate session/token over the *shared* store
+     * and throttle (never a per-request store; ADR 0006 Decision 5) — and the stitches are
+     * built from it. Packages the request-scoped wiring the README otherwise hand-rolls.
+     *
+     * Caveats inherent to request scope (not this helper): a request-scoped provider makes
+     * its consumers request-scoped too (per-request instantiation cost); and `REQUEST` only
+     * exists at the HTTP edge — in a BullMQ processor / `@Cron` / microservice, inject the
+     * singleton seam and bind explicitly instead: `seam.as(job.data.tenantId)`.
+     */
+    static forFeatureScoped(opts: StitchScopedFeatureOptions): DynamicModule {
+        const cfg = opts.seam;
+        // The singleton base seam each per-request handle derives from: a feature seam over
+        // shared infra (if `seam` given) or the root/default seam.
+        const baseToken: InjectionToken = cfg
+            ? Symbol('stitch-scoped-base-seam')
+            : STITCH_SEAM;
+        const principalToken: InjectionToken =
+            opts.seamToken ?? Symbol('stitch-principal-seam');
+        const providers: Provider[] = [];
+        const exported: InjectionToken[] = [principalToken];
+
+        if (cfg) {
+            providers.push({
+                provide: baseToken,
+                useFactory: (
+                    store: StitchStore,
+                    trace: TraceSink | 'console' | false,
+                    reg: SeamRegistry,
+                ): Seam => reg.track(seam({ ...cfg, store, trace })),
+                inject: [STITCH_STORE, STITCH_TRACE, SeamRegistry],
+            });
+        }
+
+        // The per-request principal handle. `seam.as()` is lifecycle-free (it shares the
+        // base seam's runtime), so it is intentionally NOT tracked in SeamRegistry.
+        providers.push({
+            provide: principalToken,
+            scope: Scope.REQUEST,
+            useFactory: (base: Seam, req: any): StitchHost =>
+                base.as(opts.principal(req)),
+            inject: [baseToken, REQUEST],
+        });
+
+        for (const d of opts.stitches) {
+            providers.push({
+                provide: d.token,
+                scope: Scope.REQUEST,
+                useFactory: (host: StitchHost) => d.build(host),
+                inject: [principalToken],
             });
             exported.push(d.token);
         }

--- a/packages/nest/src/sse.ts
+++ b/packages/nest/src/sse.ts
@@ -1,0 +1,79 @@
+// stitch.stream() → Nest @Sse() (ADR 0006 Decision 10 follow-up). A stitch's `stream()`
+// is an AsyncGenerator<StitchEvent>; Nest's @Sse() wants an Observable<MessageEvent>.
+// This bridges the two so a streaming endpoint is one line, and aborts the upstream
+// generator when the client disconnects (the subscription tears down).
+import { Observable } from 'rxjs';
+import type { StitchEvent } from 'stitchapi';
+
+/**
+ * The SSE message shape Nest's `@Sse()` consumes — declared structurally so this
+ * package does not import Nest's `MessageEvent` type (one less coupling); Nest's
+ * `MessageEvent` satisfies it. `data` is the only field the bridge sets.
+ */
+export interface MessageEventLike {
+    data: string | object;
+    id?: string;
+    type?: string;
+    retry?: number;
+}
+
+export interface StitchSseOptions {
+    /**
+     * Map a `delta` chunk to the SSE message `data`. Default: the chunk itself (a
+     * string is sent as-is; an object is JSON-serialised by Nest). Use this to pull
+     * the text out of a structured chunk, e.g. `data: (c) => c.choices[0].delta`.
+     */
+    data?: (chunk: unknown) => string | object;
+}
+
+/**
+ * Adapt a stitch's `stream()` (or any `AsyncIterable<StitchEvent>`) into an
+ * `Observable<MessageEventLike>` for an `@Sse()` endpoint: each `delta` becomes a
+ * message, an `error` event errors the observable, and stream end completes it. The
+ * non-output events (`start` / `progress` / `drift` / `result` / `done`) are control
+ * signals and are not forwarded to the client.
+ *
+ * ```ts
+ * @Sse('chat')
+ * chat(@Query('q') q: string) {
+ *   return stitchSse(this.complete.stream({ body: { prompt: q } }),
+ *                    { data: (c: any) => c.text });
+ * }
+ * ```
+ *
+ * When the client disconnects, Nest unsubscribes; the teardown calls the iterator's
+ * `return()` so the underlying stitch stream is aborted rather than left running.
+ */
+export function stitchSse<T>(
+    stream: AsyncIterable<StitchEvent<T>>,
+    options: StitchSseOptions = {},
+): Observable<MessageEventLike> {
+    const toData =
+        options.data ?? ((chunk: unknown) => chunk as string | object);
+    return new Observable<MessageEventLike>((subscriber) => {
+        const iterator = stream[Symbol.asyncIterator]();
+        let active = true;
+        void (async () => {
+            try {
+                while (active) {
+                    const { value: event, done } = await iterator.next();
+                    if (done) break;
+                    if (event.type === 'delta') {
+                        subscriber.next({ data: toData(event.chunk) });
+                    } else if (event.type === 'error') {
+                        subscriber.error(new Error(event.message));
+                        return;
+                    }
+                }
+                subscriber.complete();
+            } catch (err) {
+                subscriber.error(err);
+            }
+        })();
+        // Teardown on unsubscribe (client disconnect): stop consuming and abort upstream.
+        return () => {
+            active = false;
+            void iterator.return?.(undefined);
+        };
+    });
+}

--- a/packages/nest/test/exception-filter.spec.ts
+++ b/packages/nest/test/exception-filter.spec.ts
@@ -1,0 +1,110 @@
+import {
+    type StitchError,
+    StitchExceptionFilter,
+    isStitchError,
+    toHttpException,
+} from '../src';
+
+import { type ArgumentsHost, HttpException } from '@nestjs/common';
+import { BaseExceptionFilter } from '@nestjs/core';
+import { describe, expect, it } from 'vitest';
+
+// Mirror what core throws on a failed call (packages/core/src/stitch.ts).
+const stitchError = (message: string, status?: number): Error => {
+    const e = new Error(message) as Error & { status?: number };
+    e.name = 'StitchError';
+    if (status !== undefined) e.status = status;
+    return e;
+};
+
+describe('isStitchError', () => {
+    it('recognises the branded error and rejects everything else', () => {
+        expect(isStitchError(stitchError('x', 500))).toBe(true);
+        expect(isStitchError(new Error('plain'))).toBe(false);
+        expect(isStitchError('nope')).toBe(false);
+        expect(isStitchError(undefined)).toBe(false);
+    });
+});
+
+describe('toHttpException', () => {
+    it('maps every upstream failure to 502 by default, ignoring the upstream status', () => {
+        const ex = toHttpException(stitchError('rate limited', 429));
+        expect(ex).toBeInstanceOf(HttpException);
+        expect(ex!.getStatus()).toBe(502);
+        expect(ex!.message).toContain('rate limited'); // message preserved
+        // a network error / timeout (no upstream status) → 502 too
+        expect(toHttpException(stitchError('ECONNRESET'))!.getStatus()).toBe(
+            502,
+        );
+    });
+
+    it('accepts a fixed status override', () => {
+        expect(
+            toHttpException(stitchError('boom', 500), {
+                status: 503,
+            })!.getStatus(),
+        ).toBe(503);
+    });
+
+    it('accepts a status function for custom mapping (e.g. propagate the upstream status)', () => {
+        const status = (e: StitchError) => e.status ?? 502;
+        expect(
+            toHttpException(stitchError('rate limited', 429), {
+                status,
+            })!.getStatus(),
+        ).toBe(429);
+        expect(
+            toHttpException(stitchError('timeout'), { status })!.getStatus(),
+        ).toBe(502);
+    });
+
+    it('returns undefined for a non-stitch error (so the caller can rethrow)', () => {
+        expect(toHttpException(new Error('other'))).toBeUndefined();
+    });
+});
+
+describe('StitchExceptionFilter', () => {
+    // Run a filter against a patched base `catch` (what `super.catch` resolves to at call
+    // time) and capture what it delegates — asserts the mapping without a real adapter.
+    const captureDelegated = (
+        filter: StitchExceptionFilter,
+        ...errs: unknown[]
+    ): unknown[] => {
+        const seen: unknown[] = [];
+        const baseProto = BaseExceptionFilter.prototype as {
+            catch: (e: unknown, h: ArgumentsHost) => void;
+        };
+        const orig = baseProto.catch;
+        baseProto.catch = function (e: unknown): void {
+            seen.push(e);
+        };
+        try {
+            for (const e of errs) filter.catch(e, {} as ArgumentsHost);
+        } finally {
+            baseProto.catch = orig;
+        }
+        return seen;
+    };
+
+    it('maps a StitchError to a 502 HttpException by default; passes others through', () => {
+        const other = new Error('other');
+        const seen = captureDelegated(
+            new StitchExceptionFilter(),
+            stitchError('boom', 503),
+            other,
+        );
+        expect(seen[0]).toBeInstanceOf(HttpException);
+        expect((seen[0] as HttpException).getStatus()).toBe(502); // not the upstream 503
+        expect(seen[1]).toBe(other); // untouched passthrough
+    });
+
+    it('forwards status options to the mapper', () => {
+        const seen = captureDelegated(
+            new StitchExceptionFilter(undefined, {
+                status: (e) => e.status ?? 502,
+            }),
+            stitchError('boom', 503),
+        );
+        expect((seen[0] as HttpException).getStatus()).toBe(503); // propagated via options
+    });
+});

--- a/packages/nest/test/module.spec.ts
+++ b/packages/nest/test/module.spec.ts
@@ -3,6 +3,7 @@
 // adapter, asserting wire-level effects — the same style as core's tests.
 import {
     type ConfigServiceLike,
+    type LoggerLike,
     STITCH_SEAM,
     STITCH_STORE,
     STITCH_TRACE,
@@ -14,7 +15,8 @@ import {
     loggerSink,
 } from '../src';
 
-import { Logger } from '@nestjs/common';
+import { Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
 import type { Adapter, Seam, StitchStore } from 'stitchapi';
 import { memoryStore } from 'stitchapi';
 import { describe, expect, it } from 'vitest';
@@ -25,6 +27,7 @@ type FProv = {
     useFactory?: (...args: any[]) => unknown;
     useValue?: unknown;
     inject?: unknown[];
+    scope?: unknown;
 };
 
 const recordingAdapter = (sink: string[]): Adapter => {
@@ -160,6 +163,106 @@ describe('StitchModule.forFeature', () => {
     });
 });
 
+describe('StitchModule.forFeatureScoped', () => {
+    it('wires a request-scoped principal seam + request-scoped stitches over shared infra', async () => {
+        const calls: string[] = [];
+        const TENANT = Symbol('tenant');
+        const GetThing = defineStitch((h) => h.stitch({ path: '/thing' }));
+        const mod = StitchModule.forFeatureScoped({
+            seam: {
+                baseUrl: 'https://feat.test',
+                adapter: recordingAdapter(calls),
+            },
+            stitches: [GetThing],
+            seamToken: TENANT,
+            principal: (req: { tenantId: string }) => req.tenantId,
+        });
+        const providers = mod.providers as FProv[];
+
+        const principalProv = providers.find((p) => p.provide === TENANT)!;
+        const stitchProv = providers.find((p) => p.provide === GetThing.token)!;
+        const baseProv = providers.find(
+            (p) => p.provide !== TENANT && p.provide !== GetThing.token,
+        )!;
+
+        // principal + stitch are REQUEST-scoped; principal injects the base seam + REQUEST
+        expect(principalProv.scope).toBe(Scope.REQUEST);
+        expect(stitchProv.scope).toBe(Scope.REQUEST);
+        expect(principalProv.inject).toEqual([baseProv.provide, REQUEST]);
+        expect(stitchProv.inject).toEqual([TENANT]);
+
+        // resolve the chain against the mock adapter, like the forFeature tests
+        const reg = new SeamRegistry();
+        const baseSeam = baseProv.useFactory!(
+            memoryStore(),
+            false,
+            reg,
+        ) as Seam;
+        const principalSeam = principalProv.useFactory!(baseSeam, {
+            tenantId: 't1',
+        }) as Seam;
+        const stitch = stitchProv.useFactory!(principalSeam) as ReturnType<
+            typeof GetThing.build
+        >;
+        await stitch();
+        expect(calls).toEqual(['GET https://feat.test/thing']);
+    });
+
+    it('binds scoped stitches to the root seam when no feature seam is given', () => {
+        const GetThing = defineStitch((h) => h.stitch({ path: '/thing' }));
+        const providers = StitchModule.forFeatureScoped({
+            stitches: [GetThing],
+            principal: () => 't1',
+        }).providers as FProv[];
+        const principalProv = providers.find(
+            (p) => p.provide !== GetThing.token,
+        )!;
+        // no base feature-seam provider; the principal handle derives from STITCH_SEAM
+        expect(principalProv.inject).toEqual([STITCH_SEAM, REQUEST]);
+    });
+});
+
+describe('defineStitch token', () => {
+    it('generates a unique Symbol token when none is given', () => {
+        const A = defineStitch((h) => h.stitch({ path: '/a' }));
+        const B = defineStitch((h) => h.stitch({ path: '/b' }));
+        expect(typeof A.token).toBe('symbol');
+        expect(A.token).not.toBe(B.token);
+    });
+
+    it('still accepts an explicit (token, build) form', () => {
+        const A = defineStitch('GET_A', (h) => h.stitch({ path: '/a' }));
+        expect(A.token).toBe('GET_A');
+    });
+
+    it('an auto-tokened def wires through forFeature', async () => {
+        const calls: string[] = [];
+        const GetThing = defineStitch((h) => h.stitch({ path: '/thing' }));
+        const providers = StitchModule.forFeature({
+            seam: {
+                baseUrl: 'https://feat.test',
+                adapter: recordingAdapter(calls),
+            },
+            stitches: [GetThing],
+        }).providers as FProv[];
+        const stitchProv = providers.find((p) => p.provide === GetThing.token);
+        const seamProv = providers.find((p) => p.provide !== GetThing.token);
+        expect(stitchProv).toBeDefined();
+
+        const reg = new SeamRegistry();
+        const featSeam = seamProv!.useFactory!(
+            memoryStore(),
+            false,
+            reg,
+        ) as Seam;
+        const stitch = stitchProv!.useFactory!(featSeam) as ReturnType<
+            typeof GetThing.build
+        >;
+        await stitch();
+        expect(calls).toEqual(['GET https://feat.test/thing']);
+    });
+});
+
 describe('bridges', () => {
     it('borrowStore delegates get/set/incr but omits close', async () => {
         const calls: string[] = [];
@@ -187,26 +290,92 @@ describe('bridges', () => {
         expect(calls).toEqual(['get', 'set', 'incr']); // close is never delegated
     });
 
-    it('loggerSink logs lifecycle lines and redacts the URL query', () => {
-        const logs: string[] = [];
-        const errs: string[] = [];
-        const fake = {
-            log: (m: string) => logs.push(m),
-            error: (m: string) => errs.push(m),
-            warn: () => {},
-            debug: () => {},
-        } as unknown as Logger;
-        const sink = loggerSink(fake);
+    // A LoggerLike that records messages per level.
+    const recordingLogger = () => {
+        const rec = {
+            log: [] as string[],
+            warn: [] as string[],
+            error: [] as string[],
+            debug: [] as string[],
+            verbose: [] as string[],
+        };
+        const logger: LoggerLike = {
+            log: (m) => rec.log.push(m),
+            warn: (m) => rec.warn.push(m),
+            error: (m) => rec.error.push(m),
+            debug: (m) => rec.debug.push(m),
+            verbose: (m) => rec.verbose.push(m),
+        };
+        return { rec, logger };
+    };
+
+    it('loggerSink maps each event to the right level, payload-free, query redacted', () => {
+        const { rec, logger } = recordingLogger();
+        const sink = loggerSink(logger);
+        const ctx = { name: 'x' };
+
         sink.handle(
             {
                 type: 'start',
                 name: 'x',
                 method: 'GET',
                 url: 'https://h/p?token=secret',
-                input: {},
+                input: { headers: { authorization: 'Bearer s3cret' } },
                 at: 0,
             },
-            { name: 'x' },
+            ctx,
+        );
+        sink.handle(
+            {
+                type: 'progress',
+                phase: 'retry',
+                attempt: 2,
+                waitedMs: 100,
+                at: 0,
+            },
+            ctx,
+        );
+        sink.handle(
+            { type: 'progress', phase: 'throttled', attempt: 1, at: 0 },
+            ctx,
+        );
+        sink.handle(
+            {
+                type: 'drift',
+                finding: { level: 'error', path: 'a.b', change: 'missing' },
+                at: 0,
+            },
+            ctx,
+        );
+        sink.handle(
+            {
+                type: 'drift',
+                finding: { level: 'warn', path: 'a.c', change: 'type-changed' },
+                at: 0,
+            },
+            ctx,
+        );
+        sink.handle(
+            {
+                type: 'drift',
+                finding: { level: 'info', path: 'a.d', change: 'new' },
+                at: 0,
+            },
+            ctx,
+        );
+        sink.handle(
+            {
+                type: 'result',
+                value: { secretField: 'nope' },
+                status: 200,
+                attempts: 1,
+                at: 0,
+            },
+            ctx,
+        );
+        sink.handle(
+            { type: 'done', ok: true, ms: 12, attempts: 1, at: 0 },
+            ctx,
         );
         sink.handle(
             {
@@ -214,14 +383,110 @@ describe('bridges', () => {
                 name: 'x',
                 message: 'boom',
                 status: 500,
-                attempts: 1,
+                attempts: 3,
                 at: 0,
             },
+            ctx,
+        );
+        sink.handle({ type: 'delta', chunk: { secret: 'data' }, at: 0 }, ctx);
+
+        // start → debug, query stripped
+        expect(rec.debug.some((l) => l.includes('GET https://h/p?…'))).toBe(
+            true,
+        );
+        // retry → warn (surfaced); routine throttle → debug
+        expect(
+            rec.warn.some(
+                (l) => l.includes('retry#2') && l.includes('waited 100ms'),
+            ),
+        ).toBe(true);
+        expect(rec.debug.some((l) => l.includes('throttled#1'))).toBe(true);
+        // drift routed by finding.level
+        expect(rec.error.some((l) => l.includes('a.b'))).toBe(true);
+        expect(rec.warn.some((l) => l.includes('a.c'))).toBe(true);
+        expect(rec.debug.some((l) => l.includes('a.d'))).toBe(true);
+        // lifecycle: result → verbose, done → debug
+        expect(rec.verbose.some((l) => l.includes('200'))).toBe(true);
+        expect(rec.debug.some((l) => l.includes('done ok in 12ms'))).toBe(true);
+        // error always at error level, with status + attempts
+        expect(
+            rec.error.some((l) => l.includes('boom') && l.includes('500')),
+        ).toBe(true);
+        // nothing at info level (start is no longer noisy); delta dropped entirely
+        expect(rec.log).toEqual([]);
+        // payload-free: no header/body/chunk values leak through any level
+        const all = [
+            ...rec.log,
+            ...rec.warn,
+            ...rec.error,
+            ...rec.debug,
+            ...rec.verbose,
+        ].join('\n');
+        expect(all).not.toContain('secret');
+        expect(all).not.toContain('s3cret');
+        expect(all).not.toContain('nope');
+    });
+
+    it('loggerSink lifecycle:false drops start/result/done but keeps retry/drift/error', () => {
+        const { rec, logger } = recordingLogger();
+        const sink = loggerSink(logger, { lifecycle: false });
+        const ctx = { name: 'x' };
+        sink.handle(
+            {
+                type: 'start',
+                name: 'x',
+                method: 'GET',
+                url: 'https://h/p',
+                input: {},
+                at: 0,
+            },
+            ctx,
+        );
+        sink.handle(
+            { type: 'result', value: 1, status: 200, attempts: 1, at: 0 },
+            ctx,
+        );
+        sink.handle({ type: 'done', ok: true, ms: 1, attempts: 1, at: 0 }, ctx);
+        sink.handle(
+            { type: 'progress', phase: 'retry', attempt: 2, at: 0 },
+            ctx,
+        );
+        sink.handle(
+            { type: 'error', name: 'x', message: 'boom', attempts: 1, at: 0 },
+            ctx,
+        );
+        expect(rec.debug).toEqual([]); // start + done suppressed
+        expect(rec.verbose).toEqual([]); // result suppressed
+        expect(rec.warn.some((l) => l.includes('retry#2'))).toBe(true); // retry kept
+        expect(rec.error.some((l) => l.includes('boom'))).toBe(true); // error kept
+    });
+
+    it('loggerSink tolerates a logger without debug/verbose (guarded)', () => {
+        const warn: string[] = [];
+        const partial: LoggerLike = {
+            log: () => {},
+            warn: (m) => warn.push(m),
+            error: () => {},
+        };
+        const sink = loggerSink(partial);
+        expect(() =>
+            sink.handle(
+                {
+                    type: 'start',
+                    name: 'x',
+                    method: 'GET',
+                    url: 'https://h',
+                    input: {},
+                    at: 0,
+                },
+                { name: 'x' },
+            ),
+        ).not.toThrow(); // start → debug, absent → no-op
+        sink.handle(
+            { type: 'progress', phase: 'retry', attempt: 2, at: 0 },
             { name: 'x' },
         );
-        expect(logs[0]).toContain('GET https://h/p?…');
-        expect(logs[0]).not.toContain('secret');
-        expect(errs[0]).toContain('boom');
+        expect(warn.length).toBe(1);
     });
 
     it('fromConfig resolves a synchronous secret thunk from a ConfigService-like', () => {

--- a/packages/nest/test/sse.spec.ts
+++ b/packages/nest/test/sse.spec.ts
@@ -1,0 +1,99 @@
+import { stitchSse } from '../src';
+
+import type { StitchEvent } from 'stitchapi';
+import { describe, expect, it } from 'vitest';
+
+// Subscribe and collect message data until the observable terminates.
+const collect = (
+    obs: ReturnType<typeof stitchSse>,
+): Promise<{ data: unknown[]; error?: Error }> =>
+    new Promise((resolve) => {
+        const data: unknown[] = [];
+        obs.subscribe({
+            next: (m) => data.push(m.data),
+            error: (error: Error) => resolve({ data, error }),
+            complete: () => resolve({ data }),
+        });
+    });
+
+async function* events(
+    ...evs: StitchEvent[]
+): AsyncGenerator<StitchEvent, void> {
+    for (const e of evs) yield e;
+}
+
+describe('stitchSse', () => {
+    it('forwards delta chunks as messages and completes at stream end', async () => {
+        const { data, error } = await collect(
+            stitchSse(
+                events(
+                    {
+                        type: 'start',
+                        name: 'x',
+                        method: 'GET',
+                        url: 'u',
+                        input: {},
+                        at: 0,
+                    },
+                    { type: 'delta', chunk: 'a', at: 0 },
+                    { type: 'delta', chunk: 'b', at: 0 },
+                    { type: 'done', ok: true, ms: 1, attempts: 1, at: 0 },
+                ),
+            ),
+        );
+        expect(error).toBeUndefined();
+        expect(data).toEqual(['a', 'b']); // control events not forwarded
+    });
+
+    it('errors the observable on an error event, after any prior deltas', async () => {
+        const { data, error } = await collect(
+            stitchSse(
+                events(
+                    { type: 'delta', chunk: 'a', at: 0 },
+                    {
+                        type: 'error',
+                        name: 'x',
+                        message: 'boom',
+                        attempts: 1,
+                        at: 0,
+                    },
+                ),
+            ),
+        );
+        expect(data).toEqual(['a']);
+        expect(error?.message).toBe('boom');
+    });
+
+    it('applies the data mapper to each chunk', async () => {
+        const { data } = await collect(
+            stitchSse(events({ type: 'delta', chunk: { text: 'hi' }, at: 0 }), {
+                data: (c) => (c as { text: string }).text,
+            }),
+        );
+        expect(data).toEqual(['hi']);
+    });
+
+    it('aborts the upstream generator when the subscription tears down', async () => {
+        let returned = false;
+        const gen: AsyncIterable<StitchEvent> = {
+            [Symbol.asyncIterator]() {
+                return {
+                    next: () =>
+                        new Promise<IteratorResult<StitchEvent>>(() => {
+                            /* never resolves — a long-running upstream */
+                        }),
+                    return: () => {
+                        returned = true;
+                        return Promise.resolve({
+                            done: true,
+                            value: undefined,
+                        });
+                    },
+                };
+            },
+        };
+        const sub = stitchSse(gen).subscribe({ next: () => {} });
+        sub.unsubscribe();
+        expect(returned).toBe(true); // teardown called iterator.return()
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,6 +319,9 @@ importers:
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core':
+        specifier: ^11.0.0
+        version: 11.1.27(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.21


### PR DESCRIPTION
Layered on [ADR 0006](docs/adr/0006-nestjs-integration.md) (`@stitchapi/nest`), this cuts the boilerplate a NestJS integrator still writes. **All additive, no core change.** Gates green: `tsc` clean, **27/27** vitest, `tsup` build (CJS+ESM+DTS), prettier.

## What changed

**Gaps (no new deps)**

- **`loggerSink` mapping refined.** Lifecycle events (`start`/`result`/`done`) moved off the happy-path info level to `debug`/`verbose` (opt out with `{ lifecycle: false }`); `drift` routed by `finding.level`; `retry`/`circuit` progress surfaced at `warn`. Still **payload-free** — now also excludes `delta` chunks — so it stays safe on a secret-bearing seam. Structural `LoggerLike` so partial loggers / test doubles work.
- **`defineStitch` token is now optional.** `defineStitch(build)` generates a unique `Symbol`; `defineStitch(token, build)` still works (overloads, disambiguated on arg count since an `InjectionToken` can itself be a function).

**Features (add always-present Nest peers)**

- **`StitchExceptionFilter` + `toHttpException()` / `isStitchError()`.** Map a `StitchError` → `HttpException`. **`502 Bad Gateway` by default** (never leaks an upstream's `401`/`404` to the client); configurable via `status: number | (err) => number` (propagate, fix, or remap).
- **`stitchSse()`.** Adapt `stitch.stream()` → `Observable<MessageEvent>` for `@Sse()`: `delta`→message, `error`→errors the stream, client disconnect aborts the generator.
- **`StitchModule.forFeatureScoped({ stitches, principal })`.** Packages the request-scoped `seam.as(principal)` wiring the README hand-rolled (Decision 5).

## Peer policy

`@nestjs/core` + `rxjs` added as **peers** — always present in any Nest app (NestFactory needs core; rxjs is Nest's own peer), so it's free for consumers. Genuinely-optional `@nestjs/config` stays **structural** (`ConfigServiceLike`), never a dependency.

## Docs

README (new Errors→HTTP and Streaming→SSE sections; updated multi-tenant, bridges, install peers) + an ADR 0006 addendum recording the delivered follow-ups. Still non-goals: the Terminus health indicator and the Nest-GraphQL disambiguation note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)