### PR TITLE
feat(core): acceptStatus (non-2xx as result) + StitchError carries { body, url }

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -120,6 +120,12 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             info: "Retry-and-backoff policy.",
         },
         {
+            label: "acceptStatus",
+            type: "property",
+            detail: "number[] | ((status: number) => boolean)",
+            info: "Statuses that are a NORMAL result rather than an error — a number list or a predicate. An accepted non-2xx flows through interpret → transform → unwrap → validate exactly like a 2xx (the response body becomes the result), instead of throwing a . Use this when an endpoint treats e.g. `404`/`400` as expected control flow (resource-gone → fall back to a broader call) so the happy path no longer runs through a `catch`. `retry.on` still wins while attempts remain: a status listed in BOTH is retried until attempts are exhausted, then accepted (returned) on the final attempt. Orthogonal to `rateLimit.delegate`, which surfaces a  on rate-limit statuses earlier.",
+        },
+        {
             label: "throttle",
             type: "property",
             detail: "ThrottleOptions",

--- a/apps/docs/content/docs/errors/index.mdx
+++ b/apps/docs/content/docs/errors/index.mdx
@@ -6,8 +6,11 @@ description: 'How StitchAPI errors work, the code-to-docs contract, and an index
 When a stitch can't produce a result, it fails with a `StitchError` — an `Error`
 subclass exported from `stitchapi`, carrying a human-readable `message`, an
 optional `.status` (the upstream HTTP status), and `.attempts` (how many tries
-the runtime made before giving up). Await a stitch and that error is what `catch`
-receives — narrow it with `instanceof`:
+the runtime made before giving up). When the failure came from an HTTP response it
+also carries `.body` (the parsed error payload — an API's `{ error: "…" }`) and
+`.url` (the final request URL, after redirects); both are `undefined` for
+transport/internal errors. Await a stitch and that error is what `catch` receives —
+narrow it with `instanceof`:
 
 ```ts twoslash
 import { StitchError, stitch } from 'stitchapi';
@@ -21,10 +24,20 @@ try {
     await me();
 } catch (e) {
     if (e instanceof StitchError) {
-        console.error(e.message, e.status, e.attempts);
+        // .body is the parsed error payload; .url is the final request URL.
+        console.error(e.message, e.status, e.attempts, e.body, e.url);
     }
 }
 ```
+
+<Callout type="info">
+    `.body` carries the upstream error payload only to the awaited / `.safe()`
+    caller — it rides a non-enumerable channel and is **never** written to a trace
+    sink, so an `{ error: "…" }` payload can't leak into a JSONL/console log. If a
+    non-2xx is actually expected control flow (a `404` you fall back from), see
+    [`acceptStatus`](/docs/guides/resilience/accept-status) — it returns the body
+    as a normal result instead of throwing.
+</Callout>
 
 If you read the [event stream](/docs/concepts/event-stream) instead of awaiting,
 the same failure arrives as an `error` event carrying

--- a/apps/docs/content/docs/guides/resilience/accept-status.mdx
+++ b/apps/docs/content/docs/guides/resilience/accept-status.mdx
@@ -1,0 +1,86 @@
+---
+title: 'Accept status'
+description: 'Declare statuses that are a normal result, not an error — an accepted non-2xx flows through transform/unwrap/validate instead of throwing.'
+---
+
+By default every `status >= 400` is a failure: the stitch throws a
+[`StitchError`](/docs/errors), so a `404` you _expected_ — a resource that's gone,
+where you fall back to a broader call — has to be handled in a `catch`. That turns
+ordinary control flow into exception handling.
+
+`acceptStatus` lets you declare which non-2xx statuses are a **normal result**. An
+accepted status no longer throws: its response body becomes the result and flows
+through the same pipeline a `2xx` does — `interpret` → `transform` → `unwrap` →
+`output` validation — so the happy path stays on the happy path.
+
+## Example
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const lookup = stitch<{ id: string } | { missing: true }>({
+    baseUrl: 'https://api.example.com',
+    path: '/items/{id}',
+    acceptStatus: [404], // a 404 is "not found", not a thrown error
+    transform: (body) =>
+        // Reshape the 404 payload into a sentinel your code can branch on.
+        body && typeof body === 'object' && 'id' in body
+            ? body
+            : { missing: true },
+});
+
+const item = await lookup({ params: { id: 'abc' } });
+if ('missing' in item) {
+    // fall back to a broader call — no try/catch needed
+}
+```
+
+A `404` here **resolves** with the response body instead of rejecting. Everything
+else (`401`, `500`, …) still throws a `StitchError` exactly as before — `acceptStatus`
+is additive, never a blanket "ignore failures".
+
+## A list or a predicate
+
+`acceptStatus` is either a number list or a predicate `(status) => boolean`. Use a
+predicate to accept a range:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const probe = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/probe',
+    // accept every 4xx as a result; a 5xx still throws
+    acceptStatus: (status) => status >= 400 && status < 500,
+});
+```
+
+## Interaction with retry
+
+`retry.on` **wins while attempts remain**. A status listed in _both_
+[`retry.on`](/docs/guides/resilience/retry) and `acceptStatus` is retried until
+attempts are exhausted, then **accepted** (returned) on the final attempt — so you
+can retry a flaky `503` a few times and still treat a persistent one as a result
+rather than an error:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const call = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/maybe',
+    retry: { attempts: 3, on: [503] }, // retry a 503 up to 3 times…
+    acceptStatus: [503], // …then accept it on the final attempt
+});
+```
+
+`acceptStatus` is orthogonal to
+[`rateLimit.delegate`](/docs/guides/resilience/delegate-backoff), which surfaces a
+`RateLimitError` on rate-limit statuses earlier and is unaffected by this option.
+
+## When you still want the error body
+
+If a non-2xx is a _genuine_ failure but you need the API's error payload — its
+`{ error: "…" }` body — don't reach for `acceptStatus`. Let it throw and read
+[`StitchError.body`](/docs/errors) (and `.url`), which carry the parsed payload and
+final request URL on the awaited / `.safe()` path.

--- a/apps/docs/content/docs/guides/resilience/meta.json
+++ b/apps/docs/content/docs/guides/resilience/meta.json
@@ -2,6 +2,7 @@
     "title": "Resilience",
     "pages": [
         "retry",
+        "accept-status",
         "throttle",
         "timeout",
         "circuit-breaker",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -192,7 +192,7 @@ const user = await getUser({ params: { id: 1 } }); // typed { id: number; name: 
 
 ## The event stream
 
-A stitch does not return `Promise<bytes>`. It yields a typed event stream — `await` is sugar that consumes the stream and returns the final, unwrapped, validated `result` (or throws a `StitchError` carrying `.status`):
+A stitch does not return `Promise<bytes>`. It yields a typed event stream — `await` is sugar that consumes the stream and returns the final, unwrapped, validated `result` (or throws a `StitchError` carrying `.status`, plus `.body` (the parsed error payload) and `.url` (the final request URL) when the failure came from a response):
 
 ```ts
 const users = await getUsers(); // sugar: consume the stream → the result value
