### PR TITLE
feat(svelte): @stitchapi/svelte — readable stores over query-core

### DIFF
--- a/packages/svelte/LICENSE
+++ b/packages/svelte/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,0 +1,94 @@
+# @stitchapi/svelte
+
+Svelte bindings for [StitchAPI](https://stitchapi.dev). `stitchStore` / `stitchStreamStore` are real Svelte stores (`{ subscribe }`) wrapping a stitch call, plus an optional [TanStack Query](https://tanstack.com/query) adapter. Works on **Svelte 4 and 5** (built on `readable` from `svelte/store`, the surface that is unchanged across both).
+
+**Streaming-first.** A `stitch` can stream (`sse` / `stream` surfaces) — `stitchStreamStore` emits a new state as each `delta` chunk arrives. That's the differentiator over plain request/response query libraries.
+
+These stores are a thin layer over [`@stitchapi/query-core`](../query-core), the framework-agnostic store that owns the reactive lifecycle. React / Vue / Solid bindings are the same few lines against their own external-store primitive.
+
+## Install
+
+```sh
+pnpm add @stitchapi/svelte @stitchapi/query-core stitchapi svelte
+```
+
+`stitchapi` and `svelte` (`^4 || ^5`) are peer dependencies. `@tanstack/svelte-query` is an **optional** peer — only needed if you use `queryOptions`.
+
+## `stitchStore` — request / response
+
+```svelte
+<script lang="ts">
+    import { stitchStore } from '@stitchapi/svelte';
+    import { stitch } from 'stitchapi';
+
+    const getUser = stitch({
+        baseUrl: 'https://api.example.com',
+        path: '/users/{id}',
+    });
+
+    export let id: string;
+    const user = stitchStore(getUser, { params: { id } });
+</script>
+
+{#if $user.isPending}
+    <Spinner />
+{:else if $user.isError}
+    <Retry onclick={user.refetch} />
+{:else}
+    <h1>{$user.data?.name}</h1>
+{/if}
+```
+
+The run starts on the store's first subscriber (so `$user` fetches when the component mounts) and is aborted when the last subscriber leaves (component teardown). Call `refetch()` to re-run, `cancel()` to abort. Re-create the store when `input` changes — derive it in a `$:` block keyed on the input.
+
+## `stitchStreamStore` — live deltas
+
+```svelte
+<script lang="ts">
+    import { stitchStreamStore } from '@stitchapi/svelte';
+    import { sse } from 'stitchapi';
+
+    const chat = sse({ url: 'https://api.example.com/chat' });
+    export let prompt: string;
+    const tokens = stitchStreamStore(chat, { body: { prompt } });
+</script>
+
+{#each $tokens.chunks as c}<span>{c}</span>{/each}
+{#if $tokens.isStreaming}<Cursor />{/if}
+```
+
+Same state shape as `stitchStore`. `data` is the accumulated chunks (`mode: 'append'`, default) or the latest chunk (`mode: 'replace'`); `chunks` is the running list; `status` is `'streaming'` until the terminal `result`, then `'success'`.
+
+`useStitch` / `useStitchStream` are aliases of these two, for callers who prefer the `use*` naming.
+
+## State shape
+
+```ts
+interface StitchQueryState<T> {
+    status: 'idle' | 'pending' | 'streaming' | 'success' | 'error';
+    data: T | undefined;
+    error: unknown;
+    chunks: readonly unknown[];
+    isPending: boolean;
+    isError: boolean;
+    isSuccess: boolean;
+    isStreaming: boolean;
+}
+```
+
+The store value is this state; `refetch` / `cancel` are attached as methods on the store.
+
+## Optional: TanStack Query
+
+`queryOptions(stitch, input)` returns a plain `{ queryKey, queryFn }` object — no import of `@tanstack/svelte-query` required, so it works even if you never install it.
+
+```ts
+import { queryOptions } from '@stitchapi/svelte';
+import { createQuery } from '@tanstack/svelte-query';
+
+const query = createQuery(queryOptions(getUser, { params: { id } }));
+```
+
+## License
+
+Apache-2.0

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,0 +1,75 @@
+{
+    "name": "@stitchapi/svelte",
+    "version": "1.0.0-rc.2",
+    "type": "commonjs",
+    "description": "Svelte bindings for StitchAPI — stitchStore/stitchStreamStore Svelte stores over @stitchapi/query-core (unary + streaming deltas), plus an optional TanStack-shaped queryOptions helper. Works on Svelte 4 and 5.",
+    "main": "lib/index.js",
+    "module": "lib/index.mjs",
+    "types": "lib/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./lib/index.d.mts",
+                "default": "./lib/index.mjs"
+            },
+            "require": {
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
+            }
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "lib"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsup",
+        "test": "vitest run",
+        "check:types": "tsc --noEmit",
+        "prepack": "tsup",
+        "prepublishOnly": "node ../../scripts/check-release.mjs --changelog"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rejifald/StitchAPI.git",
+        "directory": "packages/svelte"
+    },
+    "keywords": [
+        "stitchapi",
+        "svelte",
+        "store",
+        "readable",
+        "streaming",
+        "query",
+        "tanstack-query"
+    ],
+    "author": "Oleksandr Zhuravlov (rejifald@gmail.com)",
+    "license": "Apache-2.0",
+    "homepage": "https://stitchapi.dev",
+    "engines": {
+        "node": ">=18.18.0"
+    },
+    "peerDependencies": {
+        "@stitchapi/query-core": "^1.0.0-rc.2",
+        "stitchapi": "^1.0.0-rc.1",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "@tanstack/svelte-query": "^5.0.0"
+    },
+    "peerDependenciesMeta": {
+        "@tanstack/svelte-query": {
+            "optional": true
+        }
+    },
+    "devDependencies": {
+        "@stitchapi/query-core": "workspace:*",
+        "@types/node": "^22.10.0",
+        "stitchapi": "workspace:*",
+        "svelte": "^5.0.0",
+        "tsup": "^8.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.8"
+    }
+}

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,0 +1,242 @@
+// @stitchapi/svelte — Svelte bindings for StitchAPI.
+//
+// These stores are a THIN layer over `@stitchapi/query-core`: that package owns
+// the reactive lifecycle (subscribe / getSnapshot / refetch / cancel), and
+// Svelte's `readable` adapts it to the `{ subscribe }` store contract — which is
+// what `$store` auto-subscription and `<script>` reactivity read. Because all the
+// behaviour lives in the framework-agnostic core, this binding is a few lines.
+//
+// `readable` is the safest cross-version surface: it is unchanged between Svelte 4
+// and Svelte 5 (runes are additive), so one store works on both.
+//
+// - `stitchStore`       — the unary request/response store.
+// - `stitchStreamStore` — the streaming store: emits a new state as each `delta`
+//                         chunk arrives. The differentiator over plain
+//                         request/response query libraries.
+// - `useStitch` / `useStitchStream` — hook-style aliases for the two above, for
+//                         callers who prefer the `use*` naming.
+// - `queryOptions`     — an OPTIONAL TanStack Query adapter (returns a plain POJO,
+//                         so it needs no import of `@tanstack/svelte-query`).
+import {
+    type CreateStitchQueryOptions,
+    type QueryInput,
+    type QueryOutput,
+    type StitchLike,
+    type StitchQuery,
+    type StitchQueryState,
+    createStitchQuery,
+} from '@stitchapi/query-core';
+import { type Readable, readable } from 'svelte/store';
+
+export type {
+    CreateStitchQueryOptions,
+    QueryInput,
+    QueryOutput,
+    StitchLike,
+    StitchQuery,
+    StitchQueryState,
+} from '@stitchapi/query-core';
+
+// ---------------------------------------------------------------------------
+// Store shape
+// ---------------------------------------------------------------------------
+
+/**
+ * A Svelte-readable view of a stitch query. It is a real `Readable<state>` (so
+ * `$store` and `subscribe` work), with the imperative `refetch` / `cancel`
+ * handles attached as methods. The underlying query is started lazily — on the
+ * store's FIRST subscriber — and `destroy()`ed when the last unsubscribes, so an
+ * unused store costs nothing and a torn-down scope aborts its run.
+ */
+export interface StitchStore<T> extends Readable<StitchQueryState<T>> {
+    /** Abort the in-flight run and re-run from scratch. */
+    refetch: () => void;
+    /** Abort the in-flight run, if any. */
+    cancel: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Shared driver
+// ---------------------------------------------------------------------------
+
+function makeStore<T>(
+    stitch: StitchLike<T, unknown>,
+    input: unknown,
+    options: CreateStitchQueryOptions<T> & { stream: boolean },
+): StitchStore<T> {
+    // The query is created EAGERLY (so `getSnapshot` has a real handle to seed
+    // the store and `refetch`/`cancel` work before the first subscriber), but its
+    // run only starts when `enabled` says so, exactly like the core store. We
+    // pass `enabled: false` to defer the actual fetch to first subscription, then
+    // kick it off in `readable`'s start callback — so a store nobody subscribes to
+    // never fires a request.
+    const { enabled = true, ...rest } = options;
+    const query: StitchQuery<T> = createStitchQuery<T, unknown>(stitch, input, {
+        ...rest,
+        enabled: false,
+    });
+
+    // `readable(initial, start)`: `start(set)` runs on the first subscriber and
+    // returns a `stop` callback invoked when the last subscriber leaves. We seed
+    // with the current snapshot, push every notification through `set`, fire the
+    // deferred fetch, and tear the query down on stop.
+    const store = readable<StitchQueryState<T>>(query.getSnapshot(), (set) => {
+        const unsubscribe = query.subscribe(() => set(query.getSnapshot()));
+        // Sync once in case state advanced between creation and subscription,
+        // then start the run if the caller didn't opt out.
+        set(query.getSnapshot());
+        if (enabled) query.refetch();
+        return () => {
+            unsubscribe();
+            query.destroy();
+        };
+    });
+
+    return {
+        subscribe: store.subscribe,
+        refetch: () => query.refetch(),
+        cancel: () => query.cancel(),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// stitchStore — unary
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a stitch as a request/response query, exposed as a Svelte store.
+ *
+ * The run starts on the store's first subscriber (so `$store` in a component
+ * fetches when the component mounts) and is aborted when the last subscriber
+ * leaves (component teardown). Call `refetch()` to re-run, `cancel()` to abort.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { stitchStore } from '@stitchapi/svelte';
+ *   export let id: string;
+ *   const user = stitchStore(getUser, { params: { id } });
+ * </script>
+ * {#if $user.isPending}<Spinner />
+ * {:else if $user.isError}<Retry onclick={user.refetch} />
+ * {:else}<h1>{$user.data?.name}</h1>{/if}
+ * ```
+ */
+export function stitchStore<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    input: QueryInput<S>,
+    options?: CreateStitchQueryOptions<QueryOutput<S>>,
+): StitchStore<QueryOutput<S>>;
+export function stitchStore<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    input: Input,
+    options?: CreateStitchQueryOptions<T>,
+): StitchStore<T>;
+export function stitchStore<T>(
+    stitch: StitchLike<T, unknown>,
+    input: unknown,
+    options: CreateStitchQueryOptions<T> = {},
+): StitchStore<T> {
+    return makeStore<T>(stitch, input, { ...options, stream: false });
+}
+
+// ---------------------------------------------------------------------------
+// stitchStreamStore — streaming
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a streaming stitch (an `sse` / `stream` surface) as a Svelte store, emitting
+ * a new state as each `delta` chunk arrives. Same state shape as
+ * {@link stitchStore}; `data` is the accumulated chunks (`mode: 'append'`,
+ * default) or the latest chunk (`mode: 'replace'`), and `chunks` is the running
+ * list. `status` is `'streaming'` until the terminal `result`, then `'success'`.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { stitchStreamStore } from '@stitchapi/svelte';
+ *   const chat = stitchStreamStore(chatStitch, { body: { prompt } });
+ * </script>
+ * {#each $chat.chunks as c}<span>{c}</span>{/each}
+ * {#if $chat.isStreaming}<Cursor />{/if}
+ * ```
+ */
+export function stitchStreamStore<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    input: QueryInput<S>,
+    options?: CreateStitchQueryOptions<QueryOutput<S>>,
+): StitchStore<QueryOutput<S>>;
+export function stitchStreamStore<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    input: Input,
+    options?: CreateStitchQueryOptions<T>,
+): StitchStore<T>;
+export function stitchStreamStore<T>(
+    stitch: StitchLike<T, unknown>,
+    input: unknown,
+    options: CreateStitchQueryOptions<T> = {},
+): StitchStore<T> {
+    return makeStore<T>(stitch, input, { ...options, stream: true });
+}
+
+// ---------------------------------------------------------------------------
+// useStitch / useStitchStream — hook-style aliases
+// ---------------------------------------------------------------------------
+
+/** Alias for {@link stitchStore}, for callers who prefer the `use*` naming. The
+ * returned value is a Svelte store — re-create it when `input`/`options` change
+ * (e.g. derive it inside a `$:` block keyed on those) and let scope teardown
+ * destroy it. */
+export const useStitch = stitchStore;
+
+/** Alias for {@link stitchStreamStore}. */
+export const useStitchStream = stitchStreamStore;
+
+// ---------------------------------------------------------------------------
+// queryOptions — optional TanStack Query adapter
+// ---------------------------------------------------------------------------
+
+// IDENTICAL to `@stitchapi/react`'s `queryOptions` — it imports no framework, so
+// the POJO is framework-neutral and feeds `@tanstack/svelte-query`'s
+// `createQuery` exactly as it feeds React's `useQuery`.
+
+/** The plain object {@link queryOptions} returns — structurally compatible with
+ * TanStack Query's `createQuery(options)` without importing the library. */
+export interface StitchQueryOptions<T> {
+    queryKey: readonly unknown[];
+    queryFn: (ctx?: { signal?: AbortSignal }) => Promise<T>;
+}
+
+/**
+ * Build a TanStack-Query-compatible options object for a stitch, WITHOUT a hard
+ * dependency on `@tanstack/svelte-query` — it just returns a POJO. Pass it
+ * straight to `createQuery`:
+ *
+ * ```ts
+ * import { createQuery } from '@tanstack/svelte-query';
+ * import { queryOptions } from '@stitchapi/svelte';
+ *
+ * const query = createQuery(queryOptions(getUser, { params: { id } }));
+ * ```
+ *
+ * The `queryFn` awaits the stitch (the validated output); the `queryKey` is the
+ * stitch's `name` (when present) plus the input, so TanStack caches per call.
+ */
+export function queryOptions<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    input: QueryInput<S>,
+): StitchQueryOptions<QueryOutput<S>>;
+export function queryOptions<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    input: Input,
+): StitchQueryOptions<T>;
+export function queryOptions<T>(
+    stitch: StitchLike<T, unknown>,
+    input: unknown,
+): StitchQueryOptions<T> {
+    const name = (stitch as { __config?: { name?: string } }).__config?.name;
+    return {
+        queryKey: [name ?? 'stitch', input ?? null],
+        queryFn: () => Promise.resolve(stitch(input)),
+    };
+}

