### PR TITLE
feat(auth): apiKey({ in: 'query' }) placement for query-param keys

### DIFF
--- a/apps/docs/content/docs/guides/auth/api-key.mdx
+++ b/apps/docs/content/docs/guides/auth/api-key.mdx
@@ -28,14 +28,41 @@ the capability boundary.
 [`env('API_KEY')`](/docs/guides/auth/secret-resolvers) so the secret is read at
 call time and never committed.
 
-`header` overrides the header name (default `x-api-key`, lowercased): pass
-`apiKey({ header: 'X-My-Key', value: env('API_KEY') })` to send the key under a
-custom header.
+`in` chooses where the key goes: `'header'` (the default) or `'query'`.
+
+`header` overrides the header name (default `x-api-key`, lowercased) when
+`in: 'header'`: pass `apiKey({ header: 'X-My-Key', value: env('API_KEY') })` to
+send the key under a custom header.
+
+## In a query parameter
+
+Some APIs (often older REST endpoints) expect the key in the query string rather
+than a header. Set `in: 'query'`; the key is appended to the request URL at call
+time, URL-encoded, onto whatever query the endpoint already carries:
+
+```ts twoslash
+import { apiKey, env, stitch } from 'stitchapi';
+
+const search = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/search?type=full', // an existing query is preserved
+    auth: apiKey({ in: 'query', name: 'api_key', value: env('API_KEY') }),
+});
+```
+
+Every call appends `&api_key=<resolved>` to the URL. `name` is the parameter name
+(default `api_key`).
 
 <Callout type="warn">
