### PR TITLE
docs(drift): confirm drift on transform output + scrape→transform→drift recipe

### DIFF
--- a/apps/docs/content/docs/guides/data/transform.mdx
+++ b/apps/docs/content/docs/guides/data/transform.mdx
@@ -55,4 +55,8 @@ and return any reshaped value. See
     <Card title="Validation" href="/docs/guides/validation/validation" />
     <Card title="Drift" href="/docs/guides/validation/drift" />
     <Card title="Reference: Config types" href="/docs/reference/config-types" />
+    <Card
+        title="Recipe: catch a silent selector rename"
+        href="/docs/recipes/catch-a-selector-rename"
+    />
 </Cards>

--- a/apps/docs/content/docs/guides/validation/drift.mdx
+++ b/apps/docs/content/docs/guides/validation/drift.mdx
@@ -123,4 +123,8 @@ See [Reference → Config types](/docs/reference/config-types) for the full
     <Card title="The event stream" href="/docs/concepts/event-stream" />
     <Card title="STITCH_DRIFT" href="/docs/errors/stitch-drift" />
     <Card title="Config types" href="/docs/reference/config-types" />
+    <Card
+        title="Recipe: catch a silent selector rename"
+        href="/docs/recipes/catch-a-selector-rename"
+    />
 </Cards>

