### PR TITLE
feat(stream): structural streaming-JSON decoder (decode: 'json')

### DIFF
--- a/packages/core/src/json-stream.ts
+++ b/packages/core/src/json-stream.ts
@@ -1,0 +1,255 @@
+// The `'json'` decoder for the `stream` surface (issue #111): a zero-dependency, hand-rolled
+// incremental JSON tokenizer over a `ReadableStream<Uint8Array>`. Unlike `'ndjson'` (newline-FRAMED
+// records), this decoder is STRUCTURAL and UNFRAMED — it follows JSON's grammar to find value
+// boundaries, so it handles cases `'ndjson'` cannot:
+//   - a single large JSON array streamed element-by-element: `[ {…}, {…}, … ]` → one delta PER
+//     element (the useful case), not the whole array.
+//   - a concatenated sequence of top-level values with no separator: `{…}{…}` → one delta each.
+//   - pretty-printed records whose internal newlines would break a `\n` split.
+//
+// Boundary detection, NOT a full parser: we scan characters to locate each structurally-complete
+// top-level value (or top-level-array element), then hand the exact slice to `JSON.parse`. The scan
+// tracks just enough state — nesting depth over `{}`/`[]`, in-string state, escape (`\`) state, and
+// the 4 hex digits of a `\uXXXX` escape — so a `}`/`]`/`"` INSIDE a string is never mistaken for
+// structure. Only COMPLETE values are ever emitted; partial/"UI fill-in" emission of a growing
+// object is deliberately OUT OF SCOPE (so per-`delta` `output` validation stays meaningful).
+//
+// Browser-first / bundle-frugal: `TextDecoder` + `ReadableStream` only — no `Buffer`, no `node:*`.
+// Reached solely through the `stream` subpath; `import { stitch }` pulls in none of it.
+
+/**
+ * Default cap on the chars the `'json'` decoder will buffer for a single in-progress value before
+ * it throws. ~8 MB: generous for real records, but bounded so a malformed / never-closing value
+ * (e.g. an unterminated `[`) can't grow the buffer without limit. Overridable per-stream via
+ * `stream.maxBufferBytes`. The engine (`runStreaming`) turns the throw into an `error` event.
+ */
+export const JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
+
+// Whitespace JSON permits between values (RFC 8259): space, tab, LF, CR.
+function isJsonWhitespace(code: number): boolean {
+    return code === 0x20 || code === 0x09 || code === 0x0a || code === 0x0d;
+}
+
+/**
+ * Structural streaming-JSON decoder. Reads `stream`, UTF-8-decodes incrementally (so a multi-byte
+ * char split across chunks is handled), and yields each structurally-complete value as it closes.
+ *
+ * Emission rules:
+ *   - a top-level OBJECT → ONE delta (the whole object).
+ *   - a top-level ARRAY → one delta per direct ELEMENT (the useful case), NOT the array itself.
+ *   - concatenated top-level values (objects/arrays/scalars, separated by optional whitespace or
+ *     nothing) → one delta each.
+ *   - bare top-level SCALARS (number/string/true/false/null): supported. A number/keyword has no
+ *     closing delimiter, so its boundary is whitespace, the start of a following value, or EOF.
+ *
+ * Each emitted slice is `JSON.parse`d; the parsed value is the delta. Throws if a single in-progress
+ * value's buffer exceeds `maxBufferBytes`, or if the stream ends mid-value, or if a slice fails to
+ * parse (a thrown error becomes an `error` event in the engine).
+ */
+export async function* jsonStream(
+    stream: ReadableStream<Uint8Array>,
+    maxBufferBytes: number = JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES,
+): AsyncGenerator<unknown, void> {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+
+    // All indices below are absolute positions into the logical character stream. `buf` is a sliding
+    // window of it: `buf[k]` is the char at absolute index `base + k`. We periodically drop an
+    // already-emitted prefix and bump `base`, so the window stays bounded by the current in-progress
+    // value, not the whole stream.
+    let buf = '';
+    let base = 0;
+    let scan = 0; // next absolute index to scan
+
+    // Structural scan state, carried across chunk boundaries.
+    let depth = 0; // nesting depth over {} / []
+    let inString = false; // inside a "..." string literal
+    let escaped = false; // previous in-string char was a backslash
+    let unicodeLeft = 0; // remaining hex digits to consume in a \uXXXX escape
+    let topIsArray = false; // the open top-level container (depth>=1) is an array
+
+    // Absolute start of the value/element currently being accumulated, or -1 when between values.
+    // At top level (depth 0, not in an array) this tracks a bare scalar/object/array start; inside a
+    // top-level array it tracks the current element's start. Exactly one is active at a time.
+    let valueStart = -1;
+    let elementStart = -1;
+
+    const at = (abs: number): number => buf.charCodeAt(abs - base);
+    const slice = (from: number, to: number): unknown =>
+        JSON.parse(buf.slice(from - base, to - base)) as unknown;
+
+    // Drop the window prefix before absolute index `upto` (must not be inside an in-progress value).
+    const compact = (upto: number): void => {
+        if (upto <= base) return;
+        buf = buf.slice(upto - base);
+        base = upto;
+    };
+
+    const guard = (): void => {
+        if (buf.length > maxBufferBytes) {
+            throw new Error(
+                `json decoder: in-progress value exceeded maxBufferBytes (${String(
+                    maxBufferBytes,
+                )}); a malformed or never-closing value was streamed`,
+            );
+        }
+    };
+
+    // Values emitted during the current scan pass, drained after each chunk so the generator yields
+    // in order without re-entering the scanner mid-iteration.
+    const pending: unknown[] = [];
+
+    try {
+        for (;;) {
+            const r = await reader.read();
+            const done = r.done;
+            const text = done
+                ? decoder.decode() // flush any held-back multi-byte tail
+                : decoder.decode(r.value, { stream: true });
+            if (text.length > 0) buf += text;
+
+            const end = base + buf.length;
+            for (; scan < end; scan++) {
+                const c = at(scan);
+
+                if (inString) {
+                    if (unicodeLeft > 0) {
+                        unicodeLeft--;
+                        continue;
+                    }
+                    if (escaped) {
+                        escaped = false;
+                        if (c === 0x75 /* u */) unicodeLeft = 4;
+                        continue;
+                    }
+                    if (c === 0x5c /* \ */) {
+                        escaped = true;
+                        continue;
+                    }
+                    if (c === 0x22 /* " */) {
+                        inString = false;
+                        // A bare top-level STRING closes at its closing quote.
+                        if (depth === 0 && valueStart >= 0) {
+                            pending.push(slice(valueStart, scan + 1));
+                            valueStart = -1;
+                        }
+                    }
+                    continue;
+                }
+
+                // --- not in a string ---
+
+                if (c === 0x22 /* " */) {
+                    // At top level a `"` opening a new value first CLOSES any bare scalar in
+                    // progress (a number/keyword with no delimiter, e.g. `42"x"`).
+                    if (depth === 0 && valueStart >= 0) {
+                        pending.push(slice(valueStart, scan));
+                        valueStart = -1;
+                    }
+                    inString = true;
+                    if (depth === 0 && valueStart < 0) valueStart = scan;
+                    else if (depth === 1 && topIsArray && elementStart < 0)
+                        elementStart = scan;
+                    continue;
+                }
+
+                if (c === 0x7b /* { */ || c === 0x5b /* [ */) {
+                    if (depth === 0) {
+                        // A new container at top level closes any bare scalar in progress
+                        // (e.g. `42{...}` — the number ends where the object begins).
+                        if (valueStart >= 0) {
+                            pending.push(slice(valueStart, scan));
+                        }
+                        topIsArray = c === 0x5b;
+                        valueStart = scan;
+                    } else if (depth === 1 && topIsArray && elementStart < 0) {
+                        elementStart = scan;
+                    }
+                    depth++;
+                    continue;
+                }
+
+                if (c === 0x7d /* } */ || c === 0x5d /* ] */) {
+                    depth--;
+                    if (depth === 0) {
+                        if (topIsArray) {
+                            // A trailing scalar element with no comma after it still closes here.
+                            if (elementStart >= 0) {
+                                pending.push(slice(elementStart, scan));
+                                elementStart = -1;
+                            }
+                            // Drop the whole (now-consumed) array including this ']'.
+                            valueStart = -1;
+                        } else {
+                            // Top-level object closes → emit the whole object.
+                            pending.push(slice(valueStart, scan + 1));
+                            valueStart = -1;
+                        }
+                    } else if (depth === 1 && topIsArray && elementStart >= 0) {
+                        // A direct CONTAINER child of a top-level array just closed → emit it.
+                        pending.push(slice(elementStart, scan + 1));
+                        elementStart = -1;
+                    }
+                    continue;
+                }
+
+                if (c === 0x2c /* , */) {
+                    // A comma at depth 1 in a top-level array ends a scalar element in progress.
+                    if (depth === 1 && topIsArray && elementStart >= 0) {
+                        pending.push(slice(elementStart, scan));
+                        elementStart = -1;
+                    }
+                    continue;
+                }
+
+                if (isJsonWhitespace(c)) {
+                    // Whitespace terminates a bare top-level SCALAR (number/keyword) with no delimiter.
+                    if (depth === 0 && valueStart >= 0) {
+                        pending.push(slice(valueStart, scan));
+                        valueStart = -1;
+                    }
+                    continue;
+                }
+
+                // Any other non-whitespace char (digits, -, t/f/n keyword chars).
+                if (depth === 0) {
+                    if (valueStart < 0) valueStart = scan; // start of a bare top-level scalar
+                } else if (depth === 1 && topIsArray && elementStart < 0) {
+                    elementStart = scan; // start of a scalar element inside a top-level array
+                }
+            }
+
+            // Emit everything found this pass, in order.
+            for (const v of pending) yield v;
+            pending.length = 0;
+
+            // Compact: drop everything before the earliest live position. When nothing is in
+            // progress, that's the scan cursor (we've consumed up to it); otherwise it's the start
+            // of the in-progress value/element.
+            const live =
+                valueStart >= 0
+                    ? valueStart
+                    : elementStart >= 0
+                      ? elementStart
+                      : scan;
+            compact(live);
+
+            guard();
+            if (done) break;
+        }
+
+        // End of stream. An unterminated string or an unclosed container is an INCOMPLETE value —
+        // surface it rather than silently dropping data (complete-value semantics). Otherwise a bare
+        // top-level scalar with no trailing delimiter (e.g. a final `42`) closes at EOF.
+        if (depth !== 0 || inString) {
+            throw new Error(
+                'json decoder: stream ended with an incomplete JSON value',
+            );
+        }
+        if (valueStart >= 0) {
+            yield slice(valueStart, scan);
+        }
+    } finally {
+        reader.releaseLock();
+    }
+}