-    `apiKey` only sets a header — it does not add a query parameter. For an API
-    that wants the key in the query string, set it through the request `query`
-    input instead.
+    A key in the URL is exposed wherever URLs travel — server access logs,
+    proxies, browser history, a `Referer` header. Prefer `in: 'header'` when the
+    API accepts it. StitchAPI keeps the key out of its own traces two ways: the
+    strategy attaches it only to the request the transport sends (the `start`
+    event's URL is the pre-auth URL, so the key never lands there), and the
+    configured query `name` is registered with the URL-credential scrubber — so
+    if it does appear in a sink (an OTLP `url.full`, the structured
+    `input.query`) it is redacted to `REDACTED`, exactly like
+    `api_key`/`access_token`. None of that protects the upstream server's logs.
 </Callout>
 
 See [Reference → Auth strategies](/docs/reference/auth-strategies) for every

--- a/apps/docs/content/docs/reference/auth-strategies.mdx
+++ b/apps/docs/content/docs/reference/auth-strategies.mdx
@@ -17,7 +17,9 @@ import { bearer } from 'stitchapi';
 
 ## apiKey
 
-Sends a secret in a header (`x-api-key` by default).
+Sends a secret in a header (`x-api-key` by default), or — with `in: 'query'` — as
+a URL query parameter (`api_key` by default), resolved and URL-encoded at call
+time.
 
 ```ts twoslash
 import { apiKey } from 'stitchapi';

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -10,7 +10,14 @@ import type {
     Stitch,
     StitchInput,
 } from './types';
-import { nodeFs, now, readEnv } from './util';
+import {
+    appendQueryString,
+    buildQuery,
+    nodeFs,
+    now,
+    readEnv,
+    registerSecretQueryKey,
+} from './util';
 
 export type Secret = string | (() => string);
 const resolve = (s: Secret): string => (typeof s === 'function' ? s() : s);
@@ -156,7 +163,46 @@ export function bearer(token: Secret | OptionalSecret): AuthStrategy {
     };
 }
 
-export function apiKey(opts: { header?: string; value: Secret }): AuthStrategy {
+/**
+ * API-key auth, in a request **header** (the default) or a **query param**. The key is a
+ * {@link Secret} resolved at call time — the caller (an agent) never sees it.
+ *
+ * - `in: 'header'` (default): writes `header` (default `'x-api-key'`, lower-cased) — byte-for-byte
+ *   the original behaviour, so existing stitches are unaffected.
+ * - `in: 'query'`: appends `name=<resolved>` (default `'api_key'`) to the request URL,
+ *   URL-encoded. The strategy runs in the attempt loop on the fully-built `req` (after
+ *   templating/query-building), so it safely appends onto whatever query the URL already carries.
+ *
+ * SECURITY: a key in the URL leaks wherever URLs go — server access logs, proxies, the browser
+ * history, a `Referer` header. Prefer `in: 'header'` when the API accepts it. The key stays out of
+ * StitchAPI's own traces two ways: the strategy mutates only the request the transport sends (the
+ * `start` event carries the pre-auth URL, so the key never lands there), and the configured query
+ * `name` is registered with the URL-credential scrubber, so if it does surface in a sink (an OTLP
+ * `url.full`, the structured `input.query`) it is REDACTED, like `api_key`/`access_token`/… are.
+ */
+export function apiKey(
+    opts:
+        | { in?: 'header'; header?: string; value: Secret }
+        | { in: 'query'; name?: string; value: Secret },
+): AuthStrategy {
+    if (opts.in === 'query') {
+        const name = opts.name ?? 'api_key';
+        // Teach the trace scrubber this param name carries a secret, so the key never reaches a
+        // sink in the clear — even when `name` is a vendor spelling the built-in stems don't catch.
+        registerSecretQueryKey(name);
+        return {
+            name: 'apiKey',
+            apply(req) {
+                // Resolve at call time (env()/thunk read per call), encode via the same query
+                // builder the engine uses, and append onto the existing query — `appendQueryString`
+                // switches the leading `?` to `&` and preserves any trailing `#fragment`.
+                req.url = appendQueryString(
+                    req.url,
+                    buildQuery({ [name]: resolve(opts.value) }),
+                );
+            },
+        };
+    }
     const header = (opts.header ?? 'x-api-key').toLowerCase();
     return {
         name: 'apiKey',

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -420,15 +420,35 @@ const SECRET_QUERY_STEMS = [
 ];
 const URL_REDACTED = 'REDACTED';
 
+// Caller-registered query-param names that carry a secret value — the escape hatch for a
+// credential whose param name the built-in set/stems don't catch. `apiKey({ in: 'query', name })`
+// registers its configured `name` here at construction, so a key placed in the URL is redacted in
+// every trace sink (the JSONL/console `start.url` via `scrubUrl`, the OTLP `url.full`, and the
+// structured `input.query` via `redactSecretQuery`) without listing every vendor spelling. The
+// default `api_key` already matches a stem; this covers an arbitrary configured name too.
+// Lower-cased on insert so the membership test in `isSecretQueryKey` stays case-insensitive.
+const REGISTERED_SECRET_QUERY_KEYS = new Set<string>();
+
+/**
+ * Register an additional query-param name whose value is a secret, so the trace URL/query
+ * scrubbers redact it. Additive and process-wide (mirroring the built-in denylist): names can be
+ * widened but never un-redacted. Idempotent — registering the same name twice is a no-op.
+ */
+export function registerSecretQueryKey(name: string): void {
+    REGISTERED_SECRET_QUERY_KEYS.add(name.toLowerCase());
+}
+
 /**
  * True when a query-param name (or any key in the same family — a `start` event's
  * `input.query`) carries a secret value: matched case-insensitively against the
- * secret key set above, or by containing one of the secret stems.
+ * secret key set above, by containing one of the secret stems, or because a caller
+ * registered it via {@link registerSecretQueryKey} (e.g. `apiKey({ in: 'query', name })`).
  */
 export function isSecretQueryKey(key: string): boolean {
     const k = key.toLowerCase();
     return (
         SECRET_QUERY_KEYS.has(k) ||
+        REGISTERED_SECRET_QUERY_KEYS.has(k) ||
         SECRET_QUERY_STEMS.some((s) => k.includes(s))
     );
 }

--- a/packages/core/test/gaps/apikey-query.spec.ts
+++ b/packages/core/test/gaps/apikey-query.spec.ts
@@ -1,0 +1,165 @@
+// Pins issue #147: apiKey({ in: 'query' }) — query-param placement for an API key, with
+// header placement staying the backward-compatible default. Covers: append onto a URL with no
+// query AND one that already has a query string, call-time resolution (the thunk is read per
+// call, not at construction), URL-encoding, and trace redaction of the configured param name.
+import { apiKey, fileSink, stitch } from '../../src';
+import { scrubUrl } from '../../src/util';
+import { startMockServer } from '../support/mock-server';
+import type { MockServer } from '../support/mock-server';
+
+import { readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Quiet default — each redaction test overrides STITCH_TRACE_FILE before constructing its stitch.
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-apikey-query-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+const cleanupPaths: string[] = [];
+
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+afterEach(() => {
+    for (const p of cleanupPaths.splice(0)) rmSync(p, { force: true });
+});
+
+describe("issue #147 — apiKey({ in: 'query' }) placement", () => {
+    // ── A. Append onto a URL with NO existing query ─────────────────────────
+    test('appends ?api_key=<value> to a query-less URL, server sees it', async () => {
+        server.route('GET', '/q-none', { body: { ok: true } });
+        const call = stitch({
+            baseUrl: server.url,
+            path: '/q-none',
+            auth: apiKey({ in: 'query', value: 'sk-123' }),
+        });
+        await expect(call()).resolves.toEqual({ ok: true });
+        // The default param name is 'api_key'.
+        expect(server.calls('/q-none')[0]?.query['api_key']).toBe('sk-123');
+    });
+
+    // ── B. Append onto a URL that ALREADY carries a query ───────────────────
+    // The `?page=2` predefined query must survive; the key is added with `&`, not a second `?`.
+    // Both params arriving at the server proves the join was `&` — a stray second `?` would have
+    // folded the key into `page`'s value and `token` would be absent.
+    test('appends with & onto an existing query, both params reach the server', async () => {
+        server.route('GET', '/q-some', { body: { ok: true } });
+        const call = stitch({
+            baseUrl: server.url,
+            path: '/q-some?page=2',
+            auth: apiKey({ in: 'query', name: 'token', value: 'sk-abc' }),
+        });
+        await expect(call()).resolves.toEqual({ ok: true });
+        const q = server.calls('/q-some')[0]?.query ?? {};
+        expect(q['page']).toBe('2');
+        expect(q['token']).toBe('sk-abc');
+    });
+
+    // ── C. Call-time resolution: the thunk is read per call, not at construction ─
+    test('resolves the Secret thunk on every call (not once at construction)', async () => {
+        server.route('GET', '/q-thunk', { body: { ok: true } });
+        let n = 0;
+        const value = (): string => `key-${++n}`;
+        const call = stitch({
+            baseUrl: server.url,
+            path: '/q-thunk',
+            auth: apiKey({ in: 'query', value }),
+        });
+        // Constructing the stitch must NOT have resolved the thunk yet.
+        expect(n).toBe(0);
+        await call();
+        await call();
+        const calls = server.calls('/q-thunk');
+        expect(calls[0]?.query['api_key']).toBe('key-1');
+        expect(calls[1]?.query['api_key']).toBe('key-2');
+    });
+
+    // ── D. URL-encoding: a key with reserved characters is percent-encoded ──
+    // Auth runs on the cloned request inside the attempt loop (after the `start` event), so the
+    // encoded key is observed on the wire — exactly where it matters — via the mock server, which
+    // decodes the percent-encoding back to the original value.
+    test('URL-encodes a value containing reserved characters', async () => {
+        server.route('GET', '/q-enc', { body: { ok: true } });
+        const raw = 'a b&c=d/e+f';
+        const call = stitch({
+            baseUrl: server.url,
+            path: '/q-enc',
+            auth: apiKey({ in: 'query', value: raw }),
+        });
+        await expect(call()).resolves.toEqual({ ok: true });
+        // The server decodes the percent-encoded value back to the exact original — so each
+        // reserved char (space, &, =, /, +) round-tripped through a single param, not split into
+        // extra params or mangled. A raw `&`/`=` would have spawned spurious params instead.
+        const q = server.calls('/q-enc')[0]?.query ?? {};
+        expect(q['api_key']).toBe(raw);
+        expect(Object.keys(q)).toEqual(['api_key']);
+    });
+
+    // ── E. Trace redaction: the configured param name is registered with the scrubber ─
+    // The engine emits `start` with the PRE-auth URL (auth mutates only the cloned request inside
+    // the attempt loop), so a query key never even reaches the `start.url` — but registering the
+    // configured `name` with the scrubber is defense-in-depth for any sink that sees a post-auth
+    // URL or the structured `input.query`. Assert both: the secret value never lands in the trace
+    // file, AND the registered name IS redacted when a URL carrying it passes through `scrubUrl`.
+    test('registers the configured query key with the URL scrubber, secret never traced', async () => {
+        const traceFile = join(
+            tmpdir(),
+            `stitch-apikey-query-redact-${process.pid}.jsonl`,
+        );
+        rmSync(traceFile, { force: true });
+        cleanupPaths.push(traceFile);
+
+        server.route('GET', '/q-redact', { body: { ok: true } });
+        // A vendor spelling the built-in stems would NOT catch on their own — so a redaction here
+        // can only come from the construction-time registration.
+        const call = stitch({
+            name: 'q-redact',
+            baseUrl: server.url,
+            path: '/q-redact',
+            auth: apiKey({
+                in: 'query',
+                name: 'appkeyparam',
+                value: 'sk-leak',
+            }),
+            trace: fileSink(traceFile),
+        });
+        await expect(call()).resolves.toEqual({ ok: true });
+
+        // The secret value never lands anywhere in the trace file.
+        const jsonl = readFileSync(traceFile, 'utf8');
+        expect(jsonl).not.toContain('sk-leak');
+
+        // And the configured name is now a redactable secret key: a URL carrying it (the shape an
+        // OTLP `url.full` or a post-auth `start.url` would have) is scrubbed to REDACTED, while a
+        // benign param survives.
+        const scrubbed = scrubUrl(
+            'https://api.example.com/x?appkeyparam=sk-leak&page=2',
+        );
+        expect(scrubbed).toContain('appkeyparam=REDACTED');
+        expect(scrubbed).not.toContain('sk-leak');
+        expect(scrubbed).toContain('page=2');
+    });
+
+    // ── F. Default placement is unchanged header behavior ───────────────────
+    test('default (in omitted) writes the x-api-key header, no query param', async () => {
+        server.route('GET', '/hdr', { body: { ok: true } });
+        const call = stitch({
+            baseUrl: server.url,
+            path: '/hdr',
+            auth: apiKey({ value: 'sk-hdr' }),
+        });
+        await expect(call()).resolves.toEqual({ ok: true });
+        const c = server.calls('/hdr')[0];
+        expect(c?.headers['x-api-key']).toBe('sk-hdr');
+        expect(c?.query['api_key']).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Closes #147

## Summary

Extends `apiKey()` with an `in` discriminator so an API key can ride in the URL **query string**, not just a header. Header placement stays the default, so the change is fully backward-compatible (byte-for-byte the prior behaviour for `apiKey({ value })` / `apiKey({ header, value })`).

```ts
apiKey({ in: 'query', name: 'api_key', value: env('API_KEY') })
```

## Key decisions

- **Reuse the engine's idiom.** `in: 'query'` builds `?name=<resolved>` with `buildQuery({ [name]: resolve(value) })` and merges it via `appendQueryString` — the exact helpers `engine.ts`'s `buildRequest` uses. That correctly handles a URL that already carries a `?query` (switches the leading `?` to `&`) and preserves a trailing `#fragment`. Value is URL-encoded by `buildQuery`; resolved per call.
- **Trace safety.** The configured query `name` is registered with the URL-credential scrubber via a new `registerSecretQueryKey()` in `util.ts`, so even an arbitrary vendor spelling the built-in stems don't catch is REDACTED across every built-in sink (`scrubUrl` → JSONL/console `start.url`, OTLP `url.full`, and the structured `input.query`). Separately, the key never reaches the `start` event at all: auth mutates the per-attempt request clone *after* `start` is emitted with the pre-auth URL.

## Files

- `packages/core/src/auth.ts` — `in` discriminator + query-append `apply`, registers the param name with the scrubber.
- `packages/core/src/util.ts` — `registerSecretQueryKey()` + an extra denylist consulted by `isSecretQueryKey`.
- `packages/core/test/gaps/apikey-query.spec.ts` — new spec (6 tests): append on query-less / existing-query URLs, per-call thunk resolution, URL-encoding round-trip, scrubber registration, unchanged-header default.
- `apps/docs/content/docs/guides/auth/api-key.mdx`, `reference/auth-strategies.mdx` — document the `in: 'query'` form + exposure tradeoff.

## Verification

`pnpm -r check:types`, `pnpm -r check:lint`, `pnpm -r test` (472 core tests, all suites green), and `pnpm format` all pass; the lefthook pre-commit gate (format/lint/typecheck) passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)