### PR TITLE
feat(adapter): per-stitch undici dispatcher/Agent passthrough in fetchAdapter

### DIFF
--- a/apps/docs/content/docs/reference/helpers.mdx
+++ b/apps/docs/content/docs/reference/helpers.mdx
@@ -22,6 +22,30 @@ import { fetchAdapter } from 'stitchapi';
 const adapter = fetchAdapter();
 ```
 
+It accepts an optional `FetchAdapterOptions` to thread a **per-stitch undici
+dispatcher** — an `Agent` for a proxy, a custom CA, or interface binding —
+straight through as Node's non-standard `dispatcher` fetch init option. The
+runtime stays zero-dependency, so StitchAPI never imports undici; you bring your
+own `Agent`. An optional `fetch` override swaps the global `fetch` for testing or
+custom runtimes. With no options, behavior is identical to `fetchAdapter()` (no
+`dispatcher` is set).
+
+```ts twoslash
+import { fetchAdapter, stitch } from 'stitchapi';
+
+// Your real `new Agent(...)` from undici is structurally an unknown dispatcher here —
+// no undici import inside StitchAPI or this snippet.
+declare const agent: unknown;
+
+const getUser = stitch({
+    url: 'https://api.example.com/users/{id}',
+    adapter: fetchAdapter({ dispatcher: agent }),
+});
+```
+
+The `axiosAdapter` equivalent is axios's own `httpAgent` / `httpsAgent`, passed
+through its `defaults` (`axiosAdapter(axios, { httpsAgent })`) — see below.
+
 ### axiosAdapter
 
 Route a stitch through a caller-supplied axios instance instead of `fetch`. The

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -483,6 +483,22 @@ const getUser = stitch({
 });
 ```
 
