### PR TITLE
feat(core): bundle-size budget gate + zero-deps/size advertising

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -42,6 +42,24 @@ jobs:
             # docs app runs generateStaticParams over every page and surfaces those.
             - run: pnpm --filter @stitchapi/docs build
 
+    # Bundle-size budget gate (packages/core/scripts/bundle-size.mjs): the core entry
+    # has a min+gzip ceiling, so a change that bloats `import { stitch }` fails here
+    # unless the budget is deliberately raised in the same PR. It measures the BUILT
+    # lib/, so it builds core first and runs as its own job.
+    size:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - uses: actions/checkout@v4
+            - uses: pnpm/action-setup@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version-file: .nvmrc
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile
+            - run: pnpm --filter stitchapi build
+            - run: pnpm --filter stitchapi check:size
+
     # The docs/sandbox playground smoke suites (docs/sandbox/tests/run-all.mjs) import the BUILT
     # `stitchapi`, so they are build-dependent integration tests — they run in their own job that
     # builds core first, not in the src-only `pnpm test` gate above.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
   The agent-native runtime where a typed, declarative <strong>stitch</strong> replaces <code>fetch</code> — for humans and agents alike.
 </p>
 
+<p align="center">
+  <a href="https://www.npmjs.com/package/stitchapi?activeTab=dependencies"><img alt="Dependencies: 0" src="https://img.shields.io/badge/dependencies-0-brightgreen" /></a>
+  <img alt="npm bundle size (minified + gzipped)" src="https://img.shields.io/bundlephobia/minzip/stitchapi" />
+</p>
+
 > [!NOTE]
 >
 > **StitchAPI is production-ready (v1.0).** The core runtime is feature-complete, zero-dependency, and covered by a green test gate. Feedback is very welcome.
