### PR TITLE
fix(types): accept params/query in the call argument when a sibling slot is declared

### DIFF
--- a/packages/core/src/infer.ts
+++ b/packages/core/src/infer.ts
@@ -264,16 +264,22 @@ type RequiredSchemaKeys<I> = {
 
 /**
  * The typed call argument for a config whose `input` is `I`: required schema slots, optional schema
- * slots, the runtime-only `signal`/`onProgress` passthrough, and — when no `variables` schema is
- * declared — the untyped `variables` passthrough. {@link Prettify} collapses the required∩optional
- * split into one flat object.
+ * slots, the runtime-only `signal`/`onProgress` passthrough, and — when no `variables`/`params`/`query`
+ * schema is declared — the untyped loose passthroughs for those slots. {@link Prettify} collapses the
+ * required∩optional split into one flat object.
  *
- * The trailing conditional restores backward compatibility: `variables` is now an {@link InputSchemas}
- * slot, so it falls OUT of {@link ExtraSlots}. A graphql config that declares a `variables` schema
- * types it through the slot machinery above; one that declares NONE (`I` has no `variables` key) would
- * otherwise lose the optional `variables?` it used to carry — so re-add it here as the loose
- * passthrough. The `I extends { variables: unknown }` probe is true only when a `variables` key was
- * actually written, so the two branches never overlap (no typed-vs-loose clash on the same key).
+ * The trailing conditionals restore backward compatibility. The mapped slots above gate on `& keyof I`,
+ * so a slot only appears when `input` actually declares it — which means declaring ONE slot (say
+ * `input: { body }`) would otherwise DROP the `params`/`query` slots from the call argument entirely,
+ * making `query: {…}`/`params: {…}` a compile error even though the runtime reads input by field name
+ * regardless (issue #134). `variables` is now an {@link InputSchemas} slot too, so it likewise falls OUT
+ * of {@link ExtraSlots} and would lose its loose passthrough. So re-add all three as loose optional
+ * passthroughs here, mirroring one another: a config that declares the schema types it through the slot
+ * machinery above; one that declares NONE keeps the loose runtime slot it has always carried. Each
+ * `I extends { X: unknown }` probe is true only when that key was actually written, yielding
+ * `Record<never, never>` (empty) so the typed and loose branches never overlap on the same key. The
+ * passthrough value types match {@link StitchInput} exactly (`Record<string, unknown>`) so the result
+ * stays assignable to `StitchInput` at the surface-helper boundary (see {@link InputOf}).
  */
 type CallInput<I> = Prettify<
     { [K in RequiredSchemaKeys<I> & keyof I]: SlotInput<I, K> } & {
@@ -285,7 +291,13 @@ type CallInput<I> = Prettify<
             variables: unknown;
         }
             ? Record<never, never>
-            : { variables?: Record<string, unknown> })
+            : { variables?: Record<string, unknown> }) &
+        (I extends { params: unknown }
+            ? Record<never, never>
+            : { params?: Record<string, unknown> }) &
+        (I extends { query: unknown }
+            ? Record<never, never>
+            : { query?: Record<string, unknown> })
 >;
 
 // ---- Path-template variables (Phase 2c) -----------------------------------

--- a/packages/core/test-d/input-inference.test-d.ts
+++ b/packages/core/test-d/input-inference.test-d.ts
@@ -101,3 +101,60 @@ expectAssignable<CallArg<typeof gqlLoose>>({ variables: { region: 'eu' } });
 // 7) a non-schema `input` slot value is rejected at compile time.
 expectError(stitch({ input: { body: 123 } }));
 expectError(stitch({ input: { params: 'nope' } }));
