### PR TITLE
docs: clarify url-vs-path/baseUrl, drift critical array-paths, and BYO-validator

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -51,19 +51,19 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "url",
             type: "property",
             detail: "string | (() => string)",
-            info: "Full request endpoint as one string — the atomic spelling, when a stitch is exactly one endpoint with no base to share. Templated (`{param}`, incl. the host) and `?query`-aware like `path`; may be a thunk for lazy/env resolution. Mutually exclusive with `baseUrl`/`path`: when both are set `url` wins, and across composed fragments the last fragment to write either spelling wins the whole slot.",
+            info: "Full request endpoint as one string — the atomic spelling, when a stitch is exactly one endpoint with no base to share. Templated (`{param}`, incl. the host) and `?query`-aware like `path`; may be a thunk for lazy/env resolution. ⚠️ `url` is the COMPLETE endpoint and is **not** joined to `baseUrl` — setting `url` makes `baseUrl` ignored. To address an endpoint *relative to* a shared `baseUrl` (e.g. a seam/fragment origin), use `path`, not a relative `url`: `url: '/users'` resolves to the un-fetchable `/users`, whereas `path: '/users'` resolves to `${baseUrl}/users`. Mutually exclusive with `baseUrl`/`path`: when both are set `url` wins, and across composed fragments the last fragment to write either spelling wins the whole slot.",
         },
         {
             label: "baseUrl",
             type: "property",
             detail: "string | (() => string)",
-            info: "Origin for the request, as a string or a thunk resolved at call time. Ignored when `url` is set.",
+            info: "Origin that `path` is appended to, as a string or a thunk resolved at call time. Ignored when `url` is set (which carries its own origin).",
         },
         {
             label: "path",
             type: "property",
             detail: "string",
-            info: "Path appended to `baseUrl`; may include `{param}` slots and a `?query` string. Ignored when `url` is set.",
+            info: "Path appended to `baseUrl` — use THIS (not a relative `url`) for an endpoint relative to a shared `baseUrl`; may include `{param}` slots and a `?query` string. Ignored when `url` is set.",
         },
         {
             label: "headers",

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -7,6 +7,16 @@ Install the package, import `stitch`, and make one typed call to confirm the
 runtime works. `stitchapi` has zero dependencies and runs anywhere `fetch`
 does — Node, the browser, and edge runtimes.
 
+<Callout type="info">
+    **Validators are bring-your-own.** Because `stitchapi` ships with zero
+    dependencies, it does **not** bundle a schema library and declares no `zod`
+    (or Valibot / ArkType / …) peer dependency. `input`/`output` accept any
+    [Standard Schema](/docs/guides/validation/standard-schema) validator — Zod,
+    Valibot, ArkType, Effect, TypeBox — or a plain predicate, but the one you
+    pick is **your** dependency: add it to your own project's `dependencies` so
+    it is never a phantom (undeclared) import.
+</Callout>
+
 ## Install
 
 ```package-install

--- a/apps/docs/content/docs/guides/data/url-shaping.mdx
+++ b/apps/docs/content/docs/guides/data/url-shaping.mdx
@@ -8,6 +8,37 @@ A stitch builds its URL from an
 `params` and `query` you pass at call time. Simple `{id}` interpolation is the
 common case; the full operator set is there when you need it.
 
+## Absolute `url` vs relative `path`
+
+How you spell the endpoint decides whether a shared
+[`baseUrl`](/docs/reference/config-types) applies:
+
+-   **`path`** is _relative_ and is **joined onto `baseUrl`** — the origin a stitch
+    inherits from a seam or a shared fragment. Reach for it whenever many stitches
+    share one host.
+-   **`url`** is the _complete_ endpoint (host included). It is templated and
+    query-aware just like `path`, but it **ignores `baseUrl`** — setting `url`
+    means "this stitch addresses itself." Reach for it for a one-off endpoint.
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+// `path` is relative → it joins `baseUrl` (typically shared via a seam or fragment).
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+});
+await getUser({ params: { id: 1 } });
+// → GET https://api.example.com/users/1
+```
+
+> [!WARNING]
+>
+> A relative `url` is **not** joined to `baseUrl`. `url: '/users/{id}'` overrides
+> the base and resolves to the bare `/users/{id}`, which isn't fetchable — it
+> fails at call time with a `StitchConfigError` ("request URL … is not absolute").
+> When you mean "relative to `baseUrl`", use `path`, not `url`.
+
 ## Path templates
 
 ```ts twoslash

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -171,9 +171,16 @@ function buildRequest(cfg: StitchConfig, input: StitchInput): AdapterRequest {
     // error here instead of a cryptic "Failed to parse URL" from fetch. A custom `adapter` may
     // legitimately resolve relative URLs, so this only guards the default transport.
     if (cfg.adapter === undefined && !/^https?:\/\//i.test(url)) {
+        // A relative `url` set alongside a `baseUrl` is the common footgun: `url` is the whole
+        // endpoint and ignores `baseUrl`, so the base is never joined — they almost certainly
+        // meant `path`. Point straight at that instead of the generic guidance.
+        const hint =
+            cfg.url !== undefined && cfg.baseUrl !== undefined
+                ? 'A relative `url` does NOT join `baseUrl` — `url` is the whole endpoint, so `baseUrl` is ignored. Pass the relative endpoint as `path` instead.'
+                : 'Set `url` to a full endpoint, or give a relative `path` a `baseUrl` (e.g. from a shared fragment).';
         const e = new Error(
             `stitch ${JSON.stringify(nameOf(cfg))}: request URL ${JSON.stringify(url)} is not absolute. ` +
-                'Set `url` to a full endpoint, or give a relative `path` a `baseUrl` (e.g. from a shared fragment).',
+                hint,
         );
         e.name = 'StitchConfigError';
         throw e;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -45,8 +45,28 @@ export interface DriftFinding {
     detail?: string;
 }
 export interface DriftOptions {
-    critical?: string[]; // paths whose change is an error
-    watch?: string[]; // paths whose change is a warning
+    /**
+     * Dotted paths whose disappearance or type change is escalated from the default
+     * `warn` to an `error`. The path grammar mirrors the response-shape walk: nested
+     * keys join with `.`, and an **array element** is addressed with `[]` — so
+     * `items[].id` matches the `id` of every element of the `items` array. A pattern
+     * matches by exact path, by a single-segment `*` wildcard, or as a prefix (`data`
+     * matches `data[].id` and everything beneath it). See `matchPath` for the full grammar.
+     *
+     * @example
+     * ```ts
+     * drift(userSchema, {
+     *     critical: [
+     *         'id', // top-level `id` going missing / changing type → error
+     *         'items[].sku', // the `sku` of ANY element of `items` → error
+     *         'meta.*', // any direct child of `meta` (single-segment wildcard)
+     *     ],
+     * });
+     * ```
+     */
+    critical?: string[];
+    /** Paths (same grammar as {@link DriftOptions.critical}, e.g. `items[].field`) whose change is leveled to a `warn`. */
+    watch?: string[];
     onNew?: DriftLevel; // level for brand-new fields (default 'info')
     snapshotFile?: string; // committed baseline (`<name>.contract.json`)
 }
@@ -361,14 +381,19 @@ export interface StitchConfig {
     /**
      * Full request endpoint as one string — the atomic spelling, when a stitch is exactly one
      * endpoint with no base to share. Templated (`{param}`, incl. the host) and `?query`-aware
-     * like `path`; may be a thunk for lazy/env resolution. Mutually exclusive with
-     * `baseUrl`/`path`: when both are set `url` wins, and across composed fragments the last
-     * fragment to write either spelling wins the whole slot.
+     * like `path`; may be a thunk for lazy/env resolution.
+     *
+     * ⚠️ `url` is the COMPLETE endpoint and is **not** joined to `baseUrl` — setting `url` makes
+     * `baseUrl` ignored. To address an endpoint *relative to* a shared `baseUrl` (e.g. a
+     * seam/fragment origin), use `path`, not a relative `url`: `url: '/users'` resolves to the
+     * un-fetchable `/users`, whereas `path: '/users'` resolves to `${baseUrl}/users`. Mutually
+     * exclusive with `baseUrl`/`path`: when both are set `url` wins, and across composed
+     * fragments the last fragment to write either spelling wins the whole slot.
      */
     url?: string | (() => string);
-    /** Origin for the request, as a string or a thunk resolved at call time. Ignored when `url` is set. */
+    /** Origin that `path` is appended to, as a string or a thunk resolved at call time. Ignored when `url` is set (which carries its own origin). */
     baseUrl?: string | (() => string);
-    /** Path appended to `baseUrl`; may include `{param}` slots and a `?query` string. Ignored when `url` is set. */
+    /** Path appended to `baseUrl` — use THIS (not a relative `url`) for an endpoint relative to a shared `baseUrl`; may include `{param}` slots and a `?query` string. Ignored when `url` is set. */
     path?: string;
     /** Static default headers merged into every request. */
     headers?: Record<string, string>;


### PR DESCRIPTION
## What

Documentation/JSDoc fixes for three DX rough edges surfaced while adopting StitchAPI across a monorepo (the `@strimko/*-seam` packages). These are the items from the triage that were small enough to fix directly rather than file as issues.

**1. drift `critical` array-paths** — `packages/core/src/types.ts`
JSDoc block + `@example` on `DriftOptions.critical` documenting the `items[].field` array-item grammar (exact / `*` wildcard / prefix, per `matchPath`); cross-referenced from `watch`.

**2. `url` vs `path`/`baseUrl` footgun** — `packages/core/src/types.ts`, `packages/core/src/engine.ts`, `apps/docs/content/docs/guides/data/url-shaping.mdx`
Strengthened `url`/`baseUrl`/`path` JSDoc with an explicit "`url` is the whole endpoint and ignores `baseUrl` — use `path` to join it" callout; a new **"Absolute `url` vs relative `path`"** section in the URL-shaping guide; and a sharper engine error — a relative `url` set alongside a `baseUrl` now points straight at `path` instead of the generic guidance.

**3. BYO-validator (phantom dependency)** — `apps/docs/content/docs/getting-started/installation.mdx`
Installation callout clarifying that validators are bring-your-own: `stitchapi` bundles none and declares no `zod` peer, so the validator you pick is **your** dependency, never a phantom import. (Confirmed core imports no validator library — it's structurally agnostic — so a `zod`-only peerDep was deliberately **not** added.)

## Why

These three were reported alongside seven other rough edges from the same monorepo adoption. The other seven are filed as separate issues: #131, #132, #133, #134, #135, #136, #137.

## Verification

- `pnpm --filter stitchapi check:types` — clean
- `pnpm --filter stitchapi check:lint` — clean
- `pnpm --filter stitchapi test` — **432 passed** (53 files); `url-contract` still asserts `/not absolute/i`, which the sharpened message preserves
- `pnpm --filter docs check:types` — clean (twoslash in the new URL-shaping example + the AutoTypeTable JSDoc render both compile)

No runtime or type behavior change beyond the improved error-message text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
