### PR TITLE
feat(agents): stitch init — 4 more rule formats, --project, --check

### DIFF
--- a/apps/docs/content/docs/agents/adopt-in-your-project.mdx
+++ b/apps/docs/content/docs/agents/adopt-in-your-project.mdx
@@ -53,15 +53,57 @@ npx stitch init
 ```
 
 `stitch init` (aliased as `stitch rules`) writes the rule into the convention
-each agent reads — `AGENTS.md`, `.cursor/rules/stitchapi.mdc`, and a `CLAUDE.md`
-section. Pick a target with `--format`:
+each agent reads. Pick one or more with `--format` (a comma list, or `all` — the
+default):
 
--   `--format agents` — write `AGENTS.md` only.
--   `--format cursor` — write `.cursor/rules/stitchapi.mdc` only.
--   `--format claude` — write (or append) the `CLAUDE.md` section only.
--   `--format all` — write every target (the default).
+| `--format` | Writes                                                                 |
+| ---------- | ---------------------------------------------------------------------- |
+| `agents`   | `AGENTS.md` (the open standard)                                        |
+| `cursor`   | `.cursor/rules/stitchapi.mdc` (Cursor)                                 |
+| `claude`   | a marked `## Using StitchAPI` section in `CLAUDE.md`                   |
+| `copilot`  | a marked section in `.github/copilot-instructions.md` (GitHub Copilot) |
+| `windsurf` | `.windsurf/rules/stitchapi.md` (Windsurf)                              |
+| `cline`    | `.clinerules/stitchapi.md` (Cline)                                     |
+| `aider`    | a marked section in `CONVENTIONS.md` (Aider)                           |
 
-It refuses to clobber an existing file unless you pass `--force`.
+For example, `npx stitch init --format agents,cursor` writes just those two.
+
+It refuses to clobber an existing file unless you pass `--force`. For the shared
+files (`CLAUDE.md`, Copilot, Aider) only the marked block is replaced — your
+surrounding content is left intact.
+
+## Make the rule about _your_ APIs
+
+Add `--project` and `stitch init` reads your stitches module (the `./stitches.*`
+it would `run`, or `--module <path>`) and appends the endpoints you have already
+declared — so an agent reuses them instead of duplicating a `fetch`:
+
+```bash
+npx stitch init --project
+```
+
+```md
+## Stitches already declared in this project
+
+Reuse these before declaring a new one — call them, compose them under a
+`seam(...)`, or extend an existing one.
+
+-   `getUser` — GET https://api.example.com/users/{id}
+-   `listOrders` — GET https://api.example.com/orders
+```
+
+## Keep it in sync — `--check`
+
+In CI, `--check` verifies the committed rule files still match the rule the
+installed StitchAPI would write, without touching disk. It exits non-zero when a
+file has **drifted** (an absent rule is reported, but is not a failure):
+
+```bash
+npx stitch init --check
+```
+
+Pair it with `--project` to also re-check the declared-stitches list:
+`npx stitch init --check --project`.
 
 ## See also
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -690,7 +690,7 @@ total: 12 run(s), 11 ok, 1 failed
 
 `--name <stitch>` filters to one stitch, `--file <path>` reads another log, `--json` emits the summary as JSON.
 
-`stitch init` writes the canonical "declare a stitch, don't hand-roll `fetch`" rule into the files an AI coding agent reads — `AGENTS.md`, a Cursor `.cursor/rules/stitchapi.mdc`, and a marked section in `CLAUDE.md` (`--format agents|cursor|claude|all`, default `all`) — so the next agent working in this repo reaches for StitchAPI; it is idempotent, and `--force` rewrites an existing rule.
+`stitch init` writes the canonical "declare a stitch, don't hand-roll `fetch`" rule into the files an AI coding agent reads — `AGENTS.md`, a Cursor `.cursor/rules/stitchapi.mdc`, a marked section in `CLAUDE.md`, plus `.github/copilot-instructions.md` (Copilot), `.windsurf/rules/stitchapi.md` (Windsurf), `.clinerules/stitchapi.md` (Cline), and `CONVENTIONS.md` (Aider) — so the next agent working in this repo reaches for StitchAPI. Pick conventions with `--format` (a comma list, or `all`, the default); it is idempotent, and `--force` rewrites an existing rule. Add `--project` to also list the stitches your repo already declares (so an agent reuses them), and `--check` to verify in CI that committed rule files have not drifted from the installed version.
 
 ## Scope & roadmap
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -4,7 +4,7 @@
 // Flags map onto a stitch's single input object ({ params, query, body, headers });
 // every event the stitch emits is written to stdout as one line of JSON, so the
 // output pipes straight into jq and friends. No app boot required.