+
+// 8) declaring ONE slot must NOT close `params`/`query`: they pass through loosely beside the typed
+//    slot, mirroring `variables`/`signal`/`onProgress` (issue #134 — the runtime reads input by field
+//    name regardless). A body-only, NON-templated stitch still accepts a call arg with `params`/`query`.
+const bodyOnly = stitch({
+    input: { body: z.object({ name: z.string() }) },
+    output: userSchema,
+});
+expectType<{ name: string }>(
+    null as unknown as CallArg<typeof bodyOnly>['body'], // body still required + schema-typed
+);
+expectAssignable<CallArg<typeof bodyOnly>>({
+    body: { name: 'Ada' },
+    params: { id: 1 }, // loose params passthrough — no longer "Object literal may only specify…"
+    query: { page: 2 }, // loose query passthrough
+});
+expectError(bodyOnly({ params: { id: 1 } })); // body still required → arg without body is an error
+
+// 9) a DECLARED `query` schema keeps `query` typed BY THE SCHEMA, not widened to Record<string, unknown>
+//    (the loose passthrough only applies when the slot is UNdeclared). Same for a declared `params`.
+const queryTyped = stitch({
+    input: { query: z.object({ page: z.number() }) },
+});
+expectType<{ page: number }>(
+    null as unknown as CallArg<typeof queryTyped>['query'],
+);
+expectError(queryTyped({ query: { page: 'one' } })); // page must be a number — schema still bites
+const paramsTyped = stitch({
+    input: { params: z.object({ id: z.string() }) },
+});
+expectType<{ id: string }>(
+    null as unknown as CallArg<typeof paramsTyped>['params'],
+);
+expectError(paramsTyped({ params: { id: 1 } })); // id must be a string — schema still bites
+
+// 10) a path-template `params` stays REQUIRED even though the loose `params?` passthrough is now in
+//     CallInput: FoldPathParams intersects a REQUIRED `params` over the base, and the required modifier
+//     wins. The folded slot is the loose passthrough INTERSECTED with the path-only `{ id }` (so extra
+//     keys are tolerated), but `params` is still required — a body-only stitch on `/users/{id}` must pass
+//     it. (path-vars.test-d.ts covers the broader path-template matrix; this pins the #134 interaction.)
+const templated = stitch({
+    path: '/users/{id}',
+    input: { body: z.object({ name: z.string() }) },
+});
+expectType<Record<string, unknown> & { id: string | number }>(
+    null as unknown as NonNullable<CallArg<typeof templated>>['params'],
+);
+expectError(templated({ body: { name: 'Ada' } })); // params still required by the path var
+expectAssignable<CallArg<typeof templated>>({
+    body: { name: 'Ada' },
+    params: { id: 1, extra: 'tolerated' }, // path-only params keep the loose index-signature tail
+});
+
+// 11) a no-input, non-templated stitch is unchanged: still the loose, fully-optional StitchInput.
+const bare = stitch({ path: '/ping' });
+expectType<StitchInput | undefined>(null as unknown as CallArg<typeof bare>);
+expectAssignable<CallArg<typeof bare>>(undefined);

--- a/packages/core/test-d/path-vars.test-d.ts
+++ b/packages/core/test-d/path-vars.test-d.ts
@@ -92,7 +92,12 @@ expectType<StitchInput | undefined>(null as unknown as CallArg<typeof plain>);
 expectAssignable<CallArg<typeof plain>>(undefined);
 
 // 10) other input slots keep their own shape/required-ness alongside a folded `params`. A required `body`
