### PR TITLE
feat(core): postMessage surface — typed iframe↔parent RPC + events (ADR 0009)

### DIFF
--- a/docs/adr/0009-postmessage-surface.md
+++ b/docs/adr/0009-postmessage-surface.md
@@ -63,6 +63,13 @@ A responder DROPS a payload that fails its `input` schema rather than replying w
 
 Every verb is an ordinary stitch run, so each gets a run-identity span ([ADR 0007](./0007-composition-causality-and-run-identity.md)) and the full `start → request → (delta…) → result → done` event spine for free: a `request`'s `start`/`result`, an `events` subscription's per-payload `delta`s, a drift finding when a payload violates `output`. A `postMessage` exchange becomes visible in the same trace/DAG as an HTTP call — the message bus stops being a blind spot.
 
+## Consumer notes (two sharp edges, by design)
+
+Surfaced by the first real adoption (strimko's template-preview channel) — documented here so they are not a surprise:
+
+-   **A stitch is a lazy result — drive it.** Every verb returns a stitch whose call yields a _cold_ `StitchResult`: the run (and thus the `postMessage`) happens only when the result is driven — `await` / `.then` / `.catch` / `.finally`. For `request`/`events` you naturally `await`/`.stream()`, so this is invisible; for fire-and-forget **`emit`** you must drive it explicitly — `void send(input).catch(() => {})` — or nothing is posted. The strimko host uses exactly this idiom for `template/update`.
+-   **`events` validation terminates the stream.** `output` on `events` validates each payload per-`delta`, and a violation ends the subscription with a `drift` error — the same loud-not-silent contract as `sse`/`stream`. That is right for a coherent stream but surprising for a _discrete_ event bus, where one malformed message should not kill the channel. There, omit `output` and validate each payload in the consumer (drop the bad one, keep listening) — the pattern the strimko `template/content-height` and `template/update` subscriptions use. A built-in `onInvalid: 'drop'` mode for `events` is noted as future work.
+
 ## Packaging
 
 -   New file `packages/core/src/postmessage.ts`; a `stitchapi/postmessage` subpath entry in `tsup.config.ts` and a `./postmessage` export block in `package.json` (browser/import/require), mirroring `./sse` exactly.

--- a/docs/adr/0009-postmessage-surface.md
+++ b/docs/adr/0009-postmessage-surface.md
@@ -1,0 +1,84 @@
+# ADR 0009 — The `postMessage` surface: typed iframe↔parent RPC + events
+
+-   **Status:** Accepted
+-   **Date:** 2026-06-17
+-   **Tags:** surfaces, transport, postmessage, browser, iframe, messageport, events, security, browser-first
+
+> [!NOTE]
+>
+> This rides the surface model ([ADR 0005](./0005-surfaces-and-the-authoring-model.md)) and the transport-replacing `Surface.execute` hook ([ADR 0008](./0008-non-http-surfaces-and-pipe.md)) — the same machinery `shell` and `llm` use — plus the run-identity spans of [ADR 0007](./0007-composition-causality-and-run-identity.md). The load-bearing decision is the **security model**: origin is first-class and gated **before** any dispatch or validation, the "structural, not advisory" bar that rejected `inferBearer` in #6 and shaped the `shell` surface.
+
+## Context
+
+The browser's `postMessage` is how a page talks to an iframe it embeds (or that embeds it), to a popup, to a Web Worker, or across a `MessageChannel`. It is _also_ a perennial source of three bugs, every one of which StitchAPI exists to remove:
+
+1.  **Drifted contracts.** The two sides agree on a message shape by convention — `{ type: 'focus', payload: … }` — written twice, in two codebases, with nothing checking they still match. The receiver reads `e.data.user.id` and one rename later it is `undefined`. This is exactly the response-shape drift `output` validation catches for HTTP, with no equivalent on the message bus.
+2.  **No validation.** `e.data` is `any`. A handler trusts whatever crossed the wire — wrong types, missing fields, a hostile peer's payload — because there is no schema between the `MessageEvent` and the application code.
+3.  **`postMessage('*')` with no origin check.** The single most common postMessage vulnerability: posting to (or accepting from) `targetOrigin: '*'`, which leaks the message to whatever document currently occupies the frame and accepts a reply from anywhere. The browser API makes the unsafe path the easy path — `'*'` is one character shorter than the right answer.
+
+A fourth, smaller waste: `postMessage` carries no request/response correlation. Every RPC-over-postMessage reinvents a `{ id }` field and a pending-promise map by hand, usually subtly wrong (no timeout, no abort, leaks the pending entry on a dropped reply).
+
+The `Surface` model already has the two pieces this needs. `Surface.execute` ([ADR 0008](./0008-non-http-surfaces-and-pipe.md)) lets a surface **replace the transport** at the engine's adapter call site, _inside_ the resilience chain, so `retry`/`throttle`/`circuit`/per-attempt `timeout`/`signal`/`trace`/`auth`/`hooks` all wrap it. `Surface.stream` ([ADR 0005](./0005-surfaces-and-the-authoring-model.md) Decision 12) marks a surface streaming and decodes a live body into `delta` chunks. A `postMessage` RPC is a custom transport (`execute`); a `postMessage` event subscription is a stream (`stream`). Nothing in the core engine needs to change.
+
+## Decision
+
+**Ship a `postMessage` surface family behind a `stitchapi/postmessage` core subpath** — typed, validated, observable RPC + events over a `Window`, an iframe's `contentWindow`, or a `MessagePort`, riding `Surface.execute` / `Surface.stream`.
+
+1.  **A `channel` abstraction binds the transport + the security policy at construction.** The browser primitive (where messages go, what origin they must carry) is _not_ a per-call concern — it is the channel's identity, bound once, exactly as a seam binds `baseUrl`/`auth` once. The entry points are `windowChannel({ target, targetOrigin, allowedOrigins? })` (a `Window`, or a `() => Window` thunk for a frame that mounts late), `portChannel(port, { allowedOrigins? })` (a `MessagePort`), and the low-level `channel(transport, { allowedOrigins })` over any `MessageTransport` (the in-memory seam the tests drive). A `MessageTransport` is the one small interface between this surface and a concrete primitive — `post(message, transfer?)` + `subscribe(handler) → unsubscribe` — which is what lets the whole surface be exercised over a fake linked pair with no DOM.
+
+2.  **Four verbs, two surface ids.** A `PostMessageChannel` mints:
+
+    -   **`request(opts)`** — correlated request→response. A **buffered** surface (`id: 'postmessage'`) whose `execute` mints an id, posts `{ type, id, payload }`, registers a pending entry, and resolves when the matching `{ type: reply, id }` lands (`reply` defaults to `` `${type}-result` ``). The reply payload is the value; `output` validates it.
+    -   **`emit(opts)`** — fire-and-forget. The same buffered surface, but `execute` posts `{ type, payload }` (no id) and resolves immediately; result `void`.
+    -   **`events(opts)`** — inbound event subscription. A **streaming** surface (`id: 'postmessage-event'`) whose `execute` hands the engine a live `ReadableStream` the channel feeds; `await` resolves to the collected payload array, `.stream()` yields live deltas; `output` validates each payload (per-`delta`, [ADR 0005](./0005-surfaces-and-the-authoring-model.md) Addendum).
+    -   **`respond(type, handler, opts?)`** — the **receiving** side (e.g. an iframe answering a parent's `focus`). Origin-gated, validates the inbound payload against `input`, runs `handler`, validates the result against `output`, posts `{ type: reply, id, payload: result }`. It is the only verb that is **not** a stitch — it makes no outbound call, so it returns a plain unsubscribe.
+
+    The registry — the pending-request map, the responder map, the event-subscription set — lives **per channel**, behind a **single** demux listener attached once at construction (the decision: per-channel, not per-surface; one listener, not one per stitch). `close()` detaches it, rejects every pending request, and ends every event stream.
+
+3.  **The demux gates origin FIRST.** On each inbound `(data, origin)` the channel: (1) **origin-gates** — an origin not in `allowedOrigins` is dropped _before_ anything else (a `MessagePort` carries no origin, `''`, and skips the gate — a port is already a private capability); (2) shape-guards `{ type: string }`; (3) correlates a **reply** by id _and_ type; (4) dispatches to a **responder** (validate inbound → run → validate result → post reply); (5) fans to matching **event** subscriptions; (6) drops the unmatched. Gate-before-validation is the security bar, not an optimisation (Decision 5).
+
+4.  **Correlation, timeout, and abort reuse the resilience chain — no bespoke timer.** `request`'s `execute` wires the engine's per-attempt `signal` (which `withTimeout` aborts on `timeout`, and a caller's `signal` aborts on cancellation) to reject-and-deregister the pending entry. A request with no matching reply therefore rejects via the engine's `timeout`/`signal`, surfacing as an ordinary `StitchError` — the concrete payoff of [ADR 0008](./0008-non-http-surfaces-and-pipe.md) Decision 1, identical to how `shell` gets timeout/cancel for free. No second timer is invented.
+
+5.  **A core subpath, not a peer package.** Unlike `shell` (Node-only, quarantined out of core), `postMessage` is the **most browser-native capability StitchAPI has** — it needs nothing but `postMessage`/`MessageEvent`/`MessagePort`/`ReadableStream`/`globalThis.crypto`. So it ships as a core subpath (`stitchapi/postmessage`), reached only through `cfg.kind`, exactly like `sse`/`stream`/`graphql`. The root entry never imports it.
+
+## How it holds the three gates
+
+-   **browser-first** — the module uses only browser-native APIs; no `node:*`, no `Buffer`. It is pinned in the `browser-bundle.spec` matrix both as a `BROWSER_LEGIT` subpath and in the streaming-surface set (its `events` verb carries a `stream` hook), asserting it bundles for `"browser"` with no `node:*` and no `EventSource`.
+-   **bundle-frugal** — reached only through the `stitchapi/postmessage` subpath; `import { stitch }` pulls in none of it (the engine reaches the surface via `cfg.kind` at runtime, never a static import).
+-   **contract-not-dependency** — `kind` round-trips to its `id` string on `__config` ([ADR 0005](./0005-surfaces-and-the-authoring-model.md) Decision 11): `'postmessage'` for request/emit, `'postmessage-event'` for events, both valid JSON. The live `execute`/`stream` hooks and the target `Window` are redacted, never serialised. The non-serializable bits — a `Window` thunk, a `MessagePort` instance — are acknowledged **sugar** in the exact category the library already draws the line at (`transform`, `paginate.next`, `cache.key`, `pipe`'s step mapping): the channel's _binding_ is sugar; a stitch's _declaration_ (its `kind` id, `type`, schemas) serializes.
+
+## Security model
+
+Origin handling is **structural, not advisory** — the bar that rejected host-inferred bearer tokens in #6 and that the `shell` surface set for command injection:
+
+-   **The `Origin` type forbids `'*'`.** `Origin = ` `` `https://${string}` | `http://${string}` `` — `'*'` is not assignable to either arm, so a wildcard `targetOrigin` is a **compile error**, not a lint warning. The unsafe path is unspellable in typed code.
+-   **`windowChannel` also throws at runtime on `'*'`** — defense in depth, so an `as any` cast past the type still fails fast at construction rather than leaking the first message.
+-   **The gate runs before dispatch and before validation.** A message from a disallowed origin is dropped in step 1 of the demux — never correlated to a pending request, never handed to a responder, never validated, never delivered to an event stream. An attacker on the wrong origin learns nothing from timing or from a validation error, because neither runs.
+-   **An empty `allowedOrigins` over an origin-bearing transport fails closed** (drops everything) — a misconfigured channel is silent, not promiscuous.
+-   **`MessagePort` is exempt by construction.** A port is a private, already-handed-out capability with no origin; gating it would be theatre. The exemption is documented, not silent.
+
+A responder DROPS a payload that fails its `input` schema rather than replying with an error (a hostile peer learns nothing from the reply shape), and never posts a result that fails its `output` schema (an off-contract reply is suppressed, not sent).
+
+## Observability (ADR 0007)
+
+Every verb is an ordinary stitch run, so each gets a run-identity span ([ADR 0007](./0007-composition-causality-and-run-identity.md)) and the full `start → request → (delta…) → result → done` event spine for free: a `request`'s `start`/`result`, an `events` subscription's per-payload `delta`s, a drift finding when a payload violates `output`. A `postMessage` exchange becomes visible in the same trace/DAG as an HTTP call — the message bus stops being a blind spot.
+
+## Packaging
+
+-   New file `packages/core/src/postmessage.ts`; a `stitchapi/postmessage` subpath entry in `tsup.config.ts` and a `./postmessage` export block in `package.json` (browser/import/require), mirroring `./sse` exactly.
+-   Browser-bundle matrix updated: `'src/postmessage.ts'` in `BROWSER_LEGIT` and in the streaming-surface `test.each`.
+-   **Zero core-engine change.** The surface rides `execute`/`stream`/`contractValue` as-is; the absolute-URL guard is already bypassed for any surface carrying `execute` (the `postmessage:<type>` pseudo-endpoint passes), and the streaming path already drives `cfg.kind.execute` for a future non-HTTP streaming surface.
+
+## Alternatives considered
+
+-   **Overload the user `adapter` instead of a surface.** Rejected for the same reason [ADR 0008](./0008-non-http-surfaces-and-pipe.md) rejected it for `shell`: `adapter` is the user's HTTP-client slot. A `postMessage` channel is a protocol with its own request shaping, correlation, and a stateful registry behind a single listener — that is a `Surface` identity (`buildRequest` + `execute`/`stream` bundled with the `id`), not a transport swap. Overloading `adapter` would also lose the per-channel registry and muddy redaction.
+-   **A full RPC `serve`-style responder primitive.** `respond` is deliberately the **minimal** responder — register one handler per `type`, validate-in/validate-out, reply. A richer surface (a routed responder table, method namespaces, a `serve`-style declarative receiver, schema-negotiated handshakes) is **future work**; it is not needed to remove the three bugs in Context, and shipping the minimum keeps the first version reviewable. The channel abstraction leaves room for it (a responder registry already exists per channel).
+-   **Use `EventSource`-style auto-reconnect / replay for `events`.** Out of scope, mirroring the `sse` decision: a dropped channel is the caller's to re-establish; buffering/replay is a separate concern.
+-   **A single callable default export** (à la `sse(config)`). Rejected: `postMessage` has _four_ verbs (request/emit/events/respond) with no single "the call", and the transport+origin must be bound before any of them. The **channel factory is the entry point**; the builders and the two `Surface` identities are the named exports.
+
+## Gates
+
+-   **browser-first** — only browser-native APIs; pinned in the `browser-bundle.spec` matrix (both legit-subpath and streaming-surface), no `node:*`, no `EventSource`.
+-   **bundle-frugal** — subpath-only; `import { stitch }` pulls in none of it.
+-   **contract-not-dependency** — `kind` round-trips as its `id` (`'postmessage'` / `'postmessage-event'`); live hooks + the target `Window`/`MessagePort` are redacted sugar, the channel's binding being in the same category as `transform`/`pipe`.
+-   **security** — origin is a first-class, non-`'*'` type **and** a runtime guard; the gate runs **before** correlation/validation/delivery; responders fail closed on bad input/output; `MessagePort` is exempt by construction with that exemption documented.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -148,6 +148,20 @@
                 "default": "./lib/download.js"
             }
         },
+        "./postmessage": {
+            "browser": {
+                "types": "./lib/postmessage.d.mts",
+                "default": "./lib/postmessage.mjs"
+            },
+            "import": {
+                "types": "./lib/postmessage.d.mts",
+                "default": "./lib/postmessage.mjs"
+            },
+            "require": {
+                "types": "./lib/postmessage.d.ts",
+                "default": "./lib/postmessage.js"
+            }
+        },
         "./llm": {
             "browser": {
                 "types": "./lib/llm.d.mts",

--- a/packages/core/src/postmessage.ts
+++ b/packages/core/src/postmessage.ts
@@ -1,0 +1,725 @@
+// The `stitchapi/postmessage` surface subpath (ADR 0009): a typed, validated, observable wrapper
+// over browser `postMessage` RPC + events. The parent↔iframe channel is the most browser-native
+// capability StitchAPI has — `Window` / iframe `contentWindow` / `MessagePort` — so it ships as a
+// CORE subpath (not a peer package), reached only through `cfg.kind`, never the root entry.
+//
+// A `PostMessageChannel` binds the raw transport + the security policy (allowed origins) ONCE at
+// construction. Its four verbs each ride an existing surface hook (ADR 0005/0008):
+//   • `request` — correlated request→response: a buffered `execute` surface (id `'postmessage'`)
+//     that posts `{ type, id, payload }` and resolves when the matching `{ type: reply, id }` lands.
+//   • `emit` — fire-and-forget: the same buffered surface, but `execute` posts `{ type, payload }`
+//     (no id) and resolves immediately; result `void`.
+//   • `events` — inbound event subscription: a STREAMING surface (id `'postmessage-event'`) whose
+//     `execute` hands back a `ReadableStream` of envelopes the channel feeds it; `await` collects the
+//     validated payloads, `.stream()` yields live deltas.
+//   • `respond` — the RECEIVING side: register an origin-gated handler that answers inbound requests
+//     of a `type`. NOT a stitch (no outbound call), just an unsubscribe.
+//
+// SECURITY — origin is FIRST-CLASS and STRUCTURAL, not advisory (the "structural, not advisory" bar
+// the shell surface and the rejected `inferBearer` set):
+//   • {@link Origin} structurally forbids `'*'` (a template-literal type) — you cannot type a
+//     wildcard targetOrigin; `windowChannel` also RUNTIME-throws on `'*'` (defense in depth).
+//   • the demux gates EVERY inbound message on its `origin` BEFORE any dispatch or validation:
+//     an origin not in `allowedOrigins` is dropped, never correlated/validated/delivered.
+//   • `MessagePort` messages carry no origin (a port is already a private channel), so the gate is
+//     bypassed for ports — documented, not silent.
+//
+// Browser-first + bundle-frugal + zero-dep: only `postMessage`/`MessageEvent`/`MessagePort`/
+// `ReadableStream`/`globalThis.crypto` — no `node:*`, no `Buffer`. Reached only through this subpath;
+// `import { stitch }` pulls in none of it.
+import type { InputOf, OutputOf, SchemaLike } from './infer';
+import { makeStitch } from './stitch';
+import type { Surface } from './surface';
+import type {
+    AdapterRequest,
+    AdapterResponse,
+    Stitch,
+    StitchConfig,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// the raw channel (transport) + the typed channel (PostMessageChannel)
+// ---------------------------------------------------------------------------
+
+/**
+ * The raw channel a {@link PostMessageChannel} rides — the one seam between this surface and a
+ * concrete browser primitive (a `Window`, an iframe's `contentWindow`, a `MessagePort`). Keeping it
+ * this small is what lets the tests drive the whole surface over an in-memory fake pair with no DOM.
+ */
+export interface MessageTransport {
+    /** Post one envelope to the peer (optionally transferring ownership of `transfer`'s objects). */
+    post(message: unknown, transfer?: Transferable[]): void;
+    /** Subscribe to inbound messages; returns an unsubscribe fn. `origin` is `''` for a MessagePort. */
+    subscribe(handler: (data: unknown, origin: string) => void): () => void;
+}
+
+/**
+ * A concrete, non-wildcard target origin: `https://app.example.com` or `http://localhost:3000`. The
+ * template-literal union structurally **forbids `'*'`** — `'*'` is not assignable to either arm — so
+ * the type itself rejects the "post to anyone" footgun that makes `postMessage('*')` a data leak.
+ */
+export type Origin = `https://${string}` | `http://${string}`;
+
+// ---- the wire envelope ----------------------------------------------------
+// Everything on the wire is one of these. `request` posts `{ type, id, payload }` and the responder
+// replies `{ type: reply, id, payload: result }`; `emit`/events use `{ type, payload }` (no id).
+interface Envelope {
+    type: string;
+    id?: string;
+    payload?: unknown;
+}
+
+// A shape-guard for an inbound message: it must be an object carrying a string `type` (everything
+// else — a bare number, a string, a `null` — is dropped by the demux). Returns the narrowed view.
+function asEnvelope(data: unknown): Envelope | undefined {
+    if (typeof data !== 'object' || data === null) return undefined;
+    const t = (data as { type?: unknown }).type;
+    if (typeof t !== 'string') return undefined;
+    return data as Envelope;
+}
+
+// A pending correlated request, keyed by its minted id. `reply` is the `type` its answer must carry.
+interface Pending {
+    reply: string;
+    resolve: (payload: unknown) => void;
+    reject: (err: Error) => void;
+}
+
+// A live event subscription (from `events(...)`): every inbound envelope whose `type` matches is
+// handed to `enqueue`, which extracts its `payload` onto the surface's ReadableStream — so a `delta`
+// and the collected result are the payload (this surface's `payload[]` shape), not the envelope.
+interface EventSub {
+    type: string;
+    enqueue: (envelope: Envelope) => void;
+}
+
+// A registered responder (from `respond(...)`): answers inbound requests of `type`. `input`/`output`
+// are optional Standard-Schema-ish validators (validated via the engine's coercer is overkill here —
+// we use the same `~standard` validate the schemas already expose); `reply` is the answer's type.
+interface Responder {
+    handler: (payload: unknown) => unknown;
+    input?: SchemaValidate;
+    output?: SchemaValidate;
+    reply: string;
+}
+
+// The minimal validate surface we need off a schema: a Standard Schema's `~standard.validate`. We
+// accept anything exposing it (Zod ≥3.24 / Valibot / ArkType / a hand-rolled one) and treat a
+// non-conforming value as a validation failure (drop). Pure structural — no validator dependency.
+type SchemaValidate =
+    | { '~standard': { validate: (v: unknown) => StandardResult } }
+    | ((v: unknown) => boolean);
+
+type StandardResult =
+    | { value: unknown; issues?: undefined }
+    | { issues: readonly unknown[] }
+    | Promise<
+          | { value: unknown; issues?: undefined }
+          | { issues: readonly unknown[] }
+      >;
+
+// Run a schema against a value: `true` ⇒ it validates. A Standard Schema returns `{ issues }` on
+// failure; a plain predicate returns a boolean. Async Standard Schemas are awaited. Anything that
+// throws counts as a failure (fail-closed). No schema ⇒ always passes.
+async function passes(
+    schema: SchemaValidate | undefined,
+    value: unknown,
+): Promise<boolean> {
+    if (schema === undefined) return true;
+    try {
+        if (typeof schema === 'function') return schema(value);
+        const out = await schema['~standard'].validate(value);
+        return (out as { issues?: readonly unknown[] }).issues === undefined;
+    } catch {
+        return false;
+    }
+}
+
+// Mint a correlation id — a real UUID where `crypto.randomUUID` exists (every modern browser /
+// Worker / Node ≥ 16.7), else a good-enough random fallback so the surface still works in a bare vm.
+function freshId(): string {
+    const c = globalThis.crypto as { randomUUID?: () => string } | undefined;
+    return (
+        c?.randomUUID?.() ??
+        `pm-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+    );
+}
+
+// ---------------------------------------------------------------------------
+// per-method options
+// ---------------------------------------------------------------------------
+// Each verb's options extend the shared StitchConfig keys MINUS `kind` (the surface owns it) and
+// `url` (synthesised as a `postmessage:<type>` pseudo-endpoint), plus the verb's own fields. The
+// resilience chain (`retry`/`throttle`/`timeout`/`circuit`/`trace`/`signal`) all apply via the
+// engine, exactly as for every other surface.
+
+/** Options for {@link PostMessageChannel.request}. */
+export type RequestOptions = Partial<Omit<StitchConfig, 'kind' | 'url'>> & {
+    /** The message `type` posted to the peer. */
+    type: string;
+    /** The `type` the correlated reply must carry. Default `` `${type}-result` ``. */
+    reply?: string;
+    /** Schema validating the outbound `body` payload (the call argument). */
+    input?: StitchConfig['input'];
+    /** Schema validating the inbound reply payload (the result). */
+    output?: StitchConfig['output'];
+};
+
+/** Options for {@link PostMessageChannel.emit}. */
+export type EmitOptions = Partial<Omit<StitchConfig, 'kind' | 'url'>> & {
+    /** The message `type` posted to the peer. */
+    type: string;
+    /** Schema validating the outbound `body` payload (the call argument). */
+    input?: StitchConfig['input'];
+};
+
+/** Options for {@link PostMessageChannel.events}. */
+export type EventsOptions = Partial<Omit<StitchConfig, 'kind' | 'url'>> & {
+    /** The inbound event `type` to subscribe to. */
+    type: string;
+    /** Schema validating each inbound event payload (the collected/streamed value). */
+    output?: StitchConfig['output'];
+};
+
+/**
+ * The typed, validated, observable channel — the entry point this surface exposes. Built by
+ * {@link channel} / {@link windowChannel} / {@link portChannel}; binds the transport + the allowed
+ * origins ONCE, then mints stitches (`request`/`emit`/`events`) and responders (`respond`) that all
+ * share its single demux listener and per-channel registry. `close()` tears the whole thing down.
+ */
+export interface PostMessageChannel {
+    /**
+     * A correlated request→response: post `{ type, id, payload }`, await the inbound
+     * `{ type: reply, id }`. A BUFFERED surface (id `'postmessage'`). `reply` defaults to
+     * `` `${type}-result` ``. The call argument is inferred from `opts.input`; the result tracks
+     * `opts.output` (the reply payload schema). Timeout/abort reuse the engine's `timeout`/`signal`.
+     */
+    request<const C extends RequestOptions>(
+        opts: C,
+    ): Stitch<OutputOf<C>, InputOf<C>>;
+    /**
+     * Fire-and-forget send (no reply awaited): post `{ type, payload }` and resolve immediately. A
+     * buffered surface (id `'postmessage'`); result `void`. The call argument is inferred from
+     * `opts.input`.
+     */
+    emit<const C extends EmitOptions>(opts: C): Stitch<void, InputOf<C>>;
+    /**
+     * Subscribe to inbound events of `opts.type`. A STREAMING surface (id `'postmessage-event'`):
+     * `await` resolves to the collected payload array, `.stream()` yields live deltas. `opts.output`
+     * validates each payload (per-`delta`, ADR 0005 Addendum).
+     */
+    events<const C extends EventsOptions>(
+        opts: C,
+    ): Stitch<OutputOf<C>[], InputOf<C>>;
+    /**
+     * Register a handler that ANSWERS inbound requests of `type` (the receiving side — e.g. an
+     * iframe answering a `focus` request). Origin-gated, validates the inbound payload against
+     * `input`, runs `handler`, validates the result against `output`, posts
+     * `{ type: reply, id, payload: result }`. Returns an unsubscribe fn. NOT a stitch.
+     *
+     * `TIn`/`TOut` are caller-supplied handler types (the payload it receives, the result it
+     * returns) — author ergonomics, each intentionally appearing once, so the no-unnecessary-type-
+     * parameters lint is waived here. `input`/`output` are BARE schemas validating the single
+     * inbound payload / the single result (not slotted `InputSchemas` — a responder answers one
+     * value, not a request with `body`/`query`/… slots).
+     */
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+    respond<TIn = unknown, TOut = unknown>(
+        type: string,
+        handler: (payload: TIn) => TOut | Promise<TOut>,
+        opts?: {
+            input?: SchemaLike;
+            output?: SchemaLike;
+            reply?: string;
+        },
+    ): () => void;
+    /** Detach the listener, reject every pending request, close every event stream. */
+    close(): void;
+}
+
+// ---------------------------------------------------------------------------
+// the surface identities (ADR 0005 Decision 11: only the `id` round-trips)
+// ---------------------------------------------------------------------------
+
+/**
+ * The buffered postMessage surface — the identity `request` and `emit` carry. Its `execute` is bound
+ * per-call (it closes over the channel + this `opts`), so the exported identity is just the redaction
+ * anchor: `request`/`emit` stitches expose `kind: 'postmessage'` on `__config`, round-tripping as
+ * JSON. The live per-call surface is built in {@link makeChannel}.
+ */
+export const postMessageSurface: Surface = { id: 'postmessage' };
+
+/**
+ * The streaming postMessage surface — the identity `events` carries. Its live `execute`/`stream` are
+ * bound per-call (they close over the channel); this exported identity is the redaction/inspection
+ * anchor (`kind: 'postmessage-event'` on `__config`). Its `contractValue` documents the validation
+ * target — the envelope's `payload`, the sse `.data` precedent — for an inspector reading the
+ * surface; the per-call `events` surface extracts that payload upstream (at enqueue) so the chunk it
+ * yields IS the payload, validated directly.
+ */
+export const postMessageEventSurface: Surface = {
+    id: 'postmessage-event',
+    contractValue: (envelope) => (envelope as Envelope).payload,
+};
+
+// ---------------------------------------------------------------------------
+// the channel builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a {@link PostMessageChannel} over ANY {@link MessageTransport} — the core builder the other
+ * two delegate to (and what the tests drive with a fake transport). Attaches the single demux
+ * listener at construction; binds `allowedOrigins` as the security policy.
+ *
+ * @param transport The raw channel (a Window / port / a fake pair in tests).
+ * @param opts.allowedOrigins Origins inbound messages may come from. An origin-bearing transport
+ *   (a Window) drops anything else BEFORE dispatch/validation; a `MessagePort` (origin `''`) skips
+ *   the gate (a port is already private).
+ */
+export function channel(
+    transport: MessageTransport,
+    opts: { allowedOrigins: string[] },
+): PostMessageChannel {
+    return makeChannel(transport, opts.allowedOrigins);
+}
+
+/**
+ * Build a {@link PostMessageChannel} over a `Window` (or an iframe's `contentWindow`, or a thunk
+ * resolving one lazily — the natural shape when the frame mounts after the channel). `post` calls
+ * `target.postMessage(msg, targetOrigin, transfer)`; `subscribe` adds a `'message'` listener on the
+ * current global. `allowedOrigins` defaults to `[targetOrigin]`.
+ *
+ * RUNTIME-throws if `targetOrigin === '*'` (defense in depth beyond the {@link Origin} type): a
+ * wildcard target posts the message to whatever document currently occupies the frame — a classic
+ * postMessage data leak. The type forbids it; this catches a `as any` cast too.
+ */
+export function windowChannel(opts: {
+    target: Window | (() => Window);
+    targetOrigin: Origin;
+    allowedOrigins?: string[];
+}): PostMessageChannel {
+    if ((opts.targetOrigin as string) === '*')
+        throw new Error(
+            "postmessage: targetOrigin '*' is forbidden — name the exact origin (e.g. 'https://app.example.com'). A wildcard posts to whatever document occupies the frame.",
+        );
+    const resolveTarget = (): Window =>
+        typeof opts.target === 'function' ? opts.target() : opts.target;
+    const transport: MessageTransport = {
+        post: (message, transfer) => {
+            resolveTarget().postMessage(
+                message,
+                opts.targetOrigin,
+                transfer ?? [],
+            );
+        },
+        subscribe: (handler) => {
+            // Inbound messages arrive on the GLOBAL `'message'` event (the `window` that receives
+            // the peer's `postMessage`). Where there is no DOM event target — SSR, a non-DOM worker
+            // pass, a test in a bare node context — degrade to a no-op subscription so constructing
+            // the channel never throws; a real browser wires the listener as expected.
+            const g = globalThis as unknown as {
+                addEventListener?: (
+                    t: string,
+                    l: (e: MessageEvent) => void,
+                ) => void;
+                removeEventListener?: (
+                    t: string,
+                    l: (e: MessageEvent) => void,
+                ) => void;
+            };
+            if (typeof g.addEventListener !== 'function')
+                return () => undefined;
+            const listener = (e: MessageEvent): void => {
+                handler(e.data, e.origin);
+            };
+            g.addEventListener('message', listener);
+            return () => {
+                g.removeEventListener?.('message', listener);
+            };
+        },
+    };
+    return makeChannel(transport, opts.allowedOrigins ?? [opts.targetOrigin]);
+}
+
+/**
+ * Build a {@link PostMessageChannel} over a `MessagePort` (a `MessageChannel` end, or a port handed
+ * across a `postMessage`). `post` is `port.postMessage`; `subscribe` adds a `'message'` listener and
+ * `port.start()`s delivery. A port carries NO origin — it is already a private, capability-style
+ * channel — so origin gating is BYPASSED (every message has origin `''`, which the gate skips).
+ */
+export function portChannel(
+    port: MessagePort,
+    opts?: { allowedOrigins?: string[] },
+): PostMessageChannel {
+    const transport: MessageTransport = {
+        post: (message, transfer) => {
+            port.postMessage(message, transfer ?? []);
+        },
+        subscribe: (handler) => {
+            const listener = (e: MessageEvent): void => {
+                handler(e.data, ''); // a port has no origin
+            };
+            port.addEventListener('message', listener);
+            port.start();
+            return () => {
+                port.removeEventListener('message', listener);
+            };
+        },
+    };
+    // A port has no origin, so allowedOrigins is moot; carry whatever was passed for symmetry.
+    return makeChannel(transport, opts?.allowedOrigins ?? []);
+}
+
+// The single implementation behind all three builders. Holds the per-channel registry (pending
+// requests, responders, event subs), attaches the one demux listener, and wires the four verbs.
+function makeChannel(
+    transport: MessageTransport,
+    allowedOrigins: string[],
+): PostMessageChannel {
+    const pending = new Map<string, Pending>();
+    const responders = new Map<string, Responder>();
+    const eventSubs = new Set<EventSub>();
+    // Live event-stream controllers, so `close()` can end each stream GRACEFULLY (a pending
+    // `await events(...)` then resolves to the payloads collected so far, rather than hanging).
+    const liveStreams = new Set<() => void>();
+    let closed = false;
+
+    // Whether this transport carries origins at all. A Window delivers a real `origin`; a port
+    // delivers `''`. We gate ONLY origin-bearing messages — a port message (origin `''`) is always
+    // allowed (it is already a private channel). An empty `allowedOrigins` over a Window therefore
+    // drops everything, which is the correct fail-closed default for a misconfigured channel.
+    const originAllowed = (origin: string): boolean =>
+        origin === '' || allowedOrigins.includes(origin);
+
+    // The ONE inbound demux: origin-gate → shape-guard → reply-correlation → responder → events →
+    // drop. Attached once here; `close()` detaches it.
+    const detach = transport.subscribe((data, origin) => {
+        // 1. Origin gate FIRST — before any dispatch or validation (the structural security bar).
+        if (!originAllowed(origin)) return;
+        // 2. Shape-guard: must be `{ type: string, ... }`.
+        const env = asEnvelope(data);
+        if (env === undefined) return;
+
+        // 3. Reply correlation: a pending request whose `reply` matches this envelope's `type` AND
+        //    whose minted id matches. Match on id AND type so an unrelated message of the same type
+        //    can't resolve a request, and a stale id can't either.
+        if (env.id !== undefined) {
+            const p = pending.get(env.id);
+            if (p?.reply === env.type) {
+                pending.delete(env.id);
+                p.resolve(env.payload);
+                return;
+            }
+        }
+
+        // 4. Responder: answer an inbound request of this `type`. Validate the inbound payload
+        //    against `input` (DROP on failure — a malformed request is ignored, not error-replied,
+        //    so a hostile peer learns nothing from the response shape), run the handler, validate
+        //    the result against `output` (drop on failure — never post an off-contract reply), then
+        //    post `{ type: reply, id, payload: result }`.
+        const responder = responders.get(env.type);
+        if (responder !== undefined) {
+            void answer(responder, env);
+            return;
+        }
+
+        // 5. Events: fan the full envelope out to every matching subscription (contractValue pulls
+        //    the payload for validation). A type may have multiple subscribers.
+        let delivered = false;
+        for (const sub of eventSubs) {
+            if (sub.type === env.type) {
+                sub.enqueue(env);
+                delivered = true;
+            }
+        }
+        if (delivered) return;
+
+        // 6. Unmatched: drop.
+    });
+
+    // Run a responder for one inbound request envelope (step 4 above), guarding both validation
+    // boundaries. Async because schema validation + the handler may be async.
+    async function answer(responder: Responder, env: Envelope): Promise<void> {
+        if (!(await passes(responder.input, env.payload))) return; // bad inbound → drop
+        let result: unknown;
+        try {
+            result = await responder.handler(env.payload);
+        } catch {
+            return; // a throwing handler does not reply (the requester times out)
+        }
+        if (!(await passes(responder.output, result))) return; // off-contract → never post
+        if (closed) return;
+        transport.post({
+            type: responder.reply,
+            ...(env.id !== undefined ? { id: env.id } : {}),
+            payload: result,
+        });
+    }
+
+    // ---- request: a buffered execute surface --------------------------------
+    function request<const C extends RequestOptions>(
+        opts: C,
+    ): Stitch<OutputOf<C>, InputOf<C>> {
+        const { type, reply, input, output, ...rest } = opts;
+        const replyType = reply ?? `${type}-result`;
+        const url = `postmessage:${type}`;
+        // `execute` (ADR 0008) replaces the transport at the engine's adapter call site, INSIDE the
+        // resilience chain — so `retry`/`throttle`/`circuit`/`timeout`/`signal`/`trace` all wrap it.
+        // It mints an id, registers a pending entry, posts the request, and resolves on the
+        // correlated reply. The engine's per-attempt `timeout` (and a caller's `signal`) reach us as
+        // `req.signal`: aborting it rejects the pending request and removes it, so a request with no
+        // matching reply rejects via the engine's `timeout`/`signal` (no separate timer is invented).
+        const surface: Surface = {
+            id: 'postmessage',
+            buildRequest: (_cfg, callInput, base) => ({
+                ...base,
+                body: callInput.body,
+            }),
+            execute: (req: AdapterRequest): Promise<AdapterResponse> =>
+                new Promise<AdapterResponse>((resolve, reject) => {
+                    if (closed) {
+                        reject(new Error('postmessage: channel is closed'));
+                        return;
+                    }
+                    const id = freshId();
+                    const settle = (payload: unknown): void => {
+                        resolve({
+                            status: 200,
+                            headers: {},
+                            body: payload,
+                            url,
+                        });
+                    };
+                    const onAbort = (): void => {
+                        if (pending.delete(id)) {
+                            req.signal?.removeEventListener('abort', onAbort);
+                            const reason = (req.signal?.reason ?? undefined) as
+                                | { name?: string }
+                                | undefined;
+                            const err = new Error(
+                                reason?.name === 'TimeoutError'
+                                    ? `postmessage: request '${type}' timed out`
+                                    : `postmessage: request '${type}' aborted`,
+                            );
+                            err.name = reason?.name ?? 'AbortError';
+                            reject(err);
+                        }
+                    };
+                    pending.set(id, {
+                        reply: replyType,
+                        resolve: (payload) => {
+                            req.signal?.removeEventListener('abort', onAbort);
+                            settle(payload);
+                        },
+                        reject: (e: Error) => {
+                            req.signal?.removeEventListener('abort', onAbort);
+                            reject(e);
+                        },
+                    });
+                    if (req.signal) {
+                        if (req.signal.aborted) {
+                            onAbort();
+                            return;
+                        }
+                        req.signal.addEventListener('abort', onAbort, {
+                            once: true,
+                        });
+                    }
+                    transport.post({ type, id, payload: req.body });
+                }),
+        };
+        // The assembled config is handed to `makeStitch` as the loose `Partial<StitchConfig>`
+        // Fragment: a generic `const C` keeps each slot's literal optionality (`C['name']` is
+        // `string | undefined`), which `exactOptionalPropertyTypes` rejects against `Fragment`'s
+        // `name?: string` — so widen the spread with `as Partial<StitchConfig>` (the generic
+        // optionality is sound at runtime), then retype the loose result back to the declared
+        // `InputOf<C>` (the sse/stream/graphql `as unknown as` idiom).
+        return makeStitch<OutputOf<C>>({
+            ...rest,
+            ...(input !== undefined ? { input } : {}),
+            ...(output !== undefined ? { output } : {}),
+            kind: surface,
+            url,
+        } as Partial<StitchConfig>) as unknown as Stitch<
+            OutputOf<C>,
+            InputOf<C>
+        >;
+    }
+
+    // ---- emit: a buffered execute surface, no reply -------------------------
+    function emit<const C extends EmitOptions>(
+        opts: C,
+    ): Stitch<void, InputOf<C>> {
+        const { type, input, ...rest } = opts;
+        const url = `postmessage:${type}`;
+        const surface: Surface = {
+            id: 'postmessage',
+            buildRequest: (_cfg, callInput, base) => ({
+                ...base,
+                body: callInput.body,
+            }),
+            // Fire-and-forget: post `{ type, payload }` (no id) and resolve immediately with no body.
+            execute: (req: AdapterRequest): Promise<AdapterResponse> => {
+                if (closed)
+                    return Promise.reject(
+                        new Error('postmessage: channel is closed'),
+                    );
+                transport.post({ type, payload: req.body });
+                return Promise.resolve({
+                    status: 200,
+                    headers: {},
+                    body: undefined,
+                    url,
+                });
+            },
+        };
+        // `makeStitch`'s generic can't be `void` (lint: void only valid as a return type) — build it
+        // loose and cast the result to the `void`-typed Stitch (emit's call resolves to nothing).
+        return makeStitch({
+            ...rest,
+            ...(input !== undefined ? { input } : {}),
+            kind: surface,
+            url,
+        } as Partial<StitchConfig>) as unknown as Stitch<void, InputOf<C>>;
+    }
+
+    // ---- events: a streaming surface ----------------------------------------
+    function events<const C extends EventsOptions>(
+        opts: C,
+    ): Stitch<OutputOf<C>[], InputOf<C>> {
+        const { type, output, ...rest } = opts;
+        const url = `postmessage:${type}`;
+        // `execute` returns a live `ReadableStream` of PAYLOADS the channel feeds via an event
+        // subscription (the inbound envelope's `payload` is extracted at enqueue), so a `delta` and
+        // the collected await result are both the payload — matching this surface's `payload[]`
+        // result type. `stream` reads the payload stream and yields each; the engine validates each
+        // chunk against `output` directly (it IS the value — no `contractValue` needed). A caller's
+        // `signal`, a stream `cancel()`, and the channel's `close()` all end the stream + unsubscribe.
+        const surface: Surface = {
+            id: 'postmessage-event',
+            execute: (req: AdapterRequest): Promise<AdapterResponse> => {
+                if (closed)
+                    return Promise.reject(
+                        new Error('postmessage: channel is closed'),
+                    );
+                let sub: EventSub | undefined;
+                let onAbort: (() => void) | undefined;
+                let endStream: (() => void) | undefined;
+                const body = new ReadableStream<unknown>({
+                    start: (controller) => {
+                        sub = {
+                            type,
+                            // Extract the payload at enqueue: the delta + collected result are the
+                            // payload, validated directly against `output`.
+                            enqueue: (envelope) => {
+                                controller.enqueue(envelope.payload);
+                            },
+                        };
+                        eventSubs.add(sub);
+                        // End the stream gracefully (resolving a pending await to what was collected)
+                        // and unsubscribe. Used by `close()` and on abort.
+                        endStream = () => {
+                            if (sub) eventSubs.delete(sub);
+                            liveStreams.delete(endStream as () => void);
+                            try {
+                                controller.close();
+                            } catch {
+                                /* already closed */
+                            }
+                        };
+                        liveStreams.add(endStream);
+                        // Caller abort (and the engine's per-attempt signal) ends the stream.
+                        if (req.signal) {
+                            onAbort = () => endStream?.();
+                            if (req.signal.aborted) onAbort();
+                            else
+                                req.signal.addEventListener('abort', onAbort, {
+                                    once: true,
+                                });
+                        }
+                    },
+                    cancel: () => {
+                        if (sub) eventSubs.delete(sub);
+                        if (endStream) liveStreams.delete(endStream);
+                        if (onAbort && req.signal)
+                            req.signal.removeEventListener('abort', onAbort);
+                    },
+                });
+                return Promise.resolve({
+                    status: 200,
+                    headers: {},
+                    body,
+                    url,
+                });
+            },
+            async *stream(res: AdapterResponse) {
+                const stream = res.body;
+                if (!(stream instanceof ReadableStream)) return;
+                const reader = (stream as ReadableStream<unknown>).getReader();
+                try {
+                    for (;;) {
+                        const r = await reader.read();
+                        if (r.done) break;
+                        yield r.value;
+                    }
+                } finally {
+                    reader.releaseLock();
+                }
+            },
+        };
+        return makeStitch<OutputOf<C>[]>({
+            ...rest,
+            ...(output !== undefined ? { output } : {}),
+            kind: surface,
+            url,
+        } as Partial<StitchConfig>) as unknown as Stitch<
+            OutputOf<C>[],
+            InputOf<C>
+        >;
+    }
+
+    // ---- respond: register an inbound handler (NOT a stitch) -----------------
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+    function respond<TIn = unknown, TOut = unknown>(
+        type: string,
+        handler: (payload: TIn) => TOut | Promise<TOut>,
+        opts?: {
+            input?: SchemaLike;
+            output?: SchemaLike;
+            reply?: string;
+        },
+    ): () => void {
+        const responder: Responder = {
+            handler: handler as (payload: unknown) => unknown,
+            reply: opts?.reply ?? `${type}-result`,
+        };
+        if (opts?.input !== undefined)
+            responder.input = opts.input as SchemaValidate;
+        if (opts?.output !== undefined)
+            responder.output = opts.output as SchemaValidate;
+        responders.set(type, responder);
+        return () => {
+            // Only delete if it is still THIS responder (a later respond(type, …) replaced it).
+            if (responders.get(type) === responder) responders.delete(type);
+        };
+    }
+
+    // ---- close: tear everything down ----------------------------------------
+    function close(): void {
+        if (closed) return;
+        closed = true;
+        detach();
+        for (const [id, p] of pending) {
+            pending.delete(id);
+            p.reject(new Error('postmessage: channel closed'));
+        }
+        // End every live event stream GRACEFULLY (closes the ReadableStream → a pending await
+        // resolves to the payloads collected so far; `.stream()` consumers see the iterator end).
+        for (const end of [...liveStreams]) end();
+        responders.clear();
+        eventSubs.clear();
+        liveStreams.clear();
+    }
+
+    return { request, emit, events, respond, close };
+}

--- a/packages/core/src/postmessage.ts
+++ b/packages/core/src/postmessage.ts
@@ -201,12 +201,21 @@ export interface PostMessageChannel {
      * Fire-and-forget send (no reply awaited): post `{ type, payload }` and resolve immediately. A
      * buffered surface (id `'postmessage'`); result `void`. The call argument is inferred from
      * `opts.input`.
+     *
+     * Like every stitch the call returns a LAZY result — it posts only when the result is driven
+     * (`await` / `.then` / `.catch` / `.finally`). For fire-and-forget, drive it explicitly:
+     * `void send(input).catch(() => {})`. A bare `send(input)` whose result is never awaited sends
+     * NOTHING.
      */
     emit<const C extends EmitOptions>(opts: C): Stitch<void, InputOf<C>>;
     /**
      * Subscribe to inbound events of `opts.type`. A STREAMING surface (id `'postmessage-event'`):
-     * `await` resolves to the collected payload array, `.stream()` yields live deltas. `opts.output`
-     * validates each payload (per-`delta`, ADR 0005 Addendum).
+     * `.stream()` yields live deltas; `await` collects until the stream ends (so prefer `.stream()`
+     * for an ongoing subscription). `opts.output` validates each payload (per-`delta`, ADR 0005
+     * Addendum) — but note a violation TERMINATES the stream with a `drift` error (the sse/stream
+     * contract: a bad value is loud, not silently dropped). For a discrete event bus where one
+     * malformed message should NOT end the subscription, omit `output` and validate each payload in
+     * the consumer — drop the bad one, keep listening (an `onInvalid: 'drop'` mode is future work).
      */
     events<const C extends EventsOptions>(
         opts: C,

--- a/packages/core/test-d/postmessage.test-d.ts
+++ b/packages/core/test-d/postmessage.test-d.ts
@@ -1,0 +1,64 @@
+// Type-level tests for the `postmessage` surface (ADR 0009): `request` infers its call argument
+// from `opts.input` and its result from `opts.output`; `events` infers the collected PAYLOAD array
+// from `opts.output`; `emit` resolves to `void`. We assert on the UNWRAPPED result via `output(...)`
+// and on the call-ARGUMENT via `CallArg` (the `Stitch<…>`-bound / `expectType<Stitch<…>>` recursive-
+// `with` quirk, same as the core inference tests in input-inference.test-d.ts).
+import { channel } from '../src/postmessage';
+import type { MessageTransport } from '../src/postmessage';
+import { type CallArg, output } from './_util';
+
+import { expectAssignable, expectError, expectType } from 'tsd';
+import { z } from 'zod';
+
+// The awaited result of a stitch call, asserted directly off `ReturnType` — `output(...)` from
+// `_util` carries an `S extends Stitch<unknown>` bound that (per its own note) rejects a stitch with
+// a REQUIRED first arg (the recursive-`with` contravariance), so a required-`body` request/emit
+// can't use it. `Awaited<ReturnType<S>>` unwraps `StitchResult<T>` to `T` with no such bound.
+type Result<S extends (...args: never[]) => { then: unknown }> = Awaited<
+    ReturnType<S>
+>;
+
+// A throwaway transport just to mint a channel for the type assertions (never executed).
+const transport = null as unknown as MessageTransport;
+const ch = channel(transport, { allowedOrigins: ['https://x.test'] });
+
+// 1) request: result inferred from `opts.output`, call argument from `opts.input`.
+const sum = ch.request({
+    type: 'sum',
+    input: { body: z.object({ a: z.number(), b: z.number() }) },
+    output: z.object({ total: z.number() }),
+});
+expectType<{ total: number }>(null as unknown as Result<typeof sum>); // result tracks opts.output
+expectType<{ a: number; b: number }>(
+    null as unknown as CallArg<typeof sum>['body'], // call arg tracks opts.input.body
+);
+expectError(sum({ body: { a: 1 } })); // missing `b`
+expectError(sum({ body: { a: 1, b: 'two' } })); // `b` must be a number
+
+// 2) request with NO output schema → result is unknown (no contract pinned); arg stays optional.
+const bare = ch.request({ type: 'ping' });
+expectType<unknown>(output(bare));
+
+// 3) emit: result is void; call argument inferred from `opts.input`.
+const log = ch.emit({
+    type: 'log',
+    input: { body: z.object({ msg: z.string() }) },
+});
+expectType<void>(null as unknown as Result<typeof log>);
+expectType<{ msg: string }>(null as unknown as CallArg<typeof log>['body']);
+expectError(log({ body: { msg: 123 } })); // msg must be a string
+
+// 4) events: result is the COLLECTED PAYLOAD ARRAY, typed from `opts.output`.
+const ticks = ch.events({
+    type: 'tick',
+    output: z.object({ n: z.number() }),
+});
+expectType<{ n: number }[]>(output(ticks)); // await ⇒ payload[] (no required arg → output() is fine)
+
+// 5) events with NO output schema → unknown[] (the loose collected array).
+const loose = ch.events({ type: 'evt' });
+expectType<unknown[]>(output(loose));
+
+// 6) a no-input request keeps a fully-OPTIONAL call argument (backward-compatible with StitchInput).
+const noInput = ch.request({ type: 'noop' });
+expectAssignable<CallArg<typeof noInput>>(undefined);

--- a/packages/core/test/gaps/browser-bundle.spec.ts
+++ b/packages/core/test/gaps/browser-bundle.spec.ts
@@ -85,6 +85,7 @@ const BROWSER_LEGIT = [
     'src/sse.ts',
     'src/stream.ts',
     'src/download.ts',
+    'src/postmessage.ts',
     'src/llm.ts',
     'src/pipe.ts',
     'src/cache.ts',
@@ -214,7 +215,9 @@ describe('streaming surfaces are browser-first (ADR 0005 Decisions 4-5)', () => 
     // Each surface subpath must bundle for the browser on fetch + Web Streams alone — no node:*
     // dep transitively, and never `EventSource` (Decision 4 rejects it: GET-only, no headers,
     // Node-absent).
-    test.each(['src/sse.ts', 'src/stream.ts'])(
+    // postmessage carries a streaming surface (its `events` verb), so it joins this matrix: it must
+    // bundle on Web Streams + postMessage alone — no node:*, and never EventSource (ADR 0009).
+    test.each(['src/sse.ts', 'src/stream.ts', 'src/postmessage.ts'])(
         '%s bundles for "browser" with no node:* specifiers and no EventSource',
         async (entry) => {
             const { errorTexts, output } = await bundleForBrowser(entry);

--- a/packages/core/test/postmessage.spec.ts
+++ b/packages/core/test/postmessage.spec.ts
@@ -1,0 +1,526 @@
+// The `postmessage` surface (ADR 0009): a typed, validated, observable wrapper over browser
+// `postMessage` RPC + events. These specs drive the WHOLE surface over an in-memory LINKED
+// TRANSPORT PAIR — two `MessageTransport`s wired to each other, each carrying a configurable
+// `origin` — simulating parent↔iframe with zero DOM. The four verbs (request/emit/events/respond),
+// the origin gate, validation, timeout/abort, and `close()` are all exercised through it.
+import {
+    type MessageTransport,
+    type PostMessageChannel,
+    channel,
+    portChannel,
+    postMessageEventSurface,
+    postMessageSurface,
+    windowChannel,
+} from '../src/postmessage';
+import { asValidator } from './support/schema';
+import { collectEvents } from './support/streams';
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// the linked transport pair
+// ---------------------------------------------------------------------------
+// Two transports wired to each other: a `post` on A delivers (async, next microtask) to every B
+// subscriber, stamped with A's configured origin, and vice-versa. The async delivery models the
+// real postMessage task hop and lets a request register its pending entry before the reply lands.
+
+interface LinkedPair {
+    a: MessageTransport;
+    b: MessageTransport;
+}
+
+function linkedPair(originA: string, originB: string): LinkedPair {
+    const subsA = new Set<(data: unknown, origin: string) => void>();
+    const subsB = new Set<(data: unknown, origin: string) => void>();
+    // A posts → B's subscribers see it, tagged with A's origin (the origin of the SENDER).
+    const a: MessageTransport = {
+        post: (message) => {
+            const clone = structuredCloneish(message);
+            queueMicrotask(() => {
+                for (const h of subsB) h(clone, originA);
+            });
+        },
+        subscribe: (handler) => {
+            subsA.add(handler);
+            return () => subsA.delete(handler);
+        },
+    };
+    const b: MessageTransport = {
+        post: (message) => {
+            const clone = structuredCloneish(message);
+            queueMicrotask(() => {
+                for (const h of subsA) h(clone, originB);
+            });
+        },
+        subscribe: (handler) => {
+            subsB.add(handler);
+            return () => subsB.delete(handler);
+        },
+    };
+    return { a, b };
+}
+
+// A cheap structured-clone stand-in (the real postMessage clones the envelope). JSON round-trip is
+// enough for our plain-data payloads and proves we never rely on referential identity across the wire.
+function structuredCloneish<T>(v: T): T {
+    return JSON.parse(JSON.stringify(v)) as T;
+}
+
+const ORIGIN_A = 'https://parent.example.com';
+const ORIGIN_B = 'https://iframe.example.com';
+
+// Build a parent↔iframe channel pair. The parent allows the iframe's origin and vice-versa.
+function channelPair(): {
+    parent: PostMessageChannel;
+    iframe: PostMessageChannel;
+    closeBoth: () => void;
+} {
+    const { a, b } = linkedPair(ORIGIN_A, ORIGIN_B);
+    const parent = channel(a, { allowedOrigins: [ORIGIN_B] });
+    const iframe = channel(b, { allowedOrigins: [ORIGIN_A] });
+    return {
+        parent,
+        iframe,
+        closeBoth: () => {
+            parent.close();
+            iframe.close();
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// surface identities + redaction (the contract gate)
+// ---------------------------------------------------------------------------
+
+describe('postmessage surface identities (ADR 0005 Decision 11)', () => {
+    test('the two surface ids are stable', () => {
+        expect(postMessageSurface.id).toBe('postmessage');
+        expect(postMessageEventSurface.id).toBe('postmessage-event');
+    });
+
+    test('request/emit kind round-trips through __config as "postmessage"', () => {
+        const { parent, closeBoth } = channelPair();
+        const req = parent.request({ type: 'focus' });
+        const ev = parent.emit({ type: 'ping' });
+        for (const s of [req, ev]) {
+            const json = JSON.parse(JSON.stringify(s.__config)) as {
+                kind?: unknown;
+            };
+            expect(json.kind).toBe('postmessage');
+        }
+        closeBoth();
+    });
+
+    test('events kind round-trips as "postmessage-event"', () => {
+        const { parent, closeBoth } = channelPair();
+        const sub = parent.events({ type: 'tick' });
+        const json = JSON.parse(JSON.stringify(sub.__config)) as {
+            kind?: unknown;
+        };
+        expect(json.kind).toBe('postmessage-event');
+        closeBoth();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// request → response
+// ---------------------------------------------------------------------------
+
+describe('request → response (correlated RPC)', () => {
+    test('happy path: B.respond answers, A awaits the validated reply', async () => {
+        const { parent, iframe, closeBoth } = channelPair();
+        // The iframe answers `sum` requests by adding two numbers.
+        const off = iframe.respond<{ a: number; b: number }, { total: number }>(
+            'sum',
+            ({ a, b }) => ({ total: a + b }),
+            {
+                input: asValidator(z.object({ a: z.number(), b: z.number() })),
+                output: asValidator(z.object({ total: z.number() })),
+            },
+        );
+        const sum = parent.request({
+            type: 'sum',
+            input: { body: z.object({ a: z.number(), b: z.number() }) },
+            output: asValidator(z.object({ total: z.number() })),
+        });
+        await expect(sum({ body: { a: 2, b: 3 } })).resolves.toEqual({
+            total: 5,
+        });
+        off();
+        closeBoth();
+    });
+
+    test('a custom `reply` type correlates the answer', async () => {
+        const { parent, iframe, closeBoth } = channelPair();
+        iframe.respond('q', () => 'answered', { reply: 'q-answer' });
+        const ask = parent.request<{
+            type: 'q';
+            reply: 'q-answer';
+        }>({ type: 'q', reply: 'q-answer' });
+        await expect(ask()).resolves.toBe('answered');
+        closeBoth();
+    });
+
+    test('the reply must match BOTH id and type — a same-type unsolicited message does not resolve it', async () => {
+        const { a, b } = linkedPair(ORIGIN_A, ORIGIN_B);
+        const parent = channel(a, { allowedOrigins: [ORIGIN_B] });
+        const iframe = channel(b, { allowedOrigins: [ORIGIN_A] });
+        // The iframe emits an UNSOLICITED `sum-result` (no id) BEFORE any responder — it must NOT
+        // resolve the pending request (whose reply correlates on the minted id too).
+        const sum = parent.request({
+            type: 'sum',
+            timeout: { perAttempt: 60 },
+        });
+        const p = sum({ body: { a: 1, b: 1 } });
+        // fire a bare {type:'sum-result'} with no id from the iframe side
+        iframe
+            .emit({ type: 'sum-result' })()
+            .catch(() => undefined);
+        await expect(p).rejects.toThrow(); // never correlated → times out
+        parent.close();
+        iframe.close();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// timeout (engine `timeout`, not a bespoke timer)
+// ---------------------------------------------------------------------------
+
+describe('request timeout reuses the engine resilience chain', () => {
+    test('no responder → the engine `timeout` rejects with a StitchError', async () => {
+        const { parent, closeBoth } = channelPair();
+        const lonely = parent.request({
+            type: 'noone-home',
+            timeout: { perAttempt: 40 },
+        });
+        await expect(lonely({ body: { x: 1 } })).rejects.toMatchObject({
+            name: 'StitchError',
+        });
+        closeBoth();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// origin gate (FIRST, before any dispatch/validation)
+// ---------------------------------------------------------------------------
+
+describe('origin gate (structural, gate-before-validation)', () => {
+    test('a reply from a DISALLOWED origin is dropped → the request times out', async () => {
+        // The iframe posts from an origin the parent does NOT allow. The parent's gate drops the
+        // reply before correlation, so the request never resolves and times out.
+        const { a, b } = linkedPair(ORIGIN_A, 'https://evil.example.com');
+        const parent = channel(a, { allowedOrigins: [ORIGIN_B] }); // only the REAL iframe origin
+        const evil = channel(b, { allowedOrigins: [ORIGIN_A] });
+        evil.respond('sum', () => ({ total: 999 }));
+        const sum = parent.request({
+            type: 'sum',
+            timeout: { perAttempt: 40 },
+        });
+        await expect(sum({ body: { a: 1, b: 2 } })).rejects.toMatchObject({
+            name: 'StitchError',
+        });
+        parent.close();
+        evil.close();
+    });
+
+    test('an event from a disallowed origin is never delivered', async () => {
+        const { a, b } = linkedPair(ORIGIN_A, 'https://evil.example.com');
+        const parent = channel(a, { allowedOrigins: [ORIGIN_B] });
+        const evil = channel(b, { allowedOrigins: [ORIGIN_A] });
+        const events = parent.events({ type: 'tick' });
+        const ctl = new AbortController();
+        const collected: unknown[] = [];
+        const drain = (async () => {
+            for await (const e of events.stream({ signal: ctl.signal })) {
+                if (e.type === 'delta') collected.push(e.chunk);
+            }
+        })();
+        // The evil frame emits a `tick`; the parent's gate drops it (wrong origin).
+        evil.emit({ type: 'tick' as const })({ body: { n: 1 } }).catch(
+            () => undefined,
+        );
+        await new Promise((r) => setTimeout(r, 30));
+        ctl.abort();
+        await drain.catch(() => undefined);
+        expect(collected).toEqual([]); // nothing crossed the gate
+        parent.close();
+        evil.close();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// inbound validation (responder input, request output/drift)
+// ---------------------------------------------------------------------------
+
+describe('validation on both boundaries', () => {
+    test('a responder DROPS a payload that fails its `input` schema (no reply → requester times out)', async () => {
+        const { parent, iframe, closeBoth } = channelPair();
+        iframe.respond('strict', (p: { n: number }) => ({ doubled: p.n * 2 }), {
+            input: asValidator(z.object({ n: z.number() })),
+        });
+        // Send a string where a number is required → the responder validates-and-drops → no reply.
+        const call = parent.request({
+            type: 'strict',
+            timeout: { perAttempt: 40 },
+        });
+        await expect(
+            call({ body: { n: 'not-a-number' } }),
+        ).rejects.toMatchObject({ name: 'StitchError' });
+        closeBoth();
+    });
+
+    test('a reply that fails the request `output` schema surfaces as drift/error', async () => {
+        const { parent, iframe, closeBoth } = channelPair();
+        // The responder replies with the WRONG shape (no `output` guard on its side).
+        iframe.respond('mismatch', () => ({ wrong: true }));
+        const call = parent.request({
+            type: 'mismatch',
+            output: asValidator(z.object({ ok: z.boolean() })),
+        });
+        // The reply correlates, but the buffered `output` contract rejects it → StitchError (drift).
+        await expect(call({ body: {} })).rejects.toMatchObject({
+            name: 'StitchError',
+        });
+        closeBoth();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// events (streaming surface)
+// ---------------------------------------------------------------------------
+
+describe('events (a streaming surface, validated payloads)', () => {
+    test('await collects the payloads; ordering is preserved over .stream()', async () => {
+        const { parent, iframe, closeBoth } = channelPair();
+        const events = parent.events({
+            type: 'tick',
+            output: asValidator(z.object({ n: z.number() })),
+        });
+
+        const ctl = new AbortController();
+        const seen: unknown[] = [];
+        const drain = (async () => {
+            for await (const e of events.stream({ signal: ctl.signal })) {
+                if (e.type === 'delta') {
+                    seen.push(e.chunk);
+                    if (seen.length === 3) ctl.abort(); // stop after three
+                }
+            }
+        })();
+
+        // Let the subscription register, then emit three ticks IN ORDER from the iframe.
+        await new Promise((r) => setTimeout(r, 5));
+        for (const n of [1, 2, 3])
+            iframe
+                .emit({ type: 'tick' as const })({ body: { n } })
+                .catch(() => undefined);
+
+        await drain.catch(() => undefined);
+        expect(seen).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]); // contractValue → the payload, in order
+        closeBoth();
+    });
+
+    test('await resolves to the collected payload array when the channel closes the stream', async () => {
+        const { parent, iframe } = channelPair();
+        const events = parent.events({ type: 'evt' });
+        // Kick off consumption NOW (`.then` starts the run and registers the subscription via
+        // `execute`); the same shared run is what we assert on below. A bare `events()` is lazy.
+        const settled = events().then((v) => v);
+
+        await new Promise((r) => setTimeout(r, 5));
+        for (const v of ['x', 'y'])
+            iframe
+                .emit({ type: 'evt' as const })({ body: v })
+                .catch(() => undefined);
+        await new Promise((r) => setTimeout(r, 20));
+        // Closing the parent ends its live event streams GRACEFULLY → the await resolves to the
+        // payloads collected so far (vs. an abort, which errors the stream — tested separately).
+        parent.close();
+        iframe.close();
+
+        await expect(settled).resolves.toEqual(['x', 'y']);
+    });
+
+    test('a payload failing the `output` schema fails the stream (the bad event is not delivered)', async () => {
+        const { parent, iframe, closeBoth } = channelPair();
+        const events = parent.events({
+            type: 'num',
+            output: asValidator(z.object({ n: z.number() })),
+        });
+        const ev = collectEvents(events.stream());
+        await new Promise((r) => setTimeout(r, 5));
+        iframe
+            .emit({ type: 'num' as const })({ body: { n: 1 } })
+            .catch(() => undefined);
+        iframe
+            .emit({ type: 'num' as const })({ body: { bad: true } })
+            .catch(() => undefined);
+        const collected = await ev;
+        expect(collected.deltas).toEqual([{ n: 1 }]);
+        expect(collected.drifts[0]?.level).toBe('error');
+        expect(collected.done?.ok).toBe(false);
+        closeBoth();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// emit (fire-and-forget)
+// ---------------------------------------------------------------------------
+
+describe('emit (fire-and-forget)', () => {
+    test('B receives the emit via respond; A resolves without awaiting a reply', async () => {
+        const { parent, iframe, closeBoth } = channelPair();
+        let received: unknown;
+        iframe.respond('log', (p) => {
+            received = p;
+            return null; // a reply nobody is waiting for
+        });
+        const log = parent.emit({ type: 'log' });
+        await expect(log({ body: { msg: 'hello' } })).resolves.toBeUndefined();
+        // give the microtask hop time to deliver to the iframe
+        await new Promise((r) => setTimeout(r, 5));
+        expect(received).toEqual({ msg: 'hello' });
+        closeBoth();
+    });
+
+    test('emit is also observable as an inbound event on the peer', async () => {
+        const { parent, iframe, closeBoth } = channelPair();
+        const events = iframe.events({ type: 'beacon' });
+        const ctl = new AbortController();
+        const seen: unknown[] = [];
+        const drain = (async () => {
+            for await (const e of events.stream({ signal: ctl.signal })) {
+                if (e.type === 'delta') {
+                    seen.push(e.chunk);
+                    ctl.abort();
+                }
+            }
+        })();
+        await new Promise((r) => setTimeout(r, 5));
+        await parent.emit({ type: 'beacon' })({ body: { hit: 1 } });
+        await drain.catch(() => undefined);
+        expect(seen).toEqual([{ hit: 1 }]);
+        closeBoth();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// abort + close lifecycle
+// ---------------------------------------------------------------------------
+
+describe('abort + close', () => {
+    test('aborting the call signal rejects the pending request and leaves no dangling entry', async () => {
+        const { parent, closeBoth } = channelPair();
+        const call = parent.request({ type: 'never-answered' });
+        const ctl = new AbortController();
+        const p = call({ body: {}, signal: ctl.signal });
+        ctl.abort();
+        await expect(p).rejects.toMatchObject({ name: 'StitchError' });
+        // A second, independently-aborted call also rejects — proving the pending map didn't wedge.
+        const ctl2 = new AbortController();
+        const p2 = call({ body: {}, signal: ctl2.signal });
+        ctl2.abort();
+        await expect(p2).rejects.toMatchObject({ name: 'StitchError' });
+        closeBoth();
+    });
+
+    test('close() rejects in-flight pending requests and detaches the listener', async () => {
+        // Drive a channel over a transport whose post never echoes — the request stays pending until
+        // close() rejects it. Closing also unsubscribes (a later inbound message reaches nobody).
+        let delivered = 0;
+        let detached = false;
+        const transport: MessageTransport = {
+            post: () => {
+                delivered += 1;
+            },
+            subscribe: () => () => {
+                detached = true;
+            },
+        };
+        const ch = channel(transport, { allowedOrigins: [ORIGIN_B] });
+        const call = ch.request({ type: 'pending' });
+        // A stitch is lazy — start consuming so `execute` actually posts and registers the pending
+        // entry, then let the resilience chain reach the transport before closing.
+        const p = call({ body: {} });
+        p.catch(() => undefined); // begin the run
+        await new Promise((r) => setTimeout(r, 10));
+        expect(delivered).toBe(1); // the request was posted once before close
+        ch.close();
+        await expect(p).rejects.toThrow(/closed/);
+        expect(detached).toBe(true); // close() detached the demux listener
+    });
+});
+
+// ---------------------------------------------------------------------------
+// windowChannel / portChannel guards
+// ---------------------------------------------------------------------------
+
+describe('windowChannel guards', () => {
+    test("targetOrigin '*' throws at runtime (defense in depth beyond the Origin type)", () => {
+        const fakeWindow = {
+            postMessage: () => undefined,
+        } as unknown as Window;
+        expect(() =>
+            windowChannel({
+                target: fakeWindow,
+                // The Origin type forbids '*'; cast to prove the RUNTIME guard also bites.
+                targetOrigin: '*' as unknown as `https://${string}`,
+            }),
+        ).toThrow(/'\*'/);
+    });
+
+    test('windowChannel posts to the resolved target with the bound origin', async () => {
+        const posts: { msg: unknown; origin: string }[] = [];
+        const fakeWindow = {
+            postMessage: (msg: unknown, origin: string) => {
+                posts.push({ msg, origin });
+            },
+        } as unknown as Window;
+        // A thunk target is resolved per post (the natural shape when the frame mounts late).
+        const ch = windowChannel({
+            target: () => fakeWindow,
+            targetOrigin: 'https://app.example.com',
+        });
+        // Fire-and-forget so no reply is awaited; we only assert the post shape.
+        await ch.emit({ type: 'hi' })({ body: { a: 1 } });
+        expect(posts).toHaveLength(1);
+        expect(posts[0]?.origin).toBe('https://app.example.com');
+        expect(posts[0]?.msg).toMatchObject({ type: 'hi', payload: { a: 1 } });
+        ch.close();
+    });
+});
+
+describe('portChannel (origin gating bypassed for ports)', () => {
+    test('a MessagePort channel does an RPC round-trip with no origin', async () => {
+        const mc = new MessageChannel();
+        const parent = portChannel(mc.port1);
+        const worker = portChannel(mc.port2);
+        worker.respond<{ x: number }, { y: number }>('double', ({ x }) => ({
+            y: x * 2,
+        }));
+        const dbl = parent.request<{ type: 'double' }>({ type: 'double' });
+        await expect(dbl({ body: { x: 21 } })).resolves.toEqual({ y: 42 });
+        parent.close();
+        worker.close();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// the raw `channel` builder over a fake transport (the core path the others delegate to)
+// ---------------------------------------------------------------------------
+
+describe('channel() over an arbitrary transport', () => {
+    test('an empty allowedOrigins over an origin-bearing transport fails closed (drops everything)', async () => {
+        const { a, b } = linkedPair(ORIGIN_A, ORIGIN_B);
+        const parent = channel(a, { allowedOrigins: [] }); // allow NOTHING
+        const iframe = channel(b, { allowedOrigins: [ORIGIN_A] });
+        iframe.respond('x', () => 'ok');
+        const call = parent.request({ type: 'x', timeout: { perAttempt: 40 } });
+        // The iframe's reply carries origin ORIGIN_B, which is not in [] → dropped → times out.
+        await expect(call({ body: {} })).rejects.toMatchObject({
+            name: 'StitchError',
+        });
+        parent.close();
+        iframe.close();
+    });
+});

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -24,6 +24,8 @@ export default defineConfig([
             'src/sse.ts',
             'src/stream.ts',
             'src/download.ts',
+            // the postMessage surface (ADR 0009) → stitchapi/postmessage
+            'src/postmessage.ts',
             // non-HTTP surfaces + composition (ADR 0008) → stitchapi/llm, stitchapi/pipe
             'src/llm.ts',
             'src/pipe.ts',


### PR DESCRIPTION
## What

A new browser-native core surface, `stitchapi/postmessage`: typed, validated, observable `postMessage` RPC + events over a Window / iframe `contentWindow` / `MessagePort`. Rides the existing `Surface.execute` (ADR 0008's transport-replacement, the `shell` precedent) and `Surface.stream` hooks — **zero core-engine change**.

Removes the three perennial postMessage bugs StitchAPI exists to kill: drifted dual contracts, no payload validation, and `postMessage('*')` with no origin checks — plus hand-rolled, leaky RPC correlation.

## API
`windowChannel({ target, targetOrigin, allowedOrigins })` / `portChannel(port)` / `channel(transport, …)` build a `PostMessageChannel` with four verbs:
- `request(opts)` — correlated request→response (buffered surface `postmessage`); `output` validates the reply.
- `emit(opts)` — fire-and-forget send.
- `events(opts)` — inbound subscription (streaming surface `postmessage-event`); `await` collects, `.stream()` is live; `output` validates each payload.
- `respond(type, handler, opts?)` — the receiving side (origin-gated, validate-in/validate-out, reply). The only verb that isn't a stitch.

## Security (the load-bearing decision)
Origin is structural, not advisory: the `Origin` type forbids `'*'` (a compile error) **and** `windowChannel` throws on `'*'` at runtime; the demux gates origin **before** correlation/validation/delivery; an empty `allowedOrigins` fails closed; `MessagePort` is exempt by construction (documented). Responders drop bad input and never post off-contract output.

## Correlation / timeout / observability
Reuse the resilience chain — a per-channel id registry; the engine's `timeout`/`signal` reject a reply-less request (no bespoke timer); every verb is a run-identity span (ADR 0007), so the message bus shows up in the trace/DAG.

## Packaging
Core subpath — the most browser-native capability in the lib, so it belongs with `sse`/`stream`, not a peer package like `shell`. Added to the `tsup` entries, the `./postmessage` export (mirrors `./sse`), and the browser-bundle gate.

## Tests / gates
A 22-test spec over an in-memory linked-transport pair (happy path, timeout, origin rejection, validation, events await+stream, emit, abort cleanup, `'*'` throw, close) + tsd type-inference tests. Verified green: `build`, **581 tests**, `check:types`, `tsd`, `lint`, `attw`, prettier, and the browser-bundle gate.

Foundation for adopting typed + observable comms in strimko's iframe template-preview channel (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)