### PR TITLE
feat(drift): readonly mode + cwd-relative snapshotFile docs

### DIFF
--- a/apps/docs/content/docs/guides/validation/drift.mdx
+++ b/apps/docs/content/docs/guides/validation/drift.mdx
@@ -45,6 +45,59 @@ This is the opposite end from plain
 malformed response hard, here and now, while drift watches for the _silent_
 contract change across calls and lets you triage it by severity.
 
+## Read-only drift in production
+
+The first call with no committed snapshot **writes** one and reports nothing — a
+convenience while you develop the contract. In a deployed/prod context that is a
+footgun: the first request silently persists a baseline (possibly to a read-only
+path) and "passes" instead of detecting drift. Set `readonly: true` to make
+drift _detect-but-never-write_ — a missing snapshot surfaces a `no-baseline`
+finding instead of being written as a call side effect:
+
+```ts twoslash
+import { drift, stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    output: drift(z.object({ id: z.number(), email: z.string() }), {
+        readonly: true,
+        // Surface a missing baseline as an error, not the default warn.
+        onMissing: 'error',
+        snapshotFile: 'users.contract.json',
+    }),
+});
+```
+
+Generate the baseline once (run the stitch without `readonly`, or commit a
+recorded response), check the `<name>.contract.json` into the repo, then ship
+with `readonly: true`. `onMissing` levels the `no-baseline` finding (default
+`'warn'`); `'error'` fails the call so a missing baseline can't slip past CI.
+
+## `snapshotFile` is resolved from `process.cwd()`
+
+A relative `snapshotFile` resolves against the **current working directory**, not
+the module that declares the stitch — so running a package's tests or app from a
+different directory writes/reads the snapshot in the wrong place. Pass an
+absolute or caller-relative path. The portable spelling anchors the file to the
+declaring module with `fileURLToPath(new URL(...))`:
+
+```ts
+import { fileURLToPath } from 'node:url';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    output: drift(userSchema, {
+        readonly: true,
+        snapshotFile: fileURLToPath(
+            new URL('./users.contract.json', import.meta.url),
+        ),
+    }),
+});
+```
+
 <Callout type="info">
     Findings arrive as `drift` events on [the event
     stream](/docs/concepts/event-stream) — subscribe to inspect `warn` and

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -334,8 +334,19 @@ async function validateOutput(
         const opts = (out as DriftSpec).options;
         if (opts.snapshotFile) {
             const snap = loadSnapshot(opts.snapshotFile);
-            if (snap === undefined) saveSnapshot(opts.snapshotFile, body);
-            else findings.push(...classifyDrift(body, snap, opts));
+            if (snap === undefined) {
+                // No committed baseline. By default record one (the spike's first-run behaviour);
+                // in `readonly` mode (deployed/prod) never write — surface a `no-baseline` finding
+                // so a drift-guarded call can't write a baseline as a side effect.
+                if (opts.readonly)
+                    findings.push({
+                        level: opts.onMissing ?? 'warn',
+                        path: '',
+                        change: 'no-baseline',
+                        detail: `no committed snapshot at ${opts.snapshotFile}; generate the baseline before enabling readonly drift`,
+                    });
+                else saveSnapshot(opts.snapshotFile, body);
+            } else findings.push(...classifyDrift(body, snap, opts));
         }
     }
     return findings;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,6 +37,7 @@ export type DriftChange =
     | 'type-changed'
     | 'nullable'
     | 'new'
