### PR TITLE
refactor(nest): delegate fromConfig/loggerSink to core secretFrom/loggerSink

### DIFF
--- a/docs/adr/0006-nestjs-integration.md
+++ b/docs/adr/0006-nestjs-integration.md
@@ -382,3 +382,17 @@ Layered on the original decisions to cut per-consumer boilerplate. All additive,
 -   **Multi-tenant wiring packaged** — `StitchModule.forFeatureScoped({ stitches, principal })` replaces the hand-rolled request-scoped `TENANT_SEAM` recipe (Decision 5). Adds `@nestjs/core` as a peer (for `REQUEST`; always present in a Nest app).
 
 Peer-dependency policy unchanged in spirit: peer-depend on what a Nest app **always** has (`@nestjs/common`, now `@nestjs/core` + `rxjs`); keep **optional** deps structural (`@nestjs/config` → `ConfigServiceLike`). Still non-goals: the Terminus health indicator and the Nest-GraphQL disambiguation note.
+
+## Addendum (2026-06-16) — bridges delegate to core's `secretFrom` / `loggerSink` (the one sanctioned core change)
+
+Core has since grown two generic primitives that the original ADRs hand-rolled inside this package: `secretFrom(source, name)` — a `SecretSource`-backed secret thunk ([`auth.ts`](../../packages/core/src/auth.ts)) — and a logger-agnostic `loggerSink(logger, opts)` ([`trace.ts`](../../packages/core/src/trace.ts)). The two bridge helpers now **delegate** to them instead of reimplementing the logic, killing the duplication:
+
+-   **`fromConfig` → `secretFrom`.** `fromConfig(config)(key)` is now `secretFrom((name) => String(config.getOrThrow(name)), key)`. A missing key still throws (`ConfigService.getOrThrow`'s own error propagates); empty values are now rejected too — matching `env()` / `secretFrom()`, so a blank credential never silently rides along. That empty-string rejection is the **one** behavior the delegation tightens (previously a present-but-empty config value returned `''`); it is strictly safer and untested before. Public type (`ConfigServiceLike`) and signature unchanged.
+-   **`loggerSink` → core `loggerSink`.** Nest's sink is _richer_ than core's twin — Nest's `Logger` has `verbose` (core's `LoggerLike` has only `info`/`debug`), it has a `{ lifecycle }` toggle, it routes `retry`/`circuit` progress to `warn` (a per-_instance_ rule core's per-_type_ `levels` map can't express), it pins info-`drift` to `debug`, and its one-liners carry glyphs + attempt counts. To let it delegate **without changing a single logged byte**, core's `loggerSink` gained two **generic** optional hooks (no NestJS concept leaks in):
+
+    -   `level?: (event, ctx) => LogLevel | null` — resolve the level per event instance (`null` drops it, `undefined` defers); a strict superset of `levels`.
+    -   `format?: (event, ctx) => string | null` — supply the metadata-only line (the host then owns the payload-free guarantee; the default formatter stays payload-free for everyone else).
+
+    Nest passes a verbose-routing `LoggerLike` adapter (core `info` → Nest `verbose`), its level rules, and its glyph formatter. Levels, messages, and the payload-free / never-log-`delta` guarantees stay byte-identical to the hand-rolled switch this replaced.
+
+This is the **deliberate exception** to the original "no core change" / "this ADR modifies no core code" stance (Context line, Decision _No core change_, and the boilerplate addendum above): the core additions are generic, additive, off-by-default, and covered by core tests, so the **contract-not-dependency** gate stays green — `@stitchapi/nest` still adds no capability, forks nothing, and peer-depends on `stitchapi`. The trade taken: a small, generic widening of core's `loggerSink` surface in exchange for deleting the duplicated dispatch / formatting / secret-resolution logic from the bridge package.

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -203,6 +203,27 @@ export interface LoggerSinkOptions {
      * cased to the finding level unless you override it here.
      */
     levels?: Partial<Record<StitchEvent['type'], LogLevel>>;
+    /**
+     * Resolve the level per event INSTANCE — a strict superset of {@link levels} (which keys only on
+     * the event *type*). Return a {@link LogLevel} to log at it, `null` to DROP the event, or
+     * `undefined` to defer to {@link levels} / the defaults. Lets a host express conditional rules the
+     * per-type map can't — e.g. a `retry`/`circuit` `progress` at `warn` but a routine throttle at
+     * `debug`, or dropping the happy-path lifecycle. Takes precedence over {@link levels}. `delta` is
+     * dropped before this runs, so it is never called for one.
+     */
+    level?: (
+        event: StitchEvent,
+        ctx: { name: string },
+    ) => LogLevel | null | undefined;
+    /**
+     * Override the payload-free one-liner. Return the message to log, or `null` to skip the event.
+     * The default formatter emits metadata only — name, method, scrubbed URL, status, attempt counts,
+     * drift path/level, timing — never `event.input`, `event.value`, or a `delta` chunk. SECURITY: if
+     * you supply your own, YOU take on that guarantee — a custom sink receives the **raw** event, so
+     * log only metadata, never a header/body/chunk value or `JSON.stringify(event)`. `delta` is
+     * dropped before this runs.
+     */
+    format?: (event: StitchEvent, ctx: { name: string }) => string | null;
 }
 
 // The DEFAULT event-type → level mapping (drift is resolved per-finding at call time, and