@@ -36,5 +41,10 @@ pnpm check:format        # prettier across the repo
 ```
 
 Scope work to one package with a filter, e.g. `pnpm --filter stitchapi test`.
+
+`pnpm --filter stitchapi size` checks the core entry against its bundle-size
+budget (`packages/core/scripts/bundle-size.mjs`) — the same gate CI enforces, so
+a change that grows the bundle past its ceiling fails unless the budget is
+raised deliberately in the same PR.
 
 The published library's own README is in [`packages/core/README.md`](packages/core/README.md).

--- a/apps/docs/content/docs/concepts/principles.mdx
+++ b/apps/docs/content/docs/concepts/principles.mdx
@@ -101,6 +101,12 @@ behind its own import — so an app never ships bytes for a CLI it will not run.
 The same frugality the event stream practices with an agent's context, the
 package practices with your bundle.
 
+Concretely, the whole `stitch` entry is about **21 kB minified + gzipped**
+(≈58 kB raw), and because every surface beyond `http` is a separate subpath
+import, a typical `import { stitch }` tree-shakes to roughly **17 kB**. With zero
+runtime dependencies, that figure is the entire cost — not the tip of a
+transitive tree.
+
 ### Contract, not dependency
 
 Redis is not the only KV store, `fetch` is not the only transport, and Zod is

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -5,7 +5,9 @@ description: 'Install stitchapi and set up the zero-dependency runtime in Node o
 
 Install the package, import `stitch`, and make one typed call to confirm the
 runtime works. `stitchapi` has zero dependencies and runs anywhere `fetch`
-does — Node, the browser, and edge runtimes.
+does — Node, the browser, and edge runtimes. The whole entry is about **21 kB
+minified + gzipped** — and with no dependencies, there is no transitive tree
+behind it (a typical `import { stitch }` tree-shakes to ~17 kB).
 
 <Callout type="info">
     **Validators are bring-your-own.** Because `stitchapi` ships with zero

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "check:types-d": "pnpm -r check:types-d",
         "check:lint": "pnpm -r check:lint",
         "check:exports": "pnpm -r check:exports",
+        "check:size": "pnpm -r check:size",
         "check:format": "prettier --check .",
         "format": "prettier --write .",
         "prepare": "lefthook install"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -25,6 +25,7 @@ The name StitchAPI combines the words “stitch” and “API,” reflecting its
 [![NPM Type Definitions](https://img.shields.io/npm/types/stitchapi)](https://www.npmjs.org/package/stitchapi)
 
 [![Codecov](https://img.shields.io/codecov/c/github/rejifald/stitchapi)](https://codecov.io/github/rejifald/StitchAPI)
+[![Dependencies](https://img.shields.io/badge/dependencies-0-brightgreen)](https://www.npmjs.com/package/stitchapi?activeTab=dependencies)
 ![npm bundle size](https://img.shields.io/bundlephobia/minzip/stitchapi)
 ![Tree Shaking](https://badgen.net/bundlephobia/tree-shaking/stitchapi)
 
@@ -106,7 +107,7 @@ For the full competitive landscape and positioning, see the [Overview](docs/OVER
 -   **CLI, HTTP & MCP surfaces** - the definition your code imports is also runnable from the shell (`stitch run <name>` streams JSONL events), served over HTTP (`stitch serve`), or exposed to agents over MCP (`stitch mcp`) — the same stitch behind every front door.
 -   **Typed URLs** - full [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) URI templates (`{id}`, `{+path}`, `{?q,sort}`, explode `*`, prefix `:n`), and a `qs`-style query builder that serializes nested objects (`a[b]=c`) and arrays — both dependency-free.
 -   **Pluggable transport** - `fetch` by default; drop in the shipped `axiosAdapter`, or any `Adapter` function, to route requests through axios or another HTTP client.
--   **Zero runtime dependencies** - `"dependencies": {}`; built on the platform's global `fetch`; tree-shakeable.
+-   **Zero runtime dependencies** - `"dependencies": {}`; built on the platform's global `fetch`; tree-shakeable. The whole entry is **~21 kB min+gzip**; a typical `import { stitch }` trims to **~17 kB** — and with no transitive tree, that is the entire cost.
 
 ## Documentation
 
@@ -145,6 +146,8 @@ const { stitch } = require("stitchapi");
 ```
 
 The runtime ships with zero dependencies. Schema validation is bring-your-own — pass a [Zod](https://zod.dev) schema or any [Standard Schema](https://standardschema.dev) validator ([Valibot](https://valibot.dev), [ArkType](https://arktype.io), …); none of them is bundled. The examples below use Zod for familiarity.
+
+**Bundle size.** The whole `stitchapi` entry is **~21 kB minified + gzipped** (~58 kB raw, ~19 kB brotli); because the package is side-effect-free and every surface beyond `http` lives behind its own subpath import, a typical `import { stitch }` tree-shakes to **~17 kB min+gzip**. With zero dependencies, that is the _whole_ cost — there is no transitive tree to install or audit.
 
 ## Quick start
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -221,6 +221,8 @@
         "check:types-d": "tsup --silent && tsd",
         "check:lint": "eslint src test",
         "check:exports": "attw --pack . --ignore-rules no-resolution",
+        "check:size": "node scripts/bundle-size.mjs",
+        "size": "tsup --silent && node scripts/bundle-size.mjs",
         "lint": "eslint src test",
         "build": "tsup",
         "prepack": "tsup"
@@ -276,6 +278,7 @@
         "@types/node": "^22.10.0",
         "@vitest/coverage-v8": "^4.1.8",
         "@vitest/eslint-plugin": "^1.6.20",
+        "esbuild": "^0.27.7",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
         "jiti": "^2.7.0",

--- a/packages/core/scripts/bundle-size.mjs
+++ b/packages/core/scripts/bundle-size.mjs
@@ -1,0 +1,144 @@
+// Bundle-size budget gate for the `stitchapi` core entry.
+//
+// "Pay only for what you import" is a stated principle; this makes it an enforced
+// gate. We measure the TREE-SHAKEN cost of importing from `stitchapi` — what a
+// downstream bundler actually emits — minified + gzipped, and fail if any scenario
+// exceeds its budget.
+//
+// Why re-bundle instead of `ls lib/index.mjs`? tsup code-splits shared engine code
+// into chunks that several subpath entries import, so the raw entry file is only
+// part of the cost and those chunks carry bytes other entries use. Re-bundling each
+// scenario with esbuild + tree-shaking reproduces what a consumer's bundler ships —
+// the same method bundlephobia uses. The numbers quoted in the READMEs and docs come
+// from here; keep them in sync (see memory: core-zero-deps-bundle-size).
+//
+// Budgets are a deliberate ceiling. Raising one is a conscious act: edit the number
+// below and justify it in the PR. Prefer trimming the entry, or moving a new
+// capability behind its own subpath import, over bumping the budget.
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { brotliCompressSync, gzipSync } from 'node:zlib';
+
+// esbuild ships as CommonJS; load it through createRequire so this stays robust
+// regardless of ESM/CJS interop.
+const require = createRequire(import.meta.url);
+const esbuild = require('esbuild');
+
+const libDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'lib');
+
+const KB = 1024;
+
+// Each scenario is a real import a consumer writes. `budget` is the min+gzip ceiling.
+const SCENARIOS = [
+    {
+        name: 'stitchapi — whole entry',
+        code: `export * from './index.mjs';`,
+        budget: 21.5 * KB,
+    },
+    {
+        name: 'import { stitch }',
+        code: `export { stitch } from './index.mjs';`,
+        budget: 17.5 * KB,
+    },
+];
+
+function measure(code) {
+    const result = esbuild.buildSync({
+        stdin: {
+            contents: code,
+            resolveDir: libDir,
+            sourcefile: 'entry.mjs',
+            loader: 'js',
+        },
+        bundle: true,
+        minify: true,
+        format: 'esm',
+        treeShaking: true,
+        platform: 'neutral',
+        external: ['node:*'], // zero deps; the root entry is browser-safe
+        write: false,
+        logLevel: 'silent',
+    });
+    const out = result.outputFiles[0].contents;
+    return {
+        min: out.length,
+        gzip: gzipSync(out, { level: 9 }).length,
+        brotli: brotliCompressSync(out).length,
+    };
+}
+
+const kb = (bytes) => `${(bytes / KB).toFixed(2)} KB`;
+
+if (!existsSync(resolve(libDir, 'index.mjs'))) {
+    console.error(
+        '✗ lib/index.mjs not found — run `pnpm build` first (or use `pnpm size`).',
+    );
+    process.exit(1);
+}
+
+const rows = SCENARIOS.map((s) => {
+    const m = measure(s.code);
+    return { ...s, ...m, over: m.gzip > s.budget };
+});
+
+const failed = rows.some((r) => r.over);
+
+if (process.argv.includes('--json')) {
+    console.log(
+        JSON.stringify(
+            rows.map(({ name, min, gzip, brotli, budget, over }) => ({
+                name,
+                min,
+                gzip,
+                brotli,
+                budget,
+                over,
+            })),
+            null,
+            2,
+        ),
+    );
+} else {
+    const col = (s, w) => String(s).padStart(w);
+    console.log('\n  Core bundle budget — tree-shaken, min+gzip\n');
+    console.log(
+        '  ' +
+            'scenario'.padEnd(26) +
+            col('minified', 11) +
+            col('gzip', 11) +
+            col('brotli', 11) +
+            col('budget', 11) +
+            '   status',
+    );
+    console.log('  ' + '─'.repeat(83));
+    for (const r of rows) {
+        const headroom = r.over
+            ? `OVER by ${kb(r.gzip - r.budget)}`
+            : `${kb(r.budget - r.gzip)} left`;
+        console.log(
+            '  ' +
+                r.name.padEnd(26) +
+                col(kb(r.min), 11) +
+                col(kb(r.gzip), 11) +
+                col(kb(r.brotli), 11) +
+                col(kb(r.budget), 11) +
+                `   ${r.over ? '✗' : '✓'} ${headroom}`,
+        );
+    }
+    console.log('');
+}
+
+if (failed) {
+    console.error(
+        '✗ Bundle budget exceeded.\n' +
+            '  Trim the entry, or move the new capability behind its own subpath import\n' +
+            '  (like cache / graphql / sse). If the growth is genuinely necessary, raise\n' +
+            '  the budget in packages/core/scripts/bundle-size.mjs and say why in the PR —\n' +
+            '  the budget is the gate, so bumping it must be deliberate.\n',
+    );
+    process.exit(1);
+}
+
+console.log('✓ Core entry within budget.\n');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       '@vitest/eslint-plugin':
         specifier: ^1.6.20
         version: 1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.8)
