### PR TITLE
Advertise bundle size everywhere + gate it against drift

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -80,6 +80,9 @@ jobs:
             - run: pnpm install --frozen-lockfile
             - run: pnpm --filter stitchapi build
             - run: pnpm --filter stitchapi check:size
+            # Advertised bundle sizes (READMEs, docs, homepage) must match the
+            # measured figure above — fails if any quote has drifted.
+            - run: pnpm check:size-docs
 
     # The docs/sandbox playground smoke suites (docs/sandbox/tests/run-all.mjs) import the BUILT
     # `stitchapi`, so they are build-dependent integration tests — they run in their own job that

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/stitchapi?activeTab=dependencies"><img alt="Dependencies: 0" src="https://img.shields.io/badge/dependencies-0-brightgreen" /></a>
   <img alt="npm bundle size (minified + gzipped)" src="https://img.shields.io/bundlephobia/minzip/stitchapi" />
+  <img alt="Bundle: ~21 kB min+gzip" src="https://img.shields.io/badge/min%2Bgzip-~21%20kB-2563EB" />
+</p>
+
+<p align="center">
+  <strong>Zero runtime dependencies · ~21&nbsp;kB min+gzip</strong> — a typical <code>import { stitch }</code> tree-shakes to ~17&nbsp;kB, and with no transitive tree there is nothing else to install or audit. The size is an <a href="packages/core/scripts/bundle-size.mjs">enforced budget in CI</a>, not an aspiration.
 </p>
 
 > [!NOTE]

