### PR TITLE
feat(deno-kv): @stitchapi/deno-kv — Deno KV StitchStore (atomic incr)

### DIFF
--- a/packages/deno-kv/LICENSE
+++ b/packages/deno-kv/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/deno-kv/README.md
+++ b/packages/deno-kv/README.md
@@ -1,0 +1,79 @@
+# @stitchapi/deno-kv
+
+A **[Deno KV](https://docs.deno.com/deploy/kv/manual/)-backed
+[`StitchStore`](https://stitchapi.dev)** for StitchAPI. Attach it and two
+process-local pieces of a stitch become fleet-wide, with **no change to the call
+site** (DESIGN §13):
+
+-   **Throttle** — rate counters live in Deno KV, so the rate budget is shared
+    across every isolate (distributed rate limiting).
+-   **Auth** — the cookie jar / token cache lives in Deno KV, so sessions & tokens
+    are shared across isolates and survive restarts.
+
+On Deno Deploy the same `Deno.openKv()` handle is replicated globally, so a
+stitch's state becomes edge-native for free.
+
+```ts
+import { denoKvStore } from '@stitchapi/deno-kv';
+import { seam } from 'stitchapi';
+
+const api = seam({ store: denoKvStore(await Deno.openKv()) });
+```
+
+## Bring your own handle
+
+This package **imports no Deno KV client** and never touches the `Deno` global.
+It runs on a small structural `DenoKvLike` surface that a real `Deno.Kv` (from
+`Deno.openKv()`, or the npm [`@deno/kv`](https://www.npmjs.com/package/@deno/kv)
+package on Node/Bun) satisfies as-is — so the package has **zero runtime
+dependencies** and is portable across runtimes:
+
+```ts
+// Deno / Deno Deploy
+import { denoKvStore } from '@stitchapi/deno-kv';
+
+const store = denoKvStore(await Deno.openKv());
+```
+
+```ts
+// Node or Bun, via the @deno/kv npm package
+import { openKv } from '@deno/kv';
+import { denoKvStore } from '@stitchapi/deno-kv';
+
+const store = denoKvStore(await openKv(process.env.DENO_KV_URL));
+```
+
+Anything that satisfies `DenoKvLike` (a test double, a proxy) is a drop-in.
+
+## Atomic counters
+
+Deno KV has no `INCR`, so `incr` is implemented as an **atomic compare-and-set
+loop**: read the current value + its `versionstamp`, then
+`atomic().check({ key, versionstamp }).set(key, next, { expireIn }).commit()`. If
+another isolate raced us, the versionstamp moved, the commit returns `ok: false`,
+and the loop re-reads and retries — so N concurrent increments net **exactly +N**
+(proven by the store contract's "20 concurrent incrs net +20" rule).
+
+The TTL (`expireIn`, which Deno KV measures in **milliseconds** — the same unit as
+the contract's `ttlMs`, no conversion at the seam) is set **only on the increment
+that creates the counter**, never extending it afterwards, so a busy rate window
+can't slide forever and never reset. `maxIncrRetries` (default `100`) bounds the
+loop under pathological contention.
+
+The store owns no connection: `store.close()` delegates to the handle, so you
+decide when KV shuts down.
+
+`keyPrefix` namespaces every key — a string key `k` maps to `[keyPrefix, k]`
+instead of the flat `[k]` — for sharing one KV database with other data:
+
+```ts
+denoKvStore(await Deno.openKv(), { keyPrefix: 'myapp' });
+```
+
+## Conformance
+
+Compliance with the store seam is proven against `verifyStoreContract` from
+`stitchapi/testing`, run hermetically against an in-memory `Deno.Kv` fake (a Map
+with expiry + a monotonic versionstamp + an atomic builder that fails a commit
+when a checked versionstamp is stale — so the compare-and-set retry path is
+genuinely exercised). See `test/conformance.spec.ts`.

--- a/packages/deno-kv/package.json
+++ b/packages/deno-kv/package.json
@@ -1,0 +1,65 @@
+{
+    "name": "@stitchapi/deno-kv",
+    "version": "1.0.0-rc.2",
+    "type": "commonjs",
+    "description": "Deno KV-backed StitchStore for StitchAPI — distributed throttle + shared sessions/tokens with atomic incr. Bring your own Deno.Kv handle.",
+    "main": "lib/index.js",
+    "module": "lib/index.mjs",
+    "types": "lib/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./lib/index.d.mts",
+                "default": "./lib/index.mjs"
+            },
+            "require": {
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
+            }
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "lib"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsup",
+        "test": "vitest run",
+        "check:types": "tsc --noEmit",
+        "prepack": "tsup",
+        "prepublishOnly": "node ../../scripts/check-release.mjs --changelog"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rejifald/StitchAPI.git",
+        "directory": "packages/deno-kv"
+    },
+    "keywords": [
+        "stitchapi",
+        "deno",
+        "deno-kv",
+        "store",
+        "rate-limit",
+        "distributed-rate-limiting",
+        "session"
+    ],
+    "author": "Oleksandr Zhuravlov (rejifald@gmail.com)",
+    "license": "Apache-2.0",
+    "homepage": "https://stitchapi.dev",
+    "engines": {
+        "node": ">=18.18.0"
+    },
+    "peerDependencies": {
+        "stitchapi": "^1.0.0-rc.1"
+    },
+    "devDependencies": {
+        "@types/node": "^22.10.0",
+        "stitchapi": "workspace:*",
+        "tsup": "^8.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.8"
+    }
+}

--- a/packages/deno-kv/src/index.ts
+++ b/packages/deno-kv/src/index.ts
@@ -1,0 +1,200 @@
+// Deno KV-backed StitchStore for StitchAPI (DESIGN.md §13).
+//
+// Attaching a shared store turns two of the engine's process-local pieces into
+// fleet-wide ones with NO change to the call site: the throttle's rate counters
+// (cross-process rate limiting) and the auth vault's cookie jar / token cache
+// (sessions & tokens shared across isolates, surviving restarts). On Deno Deploy
+// the same `Deno.openKv()` handle is replicated globally, so this package makes a
+// stitch's state edge-native for free.
+//
+// Bring your own handle. The store never imports `@deno/kv` or touches the `Deno`
+// global — it talks to a tiny structural {@link DenoKvLike} surface that the real
+// `Deno.Kv` satisfies as-is. Anything else that satisfies it (a test double, a
+// cluster proxy) is a drop-in. This mirrors core's "contract, not dependency"
+// stance (DESIGN §10, like the BYO axios adapter), and keeps the package with
+// ZERO runtime dependencies — usable from Node, Bun or Deno alike.
+//
+// Compliance with the store contract is proven against `verifyStoreContract` from
+// `stitchapi/testing` (see test/conformance.spec.ts).
+import type { StitchStore } from 'stitchapi';
+
+// ---------------------------------------------------------------------------
+// the Deno KV surface
+// ---------------------------------------------------------------------------
+
+/** Deno KV array key — we only ever build single- or two-element string keys. */
+export type DenoKvKey = readonly (string | number)[];
+
+/** The result of a `get`: the value plus its optimistic-concurrency token. */
+export interface DenoKvEntryMaybe {
+    /** Stored value, or `null` when the key is absent. */
+    value: unknown;
+    /** Opaque version token; `null` when the key is absent — used by `check`. */
+    versionstamp: string | null;
+}
+
+/** A `check` predicate: "the key must still be at this versionstamp to commit". */
+export interface DenoAtomicCheck {
+    key: DenoKvKey;
+    versionstamp: string | null;
+}
+
+/** The outcome of an atomic commit. `ok: false` ⇒ a `check` failed; retry. */
+export type DenoAtomicCommitResult =
+    | { ok: true; versionstamp: string }
+    | { ok: false };
+
+/**
+ * The fluent atomic builder Deno KV's `atomic()` returns. We use only the slice
+ * that powers a compare-and-set counter: assert the read versionstamp with
+ * {@link check}, write the next value with {@link set}, then {@link commit}.
+ */
+export interface DenoAtomicOperation {
+    check(...checks: DenoAtomicCheck[]): DenoAtomicOperation;
+    set(
+        key: DenoKvKey,
+        value: unknown,
+        options?: { expireIn?: number },
+    ): DenoAtomicOperation;
+    commit(): Promise<DenoAtomicCommitResult>;
+}
+
+/**
+ * The minimal `Deno.Kv` surface {@link denoKvStore} runs on. A real handle from
+ * `Deno.openKv()` (or the npm `@deno/kv` package) satisfies it structurally — you
+ * never implement this yourself in production.
+ *
+ * Note `expireIn` is **milliseconds** (matching the store contract's `ttlMs`),
+ * which is exactly Deno KV's own unit — no conversion at the seam.
+ */
+export interface DenoKvLike {
+    get(key: DenoKvKey): Promise<DenoKvEntryMaybe>;
+    set(
+        key: DenoKvKey,
+        value: unknown,
+        options?: { expireIn?: number },
+    ): Promise<unknown>;
+    delete(key: DenoKvKey): Promise<void>;
+    atomic(): DenoAtomicOperation;
+    /** Release the connection (optional — `denoKvStore().close()` delegates here). */
+    close?(): void;
+}
+
+// ---------------------------------------------------------------------------
+// the store
+// ---------------------------------------------------------------------------
+
+/** Options for {@link denoKvStore}. */
+export interface DenoKvStoreOptions {
+    /**
+     * Prefix segment prepended to every key, for sharing one KV database with
+     * other apps/data: a string key `k` maps to `[keyPrefix, k]` instead of
+     * `[k]`. Applied on both read and write, so the store stays self-consistent.
+     * Default `undefined` (flat one-segment keys — matches `memoryStore`).
+     */
+    keyPrefix?: string;
+    /**
+     * How many times {@link StitchStore.incr} retries a lost compare-and-set race
+     * before giving up. Each retry re-reads the current value, so the loop only
+     * spins under genuine contention. With N callers racing one counter, the
+     * unluckiest needs up to N−1 retries (each round exactly one commit wins, so
+     * contention drains one caller at a time); the default `100` therefore
+     * comfortably covers any realistic per-key concurrency on a single window.
+     */
+    maxIncrRetries?: number;
+}
+
+/**
+ * A {@link StitchStore} backed by Deno KV. Pass a {@link DenoKvLike} handle —
+ * typically the result of `await Deno.openKv()`:
+ *
+ * ```ts
+ * import { seam } from 'stitchapi';
+ * import { denoKvStore } from '@stitchapi/deno-kv';
+ *
+ * const api = seam({ store: denoKvStore(await Deno.openKv()) });
+ * ```
+ *
+ * Values round-trip through a JSON envelope so the store never wrestles with Deno
+ * KV's structured-clone edge cases (BigInt, undefined-vs-null) — it persists the
+ * exact bytes the contract handed it. The throttle's counter uses an atomic
+ * compare-and-set loop (see {@link StitchStore.incr}). The store owns no
+ * connection — `close()` delegates to the handle, so the caller decides when KV
+ * shuts down.
+ */
+export function denoKvStore(
+    kv: DenoKvLike,
+    opts: DenoKvStoreOptions = {},
+): StitchStore {
+    const prefix = opts.keyPrefix;
+    const maxRetries = opts.maxIncrRetries ?? 100;
+    // String key → Deno KV array key. With a prefix it's a two-segment key so the
+    // namespace is a real KV sub-range; without, a flat one-segment key.
+    const k = (key: string): DenoKvKey =>
+        prefix === undefined ? [key] : [prefix, key];
+
+    const store: StitchStore = {
+        async get(key) {
+            const { value } = await kv.get(k(key));
+            if (value == null) return undefined;
+            // We always write a JSON string; anything else (e.g. a bare counter
+            // written by `incr`) is handed back as-is.
+            if (typeof value !== 'string') return value;
+            try {
+                return JSON.parse(value) as unknown;
+            } catch {
+                return value;
+            }
+        },
+        async set(key, value, ttlMs) {
+            // `set(key, undefined)` is the cache's delete (ADR 0003 §8) — drop the key.
+            if (value === undefined) {
+                await kv.delete(k(key));
+                return;
+            }
+            // Deno KV rejects `expireIn` of 0/negative; only attach a positive TTL.
+            const options =
+                ttlMs != null && ttlMs > 0 ? { expireIn: ttlMs } : undefined;
+            await kv.set(k(key), JSON.stringify(value), options);
+        },
+        async incr(key, ttlMs) {
+            // Atomic counter-with-window via compare-and-set. Read the current
+            // value + its versionstamp, then commit `next` guarded by a `check`
+            // on that versionstamp: if another isolate raced us, the versionstamp
+            // moved, the commit returns `ok: false`, and we re-read and retry —
+            // so N concurrent incrs net exactly +N (the contract's rule).
+            //
+            // The TTL is set ONLY on the increment that creates the counter (when
+            // the prior versionstamp is `null`), never extending it afterwards —
+            // otherwise a busy rate window would slide forever and never reset,
+            // matching the redis adapter's "PEXPIRE only when v == 1" semantics.
+            const kk = k(key);
+            for (let attempt = 0; attempt <= maxRetries; attempt++) {
+                const entry = await kv.get(kk);
+                const current =
+                    typeof entry.value === 'number' ? entry.value : 0;
+                const next = current + 1;
+                const options =
+                    entry.versionstamp === null && ttlMs > 0
+                        ? { expireIn: ttlMs }
+                        : undefined;
+                const res = await kv
+                    .atomic()
+                    .check({ key: kk, versionstamp: entry.versionstamp })
+                    .set(kk, next, options)
+                    .commit();
+                if (res.ok) return next;
+            }
+            throw new Error(
+                `@stitchapi/deno-kv: incr(${key}) lost ${maxRetries + 1} compare-and-set races`,
+            );
+        },
+    };
+    if (kv.close) {
+        const close = kv.close.bind(kv);
+        store.close = async (): Promise<void> => {
+            close();
+        };
+    }
+    return store;
+}

--- a/packages/deno-kv/test/conformance.spec.ts
+++ b/packages/deno-kv/test/conformance.spec.ts
@@ -96,8 +96,7 @@ class FakeDenoKv implements DenoKvLike {
         this.data.set(keyId(key), {
             value,
             versionstamp,
-            expiresAt:
-                expireIn == null ? Infinity : Date.now() + expireIn,
+            expiresAt: expireIn == null ? Infinity : Date.now() + expireIn,
         });
         return versionstamp;
     }

--- a/packages/deno-kv/test/conformance.spec.ts
+++ b/packages/deno-kv/test/conformance.spec.ts
@@ -1,0 +1,159 @@
+// Conformance proof for @stitchapi/deno-kv. `denoKvStore` must pass
+// `verifyStoreContract` from `stitchapi/testing`.
+//
+// The run is hermetic and offline: a faithful in-memory `Deno.Kv` (a Map with
+// expiry + a monotonic versionstamp + an atomic builder that fails the commit
+// when a checked versionstamp is stale). Single-threaded JS makes the engine's
+// read-modify-write atomic, exactly as Deno KV's real `atomic().commit()` does
+// against its storage — so the contract's "20 concurrent incrs net +20" rule
+// holds here and on real Deno KV alike, including the compare-and-set RETRY path
+// (the fake genuinely fails losing commits, so the store must re-read and retry).
+import { denoKvStore } from '../src';
+import type {
+    DenoAtomicCheck,
+    DenoAtomicCommitResult,
+    DenoAtomicOperation,
+    DenoKvEntryMaybe,
+    DenoKvKey,
+    DenoKvLike,
+} from '../src';
+
+import { assertConformance, verifyStoreContract } from 'stitchapi/testing';
+import { describe, test } from 'vitest';
+
+// --- a faithful in-memory Deno KV -----------------------------------------
+
+interface Entry {
+    value: unknown;
+    versionstamp: string;
+    /** Epoch ms at which the key expires; `Infinity` = no expiry. */
+    expiresAt: number;
+}
+
+/** Array key → a stable string handle for the backing Map. */
+function keyId(key: DenoKvKey): string {
+    return JSON.stringify(key);
+}
+
+class FakeDenoKv implements DenoKvLike {
+    private readonly data = new Map<string, Entry>();
+    private seq = 0n;
+
+    private nextStamp(): string {
+        // Deno's versionstamps are 20-char hex; any monotonic unique string works.
+        this.seq += 1n;
+        return this.seq.toString(16).padStart(20, '0');
+    }
+
+    private live(id: string): Entry | undefined {
+        const e = this.data.get(id);
+        if (!e) return undefined;
+        if (e.expiresAt <= Date.now()) {
+            this.data.delete(id);
+            return undefined;
+        }
+        return e;
+    }
+
+    async get(key: DenoKvKey): Promise<DenoKvEntryMaybe> {
+        const e = this.live(keyId(key));
+        return e
+            ? { value: e.value, versionstamp: e.versionstamp }
+            : { value: null, versionstamp: null };
+    }
+
+    async set(
+        key: DenoKvKey,
+        value: unknown,
+        options?: { expireIn?: number },
+    ): Promise<unknown> {
+        const stamp = this.write(key, value, options?.expireIn);
+        return { ok: true, versionstamp: stamp };
+    }
+
+    async delete(key: DenoKvKey): Promise<void> {
+        this.data.delete(keyId(key));
+    }
+
+    atomic(): DenoAtomicOperation {
+        return new FakeAtomic(this);
+    }
+
+    // --- internals the atomic builder drives (sync, so no interleave) ------
+
+    /** True iff every check's versionstamp still matches the live entry. */
+    checksPass(checks: DenoAtomicCheck[]): boolean {
+        for (const c of checks) {
+            const e = this.live(keyId(c.key));
+            const live = e ? e.versionstamp : null;
+            if (live !== c.versionstamp) return false;
+        }
+        return true;
+    }
+
+    write(key: DenoKvKey, value: unknown, expireIn?: number): string {
+        const versionstamp = this.nextStamp();
+        this.data.set(keyId(key), {
+            value,
+            versionstamp,
+            expiresAt:
+                expireIn == null ? Infinity : Date.now() + expireIn,
+        });
+        return versionstamp;
+    }
+}
+
+/** A minimal `atomic()` builder: queue checks + one set, then commit-or-fail. */
+class FakeAtomic implements DenoAtomicOperation {
+    private readonly checks: DenoAtomicCheck[] = [];
+    private write:
+        | { key: DenoKvKey; value: unknown; expireIn: number | undefined }
+        | undefined;
+
+    constructor(private readonly kv: FakeDenoKv) {}
+
+    check(...checks: DenoAtomicCheck[]): DenoAtomicOperation {
+        this.checks.push(...checks);
+        return this;
+    }
+
+    set(
+        key: DenoKvKey,
+        value: unknown,
+        options?: { expireIn?: number },
+    ): DenoAtomicOperation {
+        this.write = { key, value, expireIn: options?.expireIn };
+        return this;
+    }
+
+    // Synchronous read-validate-write under JS's single thread — the same
+    // all-or-nothing guarantee Deno KV gives across isolates.
+    async commit(): Promise<DenoAtomicCommitResult> {
+        if (!this.kv.checksPass(this.checks)) return { ok: false };
+        if (!this.write) return { ok: true, versionstamp: '' };
+        const versionstamp = this.kv.write(
+            this.write.key,
+            this.write.value,
+            this.write.expireIn,
+        );
+        return { ok: true, versionstamp };
+    }
+}
+
+// --- the hermetic contract run --------------------------------------------
+
+describe('@stitchapi/deno-kv store contract', () => {
+    test('denoKvStore(...) passes the store contract', async () => {
+        assertConformance(
+            await verifyStoreContract(() => denoKvStore(new FakeDenoKv())),
+        );
+    });
+
+    test('denoKvStore(..., { keyPrefix }) passes the store contract', async () => {
+        assertConformance(
+            await verifyStoreContract(() =>
+                denoKvStore(new FakeDenoKv(), { keyPrefix: 'app:' }),
+            ),
+        );
+    });
+});

--- a/packages/deno-kv/tsconfig.json
+++ b/packages/deno-kv/tsconfig.json
@@ -1,0 +1,34 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM"],
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "exactOptionalPropertyTypes": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "verbatimModuleSyntax": true,
+        "isolatedModules": true,
+
+        "types": ["node", "vitest/globals"],
+
+        // Resolve the workspace package to its SOURCE so typecheck + tests don't
+        // depend on `stitchapi` being built first (the pre-push gate typechecks
+        // before it builds). The published `exports` map still points at `lib/`.
+        "baseUrl": ".",
+        "paths": {
+            "stitchapi/testing": ["../core/src/testing.ts"],
+            "stitchapi": ["../core/src/index.ts"]
+        }
+    },
+    "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/deno-kv/tsup.config.ts
+++ b/packages/deno-kv/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+// Single dual-format entry; `stitchapi` is the only peer dep, externalised by
+// tsup. The Deno KV surface is a structural interface (no runtime client), so
+// the bundle is just the store + the atomic-incr logic.
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    minify: true,
+    outDir: 'lib',
+    clean: true,
+});

