### PR TITLE
chore(release): 1.0.0-rc.2 (validate OIDC publishing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ npm release are grouped under the in-development version that introduced them.
 
 _Nothing yet._
 
+## [1.0.0-rc.2] — 2026-06-18
+
+A pipeline release — **no library changes**. `1.0.0-rc.1` was bootstrapped with a
+hand-run publish; `rc.2` is the first version published automatically through the
+**OIDC trusted-publishing** workflow, so every tarball now carries a signed npm
+**build-provenance** attestation. The library code is identical to `rc.1`.
+
 ## [1.0.0-rc.1] — 2026-06-18
 
 The first **v1.0 release candidate** — the library, the interactive playground, and
@@ -166,5 +173,6 @@ causality push:
 -   **Playground:** the browser Worker runner, handler registration, incremental
     streaming, and the trace → Mermaid DAG wiring.
 
-[Unreleased]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.1...HEAD
+[Unreleased]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.2...HEAD
+[1.0.0-rc.2]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.1...v1.0.0-rc.2
 [1.0.0-rc.1]: https://github.com/rejifald/StitchAPI/compare/v0.7.0...v1.0.0-rc.1

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "stitchapi",
-    "version": "1.0.0-rc.1",
+    "version": "1.0.0-rc.2",
     "type": "commonjs",
     "description": "Agent-native runtime: a typed, declarative stitch turns one HTTP/GraphQL/LLM/shell endpoint into a resilient, validated function — callable from code, the CLI, or an AI agent over MCP. Agents get a capability, never your credentials. Zero deps.",
     "main": "lib/index.js",

--- a/packages/fingerprint-arktype/package.json
+++ b/packages/fingerprint-arktype/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-arktype",
-    "version": "1.0.0-rc.1",
+    "version": "1.0.0-rc.2",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for ArkType — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-effect/package.json
+++ b/packages/fingerprint-effect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-effect",
-    "version": "1.0.0-rc.1",
+    "version": "1.0.0-rc.2",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for Effect Schema — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-typebox/package.json
+++ b/packages/fingerprint-typebox/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-typebox",
-    "version": "1.0.0-rc.1",
+    "version": "1.0.0-rc.2",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for TypeBox — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-valibot/package.json
+++ b/packages/fingerprint-valibot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-valibot",
-    "version": "1.0.0-rc.1",
+    "version": "1.0.0-rc.2",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for Valibot — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-zod/package.json
+++ b/packages/fingerprint-zod/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-zod",
-    "version": "1.0.0-rc.1",
+    "version": "1.0.0-rc.2",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for Zod — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/nest",
-    "version": "1.0.0-rc.1",
+    "version": "1.0.0-rc.2",
     "type": "commonjs",
     "description": "First-class NestJS integration for StitchAPI — StitchModule.forRoot/forFeature/forFeatureScoped, injectable stitches, Logger + ConfigService bridges, an exception filter and an SSE bridge (ADR 0006).",
     "main": "lib/index.js",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/redis",
-    "version": "1.0.0-rc.1",
+    "version": "1.0.0-rc.2",
     "type": "commonjs",
     "description": "Redis-backed StitchStore for StitchAPI — distributed throttle + shared sessions/tokens. Bring your own ioredis or node-redis client.",
     "main": "lib/index.js",

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/shell",
-    "version": "1.0.0-rc.1",
+    "version": "1.0.0-rc.2",
     "type": "commonjs",
     "description": "Run a static local command as a StitchAPI surface — Node-only, injection-proof by construction (static binary + argv array + no shell). ADR 0008.",
     "main": "lib/index.js",


### PR DESCRIPTION
Cuts **`1.0.0-rc.2`** to validate the new OIDC trusted-publishing workflow end-to-end.

- Lockstep bump of all 9 publishable packages `rc.1 → rc.2`. **No library changes** — `packages/` is identical to rc.1; this exists purely to exercise the OIDC pipeline and attach the first signed **build-provenance**.
- check:release green (lockstep, peer ranges `^1.0.0-rc.1` still admit rc.2, scoped access, LICENSE/README); changelog entry added; no lockfile drift.

## After merge → the actual OIDC test
1. `git tag v1.0.0-rc.2 <merge-commit> && git push origin v1.0.0-rc.2`
2. `gh release create v1.0.0-rc.2 --title v1.0.0-rc.2 --notes 'See CHANGELOG.md' --prerelease`
3. The Publish workflow runs over OIDC (no token) → publishes all 9 with provenance. Green = trusted-publisher setup confirmed; a misconfig fails the publish step cleanly with nothing half-broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)