### PR TITLE
feat(core): safe()/unwrap() call variants + exported StitchError

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -203,6 +203,18 @@ export const PLAYGROUND_INSTANCE_COMPLETIONS: Record<string, Completion[]> = {
             detail: "(...args: Args<TIn>) => AsyncGenerator<StitchEvent<TOut>, void>",
         },
         {
+            label: "safe",
+            type: "method",
+            detail: "(...args: Args<TIn>) => Promise<SafeResult<TOut>>",
+            info: "Call without throwing: resolves to a `SafeResult` — `{ ok, data, error }`. The eager shortcut for `stitch(...).safe()`, mirroring `.stream()`.",
+        },
+        {
+            label: "unwrap",
+            type: "method",
+            detail: "(...args: Args<TIn>) => Promise<TOut>",
+            info: "Call and unwrap to the value, throwing a `StitchError` on failure. The named twin of `.safe()` (and an explicit spelling of the throwing bare call).",
+        },
+        {
             label: "with",
             type: "method",
             detail: "(partial: P) => Stitch<TOut, RelaxKeys<TIn, keyof P>>",

--- a/apps/docs/content/docs/concepts/event-stream.mdx
+++ b/apps/docs/content/docs/concepts/event-stream.mdx
@@ -40,6 +40,32 @@ throttle, retry, pagination) and `drift` findings, then exactly one terminal
 `result` or `error`, then `done`. The union is discriminated on `type`, so
 narrowing one field tells the compiler the shape of the rest.
 
+## Awaiting without the throw
+
+Awaiting collapses the stream to its terminal — the `result` value, or a thrown
+[`StitchError`](/docs/errors) when the terminal is an `error`. When you'd rather
+branch on failure than wrap the call in `try`/`catch`, `.safe()` consumes the
+same stream and never throws: it resolves to a discriminated `{ ok, data, error }`
+where `error` is the `StitchError`, or `null` on success.
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const search = stitch({ baseUrl: 'https://api.example.com', path: '/search' });
+
+const { data, error } = await search({ query: { q: 'mango' } }).safe();
+if (error) {
+    console.error(error.status, error.attempts); // a StitchError
+} else {
+    console.log(data); // the validated result; error is null here
+}
+```
+
+`.unwrap()` is the explicit throwing twin — the value, or a thrown `StitchError`,
+exactly what awaiting the bare call does. Each also has an eager form on the
+stitch itself (`search.safe(input)` / `search.unwrap(input)`) that mirrors
+`search.stream(input)`.
+
 ## How it relates
 
 The stream is what every cross-cutting feature reports through:

--- a/apps/docs/content/docs/errors/index.mdx
+++ b/apps/docs/content/docs/errors/index.mdx
@@ -3,13 +3,14 @@ title: 'Errors & pitfalls'
 description: 'How StitchAPI errors work, the code-to-docs contract, and an index of every coded failure.'
 ---
 
-When a stitch can't produce a result, it fails with a `StitchError` — an
-`Error` with `name: 'StitchError'`, a human-readable `message`, and an optional
-`.status` carrying the upstream HTTP status. Await a stitch and that error is
-what `catch` receives:
+When a stitch can't produce a result, it fails with a `StitchError` — an `Error`
+subclass exported from `stitchapi`, carrying a human-readable `message`, an
+optional `.status` (the upstream HTTP status), and `.attempts` (how many tries
+the runtime made before giving up). Await a stitch and that error is what `catch`
+receives — narrow it with `instanceof`:
 
 ```ts twoslash
