### PR TITLE
feat(stream): infer the streamed delta element type from `output` (#115)

### DIFF
--- a/packages/core/src/sse.ts
+++ b/packages/core/src/sse.ts
@@ -6,7 +6,7 @@
 //
 // Bundle-frugal (Decision 10): this module — and the frame parser — is reached only through the
 // `sse` subpath, never from the root entry; `import { stitch }` pulls in no SSE code.
-import type { InputOf } from './infer';
+import type { InputOf, OutputOf } from './infer';
 import { lineReader } from './line-reader';
 import { seam as makeSeam } from './seam';
 import { makeStitch } from './stitch';
@@ -25,10 +25,16 @@ import {
  * One Server-Sent Event. `data` is JSON-parsed when it parses, else the raw string. `event` (the
  * type), `id` (last-event id), and `retry` (reconnect ms) are present only when the event carried
  * them. An event is only produced when at least one `data:` field was seen (the SSE spec).
+ *
+ * The `data` payload type `T` defaults to `unknown` (issue #115): the runtime parser never knows the
+ * shape, so every internal use (`parseEventStream`, `contractValue`) and every existing import stays
+ * `SseEvent<unknown>` — byte-identical to the old non-generic `SseEvent`. Only the public `sse(...)`
+ * helper refines `T` from the config's `output` schema, since `output` validates each event's `.data`
+ * (the `sse` surface's `contractValue` points per-`delta` validation at `.data`).
  */
-export interface SseEvent {
+export interface SseEvent<T = unknown> {
     event?: string;
-    data: unknown;
+    data: T;
     id?: string;
     retry?: number;
 }
@@ -117,13 +123,15 @@ export interface SseSeamApi {
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
         config: C,
-    ) => Stitch<SseEvent[], InputOf<C>>;
+    ) => Stitch<SseEvent<OutputOf<C>>[], InputOf<C>>;
     readonly seam: Seam;
 }
 
 // Standalone sse stitch: the call argument is inferred from `config.input`, the result fixed to the
-// collected event array (a streaming await resolves to all of its `delta` chunks — Stage 5). The
-// `as` retypes the loose `makeStitch` result to the declared `InputOf<C>`: now that `InputOf` reads
+// collected event array (a streaming await resolves to all of its `delta` chunks — Stage 5). Each
+// event's `.data` is typed from `config.output` via `OutputOf<C>` (#115) — `unknown` when no `output`,
+// keeping `SseEvent<unknown>[]` identical to the old `SseEvent[]`. The `as` retypes the loose
+// `makeStitch` result to the declared `InputOf<C>`/`SseEvent<OutputOf<C>>[]`: now that `InputOf` reads
 // `extends`-fragment schemas (#76) it is no longer a clean supertype of `StitchInput` under an
 // unresolved `C`, so this loose body needs the same retype `stitch()`/`seam` get from their
 // inferring overloads. Sound — the runtime stitch is byte-identical (the type tests cover it).
@@ -131,11 +139,11 @@ const sseStitch = <
     const C extends Partial<StitchConfig> = Partial<StitchConfig>,
 >(
     config: C,
-): Stitch<SseEvent[], InputOf<C>> =>
+): Stitch<SseEvent<OutputOf<C>>[], InputOf<C>> =>
     makeStitch<SseEvent[]>({
         ...config,
         kind: sseSurface,
-    }) as unknown as Stitch<SseEvent[], InputOf<C>>;
+    }) as unknown as Stitch<SseEvent<OutputOf<C>>[], InputOf<C>>;
 
 // Bind sse members to a seam through the seam's surface-agnostic `stitch({ kind })` (Decision 3) —
 // no per-surface seam method; one shared runtime / principal boundary.
@@ -144,11 +152,11 @@ function bindSeam(s: Seam): SseSeamApi {
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
         config: C,
-    ): Stitch<SseEvent[], InputOf<C>> =>
+    ): Stitch<SseEvent<OutputOf<C>>[], InputOf<C>> =>
         s.stitch<SseEvent[]>({
             ...config,
             kind: sseSurface,
-        }) as unknown as Stitch<SseEvent[], InputOf<C>>;
+        }) as unknown as Stitch<SseEvent<OutputOf<C>>[], InputOf<C>>;
     return { stitch, seam: s };
 }
 

