### PR TITLE
feat(auth): cookieSession lifecycle hooks (onAuthFailure / onRefresh)

### DIFF
--- a/apps/docs/content/docs/guides/auth/cookie-session.mdx
+++ b/apps/docs/content/docs/guides/auth/cookie-session.mdx
@@ -52,6 +52,88 @@ served with a `200`. Give two stitches the same `key` plus a shared `store` to
 share one session. See
 [Reference → Auth strategies](/docs/reference/auth-strategies) for every field.
 
+## Durable state and an external recovery loop
+
+`cookieSession` does the mechanical capture-and-replay, refreshing on the wall —
+but it can't model a host that owns **durable, categorised** auth state and its
+own recovery loop (mark a session `backoff` after a rate-limit, `failed` after
+bad creds, and retry on its own schedule). Two optional host-owned hooks hand
+that decision back to you. They fire **once per actual login attempt** — inside
+the single-flight refresh, never once per coalesced caller — and a throwing hook
+never crashes the call.
+
+-   `onRefresh({ ok, status })` runs after **every** (re)login attempt with its
+    outcome (`ok` = a cookie was captured), so you can persist session state and
+    clear or extend a cooldown.
+-   `onAuthFailure(info)` runs when an attempt captured no cookie, with a
+    `category` you map to your own status:
+    `'unauthenticated'` (a `refreshOn` status, e.g. `401` — bad/expired creds),
+    `'rate-limited'` (`429`, with `retryAfterMs` parsed from `Retry-After`),
+    `'network'` (the login threw before any response — with the thrown `error`),
+    or `'unknown'`. `info.phase` is `'apply'` for a cold session or `'refresh'`
+    for a wall that was hit mid-stream.
+
+```ts twoslash
+import { cookieSession, env, stitch } from 'stitchapi';
+import type { AuthFailureInfo, RefreshResult } from 'stitchapi';
+
+// Your own durable store — a row in a database, a Redis hash, anything.
+declare const sessionState: {
+    markActive(): Promise<void>;
+    markFailed(reason: string): Promise<void>;
+    backoffUntil(at: number): Promise<void>;
+};
+
+const login = stitch({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/login',
+    bodyType: 'form',
+});
+
+const me = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/me',
+    auth: cookieSession({
+        login,
+        cookie: '*',
+        loginInput: () => ({
+            body: { user: env('USER')(), pass: env('PASS')() },
+        }),
+        // Persist the outcome of every attempt.
+        onRefresh: async ({ ok }: RefreshResult) => {
+            if (ok) await sessionState.markActive();
+        },
+        // Categorise a failure and drive your own recovery loop.
+        onAuthFailure: async (info: AuthFailureInfo) => {
+            switch (info.category) {
+                case 'rate-limited':
+                    // Back off until the server says we may retry.
+                    await sessionState.backoffUntil(
+                        Date.now() + (info.retryAfterMs ?? 60_000),
+                    );
+                    break;
+                case 'unauthenticated':
+                    // Bad/expired creds — stop hammering; surface for re-auth.
+                    await sessionState.markFailed('credentials rejected');
+                    break;
+                case 'network':
+                    // Transport failure — your loop decides whether to retry.
+                    await sessionState.backoffUntil(Date.now() + 30_000);
+                    break;
+                default:
+                    await sessionState.markFailed('unknown auth failure');
+            }
+        },
+    }),
+});
+```
+
+The hooks are purely additive: omit them and `cookieSession` behaves exactly as
+before. They observe and record — they never change _whether_ the stitch logs in
+or retries (that stays governed by `refreshOn`/`refreshWhen`). Your external loop
+reads the durable state and decides when to call the stitch again.
+
 <Callout type="warn">
     **Anti-pattern:** don't lean on `refreshOn` status codes alone to catch an
     expired session — a soft 200 wall, where the login page comes back with

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -2,6 +2,7 @@
 // resolved at call time — the caller (an agent) never sees it. `cookieSession` performs
 // a login (another stitch) and manages the cookie jar, refreshing on a 401 wall.
 import { fetchAdapter } from './http-adapter';