--- a/apps/docs/content/docs/recipes/catch-a-selector-rename.mdx
+++ b/apps/docs/content/docs/recipes/catch-a-selector-rename.mdx
@@ -1,0 +1,134 @@
+---
+title: 'Catch a silent selector rename in scraped HTML'
+description: 'Scrape an HTML page into a structured object with transform, then drift the structured shape so a markup or selector rename becomes a loud contract error instead of a silently missing field.'
+---
+
+## Task
+
+You scrape a page that has no API — a catalog provider returns HTML, and you
+parse it into a structured object with a selector. The danger is silent: the
+provider renames a CSS class or moves a cell, your selector quietly stops
+matching, and the field comes back `undefined`. Nothing throws; downstream code
+keeps running on corrupted data until someone notices a ranking is wrong. You
+want that markup rename to surface the moment it happens, as a loud error on the
+**structured** shape — not the raw HTML.
+
+## Example
+
+The response pipeline is `transform → unwrap → validation`, so `transform`
+reshapes the HTML into a structured object **before** drift ever runs — drift
+then compares the _parsed_ value, not the raw markup. List the path that must
+not move under `critical`.
+
+```ts twoslash
+import { drift, stitch } from 'stitchapi';
+import { z } from 'zod';
+
+// A trivial hand-rolled scraper: the `score` selector keys off `td.score` —
+// exactly the class a markup rename silently breaks.
+function scrape(html: unknown): { items: Record<string, unknown>[] } {
+    const text = String(html);
+    const rows = text.split(/<tr[^>]*class="row1"[^>]*>/i).slice(1);
+    const items = rows.map((row) => {
+        const item: Record<string, unknown> = {};
+        const title = /<td[^>]*class="title"[^>]*>([^<]+)<\/td>/i.exec(row);
+        const score = /<td[^>]*class="score"[^>]*>\s*(\d+)\s*<\/td>/i.exec(
+            row,
+        )?.[1];
+        if (title) item['title'] = title[1]!.trim();
+        if (score !== undefined) item['score'] = Number(score); // omitted when the selector misses
+        return item;
+    });
+    return { items };
+}
+
+const catalog = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/catalog',
+    transform: scrape, // HTML string -> { items: [...] }
+    unwrap: 'items',
+    output: drift(
+        z.array(z.object({ title: z.string(), score: z.number().optional() })),
+        {
+            // `[].score` is a path on the STRUCTURED shape, not the raw HTML.
+            critical: ['[].score'],
+            snapshotFile: 'catalog.contract.json',
+        },
+    ),
+});
+
+const items = await catalog();
+```
+
+## How it works
+
+The first call records the baseline into `catalog.contract.json` (check it into
+the repo) from the **transformed** shape — `[{ title, score }]`, not the HTML
+body. Every call after parses the page and compares that structured value
+against the snapshot.
+
+When the provider renames the score cell's class (`score` → `rank`), the
+selector stops matching and `scrape` drops `score` from each item. Because
+`[].score` is `critical`, drift emits an `error`-level finding —
+`{ level: 'error', change: 'missing', path: '[].score' }` — which breaks the
+contract and throws [`STITCH_DRIFT`](/docs/errors/stitch-drift). The path is the
+proof: `[].score` exists only on the parsed object, so a finding on it can only
+come from drift inspecting the `transform` output, not the raw markup. The
+silent `undefined` is now a loud, immediate failure.
+
+`warn` and `info` findings (a non-critical field changing, a new field
+appearing) don't throw — they ride the
+[event stream](/docs/concepts/event-stream) as `drift` events, so you can
+[watch a field erode](/docs/recipes/watch-a-call-as-it-happens) before it
+breaks. Reserve `critical` for the few paths whose loss corrupts your data.
+
+## Ship it read-only in production
+
+The first call with no committed snapshot **writes** one and reports nothing — a
+convenience while you develop the contract, but a footgun in a deployed run,
+where the first request would silently persist a baseline and "pass" instead of
+detecting drift. Generate the baseline once, commit `catalog.contract.json`,
+then ship with `readonly: true` so drift _detects but never writes_:
+
+```ts twoslash
+import { drift, stitch } from 'stitchapi';
+import { z } from 'zod';
+
+declare function scrape(html: unknown): { items: Record<string, unknown>[] };
+// ---cut---
+const catalog = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/catalog',
+    transform: scrape,
+    unwrap: 'items',
+    output: drift(
+        z.array(z.object({ title: z.string(), score: z.number().optional() })),
+        {
+            critical: ['[].score'],
+            readonly: true, // detect-but-never-write
+            onMissing: 'error', // a missing baseline fails CI, not slips past
+            snapshotFile: 'catalog.contract.json',
+        },
+    ),
+});
+```
+
+<Callout type="warn">
+    **Anti-pattern:** don't drift the raw HTML body and skip `transform`.
+    Snapshotting the markup makes every cosmetic edit — a reordered attribute, a
+    whitespace change — look like drift, burying the one rename that matters.
+    Parse to the structured shape first, then drift the few `critical` fields
+    you actually depend on.
+</Callout>
+
+## See also
+
+<Cards>
+    <Card title="transform" href="/docs/guides/data/transform" />
+    <Card title="Leveled drift" href="/docs/guides/validation/drift" />
+    <Card
+        title="Catch a breaking API change before your users do"
+        href="/docs/recipes/catch-a-breaking-api-change"
+    />
+    <Card title="STITCH_DRIFT" href="/docs/errors/stitch-drift" />
+</Cards>

--- a/apps/docs/content/docs/recipes/index.mdx
+++ b/apps/docs/content/docs/recipes/index.mdx
@@ -55,6 +55,11 @@ a guide when you want to understand a feature on its own.
         description="Wrap output with drift to flag dropped fields, type flips, and new keys against a committed snapshot."
     />
     <Card
+        title="Catch a silent selector rename in scraped HTML"
+        href="/docs/recipes/catch-a-selector-rename"
+        description="Scrape HTML into a structured object with transform, then drift the structured shape so a markup rename becomes a loud error."
+    />
+    <Card
         title="Watch retries and throttling as they happen"
         href="/docs/recipes/watch-a-call-as-it-happens"
         description="Iterate a stitch's event stream instead of awaiting it, and observe every retry, pause, and drift."

--- a/apps/docs/content/docs/recipes/meta.json
+++ b/apps/docs/content/docs/recipes/meta.json
@@ -8,6 +8,7 @@
         "survive-a-flaky-dependency",
         "idempotent-writes",
         "catch-a-breaking-api-change",
+        "catch-a-selector-rename",
         "watch-a-call-as-it-happens",
         "mirror-a-paginated-api",
         "one-rate-limit-across-workers",