@@ -263,7 +284,10 @@ function summary(name: string, event: StitchEvent): string | null {
  * `debug`, and `drift` → the finding's own `level` ('error'|'warn'|'info'). A `delta` event is
  * **never** logged — a streamed chunk is raw response data. Override any per-type level via
  * {@link LoggerSinkOptions.levels} (e.g. `{ result: 'debug' }`); `drift` still follows the finding
- * level unless you pin it there too.
+ * level unless you pin it there too. For conditional rules the per-type map can't express, pass a
+ * {@link LoggerSinkOptions.level} resolver (per-instance; `null` drops the event); for a different
+ * house style, pass a {@link LoggerSinkOptions.format} formatter (it then owns the payload-free
+ * guarantee). `@stitchapi/nest`'s Nest-flavored `loggerSink` is built by delegating here with both.
  *
  * SECURITY: a custom sink receives the **raw** event (core only redacts inside its own built-in
  * sinks), so a `start` event's `input.headers` still holds `authorization` / `cookie` and a
@@ -287,19 +311,30 @@ export function loggerSink(
     opts?: LoggerSinkOptions,
 ): TraceSink {
     const overrides = opts?.levels;
+    const resolveLevel = opts?.level;
+    const format = opts?.format;
     return {
         handle(event: StitchEvent, ctx: { name: string }): void {
-            // A streamed chunk is raw response data — never logged, regardless of `levels`.
+            // A streamed chunk is raw response data — never logged, regardless of any option.
             if (event.type === 'delta') return;
-            const message = summary(ctx.name, event);
-            if (message == null) return;
-            // Per-type override wins; else drift follows its finding level, everything
-            // else its default. DriftLevel ⊂ LogLevel, so the finding level needs no map.
-            const level: LogLevel =
+            // Per-instance resolver wins (null ⇒ drop, undefined ⇒ defer); else per-type
+            // override; else drift follows its finding level, everything else its default.
+            // DriftLevel ⊂ LogLevel, so the finding level needs no map.
+            let level = resolveLevel?.(event, ctx);
+            if (level === null) return; // resolver dropped it
+            // `undefined` ⇒ no resolver, or it deferred: fall back to the per-type override,
+            // drift's finding level, or the default. (`level` is non-null here, so `??=` only
+            // fires on undefined.)
+            level ??=
                 overrides?.[event.type] ??
                 (event.type === 'drift'
                     ? event.finding.level
                     : DEFAULT_LEVELS[event.type]);
+            // Default formatter is payload-free; a `format` override owns that guarantee itself.
+            const message = format
+                ? format(event, ctx)
+                : summary(ctx.name, event);
+            if (message == null) return;
             logger[level](message);
         },
         // Logging is synchronous; nothing is buffered to drain.

--- a/packages/core/test/logger-sink.spec.ts
+++ b/packages/core/test/logger-sink.spec.ts
@@ -191,3 +191,127 @@ test('opts.levels can override the drift level too', () => {
 
     expect(entries.map((e) => e.level)).toEqual(['warn']);
 });
+
+// ---------------------------------------------------------------------------
+// opts.level resolver + opts.format — the per-instance hooks @stitchapi/nest
+// delegates through (a conditional level rule the per-type map can't express,
+// and a different message house style), kept generic and tested here in core.
+// ---------------------------------------------------------------------------
+
+test('opts.level resolves per instance and takes precedence over levels', () => {
+    const { logger, entries } = fakeLogger();
+    // A `retry`/`circuit` progress is surfaced at warn; a routine throttle defers
+    // (undefined) to `levels` — which the per-type map alone could never split.
+    const sink = loggerSink(logger, {
+        levels: { progress: 'debug' },
+        level: (event) =>
+            event.type === 'progress' &&
+            (event.phase === 'retry' || event.phase === 'circuit')
+                ? 'warn'
+                : undefined,
+    });
+
+    sink.handle(
+        { type: 'progress', phase: 'retry', attempt: 2, at: 0 },
+        { name: 'x' },
+    );
+    sink.handle(
+        { type: 'progress', phase: 'throttled', attempt: 1, at: 0 },
+        { name: 'x' },
+    );
+
+    expect(levelsFor(entries, 'retry#2')).toEqual(['warn']); // resolver wins
+    expect(levelsFor(entries, 'throttled#1')).toEqual(['debug']); // deferred to levels
+});
+
+test('opts.level returning null drops the event', () => {
+    const { logger, entries } = fakeLogger();
+    // Drop the happy-path lifecycle (start/result/done); keep everything else.
+    const sink = loggerSink(logger, {
+        level: (event) =>
+            event.type === 'start' ||
+            event.type === 'result' ||
+            event.type === 'done'
+                ? null
+                : undefined,
+    });
+
+    sink.handle(
+        {
+            type: 'start',
+            name: 'x',
+            method: 'GET',
+            url: 'https://h/p',
+            input: {},
+            at: 0,
+        },
+        { name: 'x' },
+    );
+    sink.handle(
+        { type: 'result', value: 1, status: 200, attempts: 1, at: 0 },
+        { name: 'x' },
+    );
+    sink.handle(
+        {
+            type: 'error',
+            name: 'x',
+            message: 'boom',
+            status: 500,
+            attempts: 1,
+            at: 0,
+        },
+        { name: 'x' },
+    );
+
+    // start + result dropped by the resolver; only the error survives.
+    expect(entries.map((e) => e.level)).toEqual(['error']);
+});
+
+test('opts.format overrides the one-liner; null skips the event', () => {
+    const { logger, entries } = fakeLogger();
+    const sink = loggerSink(logger, {
+        format: (event, ctx) =>
+            event.type === 'start' ? `custom ${ctx.name}` : null,
+    });
+
+    sink.handle(
+        {
+            type: 'start',
+            name: 'x',
+            method: 'GET',
+            url: 'https://h/p',
+            input: {},
+            at: 0,
+        },
+        { name: 'x' },
+    );
+    // a non-start event → format returns null → nothing logged for it
+    sink.handle(
+        { type: 'done', ok: true, ms: 5, attempts: 1, at: 0 },
+        { name: 'x' },
+    );
+
+    // The custom line is logged at the unchanged default level (start → debug).
+    expect(entries).toEqual([{ level: 'debug', message: 'custom x' }]);
+});
+
+test('a delta event is dropped before opts.level/opts.format ever run', () => {
+    const { logger, entries } = fakeLogger();
+    let sawDelta = false;
+    const note = () => {
+        sawDelta = true;
+        return undefined;
+    };
+    const sink = loggerSink(logger, {
+        level: note,
+        format: () => {
+            sawDelta = true;
+            return 'should-never-log';
+        },
+    });
+
+    sink.handle({ type: 'delta', chunk: SECRET_BODY, at: 0 }, { name: 's' });
+
+    expect(entries).toEqual([]); // never logged
+    expect(sawDelta).toBe(false); // neither hook was invoked
+});

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -6,9 +6,10 @@ First-class [NestJS](https://nestjs.com) integration for
 
 It is a **thin** package: `StitchModule` wires StitchAPI's `seam` into Nest's DI
 graph, plus bridge helpers (a `Logger` sink, `ConfigService` secrets), an exception
-filter, and an SSE bridge. It adds **no capability** — every piece sits on an existing
-core extension point, so `stitchapi` stays a peer dependency and core is untouched
-(contract-not-dependency).
+filter, and an SSE bridge. It adds **no capability** — every piece sits on a core
+extension point, and the `Logger` sink and `ConfigService` bridge **delegate** to core's
+`loggerSink` / `secretFrom` rather than reimplement them. So `stitchapi` stays a peer
+dependency and the package forks nothing (contract-not-dependency).
 
 ```sh
 pnpm add @stitchapi/nest stitchapi

--- a/packages/nest/src/bridges.ts
+++ b/packages/nest/src/bridges.ts
@@ -1,8 +1,17 @@
 // The three bridges between core primitives and the NestJS world (ADR 0006
-// Decisions 6-8). None of them touches core: a TraceSink, a `Secret` thunk, and a
-// StitchStore are all existing extension points.
+// Decisions 6-8). None of them CHANGES core — they are built ON it: `loggerSink` and
+// `fromConfig` DELEGATE to core's `loggerSink` / `secretFrom` (passing Nest-flavored
+// level/format/source adapters), and `borrowStore` wraps a `StitchStore`. A TraceSink,
+// a `Secret` thunk, and a StitchStore are all existing extension points.
 import { Logger } from '@nestjs/common';
-import type { StitchEvent, StitchStore, TraceSink } from 'stitchapi';
+import { loggerSink as coreLoggerSink, secretFrom } from 'stitchapi';
+import type {
+    LoggerLike as CoreLoggerLike,
+    LogLevel,
+    StitchEvent,
+    StitchStore,
+    TraceSink,
+} from 'stitchapi';
 
 /**
  * The minimal logger surface this sink calls — declared structurally so Nest's
@@ -53,60 +62,92 @@ export function loggerSink(
     options: NestLoggerSinkOptions = {},
 ): TraceSink {
     const lifecycle = options.lifecycle ?? true;
+    // DELEGATE the event→level→log dispatch (and the never-log-delta rule) to core's
+    // `loggerSink`, supplying Nest's house style: a verbose-aware logger adapter, the
+    // per-instance level rules (`nestLevel`), and the glyph one-liners (`nestFormat`). The
+    // resulting levels and messages are identical to the hand-rolled switch this replaced.
+    return coreLoggerSink(toCoreLogger(logger), {
+        level: (event) => nestLevel(event, lifecycle),
+        format: (event, ctx) => nestFormat(ctx.name, event),
+    });
+}
+
+// Adapt a Nest `Logger` to core's `LoggerLike`. Core's level vocabulary is
+// error|warn|info|debug; Nest's is error|warn|log|debug|verbose. We route core `info` →
+// Nest `verbose` (the level `result` lands on) and guard `debug`/`verbose`, which a partial
+// logger — or one whose level hides them — may omit.
+function toCoreLogger(logger: LoggerLike): CoreLoggerLike {
     return {
-        handle(event: StitchEvent, ctx: { name: string }): void {
-            const name = ctx.name;
-            switch (event.type) {
-                case 'start':
-                    if (lifecycle)
-                        logger.debug?.(
-                            `→ ${name} ${event.method} ${redactUrl(event.url)}`,
-                        );
-                    return;
-                case 'progress': {
-                    const line = `· ${name} ${event.phase}#${event.attempt}${
-                        event.waitedMs !== undefined
-                            ? ` waited ${event.waitedMs}ms`
-                            : ''
-                    }`;
-                    // A retry or a tripped circuit means the upstream is misbehaving —
-                    // surface it at warn; throttle/paginate/cache waits are routine.
-                    if (event.phase === 'retry' || event.phase === 'circuit')
-                        logger.warn(line);
-                    else logger.debug?.(line);
-                    return;
-                }
-                case 'drift': {
-                    const f = event.finding;
-                    const line = `drift ${name} ${f.path} ${f.change}${f.detail ? ` (${f.detail})` : ''}`;
-                    if (f.level === 'error') logger.error(line);
-                    else if (f.level === 'warn') logger.warn(line);
-                    else logger.debug?.(line);
-                    return;
-                }
-                case 'result':
-                    if (lifecycle)
-                        logger.verbose?.(
-                            `← ${name} ${event.status} (${event.attempts} attempt(s))`,
-                        );
-                    return;
-                case 'error':
-                    logger.error(
-                        `✗ ${name} ${event.message}${event.status != null ? ` ${event.status}` : ''} (${event.attempts} attempt(s))`,
-                    );
-                    return;
-                case 'done':
-                    if (lifecycle)
-                        logger.debug?.(
-                            `${name} done ${event.ok ? 'ok' : 'failed'} in ${event.ms}ms (${event.attempts} attempt(s))`,
-                        );
-                    return;
-                default:
-                    // 'delta' — per-chunk streaming output; never logged (raw data).
-                    return;
-            }
-        },
+        error: (m) => logger.error(m),
+        warn: (m) => logger.warn(m),
+        info: (m) => logger.verbose?.(m),
+        debug: (m) => logger.debug?.(m),
     };
+}
+
+// Nest's per-event level rules — the crux core's per-type `levels` map can't express. A
+// `retry`/`circuit` progress means the upstream is misbehaving → surface at warn, while a
+// routine throttle/paginate/cache wait stays at debug; the happy-path lifecycle is gated by
+// `lifecycle` (`null` drops it); drift follows its finding level but pins info-drift to
+// debug. `result` → core `info`, which `toCoreLogger` routes to Nest `verbose`. An `info`
+// event (a strategy announcement) is dropped, exactly as the previous switch did.
+function nestLevel(event: StitchEvent, lifecycle: boolean): LogLevel | null {
+    switch (event.type) {
+        case 'start':
+            return lifecycle ? 'debug' : null;
+        case 'progress':
+            return event.phase === 'retry' || event.phase === 'circuit'
+                ? 'warn'
+                : 'debug';
+        case 'drift':
+            return event.finding.level === 'error'
+                ? 'error'
+                : event.finding.level === 'warn'
+                  ? 'warn'
+                  : 'debug';
+        case 'result':
+            return lifecycle ? 'info' : null;
+        case 'error':
+            return 'error';
+        case 'done':
+            return lifecycle ? 'debug' : null;
+        default:
+            return null; // 'info' (announcement) + 'delta' (already dropped by core)
+    }
+}
+
+// Paint the metadata-only one-liner Nest logs — name, method, redacted URL, status, attempt
+// counts, drift path/level, timing.
+//
+// SECURITY: a custom formatter receives the **raw** event (core only redacts inside its own
+// built-in sinks), so a `start` event's `input.headers` still holds `authorization` /
+// `cookie` and a `delta`'s `chunk` is raw response data. This logs **only metadata** — never
+// `event.input`, `event.value`, a `delta` chunk, or `JSON.stringify(event)` — and strips the
+// URL query (it can carry `?api_key=…`), keeping the sink safe on a secret-bearing seam
+// independent of core's trace redaction. `null` ⇒ skip the event.
+function nestFormat(name: string, event: StitchEvent): string | null {
+    switch (event.type) {
+        case 'start':
+            return `→ ${name} ${event.method} ${redactUrl(event.url)}`;
+        case 'progress':
+            return `· ${name} ${event.phase}#${event.attempt}${
+                event.waitedMs !== undefined
+                    ? ` waited ${event.waitedMs}ms`
+                    : ''
+            }`;
+        case 'drift': {
+            const f = event.finding;
+            return `drift ${name} ${f.path} ${f.change}${f.detail ? ` (${f.detail})` : ''}`;
+        }
+        case 'result':
+            return `← ${name} ${event.status} (${event.attempts} attempt(s))`;
+        case 'error':
+            return `✗ ${name} ${event.message}${event.status != null ? ` ${event.status}` : ''} (${event.attempts} attempt(s))`;
+        case 'done':
+            return `${name} done ${event.ok ? 'ok' : 'failed'} in ${event.ms}ms (${event.attempts} attempt(s))`;
+        default:
+            return null; // 'info' + 'delta' — never formatted (dropped upstream)
+    }
 }
 
 // Drop the query string (it may carry secrets, e.g. `?api_key=…`) before logging.
@@ -122,10 +163,14 @@ export interface ConfigServiceLike {
 }
 
 /**
- * A `ConfigService`-backed secret resolver — core's `env(name)` twin. Returns a
- * synchronous `Secret` thunk (`() => string`) resolved at call time, so the credential
- * never lands on `__config` or in a trace. Pass it to any auth strategy:
+ * A `ConfigService`-backed secret resolver — core's `secretFrom(source, name)` bound to a Nest
+ * `ConfigService`. Returns a synchronous `Secret` thunk (`() => string`) resolved at call time,
+ * so the credential never lands on `__config` or in a trace. Pass it to any auth strategy:
  * `bearer(fromConfig(config)('API_TOKEN'))`.
+ *
+ * Resolution delegates to core: a missing key still throws (the `ConfigService.getOrThrow` error
+ * propagates), and — like core's `env()` / `secretFrom()` — an empty value is rejected too, so a
+ * blank credential can never silently ride along.
  *
  * NOTE: `Secret` is synchronous, so this cannot fetch a rotating secret per call — that
  * is what `oauth2` / `cookieSession` are for (they refresh asynchronously via the vault).
@@ -133,7 +178,10 @@ export interface ConfigServiceLike {
 export function fromConfig(
     config: ConfigServiceLike,
 ): (key: string) => () => string {
-    return (key: string) => () => String(config.getOrThrow<string>(key));
+    // `getOrThrow` already throws on a missing key (Nest's own error); core's `secretFrom` adds
+    // the empty-value rejection and the `() => string` thunk shape, matching `env()`/`secretFrom()`.
+    return (key: string) =>
+        secretFrom((name) => String(config.getOrThrow<string>(name)), key);
 }
 
 /**

--- a/packages/nest/test/module.spec.ts
+++ b/packages/nest/test/module.spec.ts
@@ -497,4 +497,52 @@ describe('bridges', () => {
         };
         expect(fromConfig(config)('API_TOKEN')()).toBe('val:API_TOKEN');
     });
+
+    it('fromConfig propagates ConfigService.getOrThrow on a missing key', () => {
+        const config: ConfigServiceLike = {
+            getOrThrow<T = string>(key: string): T {
+                throw new Error(`Configuration key "${key}" does not exist`);
+            },
+        };
+        // The Nest getOrThrow error still surfaces through the core secretFrom delegation.
+        expect(() => fromConfig(config)('API_TOKEN')()).toThrow(
+            'Configuration key "API_TOKEN" does not exist',
+        );
+    });
+
+    it('fromConfig rejects an empty value (delegates to core secretFrom)', () => {
+        const config: ConfigServiceLike = {
+            // Present but blank — Nest's getOrThrow does NOT throw on '' (only on undefined).
+            getOrThrow<T = string>(_key: string): T {
+                return '' as T;
+            },
+        };
+        // secretFrom rejects '' like env() does, so a blank credential never rides along.
+        expect(() => fromConfig(config)('API_TOKEN')()).toThrow(
+            'missing secret',
+        );
+    });
+
+    it('loggerSink drops an info (strategy announcement) event', () => {
+        const { rec, logger } = recordingLogger();
+        const sink = loggerSink(logger);
+        // The delegated core sink would log an `info` event at debug, but Nest's level
+        // resolver returns null for it — preserving the prior switch, which dropped it.
+        sink.handle(
+            {
+                type: 'info',
+                topic: 'auth',
+                detail: 'no token; sending unauthenticated',
+                at: 0,
+            },
+            { name: 'x' },
+        );
+        expect([
+            ...rec.log,
+            ...rec.warn,
+            ...rec.error,
+            ...rec.debug,
+            ...rec.verbose,
+        ]).toEqual([]);
+    });
 });


### PR DESCRIPTION
## What

Kill the duplication between `@stitchapi/nest`'s bridge helpers and core, now that
core exports generic `secretFrom()` (#139) and `loggerSink()` (#143) primitives. The
two bridges in `packages/nest/src/bridges.ts` now **delegate** to those primitives
instead of reimplementing the logic — with **no change to nest's public API or
behavior**.

## Refactor 1 — `fromConfig` → core `secretFrom` (the easy win)

`fromConfig(config)(key)` is now:

```ts
secretFrom((name) => String(config.getOrThrow<string>(name)), key)
```

- Happy path unchanged; the public `ConfigServiceLike` (`{ getOrThrow }`) type and
  signature are untouched.
- A **missing** key still throws — `ConfigService.getOrThrow`'s own error propagates
  through the delegation (verified by a new test).
- The **one** behavior the delegation tightens: a present-but-**empty** config value
  is now rejected (`secretFrom` treats `''` as missing, like `env()`), where it
  previously returned `''`. This is strictly safer — a blank credential can never
  silently ride along — and was untested before. Called out here and locked in with a
  new test rather than changed quietly.

## Refactor 2 — nest `loggerSink` → core `loggerSink` (the design call)

nest's sink is **richer** than core's twin, which is the crux: Nest's `Logger` has
`verbose` (core's `LoggerLike` has only `info`/`debug`); it has a `{ lifecycle }`
toggle; it routes `retry`/`circuit` `progress` to `warn` (a per-**instance** rule
core's per-**type** `levels` map can't express); it pins info-`drift` to `debug`; and
its one-liners carry glyphs + attempt counts (e.g. `done ok in 12ms (1 attempt(s))`).

**Design choice: Option A (full delegation), enabled by two _generic_ core hooks.**
Option A as literally sketched (level resolver + adapter, core formats the messages)
would change nest's logged strings — the existing `done ok in 12ms` test pins them —
which the hard behavior-preserving constraint forbids. So core's `loggerSink` gains
**two generic, optional, off-by-default hooks** (no NestJS concept leaks in):

- `level?: (event, ctx) => LogLevel | null` — resolve the level per event **instance**
  (`null` drops it, `undefined` defers to `levels`/defaults). A strict superset of the
  per-type `levels` map; lets any host express conditional rules.
- `format?: (event, ctx) => string | null` — supply the metadata-only line. The host
  then owns the payload-free guarantee; the **default formatter stays payload-free**
  for every other caller.

nest delegates with a verbose-routing `LoggerLike` adapter (core `info` → Nest
`verbose`), its level rules (`nestLevel`), and its glyph formatter (`nestFormat`).
Core owns the dispatch + the never-log-`delta` rule. **Levels, messages, and the
payload-free guarantees are byte-identical to the hand-rolled switch** this replaced.

Why not Option B (share only the formatter)? nest's messages don't cleanly generalize
to core's leaner ones (different glyphs/wording/fields), so there was nothing in the
formatting to share without changing behavior — the reusable seam is the dispatch +
the two policy hooks, which is what this does.

## Behavior-preserving — the guard held

- All **27 existing nest tests pass, unweakened**.
- Added nest tests proving the delegation: `fromConfig` missing-key propagation,
  `fromConfig` empty-value rejection, and `loggerSink` dropping an `info` (strategy
  announcement) event (which the delegated core sink would otherwise log at `debug`).
- Added core tests for both new options: `level` precedence over `levels`, `null`
  drops, `format` override + `null` skip, and `delta` dropped before either hook runs.
- The default `loggerSink` path (no `level`/`format`) is unchanged — all existing core
  logger-sink tests pass untouched.

## Docs

- `docs/adr/0006-nestjs-integration.md`: new dated addendum recording the dedup and the
  **deliberate, sanctioned exception** to the ADR's original "no core change" stance —
  the core additions are generic, additive, off-by-default, and core-tested, so the
  contract-not-dependency gate stays green. The original stance is annotated, not
  rewritten.
- `packages/nest/README.md`: the intro's "core is untouched" claim corrected to reflect
  that the bridges now delegate to core's `loggerSink`/`secretFrom`.

## Gates

Both packages green, plus the recursive suite and the full pre-push gate
(format, lint, typecheck, typecheck-d, test, exports, build-docs):

- `pnpm --filter stitchapi check:types check:types-d check:lint check:exports test` ✓
- `pnpm --filter @stitchapi/nest check:types test build` ✓ (nest has no `check:lint` /
  `check:types-d` script — only `build`, `test`, `check:types`; formatting covered by
  the repo-wide `prettier --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
