### PR TITLE
ci(publish): OIDC trusted publishing (no npm token)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,13 @@
-# Publishes the package to npm when a GitHub release is created. Publishing is
-# gated on the verify suite and the browser e2e gate passing first. See ~/Development/handbook
-# conventions/global/ci-canonical.md §13.
+# Publishes the packages to npm when a GitHub release is created, gated on the verify
+# suite and the browser e2e gate. Authentication is **OIDC trusted publishing** (no
+# long-lived npm token): the publish job mints a short-lived id-token that npm exchanges
+# for publish rights. Each package must have a Trusted Publisher configured on npmjs.com
+# (package Settings → Trusted Publisher → repo `rejifald/StitchAPI`, this workflow file).
+#
+# NOTE: a package's FIRST version cannot be published over OIDC — npm needs the package to
+# exist before a publisher can be attached. Bootstrap a brand-new package once with a local
+# interactive publish (see docs/RELEASING.md), then it rides this workflow for every release.
+# See ~/Development/handbook conventions/global/ci-canonical.md §13.
 name: Publish
 
 on:
@@ -62,30 +69,55 @@ jobs:
         needs: [verify, e2e]
         runs-on: ubuntu-latest
         timeout-minutes: 10
+        permissions:
+            contents: read
+            id-token: write # mint the OIDC token npm exchanges for publish auth (+ provenance)
         steps:
             - uses: actions/checkout@v4
             - uses: pnpm/action-setup@v4
             - uses: actions/setup-node@v4
               with:
                   node-version-file: .nvmrc
-                  registry-url: https://registry.npmjs.org/
                   cache: pnpm
             - run: pnpm install --frozen-lockfile
-            # Build every publishable package up front, so a build failure aborts
-            # before anything reaches npm (no partial release).
+            # Trusted publishing needs npm >= 11.5.1 — newer than the npm bundled with Node — and
+            # pnpm's own OIDC publish is unreliable (pnpm/pnpm#11513), so publish with `npm` below.
+            - run: npm install -g npm@latest
+            # Build every publishable package up front, so a build failure aborts before anything
+            # reaches npm (no partial release).
             - run: pnpm --filter "./packages/*" build
-            # Derive the dist-tag from the version and refuse an unsafe release:
-            # version lockstep, prerelease-aware peer ranges, scoped access, a
-            # prerelease never landing on `latest`, a CHANGELOG entry, and the
-            # release tag matching the package version.
+            # Derive the dist-tag from the version and refuse an unsafe release: version lockstep,
+            # prerelease-aware peer ranges, scoped access, a prerelease never landing on `latest`,
+            # a CHANGELOG entry, and the release tag matching the package version.
             - name: Validate release & derive dist-tag
               id: release
               run: |
                   TAG="$(node scripts/check-release.mjs --print-tag)"
                   echo "tag=$TAG" >> "$GITHUB_OUTPUT"
                   node scripts/check-release.mjs --changelog --tag "$TAG" --release-tag "${{ github.event.release.tag_name }}"