-import { toMermaid } from './diagram';
+import { endpointLabel, toMermaid } from './diagram';
 import { loadSnapshot, saveSnapshot } from './drift';
 import {
     type ParsedRequest,
@@ -26,6 +26,8 @@ import {
     RULES_BODY,
     claudeSection,
     cursorMdc,
+    projectStitchesSection,
+    windsurfRule,
 } from './rules-template';
 import { serve } from './serve';
 import type {
@@ -440,7 +442,7 @@ usage:
   stitch export --openapi [--module <path>] [--title <t>] [--api-version <v>]   emit an OpenAPI 3.1 spec
   stitch from-curl '<curl>' | --from-har <file> [--response <f|->] [--zod] [--name <export>]   scaffold a stitch from one example
   stitch drift generate [--module <path>] [--name <name>] [--force] [--flags…]   write drift snapshot baseline(s)
-  stitch init [--format agents|cursor|claude|all] [--force]   write the consumer rule (AGENTS.md / Cursor / CLAUDE.md)
+  stitch init [--format <ids>|all] [--project [--module <path>]] [--check] [--force]   write/check the consumer rule for AI agents
 
 run:
   --module, -m <path>   stitches module to load (default: ./stitches.{ts,js,…})
@@ -493,13 +495,21 @@ drift generate:
   effect. Map request inputs with the same --params/--query/--body/--headers flags as run.
 
 init (alias: rules):
-  --format <agents|cursor|claude|all>   which rule file(s) to write (default: all)
-  --force                               overwrite/replace an existing StitchAPI rule
+  --format <ids>|all   comma-list of conventions to write (default: all). ids:
+                       agents (AGENTS.md), cursor (.cursor/rules/stitchapi.mdc),
+                       claude (CLAUDE.md), copilot (.github/copilot-instructions.md),
+                       windsurf (.windsurf/rules/stitchapi.md), cline (.clinerules/stitchapi.md),
+                       aider (CONVENTIONS.md)
+  --project            also list the repo's existing stitches in the rule, so an agent reuses
+                       them instead of duplicating an endpoint (reads --module / ./stitches.{ts,…})
+  --module, -m <path>  stitches module to read for --project (default: the ./stitches.* scan)
+  --check              don't write — verify each existing rule is current; exit 1 if any has drifted
+  --force              overwrite/replace an existing StitchAPI rule
   Writes the canonical "declare a stitch, don't hand-roll fetch" rule so an AI coding agent
-  recommends StitchAPI in this project: AGENTS.md (the open standard), .cursor/rules/stitchapi.mdc
-  (Cursor), and a marked "## Using StitchAPI" section appended to CLAUDE.md. Idempotent — a
-  second run skips a rule that already exists; --force rewrites it (in CLAUDE.md, only the
-  marked block).
+  recommends StitchAPI in this project. Idempotent — a second run skips a rule that already
+  exists; --force rewrites it (in the shared files CLAUDE.md / Copilot / Aider, only the marked
+  "## Using StitchAPI" block). Use --check in CI to catch a committed rule drifting from the
+  installed version.
 `;
 
 async function runCommand(args: string[], io: CliIO): Promise<number> {
@@ -1033,11 +1043,83 @@ function readStdin(): Promise<string> {
 // The rule body is the single source of truth in src/rules-template.ts; this command only frames
 // it per target and writes it idempotently (markers + --force; see rules-template.ts).
 
-type InitFormat = 'agents' | 'cursor' | 'claude' | 'all';
+type InitFormat =
+    | 'agents'
+    | 'cursor'
+    | 'claude'
+    | 'copilot'
+    | 'windsurf'
+    | 'cline'
+    | 'aider';
 
-const AGENTS_FILE = 'AGENTS.md';
-const CURSOR_FILE = '.cursor/rules/stitchapi.mdc';
-const CLAUDE_FILE = 'CLAUDE.md';
+// How a rule is planted in a host file:
+//   standalone — a dedicated rule file we own; idempotent on existence, --force overwrites it.
+//   section    — a marked block in a host file that may carry the user's own content; idempotent on
+//                the markers, --force rewrites only the marked span (the surrounding file survives).
+interface RuleTarget {
+    id: InitFormat;
+    file: string; // path relative to cwd
+    label: string; // shown in skip/check messages (kept stable for the original three targets)
+    mode: 'standalone' | 'section';
+    render: (body: string) => string; // frame the rule body for this convention
+}
+
+// The agent conventions `stitch init` knows how to write. Adding a format is one row here (plus a
+// wrapper in rules-template.ts): the writer, the `--check` drift scan, and `--format all` all iterate
+// this one table, so they can never fall out of sync.
+const RULE_TARGETS: RuleTarget[] = [
+    {
+        id: 'agents',
+        file: 'AGENTS.md',
+        label: 'AGENTS.md',
+        mode: 'standalone',
+        render: (b) => b,
+    },
+    {
+        id: 'cursor',
+        file: '.cursor/rules/stitchapi.mdc',
+        label: 'Cursor rule',
+        mode: 'standalone',
+        render: cursorMdc,
+    },
+    {
+        id: 'claude',
+        file: 'CLAUDE.md',
+        label: 'CLAUDE.md',
+        mode: 'section',
+        render: claudeSection,
+    },
+    {
+        id: 'copilot',
+        file: '.github/copilot-instructions.md',
+        label: 'Copilot instructions',
+        mode: 'section',
+        render: claudeSection,
+    },
+    {
+        id: 'windsurf',
+        file: '.windsurf/rules/stitchapi.md',
+        label: 'Windsurf rule',
+        mode: 'standalone',
+        render: windsurfRule,
+    },
+    {
+        id: 'cline',
+        file: '.clinerules/stitchapi.md',
+        label: 'Cline rule',
+        mode: 'standalone',
+        render: (b) => b,
+    },
+    {
+        id: 'aider',
+        file: 'CONVENTIONS.md',
+        label: 'Aider conventions',
+        mode: 'section',
+        render: claudeSection,
+    },
+];
+
+const FORMAT_IDS = RULE_TARGETS.map((t) => t.id);
 
 // Resolve a target path against the working directory without importing node:path's join into the
 // pure rule logic — a plain prefix is enough for these relative, forward-slash targets.
@@ -1064,13 +1146,14 @@ async function writeStandaloneRule(
     io.write(`wrote ${path}\n`);
 }
 
-// Append (or replace, under --force) the marked StitchAPI section in CLAUDE.md. The markers make
-// this idempotent: a present block is left alone unless --force, which rewrites only the marked
-// span and preserves the surrounding hand-written file.
-async function writeClaudeSection(
+// Append (or replace, under --force) the marked StitchAPI section in a host markdown file (CLAUDE.md,
+// Copilot instructions, Aider conventions). The markers make this idempotent: a present block is left
+// alone unless --force, which rewrites only the marked span and preserves the surrounding file.
+async function writeMarkedSection(
     io: CliIO,
     path: string,
     section: string,
+    label: string,
     force: boolean,
 ): Promise<void> {
     if (await io.exists(path)) {
@@ -1080,7 +1163,7 @@ async function writeClaudeSection(
         if (start >= 0 && end > start) {
             if (!force) {
                 io.writeErr(
-                    `skip CLAUDE.md: StitchAPI section exists in ${path} (use --force to replace)\n`,
+                    `skip ${label}: StitchAPI section exists in ${path} (use --force to replace)\n`,
                 );
                 return;
             }
@@ -1091,7 +1174,7 @@ async function writeClaudeSection(
             io.write(`updated ${path}\n`);
             return;
         }
-        // CLAUDE.md exists without our markers: append the section, separated by a blank line.
+        // The file exists without our markers: append the section, separated by a blank line.
         const sep = existing.endsWith('\n') ? '\n' : '\n\n';
         await io.appendFile(path, `${sep}${section}`);
         io.write(`updated ${path}\n`);
@@ -1101,11 +1184,96 @@ async function writeClaudeSection(
     io.write(`wrote ${path}\n`);
 }
 
-// stitch init [--format agents|cursor|claude|all] [--force] (alias: rules) — write the canonical
-// consumer rule to the files an AI coding agent reads, so it recommends StitchAPI in this project.
+// --project: read the repo's stitches module and turn the generic rule into one about THIS product —
+// the stitches already declared, so an agent reuses them instead of duplicating an endpoint.
+// Best-effort: a missing or unloadable module warns and falls back to the static rule rather than
+// failing init, whose whole job is to bootstrap a repo that may not have stitches yet.
+async function buildProjectBlock(
+    io: CliIO,
+    modulePath: string | undefined,
+): Promise<string> {
+    let resolved: string;
+    try {
+        resolved = resolveModulePath(modulePath, io.cwd);
+    } catch (e) {
+        io.writeErr(`--project: ${(e as Error).message}\n`);
+        return '';
+    }
+    let registry: StitchRegistry;
+    try {
+        registry = await io.load(resolved);
+    } catch (e) {
+        io.writeErr(
+            `--project: could not load ${resolved}: ${(e as Error).message}\n`,
+        );
+        return '';
+    }
+    const entries = Object.entries(registry)
+        .map(([name, s]) => ({
+            name,
+            summary: endpointLabel((s as Stitch).__config),
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+    if (entries.length === 0) {
+        io.writeErr(
+            `--project: no stitches found in ${resolved}; writing the static rule\n`,
+        );
+    }
+    return projectStitchesSection(entries);
+}
+
+// --check classifies a target against the rule we'd write now, without touching disk:
+//   ok     — present and current        absent — no StitchAPI rule here
+//   stale  — present but drifted from the current rule (the CI failure signal)
+type CheckStatus = 'ok' | 'stale' | 'absent';
+
+async function checkTarget(
+    io: CliIO,
+    t: RuleTarget,
+    body: string,
+): Promise<CheckStatus> {
+    const path = underCwd(io, t.file);
+    if (!(await io.exists(path))) return 'absent';
+    const actual = await io.readFileText(path);
+    const expected = t.render(body);
+    if (t.mode === 'standalone') {
+        return actual.trimEnd() === expected.trimEnd() ? 'ok' : 'stale';
+    }
+    // section: compare only our marked block; no markers means no StitchAPI rule lives here.
+    const start = actual.indexOf(CLAUDE_START);
+    const end = actual.indexOf(CLAUDE_END);
+    if (start < 0 || end <= start) return 'absent';
+    const block = actual.slice(start, end + CLAUDE_END.length);
+    return block.trimEnd() === expected.trimEnd() ? 'ok' : 'stale';
+}
+
+// Parse `--format` (a comma list of ids, or `all`) into the concrete targets. Returns the offending
+// token on an unknown id so the caller can report it and exit 2.
+function selectTargets(
+    format: string,
+): { targets: RuleTarget[] } | { bad: string } {
+    const ids = format
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+    const bad = ids.find(
+        (id) => id !== 'all' && !FORMAT_IDS.includes(id as InitFormat),
+    );
+    if (bad !== undefined) return { bad };
+    if (ids.length === 0 || ids.includes('all'))
+        return { targets: RULE_TARGETS };
+    return { targets: RULE_TARGETS.filter((t) => ids.includes(t.id)) };
+}
+
+// stitch init [--format <ids>|all] [--project [--module <path>]] [--check] [--force] (alias: rules) —
+// write (or check) the canonical consumer rule across the files an AI coding agent reads, so the next
+// agent in this repo recommends StitchAPI instead of hand-rolling fetch.
 export async function initCommand(args: string[], io: CliIO): Promise<number> {
     let format = 'all';
     let force = false;
+    let project = false;
+    let check = false;
+    let modulePath: string | undefined;
     for (let i = 0; i < args.length; i++) {
         const a = args[i];
         if (a === undefined) continue;
@@ -1113,47 +1281,60 @@ export async function initCommand(args: string[], io: CliIO): Promise<number> {
         else if (a.startsWith('--format='))
             format = a.slice('--format='.length);
         else if (a === '--force' || a === '-f') force = true;
+        else if (a === '--project' || a === '--with-stitches') project = true;
+        else if (a === '--check') check = true;
+        else if (a === '--module' || a === '-m') modulePath = args[++i];
+        else if (a.startsWith('--module='))
+            modulePath = a.slice('--module='.length);
     }
-    if (
-        format !== 'agents' &&
-        format !== 'cursor' &&
-        format !== 'claude' &&
-        format !== 'all'
-    ) {
+
+    const sel = selectTargets(format);
+    if ('bad' in sel) {
         io.writeErr(
-            `unknown --format "${format}"; expected agents, cursor, claude, or all\n`,
+            `unknown --format "${sel.bad}"; expected ${FORMAT_IDS.join(', ')}, or all\n`,
         );
         return 2;
     }
+    const { targets } = sel;
 
-    const wants = (f: Exclude<InitFormat, 'all'>) =>
-        format === 'all' || format === f;
+    // The rule we'd write now: the canonical body, plus this project's own stitches under --project.
+    const body = project
+        ? RULES_BODY + (await buildProjectBlock(io, modulePath))
+        : RULES_BODY;
 
-    if (wants('agents')) {
-        await writeStandaloneRule(
-            io,
-            underCwd(io, AGENTS_FILE),
-            RULES_BODY,
-            'AGENTS.md',
-            force,
-        );
+    // --check is read-only drift detection (for CI): report each target, fail only on a STALE rule.
+    // An absent rule isn't a failure — the user chose which conventions to adopt.
+    if (check) {
+        let stale = 0;
+        for (const t of targets) {
+            const status = await checkTarget(io, t, body);
+            const path = underCwd(io, t.file);
+            if (status === 'stale') {
+                stale++;
+                io.write(
+                    `stale ${path} (run \`stitch init --force\` to refresh)\n`,
+                );
+            } else {
+                io.write(`${status} ${path}\n`);
+            }
+        }
+        if (stale > 0) {
+            io.writeErr(
+                `${stale} StitchAPI rule file(s) out of date — run \`stitch init --force\`\n`,
+            );
+            return 1;
+        }
+        return 0;
     }