--- a/packages/core/src/sse.ts
+++ b/packages/core/src/sse.ts
@@ -6,7 +6,7 @@
 //
 // Bundle-frugal (Decision 10): this module — and the frame parser — is reached only through the
 // `sse` subpath, never from the root entry; `import { stitch }` pulls in no SSE code.
-import type { InputOf } from './infer';
+import type { InputOf, OutputOf } from './infer';
 import { lineReader } from './line-reader';
 import { seam as makeSeam } from './seam';
 import { makeStitch } from './stitch';
@@ -25,10 +25,16 @@ import {
  * One Server-Sent Event. `data` is JSON-parsed when it parses, else the raw string. `event` (the
  * type), `id` (last-event id), and `retry` (reconnect ms) are present only when the event carried
  * them. An event is only produced when at least one `data:` field was seen (the SSE spec).
+ *
+ * The `data` payload type `T` defaults to `unknown` (issue #115): the runtime parser never knows the
+ * shape, so every internal use (`parseEventStream`, `contractValue`) and every existing import stays
+ * `SseEvent<unknown>` — byte-identical to the old non-generic `SseEvent`. Only the public `sse(...)`
+ * helper refines `T` from the config's `output` schema, since `output` validates each event's `.data`
+ * (the `sse` surface's `contractValue` points per-`delta` validation at `.data`).
  */
-export interface SseEvent {
+export interface SseEvent<T = unknown> {
     event?: string;
-    data: unknown;
+    data: T;
     id?: string;
     retry?: number;
 }
@@ -117,13 +123,15 @@ export interface SseSeamApi {
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
         config: C,
-    ) => Stitch<SseEvent[], InputOf<C>>;
+    ) => Stitch<SseEvent<OutputOf<C>>[], InputOf<C>>;
     readonly seam: Seam;
 }
 
 // Standalone sse stitch: the call argument is inferred from `config.input`, the result fixed to the
-// collected event array (a streaming await resolves to all of its `delta` chunks — Stage 5). The
-// `as` retypes the loose `makeStitch` result to the declared `InputOf<C>`: now that `InputOf` reads
+// collected event array (a streaming await resolves to all of its `delta` chunks — Stage 5). Each
+// event's `.data` is typed from `config.output` via `OutputOf<C>` (#115) — `unknown` when no `output`,
+// keeping `SseEvent<unknown>[]` identical to the old `SseEvent[]`. The `as` retypes the loose
+// `makeStitch` result to the declared `InputOf<C>`/`SseEvent<OutputOf<C>>[]`: now that `InputOf` reads
 // `extends`-fragment schemas (#76) it is no longer a clean supertype of `StitchInput` under an
 // unresolved `C`, so this loose body needs the same retype `stitch()`/`seam` get from their
 // inferring overloads. Sound — the runtime stitch is byte-identical (the type tests cover it).
@@ -131,11 +139,11 @@ const sseStitch = <
     const C extends Partial<StitchConfig> = Partial<StitchConfig>,
 >(
     config: C,
-): Stitch<SseEvent[], InputOf<C>> =>
+): Stitch<SseEvent<OutputOf<C>>[], InputOf<C>> =>
     makeStitch<SseEvent[]>({
         ...config,
         kind: sseSurface,
-    }) as unknown as Stitch<SseEvent[], InputOf<C>>;
+    }) as unknown as Stitch<SseEvent<OutputOf<C>>[], InputOf<C>>;
 
 // Bind sse members to a seam through the seam's surface-agnostic `stitch({ kind })` (Decision 3) —
 // no per-surface seam method; one shared runtime / principal boundary.