+### Per-stitch dispatcher (proxy, custom CA, interface binding)
+
+`fetchAdapter` takes options so you can thread a per-stitch undici **dispatcher** (an `Agent`) into the request — for a proxy, a custom CA, or binding to a specific network interface — without StitchAPI ever importing undici (the runtime stays zero-dependency, so you bring your own `Agent`). It rides through as Node's non-standard `dispatcher` fetch init option:
+
+```ts
+import { fetchAdapter, stitch } from 'stitchapi';
+import { Agent } from 'undici';
+
+const getUser = stitch({
+    path: 'https://api.example.com/users/{id}',
+    adapter: fetchAdapter({ dispatcher: new Agent({ connect: { ca } }) }),
+});
+```
+
+With no options, `fetchAdapter()` behaves exactly as before (no `dispatcher` key is set). An optional `fetch` override (`fetchAdapter({ fetch })`) swaps the global `fetch` for testing or custom runtimes. The `axiosAdapter` equivalent is axios's own `httpAgent` / `httpsAgent`, passed through its `defaults` — `axiosAdapter(axios, { httpsAgent })`.
+
 Body encoding (`json` / `form` / `multipart`), response parsing, and `set-cookie` handling are shared across transports, so swapping adapters doesn't change behavior. Any function matching the `Adapter` shape works — wrap `got`, a test double, or your own client the same way:
 
 ```ts

--- a/packages/core/src/http-adapter.ts
+++ b/packages/core/src/http-adapter.ts
@@ -7,9 +7,30 @@ import type {
     ResponseType,
 } from './types';
 
+/** Options for {@link fetchAdapter}: thread a per-stitch undici dispatcher and/or
+ *  override the global `fetch` — without StitchAPI ever importing undici (zero deps). */
+export interface FetchAdapterOptions {
+    /** An undici Dispatcher/Agent (proxy, custom CA, interface binding). Passed straight
+     *  to Node's `fetch` as the non-standard `dispatcher` init option. Typed `unknown` to
+     *  avoid a hard undici dependency — the runtime stays zero-deps; you bring your own Agent. */
+    dispatcher?: unknown;
+    /** Override the global `fetch` (testing / custom runtimes). Defaults to `globalThis.fetch`. */
+    fetch?: typeof fetch;
+}
+
+// The standard `RequestInit` has no `dispatcher` field (it's an undici extension Node's
+// `fetch` honors), so the init is typed locally as RequestInit widened with the extra key —
+// no `any`, in the spirit of the `as BlobPart` narrowings below. The intersection stays
+// assignable to RequestInit, so the call site needs no cast.
+type FetchInitWithDispatcher = RequestInit & { dispatcher?: unknown };
+
 // Returns an Adapter backed by Node's global `fetch`. Never throws on non-2xx —
 // only network/abort errors propagate; the engine decides what to do with the response.
-export function fetchAdapter(): Adapter {
+// Pass `opts.dispatcher` to route the request through an undici Agent (proxy, custom CA,
+// interface binding); pass `opts.fetch` to swap in a different fetch (testing / runtimes).
+export function fetchAdapter(opts?: FetchAdapterOptions): Adapter {
+    // Resolve the fetch implementation once (override wins; else the global).
+    const fetchImpl = opts?.fetch ?? fetch;
     return async function fetchAdapterRequest(
         req: AdapterRequest,
     ): Promise<AdapterResponse> {
@@ -24,13 +45,21 @@ export function fetchAdapter(): Adapter {
             headers['content-type'] = contentType;
         }
 
-        // Send the request. Network/abort errors propagate to the caller.
-        const response = await fetch(req.url, {
+        // Build the init as a typed local so the non-standard `dispatcher` key can be added
+        // when supplied; with no dispatcher the key is omitted entirely (identical to before).
+        const init: FetchInitWithDispatcher = {
             method,
             headers,
             ...(body !== undefined ? { body } : {}),
             ...(req.signal ? { signal: req.signal } : {}),
-        });
+            ...(opts?.dispatcher !== undefined
+                ? { dispatcher: opts.dispatcher }
+                : {}),
+        };
+
+        // Send the request. Network/abort errors propagate to the caller. The local init type
+        // (with the undici-only `dispatcher`) widens cleanly to the RequestInit fetch expects.
+        const response = await fetchImpl(req.url, init);
 
         // Collect response headers with lowercased keys; join multiple set-cookie with ', '.
         const resHeaders: Record<string, string> = {};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export {
 } from './auth';
 export type { SecretSource } from './auth';
 export { fetchAdapter } from './http-adapter';
+export type { FetchAdapterOptions } from './http-adapter';
 export { axiosAdapter } from './axios-adapter';
 export type {
     AxiosLike,

--- a/packages/core/test/gaps/fetch-dispatcher.spec.ts
+++ b/packages/core/test/gaps/fetch-dispatcher.spec.ts
@@ -1,0 +1,71 @@
+// Pins issue #148: fetchAdapter must thread a per-stitch undici dispatcher (and an optional
+// fetch override) into the request init, WITHOUT importing undici — the runtime is zero-deps.
+// A sentinel object stands in for an undici Agent; we only assert it is passed through verbatim.
+import { fetchAdapter } from '../../src';
+import type { AdapterRequest } from '../../src/types';
+
+// A typed view of the init the adapter hands to fetch, including the non-standard
+// `dispatcher` key undici's fetch honors (absent from the standard RequestInit type).
+type CapturedInit = RequestInit & { dispatcher?: unknown };
+
+// A fetch spy: records the (url, init) of every call and returns a fixed, minimal Response so
+// the adapter's downstream parsing has something well-formed to read. Typed as `typeof fetch`
+// directly — the arrow is structurally assignable, so no cast is needed.
+function makeFetchSpy(): {
+    fetch: typeof fetch;
+    calls: { url: unknown; init: CapturedInit | undefined }[];
+} {
+    const calls: { url: unknown; init: CapturedInit | undefined }[] = [];
+    const fetch: typeof globalThis.fetch = (input, init) => {
+        calls.push({ url: input, init });
+        return Promise.resolve(
+            new Response('{"ok":true}', {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+            }),
+        );
+    };
+    return { fetch, calls };
+}
+
+const req: AdapterRequest = {
+    url: 'https://api.example.com/widgets',
+    method: 'GET',
+    headers: {},
+};
+
+test('fetchAdapter({ dispatcher }) passes the dispatcher straight through to fetch init', async () => {
+    const { fetch: spy, calls } = makeFetchSpy();
+    // A sentinel — a real undici Agent is unnecessary; identity is all we assert.
+    const dispatcher = { __agent: 'sentinel' };
+
+    await fetchAdapter({ fetch: spy, dispatcher })(req);
+
+    expect(calls).toHaveLength(1);
+    // The exact object must arrive on init.dispatcher, by reference.
+    expect(calls[0]?.init?.dispatcher).toBe(dispatcher);
+});
+
+test('fetchAdapter() with no options emits no `dispatcher` key (identical to before)', async () => {
+    const { fetch: spy, calls } = makeFetchSpy();
+
+    // The fetch override is still needed to capture the init; dispatcher is intentionally unset.
+    await fetchAdapter({ fetch: spy })(req);
+
+    expect(calls).toHaveLength(1);
+    const init = calls[0]?.init ?? {};
+    // Not merely undefined — the key must be absent so behavior matches plain fetch exactly.
+    expect('dispatcher' in init).toBe(false);
+});
+
+test('fetchAdapter({ fetch }) routes the request through the injected fetch', async () => {
+    const { fetch: spy, calls } = makeFetchSpy();
+
+    const res = await fetchAdapter({ fetch: spy })(req);
+
+    // The spy — not the global fetch — saw the request, and its Response flowed back through.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(req.url);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+});


### PR DESCRIPTION
Closes #148

## Summary

`fetchAdapter()` now accepts `FetchAdapterOptions` so a per-stitch undici **dispatcher** (an `Agent` — proxy, custom CA, interface binding) can be threaded through as Node's non-standard `dispatcher` fetch init option, plus an optional `fetch` override for testing / custom runtimes.

- **Zero deps preserved** — undici is never imported. The `dispatcher` is typed `unknown` (you bring your own `Agent`), and the init is built as a locally-widened `RequestInit` (no `any`, in the spirit of the file's `as BlobPart` narrowings).
- **No behavior change with no options** — `fetchAdapter()` emits no `dispatcher` key, identical to before.
- `FetchAdapterOptions` is exported from the package root (matching the existing `export type` style).

## Wiring

```ts
import { Agent } from 'undici';
import { fetchAdapter, stitch } from 'stitchapi';

const getUser = stitch({
    path: 'https://api.example.com/users/{id}',
    adapter: fetchAdapter({ dispatcher: new Agent({ connect: { ca } }) }),
});
```

The `axiosAdapter` equivalent is axios's own `httpAgent` / `httpsAgent`, passed through its `defaults` (`axiosAdapter(axios, { httpsAgent })`).

## Tests & docs

- New spec `packages/core/test/gaps/fetch-dispatcher.spec.ts`: injects a `fetch` spy + a sentinel dispatcher object and asserts (1) the dispatcher is passed through by reference, (2) no `dispatcher` key when unset, (3) the injected fetch is the one used. No real undici Agent needed.
- Docs: `packages/core/README.md` transport section and `apps/docs/content/docs/reference/helpers.mdx` `fetchAdapter` entry gain the dispatcher passthrough + the axios equivalent note.

## Verification (all green)

`pnpm -r check:types` · `pnpm -r check:lint` · `pnpm -r test` (469 core, +3 new) · `pnpm -r check:exports` (zero-deps clean) · `pnpm format` (no changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)