### PR TITLE
feat(core): delegate-backoff mode — surface 429/Retry-After instead of internal retry+throttle

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -138,6 +138,12 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             info: "Circuit breaker that fast-fails a repeatedly failing dependency.",
         },
         {
+            label: "rateLimit",
+            type: "property",
+            detail: "{ /** Surface rate-limit outcomes instead of retrying/throttling them. Default `false`. */ delegate?: boolean; /** Statuses treated as a rate-limit signal. Default `[429]`. */ on?: number[]; }",
+            info: "Delegate backoff to the host (issue #145). When `delegate: true`, a rate-limit response (status in `on`, default `[429]`) is **not** retried internally and the built-in `throttle` is **bypassed** for the call — instead the outcome surfaces as a (carrying `status`, the `retryAfterMs` parsed from `Retry-After`, and the raw `response`) on the awaited path, and as an `error` event with `retryAfterMs` on `.stream()`. Use this when an OUTER gate/circuit owns the backoff (its own `Retry-After` hook, a DB-persisted budget) and StitchAPI's internal retry+throttle would double-count against it. ⚠️ In delegate mode the `throttle` config becomes **inert** for this stitch (the host owns the gate). A `circuit` block, if also set, still applies — the host may layer both. Non-rate-limit failures (5xx, etc.) behave exactly as today unless their status is listed in `on`. Validation, templating, transform/unwrap, and drift on the success path are unchanged.",
+        },
+        {
             label: "idempotency",
             type: "property",
             detail: "IdempotencyOptions",

--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -245,6 +245,13 @@ export const pages: Page[] = [
         kind: 'guide',
     },
     {
+        path: 'guides/resilience/delegate-backoff',
+        title: 'Delegate backoff',
+        description:
+            'Surface rate-limit outcomes as a RateLimitError so an outer gate owns the backoff, instead of retrying and throttling them internally.',
+        kind: 'guide',
+    },
+    {
         path: 'guides/resilience/idempotency',
         title: 'Idempotency keys',
         description:
@@ -511,5 +518,13 @@ export const pages: Page[] = [
             'A GraphQL 200 response carried an errors array and failed the call.',
         kind: 'error',
         code: 'STITCH_GRAPHQL',
+    },
+    {
+        path: 'errors/rate-limit',
+        title: 'RateLimitError',
+        description:
+            'A delegate-backoff stitch surfaced a rate-limit response for an outer gate to back off on, instead of retrying it.',
+        kind: 'error',
+        code: 'RateLimitError',
     },
 ];

--- a/apps/docs/content/docs/errors/index.mdx
+++ b/apps/docs/content/docs/errors/index.mdx
@@ -96,6 +96,10 @@ resolves.
         A GraphQL-over-HTTP response came back `200` but carried an `errors`
         array.
     </Card>
+    <Card title="RateLimitError" href="/docs/errors/rate-limit">
+        A delegate-backoff stitch surfaced a rate-limit response for an outer
+        gate to back off on, instead of retrying it.
+    </Card>
 </Cards>
 
 ## See also

--- a/apps/docs/content/docs/errors/meta.json
+++ b/apps/docs/content/docs/errors/meta.json
@@ -7,6 +7,7 @@
         "stitch-auth-wall",
         "stitch-timeout",
         "stitch-circuit-open",
-        "stitch-graphql"
+        "stitch-graphql",
+        "rate-limit"
     ]
 }