--- a/packages/svelte/test/stores.spec.ts
+++ b/packages/svelte/test/stores.spec.ts
@@ -83,9 +83,12 @@ const flush = async (): Promise<void> => {
 
 describe('stitchStore', () => {
     test('emits idle/pending → success on subscribe', async () => {
-        const store = stitchStore(unaryStitch(async () => ({ name: 'Ada' })), {
-            params: { id: '1' },
-        });
+        const store = stitchStore(
+            unaryStitch(async () => ({ name: 'Ada' })),
+            {
+                params: { id: '1' },
+            },
+        );
 
         const { states, unsubscribe } = collect(store);
         // The fetch is deferred to first subscription, so subscribing drives the
@@ -181,7 +184,13 @@ describe('stitchStreamStore', () => {
             { type: 'delta', chunk: 1, at: 0 },
             { type: 'delta', chunk: 2, at: 0 },
             { type: 'delta', chunk: 3, at: 0 },
-            { type: 'result', value: [1, 2, 3], status: 200, attempts: 1, at: 0 },
+            {
+                type: 'result',
+                value: [1, 2, 3],
+                status: 200,
+                attempts: 1,
+                at: 0,
+            },
             { type: 'done', ok: true, ms: 1, attempts: 1, at: 0 },
         ];
         const store = stitchStreamStore(streamStitch(events), undefined);
@@ -191,7 +200,9 @@ describe('stitchStreamStore', () => {
         // Saw a streaming state with the first chunk only.
         expect(
             states.some(
-                (s) => s.status === 'streaming' && (s.chunks as number[]).length === 1,
+                (s) =>
+                    s.status === 'streaming' &&
+                    (s.chunks as number[]).length === 1,
             ),
         ).toBe(true);
 

--- a/packages/svelte/test/stores.spec.ts
+++ b/packages/svelte/test/stores.spec.ts
@@ -1,0 +1,243 @@
+// @stitchapi/svelte store behaviour, driven by FAKE stitches in node env (no DOM):
+// we subscribe to the readable store and assert the emitted state transitions —
+// exactly how Svelte's `$store` / `subscribe` would observe them at runtime.
+import {
+    queryOptions,
+    stitchStore,
+    stitchStreamStore,
+    useStitch,
+    useStitchStream,
+} from '../src';
+
+import type { StitchCallResult, StitchLike } from '@stitchapi/query-core';
+import type { StitchEvent } from 'stitchapi';
+import { describe, expect, test, vi } from 'vitest';
+
+// --- fakes -----------------------------------------------------------------
+
+function unaryStitch<T>(
+    settle: (input: unknown) => Promise<T>,
+    config?: { name?: string },
+): StitchLike<T> {
+    const fn = (input?: unknown): StitchCallResult<T> => {
+        const promise = settle(input);
+        return {
+            then: (onf, onr) => promise.then(onf, onr),
+            stream() {
+                return (async function* () {
+                    const value = await promise;
+                    yield {
+                        type: 'result',
+                        value,
+                        status: 200,
+                        attempts: 1,
+                        at: 0,
+                    } satisfies StitchEvent<T>;
+                })();
+            },
+        };
+    };
+    if (config) (fn as { __config?: unknown }).__config = config;
+    return fn;
+}
+
+function streamStitch<T>(events: StitchEvent<T>[]): StitchLike<T> {
+    return (): StitchCallResult<T> => {
+        const terminal = events.find((e) => e.type === 'result');
+        const value =
+            terminal && terminal.type === 'result'
+                ? terminal.value
+                : (undefined as T);
+        const promise = Promise.resolve(value);
+        return {
+            then: (onf, onr) => promise.then(onf, onr),
+            stream() {
+                return (async function* () {
+                    for (const e of events) {
+                        await Promise.resolve();
+                        yield e;
+                    }
+                })();
+            },
+        };
+    };
+}
+
+// Subscribe to a store and record every emitted state; returns the live log plus
+// the unsubscribe. Subscribing is what triggers the deferred fetch.
+function collect<T>(store: {
+    subscribe: (run: (v: T) => void) => () => void;
+}): { states: T[]; unsubscribe: () => void } {
+    const states: T[] = [];
+    const unsubscribe = store.subscribe((v) => states.push(v));
+    return { states, unsubscribe };
+}
+
+// A microtask flush sufficient for the fakes' `await`s to settle. The streaming
+// fake yields after an `await Promise.resolve()` per event, so we drain plenty.
+const flush = async (): Promise<void> => {
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+};
+
+// --- stitchStore (unary) ---------------------------------------------------
+
+describe('stitchStore', () => {
+    test('emits idle/pending → success on subscribe', async () => {
+        const store = stitchStore(unaryStitch(async () => ({ name: 'Ada' })), {
+            params: { id: '1' },
+        });
+
+        const { states, unsubscribe } = collect(store);
+        // The fetch is deferred to first subscription, so subscribing drives the
+        // store from its idle seed through pending. (Svelte's `readable` runs the
+        // start callback eagerly on subscribe, so `pending` may already be the
+        // first value the subscriber observes — what matters is that the run did
+        // not start before subscription and that we transit through pending.)
+        expect(states.some((s) => s.status === 'pending')).toBe(true);
+
+        await flush();
+        const last = states[states.length - 1];
+        expect(last?.status).toBe('success');
+        expect(last?.isSuccess).toBe(true);
+        expect(last?.data).toEqual({ name: 'Ada' });
+        unsubscribe();
+    });
+
+    test('emits error on rejection', async () => {
+        const store = stitchStore(
+            unaryStitch<{ name: string }>(async () => {
+                throw new Error('nope');
+            }),
+            {},
+        );
+        const { states, unsubscribe } = collect(store);
+        await flush();
+        const last = states[states.length - 1];
+        expect(last?.status).toBe('error');
+        expect(last?.isError).toBe(true);
+        expect((last?.error as Error).message).toBe('nope');
+        unsubscribe();
+    });
+
+    test('refetch re-runs the call', async () => {
+        let n = 0;
+        const store = stitchStore(
+            unaryStitch(async () => ({ name: `v${++n}` })),
+            {},
+        );
+        const { states, unsubscribe } = collect(store);
+        await flush();
+        expect(states[states.length - 1]?.data).toEqual({ name: 'v1' });
+
+        store.refetch();
+        await flush();
+        expect(states[states.length - 1]?.data).toEqual({ name: 'v2' });
+        unsubscribe();
+    });
+
+    test('does not fetch until subscribed; aborts on last unsubscribe', async () => {
+        const settle = vi.fn(async () => ({ ok: true }));
+        const store = stitchStore(unaryStitch(settle), {});
+        // No subscriber yet → no run.
+        await flush();
+        expect(settle).not.toHaveBeenCalled();
+
+        const { unsubscribe } = collect(store);
+        await flush();
+        expect(settle).toHaveBeenCalledTimes(1);
+
+        // Last unsubscribe destroys the query; a subsequent refetch must not
+        // publish (the store is torn down).
+        unsubscribe();
+        store.refetch();
+        await flush();
+        expect(settle).toHaveBeenCalledTimes(1);
+    });
+
+    test('enabled:false starts idle and does not fetch on subscribe', async () => {
+        const settle = vi.fn(async () => 1);
+        const store = stitchStore(unaryStitch(settle), {}, { enabled: false });
+        const { states, unsubscribe } = collect(store);
+        await flush();
+        expect(settle).not.toHaveBeenCalled();
+        expect(states.every((s) => s.status === 'idle')).toBe(true);
+
+        store.refetch();
+        await flush();
+        expect(settle).toHaveBeenCalledTimes(1);
+        unsubscribe();
+    });
+
+    test('useStitch is an alias of stitchStore', () => {
+        expect(useStitch).toBe(stitchStore);
+    });
+});
+
+// --- stitchStreamStore (streaming) -----------------------------------------
+
+describe('stitchStreamStore', () => {
+    test('emits streaming states per delta then settles success', async () => {
+        const events: StitchEvent<number[]>[] = [
+            { type: 'delta', chunk: 1, at: 0 },
+            { type: 'delta', chunk: 2, at: 0 },
+            { type: 'delta', chunk: 3, at: 0 },
+            { type: 'result', value: [1, 2, 3], status: 200, attempts: 1, at: 0 },
+            { type: 'done', ok: true, ms: 1, attempts: 1, at: 0 },
+        ];
+        const store = stitchStreamStore(streamStitch(events), undefined);
+        const { states, unsubscribe } = collect(store);
+        await flush();
+
+        // Saw a streaming state with the first chunk only.
+        expect(
+            states.some(
+                (s) => s.status === 'streaming' && (s.chunks as number[]).length === 1,
+            ),
+        ).toBe(true);
+
+        const last = states[states.length - 1];
+        expect(last?.status).toBe('success');
+        expect(last?.chunks).toEqual([1, 2, 3]);
+        unsubscribe();
+    });
+
+    test('replace mode keeps only the latest chunk on data', async () => {
+        const events: StitchEvent<number>[] = [
+            { type: 'delta', chunk: 10, at: 0 },
+            { type: 'delta', chunk: 20, at: 0 },
+            { type: 'result', value: 20, status: 200, attempts: 1, at: 0 },
+        ];
+        const store = stitchStreamStore(streamStitch(events), undefined, {
+            mode: 'replace',
+        });
+        const { states, unsubscribe } = collect(store);
+        await flush();
+        const last = states[states.length - 1];
+        expect(last?.data).toBe(20);
+        expect(last?.chunks).toEqual([]);
+        unsubscribe();
+    });
+
+    test('useStitchStream is an alias of stitchStreamStore', () => {
+        expect(useStitchStream).toBe(stitchStreamStore);
+    });
+});
+
+// --- queryOptions ----------------------------------------------------------
+
+describe('queryOptions', () => {
+    test('returns a TanStack-shaped POJO with key + async queryFn', async () => {
+        const stitch = unaryStitch(async () => ({ ok: true }), {
+            name: 'getThing',
+        });
+        const opts = queryOptions(stitch, { params: { id: '7' } });
+        expect(opts.queryKey).toEqual(['getThing', { params: { id: '7' } }]);
+        await expect(opts.queryFn()).resolves.toEqual({ ok: true });
+    });
+
+    test('falls back to "stitch" when no __config.name', () => {
+        const stitch = unaryStitch(async () => 1);
+        const opts = queryOptions(stitch, null);
+        expect(opts.queryKey[0]).toBe('stitch');
+    });
+});

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -1,0 +1,35 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM"],
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "exactOptionalPropertyTypes": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "verbatimModuleSyntax": true,
+        "isolatedModules": true,
+
+        "types": ["node", "vitest/globals"],
+
+        // Resolve the workspace packages to their SOURCE so typecheck + tests
+        // don't depend on `stitchapi` / `@stitchapi/query-core` being built
+        // first. The published `exports` maps still point at `lib/`.
+        "baseUrl": ".",
+        "paths": {
+            "stitchapi/testing": ["../core/src/testing.ts"],
+            "stitchapi": ["../core/src/index.ts"],
+            "@stitchapi/query-core": ["../query-core/src/index.ts"]
+        }
+    },
+    "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/svelte/tsup.config.ts
+++ b/packages/svelte/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+// Single dual-format entry. `stitchapi`, `svelte`, and `@tanstack/svelte-query`
+// are peer deps (externalised by tsup); `@stitchapi/query-core` is a runtime dep
+// and is also kept external so the Svelte bindings stay a thin layer over it.
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    minify: true,
+    outDir: 'lib',
+    clean: true,
+    external: ['@stitchapi/query-core'],
+});

--- a/packages/svelte/vitest.config.ts
+++ b/packages/svelte/vitest.config.ts
@@ -1,0 +1,26 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+// Alias the workspace packages to their SOURCE (more specific subpaths first), so
+// tests run without `stitchapi` / `@stitchapi/query-core` being built. Mirrors
+// tsconfig `paths`.
+const core = (p: string): string =>
+    fileURLToPath(new URL(`../core/src/${p}`, import.meta.url));
+const queryCore = (): string =>
+    fileURLToPath(new URL('../query-core/src/index.ts', import.meta.url));
+
+export default defineConfig({
+    resolve: {
+        alias: [
+            { find: /^stitchapi\/testing$/, replacement: core('testing.ts') },
+            { find: /^stitchapi$/, replacement: core('index.ts') },
+            { find: /^@stitchapi\/query-core$/, replacement: queryCore() },
+        ],
+    },
+    test: {
+        // Bindings are framework-reactive but DOM-free: drive the store directly.
+        globals: true,
+        environment: 'node',
+        include: ['test/**/*.spec.ts'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -583,6 +583,34 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
+  packages/svelte:
+    dependencies:
+      '@tanstack/svelte-query':
+        specifier: ^5.0.0
+        version: 5.90.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))
+    devDependencies:
+      '@stitchapi/query-core':
+        specifier: workspace:*
+        version: link:../query-core
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.21
+      stitchapi:
+        specifier: workspace:*
+        version: link:../core
+      svelte:
+        specifier: ^5.0.0
+        version: 5.56.3(@typescript-eslint/types@8.61.0)
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+
 packages:
 
   '@alloc/quick-lru@5.2.0':
@@ -2127,6 +2155,11 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@sveltejs/acorn-typescript@1.0.10':
+    resolution: {integrity: sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -2225,10 +2258,18 @@ packages:
   '@tanstack/query-core@5.101.0':
     resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
 
+  '@tanstack/query-core@5.90.2':
+    resolution: {integrity: sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==}
+
   '@tanstack/react-query@5.101.0':
     resolution: {integrity: sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/svelte-query@5.90.2':
+    resolution: {integrity: sha512-owjnp0w8sOXlMhLZhucHrsYvCjgjHrVyII/wlqMGefxKFyroZS3xCwTee+IUx7UHbL+QmKr/HQTeTqhgxmxPQw==}
+    peerDependencies:
+      svelte: ^3.54.0 || ^4.0.0 || ^5.0.0
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2772,6 +2813,10 @@ packages:
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -3324,6 +3369,9 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
+
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -3565,6 +3613,9 @@ packages:
       jiti:
         optional: true
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3572,6 +3623,14 @@ packages:
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
+
+  esrap@2.2.11:
+    resolution: {integrity: sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -4217,6 +4276,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -4538,6 +4600,9 @@ packages:
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -5633,6 +5698,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svelte@5.56.3:
+    resolution: {integrity: sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==}
+    engines: {node: '>=18'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -6130,6 +6199,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -7498,6 +7570,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
+    dependencies:
+      acorn: 8.16.0
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -7573,10 +7649,17 @@ snapshots:
 
   '@tanstack/query-core@5.101.0': {}
 
+  '@tanstack/query-core@5.90.2': {}
+
   '@tanstack/react-query@5.101.0(react@19.2.7)':
     dependencies:
       '@tanstack/query-core': 5.101.0
       react: 19.2.7
+
+  '@tanstack/svelte-query@5.90.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))':
+    dependencies:
+      '@tanstack/query-core': 5.90.2
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -7812,8 +7895,7 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@types/trusted-types@2.0.7':
-    optional: true
+  '@types/trusted-types@2.0.7': {}
 
   '@types/unist@2.0.11': {}
 
@@ -8224,6 +8306,8 @@ snapshots:
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
+
+  aria-query@5.3.1: {}
 
   aria-query@5.3.2: {}
 
@@ -8797,6 +8881,8 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
+  devalue@5.8.1: {}
+
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
@@ -9212,6 +9298,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.2.2: {}
+
   espree@10.4.0:
     dependencies:
       acorn: 8.16.0
@@ -9221,6 +9309,12 @@ snapshots:
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
+
+  esrap@2.2.11(@typescript-eslint/types@8.61.0):
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+    optionalDependencies:
+      '@typescript-eslint/types': 8.61.0
 
   esrecurse@4.3.0:
     dependencies:
@@ -9967,6 +10061,10 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -10250,6 +10348,8 @@ snapshots:
   load-esm@1.0.3: {}
 
   load-tsconfig@0.2.5: {}
+
+  locate-character@3.0.0: {}
 
   locate-path@5.0.0:
     dependencies:
@@ -11803,6 +11903,27 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svelte@5.56.3(@typescript-eslint/types@8.61.0):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
+      '@types/estree': 1.0.9
+      '@types/trusted-types': 2.0.7
+      acorn: 8.16.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.8.1
+      esm-env: 1.2.2
+      esrap: 2.2.11(@typescript-eslint/types@8.61.0)
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
   symbol-tree@3.2.4: {}
 
   tailwind-merge@3.6.0: {}
@@ -12330,6 +12451,8 @@ snapshots:
       yargs-parser: 20.2.9
 
   yocto-queue@0.1.0: {}
+
+  zimmerframe@1.1.4: {}
 
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:


### PR DESCRIPTION
## What

A new `@stitchapi/svelte` package: Svelte bindings for StitchAPI, a thin layer over `@stitchapi/query-core`'s framework-agnostic reactive store.

- `stitchStore(stitch, input, options?)` — unary request/response, exposed as a real Svelte store (`{ subscribe }`).
- `stitchStreamStore(stitch, input, options?)` — streaming; emits a new state as each `delta` chunk arrives (`mode: 'append' | 'replace'`).
- `useStitch` / `useStitchStream` — `use*`-style aliases of the two stores.
- `queryOptions(stitch, input)` — the framework-neutral TanStack POJO, identical to `@stitchapi/react`'s (no framework import).

## Rationale

Svelte's store contract (`{ subscribe }`) maps almost 1:1 onto `StitchQuery`, so the binding is built on `readable` from `svelte/store` — the safest cross-version surface (works on Svelte 4 **and** 5). It seeds from `getSnapshot()`, `set`s on each notification, defers the fetch to the first subscriber, and runs `query.destroy()` in `readable`'s stop callback so a torn-down scope aborts its in-flight run.

Part of the #197 integration backlog wave.

## Verification

From the worktree, all green:

- `pnpm --filter @stitchapi/svelte run check:types` — passes (strict TS, no errors).
- `pnpm --filter @stitchapi/svelte run build` — tsup CJS + ESM + d.ts, build success.
- `pnpm --filter @stitchapi/svelte run test` — 11 passed (1 file). Tests run in **node env** (no DOM): they subscribe to the store and assert the emitted state transitions (idle→pending→success, error, refetch re-run, deferred-fetch-on-subscribe + abort-on-unsubscribe, `enabled:false`, streaming deltas, replace mode, alias identity, queryOptions shape) driven by a fake stitch.

## Caveats

- Mirrors the `packages/react` + `packages/query-core` layout/config verbatim (package.json, tsconfig, tsup, vitest), only swapping the framework.
- `@tanstack/svelte-query` is an optional peer (matching react's optional `@tanstack/react-query`); `queryOptions` returns a plain POJO and never imports it.
- The store starts its run lazily on the first subscriber (not eagerly at construction), which is the idiomatic Svelte store lifecycle and lets an unused store cost nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)