+    | 'no-baseline'
     | 'invalid';
 export interface DriftFinding {
     level: DriftLevel;
@@ -68,7 +69,37 @@ export interface DriftOptions {
     /** Paths (same grammar as {@link DriftOptions.critical}, e.g. `items[].field`) whose change is leveled to a `warn`. */
     watch?: string[];
     onNew?: DriftLevel; // level for brand-new fields (default 'info')
-    snapshotFile?: string; // committed baseline (`<name>.contract.json`)
+    /**
+     * Detect-but-never-write (default `false`). When `true`, a missing snapshot is NOT written;
+     * instead it surfaces a `no-baseline` finding (at {@link DriftOptions.onMissing}). Use in
+     * deployed/prod contexts so a drift-guarded call can never write a baseline as a side effect
+     * (the default first-run behaviour writes one).
+     */
+    readonly?: boolean;
+    /**
+     * Level for the `no-baseline` finding emitted in {@link DriftOptions.readonly} mode when the
+     * snapshot is absent. Default `'warn'`.
+     */
+    onMissing?: DriftLevel;
+    /**
+     * Committed baseline (`<name>.contract.json`). The path is resolved relative to
+     * `process.cwd()` — **not** the declaring module — so running a package's tests/app from a
+     * different working directory writes/reads the snapshot in the wrong place. Prefer an absolute
+     * or caller-relative path; anchor it to the module that declares the stitch with
+     * `fileURLToPath(new URL(...))`:
+     *
+     * @example
+     * ```ts
+     * import { fileURLToPath } from 'node:url';
+     *
+     * drift(userSchema, {
+     *     snapshotFile: fileURLToPath(
+     *         new URL('./users.contract.json', import.meta.url),
+     *     ),
+     * });
+     * ```
+     */
+    snapshotFile?: string;
 }
 export interface DriftSpec<T = unknown> {
     __kind: 'drift';

--- a/packages/core/test/validation-drift.spec.ts
+++ b/packages/core/test/validation-drift.spec.ts
@@ -4,6 +4,7 @@ import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
 import { asValidator } from './support/schema';
 
+import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
@@ -247,4 +248,101 @@ test('standard schema (non-Zod): valid resolves, invalid rejects with error/inva
     expect(invalid?.change).toBe('invalid');
     expect(invalid?.path).toBe('id');
     expect(events.some((e) => e.type === 'result')).toBe(false);
+});
+
+// ---------------------------------------------------------------------------
+// 7. readonly drift — a missing snapshot in `readonly` mode surfaces a
+//    `no-baseline` finding (warn by default, non-fatal) and NEVER writes the
+//    baseline as a call side effect (#132).
+// ---------------------------------------------------------------------------
+test('readonly: missing snapshot emits warn/no-baseline and writes nothing', async () => {
+    const snapshotFile = freshSnapshot(); // path that does not exist yet
+    try {
+        const schema = z.object({ id: z.number() }).passthrough();
+        server.route('GET', '/ro', { body: { id: 1, name: 'Ada' } });
+        const s = stitch({
+            baseUrl: server.url,
+            path: '/ro',
+            output: drift(schema, { readonly: true, snapshotFile }),
+        });
+
+        const events = await collect(s.stream());
+        const finding = driftFindings(events).find(
+            (f) => f.change === 'no-baseline',
+        );
+        expect(finding).toBeDefined();
+        expect(finding?.level).toBe('warn'); // onMissing default
+        expect(finding?.change).toBe('no-baseline');
+        expect(finding?.detail).toContain(snapshotFile);
+
+        // warn is non-fatal: a `result` still flows and the await resolves.
+        expect(events.some((e) => e.type === 'result')).toBe(true);
+        await expect(s()).resolves.toEqual({ id: 1, name: 'Ada' });
+
+        // The baseline must NOT have been written — readonly is detect-but-don't-write.
+        expect(existsSync(snapshotFile)).toBe(false);
+    } finally {
+        rmSync(snapshotFile, { force: true });
+    }
+});
+
+// ---------------------------------------------------------------------------
+// 8. readonly drift with onMissing:'error' — the `no-baseline` finding is an
+//    error, so the await rejects (contract violation) and still writes nothing.
+// ---------------------------------------------------------------------------
+test('readonly onMissing:error: missing snapshot rejects and writes nothing', async () => {
+    const snapshotFile = freshSnapshot();
+    try {
+        const schema = z.object({ id: z.number() }).passthrough();
+        server.route('GET', '/ro-err', { body: { id: 1 } });
+        const s = stitch({
+            baseUrl: server.url,
+            path: '/ro-err',
+            output: drift(schema, {
+                readonly: true,
+                onMissing: 'error',
+                snapshotFile,
+            }),
+        });
+
+        const events = await collect(s.stream());
+        const finding = driftFindings(events).find(
+            (f) => f.change === 'no-baseline',
+        );
+        expect(finding).toBeDefined();
+        expect(finding?.level).toBe('error');
+        // error breaks the contract: no `result`, and the await rejects.
+        expect(events.some((e) => e.type === 'result')).toBe(false);
+        await expect(s()).rejects.toThrow();
+
+        expect(existsSync(snapshotFile)).toBe(false);
+    } finally {
+        rmSync(snapshotFile, { force: true });
+    }
+});
+
+// ---------------------------------------------------------------------------
+// 9. Default (no readonly) still WRITES the baseline on first run — preserving
+//    today's behaviour: the snapshot file is created and no finding is emitted.
+// ---------------------------------------------------------------------------
+test('default (no readonly): first run writes the baseline, no finding', async () => {
+    const snapshotFile = freshSnapshot();
+    try {
+        const schema = z.object({ id: z.number() }).passthrough();
+        server.route('GET', '/baseline', { body: { id: 1 } });
+        const s = stitch({
+            baseUrl: server.url,
+            path: '/baseline',
+            output: drift(schema, { snapshotFile }),
+        });
+
+        const events = await collect(s.stream());
+        // First run records the baseline silently: no drift findings.
+        expect(driftFindings(events)).toHaveLength(0);
+        expect(events.some((e) => e.type === 'result')).toBe(true);
+        // …and the baseline file was created.
+        expect(existsSync(snapshotFile)).toBe(true);
+    } finally {
+        rmSync(snapshotFile, { force: true });
+    }
 });


### PR DESCRIPTION
## What

Two related fixes to `drift()`'s snapshot handling.

### `readonly` mode — detect-but-don't-write (#132)

Today the first call with no committed snapshot **silently writes a baseline and "passes"** instead of detecting drift. In a deployed/prod context that's a footgun: the first request persists a baseline (possibly to a read-only path) as a call side effect, and never surfaces drift.

`DriftOptions.readonly: true` makes drift detect-but-never-write — a missing snapshot now surfaces a new `no-baseline` finding instead of being written:

- `onMissing?: DriftLevel` levels that finding (default `'warn'`, so it's non-fatal and rides the event stream; `'error'` fails the call so a missing baseline can't slip past CI).
- New `'no-baseline'` member on the `DriftChange` union.
- Default (no `readonly`) behaviour is unchanged: the first run still writes the baseline.

### `snapshotFile` is `process.cwd()`-relative (#131)

A relative `snapshotFile` resolves against the current working directory, **not** the declaring module — so running a package's tests/app from a different directory reads/writes the snapshot in the wrong place. The JSDoc and the drift guide now document this and recommend anchoring with `fileURLToPath(new URL('./x.contract.json', import.meta.url))`.

## Files

- `packages/core/src/types.ts` — `'no-baseline'` on `DriftChange`; `readonly` + `onMissing` fields; enhanced `snapshotFile` JSDoc.
- `packages/core/src/engine.ts` — `validateOutput`: in `readonly` mode push a `no-baseline` finding instead of `saveSnapshot`.
- `packages/core/test/validation-drift.spec.ts` — 3 tests: readonly warn (non-fatal, no file written), readonly `onMissing:'error'` (rejects, no file written), default still writes the baseline.
- `apps/docs/content/docs/guides/validation/drift.mdx` — "Read-only drift in production" + "`snapshotFile` is resolved from `process.cwd()`" subsections.

## Notes

- Zero new dependencies; no behaviour change to the default first-run path.
- A deliberate `stitch drift generate` CLI to bake the baseline is a **separate follow-up** (out of scope here) — for now you generate the baseline by running the stitch once without `readonly`, or by committing a recorded response.

Closes #132
Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)