### PR TITLE
feat(auth): secretFrom() resolver + env() rejects empty values

### DIFF
--- a/apps/docs/content/docs/reference/auth-strategies.mdx
+++ b/apps/docs/content/docs/reference/auth-strategies.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Auth strategies'
-description: 'bearer, apiKey, basic, cookieSession, oauth2, and the env(), optionalEnv(), and secretsFile() resolvers.'
+description: 'bearer, apiKey, basic, cookieSession, oauth2, and the env(), optionalEnv(), secretsFile(), and secretFrom() resolvers.'
 ---
 
 The signatures for every auth strategy and secret resolver. Each strategy holds
@@ -50,7 +50,10 @@ before expiry, and attaches it as `Authorization: Bearer …`.
 
 ## env
 
-Resolves a secret from an environment variable at call time.
+Resolves a **required** secret from an environment variable at call time. It
+needs a non-empty value: an unset variable _and_ a set-but-empty one (`MY_TOKEN=`)
+both throw, so a blank credential is never silently sent. For the
+may-or-may-not-be-set case use [`optionalEnv`](#optionalenv).
 
 ```ts twoslash
 import { env } from 'stitchapi';
@@ -75,6 +78,24 @@ private), falling back to the environment.
 
 ```ts twoslash
 import { secretsFile } from 'stitchapi';
+```
+
+## secretFrom
+
+Resolves a **required** secret from an arbitrary injected `source` at call time —
+for DI'd apps that supply config without touching `process.env` (a
+`ConfigService`, a secrets-manager client, a validated config object). The source
+is either an object with a `get(name)` method or a plain `(name) => value`
+function; a missing or empty value throws, mirroring [`env`](#env). Compose it
+with any strategy exactly like `env()`.
+
+```ts twoslash
+import { bearer, secretFrom } from 'stitchapi';
+
+// Any object with a `get(name)` method — e.g. a NestJS ConfigService.
+declare const configService: { get(name: string): string | undefined };
+
+const auth = bearer(secretFrom(configService, 'GITHUB_TOKEN'));
 ```
 
 ## See also

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -44,11 +44,38 @@ function base64(s: string): string {
     return btoa(bin);
 }
 
-/** Resolve a secret from an environment variable at call time. */
+/**
+ * Resolve a REQUIRED secret from an environment variable at call time. An exported-but-empty var
+ * (`MY_TOKEN=`) counts as missing and throws — mirroring {@link optionalEnv}, which treats `''` as
+ * absent — so a blank credential can never silently ride along. For the may-or-may-not-be-set case,
+ * use {@link optionalEnv}.
+ */
 export function env(name: string): () => string {
     return () => {
         const v = readEnv(name);
-        if (v == null) throw new Error(`missing env var ${name}`);
+        if (v == null || v === '') throw new Error(`missing env var ${name}`);
+        return v;
+    };
+}
+
+/** A source `secretFrom` pulls a named value from: an object with a `get(name)` method
+ *  (e.g. a NestJS ConfigService or a secrets-manager client) or a plain `(name) => value` fn. */
+export type SecretSource =
+    | { get(name: string): string | undefined }
+    | ((name: string) => string | undefined);
+
+/**
+ * Resolve a REQUIRED secret from an arbitrary injected `source` at call time — for DI'd apps that
+ * supply config WITHOUT touching `process.env` (a ConfigService, a secrets-manager client, a
+ * validated config object). Throws if the source yields no value (unset or empty), mirroring
+ * {@link env}. Compose with `bearer`/`apiKey`/`basic`/`oauth2` exactly like `env()`:
+ * `bearer(secretFrom(configService, 'GITHUB_TOKEN'))`.
+ */
+export function secretFrom(source: SecretSource, name: string): () => string {
+    return () => {
+        const v =
+            typeof source === 'function' ? source(name) : source.get(name);
+        if (v == null || v === '') throw new Error(`missing secret ${name}`);
         return v;
     };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,7 +12,9 @@ export {
     env,
     optionalEnv,
     secretsFile,
+    secretFrom,
 } from './auth';
+export type { SecretSource } from './auth';
 export { fetchAdapter } from './http-adapter';
 export { axiosAdapter } from './axios-adapter';
 export type {

--- a/packages/core/test/secret-resolvers.spec.ts
+++ b/packages/core/test/secret-resolvers.spec.ts
@@ -1,0 +1,67 @@
+// The REQUIRED secret resolvers: `env` (an environment variable) and `secretFrom` (an arbitrary
+// injected source). Both resolve at call time and throw on a missing OR empty value — a blank
+// credential is never silently sent. (The optional, never-throwing path is `optionalEnv`, covered
+// in optional-env.spec.ts.) The thunks are exercised directly here — no engine, no network.
+import { env, secretFrom } from '../src';
+
+describe('env() (required)', () => {
+    test('resolves the variable when set', () => {
+        process.env['MY_TOKEN'] = 'sekret-value';
+        try {
+            expect(env('MY_TOKEN')()).toBe('sekret-value');
+        } finally {
+            delete process.env['MY_TOKEN'];
+        }
+    });
+
+    test('throws when the variable is unset', () => {
+        delete process.env['MY_TOKEN'];
+        expect(() => env('MY_TOKEN')()).toThrow(/missing env var MY_TOKEN/);
+    });
+
+    test("throws when the variable is set but empty ('')", () => {
+        const saved = process.env['MY_TOKEN'];
+        process.env['MY_TOKEN'] = '';
+        try {
+            expect(() => env('MY_TOKEN')()).toThrow(/missing env var MY_TOKEN/);
+        } finally {
+            if (saved === undefined) delete process.env['MY_TOKEN'];
+            else process.env['MY_TOKEN'] = saved;
+        }
+    });
+});
+
+describe('secretFrom() (required)', () => {
+    test('resolves via a function source `(name) => value`', () => {
+        const source = (name: string): string | undefined =>
+            name === 'GITHUB_TOKEN' ? 'fn-secret' : undefined;
+        expect(secretFrom(source, 'GITHUB_TOKEN')()).toBe('fn-secret');
+    });
+
+    test('resolves via an object source `{ get(name) }`', () => {
+        const source = {
+            get(name: string): string | undefined {
+                return name === 'GITHUB_TOKEN' ? 'obj-secret' : undefined;
+            },
+        };
+        expect(secretFrom(source, 'GITHUB_TOKEN')()).toBe('obj-secret');
+    });
+
+    test('throws when the source returns undefined', () => {
+        expect(() => secretFrom(() => undefined, 'MISSING')()).toThrow(
+            /missing secret MISSING/,
+        );
+        expect(() => secretFrom({ get: () => undefined }, 'MISSING')()).toThrow(
+            /missing secret MISSING/,
+        );
+    });
+
+    test("throws when the source returns empty ('')", () => {
+        expect(() => secretFrom(() => '', 'BLANK')()).toThrow(
+            /missing secret BLANK/,
+        );
+        expect(() => secretFrom({ get: () => '' }, 'BLANK')()).toThrow(
+            /missing secret BLANK/,
+        );
+    });
+});


### PR DESCRIPTION
Resolves two adoption-DX edges around secret resolution in `@stitchapi/core`.

## Changes

**`env()` rejects empty values (#135).** A set-but-empty variable (`MY_TOKEN=`)
now counts as missing and throws, exactly like an unset one — matching
`optionalEnv`, which already treats `''` as absent. This closes the silent
empty-credential footgun where a blank export would send `Authorization: Bearer `
with no token. The error string is unchanged (`missing env var <name>`). The
optional, never-throwing path stays `optionalEnv`.

**`secretFrom(source, name)` resolver (#136).** A generic, validator-/framework-
agnostic resolver that adapts an arbitrary injected source to the existing
`Secret` contract, resolved at call time:

```ts
bearer(secretFrom(configService, 'GITHUB_TOKEN'));
```

`source` is either an object with a `get(name)` method (a `ConfigService`, a
secrets-manager client) or a plain `(name) => value` function. It throws on a
missing or empty value, mirroring `env()`. This lets DI'd apps supply credentials
without ever touching `process.env`.

`@stitchapi/nest`'s `fromConfig(configService, name)` (shipped in #130) is the
Nest-flavored counterpart; it could later delegate to this generic core
primitive (the core `secretFrom` is the building block, `fromConfig` the Nest
sugar over a `ConfigService`).

## Surface

- `secretFrom` and the `SecretSource` type are exported from `stitchapi`.
- New unit suite `packages/core/test/secret-resolvers.spec.ts` covers `env()`
  unset/empty throwing and `secretFrom` via both source shapes plus its
  missing/empty throws.
- Docs: `reference/auth-strategies.mdx` gains a `secretFrom` section and notes
  that `env()` requires a non-empty value (pointing to `optionalEnv`).

Zero new dependencies; no behavior change outside the empty-`env()` case.

Closes #135
Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)