--- a/apps/docs/content/docs/errors/rate-limit.mdx
+++ b/apps/docs/content/docs/errors/rate-limit.mdx
@@ -1,0 +1,81 @@
+---
+title: 'RateLimitError'
+description: 'The delegate-backoff error: a rate-limit response surfaced for an outer gate to back off on, instead of being retried internally.'
+---
+
+## What you'll see
+
+A stitch with [`rateLimit: { delegate: true }`](/docs/guides/resilience/delegate-backoff)
+that gets a rate-limit response (status in `rateLimit.on`, default `[429]`)
+rejects with a **`RateLimitError`** instead of retrying. Unlike most failures,
+this is _not_ a `StitchError` — it's its own exported class, so you can catch it
+specifically and hand the signal to whatever owns your backoff:
+
+```ts twoslash
+import { RateLimitError, stitch } from 'stitchapi';
+
+const fetchPage = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/pages/{id}',
+    rateLimit: { delegate: true },
+});
+
+try {
+    await fetchPage({ params: { id: '42' } });
+} catch (e) {
+    if (e instanceof RateLimitError) {
+        console.log(e.status); // 429 (the rate-limit status that was hit)
+        console.log(e.retryAfterMs); // ms parsed from Retry-After, or undefined
+        console.log(e.response.headers); // the raw response, for other rate headers
+    }
+}
+```
+
+`RateLimitError` carries:
+
+-   **`status`** — the rate-limit status (e.g. `429`, or whatever you listed in
+    `rateLimit.on`).
+-   **`retryAfterMs`** — the wait the server asked for, parsed from `Retry-After`
+    (delta-seconds **or** an HTTP-date) into milliseconds; `undefined` when the
+    header is absent or unparseable.
+-   **`response`** — the raw `AdapterResponse`, so you can read other rate
+    headers the API sent (`X-RateLimit-Remaining`, a reset timestamp, and so on).
+
+## Why it happens
+
+You opted into delegate-backoff because an **outer** gate or circuit — not
+StitchAPI — owns the rate budget. So when the API returns a rate-limit status,
+the stitch deliberately does _not_ retry it and does _not_ pace it on the
+internal [throttle](/docs/guides/resilience/throttle): it surfaces the outcome so
+your gate can apply the backoff, persist it, and decide when to release. This is
+the mode working as designed, not a new failure — the rate limit reached you on
+purpose.
+
+## How to handle it
+
+-   **Feed it to your outer gate.** Use `retryAfterMs` (falling back to your own
+    default when it's `undefined`) to set the gate's penalty window, then let the
+    gate gate the next attempt. That's the whole point of delegating.
+-   **Read it off the stream instead.** If you consume
+    [the event stream](/docs/concepts/event-stream) rather than awaiting, the same
+    outcome arrives as an `error` event carrying `status` and `retryAfterMs` — no
+    `try`/`catch` needed.
+-   **Branch without throwing.** `.safe()` returns the failure as a `StitchError`
+    whose `.status` is the rate-limit status and whose `.cause` is the original
+    `RateLimitError` (so `retryAfterMs` is still reachable via the cause).
+-   **Reconsider whether to delegate.** If nothing outside StitchAPI actually
+    owns the backoff, you probably want internal handling instead — drop
+    `rateLimit` and use [retry](/docs/guides/resilience/retry) +
+    [throttle](/docs/guides/resilience/throttle).
+
+## Related
+
+<Cards>
+    <Card
+        title="Guide: delegate backoff"
+        href="/docs/guides/resilience/delegate-backoff"
+    />
+    <Card title="Guide: retry" href="/docs/guides/resilience/retry" />
+    <Card title="Guide: throttle" href="/docs/guides/resilience/throttle" />
+    <Card title="Reference: config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/guides/resilience/delegate-backoff.mdx
+++ b/apps/docs/content/docs/guides/resilience/delegate-backoff.mdx
@@ -1,0 +1,121 @@
+---
+title: 'Delegate backoff'
+description: 'Surface rate-limit outcomes as a RateLimitError so an outer gate owns the backoff, instead of retrying and throttling them internally.'
+---
+
+By default a stitch handles a rate limit _itself_: a `429` listed in
+[`retry.on`](/docs/guides/resilience/retry) is retried with backoff, the
+`Retry-After` header is consumed to pace that wait, and the built-in
+[`throttle`](/docs/guides/resilience/throttle) spaces calls before they leave.
+That's the right behavior when the stitch is the only thing talking to the API.
+
+It's the **wrong** behavior when something _outside_ StitchAPI already owns the
+rate budget — an outer gate or circuit with its own `Retry-After` hook and a
+persisted backoff window. There, internal retry hides the rate-limit signal from
+the gate, and the internal throttle double-counts against it. Turn on
+**delegate-backoff** mode and the stitch surfaces the rate-limit outcome instead
+of absorbing it, so the outer gate decides what to do.
+
+## Example
+
+```ts twoslash
+import { RateLimitError, stitch } from 'stitchapi';
+
+// Your own rate-gate / circuit, living outside StitchAPI.
+declare const outerGate: { penalize(ms: number): void };
+
+const fetchPage = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/pages/{id}',
+    rateLimit: { delegate: true }, // surface 429s; don't retry or throttle them
+});
+
+try {
+    await fetchPage({ params: { id: '42' } });
+} catch (e) {
+    if (e instanceof RateLimitError) {
+        // Hand the signal to your outer gate — it owns the backoff.
+        outerGate.penalize(e.retryAfterMs ?? 1000);
+    }
+}
+```
+
+A `429` no longer retries: the call rejects with a
+[`RateLimitError`](/docs/errors/rate-limit) carrying `status`, the
+`retryAfterMs` parsed from `Retry-After` (delta-seconds **or** an HTTP-date), and
+the raw `response` so you can read any other rate headers the API sent. The
+internal throttle is bypassed for the call, so it adds no pacing of its own.
+
+## Options
+
+`delegate` switches the mode on; it defaults to `false`, so a stitch behaves
+exactly as before until you opt in.
+
+`on` is the set of statuses treated as a rate-limit signal — it defaults to
+`[429]`. Widen it when an API signals back-pressure with another status (for
+example `{ delegate: true, on: [429, 503] }`); a status _not_ in `on` is left to
+the ordinary [retry](/docs/guides/resilience/retry) path.
+
+## Reading it off the stream
+
+If you iterate the [event stream](/docs/concepts/event-stream) instead of
+awaiting, the same outcome arrives as an `error` event carrying `status` and
+`retryAfterMs`, so a streaming consumer gets the identical structured hint:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+// Your own rate-gate / circuit, living outside StitchAPI.
+declare const outerGate: { penalize(ms: number): void };
+
+const fetchPage = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/pages/{id}',
+    rateLimit: { delegate: true },
+});
+
+for await (const ev of fetchPage.stream({ params: { id: '42' } })) {
+    if (ev.type === 'error' && ev.retryAfterMs !== undefined) {
+        outerGate.penalize(ev.retryAfterMs);
+    }
+}
+```
+
+## What still runs
+
+Delegate mode changes _only_ how a rate-limit status is handled. Everything else
+on a stitch is untouched: input validation, templating, `transform`, `unwrap`,
+and [drift](/docs/guides/drift/overview) all still run on a successful response,
+and non-rate-limit failures (a `500`, a transport error) behave exactly as they
+do without the flag. A [`circuit`](/docs/guides/resilience/circuit-breaker)
+block, if you also set one, still applies — you can let the host layer both.
+
+<Callout type="warn">
+    **The `throttle` block becomes inert** for a stitch in delegate mode — the
+    host owns the gate, so the stitch never acquires its internal limiter and
+    never emits a `throttled` event. If you still want StitchAPI to pace calls,
+    don't delegate: use [retry](/docs/guides/resilience/retry) +
+    [throttle](/docs/guides/resilience/throttle) instead.
+</Callout>
+
+<Callout type="info">
+    Delegate mode and internal retry-on-rate-limit are mutually exclusive _for
+    the delegated statuses_: a status in `rateLimit.on` is surfaced, never
+    retried, even if it also appears in `retry.on`.
+</Callout>
+
+See [Reference → Config types](/docs/reference/config-types) for every field.
+
+## See also
+
+<Cards>
+    <Card title="RateLimitError" href="/docs/errors/rate-limit" />
+    <Card title="Retry" href="/docs/guides/resilience/retry" />
+    <Card title="Throttle" href="/docs/guides/resilience/throttle" />
+    <Card
+        title="Circuit breaker"
+        href="/docs/guides/resilience/circuit-breaker"
+    />
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+    <Card title="Config types" href="/docs/reference/config-types" />
+</Cards>

--- a/apps/docs/content/docs/guides/resilience/meta.json
+++ b/apps/docs/content/docs/guides/resilience/meta.json
@@ -1,4 +1,11 @@
 {
     "title": "Resilience",
-    "pages": ["retry", "throttle", "timeout", "circuit-breaker", "idempotency"]
+    "pages": [
+        "retry",
+        "throttle",
+        "timeout",
+        "circuit-breaker",
+        "delegate-backoff",
+        "idempotency"
+    ]
 }

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -10,6 +10,7 @@ import { classifyDrift, loadSnapshot, saveSnapshot } from './drift';
 import { fetchAdapter } from './http-adapter';
 import {
     CircuitOpenError,
+    RateLimitError,
     TimeoutError,
     backoffDelay,
     createCircuit,
@@ -243,6 +244,13 @@ const hostKey = (req: AdapterRequest, cfg: StitchConfig): string => {
     return nameOf(cfg);
 };
 
+// A non-enumerable back-reference from an `error` event to the live error instance it was built
+// from. Used ONLY for a RateLimitError so the awaited path can re-throw the REAL instance — keeping
+// its `response` and class identity — rather than a flattened StitchError. Non-enumerable means it
+// never reaches a trace sink (which serialises via Object.entries / JSON.stringify, both of which
+// skip it), so the full `response` can't leak into a JSONL/console log. See `drain` in stitch.ts.
+export const ERROR_SOURCE = Symbol('stitch.errorSource');
+
 function errEvt(err: unknown, name: string, attempts: number): StitchEvent {
     const e = err as { message?: string; status?: number };
     const evt: Extract<StitchEvent, { type: 'error' }> = {
@@ -253,6 +261,15 @@ function errEvt(err: unknown, name: string, attempts: number): StitchEvent {
         at: now(),
     };
     if (e.status !== undefined) evt.status = e.status;
+    // Delegate-backoff signal: stamp the structured `retryAfterMs` onto the event (so `.stream()`
+    // consumers get it) and pin the live RateLimitError so the awaited path re-throws it intact.
+    if (err instanceof RateLimitError) {
+        if (err.retryAfterMs !== undefined) evt.retryAfterMs = err.retryAfterMs;
+        Object.defineProperty(evt, ERROR_SOURCE, {
+            value: err,
+            enumerable: false,
+        });
+    }
     return evt;
 }
 const doneEvt = (ok: boolean, t0: number, attempts: number): StitchEvent => ({
@@ -428,18 +445,28 @@ async function* attemptLoop(
     const perAttemptMs = parseDuration(cfg.timeout?.perAttempt);
     const key = hostKey(baseReq, cfg);
     let refreshed = false;
+    // Delegate-backoff mode (issue #145): the host owns the gate. We bypass the internal throttle
+    // for the call (no acquire/release, so `throttle` is inert and no `throttled` event fires) and,
+    // on a response whose status is in `rlOn` (default [429]), surface a RateLimitError instead of
+    // retrying. Everything else — auth, the success path, non-rate-limit failures — is unchanged.
+    const delegate = cfg.rateLimit?.delegate === true;
+    const rlOn = cfg.rateLimit?.on ?? [429];
 
     for (let attempt = 1; attempt <= max; attempt++) {
         state.attempts = attempt;
-        const { waitedMs } = await acquireWithin(rt.throttle, key, budget);
-        if (waitedMs > 0)
-            yield {
-                type: 'progress',
-                phase: 'throttled',
-                attempt,
-                waitedMs,
-                at: now(),
-            };
+        // Skip the throttle entirely in delegate mode — the outer gate paces the call, so acquiring
+        // here would double-count against it (the bug this mode fixes).
+        if (!delegate) {
+            const { waitedMs } = await acquireWithin(rt.throttle, key, budget);
+            if (waitedMs > 0)
+                yield {
+                    type: 'progress',
+                    phase: 'throttled',
+                    attempt,
+                    waitedMs,
+                    at: now(),
+                };
+        }
         try {
             const req = cloneReq(baseReq);
             if (cfg.auth) {
@@ -515,6 +542,18 @@ async function* attemptLoop(
                 continue;
             }
 
+            // Delegate-backoff: a rate-limit status is NOT retried — surface it so the host's outer
+            // gate owns the backoff. Checked BEFORE the internal retry-on-status path so it wins even
+            // when the same status is also in `retry.on` (the common `429` overlap). `Retry-After` is
+            // parsed with the same helper the internal retry uses, so the host gets an identical hint.
+            if (delegate && rlOn.includes(res.status)) {
+                throw new RateLimitError({
+                    status: res.status,
+                    retryAfterMs: parseRetryAfter(res.headers['retry-after']),
+                    response: res,
+                });
+            }
+
             if (retryOn.includes(res.status) && attempt < max) {
                 const ra = cfg.retry?.respectRetryAfter
                     ? parseRetryAfter(res.headers['retry-after'])
@@ -545,7 +584,8 @@ async function* attemptLoop(
             }
             return res;
         } finally {
-            rt.throttle.release(key);
+            // No release in delegate mode — we never acquired a slot (the host owns the gate).
+            if (!delegate) rt.throttle.release(key);
         }
     }
     throw new Error('retry attempts exhausted');

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,4 +44,7 @@ export { toValidator } from './validator';
 export type { Issue, ValidationResult, Validator } from './validator';
 export type { InferInput, InferOutput, SchemaLike } from './infer';
 export { memoryStore } from './store';
+// The delegate-backoff error (issue #145): thrown on the awaited path and surfaced as an `error`
+// event when `rateLimit.delegate` is on, so a host's outer gate owns the rate-limit backoff.
+export { RateLimitError } from './resilience';
 export * from './types';

--- a/packages/core/src/resilience.ts
+++ b/packages/core/src/resilience.ts
@@ -3,6 +3,7 @@
 // pacing/cancellation go through the shared `sleep`/`now` helpers from `./util`.
 import type {
     AcquireOptions,
+    AdapterResponse,
     CircuitOptions,
     RetryOptions,
     StitchStore,
@@ -201,6 +202,34 @@ export class CircuitOpenError extends Error {
     constructor(message = 'circuit open') {
         super(message);
         this.name = 'CircuitOpenError';
+    }
+}
+
+/**
+ * Thrown (and surfaced as an `error` event) when a stitch runs in **delegate-backoff** mode
+ * (`rateLimit.delegate`) and the response carries a rate-limit status (default `429`). Instead of
+ * retrying internally or pacing on the built-in throttle, the engine surfaces the outcome so an
+ * OUTER gate/circuit — owned by the host — decides the backoff (issue #145). Carries the structured
+ * signal that gate needs: the `status`, the `retryAfterMs` parsed from `Retry-After` (delta-seconds
+ * OR HTTP-date; `undefined` when the header is absent/unparseable), and the raw `response` so the
+ * host can read other rate headers (`X-RateLimit-*`, etc.). The full `response` rides on the live
+ * instance only — never the serialized `error` event — so it cannot leak into a trace sink.
+ */
+export class RateLimitError extends Error {
+    readonly status: number;
+    readonly retryAfterMs: number | undefined;
+    readonly response: AdapterResponse;
+    constructor(opts: {
+        status: number;
+        retryAfterMs?: number | undefined;
+        response: AdapterResponse;
+        message?: string;
+    }) {
+        super(opts.message ?? `rate limited (HTTP ${opts.status})`);
+        this.name = 'RateLimitError';
+        this.status = opts.status;
+        this.retryAfterMs = opts.retryAfterMs;
+        this.response = opts.response;
     }
 }
 

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -2,6 +2,7 @@
 // `.with()` partial application, all resolving to one canonical config. For a shared surface —
 // shared runtime + a trusted principal boundary — reach for `seam` (see seam.ts).
 import {
+    ERROR_SOURCE,
     type Runtime,
     cacheInvalidateBulk,
     cacheInvalidateExact,
@@ -218,18 +219,25 @@ export function resolveTrace(trace: StitchConfig['trace']): TraceSink {
 // ---- the streaming spine + await sugar ------------------------------------
 // Drain the event stream to its terminal: the `result` value, or the `error` event rebuilt as a
 // typed StitchError (status + attempts preserved). Shared by the throwing and safe consumers.
+// Exception: a delegate-backoff rate-limit (issue #145) pins its live RateLimitError on the event
+// via the non-enumerable ERROR_SOURCE key — re-surface THAT instance unchanged, so the caller keeps
+// the real class identity plus `retryAfterMs`/`response`, instead of a flattened StitchError.
 async function drain<T>(
     gen: AsyncGenerator<StitchEvent<T>, void>,
-): Promise<{ value: T } | { error: StitchError }> {
+): Promise<{ value: T } | { error: Error }> {
     let value: T | undefined;
-    let error: StitchError | undefined;
+    let error: Error | undefined;
     for await (const ev of gen) {
         if (ev.type === 'result') value = ev.value;
-        else if (ev.type === 'error')
-            error = new StitchError(ev.message, {
-                status: ev.status,
-                attempts: ev.attempts,
-            });
+        else if (ev.type === 'error') {
+            const source = (ev as { [ERROR_SOURCE]?: Error })[ERROR_SOURCE];
+            error =
+                source ??
+                new StitchError(ev.message, {
+                    status: ev.status,
+                    attempts: ev.attempts,
+                });
+        }
     }
     return error ? { error } : { value: value as T };
 }
@@ -244,24 +252,30 @@ async function consume<T>(
 }
 
 // Coerce any thrown value to a StitchError — a real StitchError passes through unchanged; anything
-// else is wrapped with its message and original `cause`. Shared by the safe consumers.
+// else is wrapped with its message and original `cause`. A numeric `status` on the source (e.g. a
+// delegate-backoff RateLimitError) is carried onto the wrapper so `.safe()` callers still see it.
+// Shared by the safe consumers.
 function asStitchError(e: unknown): StitchError {
-    return e instanceof StitchError
-        ? e
-        : new StitchError(e instanceof Error ? e.message : String(e), {
-              cause: e,
-          });
+    if (e instanceof StitchError) return e;
+    const status = (e as { status?: unknown }).status;
+    return new StitchError(e instanceof Error ? e.message : String(e), {
+        ...(typeof status === 'number' ? { status } : {}),
+        cause: e,
+    });
 }
 
 // Safe consumer: `stitch.safe(...)` / `stitch(...).safe()`. Never throws — an `error` event or an
-// unexpected throw both come back as `{ ok: false, data: null, error }`.
+// unexpected throw both come back as `{ ok: false, data: null, error }`. `SafeResult.error` is
+// always a StitchError by contract, so a non-StitchError terminal (e.g. a delegate-backoff
+// RateLimitError, which the throwing path re-throws verbatim) is coerced via `asStitchError`,
+// preserving the original as `.cause` and its `status`.
 async function consumeSafe<T>(
     gen: AsyncGenerator<StitchEvent<T>, void>,
 ): Promise<SafeResult<T>> {
     try {
         const out = await drain(gen);
         return 'error' in out
-            ? { ok: false, data: null, error: out.error }
+            ? { ok: false, data: null, error: asStitchError(out.error) }
             : { ok: true, data: out.value, error: null };
     } catch (e) {
         return { ok: false, data: null, error: asStitchError(e) };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -374,6 +374,11 @@ export type StitchEvent<T = unknown> =
           name: string;
           message: string;
           status?: number;
+          // Set only on a delegate-backoff rate-limit outcome (`rateLimit.delegate`): the ms parsed
+          // from `Retry-After` (delta-seconds OR HTTP-date), so a `.stream()` consumer gets the same
+          // structured backoff hint the awaited path gets off the thrown RateLimitError. Additive and
+          // optional — every other `error` event omits it (issue #145).
+          retryAfterMs?: number;
           attempts: number;
           at: number;
       }
@@ -475,6 +480,26 @@ export interface StitchConfig {
     timeout?: TimeoutOptions;
     /** Circuit breaker that fast-fails a repeatedly failing dependency. */
     circuit?: CircuitOptions;
+    /**
+     * Delegate backoff to the host (issue #145). When `delegate: true`, a rate-limit response
+     * (status in `on`, default `[429]`) is **not** retried internally and the built-in `throttle`
+     * is **bypassed** for the call — instead the outcome surfaces as a {@link RateLimitError}
+     * (carrying `status`, the `retryAfterMs` parsed from `Retry-After`, and the raw `response`) on
+     * the awaited path, and as an `error` event with `retryAfterMs` on `.stream()`. Use this when an
+     * OUTER gate/circuit owns the backoff (its own `Retry-After` hook, a DB-persisted budget) and
+     * StitchAPI's internal retry+throttle would double-count against it.
+     *
+     * ⚠️ In delegate mode the `throttle` config becomes **inert** for this stitch (the host owns the
+     * gate). A `circuit` block, if also set, still applies — the host may layer both. Non-rate-limit
+     * failures (5xx, etc.) behave exactly as today unless their status is listed in `on`. Validation,
+     * templating, transform/unwrap, and drift on the success path are unchanged.
+     */
+    rateLimit?: {
+        /** Surface rate-limit outcomes instead of retrying/throttling them. Default `false`. */
+        delegate?: boolean;
+        /** Statuses treated as a rate-limit signal. Default `[429]`. */
+        on?: number[];
+    };
     /** Inject a stable Idempotency-Key header on writes so safe retries don't duplicate. */
     idempotency?: IdempotencyOptions;
     /**

--- a/packages/core/test/gaps/delegate-backoff.spec.ts
+++ b/packages/core/test/gaps/delegate-backoff.spec.ts
@@ -1,0 +1,262 @@
+// Pins issue #145: an opt-in delegate-backoff mode that SURFACES a rate-limit outcome (status in
+// `rateLimit.on`, default [429]) as a RateLimitError instead of retrying it internally, and bypasses
+// the built-in throttle so an OUTER gate (owned by the host) — not StitchAPI — paces the backoff.
+import { RateLimitError, type StitchEvent, stitch } from '../../src';
+import { startMockServer } from '../support/mock-server';
+import type { MockServer } from '../support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-gap-delegate-backoff-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+// Await a call expected to reject; return the thrown error (narrowed to the shape these tests read).
+async function rejectionOf(
+    call: PromiseLike<unknown>,
+): Promise<RateLimitError> {
+    return Promise.resolve(call).then(
+        () => {
+            throw new Error('expected the call to reject, but it resolved');
+        },
+        (e: unknown) => e as RateLimitError,
+    );
+}
+
+// ── A. a 429 throws RateLimitError on the awaited path, with NO internal retry ──
+// `rateLimit: { delegate: true }` turns a 429 into a thrown RateLimitError carrying the parsed
+// `retryAfterMs`, and — crucially — does NOT retry: even with retry.attempts > 1 (and 429 in
+// retry.on) the adapter must be hit exactly once, because delegate mode short-circuits the loop.
+test('a 429 with Retry-After: 2 throws RateLimitError(retryAfterMs=2000) and is hit exactly once', async () => {
+    server.route('GET', '/rl', {
+        statuses: [429],
+        retryAfter: 2, // delta-seconds → Retry-After: 2
+        body: { error: 'slow down' },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/rl',
+        // retry would normally fire on 429 three times; delegate mode must override it.
+        retry: { attempts: 3, on: [429] },
+        rateLimit: { delegate: true },
+    });
+
+    const err = await rejectionOf(call());
+
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.name).toBe('RateLimitError');
+    expect(err.status).toBe(429);
+    expect(err.retryAfterMs).toBe(2000);
+    // The raw response rides along so the host can read other rate headers.
+    expect(err.response.status).toBe(429);
+    expect(err.response.body).toEqual({ error: 'slow down' });
+    // No internal retry: the route saw exactly one request.
+    expect(server.callCount('/rl')).toBe(1);
+});
+
+// ── B. the same outcome surfaces as an `error` event with retryAfterMs on .stream() ──
+test('.stream() surfaces an error event with status 429 and retryAfterMs 2000', async () => {
+    server.route('GET', '/rl-stream', {
+        statuses: [429],
+        retryAfter: 2,
+        body: { error: 'slow down' },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/rl-stream',
+        rateLimit: { delegate: true },
+    });
+
+    const events: StitchEvent[] = [];
+    for await (const ev of call.stream()) events.push(ev);
+
+    const error = events.find((e) => e.type === 'error');
+    expect(error).toBeDefined();
+    expect(error).toMatchObject({
+        type: 'error',
+        status: 429,
+        retryAfterMs: 2000,
+    });
+    // The run terminates as a failure — never a `result`.
+    expect(events.some((e) => e.type === 'result')).toBe(false);
+    expect(events.find((e) => e.type === 'done')).toMatchObject({ ok: false });
+});
+
+// ── C. delegate mode bypasses the internal throttle (no pacing, no `throttled` event) ──
+// `throttle.rate: '1/s'` would normally force ~1000ms of spacing between the 1st and 2nd call to a
+// key. In delegate mode the throttle is inert: the second call neither waits ~1s nor emits a
+// `throttled` event — the host owns the gate. (Both calls 429, so both surface a RateLimitError.)
+test('the configured throttle does not pace the call and emits no throttled event', async () => {
+    server.route('GET', '/rl-throttle', {
+        statuses: [429, 429],
+        retryAfter: 1,
+        body: { error: 'slow down' },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/rl-throttle',
+        throttle: { rate: '1/s' }, // would impose ~1000ms spacing if it were active
+        rateLimit: { delegate: true },
+    });
+
+    // First call arms the limiter's next-grant clock (if it were active).
+    await rejectionOf(call());
+
+    // Second call must NOT wait for the ~1s rate slot — delegate mode bypasses the throttle.
+    const t0 = Date.now();
+    const events: StitchEvent[] = [];
+    for await (const ev of call.stream()) events.push(ev);
+    const elapsed = Date.now() - t0;
+
+    expect(elapsed).toBeLessThan(500); // ≪ the 1000ms rate spacing a live throttle would add
+    expect(
+        events.some((e) => e.type === 'progress' && e.phase === 'throttled'),
+    ).toBe(false);
+    expect(events.find((e) => e.type === 'error')).toMatchObject({
+        status: 429,
+    });
+});
+
+// ── D. Retry-After as an HTTP-date parses to a positive retryAfterMs ──
+test('Retry-After as an HTTP-date parses to a positive retryAfterMs', async () => {
+    const when = new Date(Date.now() + 5000).toUTCString(); // ~5s in the future, RFC 1123
+    server.route('GET', '/rl-date', {
+        statuses: [429],
+        headers: { 'Retry-After': when },
+        body: { error: 'slow down' },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/rl-date',
+        rateLimit: { delegate: true },
+    });
+
+    const err = await rejectionOf(call());
+
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.retryAfterMs).toBeGreaterThan(0);
+    // ~5s out; allow generous slack for clock/transit but stay well under/over the bounds.
+    expect(err.retryAfterMs).toBeLessThanOrEqual(5000);
+    expect(err.retryAfterMs).toBeGreaterThan(3000);
+});
+
+// ── E. a missing Retry-After yields RateLimitError with retryAfterMs undefined ──
+test('a 429 without Retry-After throws RateLimitError with retryAfterMs undefined', async () => {
+    server.route('GET', '/rl-bare', {
+        statuses: [429],
+        body: { error: 'slow down' },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/rl-bare',
+        rateLimit: { delegate: true },
+    });
+
+    const err = await rejectionOf(call());
+
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.status).toBe(429);
+    expect(err.retryAfterMs).toBeUndefined();
+});
+
+// ── F. a custom `on` list lets a 503 delegate while a 429 retries normally ──
+// `on: [503]` means ONLY 503 is delegated; a 429 is no longer a rate-limit signal and falls through
+// to the ordinary retry path (here retry.on includes 429), proving `on` is honoured both ways.
+test('rateLimit.on selects which statuses delegate (503 delegates, 429 retries)', async () => {
+    server.route('GET', '/rl-503', {
+        statuses: [503],
+        retryAfter: 1,
+        body: { error: 'unavailable' },
+    });
+    const delegated = stitch({
+        baseUrl: server.url,
+        path: '/rl-503',
+        rateLimit: { delegate: true, on: [503] },
+    });
+
+    const err = await rejectionOf(delegated());
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.status).toBe(503);
+    expect(err.retryAfterMs).toBe(1000);
+    expect(server.callCount('/rl-503')).toBe(1);
+
+    // A 429 under the same `on: [503]` is NOT delegated — it flows through ordinary retry: two 429s
+    // then a 200, with retry.attempts: 3, must succeed (proving 429 was retried, not surfaced).
+    server.route('GET', '/retry-429', {
+        statuses: [429, 429, 200],
+        body: [{}, {}, { ok: true }],
+    });
+    const retried = stitch<{ ok: boolean }>({
+        baseUrl: server.url,
+        path: '/retry-429',
+        retry: { attempts: 3, on: [429], backoff: 'fixed', baseMs: 1 },
+        rateLimit: { delegate: true, on: [503] },
+    });
+    await expect(retried()).resolves.toEqual({ ok: true });
+    expect(server.callCount('/retry-429')).toBe(3);
+});
+
+// ── G. the success path still runs transform → unwrap → drift under delegate mode ──
+// Delegate mode only intercepts rate-limit statuses; a 200 must validate/transform/unwrap exactly as
+// it would without the flag — proving the mode is "validate + template + transform + drift, but
+// delegate backoff", not a bare pass-through.
+test('a success response still runs transform, unwrap, and output validation', async () => {
+    server.route('GET', '/ok', {
+        statuses: [200],
+        body: { data: { id: 7, name: 'widget' } },
+    });
+    const call = stitch<{ id: number; label: string }>({
+        baseUrl: server.url,
+        path: '/ok',
+        rateLimit: { delegate: true },
+        unwrap: 'data',
+        transform: (body) => {
+            // raw body → reshape: rename `name` to `label`. Runs before unwrap.
+            const b = body as { data: { id: number; name: string } };
+            return { data: { id: b.data.id, label: b.data.name } };
+        },
+        output: (v: unknown): v is { id: number; label: string } => {
+            const o = v as { id?: unknown; label?: unknown };
+            return typeof o.id === 'number' && typeof o.label === 'string';
+        },
+    });
+
+    await expect(call()).resolves.toEqual({ id: 7, label: 'widget' });
+});
+
+// ── H. .safe() returns a StitchError carrying the rate-limit status (never throws) ──
+// `.safe()`'s contract is a StitchError in `error`; a delegate RateLimitError is coerced to one with
+// its `status` and the original kept as `.cause`.
+test('.safe() surfaces the rate-limit status as a non-throwing StitchError', async () => {
+    server.route('GET', '/rl-safe', {
+        statuses: [429],
+        retryAfter: 2,
+        body: { error: 'slow down' },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/rl-safe',
+        rateLimit: { delegate: true },
+    });
+
+    const out = await call.safe();
+    expect(out.ok).toBe(false);
+    expect(out.error?.status).toBe(429);
+    // The real RateLimitError is preserved as the cause.
+    expect(out.error?.cause).toBeInstanceOf(RateLimitError);
+    expect((out.error?.cause as RateLimitError).retryAfterMs).toBe(2000);
+});


### PR DESCRIPTION
Closes #145

## Summary

Adds an opt-in **delegate-backoff** mode so a stitch surfaces a rate-limit outcome instead of absorbing it, letting a host's **outer** gate/circuit own the backoff (its own `Retry-After` hook, a DB-persisted budget) without StitchAPI's internal retry + throttle double-counting against it.

New config: `rateLimit?: { delegate?: boolean; on?: number[] }` (default `on: [429]`).

When `rateLimit.delegate` is on, the engine:
- **bypasses the internal throttle** for the call — no acquire/release, no `throttled` event — so it can't double-count against the host's gate;
- on a response whose status is in `on`, **does not retry**: it parses `Retry-After` via the existing `parseRetryAfter` and throws a new **`RateLimitError({ status, retryAfterMs, response })`**, checked *before* the internal retry-on-status path so it wins even on the common 429 overlap with `retry.on`;
- leaves the **success path** (validate → template → transform → unwrap → drift) and non-rate-limit failures unchanged; a `circuit` block, if also set, still applies.

`RateLimitError` is exported from the package root and survives intact to the awaited caller: `errEvt` pins the live instance on the `error` event via a non-enumerable key (so the full `response` never reaches a trace sink — `Object.entries`/`JSON.stringify` skip it) and `drain` re-throws that instance. The `error` `StitchEvent` variant gains an additive optional `retryAfterMs` so `.stream()` consumers get the same structured hint; `.safe()` coerces it to a `StitchError` carrying the status, with the original `RateLimitError` preserved as `.cause`.

## Files changed
- `packages/core/src/resilience.ts` — new `RateLimitError` class (`status`, `retryAfterMs?`, `response`).
- `packages/core/src/types.ts` — `StitchConfig.rateLimit` block; `retryAfterMs?` on the `error` event.
- `packages/core/src/engine.ts` — delegate path in `attemptLoop` (throttle bypass + `RateLimitError` on rate-limit status); `errEvt` stamps `retryAfterMs` and pins the live error.
- `packages/core/src/stitch.ts` — `drain` re-throws the pinned `RateLimitError`; `asStitchError`/`consumeSafe` carry its `status` onto the `.safe()` result.
- `packages/core/src/index.ts` — re-export `RateLimitError`.
- `packages/core/test/gaps/delegate-backoff.spec.ts` — 8 behavioral tests against the mock server.
- Docs: `guides/resilience/delegate-backoff.mdx` guide, `errors/rate-limit.mdx` page, plus `meta.json` / manifest / errors-index wiring.

## Verification
`pnpm -r check:types`, `pnpm -r check:lint`, `pnpm -r test` (core: 474 passing, incl. 8 new), `pnpm -r check:exports`, `pnpm format` — all green. The docs app also builds cleanly (`next build`), so the new twoslash blocks type-check against the real `stitchapi` types.

## Notes
- The tracked generated file `apps/docs/app/(home)/playground/playground-completions.generated.ts` updated automatically to include the new `rateLimit` autocomplete entry — it's regenerated from `StitchConfig`.
- In delegate mode the `throttle` block is intentionally **inert** (documented in the guide and the `rateLimit` JSDoc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)