--- a/packages/core/src/stream.ts
+++ b/packages/core/src/stream.ts
@@ -9,7 +9,7 @@
 //
 // Bundle-frugal (Decision 10): reached only through the `stream` subpath; `import { stitch }` pulls
 // in none of it.
-import type { InputOf } from './infer';
+import type { InputOf, OutputOf } from './infer';
 import { lineReader } from './line-reader';
 import { seam as makeSeam } from './seam';
 import { makeStitch } from './stitch';
@@ -23,6 +23,34 @@ import {
     type StitchInput,
     isSeam,
 } from './types';
+
+// ---- delta element type inference (#115) — PURELY compile-time ------------------------------------
+// The `stream` surface has NO `contractValue` (engine.ts `runStreaming`): the element the caller sees
+// is whatever the DECODER produced, so the static element type is decoder-dependent — `output` refines
+// only the structured (`'ndjson'`) decoder, never the raw `'bytes'`/`'lines'` ones (which `output`
+// can't reshape). Reading `config.stream.decode` literally fixes the branch.
+
+/** The literal `stream.decode` mode a config declares, defaulting to `'bytes'` (the runtime default). */
+type StreamDecodeOf<C> = C extends { stream: { decode: infer D } }
+    ? D
+    : 'bytes';
+
+/**
+ * The decoded delta element type for a config `C`:
+ *   - `'lines'`  → `string` (UTF-8 lines; `output` is ignored — it can't reshape a raw line).
+ *   - `'ndjson'` → `OutputOf<C>` (the structured per-record value; `unknown` when no `output`).
+ *   - `'bytes'` (default) + any unrecognised `decode` → `Uint8Array` (raw chunks; `output` ignored).
+ *
+ * NOTE: `output` deliberately refines ONLY `'ndjson'`. `stream({ output: S })` with NO `decode` stays
+ * `Uint8Array[]` — `decode` defaults to `'bytes'`, which `output` can't reshape. That is intended, not
+ * a bug. A future `'json'` decoder (issue #111) would add another `OutputOf<C>` branch here.
+ */
+type StreamElement<C> =
+    StreamDecodeOf<C> extends 'lines'
+        ? string
+        : StreamDecodeOf<C> extends 'ndjson'
+          ? OutputOf<C>
+          : Uint8Array; // 'bytes' default + any unknown decode
 
 // Decode the live body into `delta` items per `cfg.stream.decode` (default `'bytes'`).
 async function* decodeStream(
@@ -75,25 +103,27 @@ export interface StreamSeamApi {
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
         config: C,
-    ) => Stitch<unknown[], InputOf<C>>;
+    ) => Stitch<StreamElement<C>[], InputOf<C>>;
     readonly seam: Seam;
 }
 
 // Standalone stream stitch: the call argument is inferred from `config.input`, the result fixed to
 // the collected chunk array (a streaming await resolves to all of its `delta` chunks — Stage 5). The
-// `as` retypes the loose `makeStitch` result to the declared `InputOf<C>`: now that `InputOf` reads
-// `extends`-fragment schemas (#76) it is no longer a clean supertype of `StitchInput` under an
-// unresolved `C`, so this loose body needs the same retype `stitch()`/`seam` get from their
-// inferring overloads. Sound — the runtime stitch is byte-identical (the type tests cover it).
+// element type is decoder-dependent via `StreamElement<C>` (#115): `Uint8Array`/`string` for the raw
+// `'bytes'`/`'lines'` decoders, `OutputOf<C>` for `'ndjson'`. The `as` retypes the loose `makeStitch`
+// result to the declared `InputOf<C>`/`StreamElement<C>[]`: now that `InputOf` reads `extends`-fragment
+// schemas (#76) it is no longer a clean supertype of `StitchInput` under an unresolved `C`, so this
+// loose body needs the same retype `stitch()`/`seam` get from their inferring overloads. Sound — the
+// runtime stitch is byte-identical (the type tests cover it).
 const streamStitch = <
     const C extends Partial<StitchConfig> = Partial<StitchConfig>,
 >(
     config: C,
-): Stitch<unknown[], InputOf<C>> =>
+): Stitch<StreamElement<C>[], InputOf<C>> =>
     makeStitch<unknown[]>({
         ...config,
         kind: streamSurface,
-    }) as unknown as Stitch<unknown[], InputOf<C>>;
+    }) as unknown as Stitch<StreamElement<C>[], InputOf<C>>;
 
 // Bind stream members to a seam through the seam's surface-agnostic `stitch({ kind })` (Decision 3).
 function bindSeam(s: Seam): StreamSeamApi {
@@ -101,11 +131,11 @@ function bindSeam(s: Seam): StreamSeamApi {
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
         config: C,
-    ): Stitch<unknown[], InputOf<C>> =>
+    ): Stitch<StreamElement<C>[], InputOf<C>> =>
         s.stitch<unknown[]>({
             ...config,
             kind: streamSurface,
-        }) as unknown as Stitch<unknown[], InputOf<C>>;
+        }) as unknown as Stitch<StreamElement<C>[], InputOf<C>>;
     return { stitch, seam: s };
 }
 

