### PR TITLE
fix(ci): unbreak frozen-lockfile install (esbuild override drift) + add lockfile gate

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -12,11 +12,11 @@ on:
     # the PR against the base as it was when CI last ran; if another PR changes an
     # interacting file before this one lands (e.g. the root pnpm.overrides), the PR
     # can be green yet break main. `merge_group` runs these jobs against the actual
-    # merge candidate, so the lockfile gate below sees the post-merge base. This trigger
-    # is inert until the `main` branch protection enables the GitHub merge queue (or, at
-    # minimum, "Require branches to be up to date before merging") with `lockfile` +
-    # `verify` as required checks — that setting is what actually blocks the stale-base
-    # merge that broke the deploy.
+    # merge candidate, so `verify` re-runs its frozen install + docs build against the
+    # post-merge base. This trigger is inert until the `main` branch protection enables
+    # the GitHub merge queue (or, at minimum, "Require branches to be up to date before
+    # merging") with `verify` as a required check — that setting is what actually blocks
+    # the stale-base merge that broke the deploy.
     merge_group:
 
 # Default-deny; this gate only reads the repo.
@@ -29,26 +29,6 @@ concurrency:
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-    # Lockfile-integrity gate. `pnpm install --frozen-lockfile` fails when pnpm-lock.yaml
-    # has drifted from any workspace manifest OR from the root pnpm.overrides — including
-    # the case that broke the Vercel deploy: a security override (esbuild@<0.28.1 →
-    # >=0.28.1) rewrites a manifest spec the lockfile never recorded, so the install that
-    # is implicitly `--frozen` in every CI/deploy environment refuses to run. This is its
-    # own fast job (no build, scripts skipped) so the failure surfaces in ~10s with an
-    # unambiguous name, and it runs on merge_group so the lockfile is checked against the
-    # post-merge base — the angle the per-PR run misses. Make it a required check.
-    lockfile:
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
-              with:
-                  node-version-file: .nvmrc
-                  cache: pnpm
-            - run: pnpm install --frozen-lockfile --ignore-scripts
-
     verify:
         runs-on: ubuntu-latest
         timeout-minutes: 10
@@ -59,6 +39,14 @@ jobs:
               with:
                   node-version-file: .nvmrc
                   cache: pnpm
+            # Lockfile-integrity gate (step 1, so drift fails this job in ~20s). A frozen
+            # install fails when pnpm-lock.yaml has drifted from any workspace manifest OR
+            # from the root pnpm.overrides — the case that broke the Vercel deploy: a
+            # security override (esbuild@<0.28.1 → >=0.28.1) rewrote a manifest spec the
+            # lockfile never recorded. This install is implicitly `--frozen` in every
+            # CI/deploy environment, and on merge_group it runs against the post-merge
+            # base — the angle a per-PR run misses. (size/sandbox/e2e repeat it as their
+            # own step 1; this is the fast, stable one to make a required check.)
             - run: pnpm install --frozen-lockfile
             # Cheap → expensive: a fast failure surfaces first.
             - run: pnpm check:format

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,6 +8,16 @@ on:
         branches: [main, develop]
     push:
         branches: [main, develop]
+    # Re-verify the *merged* result in the queue. A `pull_request` run only tests
+    # the PR against the base as it was when CI last ran; if another PR changes an
+    # interacting file before this one lands (e.g. the root pnpm.overrides), the PR
+    # can be green yet break main. `merge_group` runs these jobs against the actual
+    # merge candidate, so the lockfile gate below sees the post-merge base. This trigger
+    # is inert until the `main` branch protection enables the GitHub merge queue (or, at
+    # minimum, "Require branches to be up to date before merging") with `lockfile` +
+    # `verify` as required checks — that setting is what actually blocks the stale-base
+    # merge that broke the deploy.
+    merge_group:
 
 # Default-deny; this gate only reads the repo.
 permissions:
@@ -19,6 +29,26 @@ concurrency:
     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+    # Lockfile-integrity gate. `pnpm install --frozen-lockfile` fails when pnpm-lock.yaml