+import { parseRetryAfter } from './resilience';
 import type {
     Adapter,
     AdapterResponse,
@@ -376,6 +377,38 @@ export function oauth2(opts: OAuth2Opts): AuthStrategy {
     };
 }
 
+/**
+ * Why an `apply`/`refresh` login attempt failed, categorised so the HOST can drive its OWN
+ * durable state machine (wrong-creds vs rate-limited vs network) — StitchAPI keeps doing the
+ * mechanical cookie capture/replay, but it can't model a host's external recovery loop, so it
+ * hands the host a categorised outcome instead. Surfaced via {@link CookieSessionOpts.onAuthFailure}.
+ */
+export interface AuthFailureInfo {
+    /** `'apply'` = cold session had no stored cookie; `'refresh'` = a 401-style wall was hit. */
+    phase: 'apply' | 'refresh';
+    /** The login response status when the login responded at all (absent when it threw). */
+    status?: number;
+    /** `Retry-After` parsed to ms when the login was rate-limited (status 429). */
+    retryAfterMs?: number;
+    /** The thrown value when the login stitch itself threw (network/transport failure). */
+    error?: unknown;
+    /**
+     * - `'unauthenticated'` — login responded with a `refreshOn` status (e.g. 401) and set no cookie (bad/expired creds);
+     * - `'rate-limited'` — login responded `429` (back off, then retry; see `retryAfterMs`);
+     * - `'network'` — the login stitch threw before any response (DNS/connection/transport);
+     * - `'unknown'` — login responded but captured no cookie for some other reason.
+     */
+    category: 'unauthenticated' | 'rate-limited' | 'network' | 'unknown';
+}
+
+/** Outcome of a single (re)login attempt, surfaced via {@link CookieSessionOpts.onRefresh}. */
+export interface RefreshResult {
+    /** A cookie (named, or any jar entry) was captured from the login response. */
+    ok: boolean;
+    /** The login response status when the login responded (absent when it threw). */
+    status?: number;
+}
+
 export interface CookieSessionOpts {
     /** The login stitch — its raw response (the Set-Cookie headers) seeds the session. */
     login: Stitch;
@@ -408,6 +441,21 @@ export interface CookieSessionOpts {
      * which never has a principal). Sessions always live in the {@link AuthContext.vault}.
      */
     scope?: 'principal' | 'app';
+    /**
+     * Host-owned hook fired once per ACTUAL login attempt that failed to capture a cookie — NOT
+     * per coalesced waiter (it runs inside the single-flight-guarded `doRefresh`). The host maps the
+     * categorised {@link AuthFailureInfo} to its own status (active/backoff/failed/unauthenticated)
+     * and owns the external recovery loop that StitchAPI's per-call single-flight can't model. A
+     * throwing hook never crashes the call (it is caught and announced on the `auth` trace topic).
+     */
+    onAuthFailure?: (info: AuthFailureInfo) => void | Promise<void>;
+    /**
+     * Host-owned hook fired once after EVERY (re)login attempt — success or failure — with its
+     * {@link RefreshResult}, so the host can persist durable session state and clear/extend its
+     * cooldown. Like {@link onAuthFailure}, it runs once per actual attempt (inside the
+     * single-flight-guarded `doRefresh`), and a throw is caught so it can't crash the call.
+     */
+    onRefresh?: (result: RefreshResult) => void | Promise<void>;
 }
 
 export function cookieSession(opts: CookieSessionOpts): AuthStrategy {
@@ -439,31 +487,135 @@ export function cookieSession(opts: CookieSessionOpts): AuthStrategy {
         return { key: `${baseKey}\u0000${principal}`, principal };
     };
 
+    // Run a host hook without ever letting it crash the call (the host owns its own recovery loop;
+    // its bookkeeping must not take the stitch down). A throw — sync or rejected promise — is
+    // swallowed and announced on the `auth` trace topic. Returns a promise the caller awaits so a
+    // slow async hook still completes before the login attempt is considered done.
+    const runHook = async (
+        ctx: AuthContext,
+        name: 'onAuthFailure' | 'onRefresh',
+        invoke: () => void | Promise<void>,
+    ): Promise<void> => {
+        try {
+            await invoke();
+        } catch (err) {
+            ctx.emit(
+                'auth',
+                `${name} hook threw: ${err instanceof Error ? err.message : String(err)}`,
+            );
+        }
+    };
+
+    // Categorise a login response that captured no cookie, given its status + headers. A 429 means
+    // rate-limited (back off per `Retry-After`); a `refreshOn` status (e.g. 401) means the creds were
+    // rejected; anything else — including a soft 200 wall that set no cookie — is `unknown`.
+    const classify = (
+        phase: 'apply' | 'refresh',
+        status: number,
+        headers: Record<string, string>,
+    ): AuthFailureInfo => {
+        if (status === 429) {
+            // Omit `retryAfterMs` entirely when the header is absent/unparseable —
+            // `exactOptionalPropertyTypes` forbids setting an optional prop to `undefined`.
+            const retryAfterMs = parseRetryAfter(headers['retry-after']);
+            return {
+                phase,
+                status,
+                category: 'rate-limited',
+                ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+            };
+        }
+        if (refreshOn.includes(status))
+            return { phase, status, category: 'unauthenticated' };
+        return { phase, status, category: 'unknown' };
+    };
+
+    // Announce one login attempt's outcome to the host. `onRefresh` fires for EVERY attempt; on a
+    // failure (no cookie captured) `onAuthFailure` fires too with the categorised `info`.
+    const report = async (
+        ctx: AuthContext,
+        ok: boolean,
+        status: number | undefined,
+        failure?: AuthFailureInfo,
+    ): Promise<void> => {
+        // Bind into locals so the optional hooks narrow to defined — no non-null assertion needed.
+        const onRefresh = opts.onRefresh;
+        if (onRefresh)
+            await runHook(ctx, 'onRefresh', () =>
+                // `status` only appears on the result object when the login actually responded.
+                onRefresh(status === undefined ? { ok } : { ok, status }),
+            );
+        const onAuthFailure = opts.onAuthFailure;
+        if (!ok && failure && onAuthFailure)
+            await runHook(ctx, 'onAuthFailure', () => onAuthFailure(failure));
+    };
+
+    // ONE actual login attempt (single-flight-guarded by the callers below, so the hooks fire once
+    // per real attempt, never per coalesced waiter). `__raw` RESOLVES only for a 2xx login and
+    // THROWS otherwise — an error with a numeric `status` (+ a `response` for its headers) is a
+    // response-derived failure (401/429/…); an error without a `status` is a transport failure. Each
+    // path fires `onRefresh` always and `onAuthFailure` on failure, then re-throws so callers see the
+    // original error exactly as before these hooks existed.
     const doRefresh = async (
         ctx: AuthContext,
         key: string,
         principal: string | undefined,
+        phase: 'apply' | 'refresh',
     ) => {
         ctx.emit('auth', 'login');
         // `__raw` runs the login once and returns its raw AdapterResponse (headers and all).
         // It is intentionally not on the public Stitch type, so reach it through a cast.
-        const res = await (
-            opts.login as unknown as {
-                __raw: (input?: StitchInput) => Promise<AdapterResponse>;
-            }
-        ).__raw(opts.loginInput?.(principal));
+        let res: AdapterResponse;
+        try {
+            res = await (
+                opts.login as unknown as {
+                    __raw: (input?: StitchInput) => Promise<AdapterResponse>;
+                }
+            ).__raw(opts.loginInput?.(principal));
+        } catch (error) {
+            // A failed login: an HTTP error carries a numeric `status` (+ the `response` for its
+            // headers); a transport error carries neither → `network`.
+            const e = error as {
+                status?: number;
+                response?: AdapterResponse;
+            };
+            const status = typeof e.status === 'number' ? e.status : undefined;
+            const failure: AuthFailureInfo =
+                status === undefined
+                    ? { phase, category: 'network', error }
+                    : classify(phase, status, e.response?.headers ?? {});
+            await report(ctx, false, status, failure);
+            // Re-throw so the caller sees the original error exactly as before these hooks existed.
+            throw error;
+        }
+
+        const status = res.status;
         const setCookie =
             res.headers['set-cookie'] ?? res.headers['Set-Cookie'];
+        let captured = false;
         if (jarMode) {
             // Capture the full jar: every name=value pair the login set.
             const jar = parseCookieJar(setCookie);
-            if (Object.keys(jar).length > 0)
+            if (Object.keys(jar).length > 0) {
                 await ctx.vault.set(key, jar, opts.ttlMs);
+                captured = true;
+            }
         } else {
             const value = parseCookie(setCookie, opts.cookie);
-            if (value != null)
+            if (value != null) {
                 await ctx.vault.set(key, `${opts.cookie}=${value}`, opts.ttlMs);
+                captured = true;
+            }
         }
+
+        // A 2xx login that set no cookie is a soft wall (a login page served with 200) — report it as
+        // a failure so the host still hears about it, classified by its (2xx) status → `unknown`.
+        await report(
+            ctx,
+            captured,
+            status,
+            captured ? undefined : classify(phase, status, res.headers),
+        );
     };
 
     return {
@@ -474,7 +626,9 @@ export function cookieSession(opts: CookieSessionOpts): AuthStrategy {
             if (!stored) {
                 // Concurrent cold sessions for the SAME principal share ONE login (the principal
                 // is in the key, so different users never coalesce — GAP-AUDIT §2.6 + ADR §3).
-                await flight(key, () => doRefresh(ctx, key, principal));
+                await flight(key, () =>
+                    doRefresh(ctx, key, principal, 'apply'),
+                );
                 stored = await ctx.vault.get(key);
             }
             // Non-jar: a stored `name=value` string. Jar: a stored map → serialize all pairs.
@@ -493,7 +647,7 @@ export function cookieSession(opts: CookieSessionOpts): AuthStrategy {
         async refresh(ctx) {
             const { key, principal } = sessionFor(ctx);
             // Simultaneous 401-driven re-logins for the same principal coalesce into one login.
-            await flight(key, () => doRefresh(ctx, key, principal));
+            await flight(key, () => doRefresh(ctx, key, principal, 'refresh'));
         },
     };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,7 @@ export {
     secretsFile,
     secretFrom,
 } from './auth';
-export type { SecretSource } from './auth';
+export type { SecretSource, AuthFailureInfo, RefreshResult } from './auth';
 export { fetchAdapter } from './http-adapter';
 export { axiosAdapter } from './axios-adapter';
 export type {

--- a/packages/core/test/gaps/cookie-session-hooks.spec.ts
+++ b/packages/core/test/gaps/cookie-session-hooks.spec.ts
@@ -1,0 +1,309 @@
+// Pins issue #146: cookieSession host-owned lifecycle hooks (onRefresh / onAuthFailure).
+//
+// A host that owns durable, CATEGORISED auth state (active / backoff / failed / unauthenticated)
+// can't drive its state machine off StitchAPI's per-call single-flight refresh — the stitch owns
+// recovery and never tells the host *why* a login failed. These hooks close that gap: `onRefresh`
+// fires after every (re)login attempt with its outcome; `onAuthFailure` fires when no cookie was
+// captured, with a category (unauthenticated / rate-limited / network / unknown) the host maps to
+// its own status. The hooks fire ONCE per actual login attempt (inside the single-flight-guarded
+// `doRefresh`), never per coalesced waiter, and a throwing hook never crashes the call.
+//
+// These standalone stitches share ONE session across all callers, so they pass `scope: 'app'`
+// explicitly — the fail-closed default `'principal'` would throw (no seam binds a principal).
+import {
+    type AuthFailureInfo,
+    type RefreshResult,
+    cookieSession,
+    env,
+    stitch,
+} from '../../src';
+import { startMockServer } from '../support/mock-server';
+import type { MockServer } from '../support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-cookie-session-hooks-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+    process.env['CSH_USER'] = 'u';
+    process.env['CSH_PASS'] = 'p';
+});
+
+const loginInput = () => ({
+    body: { u: env('CSH_USER')(), p: env('CSH_PASS')() },
+});
+
+const loginStitch = (baseUrl: string) =>
+    stitch({
+        method: 'POST',
+        baseUrl,
+        path: '/login',
+        bodyType: 'form',
+    });
+
+test('onRefresh fires with { ok: true, status: 200 } after a successful cold login', async () => {
+    server.route('POST', '/login', {
+        setCookie: { name: 'sid', value: 'ABC' },
+        body: { ok: true },
+    });
+    server.route('GET', '/data', {
+        requireCookie: { name: 'sid' },
+        body: { ok: true },
+    });
+
+    const refreshes: RefreshResult[] = [];
+    const failures: AuthFailureInfo[] = [];
+
+    const data = stitch({
+        baseUrl: server.url,
+        path: '/data',
+        auth: cookieSession({
+            login: loginStitch(server.url),
+            cookie: 'sid',
+            loginInput,
+            scope: 'app',
+            onRefresh: (r) => {
+                refreshes.push(r);
+            },
+            onAuthFailure: (f) => {
+                failures.push(f);
+            },
+        }),
+    });
+
+    await expect(data()).resolves.toEqual({ ok: true });
+
+    expect(refreshes).toEqual([{ ok: true, status: 200 }]);
+    expect(failures).toEqual([]); // a successful login never reports a failure
+});
+
+test('onRefresh fires ONCE (not per-waiter) under concurrent cold callers sharing one login', async () => {
+    server.route('POST', '/login', {
+        // Hold the first login in flight long enough that every concurrent cold
+        // caller has already taken the cache-miss branch — making the race
+        // deterministic, the same trick the single-flight token test uses.
+        delayMs: 50,
+        setCookie: { name: 'sid', value: 'ABC' },
+        body: { ok: true },
+    });
+    server.route('GET', '/data', {
+        requireCookie: { name: 'sid' },
+        body: { ok: true },
+    });
+
+    let refreshCount = 0;
+
+    const data = stitch({
+        baseUrl: server.url,
+        path: '/data',
+        auth: cookieSession({
+            login: loginStitch(server.url),
+            cookie: 'sid',
+            loginInput,
+            scope: 'app',
+            onRefresh: () => {
+                refreshCount++;
+            },
+        }),
+    });
+
+    // Fire 5 cold calls at once — none awaited before the others start.
+    const results = await Promise.all(Array.from({ length: 5 }, () => data()));
+
+    expect(results).toEqual(Array.from({ length: 5 }, () => ({ ok: true })));
+    expect(server.callCount('/login')).toBe(1); // single-flight: one real login
+    expect(refreshCount).toBe(1); // ...so the hook fires once, not per waiter
+}, 10000);
+
+test("onAuthFailure fires category 'unauthenticated' when the login returns 401 and sets no cookie", async () => {
+    // No setCookie + a 401 status: the login responded but captured nothing, and 401 is a
+    // `refreshOn` status → the host hears "the creds were rejected".
+    server.route('POST', '/login', {
+        statuses: [401],
+        body: { error: 'bad creds' },
+    });
+    server.route('GET', '/data', {
+        requireCookie: { name: 'sid' },
+        body: { ok: true },
+    });
+
+    const failures: AuthFailureInfo[] = [];
+    const refreshes: RefreshResult[] = [];
+
+    const data = stitch({
+        baseUrl: server.url,
+        path: '/data',
+        auth: cookieSession({
+            login: loginStitch(server.url),
+            cookie: 'sid',
+            loginInput,
+            scope: 'app',
+            onAuthFailure: (f) => {
+                failures.push(f);
+            },
+            onRefresh: (r) => {
+                refreshes.push(r);
+            },
+        }),
+    });
+
+    // /data still 401s (no cookie was ever captured), so the call itself fails — the point of this
+    // test is the categorised hook, not the call's success.
+    await expect(data()).rejects.toThrow();
+
+    expect(failures).toEqual([
+        { phase: 'apply', status: 401, category: 'unauthenticated' },
+    ]);
+    // onRefresh still fired, reporting the failed outcome.
+    expect(refreshes).toEqual([{ ok: false, status: 401 }]);
+});
+
+test("onAuthFailure fires category 'rate-limited' + retryAfterMs when the login returns 429 with Retry-After", async () => {
+    server.route('POST', '/login', {
+        statuses: [429],
+        retryAfter: 7, // seconds → 7000ms
+        body: { error: 'slow down' },
+    });
+    server.route('GET', '/data', {
+        requireCookie: { name: 'sid' },
+        body: { ok: true },
+    });
+
+    const failures: AuthFailureInfo[] = [];
+
+    const data = stitch({
+        baseUrl: server.url,
+        path: '/data',
+        auth: cookieSession({
+            login: loginStitch(server.url),
+            cookie: 'sid',
+            loginInput,
+            scope: 'app',
+            onAuthFailure: (f) => {
+                failures.push(f);
+            },
+        }),
+    });
+
+    await expect(data()).rejects.toThrow();
+
+    expect(failures).toEqual([
+        {
+            phase: 'apply',
+            status: 429,
+            category: 'rate-limited',
+            retryAfterMs: 7000,
+        },
+    ]);
+});
+
+test("onAuthFailure fires category 'network' + error when the login stitch throws", async () => {
+    // Point the login at a dead address (a port that refuses connections) so `__raw` throws before
+    // any response — the transport-failure path, distinct from an HTTP error status.
+    const deadUrl = 'http://127.0.0.1:1'; // port 1 is not listening
+
+    server.route('GET', '/data', {
+        requireCookie: { name: 'sid' },
+        body: { ok: true },
+    });
+
+    const failures: AuthFailureInfo[] = [];
+    const refreshes: RefreshResult[] = [];
+
+    const data = stitch({
+        baseUrl: server.url,
+        path: '/data',
+        auth: cookieSession({
+            login: loginStitch(deadUrl),
+            cookie: 'sid',
+            loginInput,
+            scope: 'app',
+            onAuthFailure: (f) => {
+                failures.push(f);
+            },
+            onRefresh: (r) => {
+                refreshes.push(r);
+            },
+        }),
+    });
+
+    await expect(data()).rejects.toThrow();
+
+    expect(failures).toHaveLength(1);
+    const f = failures[0]!;
+    expect(f.phase).toBe('apply');
+    expect(f.category).toBe('network');
+    expect(f.status).toBeUndefined(); // no response, so no status
+    expect(f.error).toBeInstanceOf(Error); // the thrown transport error rides along
+    // onRefresh still reports the failed outcome (no status, since nothing responded).
+    expect(refreshes).toEqual([{ ok: false }]);
+});
+
+test('a throwing hook does not crash the stitch call', async () => {
+    server.route('POST', '/login', {
+        setCookie: { name: 'sid', value: 'ABC' },
+        body: { ok: true },
+    });
+    server.route('GET', '/data', {
+        requireCookie: { name: 'sid' },
+        body: { ok: true },
+    });
+
+    const data = stitch({
+        baseUrl: server.url,
+        path: '/data',
+        auth: cookieSession({
+            login: loginStitch(server.url),
+            cookie: 'sid',
+            loginInput,
+            scope: 'app',
+            onRefresh: () => {
+                throw new Error('host bookkeeping blew up');
+            },
+        }),
+    });
+
+    // The hook throws on a SUCCESSFUL login, but the cookie was still captured and replayed,
+    // so the call must succeed regardless — a buggy host hook can't take the stitch down.
+    await expect(data()).resolves.toEqual({ ok: true });
+    expect(server.callCount('/login')).toBe(1);
+});
+
+test('hooks are absent → cookieSession behaves exactly as before (additive, no regression)', async () => {
+    server.route('POST', '/login', {
+        setCookie: { name: 'sid', value: 'ABC' },
+        body: { ok: true },
+    });
+    server.route('GET', '/data', {
+        requireCookie: { name: 'sid' },
+        body: { ok: true },
+    });
+
+    const data = stitch({
+        baseUrl: server.url,
+        path: '/data',
+        auth: cookieSession({
+            login: loginStitch(server.url),
+            cookie: 'sid',
+            loginInput,
+            scope: 'app',
+        }),
+    });
+
+    await expect(data()).resolves.toEqual({ ok: true });
+    expect(server.callCount('/login')).toBe(1);
+    const req = server.calls('/data')[0]!;
+    expect(req.cookies['sid']).toBe('ABC');
+});


### PR DESCRIPTION
Closes #146

## Summary

Adds two optional host-owned lifecycle hooks to `CookieSessionOpts` so a host can own **durable, categorised** auth state and drive its **own external recovery loop** — something StitchAPI's per-call single-flight refresh can't model (the stitch owns recovery and never tells the host *why* a login failed).

- **`onRefresh({ ok, status? })`** — fires after every actual (re)login attempt with its outcome (`ok` = a cookie was captured), so the host can persist session state and clear/extend a cooldown.
- **`onAuthFailure({ phase, status?, retryAfterMs?, error?, category })`** — fires when an attempt captured no cookie, categorising the failure:
  - `'unauthenticated'` — login responded with a `refreshOn` status (e.g. 401);
  - `'rate-limited'` — login responded 429, with `retryAfterMs` parsed from `Retry-After` (reuses `parseRetryAfter` from `resilience.ts`);
  - `'network'` — the login stitch threw before any response (with the thrown `error`);
  - `'unknown'` — login responded but captured no cookie for some other reason (e.g. a soft 200 wall).
  - `phase` is `'apply'` (cold session) or `'refresh'` (the 401 wall).

## Key decisions

- `__raw` resolves only for a 2xx login and **throws** otherwise, so the status is read from `res.status` on the success path and from the thrown `StitchError`'s `.status` (with `.response` headers for `Retry-After`) on the failure path.
- Hooks fire **once per actual login attempt** (inside the single-flight-guarded `doRefresh`), never per coalesced waiter; every invocation is wrapped so a throwing hook can't crash the call (it's caught and announced on the `auth` trace topic).
- Purely **additive** — `cookieSession` behaves exactly as before when the hooks are absent.

## Files

- `packages/core/src/auth.ts` — new `AuthFailureInfo` / `RefreshResult` types, the two hook fields, and the reworked `doRefresh` (capture status + cookie-captured flag, classify, report).
- `packages/core/src/index.ts` — re-export the two public payload types.
- `packages/core/test/gaps/cookie-session-hooks.spec.ts` — behavioral spec covering every acceptance criterion (success `onRefresh`, single-flight fires once, the three failure categories, throwing-hook-doesn't-crash, no-hooks regression).
- `apps/docs/content/docs/guides/auth/cookie-session.mdx` — durable-state + external-recovery example.

## Verification

`pnpm -r check:types`, `pnpm -r check:lint`, `pnpm -r test` (core: 473 tests pass, incl. 7 new), and `pnpm format` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)