### PR TITLE
docs(readme): bump current-status NOTE to 1.0.0-rc.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 > [!NOTE]
 >
-> **StitchAPI is at `1.0.0-rc.1`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is very welcome.
+> **StitchAPI is at `1.0.0-rc.2`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is very welcome.
 
 ---
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,7 +4,7 @@
 
 > [!NOTE]
 >
-> **StitchAPI is at `1.0.0-rc.1`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is very welcome.
+> **StitchAPI is at `1.0.0-rc.2`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is very welcome.
 
 **StitchAPI turns any API into a typed, resilient function.** Its one primitive — a **stitch** — takes a single endpoint and hands you back a callable: declare the endpoint's contract once (input, output, auth, resilience) and call it like a local function. No server, no codegen, no config files — only explicit composition. The same definition your code calls, the CLI runs and an AI agent can invoke without ever touching a credential.
 


### PR DESCRIPTION
## What

PR #184 bumped `packages/core/package.json` to `1.0.0-rc.2`, but the prominent `> [!NOTE]` status blocks in both READMEs still said **`1.0.0-rc.1`**, so the published README disagreed with the package version.

This updates the current-status NOTE in:

- `README.md` (after the bundle-size paragraph)
- `packages/core/README.md` (near the top)

to `1.0.0-rc.2`.

## Scope

- Only the current-status NOTE blocks changed — one line each. A grep across both READMEs confirms no other `1.0.0-rc.1` occurrences remain; no historical/changelog references were touched.
- `prettier --check` passes on both files (the GitHub-alert blank `>` line is preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)