### PR TITLE
feat: non-HTTP surfaces (execute/llm/shell) + pipe() composition (ADR 0008)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -148,6 +148,34 @@
                 "default": "./lib/download.js"
             }
         },
+        "./llm": {
+            "browser": {
+                "types": "./lib/llm.d.mts",
+                "default": "./lib/llm.mjs"
+            },
+            "import": {
+                "types": "./lib/llm.d.mts",
+                "default": "./lib/llm.mjs"
+            },
+            "require": {
+                "types": "./lib/llm.d.ts",
+                "default": "./lib/llm.js"
+            }
+        },
+        "./pipe": {
+            "browser": {
+                "types": "./lib/pipe.d.mts",
+                "default": "./lib/pipe.mjs"
+            },
+            "import": {
+                "types": "./lib/pipe.d.mts",
+                "default": "./lib/pipe.mjs"
+            },
+            "require": {
+                "types": "./lib/pipe.d.ts",
+                "default": "./lib/pipe.js"
+            }
+        },
         "./xhr": {
             "browser": {
                 "types": "./lib/xhr-adapter.d.mts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "stitchapi",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "description": "StitchAPI is a tool designed to seamlessly integrate (“stitch”) any JSON-based API into your project, simplifying the process of connecting and working with various APIs.",
     "main": "lib/index.js",
     "module": "lib/index.mjs",

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -195,9 +195,15 @@ function buildRequest(cfg: StitchConfig, input: StitchInput): AdapterRequest {
         buildQuery(query, cfg.arrayFormat),
     );
     // A relative endpoint can't be fetched by the default transport — fail with a clear config
-    // error here instead of a cryptic "Failed to parse URL" from fetch. A custom `adapter` may
-    // legitimately resolve relative URLs, so this only guards the default transport.
-    if (cfg.adapter === undefined && !/^https?:\/\//i.test(url)) {
+    // error here instead of a cryptic "Failed to parse URL" from fetch. A custom `adapter` OR a
+    // surface that replaces the transport (`cfg.kind.execute`, ADR 0008 — e.g. `shell`, whose
+    // "url" is a `shell:` pseudo-endpoint) may legitimately use a non-http URL, so this only
+    // guards the default HTTP transport.
+    if (
+        cfg.adapter === undefined &&
+        cfg.kind?.execute === undefined &&
+        !/^https?:\/\//i.test(url)
+    ) {
         // A relative `url` set alongside a `baseUrl` is the common footgun: `url` is the whole
         // endpoint and ignores `baseUrl`, so the base is never joined — they almost certainly
         // meant `path`. Point straight at that instead of the generic guidance.
@@ -554,10 +560,14 @@ async function* attemptLoop(
                           perAttemptMs ?? Infinity,
                           Math.max(0, budget.deadline - now()),
                       );
+            // A surface may REPLACE the transport (ADR 0008): `cfg.kind.execute` runs here instead
+            // of the HTTP adapter, still inside the resilience chain (retry/throttle/circuit/
+            // timeout/trace/auth all wrap it). Absent, the ordinary HTTP adapter runs.
+            const transport = cfg.kind?.execute ?? rt.adapter;
             let res: AdapterResponse;
             try {
                 res = await withTimeout(
-                    (signal) => rt.adapter({ ...req, signal }),
+                    (signal) => transport({ ...req, signal }),
                     attemptMs,
                     req.signal, // link a caller's AbortSignal (e.g. a download's) to this attempt
                 );
@@ -1057,7 +1067,9 @@ async function* runStreaming(
         if (cfg.auth) await cfg.auth.apply(req, rt.authCtx);
         await cfg.hooks?.onRequest?.({ name, attempt: 1, req });
         yield { type: 'progress', phase: 'request', attempt: 1, at: now() };
-        res = await rt.adapter(req);
+        // A surface that replaces the transport (ADR 0008) runs here too, so a future non-HTTP
+        // streaming surface gets the same treatment as the buffered path.
+        res = await (cfg.kind?.execute ?? rt.adapter)(req);
         await cfg.hooks?.onResponse?.({ name, attempt: 1, res });
     } catch (e) {
         await cfg.hooks?.onError?.({ name, attempt: 1, error: e });

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -4,10 +4,12 @@
 // mappings shipped as PLAIN CONFIG (no SDK dependency, the contract-not-dependency gate). BYO any
 // other provider by implementing the contract.
 //
-// `llm` carries NO `execute` hook: an LLM call IS http, so bearer/apiKey `auth`, `retry`,
-// `throttle`, and the `sse`/`stream` surfaces (token streaming) all apply for free — `llm` proves
-// the surface model from the buffered-HTTP side. Bundle-frugal: reached only through the `llm`
-// subpath; `import { stitch }` pulls in none of it.
+// `llm` carries NO `execute` hook: an LLM call IS http, so bearer/apiKey `auth`, `retry`, and
+// `throttle` all apply for free, and `llm` proves the surface model from the buffered-HTTP side.
+// (Token streaming is a follow-up: it needs a `stream` hook ON this surface, since `kind` is a
+// single slot the buffered llm surface already fills — the `sse`/`stream` surfaces don't compose
+// onto it yet.) Bundle-frugal: reached only through the `llm` subpath; `import { stitch }` pulls in
+// none of it.
 import { makeStitch } from './stitch';
 import type { Surface, SurfaceOutcome } from './surface';
 import type { Stitch, StitchConfig, StitchInput } from './types';
@@ -166,17 +168,29 @@ export const anthropic: LlmProvider = {
     endpoint: 'https://api.anthropic.com/v1/messages',
     headers: { 'anthropic-version': '2023-06-01' },
     defaultModel: 'claude-opus-4-8',
-    buildBody: (req) => ({
-        model: req.model,
-        max_tokens: req.maxTokens ?? 1024,
-        messages: req.messages
-            .filter((m) => m.role !== 'system')
-            .map((m) => ({ role: m.role, content: m.content })),
-        ...(req.system !== undefined ? { system: req.system } : {}),
-        ...(req.temperature !== undefined
-            ? { temperature: req.temperature }
-            : {}),
-    }),
+    buildBody: (req) => {
+        // Anthropic's `system` is a TOP-LEVEL param, not a message. Fold any system-role
+        // messages into it (after an explicit `req.system`) so a system prompt passed as a
+        // message — the natural shape for callers coming from the chat SDKs — is relocated to
+        // where the API wants it rather than silently dropped.
+        const system = [
+            ...(req.system !== undefined ? [req.system] : []),
+            ...req.messages
+                .filter((m) => m.role === 'system')
+                .map((m) => m.content),
+        ].join('\n\n');
+        return {
+            model: req.model,
+            max_tokens: req.maxTokens ?? 1024,
+            messages: req.messages
+                .filter((m) => m.role !== 'system')
+                .map((m) => ({ role: m.role, content: m.content })),
+            ...(system !== '' ? { system } : {}),
+            ...(req.temperature !== undefined
+                ? { temperature: req.temperature }
+                : {}),
+        };
+    },
     parse: (body) => {
         const b = body as {
             content?: { text?: string }[];

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -1,0 +1,254 @@
+// The `stitchapi/llm` surface subpath (ADR 0008): a preset over the **http** surface for LLM chat
+// completions. Contract-first — an {@link LlmProvider} maps a normalised request to a provider's
+// HTTP body and lifts a normalised {@link LlmResult} back out — with first-party Anthropic + OpenAI
+// mappings shipped as PLAIN CONFIG (no SDK dependency, the contract-not-dependency gate). BYO any
+// other provider by implementing the contract.
+//
+// `llm` carries NO `execute` hook: an LLM call IS http, so bearer/apiKey `auth`, `retry`,
+// `throttle`, and the `sse`/`stream` surfaces (token streaming) all apply for free — `llm` proves
+// the surface model from the buffered-HTTP side. Bundle-frugal: reached only through the `llm`
+// subpath; `import { stitch }` pulls in none of it.
+import { makeStitch } from './stitch';
+import type { Surface, SurfaceOutcome } from './surface';
+import type { Stitch, StitchConfig, StitchInput } from './types';
+
+/** A chat message in the normalised request. */
+export interface LlmMessage {
+    role: 'user' | 'assistant' | 'system';
+    content: string;
+}
+
+/** The normalised LLM request a provider maps to its wire body. */
+export interface LlmRequest {
+    model: string;
+    messages: LlmMessage[];
+    system?: string;
+    maxTokens?: number;
+    temperature?: number;
+}
+
+/** The normalised result a provider lifts out of its response. `raw` keeps the provider's full body. */
+export interface LlmResult {
+    text: string;
+    model?: string;
+    usage?: { inputTokens?: number; outputTokens?: number };
+    finishReason?: string;
+    raw: unknown;
+}
+
+/**
+ * The provider-mapping CONTRACT (ADR 0008) — the contract-not-dependency primitive for LLMs, the
+ * same shape the fingerprint contract and `axiosAdapter` follow. A provider declares its endpoint +
+ * non-secret headers, maps a {@link LlmRequest} to its HTTP body, and lifts an {@link LlmResult} out
+ * of the response. First-party {@link anthropic} / {@link openai} implement it; BYO any other by
+ * writing one. The CREDENTIAL is the stitch's `auth` (`bearer`/`apiKey`), never the provider.
+ */
+export interface LlmProvider {
+    id: string;
+    /** Completions endpoint — the default `url` when the config sets none. */
+    endpoint: string;
+    /** Non-secret default headers (e.g. an API version), merged UNDER the request headers. Never a credential. */
+    headers?: Record<string, string>;
+    /** Model used when neither the config nor the call sets one. */
+    defaultModel?: string;
+    /** Map the normalised request to the provider's HTTP request body. */
+    buildBody: (req: LlmRequest) => unknown;
+    /** Lift the normalised result out of the provider's response body. */
+    parse: (body: unknown) => LlmResult;
+}
+
+/** Per-stitch llm defaults baked into the surface (the call may override via `body`). */
+interface LlmDefaults {
+    provider: LlmProvider;
+    model?: string;
+    system?: string;
+    maxTokens?: number;
+    temperature?: number;
+}
+
+// Assemble the normalised request: the call's `body` (`{ messages, ...overrides }`) wins over the
+// llm config defaults, which win over the provider's `defaultModel`.
+function toRequest(d: LlmDefaults, input: StitchInput): LlmRequest {
+    const over = (input.body ?? {}) as Partial<LlmRequest>;
+    const model = over.model ?? d.model ?? d.provider.defaultModel;
+    if (model === undefined || model === '') {
+        const e = new Error(
+            'llm: a `model` is required — set it on `llm({ model })`, in the call `body`, or via the provider default.',
+        );
+        e.name = 'StitchConfigError';
+        throw e;
+    }
+    const req: LlmRequest = { model, messages: over.messages ?? [] };
+    const system = over.system ?? d.system;
+    if (system !== undefined) req.system = system;
+    const maxTokens = over.maxTokens ?? d.maxTokens;
+    if (maxTokens !== undefined) req.maxTokens = maxTokens;
+    const temperature = over.temperature ?? d.temperature;
+    if (temperature !== undefined) req.temperature = temperature;
+    return req;
+}
+
+// The llm surface for one provider + defaults: pack the request via `provider.buildBody` as a JSON
+// POST (provider headers under the user's), and `interpret` lifts the result via `provider.parse`.
+function llmSurface(d: LlmDefaults): Surface<StitchInput, LlmResult> {
+    const { provider } = d;
+    return {
+        id: 'llm',
+        buildRequest: (_cfg, input, base) => ({
+            ...base,
+            method: 'POST',
+            bodyType: 'json',
+            body: provider.buildBody(toRequest(d, input)),
+            headers: { ...(provider.headers ?? {}), ...base.headers },
+        }),
+        // The engine has already thrown on a non-2xx (unless `acceptStatus`), so `parse` sees a
+        // successful body. A provider's "200 with an error envelope" can be handled in its `parse`.
+        interpret: (res): SurfaceOutcome<LlmResult> => ({
+            ok: true,
+            value: provider.parse(res.body),
+        }),
+    };
+}
+
+/** Config for {@link llm}: the shared {@link StitchConfig} keys plus the llm defaults. */
+export type LlmConfig = Partial<StitchConfig> & {
+    provider: LlmProvider;
+    model?: string;
+    system?: string;
+    maxTokens?: number;
+    temperature?: number;
+};
+
+/**
+ * `llm({ provider, ... })` — a chat-completion stitch resolving to an {@link LlmResult}. The
+ * provider (and `model`/`system`/`maxTokens`/`temperature` defaults) bind to the surface; the call
+ * passes `{ body: { messages: [...] } }` (and may override the defaults). The endpoint defaults to
+ * the provider's. Bring the credential as the stitch's `auth` (`bearer(env(...))` for OpenAI,
+ * `apiKey({ name: 'x-api-key', ... })` for Anthropic).
+ *
+ * @example
+ * ```ts
+ * import { llm, anthropic } from 'stitchapi/llm';
+ * import { apiKey, env } from 'stitchapi';
+ *
+ * const chat = llm({
+ *     provider: anthropic,
+ *     model: 'claude-opus-4-8',
+ *     auth: apiKey({ name: 'x-api-key', value: env('ANTHROPIC_API_KEY') }),
+ * });
+ * const { text } = await chat({ body: { messages: [{ role: 'user', content: 'hi' }] } });
+ * ```
+ */
+export function llm(config: LlmConfig): Stitch<LlmResult> {
+    const { provider, model, system, maxTokens, temperature, ...rest } = config;
+    const defaults: LlmDefaults = { provider };
+    if (model !== undefined) defaults.model = model;
+    if (system !== undefined) defaults.system = system;
+    if (maxTokens !== undefined) defaults.maxTokens = maxTokens;
+    if (temperature !== undefined) defaults.temperature = temperature;
+    const endpointless = rest.url === undefined && rest.path === undefined;
+    return makeStitch<LlmResult>({
+        ...rest,
+        kind: llmSurface(defaults),
+        ...(endpointless ? { url: provider.endpoint } : {}),
+    });
+}
+
+// ---- first-party provider mappings (plain config — no SDK dependency) ------
+
+/**
+ * Anthropic Messages API (`/v1/messages`). System prompts ride the top-level `system` param (not a
+ * message), `max_tokens` is required (default 1024). Auth is the user's `apiKey({ name: 'x-api-key',
+ * … })`; this only sets the non-secret `anthropic-version`. Defaults to the current `claude-opus-4-8`.
+ */
+export const anthropic: LlmProvider = {
+    id: 'anthropic',
+    endpoint: 'https://api.anthropic.com/v1/messages',
+    headers: { 'anthropic-version': '2023-06-01' },
+    defaultModel: 'claude-opus-4-8',
+    buildBody: (req) => ({
+        model: req.model,
+        max_tokens: req.maxTokens ?? 1024,
+        messages: req.messages
+            .filter((m) => m.role !== 'system')
+            .map((m) => ({ role: m.role, content: m.content })),
+        ...(req.system !== undefined ? { system: req.system } : {}),
+        ...(req.temperature !== undefined
+            ? { temperature: req.temperature }
+            : {}),
+    }),
+    parse: (body) => {
+        const b = body as {
+            content?: { text?: string }[];
+            model?: string;
+            usage?: { input_tokens?: number; output_tokens?: number };
+            stop_reason?: string;
+        };
+        const result: LlmResult = {
+            text: (b.content ?? []).map((c) => c.text ?? '').join(''),
+            raw: body,
+        };
+        if (b.model !== undefined) result.model = b.model;
+        if (b.usage)
+            result.usage = {
+                ...(b.usage.input_tokens !== undefined
+                    ? { inputTokens: b.usage.input_tokens }
+                    : {}),
+                ...(b.usage.output_tokens !== undefined
+                    ? { outputTokens: b.usage.output_tokens }
+                    : {}),
+            };
+        if (b.stop_reason) result.finishReason = b.stop_reason;
+        return result;
+    },
+};
+
+/**
+ * OpenAI Chat Completions (`/v1/chat/completions`). A system prompt is prepended as a `system`
+ * message. Auth is the user's `bearer(env('OPENAI_API_KEY'))`. Defaults to `gpt-4o`.
+ */
+export const openai: LlmProvider = {
+    id: 'openai',
+    endpoint: 'https://api.openai.com/v1/chat/completions',
+    defaultModel: 'gpt-4o',
+    buildBody: (req) => ({
+        model: req.model,
+        messages: [
+            ...(req.system !== undefined
+                ? [{ role: 'system', content: req.system }]
+                : []),
+            ...req.messages.map((m) => ({ role: m.role, content: m.content })),
+        ],
+        ...(req.maxTokens !== undefined ? { max_tokens: req.maxTokens } : {}),
+        ...(req.temperature !== undefined
+            ? { temperature: req.temperature }
+            : {}),
+    }),
+    parse: (body) => {
+        const b = body as {
+            choices?: {
+                message?: { content?: string };
+                finish_reason?: string;
+            }[];
+            model?: string;
+            usage?: { prompt_tokens?: number; completion_tokens?: number };
+        };
+        const result: LlmResult = {
+            text: b.choices?.[0]?.message?.content ?? '',
+            raw: body,
+        };
+        if (b.model !== undefined) result.model = b.model;
+        if (b.usage)
+            result.usage = {
+                ...(b.usage.prompt_tokens !== undefined
+                    ? { inputTokens: b.usage.prompt_tokens }
+                    : {}),
+                ...(b.usage.completion_tokens !== undefined
+                    ? { outputTokens: b.usage.completion_tokens }
+                    : {}),
+            };
+        const fr = b.choices?.[0]?.finish_reason;
+        if (fr) result.finishReason = fr;
+        return result;
+    },
+};

--- a/packages/core/src/pipe.ts
+++ b/packages/core/src/pipe.ts
@@ -1,0 +1,79 @@
+// The `stitchapi/pipe` subpath (ADR 0008): linear composition. Run stitches in sequence, feeding
+// each result to the next, with each step a CHILD run of the prior (ADR 0007 run identity) — so a
+// trace shows the chain `stepA → stepB → stepC` and the playground DAG draws the same edges. The
+// step-to-step MAPPING is a closure (acknowledged sugar, the same category as `transform` /
+// `paginate.next`), while the STRUCTURE — the ordered member stitches — round-trips. Fail-fast: a
+// step's error rejects the pipeline. Bundle-frugal: reached only through the `pipe` subpath.
+import type { RunContext, Stitch, StitchInput } from './types';
+import { newRunContext } from './util';
+
+/** A pipe step: the stitch to run, and how to turn the previous result into its call input. */
+export interface PipeStep {
+    /** The stitch to run for this step. */
+    readonly stitch: Stitch;
+    /**
+     * Map the previous step's result to this step's call input (sugar; not serialised). Omitted ⇒
+     * the previous result is passed as the call `body`. The FIRST step receives the pipe's initial
+     * input directly and ignores this.
+     */
+    readonly input?: (prev: unknown) => StitchInput;
+}
+
+// The internal child-run invocation a stitch exposes (stitch.ts `__runWith`): run under a supplied
+// run identity and resolve to the value. Reached through a cast — it is not on the public Stitch.
+interface Runnable {
+    __runWith: (
+        input: StitchInput | undefined,
+        run: RunContext,
+    ) => Promise<unknown>;
+}
+
+const asStep = (s: PipeStep | Stitch): PipeStep =>
+    typeof s === 'function' ? { stitch: s } : s;
+
+/**
+ * Compose stitches into a linear pipeline. The returned callable takes the FIRST step's input; each
+ * later step receives the previous result through its `input` mapper (or the raw result as the call
+ * `body` when no mapper is given), and the pipeline resolves to the LAST step's result.
+ *
+ * Each step runs as a CHILD run of the previous (ADR 0007), so a trace/DAG shows the chain. Steps
+ * run sequentially and the pipeline FAILS FAST — a step's `StitchError` rejects the whole pipe.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from 'stitchapi/pipe';
+ *
+ * const flow = pipe(
+ *     fetchUser, // receives the pipe's input
+ *     { stitch: fetchPosts, input: (u) => ({ params: { userId: (u as User).id } }) },
+ * );
+ * const posts = await flow({ params: { id: 1 } });
+ * ```
+ */
+export function pipe<Out = unknown>(
+    ...steps: (PipeStep | Stitch)[]
+): (input?: StitchInput) => Promise<Out> {
+    const resolved = steps.map(asStep);
+    return async (input?: StitchInput): Promise<Out> => {
+        let value: unknown;
+        let prevRun: RunContext | undefined;
+        let first = true;
+        for (const step of resolved) {
+            const stepInput: StitchInput = first
+                ? (input ?? {})
+                : step.input
+                  ? step.input(value)
+                  : { body: value };
+            // Chain the run identity: step N is a child of step N-1 — the linear causality the
+            // trace/DAG draws. The first step (prevRun undefined) is a root run.
+            const run = newRunContext(prevRun);
+            value = await (step.stitch as unknown as Runnable).__runWith(
+                stepInput,
+                run,
+            );
+            prevRun = run;
+            first = false;
+        }
+        return value as Out;
+    };
+}

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -447,17 +447,13 @@ export function makeStitch<T = unknown>(
     const rt: Runtime = makeRuntime(cfg, throttle, trace, store, rtOpts);
     const name = cfg.name ?? cfg.path ?? 'stitch';
 
-    // One run per consumption (ADR 0007): mint the identity here so `tee`'s sink ctx and the
-    // engine's `start` event share it. Each `.stream()` / awaited call is its own run.
-    const streamFn = (input?: StitchInput) => {
-        const run = newRunContext();
-        return tee<T>(
-            execute(rt, input ?? {}, run) as never,
-            rt.trace,
-            name,
-            run,
-        );
-    };
+    // One traced run for `input` under a given run identity (ADR 0007). `streamFn` mints a fresh
+    // ROOT run per consumption; `pipe()` (stitchapi/pipe) supplies a CHILD run via `__runWith`, so a
+    // step joins the pipe's chain (its events tee with parentId set).
+    const streamWith = (input: StitchInput, run: RunContext) =>
+        tee<T>(execute(rt, input, run) as never, rt.trace, name, run);
+    const streamFn = (input?: StitchInput) =>
+        streamWith(input ?? {}, newRunContext());
 
     const result = (input?: StitchInput): StitchResult<T> => {
         const make = () => streamFn(input);
@@ -496,6 +492,10 @@ export function makeStitch<T = unknown>(
             input: StitchInput | undefined,
             parent: RunContext,
         ) => Promise<unknown>;
+        __runWith: (
+            input: StitchInput | undefined,
+            run: RunContext,
+        ) => Promise<unknown>;
     };
     stitchFn.stream = streamFn;
     stitchFn.safe = (input?: StitchInput) => consumeSafe<T>(streamFn(input));
@@ -508,6 +508,10 @@ export function makeStitch<T = unknown>(
             __rawTraced: (
                 input: StitchInput | undefined,
                 parent: RunContext,
+            ) => Promise<unknown>;
+            __runWith: (
+                input: StitchInput | undefined,
+                run: RunContext,
             ) => Promise<unknown>;
         };
         bound.stream = (input?: StitchInput) =>
@@ -527,6 +531,8 @@ export function makeStitch<T = unknown>(
                 rt.trace,
                 newRunContext(parent),
             );
+        bound.__runWith = (input, run) =>
+            consume<T>(streamWith(mergeInput(partial, input), run));
         attachMeta(bound, cfg);
         attachCacheSurface(bound, rt, (input) => mergeInput(partial, input));
         return bound;
@@ -536,6 +542,10 @@ export function makeStitch<T = unknown>(
     // caller's run. `newRunContext(parent)` inherits the parent's traceId + sets parentId.
     stitchFn.__rawTraced = (input, parent) =>
         executeRawTraced(rt, input ?? {}, rt.trace, newRunContext(parent));
+    // Run this stitch under a supplied run identity (ADR 0007) and resolve to its value — `pipe()`
+    // mints a chain of run contexts and threads each step's here, so a step is a child of the prior.
+    stitchFn.__runWith = (input, run) =>
+        consume<T>(streamWith(input ?? {}, run));
     attachMeta(stitchFn, cfg);
     attachCacheSurface(stitchFn, rt, (input) => input ?? {});
     // A seam records the stitches it created (registry/lifecycle); standalone stitches don't register.

--- a/packages/core/src/surface.ts
+++ b/packages/core/src/surface.ts
@@ -9,6 +9,7 @@
 // Stage 5 the streaming `stream` hook). Until then the engine keys its built-in graphql handling
 // on `kind.id`.
 import type {
+    Adapter,
     AdapterRequest,
     AdapterResponse,
     StitchConfig,
@@ -62,6 +63,17 @@ export interface Surface<TInput = StitchInput, TResult = unknown> {
      * describes the payload rather than the `{ event, data, id, retry }` envelope.
      */
     readonly contractValue?: (chunk: unknown) => unknown;
+    /**
+     * Replace the transport (ADR 0008): when present, the engine calls this INSTEAD of the HTTP
+     * adapter, at the same site inside the resilience chain — so `retry` / `throttle` / `circuit` /
+     * per-attempt `timeout` + `signal` / `trace` / `auth` / `hooks` all wrap it unchanged. A
+     * non-HTTP surface (`shell`, a custom transport) shapes its request in {@link Surface.buildRequest}
+     * (e.g. packing argv into `req.body`, the `graphql` precedent), runs it here, and returns an
+     * {@link AdapterResponse} that {@link Surface.interpret} maps to a value. It is the surface's own
+     * transport, bound to its identity — distinct from `StitchConfig.adapter` (the user's BYO HTTP
+     * client); a surface with `execute` ignores `adapter`. Omitted = an ordinary HTTP surface.
+     */
+    readonly execute?: Adapter;
     /** Phantom carrier so `stitch<S>` can recover a surface's call-argument type. Never read. */
     readonly __input?: (input: TInput) => void;
 }

--- a/packages/core/test/gaps/browser-bundle.spec.ts
+++ b/packages/core/test/gaps/browser-bundle.spec.ts
@@ -85,6 +85,8 @@ const BROWSER_LEGIT = [
     'src/sse.ts',
     'src/stream.ts',
     'src/download.ts',
+    'src/llm.ts',
+    'src/pipe.ts',
     'src/cache.ts',
     'src/fingerprint.ts',
     'src/xhr-adapter.ts',

--- a/packages/core/test/llm.spec.ts
+++ b/packages/core/test/llm.spec.ts
@@ -1,0 +1,120 @@
+// stitchapi/llm — the contract-first llm preset (ADR 0008 Stage B). A capturing adapter (no
+// network) proves each first-party provider maps the normalised request onto its wire body and
+// lifts the normalised result back out; `llm` is plain HTTP (no execute hook), so it rides the
+// ordinary engine path.
+import type { Adapter, AdapterRequest } from '../src';
+import { anthropic, llm, openai } from '../src/llm';
+import type { LlmProvider } from '../src/llm';
+
+function captureAdapter(response: unknown): {
+    adapter: Adapter;
+    calls: AdapterRequest[];
+} {
+    const calls: AdapterRequest[] = [];
+    return {
+        calls,
+        adapter: async (req) => {
+            calls.push(req);
+            return { status: 200, headers: {}, body: response };
+        },
+    };
+}
+
+test('anthropic: builds the Messages API body (system out of messages) and parses the result', async () => {
+    const { adapter, calls } = captureAdapter({
+        content: [{ text: 'hello' }],
+        model: 'claude-opus-4-8',
+        usage: { input_tokens: 5, output_tokens: 2 },
+        stop_reason: 'end_turn',
+    });
+    const chat = llm({
+        provider: anthropic,
+        model: 'claude-opus-4-8',
+        maxTokens: 256,
+        adapter,
+    });
+
+    const out = await chat({
+        body: {
+            system: 'be brief',
+            messages: [{ role: 'user', content: 'hi' }],
+        },
+    });
+
+    const body = calls[0]!.body as {
+        model: string;
+        max_tokens: number;
+        system?: string;
+        messages: unknown[];
+    };
+    expect(body.model).toBe('claude-opus-4-8');
+    expect(body.max_tokens).toBe(256);
+    expect(body.system).toBe('be brief'); // top-level param, NOT a message
+    expect(body.messages).toEqual([{ role: 'user', content: 'hi' }]);
+    expect(calls[0]!.headers['anthropic-version']).toBe('2023-06-01');
+    expect(calls[0]!.method).toBe('POST');
+    expect(calls[0]!.url).toBe('https://api.anthropic.com/v1/messages'); // default endpoint
+
+    expect(out).toMatchObject({
+        text: 'hello',
+        model: 'claude-opus-4-8',
+        usage: { inputTokens: 5, outputTokens: 2 },
+        finishReason: 'end_turn',
+    });
+});
+
+test('openai: builds the Chat Completions body (system prepended) and parses the result', async () => {
+    const { adapter, calls } = captureAdapter({
+        choices: [{ message: { content: 'hey' }, finish_reason: 'stop' }],
+        model: 'gpt-4o',
+        usage: { prompt_tokens: 7, completion_tokens: 3 },
+    });
+    const chat = llm({ provider: openai, adapter }); // no model → provider default
+
+    const out = await chat({
+        body: {
+            system: 'be brief',
+            messages: [{ role: 'user', content: 'hi' }],
+        },
+    });
+
+    const body = calls[0]!.body as { model: string; messages: unknown[] };
+    expect(body.model).toBe('gpt-4o'); // provider.defaultModel
+    expect(body.messages).toEqual([
+        { role: 'system', content: 'be brief' }, // prepended as a message
+        { role: 'user', content: 'hi' },
+    ]);
+    expect(calls[0]!.url).toBe('https://api.openai.com/v1/chat/completions');
+
+    expect(out).toMatchObject({
+        text: 'hey',
+        usage: { inputTokens: 7, outputTokens: 3 },
+        finishReason: 'stop',
+    });
+});
+
+test('llm requires a model (none on config, call, or provider default) — fail closed', async () => {
+    const { adapter } = captureAdapter({});
+    const bare: LlmProvider = {
+        id: 'bare',
+        endpoint: 'https://example.test/v1',
+        buildBody: anthropic.buildBody,
+        parse: anthropic.parse,
+    };
+    const chat = llm({ provider: bare, adapter });
+
+    await expect(chat({ body: { messages: [] } })).rejects.toThrow(/model/);
+});
+
+test('llm honours an explicit endpoint over the provider default', async () => {
+    const { adapter, calls } = captureAdapter({ content: [{ text: 'x' }] });
+    const chat = llm({
+        provider: anthropic,
+        model: 'claude-opus-4-8',
+        url: 'https://gateway.internal/llm',
+        adapter,
+    });
+
+    await chat({ body: { messages: [{ role: 'user', content: 'hi' }] } });
+    expect(calls[0]!.url).toBe('https://gateway.internal/llm');
+});

--- a/packages/core/test/llm.spec.ts
+++ b/packages/core/test/llm.spec.ts
@@ -106,6 +106,34 @@ test('llm requires a model (none on config, call, or provider default) — fail 
     await expect(chat({ body: { messages: [] } })).rejects.toThrow(/model/);
 });
 
+test('anthropic folds a system-role MESSAGE into the top-level `system` (never dropped)', async () => {
+    const { adapter, calls } = captureAdapter({ content: [{ text: 'ok' }] });
+    const chat = llm({
+        provider: anthropic,
+        model: 'claude-opus-4-8',
+        adapter,
+    });
+
+    await chat({
+        body: {
+            system: 'first',
+            messages: [
+                { role: 'system', content: 'second' },
+                { role: 'user', content: 'hi' },
+            ],
+        },
+    });
+
+    const body = calls[0]!.body as {
+        system?: string;
+        messages: { role: string; content: string }[];
+    };
+    // The explicit `system` AND the system-role message both survive — concatenated into the
+    // top-level param (Anthropic's shape), in order — rather than the message being silently lost.
+    expect(body.system).toBe('first\n\nsecond');
+    expect(body.messages).toEqual([{ role: 'user', content: 'hi' }]);
+});
+
 test('llm honours an explicit endpoint over the provider default', async () => {
     const { adapter, calls } = captureAdapter({ content: [{ text: 'x' }] });
     const chat = llm({

--- a/packages/core/test/pipe.spec.ts
+++ b/packages/core/test/pipe.spec.ts
@@ -1,0 +1,106 @@
+// stitchapi/pipe — linear composition (ADR 0008 Stage D). Steps run in order, each result feeds the
+// next, and each step is a CHILD run of the previous (ADR 0007) so a shared trace links the chain.
+import { stitch } from '../src';
+import type { StitchEvent, TraceContext, TraceSink } from '../src';
+import { pipe } from '../src/pipe';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+function capturingSink(): {
+    sink: TraceSink;
+    seen: { ev: StitchEvent; ctx: TraceContext }[];
+} {
+    const seen: { ev: StitchEvent; ctx: TraceContext }[] = [];
+    return {
+        seen,
+        sink: { handle: (ev, ctx) => void seen.push({ ev, ctx: { ...ctx } }) },
+    };
+}
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+test('runs steps in order, mapping each result into the next, and resolves to the last', async () => {
+    server.route('GET', '/user', { body: { id: 7 } });
+    server.route('GET', '/posts', { body: { posts: ['p1'] } });
+    const fetchUser = stitch({
+        name: 'user',
+        baseUrl: server.url,
+        path: '/user',
+    });
+    const fetchPosts = stitch({
+        name: 'posts',
+        baseUrl: server.url,
+        path: '/posts',
+    });
+
+    const flow = pipe(fetchUser, {
+        stitch: fetchPosts,
+        input: (u) => ({ query: { userId: String((u as { id: number }).id) } }),
+    });
+
+    await expect(flow()).resolves.toEqual({ posts: ['p1'] });
+    // The mapper fed step 1's `id` into step 2's request.
+    expect(server.calls('/posts')[0]?.query['userId']).toBe('7');
+});
+
+test('each step is a CHILD run of the previous — the trace links the chain', async () => {
+    server.route('GET', '/a', { body: { n: 1 } });
+    server.route('GET', '/b', { body: { n: 2 } });
+    const { sink, seen } = capturingSink();
+    const a = stitch({
+        name: 'a',
+        baseUrl: server.url,
+        path: '/a',
+        trace: sink,
+    });
+    const b = stitch({
+        name: 'b',
+        baseUrl: server.url,
+        path: '/b',
+        trace: sink,
+    });
+
+    await pipe(a, b)();
+
+    const aStart = seen.find(
+        (s) => s.ctx.name === 'a' && s.ev.type === 'start',
+    )!;
+    const bStart = seen.find(
+        (s) => s.ctx.name === 'b' && s.ev.type === 'start',
+    )!;
+    expect(aStart.ctx.parentId).toBeUndefined(); // the first step is a root run
+    expect(bStart.ctx.parentId).toBe(aStart.ctx.runId); // b is a child of a
+    expect(bStart.ctx.traceId).toBe(aStart.ctx.traceId); // one trace tree
+});
+
+test('fail-fast: a step error rejects the pipeline and stops it', async () => {
+    server.route('GET', '/ok', { body: { ok: true } });
+    let laterRan = false;
+    const ok = stitch({
+        name: 'ok',
+        baseUrl: server.url,
+        path: '/ok',
+        adapter: async () => ({ status: 500, headers: {}, body: { e: 'x' } }),
+    });
+    const later = stitch({
+        name: 'later',
+        baseUrl: server.url,
+        path: '/ok',
+        adapter: async () => {
+            laterRan = true;
+            return { status: 200, headers: {}, body: {} };
+        },
+    });
+
+    await expect(pipe(ok, later)()).rejects.toMatchObject({ status: 500 });
+    expect(laterRan).toBe(false); // the pipe stopped at the failing step
+});

--- a/packages/core/test/surface-execute.spec.ts
+++ b/packages/core/test/surface-execute.spec.ts
@@ -1,0 +1,92 @@
+// Surface.execute — the transport-replacing hook (ADR 0008 Stage A). A surface may run its own
+// transport INSTEAD of HTTP, at the same site inside the resilience chain, so retry/throttle/
+// circuit/timeout/trace all wrap it; the absolute-URL guard is bypassed; and a BYO `adapter` is
+// ignored when a surface carries `execute`.
+import { stitch } from '../src';
+import type { Adapter, AdapterRequest, Surface } from '../src';
+
+// A minimal surface that replaces the transport with an in-memory function (no network). It packs
+// `input.body` onto the request (the graphql precedent) and interprets the body as the value.
+function execSurface(execute: Adapter): Surface {
+    return {
+        id: 'exec',
+        buildRequest: (_cfg, input, base) => ({ ...base, body: input.body }),
+        execute,
+    };
+}
+
+test('execute replaces the transport (no HTTP) and flows through to the result', async () => {
+    const seen: AdapterRequest[] = [];
+    const execute: Adapter = async (req) => {
+        seen.push(req);
+        return { status: 200, headers: {}, body: { echoed: req.body } };
+    };
+    // A non-http `url` would normally fail the absolute-URL guard — `execute` bypasses it.
+    const s = stitch({
+        name: 'echo',
+        url: 'exec://echo',
+        kind: execSurface(execute),
+    });
+
+    await expect(s({ body: { hi: 1 } })).resolves.toEqual({
+        echoed: { hi: 1 },
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.url).toBe('exec://echo');
+});
+
+test('the resilience chain wraps execute — a retry-on-status re-runs it', async () => {
+    let n = 0;
+    const execute: Adapter = async () => {
+        n += 1;
+        return n === 1
+            ? { status: 503, headers: {}, body: {} }
+            : { status: 200, headers: {}, body: { ok: true } };
+    };
+    const s = stitch({
+        name: 'flaky-exec',
+        url: 'exec://x',
+        kind: execSurface(execute),
+        retry: { attempts: 3, on: [503], backoff: 'fixed', baseMs: 1 },
+    });
+
+    await expect(s()).resolves.toEqual({ ok: true });
+    expect(n).toBe(2); // retried exactly once, through the standard chain
+});
+
+test('a surface with execute ignores a BYO adapter', async () => {
+    let adapterCalled = false;
+    const adapter: Adapter = async () => {
+        adapterCalled = true;
+        return { status: 200, headers: {}, body: { from: 'adapter' } };
+    };
+    const execute: Adapter = async () => ({
+        status: 200,
+        headers: {},
+        body: { from: 'execute' },
+    });
+    const s = stitch({
+        name: 'x',
+        url: 'exec://x',
+        kind: execSurface(execute),
+        adapter,
+    });
+
+    await expect(s()).resolves.toEqual({ from: 'execute' });
+    expect(adapterCalled).toBe(false);
+});
+
+test('a non-2xx from execute throws like any HTTP failure (interpret/error path)', async () => {
+    const execute: Adapter = async () => ({
+        status: 500,
+        headers: {},
+        body: { error: 'boom' },
+    });
+    const s = stitch({
+        name: 'x',
+        url: 'exec://x',
+        kind: execSurface(execute),
+    });
+
+    await expect(s()).rejects.toMatchObject({ status: 500 });
+});

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -24,6 +24,9 @@ export default defineConfig([
             'src/sse.ts',
             'src/stream.ts',
             'src/download.ts',
+            // non-HTTP surfaces + composition (ADR 0008) → stitchapi/llm, stitchapi/pipe
+            'src/llm.ts',
+            'src/pipe.ts',
             // the browser-only xhr adapter (upload progress) → stitchapi/xhr
             'src/xhr-adapter.ts',
         ],

--- a/packages/shell/README.md
+++ b/packages/shell/README.md
@@ -1,0 +1,45 @@
+# @stitchapi/shell
+
+Run a **static local command** as a StitchAPI surface — so a subprocess gets the same `retry` /
+`throttle` / `circuit` / `timeout` / `trace` treatment as an HTTP call, through the same engine
+([ADR 0008](../../docs/adr/0008-non-http-surfaces-and-pipe.md)).
+
+This is a **Node-only peer package**: core never imports it, so `node:child_process` never reaches a
+browser bundle.
+
+```ts
+import { shell } from '@stitchapi/shell';
+
+const git = shell({ command: 'git', env: { PATH: process.env.PATH! } });
+
+const status = await git({ body: ['status', '--porcelain'] }); // stdout (string)
+```
+
+## Security — injection is impossible by construction
+
+Not "mitigated by escaping" — **structurally impossible**, the same bar that rejected
+host-inferred bearer tokens in StitchAPI's auth:
+
+- **Static executable.** `command` is bound in `shell({ command })`, **never** taken from call
+  input — exactly as a credential is bound at construction.
+- **`argv` is an array, never a string.** Arguments are a `string[]` passed straight to
+  `child_process.execFile`. There is **no shell** (`shell: true` is never set), so `;` `|` `$()`
+  backticks `*` `>` are inert data, never interpreted.
+- **No interpolation.** Each `argv` element is one process argument, verbatim. An `input` schema can
+  further constrain values, but the array boundary is the guarantee.
+- **Fail-closed env.** The subprocess inherits **no** `process.env` by default, so a secret in the
+  parent environment cannot leak into a child. Pass exactly what's needed — including `PATH` for a
+  bare command name, or use an absolute command path (as in the example).
+
+## Result
+
+- Exit `0` → the value is `stdout` (a `string`; pass `decode: 'json'` to `JSON.parse` it).
+- A non-zero exit → a `StitchError` (status `500`) whose `.body` is `{ exitCode, stdout, stderr }`
+  (or accept it as a normal result with `acceptStatus`).
+- A timeout / caller `AbortSignal` aborts the subprocess (it runs inside the resilience chain).
+
+## Options
+
+`shell(options)` takes the static `command`, optional `cwd` / `env` / `decode` / `maxBuffer`, plus
+the usual `StitchConfig` keys (`retry`, `throttle`, `timeout`, `circuit`, `trace`, …) — all applied
+by the engine around the subprocess.

--- a/packages/shell/README.md
+++ b/packages/shell/README.md
@@ -20,23 +20,23 @@ const status = await git({ body: ['status', '--porcelain'] }); // stdout (string
 Not "mitigated by escaping" — **structurally impossible**, the same bar that rejected
 host-inferred bearer tokens in StitchAPI's auth:
 
-- **Static executable.** `command` is bound in `shell({ command })`, **never** taken from call
-  input — exactly as a credential is bound at construction.
-- **`argv` is an array, never a string.** Arguments are a `string[]` passed straight to
-  `child_process.execFile`. There is **no shell** (`shell: true` is never set), so `;` `|` `$()`
-  backticks `*` `>` are inert data, never interpreted.
-- **No interpolation.** Each `argv` element is one process argument, verbatim. An `input` schema can
-  further constrain values, but the array boundary is the guarantee.
-- **Fail-closed env.** The subprocess inherits **no** `process.env` by default, so a secret in the
-  parent environment cannot leak into a child. Pass exactly what's needed — including `PATH` for a
-  bare command name, or use an absolute command path (as in the example).
+-   **Static executable.** `command` is bound in `shell({ command })`, **never** taken from call
+    input — exactly as a credential is bound at construction.
+-   **`argv` is an array, never a string.** Arguments are a `string[]` passed straight to
+    `child_process.execFile`. There is **no shell** (`shell: true` is never set), so `;` `|` `$()`
+    backticks `*` `>` are inert data, never interpreted.
+-   **No interpolation.** Each `argv` element is one process argument, verbatim. An `input` schema can
+    further constrain values, but the array boundary is the guarantee.
+-   **Fail-closed env.** The subprocess inherits **no** `process.env` by default, so a secret in the
+    parent environment cannot leak into a child. Pass exactly what's needed — including `PATH` for a
+    bare command name, or use an absolute command path (as in the example).
 
 ## Result
 
-- Exit `0` → the value is `stdout` (a `string`; pass `decode: 'json'` to `JSON.parse` it).
-- A non-zero exit → a `StitchError` (status `500`) whose `.body` is `{ exitCode, stdout, stderr }`
-  (or accept it as a normal result with `acceptStatus`).
-- A timeout / caller `AbortSignal` aborts the subprocess (it runs inside the resilience chain).
+-   Exit `0` → the value is `stdout` (a `string`; pass `decode: 'json'` to `JSON.parse` it).
+-   A non-zero exit → a `StitchError` (status `500`) whose `.body` is `{ exitCode, stdout, stderr }`
+    (or accept it as a normal result with `acceptStatus`).
+-   A timeout / caller `AbortSignal` aborts the subprocess (it runs inside the resilience chain).
 
 ## Options
 

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -44,7 +44,7 @@
     "license": "Apache-2.0",
     "homepage": "https://stitchapi.dev",
     "peerDependencies": {
-        "stitchapi": ">=0.7.0"
+        "stitchapi": ">=0.8.0"
     },
     "devDependencies": {
         "@types/node": "^22.10.0",

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,0 +1,56 @@
+{
+    "name": "@stitchapi/shell",
+    "version": "0.0.0",
+    "description": "Run a static local command as a StitchAPI surface — Node-only, injection-proof by construction (static binary + argv array + no shell). ADR 0008.",
+    "main": "lib/index.js",
+    "module": "lib/index.mjs",
+    "types": "lib/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./lib/index.d.mts",
+                "default": "./lib/index.mjs"
+            },
+            "require": {
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
+            }
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "lib"
+    ],
+    "scripts": {
+        "build": "tsup",
+        "test": "vitest run",
+        "check:types": "tsc --noEmit"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rejifald/StitchAPI.git",
+        "directory": "packages/shell"
+    },
+    "keywords": [
+        "stitchapi",
+        "shell",
+        "command",
+        "subprocess",
+        "surface",
+        "execfile",
+        "api-client"
+    ],
+    "author": "Oleksandr Zhuravlov (rejifald@gmail.com)",
+    "license": "Apache-2.0",
+    "homepage": "https://stitchapi.dev",
+    "peerDependencies": {
+        "stitchapi": ">=0.7.0"
+    },
+    "devDependencies": {
+        "@types/node": "^22.10.0",
+        "stitchapi": "workspace:*",
+        "tsup": "^8.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.8"
+    }
+}

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -1,0 +1,154 @@
+// @stitchapi/shell — run a STATIC local command as a StitchAPI surface (ADR 0008). A Node-only
+// peer package: core never imports it, so `node:child_process` never reaches a browser bundle
+// (the browser-first gate). It is the first consumer of the transport-replacing `Surface.execute`
+// hook — the command runs INSIDE the resilience chain, so `retry` / `throttle` / `circuit` /
+// `timeout` / `signal` / `trace` all apply to a subprocess exactly as they do to an HTTP call.
+//
+// SECURITY — injection is impossible by CONSTRUCTION, not by escaping (the "structural, not
+// advisory" bar that rejected host-inferred bearer tokens in #6):
+//   • the executable is STATIC, bound in `shell({ command })`, NEVER taken from call input;
+//   • arguments are an ARRAY of strings passed straight to `execFile` — there is NO shell
+//     (`shell: true` is never set, no `/bin/sh -c`), so `;` `|` `$()` backticks `*` `>` are inert
+//     data, never interpreted;
+//   • nothing is interpolated — each argv element is one process argument, verbatim;
+//   • the subprocess env is FAIL-CLOSED (empty by default) so a secret in `process.env` can't leak
+//     into a child — pass exactly what's needed (incl. `PATH` for a bare command name, or use an
+//     absolute command path).
+import { execFile } from 'node:child_process';
+import { stitch } from 'stitchapi';
+import type {
+    AdapterRequest,
+    AdapterResponse,
+    Stitch,
+    StitchConfig,
+    Surface,
+} from 'stitchapi';
+
+/** The defaults bound to a shell surface (the static command + how to run it). */
+interface ShellDefaults {
+    command: string;
+    cwd?: string;
+    env?: Record<string, string>;
+    decode: 'text' | 'json';
+    maxBuffer: number;
+}
+
+// Run the static command with the call's argv. The ONLY input is the argv array (`req.body`);
+// every element must already be a string (the array boundary + `execFile` make injection
+// structurally impossible). A non-zero exit maps to status 500 with `{ exitCode, stdout, stderr }`
+// so it surfaces as a StitchError (or an accepted result via `acceptStatus`); a spawn failure
+// (ENOENT) or an abort rejects, so the resilience chain sees a transport error.
+function runCommand(
+    d: ShellDefaults,
+    req: AdapterRequest,
+): Promise<AdapterResponse> {
+    const argv = req.body;
+    if (!Array.isArray(argv) || !argv.every((a) => typeof a === 'string')) {
+        const e = new Error(
+            'shell: arguments must be a string[] passed as the call `body` (e.g. `run({ body: ["status", "--porcelain"] })`).',
+        );
+        e.name = 'StitchConfigError';
+        return Promise.reject(e);
+    }
+    const url = `shell:${d.command}`;
+    return new Promise<AdapterResponse>((resolve, reject) => {
+        execFile(
+            d.command,
+            argv,
+            {
+                ...(d.cwd !== undefined ? { cwd: d.cwd } : {}),
+                env: d.env ?? {}, // FAIL-CLOSED: no inherited process.env
+                ...(req.signal !== undefined ? { signal: req.signal } : {}),
+                maxBuffer: d.maxBuffer,
+                encoding: 'utf8',
+            },
+            (err, stdout, stderr) => {
+                if (err) {
+                    // A non-zero EXIT carries a numeric `.code` (the exit status) → a "response".
+                    // A spawn failure (ENOENT/EACCES) or an abort carries a string code / no code
+                    // → a transport error: reject so retry/abort handling sees it.
+                    const code = (err as NodeJS.ErrnoException).code;
+                    if (typeof code === 'number') {
+                        resolve({
+                            status: 500,
+                            headers: {},
+                            body: { exitCode: code, stdout, stderr },
+                            url,
+                        });
+                        return;
+                    }
+                    reject(err);
+                    return;
+                }
+                let body: unknown = stdout;
+                if (d.decode === 'json') {
+                    try {
+                        body = JSON.parse(stdout);
+                    } catch {
+                        /* not JSON — hand back the raw text */
+                    }
+                }
+                resolve({ status: 200, headers: {}, body, url });
+            },
+        );
+    });
+}
+
+// The shell surface for one static command. `execute` replaces the transport (ADR 0008); the
+// `url` is a `shell:` pseudo-endpoint (the engine's absolute-URL guard is bypassed for a surface
+// that carries `execute`). No `interpret` — exit 0 ⇒ stdout is the value; the engine throws on a
+// non-zero exit (status 500) like any HTTP failure.
+function shellSurface(d: ShellDefaults): Surface {
+    return {
+        id: 'shell',
+        buildRequest: (_cfg, input, base) => ({ ...base, body: input.body }),
+        execute: (req) => runCommand(d, req),
+    };
+}
+
+/** Options for {@link shell}: the static `command` + run controls, plus the shared StitchConfig keys
+ *  (`retry` / `throttle` / `timeout` / `circuit` / `trace` all apply via the resilience chain). */
+export type ShellOptions = Partial<Omit<StitchConfig, 'kind'>> & {
+    /** The executable — STATIC, bound here at construction, NEVER from call input. An absolute path
+     *  needs no `PATH`; a bare name (`'git'`) needs `env: { PATH: process.env.PATH }`. */
+    command: string;
+    /** Working directory for the subprocess (default: the process cwd). */
+    cwd?: string;
+    /** Subprocess environment. FAIL-CLOSED: empty by default — pass exactly what's needed; nothing
+     *  from `process.env` leaks in unless you put it here. */
+    env?: Record<string, string>;
+    /** How to read stdout: `'text'` (default — the value is the string) or `'json'` (JSON.parse it). */
+    decode?: 'text' | 'json';
+    /** Max stdout/stderr bytes buffered (default 10 MiB); exceeding it fails the call. */
+    maxBuffer?: number;
+};
+
+/**
+ * `shell({ command })` — a stitch that runs a static local command, its `stdout` the result. The
+ * call supplies the argument vector as a `string[]` `body`; everything else (retry/throttle/
+ * timeout/trace) is the usual StitchConfig. `T` is the result type (`string` for `decode: 'text'`,
+ * your shape for `'json'`).
+ *
+ * @example
+ * ```ts
+ * import { shell } from '@stitchapi/shell';
+ *
+ * const git = shell({ command: 'git', env: { PATH: process.env.PATH! } });
+ * const status = await git({ body: ['status', '--porcelain'] }); // stdout string
+ * ```
+ */
+export function shell<T = string>(opts: ShellOptions): Stitch<T> {
+    const { command, cwd, env, decode, maxBuffer, ...rest } = opts;
+    const d: ShellDefaults = {
+        command,
+        decode: decode ?? 'text',
+        maxBuffer: maxBuffer ?? 10 * 1024 * 1024,
+    };
+    if (cwd !== undefined) d.cwd = cwd;
+    if (env !== undefined) d.env = env;
+    return stitch({
+        ...rest,
+        kind: shellSurface(d),
+        url: rest.url ?? `shell:${command}`,
+    }) as unknown as Stitch<T>;
+}

--- a/packages/shell/test/shell.spec.ts
+++ b/packages/shell/test/shell.spec.ts
@@ -1,0 +1,91 @@
+// @stitchapi/shell — the security model is the load-bearing part, so the suite proves it
+// structurally: argv arrives as literal arguments (no shell interprets metacharacters), the env is
+// fail-closed (no process.env leak), a non-zero exit is a StitchError, and the resilience chain
+// (timeout) wraps the subprocess. The node binary itself is the controlled subprocess.
+import { shell } from '../src/index';
+
+const NODE = process.execPath; // an absolute path — no PATH needed to resolve it
+
+test('runs a static command; stdout is the result (text mode)', async () => {
+    const echo = shell({ command: NODE });
+    await expect(
+        echo({ body: ['-e', 'process.stdout.write("hello")'] }),
+    ).resolves.toBe('hello');
+});
+
+test('decode: "json" parses stdout', async () => {
+    const j = shell<{ a: number }>({ command: NODE, decode: 'json' });
+    await expect(
+        j({ body: ['-e', 'process.stdout.write(JSON.stringify({a:1}))'] }),
+    ).resolves.toEqual({ a: 1 });
+});
+
+test('argv elements are literal — shell metacharacters are inert (there is no shell)', async () => {
+    const dump = shell<string[]>({ command: NODE, decode: 'json' });
+    const evil = '; rm -rf / `whoami` $HOME && echo pwned';
+    const out = await dump({
+        body: [
+            '-e',
+            'process.stdout.write(JSON.stringify(process.argv))',
+            evil,
+        ],
+    });
+    // The whole metacharacter blob arrives as ONE intact argv element — never split, expanded, or
+    // interpreted. Injection is impossible by construction, not by escaping.
+    expect(out).toContain(evil);
+    expect(out.filter((a) => a === evil)).toHaveLength(1);
+});
+
+test('fail-closed env: process.env does NOT leak into the subprocess', async () => {
+    process.env['SHELL_SECRET_LEAK'] = 'nope';
+    try {
+        const dumpEnv = shell<Record<string, string>>({
+            command: NODE,
+            decode: 'json',
+        });
+        const out = await dumpEnv({
+            body: ['-e', 'process.stdout.write(JSON.stringify(process.env))'],
+        });
+        expect(out['SHELL_SECRET_LEAK']).toBeUndefined();
+    } finally {
+        delete process.env['SHELL_SECRET_LEAK'];
+    }
+});
+
+test('explicit env IS passed to the subprocess', async () => {
+    const dumpEnv = shell<Record<string, string>>({
+        command: NODE,
+        decode: 'json',
+        env: { FOO: 'bar' },
+    });
+    const out = await dumpEnv({
+        body: ['-e', 'process.stdout.write(JSON.stringify(process.env))'],
+    });
+    expect(out['FOO']).toBe('bar');
+});
+
+test('a non-zero exit surfaces as a StitchError carrying the exit code + stderr', async () => {
+    const fail = shell({ command: NODE });
+    await expect(
+        fail({
+            body: ['-e', 'process.stderr.write("boom"); process.exit(3)'],
+        }),
+    ).rejects.toMatchObject({
+        status: 500,
+        body: { exitCode: 3, stderr: 'boom' },
+    });
+});
+
+test('arguments must be a string[] — a non-array body is rejected', async () => {
+    const x = shell({ command: NODE });
+    await expect(
+        x({ body: { not: 'an array' } as unknown as string[] }),
+    ).rejects.toThrow(/string\[\]/);
+});
+
+test('the resilience chain wraps the subprocess — a per-attempt timeout aborts it', async () => {
+    const slow = shell({ command: NODE, timeout: { perAttempt: 50 } });
+    await expect(
+        slow({ body: ['-e', 'setTimeout(() => {}, 5000)'] }),
+    ).rejects.toBeTruthy();
+});

--- a/packages/shell/test/shell.spec.ts
+++ b/packages/shell/test/shell.spec.ts
@@ -89,3 +89,11 @@ test('the resilience chain wraps the subprocess — a per-attempt timeout aborts
         slow({ body: ['-e', 'setTimeout(() => {}, 5000)'] }),
     ).rejects.toBeTruthy();
 });
+
+test('a spawn failure (missing binary) rejects as a transport error — NOT a 500 exit response', async () => {
+    // ENOENT carries a STRING `code`, so `runCommand` rejects (transport error) rather than
+    // resolving to a status-500 "response" the way a non-zero EXIT (numeric code) does — the
+    // resilience chain then sees a real transport failure (retryable/abortable), not a result.
+    const missing = shell({ command: '/no/such/binary-xyz-stitchapi' });
+    await expect(missing({ body: [] })).rejects.toThrow(/ENOENT/);
+});

--- a/packages/shell/tsconfig.json
+++ b/packages/shell/tsconfig.json
@@ -1,0 +1,40 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        // DOM is needed because the `stitchapi` source we typecheck through (the `paths` alias
+        // below) is isomorphic and references DOM types (Crypto, Blob, …). The shell source itself
+        // is Node-only. Mirrors @stitchapi/nest.
+        "lib": ["ES2022", "DOM"],
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "exactOptionalPropertyTypes": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "verbatimModuleSyntax": true,
+        "isolatedModules": true,
+
+        "types": ["node", "vitest/globals"],
+
+        // Resolve the workspace package to its SOURCE so typecheck + tests don't
+        // depend on `stitchapi` being built first (mirrors @stitchapi/nest).
+        "baseUrl": ".",
+        "paths": {
+            "stitchapi": ["../core/src/index.ts"]
+        }
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts",
+        "tsup.config.ts",
+        "vitest.config.ts"
+    ]
+}

--- a/packages/shell/tsup.config.ts
+++ b/packages/shell/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+// Single dual-format entry. `stitchapi` is a peer dep, externalised by tsup, so the bundle is just
+// the surface + the execFile wiring. Not minified.
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    minify: false,
+    outDir: 'lib',
+    clean: true,
+});

--- a/packages/shell/vitest.config.ts
+++ b/packages/shell/vitest.config.ts
@@ -1,0 +1,18 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+// Alias the workspace package to core SOURCE, so tests run without `stitchapi` being built first
+// (mirrors tsconfig `paths` + @stitchapi/nest).
+const src = (p: string): string =>
+    fileURLToPath(new URL(`../core/src/${p}`, import.meta.url));
+
+export default defineConfig({
+    resolve: {
+        alias: [{ find: /^stitchapi$/, replacement: src('index.ts') }],
+    },
+    test: {
+        globals: true,
+        environment: 'node',
+        include: ['test/**/*.spec.ts'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,7 +204,7 @@ importers:
         version: 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -377,6 +377,24 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+
+  packages/shell:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.21
+      stitchapi:
+        specifier: workspace:*
+        version: link:../core
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
 
 packages:
 
@@ -7103,7 +7121,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
+      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
   '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.8)':
     dependencies:
@@ -7113,7 +7131,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4))
+      vitest: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
Implements **ADR 0008** ([#164](https://github.com/rejifald/StitchAPI/pull/164)) — roadmap item #7. Extends the surface model past HTTP and adds linear composition, built in the five stages the review settled, **one push, single review**.

> **Stacked on [#163](https://github.com/rejifald/StitchAPI/pull/163) (ADR 0007 / run identity)** — `pipe()` builds on it. Until #163 merges this PR's diff includes its commits; I'll rebase once #163 lands.

## What it adds

- **A — `Surface.execute?` hook.** A surface may replace the transport; the engine runs it at the same site in the resilience chain (`cfg.kind?.execute ?? rt.adapter`), so retry / throttle / circuit / per-attempt timeout+signal / trace / auth all wrap it unchanged. The absolute-URL guard is bypassed for it; a surface with `execute` ignores a BYO `adapter`.
- **B — `stitchapi/llm`.** Contract-first: an `LlmProvider` mapping (`buildBody`/`parse`) is the primitive (contract-not-dependency, like the fingerprint contract). `llm()` is a preset over the **http** surface — *no* execute hook — so bearer/apiKey auth + retry + throttle + `sse`/`stream` streaming all apply for free. First-party **`anthropic`** (Messages API) + **`openai`** (Chat Completions) ship as **plain config, no SDK dependency**; the credential is the stitch's `auth`.
- **C — `@stitchapi/shell`.** A **Node-only peer package** (core never imports it → no `child_process` in a browser bundle). Injection is **impossible by construction**: static bin (never from input), argv **array** via `execFile` (no shell, no interpolation), **fail-closed env** (no `process.env` leak). A non-zero exit → a `StitchError { exitCode, stdout, stderr }`; timeout/abort kills the child.
- **D — `stitchapi/pipe`.** `pipe(...steps)` runs stitches in sequence, feeding each result to the next; each step is a **child run** of the previous (ADR 0007), so a trace/DAG shows the chain `stepA → stepB → stepC`. Mapping closures are sugar; fail-fast on a step error.
- **E — packaging.** `./llm` + `./pipe` subpaths (exports + tsup); **attw green** across CJS/ESM/types; `import { stitch }` pulls in none of it.

## Resolved review decisions (ADR 0008 thread)

`execute` data → `req.body` (graphql precedent) · `llm` contract-first + first-party mappings · `shell` fail-closed env, bin allowlist deferred · `pipe` `stitchapi/pipe` subpath, linear v1 · one push.

## Tests & gates

- **554 core tests** (`surface-execute` / `llm` / `pipe` specs) + **8 `@stitchapi/shell` security tests** (argv-literal/no-shell, env isolation, exit code, timeout-abort).
- `check:types` / `check:lint` / `check:types-d` / `check:exports` (attw) clean; **docs build (twoslash) passes**; both packages build.
- Gates: **browser-first** (`shell` quarantined in a peer package; `execute` is a plain field; `llm`/`pipe` are browser-clean subpaths), **bundle-frugal** (subpaths / out-of-core), **contract-not-dependency** (`LlmProvider` + the shell command are BYO config), **security** (shell injection structurally impossible).

Docs: the ADR + the `@stitchapi/shell` README + JSDoc cover it; user-facing MDX pages are a small follow-up.