### PR TITLE
feat(core): composition causality — an OTLP run-identity span tree (ADR 0007)

### DIFF
--- a/docs/adr/0007-composition-causality-and-run-identity.md
+++ b/docs/adr/0007-composition-causality-and-run-identity.md
@@ -1,0 +1,66 @@
+# ADR 0007 — Composition causality: run identity for the event stream
+
+-   **Status:** Proposed (DRAFT — pending review; no code yet)
+-   **Date:** 2026-06-16
+-   **Tags:** observability, tracing, otlp, playground, composition, causality, browser-first
+
+> [!NOTE]
+>
+> This is a **design draft to review before any code** — the dogfooding roadmap item #5a. It is FOUNDATIONAL for #7's `pipe()` ([ADR 0008](./0008-non-http-surfaces-and-pipe.md)), so it lands first. The _Open questions_ are genuine forks I want a decision on before implementing.
+
+## Context
+
+A stitch's events are a **flat per-call stream**: `start → progress* → (info|drift|delta)* → result|error → done`, modelled by `StitchEvent` ([`types.ts`](../../packages/core/src/types.ts)) and drained/teed to the trace sink in `tee()` ([`stitch.ts`](../../packages/core/src/stitch.ts)). Each `execute()` ([`engine.ts`](../../packages/core/src/engine.ts)) is **one logical run**. There is no notion of one run having spawned another — the stream carries no parent/child identity at all.
+
+Two consumers already want that identity and cannot get it:
+
+-   **The playground DAG** (PR [#94](https://github.com/rejifald/StitchAPI/pull/94)). `StitchTraceEntry.dependsOn` ([`docs/sandbox/component/runner.ts`](../../docs/sandbox/component/runner.ts)) exists and `traceToMermaid` already draws edges from it — but **nothing populates it**. The trace collector ([`docs/sandbox/runtime/trace-collector.ts`](../../docs/sandbox/runtime/trace-collector.ts)) is a `TraceSink` that mints synthetic `stitch-N` ids and correlates a stitch instance's calls by a per-instance FIFO, and its own header says the edges _"need the composition graph core doesn't emit"_. PR #94's open questions are exactly: does `stitch()`/`seam` **emit parent identity** into the trace, or is it inferred statically — and is an edge runtime causality or `extends` derivation?
+-   **The OTLP sink** ([`otlp.ts`](../../packages/core/src/otlp.ts)). It maps each call to one CLIENT span, but **mints a fresh `traceId`/`spanId` per `start`** and guesses correlation from a `name`-keyed stack. Sibling/child calls get unrelated trace ids; `parentSpanId` is never emitted. It is a tree-shaped exporter fed a flat, un-correlated stream.
+
+A run **already** spawns another in one shipped case: `cookieSession` runs its login stitch via `__raw` → `executeRaw` ([`auth.ts`](../../packages/core/src/auth.ts) `doRefresh`). `executeRaw` drives `attemptLoop` directly and **emits no events** — so today that child run is entirely invisible to tracing. #7's `pipe()` will spawn a child run per step. Both need a way to say "this run is a child of that one".
+
+The roadmap item: add **optional run identity** — a `runId` per call, a `parentId` when one run spawns another — kept **OTLP-span-aligned** so the existing exporter and a future trace-based diagram are just span-tree renders.
+
+## Decision (proposed — these are what I want to firm up before coding)
+
+1.  **Three ids, OTLP-aligned.** Each `execute()` mints a `runId` (the OTel **spanId**, 16 hex chars) and belongs to a `traceId` (32 hex chars, the root identity of a run tree). A run spawned by another **inherits the parent's `traceId`** and sets `parentId` = the parent's `runId` (the OTel **parentSpanId**); a root run has a fresh `traceId` and no `parentId`. This is the OTel span model verbatim, so the OTLP sink stops guessing — it keys its open-span map on `runId`, sets `parentSpanId` from `parentId`, and shares one `traceId` across a tree — and any trace-based Mermaid diagram is a span-tree walk.
+
+2.  **Identity rides on the `TraceSink` `ctx`, not on every `StitchEvent`.** Today the sink is `handle(event, ctx: { name })`. Widen the ctx to `{ name; runId; traceId; parentId? }`. Identity is **per-run** — constant across all of a run's events — so it belongs on the run-scoped ctx, not duplicated onto every event. Both consumers that need it are **sinks** (the playground DAG collector _is_ a `TraceSink`; OTLP _is_ a `TraceSink`) and already receive ctx, so this is additive: a sink that reads only `ctx.name` (the built-in JSONL/console/logger sinks) is unchanged. The three ids are strings, so the ctx round-trips as JSON (contract gate). I prefer this over per-event ids; see **Q1**.
+
+3.  **Child propagation is EXPLICIT, never ambient.** No `AsyncLocalStorage` — it is Node-only (breaks the browser-first gate, and stitches run in the playground Web Worker). Instead a run that may spawn children carries a small `RunContext { traceId, runId }`, and the engine threads it into a child's run as an optional `parent?: RunContext` (on the internal run path / `makeRuntime` / a new traced `executeRaw` variant). The child mints its own `runId`, inherits `parent.traceId`, and sets `parentId = parent.runId`. Explicit threading is portable; ambient context is not.
+
+4.  **What counts as a child run (scope).**
+
+    -   **YES — a `pipe()` step** (#7): each step's run is a child of the pipe's run.
+    -   **YES — a `cookieSession` login**: it is a sub-call of the call that triggered apply/refresh. (It runs via `executeRaw` today and emits nothing — making it a _traced_ child is a real change; see **Q3**.)
+    -   **NO — retry attempts**: already modelled as `attempt` on events within one run; not separate runs.
+    -   **NO — coalescing followers**: a follower awaits the leader's one shared result and runs no chain of its own — same logical result, not a child.
+    -   **OPEN — paginate pages**: today one run with `paginate` progress events; promoting each page to a child run is a behaviour/noise change (see **Q2**). Streaming `delta`s are emphatically NOT child runs — they are values within one streaming run.
+
+5.  **Id minting is browser-safe and shared.** Reuse the exact helper `otlp.ts#hex` already uses — `crypto.getRandomValues` where available, else `Math.random` (ids need to be unique-ish, not secret) — promoted to a shared zero-dep util. The engine mints; a **caller never supplies a run id** (an externally-named id is a correlation-spoofing surface — the same reasoning that keeps `principal` off `StitchInput` in [ADR 0002](./0002-seam-primitive-and-principal-scoped-auth.md)).
+
+## Consequences
+
+-   PR #94's DAG edges populate from **real runtime causality**: the collector uses `ctx.runId` as the node id (dropping synthetic `stitch-N`) and `ctx.parentId` for `dependsOn`, so concurrent calls on one instance correlate exactly instead of "degrading gracefully" through a FIFO.
+-   The OTLP exporter becomes a real span tree (shared `traceId`, populated `parentSpanId`) with no heuristic — a strict improvement to a shipped capability.
+-   #7's `pipe()` gets the identity it needs for step→step edges; a trace-based diagram becomes a span-tree render.
+-   Cost: a ctx widening threaded through `execute`/`tee`/the sinks; a `RunContext` arg on the internal run path; and — if we take Q3's "trace the login" option — a traced `executeRaw` variant. All additive; the flat-stream behaviour and every existing sink are unchanged.
+
+## Open questions (where I want to stop for your input)
+
+-   **Q1 — Carrier: sink `ctx` (recommended) vs. the `StitchEvent`s themselves.** ctx is per-run, lean, and both consumers are sinks. But a `.stream()` consumer (an async-iterable reader that is _not_ a sink — e.g. a future client building a DAG straight off the stream) would not see causality. If we want that, the ids must be on the events — cheapest is on `start` only (1:1 with a run). Sink channel enough, or also on `start`?
+-   **Q2 — Are paginate pages child runs?** Keep pagination as one run with `paginate` progress events (my default — additive, no behaviour change to a shipped surface), or promote each page to a child span (richer DAG, noisier traces)?
+-   **Q3 — Trace the `cookieSession` login as a child run?** (a) Leave it invisible — smallest, but the `fetch-token → call` edge PR #94's own test fixture implies stays unshown; (b) route the login through a traced path that tees to the seam's shared sink with `parentId` set — lights up the edge, but changes how login runs and adds the login's events to the stream. Which?
+-   **Q4 — `extends` derivation vs. runtime causality.** PR #94 conflates two edge meanings. This ADR provides **only runtime causality** (which run spawned which). The **static `extends` derivation** (which stitch was composed from which fragment) is a different axis the collector can't see at runtime. I propose it stays **out of scope** here — a separate optional overlay (distinct edge style / DAG toggle) if we ever want it. Agree?
+
+## Alternatives considered
+
+-   **`AsyncLocalStorage` ambient run context.** Rejected: Node-only, breaks browser-first and the playground Worker. Explicit `RunContext` threading is portable and makes the parent/child relation visible at the call site.
+-   **Per-event ids on every `StitchEvent` (as the default).** Rejected as default: duplicates per-run data on every event with no consumer that needs it there. Kept as **Q1** for the non-sink `.stream()` case.
+-   **Caller-supplied run/correlation ids.** Rejected: ids must be engine-minted and unforgeable; a caller-named id spoofs correlation (mirrors the `StitchInput`-principal rejection in ADR 0002). A future _inbound_ `traceparent` continuation (W3C Trace Context) is a separate, opt-in feature, not this.
+
+## Gates
+
+-   **browser-first** — ids via `crypto.getRandomValues`/`Math.random` (the existing `otlp.ts#hex`), no `AsyncLocalStorage`, no Node-only API on the hot path.
+-   **bundle-frugal** — a ctx widening + a small `RunContext`; no new statically-imported hot-path module (OTLP and the playground collector are already opt-in / out-of-core).
+-   **contract-not-dependency** — the three ids are strings on the run-scoped ctx; they round-trip as JSON, and no new vendor capability is introduced.

--- a/docs/adr/0007-composition-causality-and-run-identity.md
+++ b/docs/adr/0007-composition-causality-and-run-identity.md
@@ -1,66 +1,76 @@
-# ADR 0007 — Composition causality: run identity for the event stream
+# ADR 0007 — Composition causality: an OTLP span tree for the event stream
 
--   **Status:** Proposed (DRAFT — pending review; no code yet)
+-   **Status:** Proposed (decisions resolved in the 2026-06-16 review of PR [#163](https://github.com/rejifald/StitchAPI/pull/163); implementation pending)
 -   **Date:** 2026-06-16
 -   **Tags:** observability, tracing, otlp, playground, composition, causality, browser-first
 
 > [!NOTE]
 >
-> This is a **design draft to review before any code** — the dogfooding roadmap item #5a. It is FOUNDATIONAL for #7's `pipe()` ([ADR 0008](./0008-non-http-surfaces-and-pipe.md)), so it lands first. The _Open questions_ are genuine forks I want a decision on before implementing.
+> The four open questions are now **resolved** (review of PR #163, recorded below). The guiding principle the review set: **trace richly, for OTLP operators analysing real traffic** — every retry, page, login, and composed step is visible, with per-iteration performance, not just a flat per-call stream. This is FOUNDATIONAL for #7's `pipe()` ([ADR 0008](./0008-non-http-surfaces-and-pipe.md)), so it lands first.
 
 ## Context
 
-A stitch's events are a **flat per-call stream**: `start → progress* → (info|drift|delta)* → result|error → done`, modelled by `StitchEvent` ([`types.ts`](../../packages/core/src/types.ts)) and drained/teed to the trace sink in `tee()` ([`stitch.ts`](../../packages/core/src/stitch.ts)). Each `execute()` ([`engine.ts`](../../packages/core/src/engine.ts)) is **one logical run**. There is no notion of one run having spawned another — the stream carries no parent/child identity at all.
+A stitch's events are a **flat per-call stream**: `start → progress* → (info|drift|delta)* → result|error → done` (`StitchEvent`, [`types.ts`](../../packages/core/src/types.ts)), drained/teed to the trace sink in `tee()` ([`stitch.ts`](../../packages/core/src/stitch.ts)). Each `execute()` ([`engine.ts`](../../packages/core/src/engine.ts)) is **one logical run**, and the stream carries no notion of one run having spawned another, nor of structure _within_ a run.
 
-Two consumers already want that identity and cannot get it:
+Two consumers want that structure and cannot get it:
 
--   **The playground DAG** (PR [#94](https://github.com/rejifald/StitchAPI/pull/94)). `StitchTraceEntry.dependsOn` ([`docs/sandbox/component/runner.ts`](../../docs/sandbox/component/runner.ts)) exists and `traceToMermaid` already draws edges from it — but **nothing populates it**. The trace collector ([`docs/sandbox/runtime/trace-collector.ts`](../../docs/sandbox/runtime/trace-collector.ts)) is a `TraceSink` that mints synthetic `stitch-N` ids and correlates a stitch instance's calls by a per-instance FIFO, and its own header says the edges _"need the composition graph core doesn't emit"_. PR #94's open questions are exactly: does `stitch()`/`seam` **emit parent identity** into the trace, or is it inferred statically — and is an edge runtime causality or `extends` derivation?
--   **The OTLP sink** ([`otlp.ts`](../../packages/core/src/otlp.ts)). It maps each call to one CLIENT span, but **mints a fresh `traceId`/`spanId` per `start`** and guesses correlation from a `name`-keyed stack. Sibling/child calls get unrelated trace ids; `parentSpanId` is never emitted. It is a tree-shaped exporter fed a flat, un-correlated stream.
+-   **The OTLP sink** ([`otlp.ts`](../../packages/core/src/otlp.ts)) maps each call to one CLIENT span, but **mints a fresh `traceId`/`spanId` per `start`** and guesses correlation from a `name`-keyed stack; `parentSpanId` is never emitted, and a retry/page/login is at best a point-in-time **span event**, never a child span with its own latency and status. An operator cannot see "how each of the 3 attempts performed" or "page 4 took 800ms".
+-   **The playground DAG** (PR [#94](https://github.com/rejifald/StitchAPI/pull/94)). `StitchTraceEntry.dependsOn` ([`runner.ts`](../../docs/sandbox/component/runner.ts)) exists and `traceToMermaid` draws edges from it — but the trace collector ([`trace-collector.ts`](../../docs/sandbox/runtime/trace-collector.ts)) mints synthetic `stitch-N` ids and FIFO-correlates because _"the composition graph core doesn't emit"_ parent identity.
 
-A run **already** spawns another in one shipped case: `cookieSession` runs its login stitch via `__raw` → `executeRaw` ([`auth.ts`](../../packages/core/src/auth.ts) `doRefresh`). `executeRaw` drives `attemptLoop` directly and **emits no events** — so today that child run is entirely invisible to tracing. #7's `pipe()` will spawn a child run per step. Both need a way to say "this run is a child of that one".
+A run **already** spawns another: `cookieSession` runs its login stitch via `__raw` → `executeRaw` ([`auth.ts`](../../packages/core/src/auth.ts) `doRefresh`), and `executeRaw` drives `attemptLoop` directly and **emits no events** — so that child run is invisible today. #7's `pipe()` will spawn a child run per step.
 
-The roadmap item: add **optional run identity** — a `runId` per call, a `parentId` when one run spawns another — kept **OTLP-span-aligned** so the existing exporter and a future trace-based diagram are just span-tree renders.
+## Decision (resolved 2026-06-16)
 
-## Decision (proposed — these are what I want to firm up before coding)
+1.  **Model the whole thing as one OTLP trace tree.** Every traced unit is a **span** with a `spanId` (16 hex), a `traceId` (32 hex, shared across a tree), and a `parentId` (=OTel `parentSpanId`). This is the OTel span model verbatim, so the OTLP sink stops guessing — it reads ids, sets `parentSpanId`, shares one `traceId` — and a trace-based Mermaid diagram is a span-tree walk. Ids are **engine-minted** (reusing the browser-safe `otlp.ts#hex`), never caller-supplied (a caller-named id spoofs correlation — the same reasoning that keeps `principal` off `StitchInput` in [ADR 0002](./0002-seam-primitive-and-principal-scoped-auth.md)). A future _inbound_ `traceparent` continuation (W3C Trace Context) is a separate opt-in feature.
 
-1.  **Three ids, OTLP-aligned.** Each `execute()` mints a `runId` (the OTel **spanId**, 16 hex chars) and belongs to a `traceId` (32 hex chars, the root identity of a run tree). A run spawned by another **inherits the parent's `traceId`** and sets `parentId` = the parent's `runId` (the OTel **parentSpanId**); a root run has a fresh `traceId` and no `parentId`. This is the OTel span model verbatim, so the OTLP sink stops guessing — it keys its open-span map on `runId`, sets `parentSpanId` from `parentId`, and shares one `traceId` across a tree — and any trace-based Mermaid diagram is a span-tree walk.
+2.  **Three kinds of span — runs, intra-run sub-spans, child runs.** The taxonomy that reconciles "retries are not runs, but must be traced":
 
-2.  **Identity rides on the `TraceSink` `ctx`, not on every `StitchEvent`.** Today the sink is `handle(event, ctx: { name })`. Widen the ctx to `{ name; runId; traceId; parentId? }`. Identity is **per-run** — constant across all of a run's events — so it belongs on the run-scoped ctx, not duplicated onto every event. Both consumers that need it are **sinks** (the playground DAG collector _is_ a `TraceSink`; OTLP _is_ a `TraceSink`) and already receive ctx, so this is additive: a sink that reads only `ctx.name` (the built-in JSONL/console/logger sinks) is unchanged. The three ids are strings, so the ctx round-trips as JSON (contract gate). I prefer this over per-event ids; see **Q1**.
+    | Span kind              | What it is                                             | Examples                                       | New `runId`?                             |
+    | ---------------------- | ------------------------------------------------------ | ---------------------------------------------- | ---------------------------------------- |
+    | **Run span**           | One `execute()` — a whole logical call                 | the call itself                                | yes (the `runId`)                        |
+    | **Intra-run sub-span** | A sub-operation _within_ one run — not a separate call | each **retry attempt**, each **paginate page** | no — a child span under the run          |
+    | **Child-run span**     | A nested `execute()` the run caused                    | `cookieSession` **login**, a `pipe()` **step** | yes — its own `runId`, `parentId`=caller |
 
-3.  **Child propagation is EXPLICIT, never ambient.** No `AsyncLocalStorage` — it is Node-only (breaks the browser-first gate, and stitches run in the playground Web Worker). Instead a run that may spawn children carries a small `RunContext { traceId, runId }`, and the engine threads it into a child's run as an optional `parent?: RunContext` (on the internal run path / `makeRuntime` / a new traced `executeRaw` variant). The child mints its own `runId`, inherits `parent.traceId`, and sets `parentId = parent.runId`. Explicit threading is portable; ambient context is not.
+    A **retry attempt is a sub-span, not a run** (no separate `execute()`), but it is still a child span in the tree with its own start/end/status — so the operator sees count _and_ per-attempt latency/outcome. A **page** is the same. A **coalescing follower** is neither (it awaits the leader's shared result, runs no chain). Streaming `delta`s are values within the run span, not sub-spans.
 
-4.  **What counts as a child run (scope).**
+3.  **Trace everything, with per-iteration performance (the review's principle).** Retries, pages, the `cookieSession` login, and `pipe()` steps are all traced. Each retry/page sub-span carries its duration and outcome (status, retry reason); the login and each pipe step are full child-run spans. The flat per-call stream is unchanged for existing consumers; the richness is built in the **sink**, which assembles the tree from run identity + the sub-span structure the events already imply (`progress.attempt`, the `paginate` detail, the surfaced login run).
 
-    -   **YES — a `pipe()` step** (#7): each step's run is a child of the pipe's run.
-    -   **YES — a `cookieSession` login**: it is a sub-call of the call that triggered apply/refresh. (It runs via `executeRaw` today and emits nothing — making it a _traced_ child is a real change; see **Q3**.)
-    -   **NO — retry attempts**: already modelled as `attempt` on events within one run; not separate runs.
-    -   **NO — coalescing followers**: a follower awaits the leader's one shared result and runs no chain of its own — same logical result, not a child.
-    -   **OPEN — paginate pages**: today one run with `paginate` progress events; promoting each page to a child run is a behaviour/noise change (see **Q2**). Streaming `delta`s are emphatically NOT child runs — they are values within one streaming run.
+4.  **Carrier — run identity on the `TraceSink` ctx _and_ on the `start` event; sub-span structure from the events; NOT every event** (resolves Q1). Run identity (`runId`/`traceId`/`parentId`) goes on the run-scoped sink ctx — `handle(event, ctx: { name; runId; traceId; parentId? })` — because it is per-run-constant and both rich consumers (OTLP, the DAG collector) are sinks. It is **also** stamped on the `start` event (1:1 with a run) so a non-sink `.stream()` consumer can learn a run's identity once. Intra-run **sub-span** structure (which attempt/page) rides the events that already exist (`progress.attempt`; the engine will signal page/attempt boundaries explicitly rather than have the sink fragile-infer them). We deliberately do **not** stamp identity on _every_ event — see _Resolved questions Q1_ for the full give/backfire analysis; the short of it is that per-event ids add nothing to the OTLP tree (the sink has ctx) and cost the most exactly on the high-frequency `delta` path.
 
-5.  **Id minting is browser-safe and shared.** Reuse the exact helper `otlp.ts#hex` already uses — `crypto.getRandomValues` where available, else `Math.random` (ids need to be unique-ish, not secret) — promoted to a shared zero-dep util. The engine mints; a **caller never supplies a run id** (an externally-named id is a correlation-spoofing surface — the same reasoning that keeps `principal` off `StitchInput` in [ADR 0002](./0002-seam-primitive-and-principal-scoped-auth.md)).
+5.  **Child propagation is EXPLICIT, never ambient.** No `AsyncLocalStorage` (Node-only — breaks the browser-first gate and the playground Web Worker). A run that may spawn children carries a small `RunContext { traceId, runId }`, threaded into a child run as an optional `parent?: RunContext` (on the internal run path / `makeRuntime` / a **traced `executeRaw` variant** for the login). The child mints its own `runId`, inherits `parent.traceId`, sets `parentId = parent.runId`.
+
+6.  **OTLP gets the full sub-span waterfall; the DAG stays readable.** The OTLP export is the rich view: a run span with per-attempt and per-page child spans (timing + status), and child-run spans for logins/pipe steps. The playground DAG shows **run and child-run nodes + edges**, with attempt/page **counts as node annotations** (the `stream: { chunks }` annotation is the precedent), not as separate DAG nodes — intra-run detail belongs in the OTLP waterfall, not the composition graph.
+
+## Resolved questions
+
+-   **Q1 — Trace identity on events too? What it gives, where it backfires (asked in review).**
+    -   _What stamping every event gives:_ a non-sink `.stream()` consumer (reading the async-iterable directly, not via a `TraceSink`) can attribute each event to a run without external correlation, and could demultiplex if multiple runs' events were ever merged onto one stream.
+    -   _Where it backfires:_ **(a) bloat on the hot path** — identity is ~64 bytes (3 hex ids) repeated on every event, and the `delta` event fires once per chunk (thousands for an LLM/SSE stream), so per-event ids multiply event size precisely where volume is highest and already-truncated payloads live; **(b) redundancy** — the ids are per-run-constant, so per-event is denormalised run data; **(c) no OTLP benefit** — the operator consumes via the OTLP sink, which already has full identity on ctx and builds the rich tree from ctx + sub-span structure, so per-event ids add nothing to the waterfall (the richness comes from **sub-spans**, not from stamping ids on each event); **(d) public-API churn** — `StitchEvent` is a public discriminated union, so 3 new fields hit all 8 variants, ~20 engine construction sites, and every consumer's exhaustive switch.
+    -   _Resolution:_ run identity on **ctx** (sinks/OTLP — full richness) **+ on `start`** (non-sink stream consumers, 1:1 with the run, zero delta-path cost). Revisit stamping all-but-`delta` only if we later expose a merged multi-run stream.
+-   **Q2 — Paginate pages as child runs? (resolved: consistent with retries, both traced.)** Pages are **not** child runs and retries are **not** child runs — both are **intra-run sub-spans** (Decision 2). Both are traced the same way, so an operator sees how many retries were made, how many pages were scanned, and **how each performed** (per-iteration latency/status). This is the review's explicit ask.
+-   **Q3 — Trace the `cookieSession` login? (resolved: yes, as a child run.)** The login is routed through a traced path that tees to the seam's shared sink with `parentId` set — lighting up the `login → call` edge PR #94's own fixture implies. Concretely: a **traced `executeRaw` variant** so the login emits its own run span (its events no longer vanish).
+-   **Q4 — `extends` derivation vs. runtime causality? (resolved: out of scope.)** This ADR provides **only runtime causality** (which run/sub-span spawned which). The static `extends` derivation (which stitch was composed from which fragment) is a different axis the collector can't see at runtime; if ever wanted it is a separate optional overlay (distinct edge style / DAG toggle), not part of this work.
 
 ## Consequences
 
--   PR #94's DAG edges populate from **real runtime causality**: the collector uses `ctx.runId` as the node id (dropping synthetic `stitch-N`) and `ctx.parentId` for `dependsOn`, so concurrent calls on one instance correlate exactly instead of "degrading gracefully" through a FIFO.
--   The OTLP exporter becomes a real span tree (shared `traceId`, populated `parentSpanId`) with no heuristic — a strict improvement to a shipped capability.
--   #7's `pipe()` gets the identity it needs for step→step edges; a trace-based diagram becomes a span-tree render.
--   Cost: a ctx widening threaded through `execute`/`tee`/the sinks; a `RunContext` arg on the internal run path; and — if we take Q3's "trace the login" option — a traced `executeRaw` variant. All additive; the flat-stream behaviour and every existing sink are unchanged.
-
-## Open questions (where I want to stop for your input)
-
--   **Q1 — Carrier: sink `ctx` (recommended) vs. the `StitchEvent`s themselves.** ctx is per-run, lean, and both consumers are sinks. But a `.stream()` consumer (an async-iterable reader that is _not_ a sink — e.g. a future client building a DAG straight off the stream) would not see causality. If we want that, the ids must be on the events — cheapest is on `start` only (1:1 with a run). Sink channel enough, or also on `start`?
--   **Q2 — Are paginate pages child runs?** Keep pagination as one run with `paginate` progress events (my default — additive, no behaviour change to a shipped surface), or promote each page to a child span (richer DAG, noisier traces)?
--   **Q3 — Trace the `cookieSession` login as a child run?** (a) Leave it invisible — smallest, but the `fetch-token → call` edge PR #94's own test fixture implies stays unshown; (b) route the login through a traced path that tees to the seam's shared sink with `parentId` set — lights up the edge, but changes how login runs and adds the login's events to the stream. Which?
--   **Q4 — `extends` derivation vs. runtime causality.** PR #94 conflates two edge meanings. This ADR provides **only runtime causality** (which run spawned which). The **static `extends` derivation** (which stitch was composed from which fragment) is a different axis the collector can't see at runtime. I propose it stays **out of scope** here — a separate optional overlay (distinct edge style / DAG toggle) if we ever want it. Agree?
+-   The OTLP exporter becomes a real, rich span tree: shared `traceId`, populated `parentSpanId`, **per-attempt and per-page child spans** with timing/status, and child-run spans for logins/pipe steps. A strict, operator-facing upgrade to a shipped capability.
+-   PR #94's DAG edges populate from real runtime causality (the collector uses `ctx.runId` for the node id, `ctx.parentId` for `dependsOn`, attempt/page counts as annotations), dropping its synthetic ids and FIFO heuristic.
+-   #7's `pipe()` gets the parent/child identity its step→step edges need.
+-   Cost: a ctx widening + a `start`-event field; a `RunContext` arg on the run path; a **traced `executeRaw` variant** (Q3); the OTLP sink rebuilt to assemble a tree with intra-run sub-spans; the engine signalling attempt/page span boundaries. All additive — the flat-stream behaviour and every existing sink that reads only `ctx.name` are unchanged.
 
 ## Alternatives considered
 
+-   **Identity on every `StitchEvent` (as the default).** Rejected — see Q1: per-event bloat (esp. `delta`), redundancy, public-API churn, and zero OTLP benefit. Kept narrowly as the `start`-event stamp for non-sink consumers.
+-   **Retries/pages as enriched span _events_ rather than child spans.** Rejected: a span event is a timestamp, not a duration — it can't show "how each attempt/page performed". Child sub-spans are the OTel-idiomatic way to surface per-iteration latency and status, which is exactly the review's ask.
 -   **`AsyncLocalStorage` ambient run context.** Rejected: Node-only, breaks browser-first and the playground Worker. Explicit `RunContext` threading is portable and makes the parent/child relation visible at the call site.
--   **Per-event ids on every `StitchEvent` (as the default).** Rejected as default: duplicates per-run data on every event with no consumer that needs it there. Kept as **Q1** for the non-sink `.stream()` case.
--   **Caller-supplied run/correlation ids.** Rejected: ids must be engine-minted and unforgeable; a caller-named id spoofs correlation (mirrors the `StitchInput`-principal rejection in ADR 0002). A future _inbound_ `traceparent` continuation (W3C Trace Context) is a separate, opt-in feature, not this.
+-   **Caller-supplied run/correlation ids.** Rejected: ids must be engine-minted and unforgeable (mirrors the `StitchInput`-principal rejection in ADR 0002). Inbound `traceparent` continuation is a separate, opt-in future feature.
 
 ## Gates
 
 -   **browser-first** — ids via `crypto.getRandomValues`/`Math.random` (the existing `otlp.ts#hex`), no `AsyncLocalStorage`, no Node-only API on the hot path.
--   **bundle-frugal** — a ctx widening + a small `RunContext`; no new statically-imported hot-path module (OTLP and the playground collector are already opt-in / out-of-core).
--   **contract-not-dependency** — the three ids are strings on the run-scoped ctx; they round-trip as JSON, and no new vendor capability is introduced.
+-   **bundle-frugal** — a ctx widening, one `start` field, a small `RunContext`; the richer tree assembly lives in the **opt-in** OTLP sink / out-of-core playground collector, not on the `import { stitch }` hot path.
+-   **contract-not-dependency** — the ids are strings on the run-scoped ctx (+ `start`); they round-trip as JSON, and no new vendor capability is introduced.
+
+## Staged implementation (proposed)
+
+1. Run identity (`runId`/`traceId`/`parentId`) on ctx + `start`; OTLP sink reads them (shared `traceId`, `parentSpanId`); DAG collector uses `ctx.runId`/`ctx.parentId`. 2. Traced `executeRaw` variant → the `cookieSession` login becomes a child-run span (Q3). 3. Intra-run **sub-spans** for retries + pages (engine signals boundaries; OTLP renders per-iteration timing/status; DAG annotates counts). Stage 1 unblocks #7's `pipe()`; stages 2–3 deliver the operator-facing richness.

--- a/docs/sandbox/component/runner.ts
+++ b/docs/sandbox/component/runner.ts
@@ -55,6 +55,13 @@ export interface StitchTraceEntry {
      * distinctly. `chunks` is the number of stream chunks observed.
      */
     stream?: { chunks: number };
+    /**
+     * Retry attempts made (ADR 0007), present only when more than one — a DAG node annotation
+     * (per-attempt detail lives in the OTLP waterfall, not as extra DAG nodes).
+     */
+    attempts?: number;
+    /** Pages fetched for a paginated call (ADR 0007), present only when paginated — a DAG annotation. */
+    pages?: number;
 }
 
 export interface RunError {

--- a/docs/sandbox/runtime/trace-collector.test.ts
+++ b/docs/sandbox/runtime/trace-collector.test.ts
@@ -36,15 +36,23 @@ function fakeCore(opts: {
     events: () => any[];
     value?: unknown;
     onConfig?: (config: any) => void;
+    runId?: string;
 }): (config: unknown) => unknown {
     return (config: any) => {
         opts.onConfig?.(config);
         const sink = config.trace as {
-            handle: (e: any, ctx: { name: string }) => void;
+            handle: (e: any, ctx: any) => void;
         };
         const name = config.name ?? config.path ?? 'stitch';
         return (_input?: unknown) => {
-            for (const ev of opts.events()) sink.handle(ev, { name });
+            // Mimic the real engine `tee` (ADR 0007): one run identity per call, on the ctx of
+            // EVERY event. The collector keys entries by `ctx.runId`.
+            const ctx = {
+                name,
+                runId: opts.runId ?? 'run-1',
+                traceId: 'trace-1',
+            };
+            for (const ev of opts.events()) sink.handle(ev, ctx);
             return Promise.resolve(opts.value ?? { ok: true });
         };
     };
@@ -93,7 +101,7 @@ async function runTests(): Promise<void> {
             ?.entry;
         assert(
             '1 entry has id, label, request method/url',
-            entry?.id === 'stitch-1' &&
+            entry?.id === 'run-1' &&
                 entry?.label === 'getUser' &&
                 entry?.request.method === 'GET' &&
                 entry?.request.url === 'https://demo/users/2',
@@ -212,7 +220,7 @@ async function runTests(): Promise<void> {
         >[];
         assert(
             '4 chunks carry the entry id + ordered text',
-            chunks[0]?.traceId === 'stitch-1' &&
+            chunks[0]?.traceId === 'run-1' &&
                 chunks[0]?.text === 'Hel' &&
                 chunks[1]?.text === 'lo',
             chunks,
@@ -364,6 +372,67 @@ async function runTests(): Promise<void> {
             '8 value still returned with the sink unbound',
             !!value && (value as { id: number }).id === 2,
             value,
+        );
+    }
+
+    /* 9 — a CHILD run (parentId) becomes a dependsOn edge, even interleaved --- */
+    {
+        // The cookieSession login case: a child run's events arrive on the SAME sink, NESTED
+        // inside the parent's (start parent → start/result/done child → result/done parent). The
+        // run-id keying must attribute each event to the right entry (a FIFO would not) and turn
+        // the child's parentId into a `dependsOn` edge (ADR 0007).
+        const events: RunEvent[] = [];
+        let dag!: { handle: (e: any, ctx: any) => void };
+        const collector = createTraceCollector(
+            fakeCore({ events: () => [], onConfig: (c) => (dag = c.trace) }),
+        );
+        collector.bindProgress((e) => events.push(e));
+        collector.stitch({ name: 'parent' }); // realize the dag sink via onConfig
+        const parent = { name: 'parent', runId: 'p1', traceId: 't1' };
+        const child = {
+            name: 'login',
+            runId: 'c1',
+            traceId: 't1',
+            parentId: 'p1',
+        };
+        dag.handle(startEv({ name: 'parent' }), parent);
+        dag.handle(startEv({ name: 'login' }), child); // child opens mid-parent
+        dag.handle(
+            { type: 'result', value: {}, status: 200, attempts: 1, at: 1 },
+            child,
+        );
+        dag.handle(
+            { type: 'done', ok: true, ms: 2, attempts: 1, at: 2 },
+            child,
+        );
+        dag.handle(
+            { type: 'result', value: {}, status: 200, attempts: 1, at: 3 },
+            parent,
+        );
+        dag.handle(
+            { type: 'done', ok: true, ms: 4, attempts: 1, at: 4 },
+            parent,
+        );
+
+        const entries = events
+            .filter((e) => e.type === 'trace')
+            .map((e) => (e as Extract<RunEvent, { type: 'trace' }>).entry);
+        const childEntry = entries.find((en) => en.id === 'c1');
+        const parentEntry = entries.find((en) => en.id === 'p1');
+        assert(
+            '9 child run draws a dependsOn edge to its parent',
+            JSON.stringify(childEntry?.dependsOn) === JSON.stringify(['p1']),
+            childEntry,
+        );
+        assert(
+            '9 parent run has no dependsOn',
+            !!parentEntry && parentEntry.dependsOn === undefined,
+            parentEntry,
+        );
+        assert(
+            '9 interleaved runs attributed by id, not order',
+            childEntry?.label === 'login' && parentEntry?.label === 'parent',
+            entries,
         );
     }
 

--- a/docs/sandbox/runtime/trace-collector.test.ts
+++ b/docs/sandbox/runtime/trace-collector.test.ts
@@ -436,6 +436,74 @@ async function runTests(): Promise<void> {
         );
     }
 
+    /* 10 — retry / paginate progress events annotate the entry with counts ---- */
+    {
+        const events: RunEvent[] = [];
+        const collector = createTraceCollector(
+            fakeCore({
+                events: () => [
+                    startEv(),
+                    { type: 'progress', phase: 'request', attempt: 1, at: 0 },
+                    { type: 'progress', phase: 'retry', attempt: 1, at: 1 },
+                    { type: 'progress', phase: 'request', attempt: 2, at: 2 },
+                    {
+                        type: 'result',
+                        value: {},
+                        status: 200,
+                        attempts: 2,
+                        at: 3,
+                    },
+                    { type: 'done', ok: true, ms: 3, attempts: 2, at: 3 },
+                ],
+            }),
+        );
+        collector.bindProgress((e) => events.push(e));
+        await (collector.stitch({ name: 'x' }) as () => Promise<unknown>)();
+        const entry = (
+            events.find((e) => e.type === 'trace') as
+                | Extract<RunEvent, { type: 'trace' }>
+                | undefined
+        )?.entry;
+        assert(
+            '10 a retried run is annotated with its attempt count',
+            entry?.attempts === 2 && entry?.pages === undefined,
+            entry,
+        );
+    }
+
+    /* 11 — a single-attempt run carries no attempts/pages annotation --------- */
+    {
+        const events: RunEvent[] = [];
+        const collector = createTraceCollector(
+            fakeCore({
+                events: () => [
+                    startEv(),
+                    { type: 'progress', phase: 'request', attempt: 1, at: 0 },
+                    {
+                        type: 'result',
+                        value: {},
+                        status: 200,
+                        attempts: 1,
+                        at: 1,
+                    },
+                    { type: 'done', ok: true, ms: 1, attempts: 1, at: 1 },
+                ],
+            }),
+        );
+        collector.bindProgress((e) => events.push(e));
+        await (collector.stitch({ name: 'x' }) as () => Promise<unknown>)();
+        const entry = (
+            events.find((e) => e.type === 'trace') as
+                | Extract<RunEvent, { type: 'trace' }>
+                | undefined
+        )?.entry;
+        assert(
+            '11 a single clean attempt gets no count annotation',
+            entry?.attempts === undefined && entry?.pages === undefined,
+            entry,
+        );
+    }
+
     console.log(`\n${passed} passed, ${failed} failed\n`);
     if (failed === 0) {
         console.log('A2 OK');

--- a/docs/sandbox/runtime/trace-collector.ts
+++ b/docs/sandbox/runtime/trace-collector.ts
@@ -51,6 +51,10 @@ interface OpenEntry {
     status?: number;
     error?: { name: string; message: string };
     chunks: number;
+    /** Count of `request` progress events — i.e. attempts (ADR 0007); >1 means a retry happened. */
+    attempts: number;
+    /** Count of `paginate` progress events — i.e. pages fetched (ADR 0007). */
+    pages: number;
 }
 
 export interface TraceCollector {
@@ -101,6 +105,10 @@ function finalize(
     // Runtime causality (ADR 0007): a child run depends on the parent that spawned it, so the
     // DAG draws a parent → child edge (e.g. cookieSession login → the call that triggered it).
     if (e.parentId) entry.dependsOn = [e.parentId];
+    // Per-iteration counts as node annotations (ADR 0007) — only when noteworthy (a retry / a
+    // paginated run); the per-attempt/page detail lives in the OTLP waterfall, not as DAG nodes.
+    if (e.attempts > 1) entry.attempts = e.attempts;
+    if (e.pages > 0) entry.pages = e.pages;
     return entry;
 }
 
@@ -142,6 +150,8 @@ export function createTraceCollector(
                                 event.input?.headers,
                             ),
                             chunks: 0,
+                            attempts: 0,
+                            pages: 0,
                         });
                         break;
                     }
@@ -185,7 +195,17 @@ export function createTraceCollector(
                         }
                         break;
                     }
-                    // 'progress' / 'drift' / 'info' carry no DAG-node data — ignored.
+                    case 'progress': {
+                        // Count attempts (`request` per try) + pages (`paginate` per page) for the
+                        // node-annotation counts (ADR 0007); the rich per-iteration timing is OTLP's.
+                        const e = find(ctx);
+                        if (e) {
+                            if (event.phase === 'request') e.attempts += 1;
+                            else if (event.phase === 'paginate') e.pages += 1;
+                        }
+                        break;
+                    }
+                    // 'drift' / 'info' carry no DAG-node data — ignored.
                 }
             },
         };

--- a/docs/sandbox/runtime/trace-collector.ts
+++ b/docs/sandbox/runtime/trace-collector.ts
@@ -14,20 +14,21 @@
  * the run's progress sink — the SAME channel the worker body already relays to
  * the host and accumulates into the final result.
  *
- * Correlation: a stitch instance's calls are tracked in a FIFO of open entries
- * (`start` opens, `done` closes-and-emits). Sequential snippet code — the common
- * case — is exact; concurrent calls on one instance degrade gracefully (entries
- * still emit; timing may attribute to a sibling) and NEVER throw.
+ * Correlation: each call is keyed by its run id (ADR 0007), which core stamps on every event's
+ * ctx, so `start` opens an entry and `done` closes-and-emits it by that id. Concurrent calls and
+ * interleaved CHILD runs (a cookieSession login firing mid-call) attribute exactly — no FIFO
+ * guesswork — and the handler never throws.
  *
- * Scope (A2): nodes render from real runs. Dependency EDGES (`dependsOn`) need
- * the composition graph core doesn't emit, and `seam`-created stitches aren't
- * wrapped yet — both are tracked as follow-ups in RELEASE.md.
+ * Scope: nodes render from real runs, and runtime-causality EDGES (`dependsOn`) now populate from
+ * the `parentId` core stamps on a child run's ctx (ADR 0007) — a cookieSession login (or, later, a
+ * `pipe()` step) draws a parent → child edge. The STATIC `extends` composition graph is a separate
+ * axis core deliberately does not emit (ADR 0007 Q4, out of scope).
  */
 import type { StitchTraceEntry } from '../component/runner';
 import type { ProgressSink } from './worker-entry';
 
 import { multiplex } from 'stitchapi';
-import type { StitchEvent, TraceSink } from 'stitchapi';
+import type { StitchEvent, TraceContext, TraceSink } from 'stitchapi';
 
 /** Header names whose presence we surface as redacted in the trace entry. */
 const SECRET_HEADERS = new Set([
@@ -41,6 +42,8 @@ const SECRET_HEADERS = new Set([
 /** Mutable state for one in-flight stitch call (between `start` and `done`). */
 interface OpenEntry {
     id: string;
+    /** The spawning run's id (ADR 0007), when this run is a child — a cookieSession login, a pipe step. */
+    parentId?: string;
     label: string;
     method: string;
     url: string;
@@ -95,6 +98,9 @@ function finalize(
         entry.response = { status: e.status, ok, durationMs };
     if (e.error) entry.error = e.error;
     if (e.chunks > 0) entry.stream = { chunks: e.chunks };
+    // Runtime causality (ADR 0007): a child run depends on the parent that spawned it, so the
+    // DAG draws a parent → child edge (e.g. cookieSession login → the call that triggered it).
+    if (e.parentId) entry.dependsOn = [e.parentId];
     return entry;
 }
 
@@ -110,16 +116,25 @@ export function createTraceCollector(
     let activeSink: ProgressSink | undefined;
     let counter = 0;
 
-    // One DAG sink per stitch INSTANCE, so each instance's calls correlate in
-    // their own FIFO. All instances emit to the single run-scoped `activeSink`.
+    // One DAG sink per stitch INSTANCE, all emitting to the single run-scoped `activeSink`. Calls
+    // correlate by their run id (ADR 0007) — core stamps it on every event's ctx — so concurrent
+    // calls and interleaved CHILD runs (a cookieSession login firing mid-call) attribute exactly,
+    // and a child's `parentId` becomes a `dependsOn` edge. The `counter` is a defensive fallback id
+    // for the engine-impossible case of a run arriving with no id.
     const makeDagSink = (): TraceSink => {
-        const open: OpenEntry[] = [];
+        const open = new Map<string, OpenEntry>();
+        const find = (ctx: TraceContext): OpenEntry | undefined =>
+            ctx.runId ? open.get(ctx.runId) : undefined;
         return {
-            handle(event: StitchEvent, ctx: { name: string }): void {
+            handle(event: StitchEvent, ctx: TraceContext): void {
                 switch (event.type) {
-                    case 'start':
-                        open.push({
-                            id: `stitch-${(counter += 1)}`,
+                    case 'start': {
+                        const id = ctx.runId ?? `stitch-${(counter += 1)}`;
+                        open.set(id, {
+                            id,
+                            ...(ctx.parentId !== undefined
+                                ? { parentId: ctx.parentId }
+                                : {}),
                             label: ctx.name,
                             method: event.method,
                             url: event.url,
@@ -129,39 +144,48 @@ export function createTraceCollector(
                             chunks: 0,
                         });
                         break;
-                    case 'result':
-                        if (open[0]) open[0].status = event.status;
+                    }
+                    case 'result': {
+                        const e = find(ctx);
+                        if (e) e.status = event.status;
                         break;
-                    case 'error':
-                        if (open[0]) {
-                            open[0].error = {
+                    }
+                    case 'error': {
+                        const e = find(ctx);
+                        if (e) {
+                            e.error = {
                                 name: event.name,
                                 message: event.message,
                             };
                             if (event.status !== undefined)
-                                open[0].status = event.status;
+                                e.status = event.status;
                         }
                         break;
-                    case 'delta':
-                        if (open[0]) {
-                            open[0].chunks += 1;
+                    }
+                    case 'delta': {
+                        const e = find(ctx);
+                        if (e) {
+                            e.chunks += 1;
                             activeSink?.({
                                 type: 'chunk',
-                                traceId: open[0].id,
+                                traceId: e.id,
                                 text: chunkText(event.chunk),
                             });
                         }
                         break;
+                    }
                     case 'done': {
-                        const e = open.shift();
-                        if (e)
+                        const e = find(ctx);
+                        if (e && ctx.runId) {
+                            open.delete(ctx.runId);
                             activeSink?.({
                                 type: 'trace',
                                 entry: finalize(e, event.ok, event.ms),
                             });
+                        }
                         break;
                     }
-                    // 'progress' / 'drift' carry no DAG-node data — ignored.
+                    // 'progress' / 'drift' / 'info' carry no DAG-node data — ignored.
                 }
             },
         };

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -8,6 +8,7 @@ import type {
     AdapterResponse,
     AuthContext,
     AuthStrategy,
+    RunContext,
     Stitch,
     StitchInput,
 } from './types';
@@ -624,15 +625,25 @@ export function cookieSession(opts: CookieSessionOpts): AuthStrategy {
         phase: 'apply' | 'refresh',
     ) => {
         ctx.emit('auth', 'login');
-        // `__raw` runs the login once and returns its raw AdapterResponse (headers and all).
-        // It is intentionally not on the public Stitch type, so reach it through a cast.
+        // `__raw` runs the login once and returns its raw AdapterResponse (headers and all);
+        // `__rawTraced` does the same but TEES the login's events as a CHILD run (ADR 0007) of the
+        // call that triggered it. Neither is on the public Stitch type, so reach them through a cast.
+        const login = opts.login as unknown as {
+            __raw: (input?: StitchInput) => Promise<AdapterResponse>;
+            __rawTraced?: (
+                input: StitchInput | undefined,
+                parent: RunContext,
+            ) => Promise<AdapterResponse>;
+        };
+        const loginInput = opts.loginInput?.(principal);
         let res: AdapterResponse;
         try {
-            res = await (
-                opts.login as unknown as {
-                    __raw: (input?: StitchInput) => Promise<AdapterResponse>;
-                }
-            ).__raw(opts.loginInput?.(principal));
+            // Trace the login as a child of the caller's run when one is bound and the login
+            // supports it; otherwise the original silent raw call (back-compat / standalone).
+            res =
+                ctx.run && login.__rawTraced
+                    ? await login.__rawTraced(loginInput, ctx.run)
+                    : await login.__raw(loginInput);
         } catch (error) {
             // A failed login: an HTTP error carries a numeric `status` (+ the `response` for its
             // headers); a transport error carries neither → `network`.

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -109,9 +109,16 @@ export function makeRuntime(
 // Runtime (and its `authCtx`) is shared across a stitch's concurrent calls, so the buffer must be
 // per-call: spread a fresh ctx (sharing store/vault/principal) with a private emit, run the
 // strategy, then yield whatever it announced. `apply`/`refresh` are plain async fns and can't yield.
-function emitInto(authCtx: AuthContext, sink: StitchEvent[]): AuthContext {
+function emitInto(
+    authCtx: AuthContext,
+    sink: StitchEvent[],
+    run: RunContext,
+): AuthContext {
     return {
         ...authCtx,
+        // The current run (ADR 0007) so a strategy that spawns a sub-call — `cookieSession`'s
+        // login — can run it as a CHILD of this run (parentId = run.runId).
+        run,
         emit: (topic, detail) =>
             sink.push({
                 type: 'info',
@@ -493,6 +500,7 @@ async function* attemptLoop(
     rt: Runtime,
     baseReq: AdapterRequest,
     state: { attempts: number },
+    run: RunContext,
     budget?: TotalBudget,
 ): AsyncGenerator<StitchEvent, AdapterResponse> {
     const { cfg } = rt;
@@ -532,7 +540,7 @@ async function* attemptLoop(
             const req = cloneReq(baseReq);
             if (cfg.auth) {
                 const infos: StitchEvent[] = [];
-                await cfg.auth.apply(req, emitInto(rt.authCtx, infos));
+                await cfg.auth.apply(req, emitInto(rt.authCtx, infos, run));
                 yield* infos;
             }
             await cfg.hooks?.onRequest?.({ name: nameOf(cfg), attempt, req });
@@ -597,7 +605,7 @@ async function* attemptLoop(
                     at: now(),
                 };
                 const infos: StitchEvent[] = [];
-                await cfg.auth.refresh(emitInto(rt.authCtx, infos));
+                await cfg.auth.refresh(emitInto(rt.authCtx, infos, run));
                 yield* infos;
                 attempt--; // redo this attempt with fresh auth, don't count it
                 continue;
@@ -661,11 +669,12 @@ async function* attemptWithCircuit(
     rt: Runtime,
     baseReq: AdapterRequest,
     state: { attempts: number },
+    run: RunContext,
     budget?: TotalBudget,
 ): AsyncGenerator<StitchEvent, AdapterResponse> {
     const { cfg } = rt;
     if (!cfg.circuit) {
-        return yield* attemptLoop(rt, baseReq, state, budget);
+        return yield* attemptLoop(rt, baseReq, state, run, budget);
     }
     const circuit = createCircuit(cfg.circuit, rt.store, hostKey(baseReq, cfg));
     if ((await circuit.phase()) === 'open') {
@@ -679,7 +688,7 @@ async function* attemptWithCircuit(
         throw new CircuitOpenError(); // fast-fail: do NOT touch the network
     }
     try {
-        const res = yield* attemptLoop(rt, baseReq, state, budget);
+        const res = yield* attemptLoop(rt, baseReq, state, run, budget);
         await circuit.onSuccess();
         return res;
     } catch (e) {
@@ -733,7 +742,7 @@ async function* paginated(
         const req = buildRequest(cfg, pageInput);
         let res: AdapterResponse;
         try {
-            res = yield* attemptWithCircuit(rt, req, state, budget);
+            res = yield* attemptWithCircuit(rt, req, state, run, budget);
         } catch (e) {
             yield errEvt(e, name, state.attempts);
             yield doneEvt(false, t0, state.attempts);
@@ -931,12 +940,13 @@ async function* runFrom(
     name: string,
     state: { attempts: number },
     t0: number,
+    run: RunContext,
     budget?: TotalBudget,
 ): AsyncGenerator<StitchEvent, RunOutcome> {
     const { cfg } = rt;
     let res: AdapterResponse;
     try {
-        res = yield* attemptWithCircuit(rt, baseReq, state, budget);
+        res = yield* attemptWithCircuit(rt, baseReq, state, run, budget);
     } catch (e) {
         yield errEvt(e, name, state.attempts);
         yield doneEvt(false, t0, state.attempts);
@@ -1142,7 +1152,7 @@ async function* runOnce(
         return { ok: false };
     }
     yield startEvt(name, baseReq, input, run);
-    return yield* runFrom(rt, baseReq, name, state, t0, budget);
+    return yield* runFrom(rt, baseReq, name, state, t0, run, budget);
 }
 
 // The cached path: lookup is OUTERMOST over the expensive chain; a hit short-circuits
@@ -1174,13 +1184,13 @@ async function* runCached(
     // did not opt into re-validate-on-hit — fail closed, never store, and surface WHY for traces.
     if (ctl.policy === 'refuse') {
         yield cacheEvt(`bypass: ${ctl.reason}`);
-        yield* runFrom(rt, baseReq, name, state, t0, budget);
+        yield* runFrom(rt, baseReq, name, state, t0, run, budget);
         return;
     }
 
     // A non-cacheable method (a mutation sharing a fragment) runs normally, uncached.
     if (!ctl.cacheableMethod(baseReq.method)) {
-        yield* runFrom(rt, baseReq, name, state, t0, budget);
+        yield* runFrom(rt, baseReq, name, state, t0, run, budget);
         return;
     }
     // A non-storable response (binary read straight into the store) warns and passes through —
@@ -1191,7 +1201,7 @@ async function* runCached(
         baseReq.responseType === 'arrayBuffer'
     ) {
         yield cacheEvt('bypass: non-storable responseType');
-        yield* runFrom(rt, baseReq, name, state, t0, budget);
+        yield* runFrom(rt, baseReq, name, state, t0, run, budget);
         return;
     }
 
@@ -1199,7 +1209,7 @@ async function* runCached(
     const key = ctl.key(d, input);
     if (key === undefined) {
         yield cacheEvt('bypass: unhashable request');
-        yield* runFrom(rt, baseReq, name, state, t0, budget);
+        yield* runFrom(rt, baseReq, name, state, t0, run, budget);
         return;
     }
 
@@ -1234,7 +1244,7 @@ async function* runCached(
 
     // Coalescing disabled: run the chain, write the cache last.
     if (ctl.coalesce === false) {
-        await store(yield* runFrom(rt, baseReq, name, state, t0, budget));
+        await store(yield* runFrom(rt, baseReq, name, state, t0, run, budget));
         return;
     }
 
@@ -1243,7 +1253,7 @@ async function* runCached(
     if (claim.leader) {
         let out: RunOutcome;
         try {
-            out = yield* runFrom(rt, baseReq, name, state, t0, budget);
+            out = yield* runFrom(rt, baseReq, name, state, t0, run, budget);
         } catch (e) {
             claim.fail(e);
             throw e;
@@ -1263,7 +1273,7 @@ async function* runCached(
         shared = await claim.promise;
     } catch {
         // The leader failed (or did not cache): proceed independently, uncoalesced.
-        await store(yield* runFrom(rt, baseReq, name, state, t0, budget));
+        await store(yield* runFrom(rt, baseReq, name, state, t0, run, budget));
         return;
     }
     yield cacheEvt('coalesced');
@@ -1370,8 +1380,58 @@ export async function executeRaw(
 ): Promise<AdapterResponse> {
     const baseReq = buildRequest(rt.cfg, input);
     const state = { attempts: 0 };
-    const gen = attemptLoop(rt, baseReq, state, totalBudget(rt.cfg, now()));
+    const gen = attemptLoop(
+        rt,
+        baseReq,
+        state,
+        newRunContext(),
+        totalBudget(rt.cfg, now()),
+    );
     let step = await gen.next();
     while (!step.done) step = await gen.next();
     return step.value;
+}
+
+/**
+ * Like {@link executeRaw}, but TEES the run's events to `sink` as a CHILD run (ADR 0007) and
+ * returns the raw response. `cookieSession` uses it to run its login as a traced child of the call
+ * that triggered it (`run.parentId` = the caller's runId), so the login is no longer an invisible
+ * side-call. The login's `result` carries only its **status** — never the (sensitive) login body —
+ * and any `throttled`/`retry`/`info` events from the login's own attempts are teed through.
+ */
+export async function executeRawTraced(
+    rt: Runtime,
+    input: StitchInput,
+    sink: TraceSink,
+    run: RunContext,
+): Promise<AdapterResponse> {
+    const { cfg } = rt;
+    const name = nameOf(cfg);
+    const t0 = now();
+    const state = { attempts: 0 };
+    const ctx = {
+        name,
+        runId: run.runId,
+        traceId: run.traceId,
+        ...(run.parentId !== undefined ? { parentId: run.parentId } : {}),
+    };
+    const baseReq = buildRequest(cfg, input);
+    sink.handle(startEvt(name, baseReq, input, run), ctx);
+    try {
+        const gen = attemptLoop(rt, baseReq, state, run, totalBudget(cfg, t0));
+        let step = await gen.next();
+        while (!step.done) {
+            sink.handle(step.value, ctx);
+            step = await gen.next();
+        }
+        const res = step.value;
+        // Status only — a login response body is sensitive; the span needs only its outcome.
+        sink.handle(resultEvt(undefined, res.status, state.attempts), ctx);
+        sink.handle(doneEvt(true, t0, state.attempts), ctx);
+        return res;
+    } catch (e) {
+        sink.handle(errEvt(e, name, state.attempts), ctx);
+        sink.handle(doneEvt(false, t0, state.attempts), ctx);
+        throw e;
+    }
 }

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -27,6 +27,7 @@ import type {
     AuthContext,
     DriftFinding,
     DriftSpec,
+    RunContext,
     StitchConfig,
     StitchEvent,
     StitchInput,
@@ -39,6 +40,7 @@ import {
     expandPath,
     getPath,
     matchAny,
+    newRunContext,
     now,
     parseDuration,
     sleep,
@@ -712,6 +714,7 @@ async function* paginated(
     input: StitchInput,
     state: { attempts: number },
     t0: number,
+    run: RunContext,
     budget?: TotalBudget,
 ): AsyncGenerator<StitchEvent, void> {
     const { cfg } = rt;
@@ -724,14 +727,7 @@ async function* paginated(
     let lastStatus = 200;
 
     const first = buildRequest(cfg, pageInput);
-    yield {
-        type: 'start',
-        name,
-        method: first.method,
-        url: first.url,
-        input,
-        at: now(),
-    };
+    yield startEvt(name, first, input, run);
 
     for (;;) {
         const req = buildRequest(cfg, pageInput);
@@ -871,6 +867,7 @@ const startEvt = (
     name: string,
     baseReq: AdapterRequest,
     input: StitchInput,
+    run: RunContext,
 ): StitchEvent => ({
     type: 'start',
     name,
@@ -878,6 +875,9 @@ const startEvt = (
     url: baseReq.url,
     input,
     at: now(),
+    runId: run.runId,
+    traceId: run.traceId,
+    ...(run.parentId !== undefined ? { parentId: run.parentId } : {}),
 });
 
 const cacheEvt = (detail: string): StitchEvent => ({
@@ -997,6 +997,7 @@ async function* runStreaming(
     name: string,
     state: { attempts: number },
     t0: number,
+    run: RunContext,
     budget?: TotalBudget,
 ): AsyncGenerator<StitchEvent, void> {
     const { cfg } = rt;
@@ -1013,7 +1014,7 @@ async function* runStreaming(
     }
     // Ask the transport for the live body — un-buffered, un-parsed (ADR 0005 Q1).
     baseReq = { ...baseReq, stream: true };
-    yield startEvt(name, baseReq, input);
+    yield startEvt(name, baseReq, input, run);
     state.attempts = 1;
 
     // Charge the rate limiter once at open, but take NO concurrency slot (Decision 12). A rate
@@ -1129,6 +1130,7 @@ async function* runOnce(
     name: string,
     state: { attempts: number },
     t0: number,
+    run: RunContext,
     budget?: TotalBudget,
 ): AsyncGenerator<StitchEvent, RunOutcome> {
     let baseReq: AdapterRequest;
@@ -1139,7 +1141,7 @@ async function* runOnce(
         yield doneEvt(false, t0, 0);
         return { ok: false };
     }
-    yield startEvt(name, baseReq, input);
+    yield startEvt(name, baseReq, input, run);
     return yield* runFrom(rt, baseReq, name, state, t0, budget);
 }
 
@@ -1153,6 +1155,7 @@ async function* runCached(
     name: string,
     state: { attempts: number },
     t0: number,
+    run: RunContext,
     budget?: TotalBudget,
 ): AsyncGenerator<StitchEvent, void> {
     const { cfg } = rt;
@@ -1164,7 +1167,7 @@ async function* runCached(
         yield doneEvt(false, t0, 0);
         return;
     }
-    yield startEvt(name, baseReq, input);
+    yield startEvt(name, baseReq, input, run);
 
     // 'refuse' (ADR 0004): the output contract can't be soundly fingerprinted (no strategy for the
     // vendor / a non-Standard-Schema validator / an opaque un-versioned transform) and the caller
@@ -1271,6 +1274,11 @@ async function* runCached(
 export async function* execute(
     rt: Runtime,
     input: StitchInput = {},
+    // Run identity (ADR 0007). Defaults to a fresh root run; the caller supplies one to make
+    // this a CHILD run — `newRunContext(parent)` inherits the parent's `traceId` and sets
+    // `parentId` (a `cookieSession` login, a `pipe()` step). Stamped on the `start` event and
+    // carried onto the trace-sink ctx by `tee` (stitch.ts).
+    run: RunContext = newRunContext(),
 ): AsyncGenerator<StitchEvent, void> {
     const { cfg } = rt;
     const name = nameOf(cfg);
@@ -1290,12 +1298,12 @@ export async function* execute(
     // chunks (Decisions 4-5). Streaming bypasses pagination and the cache, and is exempt from the
     // concurrency bucket (Decision 12). Checked before both so neither can wrap a live stream.
     if (cfg.kind?.stream) {
-        yield* runStreaming(rt, input, name, state, t0, budget);
+        yield* runStreaming(rt, input, name, state, t0, run, budget);
         return;
     }
 
     if (cfg.paginate) {
-        yield* paginated(rt, input, state, t0, budget);
+        yield* paginated(rt, input, state, t0, run, budget);
         return;
     }
 
@@ -1303,11 +1311,11 @@ export async function* execute(
     // never tunnel an invalid call past the boundary and the key mirrors the resolved request.
     const ctl = await ensureCache(rt);
     if (ctl) {
-        yield* runCached(rt, ctl, input, name, state, t0, budget);
+        yield* runCached(rt, ctl, input, name, state, t0, run, budget);
         return;
     }
 
-    yield* runOnce(rt, input, name, state, t0, budget);
+    yield* runOnce(rt, input, name, state, t0, run, budget);
 }
 
 // ---- cache surfaces (lazy; no static cache import on the hot path) ---------

--- a/packages/core/src/otlp.ts
+++ b/packages/core/src/otlp.ts
@@ -45,6 +45,84 @@ function serverAddress(url: string): string | undefined {
     }
 }
 
+// Build the FLAT per-iteration CHILD spans of a finished run span (ADR 0007, piece 3) — what makes
+// the OTLP waterfall show "how each retry/page performed". Derived from the run's own span events
+// (the engine's `request`/`paginate`/`retry` progress markers): a paginated run yields one `page N`
+// child per completed page; a non-paginated run that retried yields one `attempt N` child per
+// request (the non-final ones marked ERROR with the retry reason). A single clean request yields
+// none — the run span IS the one operation. Children are flat (same traceId, parentSpanId = the run
+// span), per the review's "flat, context-appropriate" choice: a paginated run shows pages, and a
+// per-page retry stays a span event on the run, not a nested span.
+function buildChildSpans(run: OtelSpan): OtelSpan[] {
+    const child = (
+        name: string,
+        startUnixMs: number,
+        endUnixMs: number,
+        attributes: SpanAttributes,
+        status: OtelSpan['status'],
+    ): OtelSpan => ({
+        name,
+        kind: 'CLIENT',
+        traceId: run.traceId,
+        spanId: hex(8),
+        parentSpanId: run.spanId,
+        startUnixMs,
+        endUnixMs,
+        attributes,
+        status,
+        events: [],
+    });
+
+    const pages = run.events.filter((e) => e.name === 'paginate');
+    if (pages.length > 0) {
+        let prev = run.startUnixMs;
+        return pages.map((p, i) => {
+            const span = child(
+                `page ${i + 1}`,
+                prev,
+                p.timeUnixMs,
+                { 'stitch.page': i + 1 },
+                { code: 'OK' }, // a page that emitted a paginate marker completed
+            );
+            prev = p.timeUnixMs;
+            return span;
+        });
+    }
+
+    const reqs = run.events.filter((e) => e.name === 'request');
+    if (reqs.length > 1) {
+        return reqs.map((r, i) => {
+            const next = reqs[i + 1];
+            const attempt = Number(r.attributes?.['stitch.attempt'] ?? i + 1);
+            // A non-final attempt was followed by another request → it failed and was retried;
+            // carry the retry reason. The final attempt's outcome IS the run's.
+            const retry = run.events.find(
+                (e) =>
+                    e.name === 'retry' &&
+                    e.timeUnixMs >= r.timeUnixMs &&
+                    (next === undefined || e.timeUnixMs <= next.timeUnixMs),
+            );
+            const detail = retry?.attributes?.['stitch.detail'];
+            const status: OtelSpan['status'] = next
+                ? {
+                      code: 'ERROR',
+                      ...(detail !== undefined
+                          ? { message: String(detail) }
+                          : {}),
+                  }
+                : run.status;
+            return child(
+                `attempt ${attempt}`,
+                r.timeUnixMs,
+                next ? next.timeUnixMs : run.endUnixMs,
+                { 'stitch.attempt': attempt },
+                status,
+            );
+        });
+    }
+    return [];
+}
+
 /**
  * A TraceSink that turns each stitch call's events (start → … → done) into a single OTel CLIENT
  * span, exported on `done`. Attributes follow the OTel HTTP semantic conventions
@@ -72,9 +150,9 @@ export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
         return stack?.[stack.length - 1];
     };
 
-    const emit = (span: OtelSpan): void => {
+    const emit = (spans: OtelSpan[]): void => {
         try {
-            const r = exporter.export([span]) as unknown;
+            const r = exporter.export(spans) as unknown;
             if (r instanceof Promise)
                 r.catch(() => {
                     /* swallow: an export failure must never break the stream */
@@ -187,7 +265,9 @@ export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
                     const span = open.get(key)?.pop();
                     if (span) {
                         span.endUnixMs = event.at;
-                        emit(span);
+                        // Export the run span PLUS its flat per-iteration child spans (attempts /
+                        // pages) so the operator's waterfall shows how each performed (ADR 0007).
+                        emit([span, ...buildChildSpans(span)]);
                     }
                     break;
                 }

--- a/packages/core/src/otlp.ts
+++ b/packages/core/src/otlp.ts
@@ -2,8 +2,8 @@
 // logical call, using OTel HTTP semantic-convention attributes, and hands finished spans to a
 // SpanExporter. The default exporter POSTs OTLP/JSON to a collector; tests inject a stub
 // exporter (no running collector). It is a normal TraceSink, so it tees alongside console/JSONL.
-import type { StitchEvent, TraceSink } from './types';
-import { readEnv, scrubUrl } from './util';
+import type { StitchEvent, TraceContext, TraceSink } from './types';
+import { hex, readEnv, scrubUrl } from './util';
 
 export type SpanAttributes = Record<string, string | number | boolean>;
 
@@ -18,6 +18,7 @@ export interface OtelSpan {
     kind: 'CLIENT';
     traceId: string; // 32 hex chars
     spanId: string; // 16 hex chars
+    parentSpanId?: string; // 16 hex chars — the spawning run's spanId (ADR 0007), absent for a root
     startUnixMs: number;
     endUnixMs: number;
     attributes: SpanAttributes;
@@ -36,18 +37,6 @@ export interface OtlpOptions {
     headers?: Record<string, string>; // extra headers for the OTLP POST (e.g. auth)
 }
 
-// Browser-safe random hex ids: crypto.getRandomValues where available, else Math.random
-// (ids only need to be unique-ish, not secret).
-function hex(bytes: number): string {
-    const buf = new Uint8Array(bytes);
-    const c = globalThis.crypto as Crypto | undefined;
-    if (c?.getRandomValues) c.getRandomValues(buf);
-    else
-        for (let i = 0; i < buf.length; i++)
-            buf[i] = Math.floor(Math.random() * 256);
-    return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
-}
-
 function serverAddress(url: string): string | undefined {
     try {
         return new URL(url).hostname;
@@ -61,7 +50,9 @@ function serverAddress(url: string): string | undefined {
  * span, exported on `done`. Attributes follow the OTel HTTP semantic conventions
  * (`http.request.method`, `url.full`, `server.address`, `http.response.status_code`,
  * `error.type`); a future LLM-kind stitch would map to the gen_ai.* conventions the same way.
- * Spans are correlated per stitch name (sequential calls keep 0–1 open; a stack tolerates nesting).
+ * Spans are correlated by the run id on the {@link TraceContext} ctx (ADR 0007) — a real
+ * `traceId`/`spanId`/`parentSpanId` tree — falling back to the stitch name (a tolerant stack) only
+ * when a sink is fed events by hand without ids (e.g. synthetic test events).
  */
 export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
     const exporter =
@@ -94,8 +85,11 @@ export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
     };
 
     return {
-        handle(event: StitchEvent, ctx: { name: string }): void {
+        handle(event: StitchEvent, ctx: TraceContext): void {
             const name = ctx.name;
+            // Correlate by run id (ADR 0007) — each run is unique, so no name-stack is needed;
+            // fall back to the name when a sink is fed events by hand without ids.
+            const key = ctx.runId ?? name;
             switch (event.type) {
                 case 'start': {
                     // url.full is OTLP's only secret-bearing attribute (it never exports
@@ -106,11 +100,16 @@ export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
                     };
                     const host = serverAddress(event.url);
                     if (host) attributes['server.address'] = host;
-                    push(name, {
+                    push(key, {
                         name: `${event.method} ${name}`,
                         kind: 'CLIENT',
-                        traceId: hex(16),
-                        spanId: hex(8),
+                        // Read the engine-minted ids off the ctx (real trace tree); fall back to
+                        // freshly-minted ids for a hand-fed sink with no run identity.
+                        traceId: ctx.traceId ?? hex(16),
+                        spanId: ctx.runId ?? hex(8),
+                        ...(ctx.parentId !== undefined
+                            ? { parentSpanId: ctx.parentId }
+                            : {}),
                         startUnixMs: event.at,
                         endUnixMs: event.at,
                         attributes,
@@ -120,7 +119,7 @@ export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
                     break;
                 }
                 case 'progress': {
-                    top(name)?.events.push({
+                    top(key)?.events.push({
                         name: event.phase,
                         timeUnixMs: event.at,
                         attributes: {
@@ -136,7 +135,7 @@ export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
                     break;
                 }
                 case 'info': {
-                    top(name)?.events.push({
+                    top(key)?.events.push({
                         name: `info:${event.topic}`,
                         timeUnixMs: event.at,
                         attributes: {
@@ -149,7 +148,7 @@ export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
                     break;
                 }
                 case 'drift': {
-                    top(name)?.events.push({
+                    top(key)?.events.push({
                         name: 'drift',
                         timeUnixMs: event.at,
                         attributes: {
@@ -161,7 +160,7 @@ export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
                     break;
                 }
                 case 'result': {
-                    const span = top(name);
+                    const span = top(key);
                     if (span) {
                         span.attributes['http.response.status_code'] =
                             event.status;
@@ -171,7 +170,7 @@ export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
                     break;
                 }
                 case 'error': {
-                    const span = top(name);
+                    const span = top(key);
                     if (span) {
                         if (event.status != null)
                             span.attributes['http.response.status_code'] =
@@ -185,7 +184,7 @@ export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
                     break;
                 }
                 case 'done': {
-                    const span = open.get(name)?.pop();
+                    const span = open.get(key)?.pop();
                     if (span) {
                         span.endUnixMs = event.at;
                         emit(span);
@@ -234,6 +233,9 @@ export function toOtlpJson(spans: OtelSpan[]): unknown {
                         spans: spans.map((s) => ({
                             traceId: s.traceId,
                             spanId: s.spanId,
+                            ...(s.parentSpanId
+                                ? { parentSpanId: s.parentSpanId }
+                                : {}),
                             name: s.name,
                             kind: SPAN_KIND_CLIENT,
                             startTimeUnixNano: toNano(s.startUnixMs),

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -9,6 +9,7 @@ import {
     cacheKeyOf,
     execute,
     executeRaw,
+    executeRawTraced,
     makeRuntime,
 } from './engine';
 import type { InferOutput, InputOf, ResolveOutput } from './infer';
@@ -491,6 +492,10 @@ export function makeStitch<T = unknown>(
 
     const stitchFn = result as unknown as Stitch<T> & {
         __raw: (input?: StitchInput) => Promise<unknown>;
+        __rawTraced: (
+            input: StitchInput | undefined,
+            parent: RunContext,
+        ) => Promise<unknown>;
     };
     stitchFn.stream = streamFn;
     stitchFn.safe = (input?: StitchInput) => consumeSafe<T>(streamFn(input));
@@ -500,6 +505,10 @@ export function makeStitch<T = unknown>(
         const bound = ((input?: StitchInput) =>
             result(mergeInput(partial, input))) as unknown as Stitch<T> & {
             __raw: (input?: StitchInput) => Promise<unknown>;
+            __rawTraced: (
+                input: StitchInput | undefined,
+                parent: RunContext,
+            ) => Promise<unknown>;
         };
         bound.stream = (input?: StitchInput) =>
             streamFn(mergeInput(partial, input));
@@ -511,11 +520,22 @@ export function makeStitch<T = unknown>(
             stitchFn.with(mergeInput(partial, more));
         bound.__raw = (input?: StitchInput) =>
             executeRaw(rt, mergeInput(partial, input));
+        bound.__rawTraced = (input, parent) =>
+            executeRawTraced(
+                rt,
+                mergeInput(partial, input),
+                rt.trace,
+                newRunContext(parent),
+            );
         attachMeta(bound, cfg);
         attachCacheSurface(bound, rt, (input) => mergeInput(partial, input));
         return bound;
     };
     stitchFn.__raw = (input?: StitchInput) => executeRaw(rt, input ?? {});
+    // Traced login child-run (ADR 0007): cookieSession reaches this to run its login under the
+    // caller's run. `newRunContext(parent)` inherits the parent's traceId + sets parentId.
+    stitchFn.__rawTraced = (input, parent) =>
+        executeRawTraced(rt, input ?? {}, rt.trace, newRunContext(parent));
     attachMeta(stitchFn, cfg);
     attachCacheSurface(stitchFn, rt, (input) => input ?? {});
     // A seam records the stitches it created (registry/lifecycle); standalone stitches don't register.

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -23,6 +23,7 @@ import {
     type HookContext,
     type Hooks,
     type InputSchemas,
+    type RunContext,
     type SafeResult,
     type SecurityScheme,
     type Stitch,
@@ -35,7 +36,7 @@ import {
     type TraceSink,
     isStitch,
 } from './types';
-import { deepMerge, readEnv } from './util';
+import { deepMerge, newRunContext, readEnv } from './util';
 import { type Validator, toValidator } from './validator';
 
 export type Fragment = Partial<StitchConfig> | Stitch | string;
@@ -318,10 +319,20 @@ function tee<T>(
     gen: AsyncGenerator<StitchEvent<T>, void>,
     trace: TraceSink,
     name: string,
+    run: RunContext,
 ): AsyncGenerator<StitchEvent<T>, void> {
+    // Run identity (ADR 0007) is per-run-constant, so build the ctx once and hand it to the
+    // sink with every event — the OTLP sink and the playground DAG collector read it to build
+    // the span tree; a sink that reads only `ctx.name` is unaffected.
+    const ctx = {
+        name,
+        runId: run.runId,
+        traceId: run.traceId,
+        ...(run.parentId !== undefined ? { parentId: run.parentId } : {}),
+    };
     async function* wrapped() {
         for await (const ev of gen) {
-            trace.handle(ev, { name });
+            trace.handle(ev, ctx);
             yield ev;
         }
     }
@@ -435,8 +446,17 @@ export function makeStitch<T = unknown>(
     const rt: Runtime = makeRuntime(cfg, throttle, trace, store, rtOpts);
     const name = cfg.name ?? cfg.path ?? 'stitch';
 
-    const streamFn = (input?: StitchInput) =>
-        tee<T>(execute(rt, input ?? {}) as never, rt.trace, name);
+    // One run per consumption (ADR 0007): mint the identity here so `tee`'s sink ctx and the
+    // engine's `start` event share it. Each `.stream()` / awaited call is its own run.
+    const streamFn = (input?: StitchInput) => {
+        const run = newRunContext();
+        return tee<T>(
+            execute(rt, input ?? {}, run) as never,
+            rt.trace,
+            name,
+            run,
+        );
+    };
 
     const result = (input?: StitchInput): StitchResult<T> => {
         const make = () => streamFn(input);

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -1,6 +1,6 @@
 // Zero-infra observability sink: append every StitchEvent as a JSONL record and,
 // optionally, print a compact colored one-line-per-event summary to stderr. No deps.
-import type { DriftLevel, StitchEvent, TraceSink } from './types';
+import type { DriftLevel, StitchEvent, TraceContext, TraceSink } from './types';
 import { dirnameOf, isSecretQueryKey, nodeFs, readEnv, scrubUrl } from './util';
 
 export interface TraceOptions {
@@ -213,7 +213,7 @@ export interface LoggerSinkOptions {
      */
     level?: (
         event: StitchEvent,
-        ctx: { name: string },
+        ctx: TraceContext,
     ) => LogLevel | null | undefined;
     /**
      * Override the payload-free one-liner. Return the message to log, or `null` to skip the event.
@@ -223,7 +223,7 @@ export interface LoggerSinkOptions {
      * log only metadata, never a header/body/chunk value or `JSON.stringify(event)`. `delta` is
      * dropped before this runs.
      */
-    format?: (event: StitchEvent, ctx: { name: string }) => string | null;
+    format?: (event: StitchEvent, ctx: TraceContext) => string | null;
 }
 
 // The DEFAULT event-type → level mapping (drift is resolved per-finding at call time, and
@@ -314,7 +314,7 @@ export function loggerSink(
     const resolveLevel = opts?.level;
     const format = opts?.format;
     return {
-        handle(event: StitchEvent, ctx: { name: string }): void {
+        handle(event: StitchEvent, ctx: TraceContext): void {
             // A streamed chunk is raw response data — never logged, regardless of any option.
             if (event.type === 'delta') return;
             // Per-instance resolver wins (null ⇒ drop, undefined ⇒ defer); else per-type
@@ -379,7 +379,7 @@ export function createTrace(
 
     return {
         path,
-        handle(event: StitchEvent, ctx: { name: string }): void {
+        handle(event: StitchEvent, ctx: TraceContext): void {
             if (fs && path) {
                 if (!dirReady) {
                     fs.mkdirSync(dirnameOf(path), { recursive: true });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -308,6 +308,12 @@ export interface AuthContext {
      */
     principal?: string;
     /**
+     * The current run (ADR 0007), threaded per-call by the engine. A strategy that spawns a
+     * sub-call — `cookieSession`'s login — runs it as a CHILD of this run so it appears in the
+     * trace/span tree under the call that triggered it. `undefined` outside a traced run.
+     */
+    run?: RunContext;
+    /**
      * Announce an `info` StitchEvent onto the run's event stream — a strategy reporting a
      * decision it made (e.g. which env var a `bearer` token resolved from via `optionalEnv`, or
      * that `oauth2` fetched a token). NEVER carries the secret itself. The engine buffers these

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -385,6 +385,12 @@ export type StitchEvent<T = unknown> =
           url: string;
           input: StitchInput;
           at: number;
+          // Run identity (ADR 0007) — also delivered on the {@link TraceContext} ctx. Stamped
+          // here too so a non-sink `.stream()` consumer can read a run's identity off its first
+          // event. Optional: a `start` event built by hand (tests) may omit them.
+          runId?: string;
+          traceId?: string;
+          parentId?: string;
       }
     | {
           type: 'progress';
@@ -699,9 +705,38 @@ export function isSeam(x: unknown): x is Seam {
     );
 }
 
+// ---- Run identity (ADR 0007) ----------------------------------------------
+/**
+ * OTLP-aligned identity for one logical call ({@link Stitch} run) and its place in a run
+ * tree. `runId` is the OTel **spanId**; `traceId` is shared across a whole tree; `parentId`
+ * (the OTel **parentSpanId**) is set when one run spawns another — a `cookieSession` login,
+ * a `pipe()` step. Minted by the engine (`newRunContext`), never supplied by a caller.
+ */
+export interface RunContext {
+    /** 32-hex trace id, shared across every run in a tree. */
+    traceId: string;
+    /** 16-hex id for this run (the OTel spanId). */
+    runId: string;
+    /** The spawning run's `runId` (OTel parentSpanId); absent for a root run. */
+    parentId?: string;
+}
+
+/**
+ * The per-run metadata a {@link TraceSink} receives alongside every event: the stitch
+ * `name` plus the run identity (ADR 0007). The id fields are present for every
+ * engine-driven run, but **optional** so a sink fed events by hand (tests, custom
+ * pipelines) can still pass just `{ name }`; a sink reading only `ctx.name` is unchanged.
+ */
+export interface TraceContext {
+    name: string;
+    runId?: string;
+    traceId?: string;
+    parentId?: string;
+}
+
 // A trace sink consumes every event a stitch emits.
 export interface TraceSink {
-    handle(event: StitchEvent, ctx: { name: string }): void;
+    handle(event: StitchEvent, ctx: TraceContext): void;
     flush?(): void | Promise<void>;
 }
 

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -1,6 +1,40 @@
 // Small dependency-free helpers shared across the prototype.
+import type { RunContext } from './types';
 
 export const now = (): number => Date.now();
+
+// ---- run identity (ADR 0007) ----------------------------------------------
+// Browser-safe random hex ids for the OTLP-aligned span tree: crypto.getRandomValues
+// where available, else Math.random (ids need to be unique-ish, not secret). 16 bytes
+// → a 32-hex traceId, 8 bytes → a 16-hex spanId/runId. The lone minter, shared by the
+// engine (run identity) and the OTLP sink (its fallback when fed events by hand).
+export function hex(bytes: number): string {
+    const buf = new Uint8Array(bytes);
+    const c = globalThis.crypto as Crypto | undefined;
+    if (c?.getRandomValues) c.getRandomValues(buf);
+    else
+        for (let i = 0; i < buf.length; i++)
+            buf[i] = Math.floor(Math.random() * 256);
+    return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Mint a {@link RunContext} for one logical call (ADR 0007). A root run gets a fresh
+ * 32-hex `traceId` and a 16-hex `runId`; a child run (a `cookieSession` login, a `pipe()`
+ * step) passes its caller's context to **inherit** the `traceId` and set `parentId` to the
+ * caller's `runId`, so runs form one OTLP span tree. Ids are engine-minted, never supplied
+ * by a caller (a caller-named id would spoof correlation — ADR 0002 §2 reasoning).
+ */
+export function newRunContext(parent?: {
+    traceId: string;
+    runId: string;
+}): RunContext {
+    return {
+        traceId: parent?.traceId ?? hex(16),
+        runId: hex(8),
+        ...(parent ? { parentId: parent.runId } : {}),
+    };
+}
 
 export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
     return new Promise((resolve, reject) => {

--- a/packages/core/test/run-identity.spec.ts
+++ b/packages/core/test/run-identity.spec.ts
@@ -3,7 +3,13 @@
 // The OTLP sink reads them to build a real span tree (shared traceId, parentSpanId) instead of
 // minting per-start and guessing by name; a child run inherits the parent's traceId and points
 // parentId at the parent's runId. Ids are engine-minted, never caller-supplied (ADR 0002 §2).
-import { multiplex, otlpTrace, stitch, toOtlpJson } from '../src';
+import {
+    cookieSession,
+    multiplex,
+    otlpTrace,
+    stitch,
+    toOtlpJson,
+} from '../src';
 import type {
     OtelSpan,
     SpanExporter,
@@ -213,4 +219,49 @@ test('a hand-fed OTLP sink (no ctx ids) still mints a valid span — back-compat
     expect(spans[0]!.traceId).toMatch(/^[0-9a-f]{32}$/);
     expect(spans[0]!.spanId).toMatch(/^[0-9a-f]{16}$/);
     expect(spans[0]!.parentSpanId).toBeUndefined();
+});
+
+test('cookieSession runs its login as a traced CHILD of the call that triggered it', async () => {
+    server.route('POST', '/login', {
+        setCookie: { name: 'sid', value: 'GOOD' },
+        body: { ok: true },
+    });
+    server.route('GET', '/me', {
+        requireCookie: { name: 'sid' },
+        body: { user: 'ada' },
+    });
+    // login + member share ONE sink (as seam members would), so the capturing sink sees both runs.
+    const { sink, seen } = capturingSink();
+    const signIn = stitch({
+        name: 'login',
+        method: 'POST',
+        baseUrl: server.url,
+        path: '/login',
+        trace: sink,
+    });
+    const me = stitch({
+        name: 'me',
+        baseUrl: server.url,
+        path: '/me',
+        trace: sink,
+        auth: cookieSession({ login: signIn, cookie: 'sid', scope: 'app' }),
+    });
+
+    await expect(me()).resolves.toEqual({ user: 'ada' });
+
+    const meStart = seen.find(
+        (s) => s.ctx.name === 'me' && s.ev.type === 'start',
+    )!;
+    const loginStart = seen.find(
+        (s) => s.ctx.name === 'login' && s.ev.type === 'start',
+    );
+    // The login is no longer an invisible side-call: it is a child run under the `me` call.
+    expect(loginStart).toBeDefined();
+    expect(loginStart!.ctx.parentId).toBe(meStart.ctx.runId); // parent = the triggering run
+    expect(loginStart!.ctx.traceId).toBe(meStart.ctx.traceId); // one trace tree
+    expect(loginStart!.ctx.runId).not.toBe(meStart.ctx.runId); // its own span
+    // …and the child run opens AND closes (start → done), so its span is complete.
+    expect(
+        seen.some((s) => s.ctx.name === 'login' && s.ev.type === 'done'),
+    ).toBe(true);
 });

--- a/packages/core/test/run-identity.spec.ts
+++ b/packages/core/test/run-identity.spec.ts
@@ -265,3 +265,58 @@ test('cookieSession runs its login as a traced CHILD of the call that triggered 
         seen.some((s) => s.ctx.name === 'login' && s.ev.type === 'done'),
     ).toBe(true);
 });
+
+test('OTLP: a retried call emits flat per-attempt child spans parented to the run', async () => {
+    server.route('GET', '/flaky', { statuses: [503, 200], body: { ok: true } });
+    const { exporter, spans } = stubExporter();
+    const flaky = stitch({
+        name: 'flaky',
+        baseUrl: server.url,
+        path: '/flaky',
+        retry: { attempts: 3, on: [503], backoff: 'fixed', baseMs: 1 },
+        trace: otlpTrace({ exporter }),
+    });
+
+    await flaky();
+
+    const run = spans.find((s) => s.parentSpanId === undefined)!;
+    const attempts = spans.filter((s) => s.name.startsWith('attempt '));
+    expect(attempts).toHaveLength(2); // 503, then 200
+    // Flat children of the run span — same trace, parented to the run, not nested in each other.
+    expect(
+        attempts.every(
+            (a) => a.parentSpanId === run.spanId && a.traceId === run.traceId,
+        ),
+    ).toBe(true);
+    // The first attempt failed and was retried; the second is the run's successful outcome.
+    expect(attempts[0]!.status.code).toBe('ERROR');
+    expect(attempts[1]!.status.code).toBe('OK');
+});
+
+test('OTLP: a paginated call emits flat per-page child spans parented to the run', async () => {
+    server.route('GET', '/list', { body: [1, 2] });
+    const { exporter, spans } = stubExporter();
+    const list = stitch({
+        name: 'list',
+        baseUrl: server.url,
+        path: '/list',
+        paginate: {
+            next: (_body, page) =>
+                page < 3 ? { query: { page: page + 1 } } : undefined,
+        },
+        trace: otlpTrace({ exporter }),
+    });
+
+    await list();
+
+    const run = spans.find((s) => s.parentSpanId === undefined)!;
+    const pages = spans.filter((s) => s.name.startsWith('page '));
+    expect(pages).toHaveLength(3);
+    expect(
+        pages.every(
+            (p) => p.parentSpanId === run.spanId && p.traceId === run.traceId,
+        ),
+    ).toBe(true);
+    // A non-paginated path would have produced `attempt` children — a paginated one shows pages.
+    expect(spans.some((s) => s.name.startsWith('attempt '))).toBe(false);
+});

--- a/packages/core/test/run-identity.spec.ts
+++ b/packages/core/test/run-identity.spec.ts
@@ -1,0 +1,216 @@
+// Run identity (ADR 0007): each execute() mints an OTLP-aligned runId (=spanId) + traceId,
+// stamped on the `start` event and carried on the TraceSink ctx for EVERY event of the run.
+// The OTLP sink reads them to build a real span tree (shared traceId, parentSpanId) instead of
+// minting per-start and guessing by name; a child run inherits the parent's traceId and points
+// parentId at the parent's runId. Ids are engine-minted, never caller-supplied (ADR 0002 §2).
+import { multiplex, otlpTrace, stitch, toOtlpJson } from '../src';
+import type {
+    OtelSpan,
+    SpanExporter,
+    StitchEvent,
+    TraceContext,
+    TraceSink,
+} from '../src';
+import { newRunContext } from '../src/util';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+type StartEvent = Extract<StitchEvent, { type: 'start' }>;
+
+// A sink that records every (event, ctx) pair, so a test can assert what identity the engine
+// stamps and that it is constant across a run.
+function capturingSink(): {
+    sink: TraceSink;
+    seen: { ev: StitchEvent; ctx: TraceContext }[];
+} {
+    const seen: { ev: StitchEvent; ctx: TraceContext }[] = [];
+    return {
+        seen,
+        sink: {
+            handle(ev, ctx) {
+                // Snapshot the ctx — the engine reuses one object per run, so copy it.
+                seen.push({ ev, ctx: { ...ctx } });
+            },
+        },
+    };
+}
+
+function stubExporter(): { exporter: SpanExporter; spans: OtelSpan[] } {
+    const spans: OtelSpan[] = [];
+    return {
+        spans,
+        exporter: { export: (batch) => void spans.push(...batch) },
+    };
+}
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+test('a call stamps OTLP-aligned run identity on `start` and shares it across the run', async () => {
+    server.route('GET', '/thing', { body: { ok: true } });
+    const { sink, seen } = capturingSink();
+    const thing = stitch({
+        name: 'thing',
+        baseUrl: server.url,
+        path: '/thing',
+        trace: sink,
+    });
+
+    for await (const _ev of thing.stream()) void _ev; // drain
+
+    const start = seen.find((s) => s.ev.type === 'start')!.ev as StartEvent;
+    expect(start.runId).toMatch(/^[0-9a-f]{16}$/); // = OTel spanId
+    expect(start.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(start.parentId).toBeUndefined(); // a root run
+
+    // EVERY event of the run carries the SAME identity on the ctx (it is per-run-constant).
+    expect(new Set(seen.map((s) => s.ctx.runId))).toEqual(
+        new Set([start.runId]),
+    );
+    expect(new Set(seen.map((s) => s.ctx.traceId))).toEqual(
+        new Set([start.traceId]),
+    );
+    expect(seen.every((s) => s.ctx.parentId === undefined)).toBe(true);
+});
+
+test('each call of one stitch is its own run with a distinct id', async () => {
+    server.route('GET', '/thing', { body: { ok: true } });
+    const { sink, seen } = capturingSink();
+    const thing = stitch({
+        name: 'thing',
+        baseUrl: server.url,
+        path: '/thing',
+        trace: sink,
+    });
+
+    await thing();
+    await thing();
+
+    const runIds = [
+        ...new Set(
+            seen.filter((s) => s.ev.type === 'start').map((s) => s.ctx.runId),
+        ),
+    ];
+    expect(runIds).toHaveLength(2);
+    expect(runIds[0]).not.toBe(runIds[1]);
+});
+
+test('newRunContext: a root mints fresh ids; a child inherits traceId and sets parentId', () => {
+    const root = newRunContext();
+    expect(root.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(root.runId).toMatch(/^[0-9a-f]{16}$/);
+    expect(root.parentId).toBeUndefined();
+
+    const child = newRunContext(root);
+    expect(child.traceId).toBe(root.traceId); // same tree
+    expect(child.runId).not.toBe(root.runId); // its own span
+    expect(child.parentId).toBe(root.runId); // linked to the parent
+});
+
+test('the OTLP sink builds a span tree from the ctx ids (traceId / spanId / parentSpanId)', () => {
+    const { exporter, spans } = stubExporter();
+    const sink = otlpTrace({ exporter });
+    const parent = newRunContext();
+    const child = newRunContext(parent); // shares traceId, parentId = parent.runId
+
+    const emit = (name: string, run: typeof parent) => {
+        const ctx: TraceContext = { name, ...run };
+        sink.handle(
+            {
+                type: 'start',
+                name,
+                method: 'GET',
+                url: 'http://api.example.com/x',
+                input: {},
+                at: 1,
+            },
+            ctx,
+        );
+        sink.handle(
+            { type: 'result', value: {}, status: 200, attempts: 1, at: 2 },
+            ctx,
+        );
+        sink.handle({ type: 'done', ok: true, ms: 1, attempts: 1, at: 2 }, ctx);
+    };
+    emit('parentCall', parent);
+    emit('childCall', child);
+
+    expect(spans).toHaveLength(2);
+    const ps = spans.find((s) => s.name.includes('parentCall'))!;
+    const cs = spans.find((s) => s.name.includes('childCall'))!;
+    expect(ps.traceId).toBe(parent.traceId);
+    expect(ps.spanId).toBe(parent.runId);
+    expect(ps.parentSpanId).toBeUndefined();
+    expect(cs.traceId).toBe(parent.traceId); // one tree
+    expect(cs.spanId).toBe(child.runId);
+    expect(cs.parentSpanId).toBe(parent.runId); // linked to its parent
+
+    // …and parentSpanId is serialised onto the child span only.
+    const out = toOtlpJson(spans) as {
+        resourceSpans: {
+            scopeSpans: {
+                spans: { spanId: string; parentSpanId?: string }[];
+            }[];
+        }[];
+    };
+    const outSpans = out.resourceSpans[0]!.scopeSpans[0]!.spans;
+    expect(outSpans.find((s) => s.spanId === child.runId)!.parentSpanId).toBe(
+        parent.runId,
+    );
+    expect(
+        outSpans.find((s) => s.spanId === parent.runId)!.parentSpanId,
+    ).toBeUndefined();
+});
+
+test('end-to-end: a real call feeds the OTLP sink the same ids it stamped on `start`', async () => {
+    server.route('GET', '/ping', { body: { ok: true } });
+    const { exporter, spans } = stubExporter();
+    const { sink: cap, seen } = capturingSink();
+    const ping = stitch({
+        name: 'ping',
+        baseUrl: server.url,
+        path: '/ping',
+        trace: multiplex(cap, otlpTrace({ exporter })),
+    });
+
+    await ping();
+
+    const start = seen.find((s) => s.ev.type === 'start')!.ev as StartEvent;
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.traceId).toBe(start.traceId);
+    expect(spans[0]!.spanId).toBe(start.runId); // the span IS the run
+});
+
+test('a hand-fed OTLP sink (no ctx ids) still mints a valid span — back-compat', () => {
+    const { exporter, spans } = stubExporter();
+    const sink = otlpTrace({ exporter });
+    const name = 'legacy';
+    sink.handle(
+        {
+            type: 'start',
+            name,
+            method: 'GET',
+            url: 'http://api.example.com/x',
+            input: {},
+            at: 1,
+        },
+        { name }, // no runId/traceId — the fallback path
+    );
+    sink.handle(
+        { type: 'done', ok: true, ms: 1, attempts: 1, at: 2 },
+        { name },
+    );
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(spans[0]!.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(spans[0]!.parentSpanId).toBeUndefined();
+});


### PR DESCRIPTION
Implements **ADR 0007** (#5a) — composition causality. Turns the flat per-call event stream into an OTLP-aligned **span tree**, so traces show real runtime causality and the playground DAG's `dependsOn` edges finally populate. The ADR is the first commit; the implementation follows in three reviewable commits.

## What it does

- **Run identity.** Every `execute()` mints a `runId` (= OTel spanId) + `traceId`, carried on the `TraceSink` ctx for every event (and stamped on `start` for non-sink `.stream()` readers). Engine-minted, never caller-supplied (the ADR 0002 §2 anti-spoofing reasoning). Browser-safe `hex` minting, **no `AsyncLocalStorage`**.
- **OTLP span tree.** The OTLP sink reads the ctx ids — shared `traceId`, emitted `parentSpanId` — instead of minting per-`start` and guessing by name (with a fallback for hand-fed sinks).
- **Traced `cookieSession` login.** The login is no longer an invisible side-call: `executeRawTraced` runs it as a **child run** (`parentId` = the triggering call), status-only result so the sensitive login body never enters a trace.
- **DAG edges + counts.** The playground collector keys entries by `runId` (interleaved child runs attribute exactly — the old FIFO would mis-attribute) and fills `dependsOn` from `parentId`. Run nodes are annotated with attempt/page **counts**.
- **Flat per-iteration child spans.** The OTLP waterfall shows one `attempt N` child per retry (non-final ones ERROR with the retry reason) **or** one `page N` child per paginated page — derived from the engine's existing `request`/`paginate` progress markers, so **no engine change**. Flat & context-appropriate (the reviewed choice): a paginated run shows pages; a per-page retry stays a span event, not a nested span.

## Resolved review decisions (from the ADR thread)

- **Q1** — identity on the sink **ctx + `start`** (not every event: per-event bloats the `delta` hot path and adds nothing to OTLP, which builds the tree from ctx).
- **Q2** — retries **and** pages are consistent intra-run sub-spans, both with per-iteration timing/status.
- **Q3** — the `cookieSession` login is traced as a child run.
- **Q4** — runtime causality only; the static `extends` graph stays out of scope.
- Sub-span shape: **flat, context-appropriate** (not nested).

## Tests & gates

- **543 core tests** (`test/run-identity.spec.ts`: run identity, the login child-run, the OTLP span tree, flat per-attempt/page sub-spans, hand-fed back-compat) + **11 sandbox suites** (A2 collector reworked to run-id keying, an interleaved-child `dependsOn` proof, count-annotation proofs).
- `check:types` / `check:lint` / `check:types-d` clean; additive only — every existing sink that reads just `ctx.name` is unchanged.
- Gates: **browser-first** (crypto/Math.random ids, no ALS), **bundle-frugal** (ctx widening + a `RunContext`; the tree assembly lives in the opt-in OTLP sink / out-of-core collector), **contract-not-dependency** (the ids are JSON-serialisable strings on the ctx).

Unblocks #7 (`pipe()` child runs, [ADR 0008](https://github.com/rejifald/StitchAPI/pull/164)) and PR #94's trace DAG.