--- a/packages/core/test-d/streaming-inference.test-d.ts
+++ b/packages/core/test-d/streaming-inference.test-d.ts
@@ -1,0 +1,75 @@
+// The streaming surfaces refine their delta ELEMENT type from `config.output` (issue #115). PURELY
+// compile-time: the runtime decode/emit path is unchanged. `sse` types each event's `.data` from
+// `output` (its `contractValue` validates `.data`); `stream`'s element type is DECODER-dependent —
+// `output` refines only the structured `'ndjson'` decoder, never raw `'bytes'`/`'lines'`.
+//
+// Assertions follow stitch.test-d.ts: assert on the UNWRAPPED (awaited) result via `output(...)` from
+// `_util` rather than `expectType<Stitch<…>>` (tsd's recursive-`with` identity quirk). Streaming await
+// resolves to the collected `delta` array, so `output(sse(...))` is `SseEvent<…>[]` and
+// `output(stream(...))` is `<element>[]`.
+import { type SseEvent, sse } from '../src/sse';
+import { stream } from '../src/stream';
+import { output } from './_util';
+
+import { expectType } from 'tsd';
+import { z } from 'zod';
+
+const itemSchema = z.object({ id: z.number() });
+type Item = z.infer<typeof itemSchema>;
+
+// ---- sse: `output` refines each event's `.data` payload --------------------------------------------
+
+// 1) `sse({ output })` → awaited result `SseEvent<Item>[]`, and `.data` is the inferred type.
+const events = sse({ baseUrl: 'x', path: '/stream', output: itemSchema });
+expectType<SseEvent<Item>[]>(output(events));
+expectType<Item>(output(events)[0]!.data);
+
+// 2) `sse({})` with NO `output` → `SseEvent<unknown>[]` (the unchanged baseline; `.data` is `unknown`).
+const bare = sse({ path: '/stream' });
+expectType<SseEvent<unknown>[]>(output(bare));
+expectType<unknown>(output(bare)[0]!.data);
+
+// 3) a seam-bound sse member infers `.data` identically (covers `bindSeam`). Pass `SeamOptions` (not a
+//    pre-built `Seam`) so the seam is minted inside the same module family as `sse` — a `Seam` imported
+//    from the root entry is a nominally distinct (built-`lib`) type from `src`'s here.
+const member = sse
+    .seam({ baseUrl: 'https://x' })
+    .stitch({ path: '/s', output: itemSchema });
+expectType<SseEvent<Item>[]>(output(member));
+
+// ---- stream: the element type is DECODER-dependent ------------------------------------------------
+
+// 4) `decode: 'ndjson'` + `output` → the inferred record array (the structured decoder takes `output`).
+const ndjson = stream({
+    path: '/s',
+    stream: { decode: 'ndjson' },
+    output: itemSchema,
+});
+expectType<Item[]>(output(ndjson));
+
+// 5) `decode: 'ndjson'` with NO `output` → `unknown[]` (OutputOf<C> falls back to `unknown`).
+const ndjsonBare = stream({ path: '/s', stream: { decode: 'ndjson' } });
+expectType<unknown[]>(output(ndjsonBare));
+
+// 6) `decode: 'lines'` → `string[]` (raw lines; `output`, if any, is IGNORED).
+const lines = stream({ path: '/s', stream: { decode: 'lines' } });
+expectType<string[]>(output(lines));
+
+// 7) `decode: 'bytes'` → `Uint8Array[]` (raw chunks; `output` ignored).
+const bytes = stream({ path: '/s', stream: { decode: 'bytes' } });
+expectType<Uint8Array[]>(output(bytes));
+
+// 8) no `decode` at all → `Uint8Array[]` (default `'bytes'`).
+const defaulted = stream({ path: '/s' });
+expectType<Uint8Array[]>(output(defaulted));
+
+// 9) `stream({ output })` with NO `decode` stays `Uint8Array[]` — `output` does NOT apply to the
+//    default `'bytes'` decoder. This is intended (see StreamElement's NOTE), NOT a bug.
+const outputNoDecode = stream({ path: '/s', output: itemSchema });
+expectType<Uint8Array[]>(output(outputNoDecode));
+
+// 10) a seam-bound `stream` member is decoder-dependent too (covers `bindSeam`).
+const streamMember = stream
+    .seam({ baseUrl: 'https://x' })
+    .stitch({ path: '/s', stream: { decode: 'ndjson' }, output: itemSchema });
+expectType<Item[]>(output(streamMember));