@@ -144,11 +152,11 @@ function bindSeam(s: Seam): SseSeamApi {
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
         config: C,
-    ): Stitch<SseEvent[], InputOf<C>> =>
+    ): Stitch<SseEvent<OutputOf<C>>[], InputOf<C>> =>
         s.stitch<SseEvent[]>({
             ...config,
             kind: sseSurface,
-        }) as unknown as Stitch<SseEvent[], InputOf<C>>;
+        }) as unknown as Stitch<SseEvent<OutputOf<C>>[], InputOf<C>>;
     return { stitch, seam: s };
 }
 

--- a/packages/core/src/stream.ts
+++ b/packages/core/src/stream.ts
@@ -4,12 +4,16 @@
 //   - `'bytes'`  (default) — raw `Uint8Array` chunks, lossless, no encoding assumed (Q2).
 //   - `'lines'`  — UTF-8 lines (split on `\n`).
 //   - `'ndjson'` — `'lines'` + `JSON.parse` per non-blank line.
+//   - `'json'`   — STRUCTURAL streaming-JSON (issue #111): one delta per complete value / top-level
+//                  array element, tolerant of internal newlines + concatenated values (`json-stream`).
 // The `'lines'`/`'ndjson'` decoders share the byte→line plumbing with `sse` (the `lineReader`), but
 // `sse` layers its own event-stream frame parser on top — they share plumbing, not a decoder (Q3).
+// `'json'` does NOT use the line plumbing at all — it scans JSON structure directly.
 //
 // Bundle-frugal (Decision 10): reached only through the `stream` subpath; `import { stitch }` pulls
 // in none of it.
 import type { InputOf, OutputOf } from './infer';
+import { jsonStream } from './json-stream';
 import { lineReader } from './line-reader';
 import { seam as makeSeam } from './seam';
 import { makeStitch } from './stitch';
