### PR TITLE
ci(publish): gate npm publish on the browser e2e suite

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,5 +1,5 @@
 # Publishes the package to npm when a GitHub release is created. Publishing is
-# gated on the full verify suite passing first. See ~/Development/handbook
+# gated on the verify suite and the browser e2e gate passing first. See ~/Development/handbook
 # conventions/global/ci-canonical.md §13.
 name: Publish
 
@@ -39,8 +39,26 @@ jobs:
                   token: ${{ secrets.CODECOV_TOKEN }}
                   files: ./packages/core/coverage/lcov.info
 
+    # Pre-publish browser gate: the Playwright harness (real Chromium) proves the
+    # sandbox CSP + Worker egress blocking and that a RunResult.trace reaches the
+    # playground DAG. A release waits on it so we never publish a broken browser
+    # sandbox. Mirrors the `e2e` job in verify.yml.
+    e2e:
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        steps:
+            - uses: actions/checkout@v4
+            - uses: pnpm/action-setup@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version-file: .nvmrc
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile
+            - run: pnpm --filter @stitchapi/docs test:e2e:install
+            - run: pnpm --filter @stitchapi/docs test:e2e
+
     publish-npm:
-        needs: verify
+        needs: [verify, e2e]
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:


### PR DESCRIPTION
## Why

Publishing (`npm-publish.yml`) was gated **only** on the `verify` job — format / lint / types / `test:coverage` / exports. The Playwright **e2e** suite (real Chromium: sandbox CSP + Worker egress blocking, and that a `RunResult.trace` reaches the playground DAG) ran on PRs but was never a release gate. So a release could in principle ship a broken browser sandbox.

## What

- Add an `e2e` job to `npm-publish.yml`, mirroring the one in `verify.yml`.
- `publish-npm` now `needs: [verify, e2e]` — `verify` and `e2e` run in parallel and publishing waits on **both**.

```diff
-    publish-npm:
-        needs: verify
+    publish-npm:
+        needs: [verify, e2e]
```

## Stability

Safe to gate on — e2e has been green on the **last 12 `main` runs** and on #170 (2m58s). The harness landed in #168 (11/11).

## Validation note

`npm-publish.yml` triggers only on `release: created`, so **this PR's CI cannot exercise the publish workflow itself**. Validated by: Prettier parse + format (clean), structural review (`needs` resolves to existing jobs, `e2e` is byte-identical to the proven `verify.yml` job). This PR's own `verify.yml` run still executes the e2e job against this branch, re-confirming it's green.

## Not included (happy to add if you want)

The publish gate still omits **`sandbox`** and the new **`size`** budget gate (#170). Say the word and I'll make `publish-npm` wait on those too, so pre-publish runs the full PR suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
