### PR TITLE
feat(drift): stitch drift generate — write snapshot baselines deliberately (#132)

### DIFF
--- a/apps/docs/content/docs/guides/validation/drift.mdx
+++ b/apps/docs/content/docs/guides/validation/drift.mdx
@@ -70,10 +70,39 @@ const getUser = stitch({
 });
 ```
 
-Generate the baseline once (run the stitch without `readonly`, or commit a
-recorded response), check the `<name>.contract.json` into the repo, then ship
-with `readonly: true`. `onMissing` levels the `no-baseline` finding (default
+[Generate the baseline](#generate-baselines-deliberately) once with `stitch
+drift generate`, check the `<name>.contract.json` into the repo, then ship with
+`readonly: true`. `onMissing` levels the `no-baseline` finding (default
 `'warn'`); `'error'` fails the call so a missing baseline can't slip past CI.
+
+## Generate baselines deliberately
+
+Letting the first call write the baseline is convenient early on, but it couples
+the contract to whatever the first response happened to be — and under
+`readonly: true` it never writes at all. Produce baselines on purpose in dev/CI
+with `stitch drift generate`:
+
+```bash
+# Baseline every drift-guarded stitch in the module
+stitch drift generate --module ./stitches.ts
+
+# Just one, by export name or configured name
+stitch drift generate --name getUser
+
+# A parameterized stitch — request inputs map exactly like `stitch run`
+stitch drift generate --name getUser --id 7
+```
+
+It loads the module, runs each stitch whose `output` is a
+`drift({ …, snapshotFile })` once against the live API, and writes its
+`<name>.contract.json` — the **same** post-transform/unwrap body a live run
+compares against, so a generated baseline never diverges from what drift
+detection sees. Each path written is printed to stdout.
+
+Existing snapshots are kept (the stitch is skipped) unless you pass `--force`:
+baseline a newly added stitch without re-fetching the rest, and refresh a
+deliberately changed contract with `--force` when the API moves. A failed run
+never overwrites a committed baseline.
 
 ## `snapshotFile` is resolved from `process.cwd()`
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -5,6 +5,7 @@
 // every event the stitch emits is written to stdout as one line of JSON, so the
 // output pipes straight into jq and friends. No app boot required.
 import { toMermaid } from './diagram';
+import { loadSnapshot, saveSnapshot } from './drift';
 import { serveStdio } from './mcp';
 import {
     type StitchRegistry,
@@ -13,7 +14,13 @@ import {
     selectStitch,
 } from './registry';
 import { serve } from './serve';
-import type { Stitch, StitchEvent, StitchInput } from './types';
+import type {
+    DriftSpec,
+    SafeResult,
+    Stitch,
+    StitchEvent,
+    StitchInput,
+} from './types';
 
 import { existsSync, readFileSync } from 'node:fs';
 
@@ -394,6 +401,7 @@ usage:
   stitch serve [--module <path>] [--port <n>] [--host <h>]   HTTP: POST /stitch/:name
   stitch mcp [--module <path>]                               MCP over stdio (run_stitch)
   stitch diagram [--module <path>] [--name <name>]           Mermaid flowchart of the stitches
+  stitch drift generate [--module <path>] [--name <name>] [--force] [--flags…]   write drift snapshot baseline(s)
 
 run:
   --module, -m <path>   stitches module to load (default: ./stitches.{ts,js,…})
@@ -412,6 +420,14 @@ diagram:
   Emits a Mermaid flowchart of each stitch's configured pipeline (throttle, request,
   retry, surface, pagination, validation, transform, unwrap, cache). Auth is redacted
   from a stitch's public config, so it is not shown.
+
+drift generate:
+  --name <name>    baseline only this stitch (by export name or configured name)
+  --force, -f      overwrite an existing snapshot (default: keep it, skip the stitch)
+  Runs each drift-guarded stitch (output: drift({ …, snapshotFile })) once against the live
+  API and writes its <name>.contract.json baseline — the same body a live run compares
+  against — so you commit baselines deliberately instead of relying on the first-run side
+  effect. Map request inputs with the same --params/--query/--body/--headers flags as run.
 `;
 
 async function runCommand(args: string[], io: CliIO): Promise<number> {
@@ -614,6 +630,164 @@ async function diagramCommand(args: string[], io: CliIO): Promise<number> {
     return 0;
 }
 
+// ---- drift generate: write the snapshot baseline(s) deliberately ----------
+// Today a drift baseline is written as a side effect of the first real call (engine
+// `validateOutput` → `saveSnapshot`). `drift generate` produces the baseline DELIBERATELY in
+// dev/CI instead — run each drift-guarded stitch once against the live API and commit the result
+// (issue #132; pairs with `DriftOptions.readonly`, which makes deployed runs detect-but-never-write).
+
+// A drift-guarded stitch we can baseline: its `output` is a `drift(…)` carrying a snapshotFile.
+interface DriftTarget {
+    name: string;
+    stitch: Stitch;
+    spec: DriftSpec;
+    file: string;
+}
+
+// The drift-guarded stitches to baseline: all of them, or just the one named by --name (matched by
+// export key or configured name, like selectStitch). A `drift()` without a snapshotFile has no
+// baseline to write and is skipped. Returns an `error` message when --name resolves to no
+// drift-guarded stitch, so the caller can print it and exit non-zero.
+function driftTargets(
+    registry: StitchRegistry,
+    only: string | undefined,
+): { targets: DriftTarget[] } | { error: string } {
+    const all: DriftTarget[] = [];
+    for (const [name, s] of Object.entries(registry)) {
+        const out = (s as Stitch).__config.output;
+        if (!out || (out as { __kind?: unknown }).__kind !== 'drift') continue;
+        const spec = out as DriftSpec;
+        if (!spec.options.snapshotFile) continue;
+        all.push({
+            name,
+            stitch: s as Stitch,
+            spec,
+            file: spec.options.snapshotFile,
+        });
+    }
+    if (only === undefined) return { targets: all };
+
+    const picked = all.filter(
+        (t) => t.name === only || t.stitch.__config.name === only,
+    );
+    if (picked.length) return { targets: picked };
+    // Distinguish "no such stitch" from "that stitch isn't drift-guarded" for a useful message.
+    const known =
+        only in registry ||
+        Object.values(registry).some((s) => s.__config.name === only);
+    return {
+        error: known
+            ? `stitch "${only}" has no drift() output with a snapshotFile to baseline`
+            : `unknown stitch "${only}"`,
+    };
+}
+
+// Capture the baseline body the engine would write: run the stitch once, but with its snapshot
+// comparison suppressed for the run — so we read the live response uncoloured by any existing
+// (possibly stale) baseline or a `readonly` no-baseline finding — then persist that exact body via
+// `saveSnapshot`, the same writer the engine uses on first run. `result.value` is the post
+// transform/unwrap body the engine baselines, so a generated snapshot matches what a live run
+// compares against (not a hand-rolled, divergent capture). The DriftSpec on the public __config is
+// the one the runtime reads (`redactConfig` keeps `output` by reference), so the suppression takes
+// effect; it is restored in `finally`, and the snapshot is only (over)written on a clean capture —
+// a failed run never destroys an existing baseline.
+async function captureBaseline(
+    t: DriftTarget,
+    input: StitchInput,
+): Promise<SafeResult<unknown>> {
+    delete t.spec.options.snapshotFile;
+    try {
+        return await t.stitch.safe(input);
+    } finally {
+        t.spec.options.snapshotFile = t.file;
+    }
+}
+
+// stitch drift generate [--module <path>] [--name <name>] [--force] [--flags…] — write the drift
+// snapshot baseline(s) for the drift-guarded stitches in a module by running each once against the
+// live API. Request inputs map from the same --params/--query/--body/--headers flags as `run`.
+// Existing snapshots are kept unless --force is given. Prints each path written to stdout.
+async function driftCommand(args: string[], io: CliIO): Promise<number> {
+    const [sub, ...rest] = args;
+    if (sub !== 'generate') {
+        io.writeErr(
+            'usage: stitch drift generate [--module <path>] [--name <name>] [--force] [--flags…]\n',
+        );
+        return 2;
+    }
+
+    let modulePath: string | undefined;
+    let name: string | undefined;
+    let force = false;
+    const flags: string[] = [];
+    for (let i = 0; i < rest.length; i++) {
+        const a = rest[i];
+        if (a === undefined) continue;
+        if (a === '--module' || a === '-m') modulePath = rest[++i];
+        else if (a.startsWith('--module='))
+            modulePath = a.slice('--module='.length);
+        else if (a === '--name') name = rest[++i];
+        else if (a.startsWith('--name=')) name = a.slice('--name='.length);
+        else if (a === '--force' || a === '-f') force = true;
+        else flags.push(a);
+    }
+
+    let registry: StitchRegistry;
+    try {
+        registry = await io.load(resolveModulePath(modulePath, io.cwd));
+    } catch (e) {
+        io.writeErr(`${(e as Error).message}\n`);
+        return 1;
+    }
+
+    const found = driftTargets(registry, name);
+    if ('error' in found) {
+        io.writeErr(`${found.error}\n`);
+        return 1;
+    }
+    if (!found.targets.length) {
+        io.writeErr(
+            'no drift-guarded stitches to baseline (an output of drift({ …, snapshotFile }))\n',
+        );
+        return 1;
+    }
+
+    let exit = 0;
+    for (const t of found.targets) {
+        if (!force && loadSnapshot(t.file) !== undefined) {
+            io.writeErr(
+                `skip ${t.name}: snapshot exists at ${t.file} (use --force to overwrite)\n`,
+            );
+            continue;
+        }
+        const { input } = argsToInput(flags, paramNamesOf(t.stitch));
+        const captured = await captureBaseline(t, input);
+        if (!captured.ok) {
+            io.writeErr(`failed ${t.name}: ${captured.error.message}\n`);
+            exit = 1;
+            continue;
+        }
+        if (captured.data === undefined) {
+            // A run that yields no value (e.g. an `unwrap` path that misses) can't be baselined —
+            // and `saveSnapshot` can't serialise `undefined`. Report it instead of throwing.
+            io.writeErr(
+                `failed ${t.name}: run produced no value to baseline\n`,
+            );
+            exit = 1;
+            continue;
+        }
+        try {
+            saveSnapshot(t.file, captured.data);
+            io.write(`wrote ${t.file}\n`);
+        } catch (e) {
+            // A write failure (read-only path, missing parent it can't create) is a clean failure.
+            io.writeErr(`failed ${t.name}: ${(e as Error).message}\n`);
+            exit = 1;
+        }
+    }
+    return exit;
+}
+
 // Entry point. Returns the process exit code; the bin shim calls process.exit.
 export async function main(
     argv: string[],
@@ -632,6 +806,8 @@ export async function main(
             return mcpCommand(rest, io);
         case 'diagram':
             return diagramCommand(rest, io);
+        case 'drift':
+            return driftCommand(rest, io);
         case undefined:
         case '-h':
         case '--help':

--- a/packages/core/test/cli.spec.ts
+++ b/packages/core/test/cli.spec.ts
@@ -1,14 +1,17 @@
 // Set the trace file before importing ../src so the JSONL sink is captured/quiet.
-import { stitch } from '../src';
+import { drift, stitch } from '../src';
 import {
     argsToInput,
     formatTraceSummary,
+    main,
     paramNamesOf,
     runStitch,
     splitRunArgs,
     summarizeTrace,
 } from '../src/cli';
+import { loadSnapshot } from '../src/drift';
 import { collectStitches, loadStitches, selectStitch } from '../src/registry';
+import type { StitchRegistry } from '../src/registry';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
 import { asValidator } from './support/schema';
@@ -288,5 +291,197 @@ describe('summarizeTrace', () => {
         expect(out).toContain('a');
         expect(out).toContain('b');
         expect(out).toContain('total: 4 run(s), 3 ok, 1 failed');
+    });
+});
+
+// ---- drift generate: write the snapshot baseline(s) deliberately ----------
+
+describe('stitch drift generate (CLI)', () => {
+    // Drive `main` with an injected registry loader (like diagram.spec), capturing stdout/stderr.
+    const runGenerate = (registry: StitchRegistry, args: string[] = []) => {
+        const out: string[] = [];
+        const err: string[] = [];
+        return main(['drift', 'generate', '--module', 'x', ...args], {
+            cwd: '/',
+            load: async () => registry,
+            write: (s) => out.push(s),
+            writeErr: (s) => err.push(s),
+        }).then((code) => ({ code, out: out.join(''), err: err.join('') }));
+    };
+    const snapDir = () => mkdtempSync(join(tmpdir(), 'stitch-drift-'));
+
+    test('runs a drift-guarded stitch and writes its baseline (the post-unwrap body)', async () => {
+        server.route('GET', '/widgets/7', {
+            body: { data: { id: 7, name: 'Cog' } },
+        });
+        const file = join(snapDir(), 'widget.contract.json');
+        const getWidget = stitch({
+            baseUrl: server.url,
+            path: '/widgets/{id}',
+            unwrap: 'data',
+            output: drift(z.object({ id: z.number(), name: z.string() }), {
+                critical: ['id'],
+                snapshotFile: file,
+            }),
+        });
+
+        const { code, out } = await runGenerate({ getWidget }, ['--id', '7']);
+
+        expect(code).toBe(0);
+        expect(out).toContain(`wrote ${file}`);
+        // The baseline is the engine's post-unwrap body — exactly what a live run compares against.
+        expect(loadSnapshot(file)).toEqual({ id: 7, name: 'Cog' });
+        expect(server.callCount('/widgets/7')).toBe(1);
+    });
+
+    test('a generated baseline produces no drift on a subsequent live run', async () => {
+        server.route('GET', '/things', { body: { id: 1, kind: 'a' } });
+        const file = join(snapDir(), 'thing.contract.json');
+        const getThing = stitch({
+            baseUrl: server.url,
+            path: '/things',
+            output: drift(z.object({ id: z.number(), kind: z.string() }), {
+                critical: ['id'],
+                snapshotFile: file,
+            }),
+        });
+
+        const { code } = await runGenerate({ getThing });
+        expect(code).toBe(0);
+
+        // Re-run live against the just-written baseline: an identical body → zero drift findings.
+        const lines: string[] = [];
+        const runCode = await runStitch({ getThing }, 'getThing', [], (l) =>
+            lines.push(l),
+        );
+        expect(runCode).toBe(0);
+        const events = parseLines(lines);
+        expect(events.some((e) => e.type === 'drift')).toBe(false);
+        expect(events.find((e) => e.type === 'result').value).toEqual({
+            id: 1,
+            kind: 'a',
+        });
+    });
+
+    test('--name baselines only the named stitch, by export key', async () => {
+        server.route('GET', '/a', { body: { id: 1 } });
+        server.route('GET', '/b', { body: { id: 2 } });
+        const dir = snapDir();
+        const fileA = join(dir, 'a.contract.json');
+        const fileB = join(dir, 'b.contract.json');
+        const a = stitch({
+            baseUrl: server.url,
+            path: '/a',
+            output: drift(z.object({ id: z.number() }), {
+                snapshotFile: fileA,
+            }),
+        });
+        const b = stitch({
+            baseUrl: server.url,
+            path: '/b',
+            output: drift(z.object({ id: z.number() }), {
+                snapshotFile: fileB,
+            }),
+        });
+
+        const { code } = await runGenerate({ a, b }, ['--name', 'b']);
+
+        expect(code).toBe(0);
+        expect(loadSnapshot(fileB)).toEqual({ id: 2 });
+        expect(loadSnapshot(fileA)).toBeUndefined(); // a was left untouched
+        expect(server.callCount('/a')).toBe(0);
+        expect(server.callCount('/b')).toBe(1);
+    });
+
+    test('keeps an existing snapshot by default; --force overwrites a stale one', async () => {
+        server.route('GET', '/u', { body: { id: 9, role: 'admin' } });
+        const file = join(snapDir(), 'u.contract.json');
+        // Pre-seed a STALE baseline that critically differs (id is a string, not a number): a live
+        // run would fail it at the `critical` path, yet --force must still regenerate from live.
+        writeFileSync(file, JSON.stringify({ id: 'old', role: 'admin' }));
+        const getU = stitch({
+            baseUrl: server.url,
+            path: '/u',
+            output: drift(z.object({ id: z.number(), role: z.string() }), {
+                critical: ['id'],
+                snapshotFile: file,
+            }),
+        });
+
+        // Default: the existing snapshot is kept, the stitch is skipped, and no call is made.
+        const skip = await runGenerate({ getU });
+        expect(skip.code).toBe(0);
+        expect(skip.err).toContain('skip getU');
+        expect(loadSnapshot(file)).toEqual({ id: 'old', role: 'admin' });
+        expect(server.callCount('/u')).toBe(0);
+
+        // --force: overwrite with the live body even though it critically drifts from the stale one.
+        const force = await runGenerate({ getU }, ['--force']);
+        expect(force.code).toBe(0);
+        expect(force.out).toContain(`wrote ${file}`);
+        expect(loadSnapshot(file)).toEqual({ id: 9, role: 'admin' });
+        expect(server.callCount('/u')).toBe(1);
+    });
+
+    test('exits non-zero when the module has no drift-guarded stitches', async () => {
+        const plain = stitch({ baseUrl: server.url, path: '/plain' });
+        const { code, err } = await runGenerate({ plain });
+        expect(code).toBe(1);
+        expect(err).toContain('no drift-guarded stitches');
+    });
+
+    test('exits non-zero when --name does not resolve to a drift-guarded stitch', async () => {
+        const file = join(snapDir(), 'x.contract.json');
+        const a = stitch({
+            baseUrl: server.url,
+            path: '/a',
+            output: drift(z.object({ id: z.number() }), { snapshotFile: file }),
+        });
+        const { code, err } = await runGenerate({ a }, ['--name', 'nope']);
+        expect(code).toBe(1);
+        expect(err).toContain('unknown stitch "nope"');
+        expect(loadSnapshot(file)).toBeUndefined();
+    });
+
+    test('reports a failed run and exits non-zero without writing a baseline', async () => {
+        server.route('GET', '/boom', { statuses: [500] });
+        const file = join(snapDir(), 'boom.contract.json');
+        const boom = stitch({
+            baseUrl: server.url,
+            path: '/boom',
+            output: drift(z.object({ id: z.number() }), { snapshotFile: file }),
+        });
+        const { code, err } = await runGenerate({ boom });
+        expect(code).toBe(1);
+        expect(err).toContain('failed boom');
+        expect(loadSnapshot(file)).toBeUndefined();
+    });
+
+    test('reports a run that yields no value (an unwrap that misses), not a crash', async () => {
+        server.route('GET', '/empty', { body: { nope: 1 } });
+        const file = join(snapDir(), 'empty.contract.json');
+        const empty = stitch({
+            baseUrl: server.url,
+            path: '/empty',
+            unwrap: 'data', // no `data` key on the body → the value is `undefined`
+            output: drift(z.unknown(), { snapshotFile: file }),
+        });
+        const { code, err } = await runGenerate({ empty });
+        expect(code).toBe(1);
+        expect(err).toContain(
+            'failed empty: run produced no value to baseline',
+        );
+        expect(loadSnapshot(file)).toBeUndefined();
+    });
+
+    test('bare `drift` (no subcommand) prints usage and exits 2', async () => {
+        const err: string[] = [];
+        const code = await main(['drift'], {
+            cwd: '/',
+            write: () => undefined,
+            writeErr: (s) => err.push(s),
+        });
+        expect(code).toBe(2);
+        expect(err.join('')).toContain('usage: stitch drift generate');
     });
 });


### PR DESCRIPTION
## What

Adds a `stitch drift generate [--module <path>] [--name <name>] [--force] [--flags…]` subcommand that writes the drift snapshot baseline(s) for the drift-guarded stitches in a module — **deliberately**, in dev/CI — instead of relying on the engine's first-run side effect (`validateOutput` → `saveSnapshot`).

Completes the **CLI half of #132** (deferred when #132 was closed). Pairs with `DriftOptions.readonly` (#140, the detect-but-never-write half): generate the baseline, commit `<name>.contract.json`, then ship with `readonly: true`.

```bash
stitch drift generate --module ./stitches.ts        # baseline every drift-guarded stitch
stitch drift generate --name getUser --id 7          # just one; inputs map like `stitch run`
stitch drift generate --name getUser --force         # refresh a committed baseline
```

## How it captures (no divergent re-implementation)

For each stitch whose `output` is a `drift({ …, snapshotFile })`, it runs the stitch once via `.safe()` with the snapshot comparison **transiently suppressed**, then writes `result.value` — the *exact* post-transform/unwrap body the engine baselines — via `saveSnapshot`, the engine's own writer. So a generated baseline is byte-identical to what a live run compares against.

Suppressing the comparison during capture means the baseline is never coloured by:
- a **stale** existing baseline → `--force` can refresh even when the live API critically drifts from the old one (verified in tests + the smoke run);
- a `readonly` no-baseline finding.

The snapshot is only (over)written on a clean capture, so a failed run never destroys an existing baseline. A run that errors, yields no value (e.g. an `unwrap` that misses), or fails to write becomes a clean `failed <name>: …` line + non-zero exit — never an uncaught crash.

## Design decision: overwrite policy

Existing snapshots are **kept** (the stitch is skipped with a notice) unless `--force` is given. Rationale: a committed `.contract.json` is a reviewed artifact; silently clobbering it (and making a network call to do so) on every invocation is surprising and against the repo's no-side-effects-by-default principle. Skipping also lets you baseline a *newly added* stitch without re-fetching the rest; `--force` is the explicit "refresh from live" escape hatch.

## Changes

- **`packages/core/src/cli.ts`** — `drift` command + helpers (`driftTargets`, `captureBaseline`), `--help` usage line + detail block, wired into `main()`'s switch. Matches the `diagram`/`run` conventions (option parsing, `io.load`/`resolveModulePath`, `io.write`/`writeErr`, exit codes; reuses `argsToInput`/`paramNamesOf`).
- **`packages/core/test/cli.spec.ts`** — tests (mock IO + mock server) covering: baseline == post-unwrap body; no drift on a subsequent live run; `--name` filter; keep-by-default vs `--force` over a *critically-stale* baseline; no-targets / unknown-name / failed-run / no-value exits; subcommand guard.
- **`apps/docs/content/docs/guides/validation/drift.mdx`** — new "Generate baselines deliberately" section; the readonly section now links to it.

## Verification

Stated gates all green: `pnpm --filter stitchapi check:types && check:types-d && check:lint && test` (500 passed) + the docs build. Whole-tree `check:format` and `check:exports` also pass. Additionally verified **end-to-end through the real `stitch` bin** against a local HTTP server (generate-all, post-unwrap capture, skip-without-`--force`/no-network, `--name`+`--force` scoping).

Closes #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