@@ -39,16 +43,18 @@ type StreamDecodeOf<C> = C extends { stream: { decode: infer D } }
  * The decoded delta element type for a config `C`:
  *   - `'lines'`  → `string` (UTF-8 lines; `output` is ignored — it can't reshape a raw line).
  *   - `'ndjson'` → `OutputOf<C>` (the structured per-record value; `unknown` when no `output`).
+ *   - `'json'`   → `OutputOf<C>` (issue #111) — structural streaming-JSON values are structured,
+ *     exactly like `'ndjson'`, so `output` refines each emitted value too.
  *   - `'bytes'` (default) + any unrecognised `decode` → `Uint8Array` (raw chunks; `output` ignored).
  *
- * NOTE: `output` deliberately refines ONLY `'ndjson'`. `stream({ output: S })` with NO `decode` stays
- * `Uint8Array[]` — `decode` defaults to `'bytes'`, which `output` can't reshape. That is intended, not
- * a bug. A future `'json'` decoder (issue #111) would add another `OutputOf<C>` branch here.
+ * NOTE: `output` deliberately refines ONLY the structured decoders (`'ndjson'`/`'json'`).
+ * `stream({ output: S })` with NO `decode` stays `Uint8Array[]` — `decode` defaults to `'bytes'`,
+ * which `output` can't reshape. That is intended, not a bug.
  */
 type StreamElement<C> =
     StreamDecodeOf<C> extends 'lines'
         ? string
-        : StreamDecodeOf<C> extends 'ndjson'
+        : StreamDecodeOf<C> extends 'ndjson' | 'json'
           ? OutputOf<C>
           : Uint8Array; // 'bytes' default + any unknown decode
 
@@ -72,6 +78,13 @@ async function* decodeStream(
             const parsed: unknown = JSON.parse(line);
             yield parsed;
         }
+        return;
+    }
+    if (decode === 'json') {
+        // Structural, unframed streaming-JSON (issue #111): one delta per complete value / top-level
+        // array element. `maxBufferBytes` (if set) bounds a single in-progress value; a throw on
+        // overflow / mid-value EOF becomes an `error` event in the engine.
+        yield* jsonStream(stream, cfg.stream?.maxBufferBytes);
         return;
     }
     // 'bytes' (default): hand back raw chunks exactly as they arrive on the wire.

--- a/packages/core/src/stream.ts
+++ b/packages/core/src/stream.ts
@@ -9,7 +9,7 @@
 //
 // Bundle-frugal (Decision 10): reached only through the `stream` subpath; `import { stitch }` pulls
 // in none of it.
-import type { InputOf } from './infer';
+import type { InputOf, OutputOf } from './infer';
 import { lineReader } from './line-reader';
 import { seam as makeSeam } from './seam';
 import { makeStitch } from './stitch';
@@ -23,6 +23,34 @@ import {
     type StitchInput,
     isSeam,
 } from './types';
+
+// ---- delta element type inference (#115) — PURELY compile-time ------------------------------------
+// The `stream` surface has NO `contractValue` (engine.ts `runStreaming`): the element the caller sees
+// is whatever the DECODER produced, so the static element type is decoder-dependent — `output` refines
+// only the structured (`'ndjson'`) decoder, never the raw `'bytes'`/`'lines'` ones (which `output`
+// can't reshape). Reading `config.stream.decode` literally fixes the branch.
+
+/** The literal `stream.decode` mode a config declares, defaulting to `'bytes'` (the runtime default). */
+type StreamDecodeOf<C> = C extends { stream: { decode: infer D } }
+    ? D
+    : 'bytes';
+
+/**
+ * The decoded delta element type for a config `C`:
+ *   - `'lines'`  → `string` (UTF-8 lines; `output` is ignored — it can't reshape a raw line).
+ *   - `'ndjson'` → `OutputOf<C>` (the structured per-record value; `unknown` when no `output`).
+ *   - `'bytes'` (default) + any unrecognised `decode` → `Uint8Array` (raw chunks; `output` ignored).
+ *
+ * NOTE: `output` deliberately refines ONLY `'ndjson'`. `stream({ output: S })` with NO `decode` stays
+ * `Uint8Array[]` — `decode` defaults to `'bytes'`, which `output` can't reshape. That is intended, not
+ * a bug. A future `'json'` decoder (issue #111) would add another `OutputOf<C>` branch here.
+ */
+type StreamElement<C> =
+    StreamDecodeOf<C> extends 'lines'
+        ? string
+        : StreamDecodeOf<C> extends 'ndjson'
+          ? OutputOf<C>
+          : Uint8Array; // 'bytes' default + any unknown decode
 
 // Decode the live body into `delta` items per `cfg.stream.decode` (default `'bytes'`).
 async function* decodeStream(
@@ -75,25 +103,27 @@ export interface StreamSeamApi {
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
         config: C,
-    ) => Stitch<unknown[], InputOf<C>>;
+    ) => Stitch<StreamElement<C>[], InputOf<C>>;
     readonly seam: Seam;
 }
 
 // Standalone stream stitch: the call argument is inferred from `config.input`, the result fixed to
 // the collected chunk array (a streaming await resolves to all of its `delta` chunks — Stage 5). The
-// `as` retypes the loose `makeStitch` result to the declared `InputOf<C>`: now that `InputOf` reads
-// `extends`-fragment schemas (#76) it is no longer a clean supertype of `StitchInput` under an
-// unresolved `C`, so this loose body needs the same retype `stitch()`/`seam` get from their
-// inferring overloads. Sound — the runtime stitch is byte-identical (the type tests cover it).
+// element type is decoder-dependent via `StreamElement<C>` (#115): `Uint8Array`/`string` for the raw
+// `'bytes'`/`'lines'` decoders, `OutputOf<C>` for `'ndjson'`. The `as` retypes the loose `makeStitch`
+// result to the declared `InputOf<C>`/`StreamElement<C>[]`: now that `InputOf` reads `extends`-fragment
+// schemas (#76) it is no longer a clean supertype of `StitchInput` under an unresolved `C`, so this
+// loose body needs the same retype `stitch()`/`seam` get from their inferring overloads. Sound — the
+// runtime stitch is byte-identical (the type tests cover it).
 const streamStitch = <
     const C extends Partial<StitchConfig> = Partial<StitchConfig>,
 >(
     config: C,
-): Stitch<unknown[], InputOf<C>> =>
+): Stitch<StreamElement<C>[], InputOf<C>> =>
     makeStitch<unknown[]>({
         ...config,
         kind: streamSurface,
-    }) as unknown as Stitch<unknown[], InputOf<C>>;
+    }) as unknown as Stitch<StreamElement<C>[], InputOf<C>>;
 
 // Bind stream members to a seam through the seam's surface-agnostic `stitch({ kind })` (Decision 3).
 function bindSeam(s: Seam): StreamSeamApi {
@@ -101,11 +131,11 @@ function bindSeam(s: Seam): StreamSeamApi {
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
         config: C,
-    ): Stitch<unknown[], InputOf<C>> =>
+    ): Stitch<StreamElement<C>[], InputOf<C>> =>
         s.stitch<unknown[]>({
             ...config,
             kind: streamSurface,
-        }) as unknown as Stitch<unknown[], InputOf<C>>;
+        }) as unknown as Stitch<StreamElement<C>[], InputOf<C>>;
     return { stitch, seam: s };
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -127,11 +127,22 @@ export interface MultipartOptions {
  * - `'bytes'` (default) — raw `Uint8Array` chunks, lossless, no encoding assumed.
  * - `'lines'` — UTF-8, split on `\n`; each `delta` chunk is a `string`.
  * - `'ndjson'` — `'lines'` + `JSON.parse` per non-blank line; each chunk a parsed value.
+ * - `'json'` — a STRUCTURAL streaming-JSON decoder (issue #111): emits each complete JSON value
+ *   (and each top-level array element) as its own `delta`, tolerant of pretty-printed records with
+ *   internal newlines and of concatenated values with no separator. Distinct from `'ndjson'`
+ *   (newline-FRAMED): `'json'` is unframed and follows JSON structure (nesting/strings/escapes).
  */
-export type StreamDecode = 'bytes' | 'lines' | 'ndjson';
+export type StreamDecode = 'bytes' | 'lines' | 'ndjson' | 'json';
 export interface StreamOptions {
     /** Decoder for a `stream` surface body. Default `'bytes'` (total + lossless). */
     decode?: StreamDecode;
+    /**
+     * Max bytes the `'json'` decoder will buffer for a single in-progress value before throwing
+     * (the engine turns the throw into an `error` event). Guards against a malformed / never-closing
+     * value growing without limit. Default ~8 MB (see `json-stream.ts`). Only meaningful for
+     * `decode: 'json'`.
+     */
+    maxBufferBytes?: number;
 }
 /**
  * Byte-transfer progress for a single request (ADR 0005 Decision 9). Reported through
@@ -459,7 +470,10 @@ export interface StitchConfig {
     multipart?: MultipartOptions;
     /**
      * Streaming options (ADR 0005 Decision 5) — how a `stream` surface decodes the live body
-     * (`'bytes'` default / `'lines'` / `'ndjson'`). Only meaningful for the `stream` surface.
+     * (`'bytes'` default / `'lines'` / `'ndjson'` / `'json'`). `'json'` is the structural,
+     * unframed streaming-JSON decoder (issue #111): one `delta` per complete value / top-level
+     * array element, tolerant of internal newlines and concatenated values. Only meaningful for
+     * the `stream` surface.
      */
     stream?: StreamOptions;
     /** How to read the response body. Default: auto by content-type. */

--- a/packages/core/test-d/streaming-inference.test-d.ts
+++ b/packages/core/test-d/streaming-inference.test-d.ts
@@ -51,6 +51,19 @@ expectType<Item[]>(output(ndjson));
 const ndjsonBare = stream({ path: '/s', stream: { decode: 'ndjson' } });
 expectType<unknown[]>(output(ndjsonBare));
 
+// 5b) `decode: 'json'` + `output` → the inferred value array (the structural JSON decoder takes
+//     `output`, exactly like `'ndjson'` — issue #111).
+const json = stream({
+    path: '/s',
+    stream: { decode: 'json' },
+    output: itemSchema,
+});
+expectType<Item[]>(output(json));
+
+// 5c) `decode: 'json'` with NO `output` → `unknown[]`.
+const jsonBare = stream({ path: '/s', stream: { decode: 'json' } });
+expectType<unknown[]>(output(jsonBare));
+
 // 6) `decode: 'lines'` → `string[]` (raw lines; `output`, if any, is IGNORED).
 const lines = stream({ path: '/s', stream: { decode: 'lines' } });
 expectType<string[]>(output(lines));

--- a/packages/core/test-d/streaming-inference.test-d.ts
+++ b/packages/core/test-d/streaming-inference.test-d.ts
@@ -1,0 +1,75 @@
+// The streaming surfaces refine their delta ELEMENT type from `config.output` (issue #115). PURELY
+// compile-time: the runtime decode/emit path is unchanged. `sse` types each event's `.data` from
+// `output` (its `contractValue` validates `.data`); `stream`'s element type is DECODER-dependent —
+// `output` refines only the structured `'ndjson'` decoder, never raw `'bytes'`/`'lines'`.
+//
+// Assertions follow stitch.test-d.ts: assert on the UNWRAPPED (awaited) result via `output(...)` from
+// `_util` rather than `expectType<Stitch<…>>` (tsd's recursive-`with` identity quirk). Streaming await
+// resolves to the collected `delta` array, so `output(sse(...))` is `SseEvent<…>[]` and
+// `output(stream(...))` is `<element>[]`.
+import { type SseEvent, sse } from '../src/sse';
+import { stream } from '../src/stream';
+import { output } from './_util';
+
+import { expectType } from 'tsd';
+import { z } from 'zod';
+
+const itemSchema = z.object({ id: z.number() });
+type Item = z.infer<typeof itemSchema>;
+
+// ---- sse: `output` refines each event's `.data` payload --------------------------------------------
+
+// 1) `sse({ output })` → awaited result `SseEvent<Item>[]`, and `.data` is the inferred type.
+const events = sse({ baseUrl: 'x', path: '/stream', output: itemSchema });
+expectType<SseEvent<Item>[]>(output(events));
+expectType<Item>(output(events)[0]!.data);
+
+// 2) `sse({})` with NO `output` → `SseEvent<unknown>[]` (the unchanged baseline; `.data` is `unknown`).
+const bare = sse({ path: '/stream' });
+expectType<SseEvent<unknown>[]>(output(bare));
+expectType<unknown>(output(bare)[0]!.data);
+
+// 3) a seam-bound sse member infers `.data` identically (covers `bindSeam`). Pass `SeamOptions` (not a
+//    pre-built `Seam`) so the seam is minted inside the same module family as `sse` — a `Seam` imported
+//    from the root entry is a nominally distinct (built-`lib`) type from `src`'s here.
+const member = sse
+    .seam({ baseUrl: 'https://x' })
+    .stitch({ path: '/s', output: itemSchema });
+expectType<SseEvent<Item>[]>(output(member));
+
+// ---- stream: the element type is DECODER-dependent ------------------------------------------------
+
+// 4) `decode: 'ndjson'` + `output` → the inferred record array (the structured decoder takes `output`).
+const ndjson = stream({
+    path: '/s',
+    stream: { decode: 'ndjson' },
+    output: itemSchema,
+});
+expectType<Item[]>(output(ndjson));
+
+// 5) `decode: 'ndjson'` with NO `output` → `unknown[]` (OutputOf<C> falls back to `unknown`).
+const ndjsonBare = stream({ path: '/s', stream: { decode: 'ndjson' } });
+expectType<unknown[]>(output(ndjsonBare));
+
+// 6) `decode: 'lines'` → `string[]` (raw lines; `output`, if any, is IGNORED).
+const lines = stream({ path: '/s', stream: { decode: 'lines' } });
+expectType<string[]>(output(lines));
+
+// 7) `decode: 'bytes'` → `Uint8Array[]` (raw chunks; `output` ignored).
+const bytes = stream({ path: '/s', stream: { decode: 'bytes' } });
+expectType<Uint8Array[]>(output(bytes));
+
+// 8) no `decode` at all → `Uint8Array[]` (default `'bytes'`).
+const defaulted = stream({ path: '/s' });
+expectType<Uint8Array[]>(output(defaulted));
+
+// 9) `stream({ output })` with NO `decode` stays `Uint8Array[]` — `output` does NOT apply to the
+//    default `'bytes'` decoder. This is intended (see StreamElement's NOTE), NOT a bug.
+const outputNoDecode = stream({ path: '/s', output: itemSchema });
+expectType<Uint8Array[]>(output(outputNoDecode));
+
+// 10) a seam-bound `stream` member is decoder-dependent too (covers `bindSeam`).
+const streamMember = stream
+    .seam({ baseUrl: 'https://x' })
+    .stitch({ path: '/s', stream: { decode: 'ndjson' }, output: itemSchema });
+expectType<Item[]>(output(streamMember));

--- a/packages/core/test/json-stream.spec.ts
+++ b/packages/core/test/json-stream.spec.ts
@@ -1,0 +1,243 @@
+// The `'json'` structural streaming-JSON tokenizer (issue #111), driven DIRECTLY so chunk
+// boundaries are fully controlled. The headline guarantee — a streaming tokenizer lives or dies on
+// chunk-split correctness — is asserted by an exhaustive matrix: each input is fed split at EVERY
+// byte offset (incl. mid-string, mid-escape, mid-multibyte-UTF8, mid-number, between values) and
+// byte-by-byte, and must yield identical deltas every time.
+import {
+    JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES,
+    jsonStream,
+} from '../src/json-stream';
+
+const enc = new TextEncoder();
+
+/** A `ReadableStream` that emits each pre-encoded byte chunk as its own read, then closes. */
+function streamOfBytes(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+    let i = 0;
+    return new ReadableStream<Uint8Array>({
+        pull(controller) {
+            if (i >= chunks.length) {
+                controller.close();
+                return;
+            }
+            controller.enqueue(chunks[i++]);
+        },
+    });
+}
+
+/** Drain the tokenizer over `chunks` into the array of emitted deltas. */
+async function decode(
+    chunks: Uint8Array[],
+    maxBufferBytes?: number,
+): Promise<unknown[]> {
+    const out: unknown[] = [];
+    for await (const v of jsonStream(streamOfBytes(chunks), maxBufferBytes))
+        out.push(v);
+    return out;
+}
+
+/** Feed a single string as one UTF-8 chunk. */
+function decodeText(s: string, maxBufferBytes?: number): Promise<unknown[]> {
+    return decode([enc.encode(s)], maxBufferBytes);
+}
+
+describe('json-stream tokenizer: value boundaries', () => {
+    test('a top-level array emits each ELEMENT as its own delta (not the whole array)', async () => {
+        expect(await decodeText('[{"a":1},{"a":2}]')).toEqual([
+            { a: 1 },
+            { a: 2 },
+        ]);
+    });
+
+    test('concatenated objects with NO separator → one delta each', async () => {
+        expect(await decodeText('{"a":1}{"a":2}')).toEqual([
+            { a: 1 },
+            { a: 2 },
+        ]);
+    });
+
+    test('concatenated objects with whitespace/newlines between → one delta each', async () => {
+        expect(await decodeText('{"a":1}\n  \t{"a":2}\n')).toEqual([
+            { a: 1 },
+            { a: 2 },
+        ]);
+    });
+
+    test('pretty-printed records with internal newlines (ndjson would break) → correct deltas', async () => {
+        const pretty = '{\n  "a": 1,\n  "b": [1, 2]\n}\n{\n  "c": 3\n}\n';
+        expect(await decodeText(pretty)).toEqual([
+            { a: 1, b: [1, 2] },
+            { c: 3 },
+        ]);
+    });
+
+    test('a }/]/" INSIDE a string value is not treated as structure → one correct delta', async () => {
+        expect(await decodeText('{"s":"a}b]c\\"d"}')).toEqual([
+            { s: 'a}b]c"d' },
+        ]);
+    });
+
+    test('escapes and a \\uXXXX sequence inside strings parse correctly', async () => {
+        expect(
+            await decodeText('{"s":"tab\\tnl\\nq\\"\\u0041\\u00e9"}'),
+        ).toEqual([{ s: 'tab\tnl\nq"Aé' }]);
+    });
+
+    test('nested structures (objects in arrays in objects) emit the right top-level boundaries', async () => {
+        expect(
+            await decodeText('{"x":{"y":[{"z":1},{"z":2}]}}{"w":3}'),
+        ).toEqual([{ x: { y: [{ z: 1 }, { z: 2 }] } }, { w: 3 }]);
+    });
+
+    test('a top-level array of nested arrays emits each element', async () => {
+        expect(await decodeText('[[1,2],[3,4],{"k":[5]}]')).toEqual([
+            [1, 2],
+            [3, 4],
+            { k: [5] },
+        ]);
+    });
+
+    test('empty array → no deltas; empty object → one delta', async () => {
+        expect(await decodeText('[]')).toEqual([]);
+        expect(await decodeText('{}')).toEqual([{}]);
+    });
+
+    test('a top-level array of mixed scalars + containers emits each element', async () => {
+        expect(await decodeText('[1, "a", true, null, {"k":2}, [9]]')).toEqual([
+            1,
+            'a',
+            true,
+            null,
+            { k: 2 },
+            [9],
+        ]);
+    });
+});
+
+describe('json-stream tokenizer: bare top-level scalars', () => {
+    test('a single number at EOF (no trailing delimiter)', async () => {
+        expect(await decodeText('42')).toEqual([42]);
+    });
+
+    test('whitespace-separated bare scalars → one delta each', async () => {
+        expect(await decodeText('1 2 -3.5e2\n4\t5')).toEqual([
+            1, 2, -350, 4, 5,
+        ]);
+    });
+
+    test('bare top-level strings (the closing quote is the boundary)', async () => {
+        expect(await decodeText('"hello""world"')).toEqual(['hello', 'world']);
+    });
+
+    test('bare top-level keywords true/false/null', async () => {
+        expect(await decodeText('true false null')).toEqual([
+            true,
+            false,
+            null,
+        ]);
+    });
+
+    test('a bare scalar followed by an object with no separator', async () => {
+        expect(await decodeText('42{"a":1}')).toEqual([42, { a: 1 }]);
+    });
+});
+
+describe('json-stream tokenizer: chunk-split robustness (the load-bearing matrix)', () => {
+    // Each input carries the hard cases: a brace/bracket/quote INSIDE a string, backslash escapes,
+    // a \uXXXX, a multibyte UTF-8 char (é = 2 bytes, 😀 = 4 bytes), signed/exponent numbers, and
+    // nesting — so splitting at every byte offset exercises mid-string / mid-escape / mid-multibyte
+    // / mid-number / between-value splits.
+    const INPUTS: { name: string; text: string; want: unknown[] }[] = [
+        {
+            name: 'array of objects',
+            text: '[{"a":1},{"a":2},{"a":3}]',
+            want: [{ a: 1 }, { a: 2 }, { a: 3 }],
+        },
+        {
+            name: 'concatenated objects',
+            text: '{"a":1}{"b":2}{"c":3}',
+            want: [{ a: 1 }, { b: 2 }, { c: 3 }],
+        },
+        {
+            name: 'strings with structure + escapes + multibyte',
+            text: '{"s":"a}b]c\\"d\\n\\u00e9é😀"}{"x":[1,2,{"y":3}]}',
+            want: [{ s: 'a}b]c"d\néé😀' }, { x: [1, 2, { y: 3 }] }],
+        },
+        {
+            name: 'array of mixed scalars (signed/exponent/unicode)',
+            text: '[1, 2.5, -3e10, true, false, null, "x😀y"]',
+            want: [1, 2.5, -3e10, true, false, null, 'x😀y'],
+        },
+        {
+            name: 'whitespace-separated bare scalars',
+            text: '  1\n  2\n  -42\n',
+            want: [1, 2, -42],
+        },
+        {
+            name: 'deeply nested top-level array elements',
+            text: '[{"n":{"m":[1,2]}},{"k":"v"}]',
+            want: [{ n: { m: [1, 2] } }, { k: 'v' }],
+        },
+    ];
+
+    test.each(INPUTS)(
+        '$name: identical deltas at every two-way byte split',
+        async ({ text, want }) => {
+            const full = enc.encode(text);
+            for (let off = 0; off <= full.length; off++) {
+                const got = await decode([full.slice(0, off), full.slice(off)]);
+                expect(got).toEqual(want);
+            }
+        },
+    );
+
+    test.each(INPUTS)(
+        '$name: identical deltas fed byte-by-byte (one byte per chunk)',
+        async ({ text, want }) => {
+            const full = enc.encode(text);
+            const perByte = Array.from(full, (b) => Uint8Array.of(b));
+            expect(await decode(perByte)).toEqual(want);
+        },
+    );
+
+    test('a multibyte char split exactly across a chunk boundary decodes once, intact', async () => {
+        // 😀 is 4 UTF-8 bytes; split it 2/2 between chunks.
+        const full = enc.encode('{"e":"😀"}');
+        const emoji = enc.encode('😀'); // 4 bytes
+        const head = full.subarray(0, full.length - 1 - emoji.length + 2); // up to mid-emoji
+        const tail = full.subarray(head.length);
+        expect(await decode([head, tail])).toEqual([{ e: '😀' }]);
+    });
+});
+
+describe('json-stream tokenizer: max-buffer guard + incomplete streams', () => {
+    test('the default cap is a few MB (exported)', () => {
+        expect(JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES).toBeGreaterThan(
+            1024 * 1024,
+        );
+    });
+
+    test('a never-closing value throws once the buffer exceeds maxBufferBytes', async () => {
+        // An open `[` whose content never closes; cap at 64 bytes so it trips quickly.
+        const chunks = [
+            enc.encode('['),
+            ...Array.from({ length: 50 }, () => enc.encode('1234567890')),
+        ];
+        await expect(decode(chunks, 64)).rejects.toThrow(/maxBufferBytes/);
+    });
+
+    test('a stream that ends mid-value throws (complete-value semantics)', async () => {
+        await expect(decodeText('{"a":')).rejects.toThrow(/incomplete/);
+        await expect(decodeText('[1, 2')).rejects.toThrow(/incomplete/);
+        await expect(decodeText('"unterminated')).rejects.toThrow(/incomplete/);
+    });
+
+    test('a value just UNDER the cap still emits (the cap bounds, does not corrupt)', async () => {
+        // A ~1KB object well under an 8KB cap parses fine.
+        const big = { s: 'x'.repeat(900) };
+        expect(await decodeText(JSON.stringify(big), 8 * 1024)).toEqual([big]);
+    });
+
+    test('an empty stream yields nothing', async () => {
+        expect(await decode([])).toEqual([]);
+    });
+});

--- a/packages/core/test/stream.spec.ts
+++ b/packages/core/test/stream.spec.ts
@@ -45,7 +45,7 @@ describe('stream decoders (Decision 5)', () => {
 
         const chunks = await s();
         expect(chunks.every((c) => c instanceof Uint8Array)).toBe(true);
-        const joined = chunks.map((c) => td.decode(c as Uint8Array)).join('');
+        const joined = chunks.map((c) => td.decode(c)).join('');
         expect(joined).toBe('abcd');
     });
 

--- a/packages/core/test/stream.spec.ts
+++ b/packages/core/test/stream.spec.ts
@@ -1,5 +1,6 @@
 // The `stream` surface (ADR 0005 Decision 5): raw response streaming with a configurable
-// decoder (`bytes` default / `lines` / `ndjson`), emitting one `delta` chunk per decoded item.
+// decoder (`bytes` default / `lines` / `ndjson` / `json`), emitting one `delta` chunk per decoded
+// item. The structural `json` tokenizer itself is unit-tested in json-stream.spec.ts.
 // Plus Decision 12: a streaming member is exempt from the seam concurrency bucket but still
 // charges the rate gate at open. Streams are driven by a fake adapter over Web Streams, so chunk
 // boundaries are fully controlled (no socket).
@@ -70,6 +71,41 @@ describe('stream decoders (Decision 5)', () => {
         });
 
         expect(await s()).toEqual([{ a: 1 }, { b: 2 }]);
+    });
+
+    test('decode "json": a top-level array emits one delta per element', async () => {
+        const s = stream({
+            url: 'https://x.test/j',
+            stream: { decode: 'json' },
+            // the array body is split across chunks, including mid-element
+            adapter: streamAdapter(streamOf(['[{"a":1},{"a', '":2},{"a":3}]'])),
+        });
+
+        expect(await s()).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }]);
+    });
+
+    test('decode "json": concatenated values + pretty-printed records (ndjson would break)', async () => {
+        const s = stream({
+            url: 'https://x.test/j',
+            stream: { decode: 'json' },
+            // pretty-printed objects with INTERNAL newlines, concatenated with no separator —
+            // the exact shape ndjson's \n-split mangles. Chunked at awkward offsets.
+            adapter: streamAdapter(
+                streamOf(['{\n  "a": 1\n}{\n  "b', '": [1,\n2]\n}']),
+            ),
+        });
+
+        expect(await s()).toEqual([{ a: 1 }, { b: [1, 2] }]);
+    });
+
+    test('decode "json": a }/]/" inside a string is not structure (one delta)', async () => {
+        const s = stream({
+            url: 'https://x.test/j',
+            stream: { decode: 'json' },
+            adapter: streamAdapter(streamOf(['{"s":"a}b]c\\"d"}'])),
+        });
+
+        expect(await s()).toEqual([{ s: 'a}b]c"d' }]);
     });
 });
 