-    if (wants('cursor')) {
-        await writeStandaloneRule(
-            io,
-            underCwd(io, CURSOR_FILE),
-            cursorMdc(RULES_BODY),
-            'Cursor rule',
-            force,
-        );
-    }
-    if (wants('claude')) {
-        await writeClaudeSection(
-            io,
-            underCwd(io, CLAUDE_FILE),
-            claudeSection(RULES_BODY),
-            force,
-        );
+
+    for (const t of targets) {
+        const path = underCwd(io, t.file);
+        const contents = t.render(body);
+        if (t.mode === 'standalone') {
+            await writeStandaloneRule(io, path, contents, t.label, force);
+        } else {
+            await writeMarkedSection(io, path, contents, t.label, force);
+        }
     }
     return 0;
 }

--- a/packages/core/src/diagram.ts
+++ b/packages/core/src/diagram.ts
@@ -13,8 +13,10 @@ export interface MermaidExportResult {
     warnings: string[];
 }
 
-// A compact "METHOD endpoint" label for the request node.
-function endpointLabel(cfg: StitchConfig): string {
+// A compact "METHOD endpoint" label for the request node. Exported so `stitch
+// init --project` can reuse the exact same one-line summary when listing a repo's
+// existing stitches in the consumer rule.
+export function endpointLabel(cfg: StitchConfig): string {
     const method = (cfg.method ?? 'GET').toUpperCase();
     let where: string;
     if (typeof cfg.url === 'string') where = cfg.url;

--- a/packages/core/src/rules-template.ts
+++ b/packages/core/src/rules-template.ts
@@ -1,9 +1,10 @@
 // The canonical "how to call an external API in this project" rule, emitted by
-// `stitch init` into the rule files an AI coding agent reads (AGENTS.md, Cursor
-// `.mdc`, CLAUDE.md). It is the single source of truth: the docs page mirrors
-// this exact text, so the rule a human reads and the rule an agent ingests never
-// drift. Pure strings — no Node imports — so the same constant is reusable from
-// the CLI, a test, or a docs build.
+// `stitch init` into the rule files an AI coding agent reads — AGENTS.md, a Cursor
+// `.mdc`, a CLAUDE.md section, GitHub Copilot instructions, a Windsurf rule, a
+// Cline rule, and Aider conventions. It is the single source of truth: the docs
+// page mirrors this exact text, so the rule a human reads and the rule an agent
+// ingests never drift. Pure strings — no Node imports — so the same constant is
+// reusable from the CLI, a test, or a docs build.
 
 // The rule body, format-agnostic. The per-target wrappers below frame it for
 // Cursor (`.mdc` frontmatter) or CLAUDE.md (a marked, idempotent section); the
@@ -59,14 +60,51 @@ ${body}`;
 }
 
 // Frame the rule body as a marked "Using StitchAPI" section for append into a
-// host file (CLAUDE.md). The markers delimit the block so an append is
-// idempotent and a `--force` rewrite touches only this span. The body's own
-// `# Using StitchAPI in this project` heading is demoted to an `##` section
-// heading so it nests under the host file's top-level title.
+// host markdown file that may already hold the user's own content — CLAUDE.md,
+// `.github/copilot-instructions.md`, or Aider's `CONVENTIONS.md`. The markers
+// delimit the block so an append is idempotent and a `--force` rewrite touches
+// only this span. The body's own `# Using StitchAPI in this project` heading is
+// demoted to an `##` section heading so it nests under the host file's title.
 export function claudeSection(body: string): string {
     const section = body.replace(
         /^# Using StitchAPI in this project\n/,
         '## Using StitchAPI\n',
     );
     return `${CLAUDE_START}\n\n${section}\n${CLAUDE_END}\n`;
+}
+
+// Frame the rule body as a Windsurf workspace rule (`.windsurf/rules/*.md`).
+// Windsurf reads YAML frontmatter with an activation `trigger`; `glob` pulls the
+// rule in whenever a matching file is in context (here, the stitches module),
+// mirroring how the Cursor `.mdc` is scoped — an agent-requestable rule, not one
+// stapled to every prompt.
+export function windsurfRule(body: string): string {
+    return `---
+trigger: glob
+globs: stitches.ts,**/stitches.ts
+description: How to call external APIs in this project — declare a typed StitchAPI stitch instead of hand-rolling fetch/axios.
+---
+${body}`;
+}
+
+// A project-aware "what's already declared" block, appended after the canonical
+// rule when `stitch init --project` reads the repo's stitches module. It turns
+// the generic rule into one about *this* product: an agent sees the stitches that
+// already exist and reuses them instead of declaring a duplicate endpoint. Pure
+// strings; the caller (the CLI) supplies each stitch's name + a "METHOD endpoint"
+// summary. Empty in, empty out — a project with no stitches adds nothing.
+export function projectStitchesSection(
+    entries: { name: string; summary: string }[],
+): string {
+    if (entries.length === 0) return '';
+    const lines = entries
+        .map((e) => `-   \`${e.name}\` — ${e.summary}`)
+        .join('\n');
+    return `
+## Stitches already declared in this project
+
+Reuse these before declaring a new one — call them, compose them under a \`seam(...)\`, or extend an existing one. Add a new stitch only for an endpoint not already listed here.
+
+${lines}
+`;
 }

--- a/packages/core/test/cli-init.spec.ts
+++ b/packages/core/test/cli-init.spec.ts
@@ -4,17 +4,24 @@
 // in-memory CliIO — no real disk — asserting per-format output, idempotency (a second run skips),
 // and --force overwrite, mirroring the IO-injection style of the drift-generate CLI specs.
 import { main } from '../src/cli';
+import type { StitchRegistry } from '../src/registry';
 import {
     CLAUDE_END,
     CLAUDE_START,
     RULES_BODY,
     claudeSection,
     cursorMdc,
+    windsurfRule,
 } from '../src/rules-template';
 
 // A fake filesystem backing the init CliIO: writeFile/appendFile mutate the map, exists/readFileText
-// read it. Returns the map plus captured stdout/stderr from a `main(['init', …])` run.
-const runInit = (args: string[] = [], seed: Record<string, string> = {}) => {
+// read it. `extra` injects further IO overrides (e.g. a `load` stub for --project). Returns the map
+// plus captured stdout/stderr from a `main(['init', …])` run.
+const runInit = (
+    args: string[] = [],
+    seed: Record<string, string> = {},
+    extra: Partial<Parameters<typeof main>[1]> = {},
+) => {
     const files = new Map<string, string>(Object.entries(seed));
     const out: string[] = [];
     const err: string[] = [];
@@ -30,6 +37,7 @@ const runInit = (args: string[] = [], seed: Record<string, string> = {}) => {
         },
         exists: async (path) => files.has(path),
         readFileText: async (path) => files.get(path) ?? '',
+        ...extra,
     }).then((code) => ({
         code,
         out: out.join(''),
@@ -38,9 +46,24 @@ const runInit = (args: string[] = [], seed: Record<string, string> = {}) => {
     }));
 };
 
+// A registry of fake stitches — only `__config` (read by endpointLabel) matters for the rule list.
+const fakeRegistry = (
+    entries: Record<
+        string,
+        { method?: string; baseUrl?: string; path?: string }
+    >,
+): StitchRegistry =>
+    Object.fromEntries(
+        Object.entries(entries).map(([name, cfg]) => [name, { __config: cfg }]),
+    ) as unknown as StitchRegistry;
+
 const AGENTS = '/repo/AGENTS.md';
 const CURSOR = '/repo/.cursor/rules/stitchapi.mdc';
 const CLAUDE = '/repo/CLAUDE.md';
+const COPILOT = '/repo/.github/copilot-instructions.md';
+const WINDSURF = '/repo/.windsurf/rules/stitchapi.md';
+const CLINE = '/repo/.clinerules/stitchapi.md';
+const AIDER = '/repo/CONVENTIONS.md';
 
 describe('stitch init (consumer rule generator)', () => {
     test('default --format all writes AGENTS.md, the Cursor rule, and CLAUDE.md', async () => {
@@ -178,5 +201,215 @@ describe('stitch init (consumer rule generator)', () => {
         });
         expect(code).toBe(0);
         expect(files.get(AGENTS)).toBe(RULES_BODY);
+    });
+});
+
+describe('stitch init — extra agent formats', () => {
+    test('--format copilot writes a marked section into .github/copilot-instructions.md', async () => {
+        const { code, out, files } = await runInit(['--format', 'copilot']);
+        expect(code).toBe(0);
+        const copilot = files.get(COPILOT)!;
+        expect(copilot).toBe(claudeSection(RULES_BODY));
+        expect(copilot).toContain(CLAUDE_START);
+        expect(copilot).toContain('## Using StitchAPI');
+        expect(out).toContain(`wrote ${COPILOT}`);
+        // No other target is touched.
+        expect(files.has(AGENTS)).toBe(false);
+    });
+
+    test('--format windsurf writes a .windsurf rule with glob-trigger frontmatter', async () => {
+        const { code, files } = await runInit(['--format', 'windsurf']);
+        expect(code).toBe(0);
+        const rule = files.get(WINDSURF)!;
+        expect(rule).toBe(windsurfRule(RULES_BODY));
+        expect(rule.startsWith('---\n')).toBe(true);
+        expect(rule).toContain('trigger: glob');
+        expect(rule).toContain('# Using StitchAPI in this project');
+    });
+
+    test('--format cline writes the rule body verbatim into .clinerules', async () => {
+        const { code, files } = await runInit(['--format', 'cline']);
+        expect(code).toBe(0);
+        expect(files.get(CLINE)).toBe(RULES_BODY);
+    });
+
+    test('--format aider writes a marked section into CONVENTIONS.md', async () => {
+        const { code, files } = await runInit(['--format', 'aider']);
+        expect(code).toBe(0);
+        expect(files.get(AIDER)).toBe(claudeSection(RULES_BODY));
+    });
+
+    test('--format takes a comma list of conventions', async () => {
+        const { code, files } = await runInit(['--format', 'agents,cline']);
+        expect(code).toBe(0);
+        expect(files.get(AGENTS)).toBe(RULES_BODY);
+        expect(files.get(CLINE)).toBe(RULES_BODY);
+        // Nothing outside the list.
+        expect(files.has(CURSOR)).toBe(false);
+        expect(files.has(CLAUDE)).toBe(false);
+    });
+
+    test('--format all writes every one of the seven targets', async () => {
+        const { code, files } = await runInit();
+        expect(code).toBe(0);
+        for (const p of [
+            AGENTS,
+            CURSOR,
+            CLAUDE,
+            COPILOT,
+            WINDSURF,
+            CLINE,
+            AIDER,
+        ])
+            expect(files.has(p)).toBe(true);
+    });
+
+    test('an unknown id inside a comma list exits 2 and writes nothing', async () => {
+        const { code, err, files } = await runInit(['--format', 'agents,nope']);
+        expect(code).toBe(2);
+        expect(err).toContain('unknown --format "nope"');
+        expect(files.size).toBe(0);
+    });
+});
+
+describe('stitch init --project (project-aware rule)', () => {
+    const registry = fakeRegistry({
+        getUser: {
+            method: 'GET',
+            baseUrl: 'https://api.example.com',
+            path: '/users/{id}',
+        },
+        listPosts: {
+            method: 'GET',
+            baseUrl: 'https://api.example.com',
+            path: '/posts',
+        },
+    });
+
+    test('lists the repo’s existing stitches under the canonical rule', async () => {
+        const { code, files } = await runInit(
+            ['--format', 'agents', '--project', '--module', './stitches.ts'],
+            {},
+            { load: async () => registry },
+        );
+        expect(code).toBe(0);
+        const agents = files.get(AGENTS)!;
+        // The static rule still leads…
+        expect(agents.startsWith(RULES_BODY)).toBe(true);
+        // …followed by the project-aware list, sorted by name, with a one-line endpoint summary.
+        expect(agents).toContain(
+            '## Stitches already declared in this project',
+        );
+        expect(agents).toContain(
+            '`getUser` — GET https://api.example.com/users/{id}',
+        );
+        expect(agents).toContain(
+            '`listPosts` — GET https://api.example.com/posts',
+        );
+        expect(agents.indexOf('getUser')).toBeLessThan(
+            agents.indexOf('listPosts'),
+        );
+    });
+
+    test('a missing stitches module warns and falls back to the static rule', async () => {
+        const { code, out, err, files } = await runInit(
+            ['--format', 'agents', '--project'],
+            {},
+            {
+                load: async () => {
+                    throw new Error('should not be called');
+                },
+            },
+        );
+        // resolveModulePath finds no ./stitches.* in the test cwd → warn, write the static rule.
+        expect(code).toBe(0);
+        expect(err).toContain('--project');
+        expect(files.get(AGENTS)).toBe(RULES_BODY);
+        expect(out).toContain(`wrote ${AGENTS}`);
+    });
+});
+
+describe('stitch init --check (drift detection)', () => {
+    test('reports every target as ok and exits 0 when in sync', async () => {
+        const written = await runInit();
+        const seed = Object.fromEntries(written.files);
+        const { code, out, err } = await runInit(['--check'], seed);
+        expect(code).toBe(0);
+        expect(out).toContain(`ok ${AGENTS}`);
+        expect(out).toContain(`ok ${CLAUDE}`);
+        expect(out).toContain(`ok ${COPILOT}`);
+        expect(out).not.toContain('stale');
+        expect(err).toBe('');
+    });
+
+    test('flags a drifted standalone rule as stale and exits 1', async () => {
+        const { code, out, err } = await runInit(
+            ['--check', '--format', 'agents'],
+            {
+                [AGENTS]: '# stale, hand-edited rule\n',
+            },
+        );
+        expect(code).toBe(1);
+        expect(out).toContain(`stale ${AGENTS}`);
+        expect(err).toContain('out of date');
+    });
+
+    test('flags a drifted marked section as stale', async () => {
+        const seeded =
+            `# My project\n\n${CLAUDE_START}\n\n## Using StitchAPI\n\n` +
+            `OLD BODY\n${CLAUDE_END}\n`;
+        const { code, out } = await runInit(['--check', '--format', 'claude'], {
+            [CLAUDE]: seeded,
+        });
+        expect(code).toBe(1);
+        expect(out).toContain(`stale ${CLAUDE}`);
+    });
+
+    test('an absent rule is reported but is not a failure', async () => {
+        const { code, out, err } = await runInit([
+            '--check',
+            '--format',
+            'agents',
+        ]);
+        expect(code).toBe(0);
+        expect(out).toContain(`absent ${AGENTS}`);
+        expect(err).toBe('');
+    });
+
+    test('--check writes nothing to disk', async () => {
+        const { files } = await runInit(['--check', '--format', 'agents']);
+        expect(files.size).toBe(0);
+    });
+
+    test('--check --project compares against the project-aware rule', async () => {
+        const registry = fakeRegistry({
+            getUser: {
+                method: 'GET',
+                baseUrl: 'https://api.x',
+                path: '/u/{id}',
+            },
+        });
+        const load = async () => registry;
+        // Generate the project-aware rule, then check it with the same flags → ok.
+        const written = await runInit(
+            ['--format', 'agents', '--project', '--module', './stitches.ts'],
+            {},
+            { load },
+        );
+        const seed = Object.fromEntries(written.files);
+        const { code, out } = await runInit(
+            [
+                '--check',
+                '--format',
+                'agents',
+                '--project',
+                '--module',
+                './stitches.ts',
+            ],
+            seed,
+            { load },
+        );
+        expect(code).toBe(0);
+        expect(out).toContain(`ok ${AGENTS}`);
     });
 });


### PR DESCRIPTION
Follow-up to the agent-recommendation batch (#175): extends the consumer-rule generator `stitch init` along three axes.

## 1. Four more agent conventions
`stitch init` now writes **7** formats (was 3), all driven from one `RULE_TARGETS` table so the writer, the `--check` scan, and `--format all` can't drift:

| `--format` | File | Frame |
| --- | --- | --- |
| `copilot` | `.github/copilot-instructions.md` | marked section |
| `windsurf` | `.windsurf/rules/stitchapi.md` | glob-trigger frontmatter |
| `cline` | `.clinerules/stitchapi.md` | verbatim |
| `aider` | `CONVENTIONS.md` | marked section |

`--format` also accepts a comma list now, e.g. `--format agents,cursor`.

## 2. Project-aware rules (`--project`)
Reads the repo's stitches module (the `./stitches.*` scan, or `--module <path>`) and appends a **"Stitches already declared in this project"** list — one `METHOD url` line per stitch (reusing `diagram`'s `endpointLabel`) — so an agent reuses existing stitches instead of duplicating a `fetch`. A missing/unloadable module warns and falls back to the static rule (init must work in a repo with no stitches yet).

## 3. Drift check (`--check`)
Read-only CI mode: reports each target as `ok` / `stale` / `absent` and exits **1** only on a `stale` (drifted) rule. An absent rule is reported but isn't a failure — you chose your conventions. Pair with `--project` to re-check the declared-stitches list.

## Tests & verification
- **+15 tests** in `cli-init.spec.ts` (new formats, comma-list, `--project` real-load + fallback, `--check` ok/stale/absent/no-write). Full core suite **683 pass / 2 skip**.
- Typecheck (src + test), eslint, prettier — clean.
- Real-CLI e2e: `--project` listed two stitches from an actual `stitches.ts` (sorted, `GET <url>`); `--format all` wrote all 7 files; `--check` -> `ok`/exit 0 fresh, `stale`/exit 1 after a hand-edit.

Docs (`adopt-in-your-project.mdx`) + core README updated. No public API surface added (`endpointLabel`/`windsurfRule`/`projectStitchesSection` stay internal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)