+      esbuild:
+        specifier: ^0.27.7
+        version: 0.27.7
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)


### PR DESCRIPTION
## Why

We ship **zero runtime dependencies** and a small core — but the repo neither *advertised* it nor *enforced* it. This PR does both: surfaces the zero-deps story, and turns the existing "pay only for what you import" principle into a CI **budget gate** so the core entry can't quietly grow.

## The numbers (measured, current `main` + this branch)

Tree-shaken cost of importing from `stitchapi`, min+gzip — the same method bundlephobia uses (re-bundle `lib/index.mjs` and tree-shake; a raw `ls` overcounts because tsup's shared chunks carry bytes other subpath entries use):

| Import | minified | **min+gzip** | brotli | budget |
|---|---|---|---|---|
| `stitchapi` — whole entry | 58.0 KB | **20.7 KB** | 18.6 KB | 21.5 KB |
| `import { stitch }` | 45.9 KB | **16.6 KB** | 15.1 KB | 17.5 KB |

With zero dependencies, that figure is the *whole* cost — no transitive tree.

## The gate

- **`packages/core/scripts/bundle-size.mjs`** — measures each scenario, prints a table, and **exits non-zero past budget**. Forcing a breach was verified to exit `1`.
- **Budgets** live in that file. Raising one means editing the number → visible in the diff, deliberate by construction. The failure message tells you to trim the entry or move the new capability behind its own subpath import (like `cache` / `graphql` / `sse`) before bumping the ceiling.
- **Scripts**: `pnpm --filter stitchapi size` (build + measure, for humans) and `check:size` (measure-only, for CI).
- **CI**: a dedicated `size` job in `verify.yml` builds core and runs the gate.
- **`esbuild`** added as a core devDependency, pinned to the `0.27.7` already in the tree → the lockfile diff is a single importer reference (no toolchain churn). It does **not** affect the published package (devDep only; the zero-deps brag is about runtime/peer deps).

## Advertising

- `dependencies: 0` badge in both READMEs (+ the bundlephobia minzip badge on the root README).
- A "Bundle size" note in the core README; concrete figures added to the **Pay only for what you import** principle and the **Installation** page.

## Verification

- ✅ Gate passes; a forced over-budget run exits `1`.
- ✅ `pnpm install --frozen-lockfile` consistent (CI install will pass).
- ✅ Prettier clean; pre-commit `format` + `typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