--- a/apps/docs/app/(home)/components/metrics.tsx
+++ b/apps/docs/app/(home)/components/metrics.tsx
@@ -1,0 +1,43 @@
+const metrics = [
+    {
+        value: '0',
+        unit: 'runtime deps',
+        body: 'Built on the platform’s global fetch — nothing to install, nothing to audit, nothing in your transitive tree.',
+    },
+    {
+        value: '~21 kB',
+        unit: 'min + gzip',
+        body: 'The whole stitchapi entry, tree-shaken — and it is an enforced budget in CI, not an aspiration.',
+    },
+    {
+        value: '~17 kB',
+        unit: 'import { stitch }',
+        body: 'Pay only for what you import: every surface beyond http lives behind its own subpath, so the core trims down.',
+    },
+];
+
+export function Metrics() {
+    return (
+        <section className="border-b border-fd-border px-6 py-14">
+            <div className="mx-auto w-full max-w-5xl">
+                <div className="grid gap-px overflow-hidden rounded-2xl border border-fd-border bg-fd-border sm:grid-cols-3">
+                    {metrics.map(({ value, unit, body }) => (
+                        <div key={unit} className="bg-fd-card p-7">
+                            <div className="flex items-baseline gap-2">
+                                <span className="font-display text-4xl font-black tracking-[-0.03em] text-stitch">
+                                    {value}
+                                </span>
+                                <span className="font-mono text-sm text-fd-muted-foreground">
+                                    {unit}
+                                </span>
+                            </div>
+                            <p className="mt-3 text-sm leading-relaxed text-fd-muted-foreground">
+                                {body}
+                            </p>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/apps/docs/app/(home)/page.tsx
+++ b/apps/docs/app/(home)/page.tsx
@@ -2,6 +2,7 @@ import { Cta, Footer } from './components/cta';
 import { Differentiator } from './components/differentiator';
 import { Features } from './components/features';
 import { Hero } from './components/hero';
+import { Metrics } from './components/metrics';
 import { Problem } from './components/problem';
 import { Surfaces } from './components/surfaces';
 
@@ -37,6 +38,7 @@ export default function HomePage() {
     return (
         <main className="flex flex-1 flex-col">
             <Hero />
+            <Metrics />
             <Problem />
             <Surfaces />
             <Features />

--- a/apps/docs/content/docs/concepts/principles.mdx
+++ b/apps/docs/content/docs/concepts/principles.mdx
@@ -101,9 +101,9 @@ behind its own import — so an app never ships bytes for a CLI it will not run.
 The same frugality the event stream practices with an agent's context, the
 package practices with your bundle.
 
-Concretely, the whole `stitch` entry is about **21 kB minified + gzipped**
+Concretely, the whole `stitch` entry is **~21 kB minified + gzipped**
 (≈58 kB raw), and because every surface beyond `http` is a separate subpath
-import, a typical `import { stitch }` tree-shakes to roughly **17 kB**. With zero
+import, a typical `import { stitch }` tree-shakes to **~17 kB**. With zero
 runtime dependencies, that figure is the entire cost — not the tip of a
 transitive tree.
 

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -5,7 +5,7 @@ description: 'Install stitchapi and set up the zero-dependency runtime in Node o
 
 Install the package, import `stitch`, and make one typed call to confirm the
 runtime works. `stitchapi` has zero dependencies and runs anywhere `fetch`
-does — Node, the browser, and edge runtimes. The whole entry is about **21 kB
+does — Node, the browser, and edge runtimes. The whole entry is **~21 kB
 minified + gzipped** — and with no dependencies, there is no transitive tree
 behind it (a typical `import { stitch }` tree-shakes to ~17 kB).
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,6 +13,13 @@ pre-commit:
         - name: completions
           glob: 'packages/core/src/**/*.ts'
           run: pnpm --filter @stitchapi/docs run gen:completions && git add "apps/docs/app/(home)/playground/playground-completions.generated.ts"
+        # Catch a partial edit to the advertised bundle size before it lands. No
+        # build here, so this runs the consensus check (every quote must agree);
+        # CI's `size` job does the authoritative measured check. Keep this glob in
+        # sync with the FILES list in scripts/check-size-docs.mjs.
+        - name: size-docs
+          glob: '{README.md,packages/core/README.md,apps/docs/**/installation.mdx,apps/docs/**/principles.mdx,apps/docs/**/metrics.tsx,packages/core/scripts/bundle-size.mjs}'
+          run: pnpm check:size-docs
         - name: format
           # Keep in sync with CI's `prettier --check .` (verify.yml) — cover every
           # extension Prettier handles here so committed files are never left unformatted

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "check:lint": "pnpm -r check:lint",
         "check:exports": "pnpm -r check:exports",
         "check:size": "pnpm -r check:size",
+        "check:size-docs": "node scripts/check-size-docs.mjs",
         "check:format": "prettier --check .",
         "check:release": "node scripts/check-release.mjs",
         "format": "prettier --write .",

--- a/packages/core/scripts/bundle-size.mjs
+++ b/packages/core/scripts/bundle-size.mjs
@@ -141,4 +141,8 @@ if (failed) {
     process.exit(1);
 }
 
-console.log('✓ Core entry within budget.\n');
+// Keep --json output pure (it is consumed by scripts/check-size-docs.mjs);
+// the human-readable confirmation is only for the table view.
+if (!process.argv.includes('--json')) {
+    console.log('✓ Core entry within budget.\n');
+}

--- a/scripts/check-size-docs.mjs
+++ b/scripts/check-size-docs.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// Keep every *advertised* bundle size in sync with the *measured* one.
+//
+// The bundle size is a selling point, so it is quoted in several human-facing
+// places — both READMEs, two docs pages, and the homepage metrics band. Each
+// quote is a hand-typed number, and a hand-typed number drifts: the gate
+// (packages/core/scripts/bundle-size.mjs) trims the entry to 20.7 kB while a
+// README still brags "~24 kB", or someone bumps the budget and forgets the prose.
+//
+// This makes the gate the single source of truth and fails the build when any
+// quote disagrees with it. The advertised figure is the *rounded* gzip size
+// (`~21 kB`) — the `~` plus rounding means the number only changes when it
+// genuinely should, so this does not churn on every byte.
+//
+// Two modes, one script:
+//   • measured  — when packages/core/lib is built (CI `size` job, `pnpm size`),
+//                 run the real measurement and assert each file quotes it.
+//   • consensus — when lib is not built (lefthook pre-commit, no build step),
+//                 fall back to asserting every file agrees with the others, so a
+//                 partial edit ("changed the README, forgot the docs") still trips.
+//
+// Invoked from:
+//   - `pnpm check:size-docs`           — verify.yml `size` job (after the build)
+//   - lefthook pre-commit `size-docs`  — when an advertising file is staged
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Every place that advertises the gzipped bundle size. `allow` lists numbers
+// that legitimately appear alongside the gzip figure but are NOT it (e.g. the
+// core README also cites raw and brotli sizes) so the check ignores them.
+const FILES = [
+    { rel: 'README.md', allow: [] },
+    { rel: 'packages/core/README.md', allow: [58, 19] },
+    {
+        rel: 'apps/docs/content/docs/getting-started/installation.mdx',
+        allow: [],
+    },
+    { rel: 'apps/docs/content/docs/concepts/principles.mdx', allow: [] },
+    { rel: 'apps/docs/app/(home)/components/metrics.tsx', allow: [] },
+];
+
+// A bundle-size quote: `~21 kB`. Tolerates the separators used across markdown,
+// HTML prose, and shields.io badge URLs (` `, `&nbsp;`, `%20`).
+const TOKEN = /~\s*(\d+)\s*kB/g;
+
+const eqSet = (a, b) => a.length === b.length && a.every((n, i) => n === b[i]);
+const sortedUnique = (nums) => [...new Set(nums)].sort((a, b) => a - b);
+const fmt = (nums) => nums.map((n) => `~${n} kB`).join(' / ');
+
+/** The two rounded gzip figures, or null if core/lib is not built. */
+function measure() {
+    try {
+        const out = execFileSync(
+            'node',
+            [join(repoRoot, 'packages/core/scripts/bundle-size.mjs'), '--json'],
+            { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+        );
+        const rows = JSON.parse(out);
+        const kb = (re) => {
+            const row = rows.find((r) => re.test(r.name));
+            return row ? Math.round(row.gzip / 1024) : null;
+        };
+        const entry = kb(/whole entry/i);
+        const imported = kb(/import \{ stitch \}/i);
+        if (entry == null || imported == null) return null;
+        return sortedUnique([entry, imported]);
+    } catch {
+        return null; // lib not built — caller falls back to consensus mode
+    }
+}
+
+/** The bundle-size numbers quoted in one file, minus its allowlist. */
+function quoted({ rel, allow }) {
+    const text = readFileSync(join(repoRoot, rel), 'utf8').replace(
+        /&nbsp;|%20/g,
+        ' ',
+    );
+    const nums = [...text.matchAll(TOKEN)].map((m) => Number(m[1]));
+    return sortedUnique(nums.filter((n) => !allow.includes(n)));
+}
+
+const files = FILES.map((f) => ({ ...f, nums: quoted(f) }));
+const expected = measure();
+const failures = [];
+let truth;
+
+if (expected) {
+    truth = expected;
+} else {
+    // Consensus: the figure the most files agree on is the reference.
+    const tally = new Map();
+    for (const f of files) {
+        const key = f.nums.join(',');
+        tally.set(key, (tally.get(key) ?? 0) + 1);
+    }
+    const ref = [...tally.entries()].sort((a, b) => b[1] - a[1])[0][0];
+    truth = ref ? ref.split(',').filter(Boolean).map(Number) : [];
+}
+
+for (const f of files) {
+    if (!eqSet(f.nums, truth)) {
+        failures.push(`  ${f.rel} — quotes ${fmt(f.nums) || '(none)'}`);
+    }
+}
+
+const source = expected ? 'measured' : 'consensus';
+
+if (failures.length) {
+    console.error(
+        `\n✗ Advertised bundle size has drifted (source: ${source} = ${fmt(truth)}).\n` +
+            failures.join('\n') +
+            `\n\n  Every quote must read ${fmt(truth)}. Update the file(s) above, or\n` +
+            `  if the bundle genuinely changed, re-measure with \`pnpm --filter stitchapi size\`\n` +
+            `  and update all advertised numbers together.\n`,
+    );
+    process.exit(1);
+}
+
+console.log(
+    `✓ Advertised bundle size in sync across ${files.length} files (${source}: ${fmt(truth)}).`,
+);


### PR DESCRIPTION
## Why

The zero-deps / small-bundle story is a core selling point, but it was only visible on the npm-package README and two deep docs pages. The two highest-traffic surfaces — the GitHub landing README and the docs homepage — didn't show it at all. And the numbers that *were* there lived as hand-typed copies in 6 places with 3 different phrasings, kept aligned only by a "keep in sync" comment.

This PR does both halves: **advertise** the bundle size where people actually look, and **prevent it from ever drifting** from the measured value.

## Advertise (`docs:`)

- **Docs homepage** — a metrics band below the hero: `0` runtime deps · `~21 kB` min+gzip · `~17 kB` for `import { stitch }`, built from the existing design tokens. Verified rendering in light/dark and at mobile/desktop breakpoints.
- **Root README** — an explicit `~21 kB` min+gzip badge plus a prose line. (The pre-existing bundlephobia badge tracks the *published* version and carries no explicit number.)

## Gate against drift (`ci:`)

- [`scripts/check-size-docs.mjs`](scripts/check-size-docs.mjs) makes the measured figure the **single source of truth**: it derives `~N kB` from `bundle-size.mjs --json`, then checks every advertised location and fails with the exact file + what it found.
  - **measured** mode in CI (lib built) — authoritative.
  - **consensus** mode in pre-commit (no build) — catches partial edits ("changed the README, forgot the docs").
- Wired into the `verify.yml` **`size`** job and a lefthook pre-commit **`size-docs`** job (mirrors the existing `completions` pattern).
- Normalized `about 21 kB` / `roughly 17 kB` → one `~N kB` form.
- Fixed a latent bug: `bundle-size.mjs --json` was appending a human-readable line to stdout, making the output invalid JSON.

Numbers are gate-verified: measured gzip is **20.73 KB** (entry) and **16.63 KB** (`import { stitch }`), rounding to the advertised `~21` / `~17`.

## Verification

- `pnpm check:size-docs` passes (measured); injecting a drifted number fails with exit 1 and names the file; consensus mode pass/fail confirmed.
- `prettier --check`, docs `tsc --noEmit`, and `eslint` clean on changed files.
- Table-mode `check:size` output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)