-import { stitch } from 'stitchapi';
+import { StitchError, stitch } from 'stitchapi';
 
 const me = stitch({
     baseUrl: 'https://api.example.com',
@@ -19,9 +20,8 @@ const me = stitch({
 try {
     await me();
 } catch (e) {
-    if (e instanceof Error && e.name === 'StitchError') {
-        const status = (e as Error & { status?: number }).status;
-        console.error(e.message, status);
+    if (e instanceof StitchError) {
+        console.error(e.message, e.status, e.attempts);
     }
 }
 ```
@@ -30,6 +30,28 @@ If you read the [event stream](/docs/concepts/event-stream) instead of awaiting,
 the same failure arrives as an `error` event carrying
 `{ name, message, status?, attempts, at }` — `attempts` is how many tries the
 runtime made before giving up, `at` is when it gave up.
+
+## Handle failure without throwing
+
+`await` and `.unwrap()` throw on failure. When you'd rather branch than wrap the
+call in `try`/`catch`, `.safe()` consumes the call and never throws — it resolves
+to a discriminated `{ ok, data, error }`, where `error` is the same `StitchError`,
+or `null` on success:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const me = stitch({ baseUrl: 'https://api.example.com', path: '/me' });
+
+const { data, error } = await me.safe();
+if (error) console.error(error.status, error.attempts);
+else console.log(data); // the validated result; error is null here
+```
+
+`.unwrap()` is the explicit throwing twin of `.safe()` — the value, or a thrown
+`StitchError`, exactly like awaiting the bare call. See
+[the event stream](/docs/concepts/event-stream) for the iterate-instead-of-await
+view of the same outcomes.
 
 ## The code-to-docs contract
 

--- a/apps/docs/content/docs/errors/stitch-graphql.mdx
+++ b/apps/docs/content/docs/errors/stitch-graphql.mdx
@@ -12,7 +12,7 @@ surfaced the failure instead. The thrown error carries the GraphQL message(s),
 prefixed `GraphQL:` and joined with `; ` when there is more than one:
 
 ```ts twoslash
-import { graphql } from 'stitchapi';
+import { StitchError, graphql } from 'stitchapi';
 
 const user = graphql({
     baseUrl: 'https://api.example.com',
@@ -23,9 +23,10 @@ const user = graphql({
 try {
     await user({ variables: { id: '42' } });
 } catch (err) {
-    // err.name === 'StitchError'
-    // err.message === 'GraphQL: Not authorized to view user 42.'
-    console.error(err);
+    if (err instanceof StitchError) {
+        // err.message === 'GraphQL: Not authorized to view user 42.'
+        console.error(err.message);
+    }
 }
 ```
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -198,6 +198,16 @@ A stitch does not return `Promise<bytes>`. It yields a typed event stream — `a
 const users = await getUsers(); // sugar: consume the stream → the result value
 ```
 
+Prefer to handle failure inline rather than with `try`/`catch`? `.safe()` never throws — it resolves to a `{ ok, data, error }` result you destructure (discriminate on `error`):
+
+```ts
+const { data, error } = await getUsers.safe();
+if (error) return; // error: StitchError (.status, .attempts); data is null
+use(data); // narrowed: data is the validated result, error is null
+```
+
+`.unwrap()` is the explicit throwing twin — it returns the value or throws a `StitchError`, exactly like awaiting the bare call. Both also have a result-object form (`getUsers(input).safe()`).
+
 Consume the stream directly to see progress, throttle waits, retries, and drift as they happen — it is the same spine that powers observability:
 
 ```ts

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -22,8 +22,10 @@ import {
     type HookContext,
     type Hooks,
     type InputSchemas,
+    type SafeResult,
     type Stitch,
     type StitchConfig,
+    StitchError,
     type StitchEvent,
     type StitchInput,
     type StitchResult,
@@ -214,25 +216,56 @@ export function resolveTrace(trace: StitchConfig['trace']): TraceSink {
 }
 
 // ---- the streaming spine + await sugar ------------------------------------
-async function consume<T>(
-    gen: AsyncGenerator<{ type: string } & Record<string, unknown>>,
-): Promise<T> {
-    let result: T | undefined;
-    let failure: { message?: string; status?: number } | undefined;
+// Drain the event stream to its terminal: the `result` value, or the `error` event rebuilt as a
+// typed StitchError (status + attempts preserved). Shared by the throwing and safe consumers.
+async function drain<T>(
+    gen: AsyncGenerator<StitchEvent<T>, void>,
+): Promise<{ value: T } | { error: StitchError }> {
+    let value: T | undefined;
+    let error: StitchError | undefined;
     for await (const ev of gen) {
-        if (ev.type === 'result') result = ev['value'] as T;
+        if (ev.type === 'result') value = ev.value;
         else if (ev.type === 'error')
-            failure = ev as { message?: string; status?: number };
+            error = new StitchError(ev.message, {
+                status: ev.status,
+                attempts: ev.attempts,
+            });
     }
-    if (failure) {
-        const e = new Error(failure.message ?? 'stitch failed') as Error & {
-            status?: number;
-        };
-        e.name = 'StitchError';
-        if (failure.status !== undefined) e.status = failure.status;
-        throw e;
+    return error ? { error } : { value: value as T };
+}
+
+// Throwing consumer: `await stitch(...)` / `stitch.unwrap(...)`. Rejects with the StitchError.
+async function consume<T>(
+    gen: AsyncGenerator<StitchEvent<T>, void>,
+): Promise<T> {
+    const out = await drain(gen);
+    if ('error' in out) throw out.error;
+    return out.value;
+}
+
+// Coerce any thrown value to a StitchError — a real StitchError passes through unchanged; anything
+// else is wrapped with its message and original `cause`. Shared by the safe consumers.
+function asStitchError(e: unknown): StitchError {
+    return e instanceof StitchError
+        ? e
+        : new StitchError(e instanceof Error ? e.message : String(e), {
+              cause: e,
+          });
+}
+
+// Safe consumer: `stitch.safe(...)` / `stitch(...).safe()`. Never throws — an `error` event or an
+// unexpected throw both come back as `{ ok: false, data: null, error }`.
+async function consumeSafe<T>(
+    gen: AsyncGenerator<StitchEvent<T>, void>,
+): Promise<SafeResult<T>> {
+    try {
+        const out = await drain(gen);
+        return 'error' in out
+            ? { ok: false, data: null, error: out.error }
+            : { ok: true, data: out.value, error: null };
+    } catch (e) {
+        return { ok: false, data: null, error: asStitchError(e) };
     }
-    return result as T;
 }
 
 function tee<T>(
@@ -358,11 +391,26 @@ export function makeStitch<T = unknown>(
         // make() independently per handler, so then+catch ran the stitch twice). `stream()` stays a
         // separate, un-memoised consumption path (its own generator each time).
         let consumed: Promise<T> | undefined;
-        const run = () => (consumed ??= consume<T>(make() as never));
+        const run = () => (consumed ??= consume<T>(make()));
         return {
             then: (onF, onR) => run().then(onF, onR),
             catch: (onR: (e: unknown) => unknown) => run().catch(onR),
             finally: (onF: (() => void) | null) => run().finally(onF),
+            // `safe()` shares that same single run — converting its resolve/reject into the
+            // SafeResult shape — so it never re-executes the call and never throws.
+            safe: (): Promise<SafeResult<T>> =>
+                run().then(
+                    (data): SafeResult<T> => ({
+                        ok: true,
+                        data,
+                        error: null,
+                    }),
+                    (e: unknown): SafeResult<T> => ({
+                        ok: false,
+                        data: null,
+                        error: asStitchError(e),
+                    }),
+                ),
             stream: () => make(),
         } as StitchResult<T>;
     };
@@ -371,6 +419,8 @@ export function makeStitch<T = unknown>(
         __raw: (input?: StitchInput) => Promise<unknown>;
     };
     stitchFn.stream = streamFn;
+    stitchFn.safe = (input?: StitchInput) => consumeSafe<T>(streamFn(input));
+    stitchFn.unwrap = (input?: StitchInput) => consume<T>(streamFn(input));
     stitchFn.with = (partial: StitchInput) => {
         // bind partial input; the bound stitch reuses the same runtime (cookies/throttle persist)
         const bound = ((input?: StitchInput) =>
@@ -379,6 +429,10 @@ export function makeStitch<T = unknown>(
         };
         bound.stream = (input?: StitchInput) =>
             streamFn(mergeInput(partial, input));
+        bound.safe = (input?: StitchInput) =>
+            consumeSafe<T>(streamFn(mergeInput(partial, input)));
+        bound.unwrap = (input?: StitchInput) =>
+            consume<T>(streamFn(mergeInput(partial, input)));
         bound.with = (more: StitchInput) =>
             stitchFn.with(mergeInput(partial, more));
         bound.__raw = (input?: StitchInput) =>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -516,13 +516,52 @@ export interface StitchConfig {
     trace?: TraceSink | 'console' | false;
 }
 
+/**
+ * The error a failed stitch raises: a non-2xx response (after retries), a contract/validation
+ * breach, a timeout, or an open circuit. It is what `await stitch(...)` and {@link Stitch.unwrap}
+ * throw, and what rides in `error` on the {@link SafeResult} from {@link Stitch.safe}.
+ */
+export class StitchError extends Error {
+    /** HTTP status when the failure came from a response; `undefined` for transport/internal errors. */
+    readonly status: number | undefined;
+    /** Attempts made before giving up (1 = no retry). */
+    readonly attempts: number;
+    constructor(
+        message: string,
+        opts: {
+            status?: number | undefined;
+            attempts?: number | undefined;
+            cause?: unknown;
+        } = {},
+    ) {
+        super(
+            message,
+            opts.cause !== undefined ? { cause: opts.cause } : undefined,
+        );
+        this.name = 'StitchError';
+        this.status = opts.status;
+        this.attempts = opts.attempts ?? 0;
+    }
+}
+
+/**
+ * The outcome of a never-throwing call ({@link Stitch.safe}). A discriminated union: check `error`
+ * (or `ok`) — when `error` is `null` the call succeeded and `data` is the result; otherwise `error`
+ * is the {@link StitchError} and `data` is `null`.
+ */
+export type SafeResult<T> =
+    | { ok: true; data: T; error: null }
+    | { ok: false; data: null; error: StitchError };
+
 export interface StitchResult<T> extends PromiseLike<T> {
     stream(): AsyncGenerator<StitchEvent<T>, void>;
-    /** Attach a rejection handler (like `Promise.catch`); the stitch runs once, shared with `then`/`finally`. */
+    /** Consume the call without throwing — resolves to `{ ok, data, error }` (see {@link SafeResult}); shares the one run with `then`/`catch`/`finally`. */
+    safe(): Promise<SafeResult<T>>;
+    /** Attach a rejection handler (like `Promise.catch`); the stitch runs once, shared with `then`/`finally`/`safe`. */
     catch<R = never>(
         onrejected?: ((reason: unknown) => R | PromiseLike<R>) | null,
     ): Promise<T | R>;
-    /** Run a callback when the call settles (like `Promise.finally`); shared with `then`/`catch`. */
+    /** Run a callback when the call settles (like `Promise.finally`); shared with `then`/`catch`/`safe`. */
     finally(onfinally?: (() => void) | null): Promise<T>;
 }
 /**
@@ -536,6 +575,16 @@ export interface StitchResult<T> extends PromiseLike<T> {
 export interface Stitch<TOut = unknown, TIn = StitchInput> {
     (...args: Args<TIn>): StitchResult<TOut>;
     stream(...args: Args<TIn>): AsyncGenerator<StitchEvent<TOut>, void>;
+    /**
+     * Call without throwing: resolves to a `SafeResult` — `{ ok, data, error }`. The eager
+     * shortcut for `stitch(...).safe()`, mirroring `.stream()`.
+     */
+    safe(...args: Args<TIn>): Promise<SafeResult<TOut>>;
+    /**
+     * Call and unwrap to the value, throwing a `StitchError` on failure. The named twin
+     * of `.safe()` (and an explicit spelling of the throwing bare call).
+     */
+    unwrap(...args: Args<TIn>): Promise<TOut>;
     with<const P extends Partial<TIn>>(
         partial: P,
     ): Stitch<TOut, RelaxKeys<TIn, keyof P>>;

--- a/packages/core/test/safe-unwrap.spec.ts
+++ b/packages/core/test/safe-unwrap.spec.ts
@@ -1,0 +1,100 @@
+// The never-throwing call surfaces (`stitch.safe()` / `stitch(...).safe()`) and the explicit
+// throwing twin (`stitch.unwrap()`), plus the typed StitchError they share. Driven by the real
+// mock server so status/attempts come off an actual response, like resilience.spec.
+import { StitchError, stitch } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+let server: MockServer;
+
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+// ── safe(): success ─────────────────────────────────────────────────────────
+test('safe() resolves { ok: true, data, error: null } on success', async () => {
+    server.route('GET', '/u', { body: { ok: true } });
+    const call = stitch({ baseUrl: server.url, path: '/u' });
+
+    const res = await call.safe();
+
+    // Discriminated union: `ok`/`error`/`data` all line up on the success branch.
+    expect(res).toEqual({ ok: true, data: { ok: true }, error: null });
+});
+
+// ── safe(): failure never throws ────────────────────────────────────────────
+test('safe() returns { ok: false, data: null, error } instead of throwing', async () => {
+    server.route('GET', '/down', {
+        statuses: [503, 503, 503],
+        body: { error: 'unavailable' },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/down',
+        retry: { attempts: 3, on: [503], baseMs: 5 },
+    });
+
+    const res = await call.safe();
+
+    expect(res.ok).toBe(false);
+    expect(res.data).toBeNull();
+    expect(res.error).toBeInstanceOf(StitchError);
+    expect(res.error).toMatchObject({ status: 503, attempts: 3 });
+    expect(server.callCount('/down')).toBe(3);
+});
+
+// ── safe(): also on the result object (parity with the eager method) ─────────
+test('stitch(input).safe() mirrors stitch.safe(input)', async () => {
+    server.route('GET', '/u', { body: { ok: true } });
+    const call = stitch({ baseUrl: server.url, path: '/u' });
+
+    expect(await call().safe()).toEqual({
+        ok: true,
+        data: { ok: true },
+        error: null,
+    });
+});
+
+// ── unwrap(): the explicit throwing twin ────────────────────────────────────
+test('unwrap() resolves the value on success and throws StitchError on failure', async () => {
+    server.route('GET', '/ok', { body: { id: 1 } });
+    server.route('GET', '/bad', { statuses: [500], body: { error: 'boom' } });
+
+    await expect(
+        stitch({ baseUrl: server.url, path: '/ok' }).unwrap(),
+    ).resolves.toEqual({ id: 1 });
+
+    await expect(
+        stitch({ baseUrl: server.url, path: '/bad' }).unwrap(),
+    ).rejects.toBeInstanceOf(StitchError);
+});
+
+// ── the bare await still throws the same typed error (refactor regression) ───
+test('await sugar still rejects with a StitchError carrying .status', async () => {
+    server.route('GET', '/bad', { statuses: [500], body: { error: 'boom' } });
+    const call = stitch({ baseUrl: server.url, path: '/bad' });
+
+    await expect(call()).rejects.toBeInstanceOf(StitchError);
+    await expect(call()).rejects.toMatchObject({ status: 500 });
+});
+
+// ── .with(...) composes with safe()/unwrap() ────────────────────────────────
+test('a bound stitch (.with) exposes safe() and unwrap()', async () => {
+    server.route('GET', '/u', { body: { ok: true } });
+    const bound = stitch({ baseUrl: server.url, path: '/u' }).with({
+        query: { expand: 'roles' },
+    });
+
+    expect(await bound.safe()).toEqual({
+        ok: true,
+        data: { ok: true },
+        error: null,
+    });
+    await expect(bound.unwrap()).resolves.toEqual({ ok: true });
+});


### PR DESCRIPTION
## What

Adds two intention-revealing call surfaces alongside the bare `await` and `.stream()`, so a caller picks how failure is handled at the call site:

```ts
const { data, error } = await getUser.safe({ params: { id } }); // never throws
//      ^ StitchError | null — discriminate on `error`, `data` narrows to the value

const user = await getUser.unwrap({ params: { id } }); // value, or throws StitchError
```

- **`.safe(...)`** — on the callable (`stitch.safe(input)`) and the result object (`stitch(input).safe()`), mirroring `.stream()`. Resolves to `SafeResult<T>`, a discriminated `{ ok, data, error }` that **never throws**.
- **`.unwrap(...)`** — the explicit throwing twin; returns `Promise<T>` or throws. An explicit spelling of what awaiting the bare call already does.

## `StitchError` is now a real exported class

Previously `consume()` threw an ad-hoc `Error` with `name: 'StitchError'` stamped on — callers had to duck-type (`e.name === 'StitchError'`) and cast for `.status`. It's now an exported `Error` subclass carrying `.status` and `.attempts`, so `e instanceof StitchError` works and `error` in a `SafeResult` is fully typed. `await` and `.catch` stay backward-compatible (the thrown value is unchanged in shape, just typed).

## How

Wired once in `makeStitch` via a shared `drain()` helper that walks the event stream to its terminal. So **every** surface that funnels through `makeStitch` — `stream`, `sse`, `download`, `graphql`, `seam` members — and every `.with(...)`-bound stitch gets `safe`/`unwrap` for free, with no per-surface code.

## Docs

- `concepts/event-stream.mdx` and `errors/index.mdx` describe the `.safe()`/`.unwrap()` alternatives.
- The `errors` examples modernize from duck-typing to `instanceof StitchError` (now that the class is exported) — including `errors/stitch-graphql.mdx`.
- Playground autocomplete completions regenerated.

## Tests / verification

- New `packages/core/test/safe-unwrap.spec.ts` (6 tests): success/failure for both variants, result-object parity, `.with` composition, and a bare-`await` regression.
- Full pre-push gate green locally: typecheck, **tsd**, **455 tests** (+6), lint, exports, prettier, **docs build** (twoslash type-checks the new examples against the built core).

## Deferred

A `kind: 'http' | 'timeout' | …` discriminant on `StitchError` — the error event currently carries the *stitch* name, not the error class, so real classification is a separate lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)