### PR TITLE
feat(trace): logger-agnostic loggerSink(logger, opts?)

### DIFF
--- a/apps/docs/content/docs/guides/observability/trace-sinks.mdx
+++ b/apps/docs/content/docs/guides/observability/trace-sinks.mdx
@@ -97,6 +97,56 @@ single-purpose sinks, `createTrace({ console, file })` returns one that does
 both, and `multiplex(a, b, ...)` fans one event stream out to several sinks at
 once. All are exported from [`stitchapi`](/docs/reference/helpers).
 
+## Logging to a host logger
+
+Already running pino, winston, or just `console`? `loggerSink(logger)` bridges the
+event stream straight onto it — no JSONL file, no OTLP collector. It is
+**logger-agnostic** (anything with `error` / `warn` / `info` / `debug` methods
+satisfies the `LoggerLike` shape) and **payload-free**: it logs only metadata —
+name, method, scrubbed URL, status, attempt counts, drift path/level, timing —
+never `event.input`, `event.value`, or a streamed `delta` chunk.
+
+```ts twoslash
+import { loggerSink, stitch } from 'stitchapi';
+
+// `console` already satisfies LoggerLike; swap in `pino()` / a winston logger / a
+// Nest `Logger` and nothing else changes.
+const search = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/search',
+    trace: loggerSink(console),
+});
+```
+
+Each `StitchEvent` maps to a level:
+
+| Event                                  | Level                                                   |
+| -------------------------------------- | ------------------------------------------------------- |
+| `result`                               | `info`                                                  |
+| `error`                                | `error`                                                 |
+| `drift`                                | the finding's own level (`error` / `warn` / `info`)     |
+| `start` / `progress` / `info` / `done` | `debug`                                                 |
+| `delta`                                | _never logged_ — a streamed chunk is raw response data. |
+
+Override any per-type level with `levels` — for example, demote the happy-path
+`result` to `debug` so production logs stay quiet until something drifts or errors:
+
+```ts twoslash
+import { loggerSink, stitch } from 'stitchapi';
+
+const search = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/search',
+    trace: loggerSink(console, { levels: { result: 'debug' } }),
+});
+```
+
+<Callout type="info">
+    This is the generic core counterpart to `@stitchapi/nest`'s NestJS-specific
+    `loggerSink`, which forwards the same payload-free metadata to a Nest
+    `Logger` — see [NestJS integration](/docs/integrations/nestjs).
+</Callout>
+
 ## Turning tracing off
 
 There are two off switches, both of which disable the built-in sinks:

--- a/apps/docs/content/docs/reference/helpers.mdx
+++ b/apps/docs/content/docs/reference/helpers.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Helpers'
-description: 'fetchAdapter, axiosAdapter, xhrAdapter, consoleSink, fileSink, createTrace, multiplex, the OTLP exporters, memoryStore, and toValidator.'
+description: 'fetchAdapter, axiosAdapter, xhrAdapter, consoleSink, fileSink, createTrace, multiplex, loggerSink, the OTLP exporters, memoryStore, and toValidator.'
 ---
 
 The exported helper functions you wire into a stitch: the default transport, the
@@ -117,6 +117,24 @@ OTLP — flushing each in turn.
 import { createTrace, multiplex, otlpTrace } from 'stitchapi';
 
 const sink = multiplex(createTrace(), otlpTrace());