--- a/packages/deno-kv/vitest.config.ts
+++ b/packages/deno-kv/vitest.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+// Alias the workspace package to core SOURCE (more specific subpaths first), so
+// tests run without `stitchapi` being built. Mirrors tsconfig `paths`.
+const src = (p: string): string =>
+    fileURLToPath(new URL(`../core/src/${p}`, import.meta.url));
+
+export default defineConfig({
+    resolve: {
+        alias: [
+            { find: /^stitchapi\/testing$/, replacement: src('testing.ts') },
+            { find: /^stitchapi$/, replacement: src('index.ts') },
+        ],
+    },
+    test: {
+        globals: true,
+        environment: 'node',
+        include: ['test/**/*.spec.ts'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,24 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
 
+  packages/deno-kv:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.21
+      stitchapi:
+        specifier: workspace:*
+        version: link:../core
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+
   packages/eval-harness:
     dependencies:
       '@stitchapi/sandbox-sim':


### PR DESCRIPTION
## What this adds

`@stitchapi/deno-kv` — a `StitchStore` backed by [Deno KV](https://docs.deno.com/deploy/kv/manual/). Attaching it makes a stitch's throttle rate counters and auth cookie jar / token cache fleet-wide with no change to the call site (DESIGN §13), and on Deno Deploy the globally-replicated `Deno.openKv()` handle makes that state edge-native for free.

It mirrors `@stitchapi/redis` exactly in layout, build, and house style:
- **Bring your own handle** — runs on a structural `DenoKvLike` surface that a real `Deno.Kv` (or the npm `@deno/kv` package on Node/Bun) satisfies as-is. Imports no client and never touches the `Deno` global, so the package has **zero runtime dependencies**.
- **JSON envelope** on `set`/`get`; `set(key, undefined)` deletes (ADR 0003 §8).
- **Atomic `incr`** — Deno KV has no `INCR`, so it's a compare-and-set loop: read value + versionstamp, then `atomic().check({ key, versionstamp }).set(key, next, { expireIn }).commit()`, retrying on `ok === false`. Nets exactly +N for N concurrent increments and sets the TTL (`expireIn`, in ms — Deno KV's native unit) only on the counter-creating increment.
- `close()` delegates to the handle; `keyPrefix` namespaces keys as `[prefix, key]`.

## Rationale

Gives StitchAPI a first-party distributed store for the Deno / Deno Deploy edge runtime, complementing the Redis adapter for Node fleets.

Part of the #197 integration backlog wave.

## Verification

Run from the worktree against core SOURCE (tsconfig/vitest alias `stitchapi` → `../core/src`):

- `check:types` — **pass** (`tsc --noEmit`, strict + `exactOptionalPropertyTypes`)
- `build` — **pass** (`tsup`, dual cjs/esm + dts)
- `test` — **pass** (`vitest run`, 2/2): `verifyStoreContract` against a hermetic in-memory `Deno.Kv` fake (Map + monotonic versionstamp + an atomic builder that fails a commit when a checked versionstamp is stale — so the compare-and-set retry path is genuinely exercised), with and without `keyPrefix`. Includes the contract's "20 concurrent incrs net +20" rule.

## Caveats

- No live Deno KV opt-in test (unlike redis's `REDIS_URL` hook) — Deno KV needs the Deno runtime / `@deno/kv`, neither a devDependency here; the hermetic fake fully exercises the CAS + TTL semantics.
- Under pathological per-key contention the CAS loop is bounded by `maxIncrRetries` (default 100); each round drains exactly one caller, so this comfortably covers any realistic single-window concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)