@@ -147,6 +183,23 @@ describe('stream event spine (Decisions 5, 12)', () => {
         const ev = await collectEvents(s.stream());
         expect(ev.deltas).toEqual(['one', 'two']);
         expect(ev.types).toContain('error');
+        expect(ev.done?.ok).toBe(false);
+    });
+
+    test('decode "json": a never-closing value past maxBufferBytes surfaces an error event', async () => {
+        const s = stream({
+            url: 'https://x.test/overflow',
+            stream: { decode: 'json', maxBufferBytes: 64 },
+            // an open object whose single string value never closes — the in-progress slice grows
+            // without bound (nothing can be emitted/compacted), so the cap trips.
+            adapter: streamAdapter(
+                streamOf(['{"s":"', 'a'.repeat(50), 'a'.repeat(50)]),
+            ),
+        });
+
+        const ev = await collectEvents(s.stream());
+        expect(ev.types).toContain('error');
+        expect(ev.error?.message).toMatch(/maxBufferBytes/);
         expect(ev.done?.ok).toBe(false);
     });
 });
@@ -246,6 +299,32 @@ describe('per-`delta` validation against `output` (ADR 0005 Addendum)', () => {
         expect(ev.drifts).toEqual([]);
         expect(ev.deltas).toEqual([{ anything: 1 }]);
         expect(ev.done?.ok).toBe(true);
+    });
+
+    test('decode "json": `output` validates each emitted value; a bad one fails the stream', async () => {
+        const s = stream({
+            url: 'https://x.test/vj',
+            stream: { decode: 'json' },
+            output: asValidator(z.object({ n: z.number() })),
+            // a top-level array whose second element violates the schema
+            adapter: streamAdapter(
+                streamOf(['[{"n":1},{"bad":true},{"n":3}]']),
+            ),
+        });
+
+        const ev = await collectEvents(s.stream());
+        // element 1 delivered; element 2 fails → drift(error)+error+done(false); element 3 unseen.
+        expect(ev.deltas).toEqual([{ n: 1 }]);
+        expect(ev.types).toEqual([
+            'start',
+            'progress',
+            'delta',
+            'drift',
+            'error',
+            'done',
+        ]);
+        expect(ev.error?.message).toMatch(/contract violation/);
+        expect(ev.done?.ok).toBe(false);
     });
 });
 


