### PR TITLE
fix(playground): make Call-graph header a flush bar like Console/Server-knobs

### DIFF
--- a/apps/docs/app/(home)/playground/playground.css
+++ b/apps/docs/app/(home)/playground/playground.css
@@ -350,6 +350,30 @@
 .stitch-playground__dag {
     margin-top: 0.75rem;
 }
+/* Render the "Call graph" label as a flush, full-width bar identical to the
+   Console / Server-knobs pane heads — not an inset box floating on the extras
+   strip. The head reuses .stitch-playground__pane-head (tint bg + bottom
+   border); the only thing setting it apart was the surrounding strip padding,
+   so cancel that horizontal padding with negative margins to reach both pane
+   edges, and draw a top border so it frames as a section divider. The 1rem
+   matches the horizontal padding of both hosts (.output-extras / .output). */
+.stitch-playground__dag .stitch-playground__pane-head {
+    margin-left: -1rem;
+    margin-right: -1rem;
+    margin-bottom: 0.6rem;
+    border-top: 1px solid var(--color-fd-border);
+}
+/* Common success case — the Call graph is the only extra, so it's the strip's
+   first child (its top margin is already zeroed by the rule below). Seat the
+   bar flush against the strip's top edge by cancelling the strip's top padding,
+   and drop the now-redundant top border (the strip already draws one) so it
+   sits exactly like the Console head atop its pane. */
+.stitch-playground__output-extras
+    > .stitch-playground__dag:first-child
+    .stitch-playground__pane-head {
+    margin-top: -0.6rem;
+    border-top: 0;
+}
 .stitch-playground__dag-streaming-badge {
     display: inline-block;
     margin-bottom: 0.25rem;


### PR DESCRIPTION
## What

The playground's **Call graph** section header now renders as a flush, full-width bar — visually identical to the **Console**, **Code**, and **Server knobs** pane heads — instead of an inset box floating on the lighter extras strip.

| Before | After |
|---|---|
| Inset 16px on each side, sitting on the secondary-bg extras strip → reads as a floating box | Flush edge-to-edge bar (`641→1255`), identical span/styling to Console & Server knobs |

## Why

All four headers already reuse `.stitch-playground__pane-head` (same tint background, bottom border, uppercase 600-weight muted label). The Console / Code / Server-knobs heads sit flush at their pane edges, but the Call-graph head lives inside the padded `.stitch-playground__output-extras` strip, so the strip's 16px horizontal padding inset it on both sides and dropped it onto the strip's lighter background — making it the odd one out.

## How

In `apps/docs/app/(home)/playground/playground.css`:

- **Negative `±1rem` side margins** on `.stitch-playground__dag .stitch-playground__pane-head` cancel the host's horizontal padding so the bar reaches both pane edges. `1rem` matches both possible hosts — `.output-extras` (editor mode) and `.output` (inline mode).
- A **`border-top`** frames it as a section divider in the rarer case where an error / notices strip precedes it.
- In the **common success case** (Call graph is the strip's first child), it's seated flush against the strip's top edge — the strip's top padding is cancelled and the now-redundant top border dropped, so it sits exactly like the Console head atop its pane.

## Verification

Driven in the live dev server (real run producing the 4-node call graph):

- Measured computed styles across all four heads — background, border, font-size/weight/letter-spacing/text-transform/color all match.
- Call-graph head now spans **641→1255**, identical to Console and Server knobs (was inset to `657→1239`).
- Confirmed in both **light and dark** mode.
- Prettier clean; full pre-push gate green (format, lint, typecheck, typecheck-d, test, exports, build-docs).

CSS-only change; no behavioral or bundle impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)