+```
+
+### loggerSink
+
+Bridge the event stream to any host logger — pino, winston, the `console`,
+anything with `error` / `warn` / `info` / `debug` methods (`LoggerLike`). It is
+**payload-free** (logs only metadata — name, method, scrubbed URL, status, attempt
+counts, drift path/level, timing — never the body, result value, or a `delta`
+chunk) and maps each event to a level: `result` → `info`, `error` → `error`,
+`drift` → the finding's level, `start`/`progress`/`info`/`done` → `debug`, and
+`delta` is never logged. Override per type with `levels`. The logger-agnostic core
+twin of `@stitchapi/nest`'s `loggerSink`.
+
+```ts twoslash
+import { loggerSink } from 'stitchapi';
+
+// `console` satisfies LoggerLike; pass `pino()` or a winston logger just the same.
+const sink = loggerSink(console, { levels: { result: 'debug' } });
 ```
 
 ### otlpTrace

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,14 @@ export type {
 } from './axios-adapter';
 export { xhrAdapter } from './xhr-adapter';
 export type { XhrLike, XhrLikeCtor, XhrProgress } from './xhr-adapter';
-export { createTrace, consoleSink, fileSink, multiplex } from './trace';
+export {
+    createTrace,
+    consoleSink,
+    fileSink,
+    multiplex,
+    loggerSink,
+} from './trace';
+export type { LoggerLike, LoggerSinkOptions, LogLevel } from './trace';
 export { otlpTrace, otlpHttpExporter, toOtlpJson } from './otlp';
 export type {
     SpanExporter,

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -182,6 +182,130 @@ function format(name: string, event: StitchEvent): string | null {
     }
 }
 
+// The log levels {@link loggerSink} maps events onto. A strict subset of the methods
+// every host logger (pino/winston/console) exposes — DriftLevel ('error'|'warn'|'info')
+// is a subset too, so a drift finding's own level is a valid LogLevel as-is.
+export type LogLevel = 'error' | 'warn' | 'info' | 'debug';
+
+/** The minimal logger `loggerSink` needs — pino, winston, console, and most host loggers satisfy it. */
+export interface LoggerLike {
+    error(message: string): void;
+    warn(message: string): void;
+    info(message: string): void;
+    debug(message: string): void;
+}
+
+export interface LoggerSinkOptions {
+    /**
+     * Override the default event-type → level mapping. By default: result→info, error→error,
+     * start/progress/info/done→debug, drift→the finding's own level, and `delta` is never logged
+     * (it carries response-body data). Set a type to a level to override; `drift` is special-
+     * cased to the finding level unless you override it here.
+     */
+    levels?: Partial<Record<StitchEvent['type'], LogLevel>>;
+}
+
+// The DEFAULT event-type → level mapping (drift is resolved per-finding at call time, and
+// 'delta' is absent because it is never logged — a streamed chunk is raw response data).
+const DEFAULT_LEVELS: Record<
+    Exclude<StitchEvent['type'], 'drift' | 'delta'>,
+    LogLevel
+> = {
+    start: 'debug',
+    progress: 'debug',
+    info: 'debug',
+    result: 'info',
+    error: 'error',
+    done: 'debug',
+};
+
+// Render one StitchEvent as a PLAIN (no ANSI) metadata-only one-liner — the same
+// name/method/scrubbed-url/status/attempts/timing fields `format` paints, minus colour and
+// glyphs. NEVER includes the response body / result value / delta chunk, so it is safe to log
+// verbatim even though a custom sink receives the un-redacted event. `null` ⇒ don't log.
+function summary(name: string, event: StitchEvent): string | null {
+    switch (event.type) {
+        case 'start':
+            return `${name} ${event.method} ${scrubUrl(event.url)}`;
+        case 'progress': {
+            const waited =
+                event.waitedMs != null ? ` waited ${event.waitedMs}ms` : '';
+            return `${name} ${event.phase}#${event.attempt}${waited}`;
+        }
+        case 'info': {
+            const detail = event.detail != null ? `: ${event.detail}` : '';
+            return `${name} ${event.topic}${detail}`;
+        }
+        case 'drift': {
+            const f = event.finding;
+            const detail = f.detail != null ? ` (${f.detail})` : '';
+            return `${name} drift[${f.level}] ${f.path} ${f.change}${detail}`;
+        }
+        case 'result':
+            return `${name} ${event.status} ok (${event.attempts} attempt(s))`;
+        case 'error': {
+            const status = event.status != null ? ` ${event.status}` : '';
+            return `${name} ${event.message}${status}`;
+        }
+        case 'done':
+            return `${name} done in ${event.ms}ms`;
+        default:
+            return null; // 'delta': raw response data — never logged.
+    }
+}
+
+/**
+ * A {@link TraceSink} that bridges the stitch event stream to any host logger — pino, winston,
+ * the `console`, anything that is a {@link LoggerLike} — mapping each {@link StitchEvent} to a
+ * log level. The logger-agnostic core twin of `@stitchapi/nest`'s NestJS-specific `loggerSink`.
+ *
+ * Default level map: `result` → `info`, `error` → `error`, `start`/`progress`/`info`/`done` →
+ * `debug`, and `drift` → the finding's own `level` ('error'|'warn'|'info'). A `delta` event is
+ * **never** logged — a streamed chunk is raw response data. Override any per-type level via
+ * {@link LoggerSinkOptions.levels} (e.g. `{ result: 'debug' }`); `drift` still follows the finding
+ * level unless you pin it there too.
+ *
+ * SECURITY: a custom sink receives the **raw** event (core only redacts inside its own built-in
+ * sinks), so a `start` event's `input.headers` still holds `authorization` / `cookie` and a
+ * `delta`'s `chunk` is raw response data. This sink therefore logs **only metadata** — name,
+ * method, scrubbed URL, status, attempt counts, drift path/level, timing — never `event.input`,
+ * `event.value`, a `delta` chunk, or `JSON.stringify(event)`, and it strips the URL query (it can
+ * carry `?api_key=…`). That keeps it payload-free on a secret-bearing seam regardless of core's
+ * trace redaction.
+ *
+ * @example
+ * ```ts
+ * import { stitch } from 'stitchapi';
+ * import { loggerSink } from 'stitchapi';
+ * import pino from 'pino';
+ *
+ * const api = stitch({ baseUrl: '…', path: '/users', trace: loggerSink(pino()) });
+ * ```
+ */
+export function loggerSink(
+    logger: LoggerLike,
+    opts?: LoggerSinkOptions,
+): TraceSink {
+    const overrides = opts?.levels;
+    return {
+        handle(event: StitchEvent, ctx: { name: string }): void {
+            // A streamed chunk is raw response data — never logged, regardless of `levels`.
+            if (event.type === 'delta') return;
+            const message = summary(ctx.name, event);
+            if (message == null) return;
+            // Per-type override wins; else drift follows its finding level, everything
+            // else its default. DriftLevel ⊂ LogLevel, so the finding level needs no map.
+            const level: LogLevel =
+                overrides?.[event.type] ??
+                (event.type === 'drift'
+                    ? event.finding.level
+                    : DEFAULT_LEVELS[event.type]);
+            logger[level](message);
+        },
+        // Logging is synchronous; nothing is buffered to drain.
+    };
+}
+
 // Resolve the JSONL path once: `false` disables (null), `undefined` => default under $HOME.
 function resolvePath(file: TraceOptions['file']): string | null {
     if (file === false) return null;

--- a/packages/core/test/logger-sink.spec.ts
+++ b/packages/core/test/logger-sink.spec.ts
@@ -1,0 +1,193 @@
+import { loggerSink, stitch } from '../src';
+import type { LoggerLike, StitchEvent } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+// loggerSink bridges the event stream to any host logger, mapping each StitchEvent
+// to a level and NEVER logging the request/response payload (metadata only). These
+// tests drive it two ways: through a real stitch run (start/result/error) and by
+// synthesizing events directly (drift/delta), the latter to pin the payload-free
+// guarantee and the never-log-delta rule without a streaming surface.
+
+// A sentinel only ever present in response bodies / streamed chunks. If it shows up
+// in ANY logged message, the sink leaked a payload.
+const SECRET_BODY = 'sk-PAYLOAD-LEAK-DO-NOT-LOG';
+
+// A fake LoggerLike that records every call as { level, message }. The four methods
+// are exactly the LoggerLike surface, so this doubles as a type-level conformance check.
+function fakeLogger(): {
+    logger: LoggerLike;
+    entries: { level: string; message: string }[];
+} {
+    const entries: { level: string; message: string }[] = [];
+    const push = (level: string) => (message: string) =>
+        entries.push({ level, message });
+    return {
+        entries,
+        logger: {
+            error: push('error'),
+            warn: push('warn'),
+            info: push('info'),
+            debug: push('debug'),
+        },
+    };
+}
+
+const levelsFor = (
+    entries: { level: string; message: string }[],
+    needle: string,
+): string[] =>
+    entries.filter((e) => e.message.includes(needle)).map((e) => e.level);
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+// ---------------------------------------------------------------------------
+// Real stitch runs: the lifecycle event → level mapping.
+// ---------------------------------------------------------------------------
+
+test('a successful call logs result at info and start at debug', async () => {
+    const { logger, entries } = fakeLogger();
+    server.route('GET', '/ping', { body: { token: SECRET_BODY } });
+    const ping = stitch({
+        name: 'ping',
+        baseUrl: server.url,
+        path: '/ping',
+        trace: loggerSink(logger),
+    });
+
+    await expect(ping()).resolves.toEqual({ token: SECRET_BODY });
+
+    // start → debug, result → info, done → debug.
+    expect(levelsFor(entries, 'ping GET')).toEqual(['debug']);
+    expect(levelsFor(entries, 'ping 200 ok')).toEqual(['info']);
+    expect(levelsFor(entries, 'ping done in')).toEqual(['debug']);
+
+    // PAYLOAD-FREE: the response body's sentinel must never appear in any message.
+    for (const { message } of entries)
+        expect(message).not.toContain(SECRET_BODY);
+});
+
+test('an erroring call logs at error', async () => {
+    const { logger, entries } = fakeLogger();
+    // A 500 with no retry budget surfaces as an `error` event.
+    server.route('POST', '/boom', {
+        statuses: [500],
+        body: { detail: SECRET_BODY },
+    });
+    const boom = stitch({
+        name: 'boom',
+        method: 'POST',
+        baseUrl: server.url,
+        path: '/boom',
+        trace: loggerSink(logger),
+    });
+
+    await expect(boom()).rejects.toBeInstanceOf(Error);
+
+    // The error event is logged at `error`, and names the stitch.
+    const errorLines = entries.filter((e) => e.level === 'error');
+    expect(errorLines.length).toBeGreaterThanOrEqual(1);
+    expect(errorLines.some((e) => e.message.startsWith('boom '))).toBe(true);
+
+    // PAYLOAD-FREE even on the error path (the 500 body carried the sentinel).
+    for (const { message } of entries)
+        expect(message).not.toContain(SECRET_BODY);
+});
+
+// ---------------------------------------------------------------------------
+// Synthesized events: drift level, delta-never-logged, overrides.
+// ---------------------------------------------------------------------------
+
+test("a drift event logs at the finding's own level", () => {
+    const { logger, entries } = fakeLogger();
+    const sink = loggerSink(logger);
+    const ctx = { name: 'users' };
+
+    // An error-level finding → error; a warn-level finding → warn; info → info.
+    sink.handle(
+        {
+            type: 'drift',
+            finding: { level: 'error', path: 'id', change: 'missing' },
+            at: 0,
+        },
+        ctx,
+    );
+    sink.handle(
+        {
+            type: 'drift',
+            finding: { level: 'warn', path: 'name', change: 'nullable' },
+            at: 0,
+        },
+        ctx,
+    );
+    sink.handle(
+        {
+            type: 'drift',
+            finding: { level: 'info', path: 'extra', change: 'new' },
+            at: 0,
+        },
+        ctx,
+    );
+
+    expect(entries.map((e) => e.level)).toEqual(['error', 'warn', 'info']);
+    // The drift line carries the path/change metadata, not any value.
+    expect(entries[0]?.message).toContain('drift[error] id missing');
+});
+
+test('a delta event is never logged', () => {
+    const { logger, entries } = fakeLogger();
+    const sink = loggerSink(logger);
+
+    // A streamed chunk is raw response data — even carrying the sentinel, it is dropped.
+    const delta: StitchEvent = { type: 'delta', chunk: SECRET_BODY, at: 0 };
+    sink.handle(delta, { name: 'stream' });
+
+    // Nothing logged at all, and certainly no payload.
+    expect(entries).toEqual([]);
+});
+
+test('opts.levels overrides the default per event type', () => {
+    const { logger, entries } = fakeLogger();
+    // Route `result` to debug instead of its default info.
+    const sink = loggerSink(logger, { levels: { result: 'debug' } });
+
+    const result: StitchEvent = {
+        type: 'result',
+        value: { token: SECRET_BODY },
+        status: 200,
+        attempts: 1,
+        at: 0,
+    };
+    sink.handle(result, { name: 'ping' });
+
+    expect(levelsFor(entries, 'ping 200 ok')).toEqual(['debug']);
+    // Even when logged, a result NEVER carries its value.
+    for (const { message } of entries)
+        expect(message).not.toContain(SECRET_BODY);
+});
+
+test('opts.levels can override the drift level too', () => {
+    const { logger, entries } = fakeLogger();
+    // Pin every drift to warn, regardless of the finding's own level.
+    const sink = loggerSink(logger, { levels: { drift: 'warn' } });
+
+    sink.handle(
+        {
+            type: 'drift',
+            finding: { level: 'error', path: 'id', change: 'missing' },
+            at: 0,
+        },
+        { name: 'users' },
+    );
+
+    expect(entries.map((e) => e.level)).toEqual(['warn']);
+});


### PR DESCRIPTION
## What

Adds a logger-agnostic `loggerSink(logger, opts?)` to core (`packages/core/src/trace.ts`): a `TraceSink` that bridges a stitch's event stream to **any** host logger — pino, winston, the `console`, anything satisfying the minimal `LoggerLike` (`error`/`warn`/`info`/`debug`). It is the generic core counterpart to `@stitchapi/nest`'s NestJS-specific `loggerSink` (which could later delegate to it).

## Default level mapping

| Event | Level |
| ----- | ----- |
| `result` | `info` |
| `error` | `error` |
| `drift` | the finding's own level (`error` / `warn` / `info`) |
| `start` / `progress` / `info` / `done` | `debug` |
| `delta` | **never logged** — a streamed chunk is raw response data |

`opts.levels` overrides any per-type level (e.g. `{ result: 'debug' }`); `drift` still follows the finding level unless pinned there too.

## Payload-free guarantee

A custom sink receives the **raw** event (core only redacts inside its own built-in sinks). This sink therefore logs **metadata only** — name, method, scrubbed URL (`scrubUrl`, same as `format()`), status, attempt counts, drift path/level, timing — and never `event.input`, `event.value`, a `delta` chunk, or `JSON.stringify(event)`. It reuses the exact fields the existing colored `format()` paints, minus ANSI. The new spec asserts a body sentinel never appears in any logged message (happy path, error path, overridden `result`, and a `delta` carrying the sentinel — which is dropped entirely).

## Files

- `packages/core/src/trace.ts` — `LogLevel`, `LoggerLike`, `LoggerSinkOptions`, the `summary()` plain-message helper, and `loggerSink()`.
- `packages/core/src/index.ts` — export `loggerSink` + the three types.
- `packages/core/test/logger-sink.spec.ts` — 6 tests (fake `LoggerLike` capturing `{level,message}[]`; real stitch runs + synthesized drift/delta/override events).
- `apps/docs/.../guides/observability/trace-sinks.mdx` + `reference/helpers.mdx` — doc entries (twoslash-checked).

## Gates

`check:types`, `check:types-d`, `check:lint`, `test` (460 pass), `check:format`, `check:exports`, and `build-docs` all green locally and via the pre-push hook.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)