-//     schema stays required; `params` is added required from the path var.
+//     schema stays required; `params` is added required from the path var. Since a declared sibling slot
+//     (`body`) now leaves `params` with its loose `Record<string, unknown>` passthrough (issue #134), the
+//     folded slot is that passthrough INTERSECTED with the path-only `{ id }` — the required modifier from
+//     the fold wins (still required), and the path-only key keeps `string | number`; extra loose keys are
+//     tolerated. A no-input templated stitch (case 1) stays byte-clean `{ id }` — only a declared sibling
+//     brings the index-signature tail.
 const withBody = stitch({
     path: '/u/{id}',
     input: { body: z.object({ name: z.string() }) },
@@ -100,11 +105,15 @@ const withBody = stitch({
 expectType<{ name: string }>(
     null as unknown as NonNullable<CallArg<typeof withBody>>['body'],
 );
-expectType<{ id: string | number }>(
+expectType<Record<string, unknown> & { id: string | number }>(
     null as unknown as NonNullable<CallArg<typeof withBody>>['params'],
 );
 expectError(withBody({ body: { name: 'Ada' } })); // params still required
 expectError(withBody({ params: { id: 1 } })); // body still required
+expectAssignable<CallArg<typeof withBody>>({
+    body: { name: 'Ada' },
+    params: { id: 1, extra: 'tolerated' }, // path-only params carry the loose index-signature tail
+});
 
 // 11) seam members (root, principal-bound, and graphql) fold path vars identically.
 const api = seam({ baseUrl: 'https://x' });


### PR DESCRIPTION
## The problem (#134)

`CallInput<I>` (the typed call argument inferred from a config's `input` schemas, in `packages/core/src/infer.ts`) builds its slots from mapped types gated on `& keyof I`. So a slot only appears in the call argument when `input` *actually declares* it. The sibling slots `variables`, `signal`, and `onProgress` are re-added as loose optional passthroughs right beside those mapped slots — but `params` and `query` were **not**.

The result: declaring **one** input slot (e.g. `input: { body }`) silently **closed** `params`/`query`, so passing them became a compile error —

> Object literal may only specify known properties, and `'query'` does not exist in type `…`

even though the runtime input path (`normalizeInput` → `validateInput`) reads input **by field name** regardless of static type. `params`/`query` were the only two call slots that closed when a sibling was declared.

## The fix

Mirror the existing `variables` passthrough arm exactly, for `params` and `query`:

```ts
& (I extends { params: unknown } ? Record<never, never> : { params?: Record<string, unknown> })
& (I extends { query: unknown }  ? Record<never, never> : { query?: Record<string, unknown> })
```

- The `I extends { X: unknown }` probe is true **only** when that key was actually written into `input` — in which case the slot machinery above already types it and the arm collapses to `Record<never, never>` (empty). So a **declared** `params`/`query` schema still wins (stays typed by the schema, not widened).
- The passthrough value type is `Record<string, unknown>`, matching `StitchInput.params` / `StitchInput.query` **exactly**, so the result stays assignable to `StitchInput` at the surface-helper boundary (every surface helper assigns the engine's loose `Stitch<TOut, StitchInput>` to its declared `Stitch<TOut, InputOf<C>>`, and the call argument sits contravariantly there).

Pure type-level widening — **non-breaking**, zero runtime change, zero new deps. `InputOf` / `FoldPathParams` / `PathParams` / the path-template machinery are untouched.

## Path-template interaction (verified by tsd)

For a templated endpoint, `FoldPathParams` intersects a **required** `params` over the base. Intersecting that required `params` with the new loose `params?` passthrough keeps `params` **required** (the required modifier wins) and merely widens its value to `Record<string, unknown> & { …pathVars }` — so a path var like `/users/{id}` is still required, and extra loose keys are now tolerated. A no-input templated stitch is unchanged (it never goes through `CallInput`, so its `params` stays byte-clean `{ id }`). One pre-existing tsd assertion in `path-vars.test-d.ts` (the `{id}` + declared-`body` case) was updated to reflect this deliberately-widened, behaviorally-superset type.

## tsd coverage (`check:types-d`, mandatory)

Added assertions proving:
1. **New acceptance** — a body-only, non-templated stitch accepts a call arg with `params`/`query`, and `body` stays required.
2. **Declared slot unchanged** — a declared `query`/`params` schema keeps the slot typed *by the schema* (a wrong value still errors), not widened.
3. **Path-template params still required** — `/users/{id}` still requires `params: { id }`; extra loose keys tolerated.
4. **No-input stitch unchanged** — still the loose, fully-optional `StitchInput`.

## Gates

| Gate | Result |
| --- | --- |
| `check:types` (surface helpers: download/sse/stream/graphql/seam boundary) | ✅ pass |
| `check:types-d` (tsd) | ✅ pass |
| `check:lint` | ✅ pass |
| `test` (full suite) | ✅ 454 passed / 56 files |
| pre-push (format, lint, typecheck, typecheck-d, test, exports, build-docs) | ✅ all green |

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)