@@ -202,7 +202,7 @@ Prefer to handle failure inline rather than with `try`/`catch`? `.safe()` never 
 
 ```ts
 const { data, error } = await getUsers.safe();
-if (error) return; // error: StitchError (.status, .attempts); data is null
+if (error) return; // error: StitchError (.status, .attempts, .body, .url); data is null
 use(data); // narrowed: data is the validated result, error is null
 ```
 

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -269,6 +269,15 @@ function errEvt(err: unknown, name: string, attempts: number): StitchEvent {
             value: err,
             enumerable: false,
         });
+    } else if ((err as { response?: AdapterResponse }).response !== undefined) {
+        // HTTP failure (issue #155): the thrown error carries the full `.response` (body + url).
+        // Pin it on the SAME non-enumerable channel so `drain`/`asStitchError` can populate
+        // `StitchError.body`/`.url`. Non-enumerable ⇒ the body never serialises into a trace sink
+        // (privacy preserved); the enumerable `status`/`message` are all a sink sees.
+        Object.defineProperty(evt, ERROR_SOURCE, {
+            value: err,
+            enumerable: false,
+        });
     }
     return evt;
 }
@@ -433,6 +442,51 @@ async function acquireWithin(
     }
 }
 
+// Normalize `acceptStatus` (a number list, a predicate, or unset) into a single predicate. Unset →
+// accept nothing (every `>= 400` still throws). Shared by the buffered/paginated `attemptLoop` and
+// the streaming path so both honour the same per-stitch policy.
+function acceptsStatus(
+    accept: number[] | ((status: number) => boolean) | undefined,
+): (status: number) => boolean {
+    if (accept === undefined) return () => false;
+    if (typeof accept === 'function') return accept;
+    return (status) => accept.includes(status);
+}
+
+// Materialize a streaming-path error body for StitchError.body. A streaming adapter hands back the
+// live `ReadableStream` unparsed (so it can be decoded into deltas); on the error branch the stream
+// is never decoded, so read it to text and best-effort JSON-parse it — the same shape the buffered
+// path produces. A non-stream body (an adapter that already buffered) passes through unchanged; a
+// read failure degrades to `undefined` rather than throwing over the original HTTP error.
+async function drainErrorBody(body: unknown): Promise<unknown> {
+    if (
+        body == null ||
+        typeof (body as ReadableStream<Uint8Array>).getReader !== 'function'
+    ) {
+        return body; // already buffered/parsed (or empty) — nothing to drain.
+    }
+    try {
+        const reader = (body as ReadableStream<Uint8Array>).getReader();
+        const dec = new TextDecoder();
+        let text = '';
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            // After `done` is false, `value` is a Uint8Array (never undefined).
+            text += dec.decode(value, { stream: true });
+        }
+        text += dec.decode();
+        if (text === '') return undefined;
+        try {
+            return JSON.parse(text);
+        } catch {
+            return text; // not JSON — keep the raw text payload.
+        }
+    } catch {
+        return undefined; // body already consumed / errored — don't mask the HTTP error.
+    }
+}
+
 async function* attemptLoop(
     rt: Runtime,
     baseReq: AdapterRequest,
@@ -451,6 +505,11 @@ async function* attemptLoop(
     // retrying. Everything else — auth, the success path, non-rate-limit failures — is unchanged.
     const delegate = cfg.rateLimit?.delegate === true;
     const rlOn = cfg.rateLimit?.on ?? [429];
+    // acceptStatus (issue #155): statuses the caller declares NORMAL — an accepted non-2xx returns
+    // `res` like a 2xx (flowing through interpret → transform → unwrap → validate) instead of
+    // throwing. Checked at the `>= 400` site, i.e. AFTER the retry-on-status path, so `retry.on`
+    // still wins while attempts remain (retried, then accepted on the final attempt).
+    const accepts = acceptsStatus(cfg.acceptStatus);
 
     for (let attempt = 1; attempt <= max; attempt++) {
         state.attempts = attempt;
@@ -573,7 +632,7 @@ async function* attemptLoop(
                 continue;
             }
 
-            if (res.status >= 400) {
+            if (res.status >= 400 && !accepts(res.status)) {
                 const e = new Error(`HTTP ${res.status}`) as Error & {
                     status: number;
                     response: AdapterResponse;
@@ -582,6 +641,7 @@ async function* attemptLoop(
                 e.response = res;
                 throw e;
             }
+            // A 2xx, or an accepted non-2xx: return it so it flows through the success pipeline.
             return res;
         } finally {
             // No release in delegate mode — we never acquired a slot (the host owns the gate).
@@ -995,9 +1055,24 @@ async function* runStreaming(
         return;
     }
 
-    if (res.status >= 400) {
-        const e = new Error(`HTTP ${res.status}`) as Error & { status: number };
+    // acceptStatus (issue #155): an accepted non-2xx streams its live body like a 2xx instead of
+    // failing — same per-stitch policy the buffered/paginated `attemptLoop` honours.
+    if (res.status >= 400 && !acceptsStatus(cfg.acceptStatus)(res.status)) {
+        // The error response carries the parsed payload, not a live stream — drain the unread body
+        // (a small `{ error: "…" }`, not a real stream the caller wants) so StitchError.body is the
+        // PARSED payload, matching the buffered path. Pin it (with `.url`) via ERROR_SOURCE.
+        const errored: AdapterResponse = {
+            status: res.status,
+            headers: res.headers,
+            body: await drainErrorBody(res.body),
+            ...(res.url !== undefined ? { url: res.url } : {}),
+        };
+        const e = new Error(`HTTP ${res.status}`) as Error & {
+            status: number;
+            response: AdapterResponse;
+        };
         e.status = res.status;
+        e.response = errored; // carries body + url for StitchError.body/.url (pinned via ERROR_SOURCE)
         yield errEvt(e, name, 1);
         yield doneEvt(false, t0, 1);
         return;

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -13,7 +13,7 @@ import {
 } from './engine';
 import type { InferOutput, InputOf, ResolveOutput } from './infer';
 import { otlpTrace } from './otlp';
-import { createThrottle } from './resilience';
+import { RateLimitError, createThrottle } from './resilience';
 import { createStoreThrottle, memoryStore } from './store';
 import { graphqlSurface } from './surface';
 import { consoleSink, createTrace, exportsFromEnv, multiplex } from './trace';
@@ -219,9 +219,14 @@ export function resolveTrace(trace: StitchConfig['trace']): TraceSink {
 // ---- the streaming spine + await sugar ------------------------------------
 // Drain the event stream to its terminal: the `result` value, or the `error` event rebuilt as a
 // typed StitchError (status + attempts preserved). Shared by the throwing and safe consumers.
-// Exception: a delegate-backoff rate-limit (issue #145) pins its live RateLimitError on the event
-// via the non-enumerable ERROR_SOURCE key — re-surface THAT instance unchanged, so the caller keeps
-// the real class identity plus `retryAfterMs`/`response`, instead of a flattened StitchError.
+//
+// The non-enumerable ERROR_SOURCE key (engine.ts) pins the live error behind the event without
+// leaking its payload into a trace sink. Two kinds ride it:
+//   • a delegate-backoff RateLimitError (issue #145): re-surface THAT instance unchanged, so the
+//     caller keeps the real class identity plus `retryAfterMs`/`response`.
+//   • a plain HTTP error carrying `.response` (issue #155): flatten into a StitchError, lifting the
+//     response `body`/`url` onto the error so a result-shaped caller can read the API's error
+//     payload (`{ error: "…" }`) it would otherwise never see.
 async function drain<T>(
     gen: AsyncGenerator<StitchEvent<T>, void>,
 ): Promise<{ value: T } | { error: Error }> {
@@ -231,12 +236,38 @@ async function drain<T>(
         if (ev.type === 'result') value = ev.value;
         else if (ev.type === 'error') {
             const source = (ev as { [ERROR_SOURCE]?: Error })[ERROR_SOURCE];
-            error =
-                source ??
-                new StitchError(ev.message, {
+            const res =
+                source === undefined
+                    ? undefined
+                    : (
+                          source as {
+                              response?: { body?: unknown; url?: string };
+                          }
+                      ).response;
+            // A pinned HTTP error (has `.response`, but is neither a StitchError nor a
+            // RateLimitError): rebuild as a StitchError carrying the response `body`/`url`. A
+            // RateLimitError keeps its class identity (re-surfaced unchanged) so the delegate-backoff
+            // caller still gets `retryAfterMs`/`response`.
+            if (
+                res !== undefined &&
+                !(source instanceof StitchError) &&
+                !(source instanceof RateLimitError)
+            ) {
+                error = new StitchError(ev.message, {
                     status: ev.status,
                     attempts: ev.attempts,
+                    body: res.body,
+                    url: res.url,
+                    cause: source,
                 });
+            } else {
+                error =
+                    source ??
+                    new StitchError(ev.message, {
+                        status: ev.status,
+                        attempts: ev.attempts,
+                    });
+            }
         }
     }
     return error ? { error } : { value: value as T };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -474,6 +474,18 @@ export interface StitchConfig {
     auth?: AuthStrategy;
     /** Retry-and-backoff policy. */
     retry?: RetryOptions;
+    /**
+     * Statuses that are a NORMAL result rather than an error — a number list or a predicate.
+     * An accepted non-2xx flows through interpret → transform → unwrap → validate exactly like a
+     * 2xx (the response body becomes the result), instead of throwing a {@link StitchError}. Use
+     * this when an endpoint treats e.g. `404`/`400` as expected control flow (resource-gone → fall
+     * back to a broader call) so the happy path no longer runs through a `catch`.
+     *
+     * `retry.on` still wins while attempts remain: a status listed in BOTH is retried until attempts
+     * are exhausted, then accepted (returned) on the final attempt. Orthogonal to
+     * `rateLimit.delegate`, which surfaces a {@link RateLimitError} on rate-limit statuses earlier.
+     */
+    acceptStatus?: number[] | ((status: number) => boolean);
     /** Rate and concurrency limits. */
     throttle?: ThrottleOptions;
     /** Total and per-attempt timeouts. */
@@ -551,11 +563,22 @@ export class StitchError extends Error {
     readonly status: number | undefined;
     /** Attempts made before giving up (1 = no retry). */
     readonly attempts: number;
+    /**
+     * The parsed response body of the failing response (an API's `{ error: "..." }` payload),
+     * when the failure came from an HTTP response; `undefined` for transport/internal errors. Only
+     * populated on the awaited / `.safe()` path — it is carried over the non-enumerable error
+     * channel and so never serialises into a trace sink.
+     */
+    readonly body?: unknown;
+    /** The final request URL (after redirects) of the failing response, when the transport exposes it. */
+    readonly url?: string;
     constructor(
         message: string,
         opts: {
             status?: number | undefined;
             attempts?: number | undefined;
+            body?: unknown;
+            url?: string | undefined;
             cause?: unknown;
         } = {},
     ) {
@@ -566,6 +589,8 @@ export class StitchError extends Error {
         this.name = 'StitchError';
         this.status = opts.status;
         this.attempts = opts.attempts ?? 0;
+        if (opts.body !== undefined) this.body = opts.body;
+        if (opts.url !== undefined) this.url = opts.url;
     }
 }
 

--- a/packages/core/test/gaps/accept-status.spec.ts
+++ b/packages/core/test/gaps/accept-status.spec.ts
@@ -1,0 +1,193 @@
+// Pins issue #155 part A: `acceptStatus` — declare statuses (a number list or a predicate) that are
+// a NORMAL result rather than an error. An accepted non-2xx returns its body and flows through the
+// SAME success pipeline a 2xx does (interpret → transform → unwrap → validate) instead of throwing.
+// `retry.on` still wins while attempts remain (retried, then accepted on the final attempt); the
+// policy is honoured on the buffered, paginated, and streaming paths via the shared `attemptLoop`.
+import { type StitchError, type StitchEvent, stitch } from '../../src';
+import { startMockServer } from '../support/mock-server';
+import type { MockServer } from '../support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-gap-accept-status-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+// Await a call expected to reject; return the thrown error narrowed to a StitchError.
+async function rejectionOf(call: PromiseLike<unknown>): Promise<StitchError> {
+    return Promise.resolve(call).then(
+        () => {
+            throw new Error('expected the call to reject, but it resolved');
+        },
+        (e: unknown) => e as StitchError,
+    );
+}
+
+// ── A. an accepted 404 RESOLVES with the 404 body (no throw) ──
+// `acceptStatus: [404]` turns a 404 into a normal result: the awaited path resolves to the response
+// body — exactly the "resource-gone → fall back" control flow that today runs through a `catch`.
+test('acceptStatus: [404] resolves with the 404 body instead of throwing', async () => {
+    server.route('GET', '/missing', {
+        statuses: [404],
+        body: { error: 'not_found', code: 'gone' },
+    });
+    const call = stitch<{ error: string; code: string }>({
+        baseUrl: server.url,
+        path: '/missing',
+        acceptStatus: [404],
+    });
+
+    await expect(call()).resolves.toEqual({ error: 'not_found', code: 'gone' });
+});
+
+// ── B. transform / unwrap / output validation still run on an accepted non-2xx ──
+// An accepted 404 is NOT a bare pass-through: it flows through the whole success pipeline. Here a
+// 404 body { data: {...} } is unwrapped, reshaped by transform, and validated by the output guard —
+// proving the accepted response is treated identically to a 2xx.
+test('an accepted non-2xx still runs transform, unwrap, and output validation', async () => {
+    server.route('GET', '/accepted-pipeline', {
+        statuses: [404],
+        body: { data: { id: 7, name: 'widget' } },
+    });
+    const call = stitch<{ id: number; label: string }>({
+        baseUrl: server.url,
+        path: '/accepted-pipeline',
+        acceptStatus: [404],
+        unwrap: 'data',
+        transform: (body) => {
+            const b = body as { data: { id: number; name: string } };
+            return { data: { id: b.data.id, label: b.data.name } };
+        },
+        output: (v: unknown): v is { id: number; label: string } => {
+            const o = v as { id?: unknown; label?: unknown };
+            return typeof o.id === 'number' && typeof o.label === 'string';
+        },
+    });
+
+    await expect(call()).resolves.toEqual({ id: 7, label: 'widget' });
+});
+
+// ── C. a predicate accepts a 400 but still throws on a 500 ──
+// `acceptStatus: (s) => s < 500` — a 400 is accepted (resolves), a 500 is not (still a StitchError).
+test('acceptStatus predicate accepts a 400 and still throws on a 500', async () => {
+    server.route('GET', '/bad-request', {
+        statuses: [400],
+        body: { error: 'bad_input' },
+    });
+    server.route('GET', '/server-error', {
+        statuses: [500],
+        body: { error: 'boom' },
+    });
+    const accept4xx = (s: number): boolean => s < 500;
+
+    const ok = stitch<{ error: string }>({
+        baseUrl: server.url,
+        path: '/bad-request',
+        acceptStatus: accept4xx,
+    });
+    await expect(ok()).resolves.toEqual({ error: 'bad_input' });
+
+    const bad = stitch({
+        baseUrl: server.url,
+        path: '/server-error',
+        acceptStatus: accept4xx,
+    });
+    const err = await rejectionOf(bad());
+    expect(err.name).toBe('StitchError');
+    expect(err.status).toBe(500);
+});
+
+// ── D. retry.on wins while attempts remain, then accept on the final attempt ──
+// A status in BOTH `retry.on` and `acceptStatus` is RETRIED until attempts are exhausted, then
+// ACCEPTED (returned) on the final attempt. Here two 503s then a third 503: with retry.attempts: 3
+// the first two are retried, the third (final attempt) is accepted and its body resolves — proving
+// the accept check sits AFTER the retry-on-status path (3 requests, no throw).
+test('a status in both retry.on and acceptStatus is retried, then accepted on the final attempt', async () => {
+    server.route('GET', '/retry-then-accept', {
+        statuses: [503, 503, 503],
+        body: [{ try: 1 }, { try: 2 }, { ok: true, last: true }],
+    });
+    const call = stitch<{ ok: boolean; last: boolean }>({
+        baseUrl: server.url,
+        path: '/retry-then-accept',
+        retry: { attempts: 3, on: [503], backoff: 'fixed', baseMs: 1 },
+        acceptStatus: [503],
+    });
+
+    await expect(call()).resolves.toEqual({ ok: true, last: true });
+    // Retried twice, accepted on the third — the route saw exactly three requests.
+    expect(server.callCount('/retry-then-accept')).toBe(3);
+});
+
+// ── E. acceptStatus is honoured on the streaming path too ──
+// Streaming shares the same per-stitch policy: an accepted non-2xx streams its live body as `delta`
+// chunks and terminates as a success (a `result`, `done.ok: true`) rather than an `error` event.
+test('acceptStatus lets a streaming surface accept a non-2xx and stream its body', async () => {
+    server.route('GET', '/accept-stream', {
+        statuses: [404],
+        stream: { chunks: ['hello ', 'world'] },
+        headers: { 'content-type': 'text/plain' },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/accept-stream',
+        acceptStatus: [404],
+        kind: {
+            id: 'text-stream',
+            // Minimal text-stream surface: decode each Uint8Array chunk to a string `delta`.
+            stream: async function* (res) {
+                const body = res.body as ReadableStream<Uint8Array>;
+                const reader = body.getReader();
+                const dec = new TextDecoder();
+                for (;;) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    yield dec.decode(value, { stream: true });
+                }
+            },
+        },
+    });
+
+    const events: StitchEvent[] = [];
+    for await (const ev of call.stream()) events.push(ev);
+
+    // No error event: the accepted 404 streamed as a success.
+    expect(events.some((e) => e.type === 'error')).toBe(false);
+    expect(events.find((e) => e.type === 'done')).toMatchObject({ ok: true });
+    const deltas = events
+        .filter((e) => e.type === 'delta')
+        .map((e) => (e as { chunk: unknown }).chunk);
+    expect(deltas.join('')).toBe('hello world');
+});
+
+// ── F. a non-accepted status under acceptStatus still throws ──
+// Sanity: acceptStatus is additive — a status NOT in the list/predicate keeps the ordinary failure.
+test('a status outside acceptStatus still throws a StitchError', async () => {
+    server.route('GET', '/still-throws', {
+        statuses: [403],
+        body: { error: 'forbidden' },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/still-throws',
+        acceptStatus: [404], // 403 is NOT accepted
+    });
+
+    const err = await rejectionOf(call());
+    expect(err.name).toBe('StitchError');
+    expect(err.status).toBe(403);
+});

--- a/packages/core/test/gaps/stitch-error-body.spec.ts
+++ b/packages/core/test/gaps/stitch-error-body.spec.ts
@@ -1,0 +1,167 @@
+// Pins issue #155 part B: a thrown `StitchError` now carries `{ body, url }` — the parsed error
+// payload and the final request URL of the failing response — alongside `.status`/`.attempts`, on
+// BOTH the awaited path and `.safe()`. The response rides a NON-enumerable error channel
+// (ERROR_SOURCE), so a result-shaped caller can read the API's `{ error: "…" }` payload while the
+// body never serialises into a trace sink (privacy preserved). Applies to the buffered and
+// streaming throw sites.
+import {
+    type StitchError,
+    type StitchEvent,
+    type TraceSink,
+    stitch,
+} from '../../src';
+import { startMockServer } from '../support/mock-server';
+import type { MockServer } from '../support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-gap-error-body-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+// Await a call expected to reject; return the thrown error narrowed to a StitchError.
+async function rejectionOf(call: PromiseLike<unknown>): Promise<StitchError> {
+    return Promise.resolve(call).then(
+        () => {
+            throw new Error('expected the call to reject, but it resolved');
+        },
+        (e: unknown) => e as StitchError,
+    );
+}
+
+// ── A. the awaited path throws a StitchError carrying status + body + url ──
+test('await throws a StitchError with .status, .body (parsed payload), and .url', async () => {
+    server.route('GET', '/err', {
+        statuses: [422],
+        body: { error: 'unprocessable', field: 'email' },
+    });
+    const call = stitch({ baseUrl: server.url, path: '/err' });
+
+    const err = await rejectionOf(call());
+
+    expect(err.name).toBe('StitchError');
+    expect(err.status).toBe(422);
+    // The parsed error payload — exactly what an API's `{ error: "…" }` body needs.
+    expect(err.body).toEqual({ error: 'unprocessable', field: 'email' });
+    // The final request URL (after redirects), surfaced from the response.
+    expect(err.url).toBe(`${server.url}/err`);
+});
+
+// ── B. .safe() surfaces the same body + url without throwing ──
+test('.safe() returns a StitchError carrying .body and .url (never throws)', async () => {
+    server.route('GET', '/err-safe', {
+        statuses: [400],
+        body: { error: 'bad_request' },
+    });
+    const call = stitch({ baseUrl: server.url, path: '/err-safe' });
+
+    const out = await call.safe();
+    expect(out.ok).toBe(false);
+    expect(out.error?.status).toBe(400);
+    expect(out.error?.body).toEqual({ error: 'bad_request' });
+    expect(out.error?.url).toBe(`${server.url}/err-safe`);
+});
+
+// ── C. the error body does NOT reach a trace sink's error event (privacy) ──
+// The response rides the non-enumerable ERROR_SOURCE channel, never an enumerable field. A capturing
+// sink sees the enumerable `status`/`message`/`attempts` of the error event but never the body or
+// the raw response — so a JSONL/console trace can't leak the failing payload.
+test('the error body is absent from a capturing trace sink event', async () => {
+    server.route('GET', '/err-trace', {
+        statuses: [403],
+        body: { error: 'forbidden', secret: 'do-not-log-me' },
+    });
+    const captured: StitchEvent[] = [];
+    const sink: TraceSink = {
+        handle(event) {
+            captured.push(event);
+        },
+        flush() {
+            /* nothing buffered */
+        },
+    };
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/err-trace',
+        trace: sink,
+    });
+
+    // The awaited caller still gets the body…
+    const err = await rejectionOf(call());
+    expect(err.body).toEqual({ error: 'forbidden', secret: 'do-not-log-me' });
+
+    // …but the sink's error event must not carry it. Assert across the raw event AND its JSON
+    // serialisation (what a JSONL/console sink would actually write), since ERROR_SOURCE is a
+    // non-enumerable Symbol key that both Object.keys and JSON.stringify skip.
+    const errorEvent = captured.find((e) => e.type === 'error');
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent).toHaveProperty('status', 403);
+    expect(errorEvent).not.toHaveProperty('body');
+    expect(errorEvent).not.toHaveProperty('response');
+    expect(errorEvent).not.toHaveProperty('url');
+    const serialised = JSON.stringify(captured);
+    expect(serialised).not.toContain('do-not-log-me');
+});
+
+// ── D. the streaming throw site also carries body + url ──
+// A streaming surface that hits a non-accepted error surfaces it through the SAME pinned channel, so
+// the awaited (collected) path's StitchError carries `.body`/`.url` too.
+test('a failing streaming call throws a StitchError with .body and .url', async () => {
+    server.route('GET', '/err-stream', {
+        statuses: [500],
+        body: { error: 'stream_boom' },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/err-stream',
+        kind: {
+            id: 'text-stream',
+            stream: async function* (res) {
+                const body = res.body as ReadableStream<Uint8Array>;
+                const reader = body.getReader();
+                const dec = new TextDecoder();
+                for (;;) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    yield dec.decode(value, { stream: true });
+                }
+            },
+        },
+    });
+
+    const err = await rejectionOf(call());
+    expect(err.status).toBe(500);
+    expect(err.body).toEqual({ error: 'stream_boom' });
+    expect(err.url).toBe(`${server.url}/err-stream`);
+});
+
+// ── E. a transport/internal error leaves body + url undefined ──
+// `.body`/`.url` are populated only from an HTTP response. A connection failure (no response) yields
+// a StitchError with no status, body, or url — proving the fields are additive, not always-present.
+test('a transport error yields a StitchError with body and url undefined', async () => {
+    // Point at a closed port on localhost — the connection is refused before any response.
+    const call = stitch({
+        baseUrl: 'http://127.0.0.1:1',
+        path: '/nope',
+        timeout: { perAttempt: '500ms' },
+    });
+
+    const err = await rejectionOf(call());
+    expect(err.name).toBe('StitchError');
+    expect(err.body).toBeUndefined();
+    expect(err.url).toBeUndefined();
+});


### PR DESCRIPTION
Closes #155

## Summary

Two cohesive gaps in how a non-2xx response is handled — both rewrite the shared `res.status >= 400` branch in `attemptLoop` and both touch `StitchError`, so they ship together.

### A. `acceptStatus` — a non-2xx as a normal result
- New `acceptStatus?: number[] | ((status: number) => boolean)` on `StitchConfig`. An accepted status **returns** its response instead of throwing, flowing through `interpret → transform → unwrap → validate` exactly like a 2xx (the body becomes the result).
- Checked at the `>= 400` site *after* the retry-on-status path, so `retry.on` still wins while attempts remain: a status in **both** is retried until attempts are exhausted, then accepted on the final attempt.
- Honoured uniformly on the buffered, paginated (shared `attemptLoop`), and streaming paths. Orthogonal to `rateLimit.delegate`.

### B. `StitchError` carries `{ body, url }`
- Added `readonly body?: unknown` (the parsed error payload — an API's `{ error: "…" }`) and `readonly url?: string` (final request URL) to `StitchError`.
- The thrown HTTP error already carries `.response`; it's now pinned on the `error` event via the **existing non-enumerable `ERROR_SOURCE` channel** (the same one `RateLimitError` uses). `drain` rebuilds a `StitchError` with `body: res.body` / `url: res.url` on both `await` and `.safe()`. A `RateLimitError` keeps its class identity (re-surfaced unchanged).
- Because `ERROR_SOURCE` is non-enumerable, the body **never** serialises into a trace sink (privacy preserved — covered by a capturing-sink assertion).
- The streaming branch drains+parses the live `ReadableStream` error body first so its `StitchError.body` matches the buffered shape.

## Docs
- New `guides/resilience/accept-status` page (+ meta), `StitchError.body`/`.url` documented in the errors index, README claim reconciled.

## Tests
- `test/gaps/accept-status.spec.ts` and `test/gaps/stitch-error-body.spec.ts` cover every acceptance criterion, including the trace-privacy assertion.

## Verification (all green)
`pnpm -r check:types`, `pnpm -r check:lint`, `pnpm -r test` (core: 502 passing), `pnpm -r check:exports`, `pnpm format`. The lefthook pre-commit gate (format + lint + typecheck, incl. docs MDX build) also passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)