### PR DESCRIPTION
Closes #111

## Summary

Adds a `decode: 'json'` decoder to the `stream` surface, backed by a **zero-dependency, hand-rolled incremental JSON tokenizer** (`packages/core/src/json-stream.ts`). Where `'ndjson'` is newline-**framed** (and breaks on a single large array, concatenated values, or pretty-printed records with internal newlines), `'json'` is **structural and unframed** — it follows JSON's grammar to find value boundaries.

Emission is **complete-value semantics only**:
- a top-level **array** → one `delta` per direct **element** (the useful case), not the whole array;
- **concatenated** top-level objects/arrays (with optional whitespace or nothing between) → one `delta` each;
- **pretty-printed** records with internal newlines → correct deltas;
- bare top-level **scalars** (number/string/true/false/null) are supported — a number/keyword's boundary is whitespace, a following value's opening, or EOF.

Partial/"UI fill-in" emission of a growing object is deliberately **out of scope**, so per-`delta` `output` validation stays meaningful.

## Tokenizer

A streaming `TextDecoder` (`{ stream: true }`) UTF-8-decodes incrementally, so a multi-byte char split across chunks is handled. A structural scan tracks nesting depth over `{}`/`[]`, in-string state, escape (`\`) state, and the 4 hex digits of `\uXXXX`, so a `}`/`]`/`"` **inside a string** is never mistaken for structure. Each structurally-complete slice is `JSON.parse`d to the emitted value (no full hand-rolled parser — we scan for boundaries, then parse the slice). A sliding window keeps the buffer bounded to the current in-progress value.