--- a/packages/core/test/stream.spec.ts
+++ b/packages/core/test/stream.spec.ts
@@ -45,7 +45,7 @@ describe('stream decoders (Decision 5)', () => {
 
         const chunks = await s();
         expect(chunks.every((c) => c instanceof Uint8Array)).toBe(true);
-        const joined = chunks.map((c) => td.decode(c as Uint8Array)).join('');
+        const joined = chunks.map((c) => td.decode(c)).join('');
         expect(joined).toBe('abcd');
     });
 


### PR DESCRIPTION
Closes #115

## What

The streaming surfaces hardwired their delta element type — `sse` to `SseEvent[]` (with `data: unknown`) and `stream` to `unknown[]`. Setting `output: someSchema` validated each delta at runtime but never refined the element type the caller sees. This makes `output` refine the **static** element type.

This is **purely compile-time**: no runtime code path, decoded value, or emitted event is touched. The built `lib/sse.mjs`/`lib/stream.mjs` are byte-identical to `main` modulo non-deterministic minifier identifier renames, and the root-entry bundle-size gate is unchanged.

## Final type signatures

- `sse(config)` / `sse.stitch(config)` / seam-bound `stitch(config)` → `Stitch<SseEvent<OutputOf<C>>[], InputOf<C>>`
  - no `output` → `SseEvent<unknown>[]` (identical to today)
  - `output: S` → each event's `.data` is the inferred type (the `sse` surface's `contractValue` validates `.data`)
- `stream(config)` / `stream.stitch(config)` / seam-bound → `Stitch<StreamElement<C>[], InputOf<C>>`, where `StreamElement<C>` is decoder-dependent:
  - `'lines'` → `string` (output ignored — can't reshape a raw line)
  - `'ndjson'` → `OutputOf<C>` (the structured per-record value; `unknown` when no `output`)
  - `'bytes'` (default) + any unknown decode → `Uint8Array` (output ignored)
  - **`stream({ output: S })` with no `decode` stays `Uint8Array[]`** — intended, documented in a comment (a future `'json'` decoder, #111, would add another `OutputOf<C>` branch).

## Changes

- `SseEvent` is now `SseEvent<T = unknown>`; the `= unknown` default keeps the parser, `contractValue`, and every existing import compiling unchanged. Runtime `parseEventStream`/`parseData` untouched.
- New local, well-commented `StreamElement<C>` / `StreamDecodeOf<C>` helpers in `stream.ts`.
- `OutputOf<C>` threaded through `SseSeamApi`/`StreamSeamApi`, the standalone `sseStitch`/`streamStitch`, and both `bindSeam` inner `stitch` functions; the existing `as unknown as Stitch<…>` retype pattern is preserved.
- Adds `test-d/streaming-inference.test-d.ts` (the proof — the change is invisible at runtime).
- Drops a now-unnecessary `as Uint8Array` cast in `test/stream.spec.ts` (the default-decode result is now `Uint8Array[]`).

## Gates (all green)

| gate | result |
| --- | --- |
| `pnpm -C packages/core check:types` | ✅ |
| `pnpm -C packages/core check:types-d` (tsup → tsd) | ✅ |
| `pnpm -C packages/core test` | ✅ 618 passed |
| `pnpm -C packages/core check:lint` | ✅ |
| `pnpm -C packages/core check:size` | ✅ unchanged — whole entry 21.01 KB gz, `import { stitch }` 16.84 KB gz |
| Prettier `check:format` | ✅ |

Size is unchanged because `sse`/`stream` are bundle-frugal subpaths the root entry never imports; a normalized diff of the built subpath bundles vs `main` shows only minifier identifier renames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)