--- a/packages/core/test/gaps/drift-on-transform-output.spec.ts
+++ b/packages/core/test/gaps/drift-on-transform-output.spec.ts
@@ -1,0 +1,162 @@
+// Pins issue #149: drift runs on the TRANSFORM output, not the raw response body.
+//
+// The engine pipeline is transform → unwrap → validateOutput (engine.ts), so when a stitch
+// scrapes an HTML string into a structured object via `transform`, drift compares the
+// *structured* value against the baseline — exactly the high-value case where a silent
+// markup/selector rename must become a loud contract error.
+//
+// The proof is in the drift PATH: `[].score` exists only on the parsed shape, never anywhere
+// in the raw HTML string. An error/missing finding on that path can only come from drift
+// inspecting the transformed value.
+import { drift, stitch } from '../../src';
+import type { DriftFinding, StitchEvent } from '../../src';
+import { startMockServer } from '../support/mock-server';
+import type { MockServer } from '../support/mock-server';
+
+import { existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { z } from 'zod';
+
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-gap-drift-transform-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+const freshSnapshot = (): string =>
+    join(
+        tmpdir(),
+        `stitch-gap-drift-transform-${process.pid}-${Date.now()}.contract.json`,
+    );
+
+// Drain a stream into every event so we can inspect drift findings and ordering.
+async function collect<T>(
+    gen: AsyncGenerator<StitchEvent<T>, void>,
+): Promise<StitchEvent<T>[]> {
+    const events: StitchEvent<T>[] = [];
+    for await (const ev of gen) events.push(ev);
+    return events;
+}
+
+const driftFindings = (events: StitchEvent[]): DriftFinding[] =>
+    events
+        .filter(
+            (e): e is Extract<StitchEvent, { type: 'drift' }> =>
+                e.type === 'drift',
+        )
+        .map((e) => e.finding);
+
+// One catalog row. The score cell's class is the selector the parser keys off — renaming it
+// is the silent markup break we want drift to catch.
+const row = (scoreClass: string): string =>
+    `<tr class="row1">` +
+    `<td class="title"><a href="/i/1">Item A</a></td>` +
+    `<td class="${scoreClass}">42</td>` +
+    `</tr>`;
+
+const page = (scoreClass: string): string =>
+    `<table id="catalog">${row(scoreClass)}</table>`;
+
+// A trivial hand-rolled scraper (no cheerio dependency). The score selector is hardcoded to
+// `td.score` — precisely what a markup rename (score -> rank) silently breaks: `score` is
+// simply omitted from the parsed item, with no error at the HTTP layer.
+function scrape(html: unknown): { items: Record<string, unknown>[] } {
+    const text = String(html);
+    const rows = text.split(/<tr[^>]*class="row1"[^>]*>/i).slice(1);
+    const items = rows.map((chunk) => {
+        const item: Record<string, unknown> = {};
+        const title =
+            /<td[^>]*class="title"[^>]*>\s*<a[^>]*href="([^"]+)"[^>]*>([^<]+)<\/a>/i.exec(
+                chunk,
+            );
+        const score = /<td[^>]*class="score"[^>]*>\s*(\d+)\s*<\/td>/i.exec(
+            chunk,
+        )?.[1];
+        if (title) {
+            item['title'] = title[2]!.trim();
+            item['link'] = title[1];
+        }
+        if (score !== undefined) item['score'] = Number(score);
+        return item;
+    });
+    return { items };
+}
+
+// The structured contract the rest of the pipeline (and drift) is written for.
+const schema = z.array(
+    z.object({
+        title: z.string(),
+        link: z.string().optional(),
+        score: z.number().optional(),
+    }),
+);
+
+test('drift fires on the TRANSFORM output: a critical scraped field renamed away is an error', async () => {
+    const snapshotFile = freshSnapshot();
+    try {
+        // call #1 has the original markup; call #2 renames the score cell's class.
+        server.route('GET', '/catalog', {
+            body: [page('score'), page('rank')],
+        });
+
+        const listings = stitch({
+            baseUrl: server.url,
+            path: '/catalog',
+            transform: scrape, // HTML string -> { items: [...] }
+            unwrap: 'items',
+            output: drift(schema, {
+                // `[].score` is a path on the STRUCTURED shape, not the raw HTML — losing it
+                // silently corrupts ranking, so make it loud.
+                critical: ['[].score'],
+                snapshotFile,
+            }),
+        });
+
+        // First call: original markup. The transform yields a complete item; this records the
+        // baseline from the *transformed* shape (no drift, file written).
+        const first = await collect(listings.stream());
+        expect(driftFindings(first)).toHaveLength(0);
+        const firstResult = first.find((e) => e.type === 'result');
+        expect(firstResult).toBeDefined();
+        expect(
+            (firstResult as Extract<StitchEvent, { type: 'result' }>).value,
+        ).toEqual([{ title: 'Item A', link: '/i/1', score: 42 }]);
+        expect(existsSync(snapshotFile)).toBe(true);
+
+        // Second call: the score cell renamed `score` -> `rank`. The scraper silently drops
+        // `score`; the HTTP layer is none the wiser. Drift, seeing the transformed value, must
+        // SHOUT — and on a path (`[].score`) that exists only on the parsed object.
+        const second = await collect(listings.stream());
+        const findings = driftFindings(second);
+        const missing = findings.find((f) => f.path.includes('score'));
+        expect(missing).toBeDefined();
+        expect(missing?.level).toBe('error');
+        expect(missing?.change).toBe('missing');
+        // The path is the structured shape's index path, proving drift inspected the transform
+        // output, not the raw HTML body (which has no `score` field anywhere).
+        expect(missing?.path).toContain('score');
+
+        // A critical-field drift is a contract violation: no `result`, the stream errors, and
+        // the await path rejects (not a silent `undefined`).
+        expect(second.some((e) => e.type === 'result')).toBe(false);
+        expect(second.some((e) => e.type === 'error')).toBe(true);
+
+        server.reset();
+        server.route('GET', '/catalog', { body: page('rank') }); // always drifted now
+        await expect(listings()).rejects.toThrow();
+    } finally {
+        rmSync(snapshotFile, { force: true });
+    }
+});