**Max-buffer guard**: a single in-progress value is bounded — default ~8 MB, overridable per-stream via `stream.maxBufferBytes` — and throws when exceeded; `runStreaming` turns the throw into an `error` event. A stream that ends mid-value also throws (no silent data loss).

**Browser-first / bundle-frugal**: `TextDecoder` + `ReadableStream` only (no `Buffer`/`node:*`), reached solely through the `stream` subpath — the root entry is untouched. `StreamElement<C>` maps `'json'` → `OutputOf<C>` (structured, like `'ndjson'`).

## Decisions
- **Decoder name** `'json'` — matches the bare style of the others; documented as "structural / unframed", distinct from newline-framed `'ndjson'`.
- **Top-level array** emits each element as its own delta.
- **Bare top-level scalars** are fully supported (no restriction needed).
- **Max-buffer** default ~8 MB, overridable via `stream.maxBufferBytes`.

## Tests
- `test/json-stream.spec.ts` drives the tokenizer directly. The load-bearing **chunk-split matrix** feeds each input split at **every** byte offset and byte-by-byte (mid-string / mid-escape / mid-multibyte-UTF8 / mid-number / between-value) and asserts identical deltas every time; plus string-internal `}`/`]`/`"`, escapes & `\uXXXX`, nesting, concatenation, bare scalars, the max-buffer guard, and mid-value EOF.
- `test/stream.spec.ts` covers the surface: top-level array, concatenated + pretty-printed, string-internal structure, per-`delta` `output` validation failing the stream, and the max-buffer guard surfacing as an `error` event.
- `test-d/streaming-inference.test-d.ts`: `stream({ decode: 'json', output: S })` → `InferOutput<S>[]`.

## Gates run (all green)
- `check:types`, `check:types-d` (tsup build + tsd)
- `test` — 656 passing
- `check:lint`
- `check:size` — root entry **unchanged & in budget**: whole entry 21.01 KB gz (budget 21.50), `import { stitch }` 16.84 KB gz (budget 17.50). The tokenizer lives behind the `stream` subpath; no root leak.
- Prettier clean

## Stacked PR
This branch is **stacked on #115 (`feat/stream-output-inference`)** and should merge **after** it. Until #115 merges, this diff also shows #115's changes — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)