-            # Publish core + every companion under the derived tag. pnpm skips
-            # private packages and any version already on the registry.
-            - run: pnpm -r publish --tag "${{ steps.release.outputs.tag }}" --no-git-checks
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+            # Publish each non-private package over OIDC. `pnpm pack` produces the tarball (it
+            # rewrites the `workspace:` protocol and runs each prepack/tsup build); `npm publish`
+            # uploads that tarball authenticated by the workflow's id-token — no NODE_AUTH_TOKEN.
+            # A version already on the registry is skipped, so a re-run after a partial publish is
+            # idempotent. `--provenance` attaches a signed build-provenance attestation.
+            - name: Publish (OIDC trusted publishing)
+              run: |
+                  set -euo pipefail
+                  TAG="${{ steps.release.outputs.tag }}"
+                  OUT="$(mktemp -d)"
+                  for d in packages/*/; do
+                      d="${d%/}"
+                      if [ "$(node -p "require('./$d/package.json').private === true")" = "true" ]; then
+                          continue
+                      fi
+                      name="$(node -p "require('./$d/package.json').name")"
+                      version="$(node -p "require('./$d/package.json').version")"
+                      if npm view "$name@$version" version >/dev/null 2>&1; then
+                          echo "✓ skip $name@$version (already on the registry)"
+                          continue
+                      fi
+                      (cd "$d" && pnpm pack --pack-destination "$OUT" >/dev/null)
+                      tgz="$OUT/$(echo "$name" | sed 's/@//; s#/#-#')-$version.tgz"
+                      echo "→ publishing $name@$version under dist-tag '$TAG'"
+                      npm publish "$tgz" --provenance --tag "$TAG"
+                  done

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -99,7 +99,9 @@ Flags: `--print-tag` (print the derived dist-tag and exit), `--changelog`,
         `rc`/`beta`/`alpha` (drop `--prerelease` for a stable one):
         `gh release create vX.Y.Z --title vX.Y.Z --notes "See CHANGELOG.md" --prerelease`.
         This fires [`npm-publish.yml`](../.github/workflows/npm-publish.yml), which
-        re-runs the verify gate and then `pnpm -r publish --tag <derived>`.
+        re-runs the verify + e2e gates and then publishes every package over OIDC
+        (`pnpm pack` → `npm publish <tarball> --provenance`). New packages must be
+        bootstrapped first — see _Bootstrapping a new package's first publish_ below.
 11. [ ] Confirm on npm: `npm view stitchapi dist-tags` and
         `npm view stitchapi@<derived-tag> version`.
 
@@ -114,17 +116,39 @@ build instead of cutting a new one:
 npm dist-tag add stitchapi@1.0.0 latest
 ```
 
-## CI & secrets
+## CI & authentication (OIDC trusted publishing)
 
 -   `npm-publish.yml` triggers on `release: created`, runs the full verify gate
     (`check:format` → `lint` → `types` → `test:coverage` → `exports` →
-    `check:release`), then publishes. Node version comes from
+    `check:release`) + the browser e2e gate, then publishes. Node version comes from
     [`.nvmrc`](../.nvmrc).
--   Requires the repo secret **`npm_token`** — an npm automation token with publish
-    rights to `stitchapi` and the `@stitchapi` scope (exposed to the job as
-    `NODE_AUTH_TOKEN`). The first publish of each scoped package needs
-    `publishConfig.access: public`, which is set on every companion and enforced by
-    the guardrail.
+-   **No npm token.** The publish job authenticates with **OIDC trusted publishing**:
+    it requests an `id-token: write` permission, mints a short-lived token, and npm
+    exchanges it for publish rights — nothing to store, rotate, or leak. It then runs
+    `pnpm pack` (which rewrites the `workspace:` protocol and builds via `prepack`) and
+    `npm publish <tarball> --provenance`, so every release also carries a signed
+    build-provenance attestation. `publishConfig.access: public` (set on every
+    companion) makes the scoped publishes public.
+-   **Each package needs a Trusted Publisher** configured once on npmjs.com: the
+    package's _Settings → Trusted Publisher_ → GitHub Actions, repo `rejifald/StitchAPI`,
+    workflow `npm-publish.yml`. Without it that package's publish step fails to
+    authenticate.
+
+## Bootstrapping a new package's first publish
+
+OIDC can only publish a package that **already exists** on npm (a Trusted Publisher is
+attached to an existing package — there is no way to OIDC-publish a brand-new name). A
+new package's **first** version is therefore published once outside the workflow, after
+which it rides `npm-publish.yml` for every release:
+
+1. [ ] `npm login` — completes **interactive 2FA**. This works even under the strict
+       "require two-factor authentication and disallow tokens" package/org policy,
+       because interactive 2FA is not a token.
+2. [ ] Build, then publish locally — `pnpm -r publish --tag <derived>` bootstraps the
+       whole set at once (enter the OTP when prompted), or per package from its dir:
+       `pnpm pack` then `npm publish <tarball> --tag <derived>`.
+3. [ ] On npmjs.com, add the **Trusted Publisher** to each now-existing package.
+4. [ ] Subsequent releases publish automatically over OIDC — no further local steps.
 
 ## Rollback
 


### PR DESCRIPTION
Switches the publish workflow from a long-lived `npm_token` to **OIDC trusted publishing**.

## What changed
- `publish-npm` requests `id-token: write`, drops `NODE_AUTH_TOKEN`/`registry-url`, and upgrades to `npm@latest` (trusted publishing needs npm ≥ 11.5.1).
- Publishes each non-private package via `pnpm pack` (rewrites the `workspace:` protocol + runs `prepack`) → `npm publish <tarball> --provenance`. Verified locally that `pnpm pack` rewrites `workspace:* → 1.0.0-rc.1` in the tarball (raw `npm publish` would ship the broken `workspace:` literal). pnpm's own OIDC publish is flaky ([pnpm#11513](https://github.com/pnpm/pnpm/issues/11513)), so npm does the upload.
- Skips versions already on the registry (idempotent re-runs); attaches signed build provenance.
- `docs/RELEASING.md`: documents the OIDC model + the one-time local bootstrap for a brand-new package (OIDC can't publish a name that doesn't exist yet).

## Required npm-side setup (per package, one-time)
Each package needs a **Trusted Publisher** on npmjs.com → _Settings → Trusted Publisher_ → GitHub Actions, repo `rejifald/StitchAPI`, workflow `npm-publish.yml`.

## ⚠️ First publish of new packages can't use this
OIDC only publishes names that already exist. The 8 `@stitchapi/*` companions are brand-new, so `1.0.0-rc.1` must be **bootstrapped locally** (interactive 2FA) once; this workflow takes over from the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)