### PR DESCRIPTION
## Summary

`drift` already runs on the **transform output** — the engine pipeline is
`transform → unwrap → validateOutput`, so a stitch that scrapes HTML into a
structured object via `transform` drifts the *structured* value, not the raw
markup. That high-value selector-drift case was correct on `main` but
undocumented and untested. This PR proves it and documents it.

- **Confirming spec** — `packages/core/test/gaps/drift-on-transform-output.spec.ts`:
  a stitch whose adapter returns an HTML string, a trivial in-test regex parser as
  `transform` (no cheerio / no new dependency), and `drift(schema, { critical: ['[].score'], snapshotFile })`.
  The first run records the baseline from the transformed shape; a second run that
  renames the score cell's class drops the critical `[].score` field and fires an
  `error`/`missing` drift finding — on a path that exists **only** on the parsed
  object, proving drift sees the transformed value, not the raw HTML.
- **Recipe** — `apps/docs/content/docs/recipes/catch-a-selector-rename.mdx`:
  worked scrape→transform→drift example framed as "turn a silent markup/selector
  rename into a loud contract error," showing `critical` paths on the structured
  shape and the resulting `error` finding, plus the `readonly` drift mode for prod.
  Neutral archetype (a "catalog provider", `api.example.com`).
- **Wiring** — recipe added to `recipes/meta.json` + `recipes/index.mdx`, and
  cross-linked from `guides/validation/drift.mdx` and `guides/data/transform.mdx`.

## Verification

`pnpm -r check:types`, `pnpm -r check:lint`, `pnpm -r test` (core: 467 tests),
and `pnpm format` all pass. The docs `check:types` compiles the recipe's
twoslash blocks against the real `stitchapi` types.

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)