### PR TITLE
fix(core): StitchResult exposes .catch/.finally and runs once

### DIFF
--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -353,10 +353,16 @@ export function makeStitch<T = unknown>(
 
     const result = (input?: StitchInput): StitchResult<T> => {
         const make = () => streamFn(input);
+        // Consume the stream at most ONCE and share that promise across then/catch/finally —
+        // attaching more than one terminal handler must not re-run the call (the old code called
+        // make() independently per handler, so then+catch ran the stitch twice). `stream()` stays a
+        // separate, un-memoised consumption path (its own generator each time).
+        let consumed: Promise<T> | undefined;
+        const run = () => (consumed ??= consume<T>(make() as never));
         return {
-            then: (onF, onR) => consume<T>(make() as never).then(onF, onR),
-            catch: (onR: (e: unknown) => unknown) =>
-                consume<T>(make() as never).catch(onR),
+            then: (onF, onR) => run().then(onF, onR),
+            catch: (onR: (e: unknown) => unknown) => run().catch(onR),
+            finally: (onF: (() => void) | null) => run().finally(onF),
             stream: () => make(),
         } as StitchResult<T>;
     };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -518,6 +518,12 @@ export interface StitchConfig {
 
 export interface StitchResult<T> extends PromiseLike<T> {
     stream(): AsyncGenerator<StitchEvent<T>, void>;
+    /** Attach a rejection handler (like `Promise.catch`); the stitch runs once, shared with `then`/`finally`. */
+    catch<R = never>(
+        onrejected?: ((reason: unknown) => R | PromiseLike<R>) | null,
+    ): Promise<T | R>;
+    /** Run a callback when the call settles (like `Promise.finally`); shared with `then`/`catch`. */
+    finally(onfinally?: (() => void) | null): Promise<T>;
 }
 /**
  * The callable a stitch resolves to. `TOut` is the result type (inferred from `config.output`);

--- a/packages/core/test-d/stitch.test-d.ts
+++ b/packages/core/test-d/stitch.test-d.ts
@@ -36,3 +36,11 @@ expectType<User>(output(stitch({ output: userSchema, unwrap: 'data' })));
 // 8) a non-schema `output` is rejected at compile time.
 expectError(stitch({ output: 123 }));
 expectError(stitch({ output: 'not-a-schema' }));
+
+// 9) the call result is a thenable that also types `.catch` and `.finally` (#133): both compile
+//    without a cast, and `.catch`'s recovery value widens the resolved type. `then` keeps its
+//    inherited `PromiseLike` return; catch/finally resolve to a real `Promise`.
+const u = stitch({ path: '/u', output: userSchema });
+expectType<PromiseLike<User>>(u().then((x) => x));
+expectType<Promise<User | null>>(u().catch(() => null));
+expectType<Promise<User>>(u().finally(() => undefined));

--- a/packages/core/test/stitch-result.spec.ts
+++ b/packages/core/test/stitch-result.spec.ts
@@ -1,0 +1,84 @@
+// The value a stitch CALL returns is a `StitchResult` — a thenable that also exposes `.catch`,
+// `.finally`, and `.stream`. then/catch/finally share ONE execution of the call (#133); `stream()`
+// is a separate consumption path. A custom adapter (no network) makes execution exactly countable.
+import { stitch } from '../src';
+import type { Adapter } from '../src/types';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-result-${process.pid}.jsonl`,
+);
+
+// A succeeding adapter that counts how many times the call actually executes.
+function countingAdapter(): { adapter: Adapter; calls: () => number } {
+    let calls = 0;
+    const adapter: Adapter = async () => {
+        calls += 1;
+        return { status: 200, headers: {}, body: { ok: true } };
+    };
+    return { adapter, calls: () => calls };
+}
+
+// An adapter that always fails (so the call rejects).
+const failing: Adapter = async () => ({
+    status: 500,
+    headers: {},
+    body: { error: 'boom' },
+});
+
+test('.finally runs the callback and resolves to the value on success', async () => {
+    const { adapter } = countingAdapter();
+    const ping = stitch({ url: 'https://api.example.com/ping', adapter });
+    let ran = false;
+    await expect(ping().finally(() => void (ran = true))).resolves.toEqual({
+        ok: true,
+    });
+    expect(ran).toBe(true);
+});
+
+test('.finally runs the callback on failure too', async () => {
+    const boom = stitch({
+        url: 'https://api.example.com/boom',
+        adapter: failing,
+    });
+    let ran = false;
+    await boom()
+        .finally(() => void (ran = true))
+        .catch(() => undefined);
+    expect(ran).toBe(true);
+});
+
+test('.catch handles a rejected call (and is callable without @ts-expect-error)', async () => {
+    const boom = stitch({
+        url: 'https://api.example.com/boom',
+        adapter: failing,
+    });
+    let reason: unknown;
+    const caught = await boom().catch((e: unknown) => {
+        reason = e;
+        return 'recovered' as const;
+    });
+    expect(caught).toBe('recovered');
+    expect(reason).toBeInstanceOf(Error);
+});
+
+test('then + catch on the SAME result run the call exactly once', async () => {
+    const { adapter, calls } = countingAdapter();
+    const ping = stitch({ url: 'https://api.example.com/ping', adapter });
+    const r = ping();
+    await Promise.all([r.then((x) => x), r.catch(() => undefined)]);
+    // The latent double-make() regression would make this 2.
+    expect(calls()).toBe(1);
+});
+
+test('stream() is a separate consumption path from the awaited result', async () => {
+    const { adapter, calls } = countingAdapter();
+    const ping = stitch({ url: 'https://api.example.com/ping', adapter });
+    await ping();
+    for await (const _ of ping.stream()) void _;
+    // An awaited call plus an independent stream() are two executions, as expected.
+    expect(calls()).toBe(2);
+});


### PR DESCRIPTION
Resolves #133 — the value a stitch **call** returns (`StitchResult<T>`) was typed `extends PromiseLike<T>`, exposing only `.then` + `.stream`. Three problems followed; this PR fixes all three.

### The three fixes

1. **`.catch` is now typed.** It already worked at runtime (the result object implemented it) but wasn't on the interface, so `stitch().catch(fn)` ran fine yet failed to compile. Added the `catch<R>(onrejected?)` signature (reason typed `unknown`, never `any`).
2. **`.finally` is new.** It was missing from *both* the type and the runtime object; it's now implemented and typed (`finally(onfinally?): Promise<T>`).
3. **Single execution.** The old `then` and `catch` each called `make()` independently, so attaching both terminal handlers to one result ran the stitch **twice**. The consumed promise is now memoized (`consumed ??= consume(make())`) and shared across `then`/`catch`/`finally`.

Lazy semantics are preserved — the call still runs only when a terminal handler is attached — and `stream()` is unchanged (it stays a separate, un-memoized consumption path with its own generator each time).

### Tests
New `packages/core/test/stitch-result.spec.ts` (custom adapter, no network, execution is exactly countable):
- `.finally(fn)` runs `fn` and resolves to the value on success, and runs `fn` on failure too.
- `.catch(fn)` recovers a rejected call and type-checks with no `@ts-expect-error`.
- **Single-execution guard:** one result, both `then` + `catch` attached via `Promise.all`, adapter counter asserts the call ran exactly **once** (was 2 before this fix).
- `stream()` remains an independent consumption path (awaited call + `stream()` = two executions, as expected).

tsd: added assertions in `stitch.test-d.ts` that `.catch(...)` and `.finally(...)` type-check off a call result (and `.catch`'s recovery value widens the resolved type).

### Gates
`prettier --check`, `check:types`, `check:types-d`, `check:lint`, `test` (454 passed) all green locally; full pre-push gate (incl. `build-docs`, `exports`) green. Zero new dependencies.

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)