+    # has drifted from any workspace manifest OR from the root pnpm.overrides — including
+    # the case that broke the Vercel deploy: a security override (esbuild@<0.28.1 →
+    # >=0.28.1) rewrites a manifest spec the lockfile never recorded, so the install that
+    # is implicitly `--frozen` in every CI/deploy environment refuses to run. This is its
+    # own fast job (no build, scripts skipped) so the failure surfaces in ~10s with an
+    # unambiguous name, and it runs on merge_group so the lockfile is checked against the
+    # post-merge base — the angle the per-PR run misses. Make it a required check.
+    lockfile:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - uses: actions/checkout@v4
+            - uses: pnpm/action-setup@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version-file: .nvmrc
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile --ignore-scripts
+
     verify:
         runs-on: ubuntu-latest
         timeout-minutes: 10

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -279,7 +279,7 @@
         "@types/node": "^22.10.0",
         "@vitest/coverage-v8": "^4.1.8",
         "@vitest/eslint-plugin": "^1.6.20",
-        "esbuild": "^0.27.7",
+        "esbuild": "^0.28.1",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
         "jiti": "^2.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,8 +189,8 @@ importers:
         specifier: ^1.6.20
         version: 1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.8)
       esbuild:
-        specifier: ^0.27.7
-        version: 0.27.7
+        specifier: ^0.28.1
+        version: 0.28.1
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)


### PR DESCRIPTION
## What broke

`main`'s `pnpm install --frozen-lockfile` — the install that's implicitly `--frozen` in every CI job and on the Vercel docs deploy — fails:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/packages/core/package.json
  - esbuild (lockfile: ^0.27.7, manifest: >=0.28.1)
```

The push-to-`main` `Verify` runs for [#170](https://github.com/rejifald/StitchAPI/pull/170) and [#171](https://github.com/rejifald/StitchAPI/pull/171) are both red (fail at install in ~20s); Vercel hit the same wall.

## Root cause — a stale-base merge conflict, not a missing check

- The root `pnpm.overrides` carries a security pin `esbuild@<0.28.1: ">=0.28.1"` (the esbuild dev-server CVE).
- [#170](https://github.com/rejifald/StitchAPI/pull/170) added `esbuild: ^0.27.7` to `packages/core` and committed a lockfile recording `0.27.7` for that importer.
- pnpm applies the override to the **manifest** spec (`^0.27.7` → `>=0.28.1`), then compares it against the lockfile's recorded importer spec (`^0.27.7`) → mismatch → refuses to install.
- [#170](https://github.com/rejifald/StitchAPI/pull/170)'s own CI was **green** because it was tested against an older base that predated the override. The conflict only materialised once it squash-landed on top. The existing frozen-install gate works — it just never saw the conflicting combination, because a `pull_request` run isn't re-executed when the base advances.

## The fix

Bump core's `esbuild` devDep `^0.27.7` → `^0.28.1` so the manifest is **truthful**: it sits at the override's floor (the override no longer silently rewrites it) and matches what already resolves in the tree (vite pulls `0.28.1`). Regenerate the lockfile — a 4-line importer change; the old entry pointed at a `0.27.7` snapshot that didn't even exist in the file.

Verified locally:
- `pnpm install --frozen-lockfile` → **`Lockfile is up to date`**
- `pnpm --filter stitchapi build` → ok
- `pnpm --filter stitchapi check:size` → **green on 0.28.1** (20.73 KB / 16.63 KB gzip, both within budget)

## The gate

The hole was never a *missing* check — every job runs `pnpm install --frozen-lockfile` as step 1, so drift already fails them fast. The hole was that a `pull_request` run isn't re-executed against the base after it advances. So:

- **`merge_group` trigger** added to `verify.yml` so the whole gate re-runs against the **post-merge** base — the exact angle a per-PR run misses.
- **`verify`** is documented as the lockfile-drift anchor: its step-1 frozen install fails in ~20s, *and* it builds the docs app (the Vercel artifact). It's the fast, stable, required check — versus `e2e`, which catches both too but is the slowest job and explicitly "not yet a required check (settling in CI)".

> [!IMPORTANT]
> `merge_group` is inert until `main` branch protection enables the GitHub **merge queue** (or, at minimum, **"Require branches to be up to date before merging"**) with `verify` as a required check. That setting is what actually *blocks* the stale-base merge — the workflow change just makes CI ready for it. I can't flip repo settings from here; say the word and I'll script it via `gh api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)