### PR TITLE
feat(vue): @stitchapi/vue — useStitch/useStitchStream composables over query-core

### DIFF
--- a/packages/vue/LICENSE
+++ b/packages/vue/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,0 +1,102 @@
+# @stitchapi/vue
+
+Vue 3 bindings for [StitchAPI](https://stitchapi.dev). Reactive `useStitch` / `useStitchStream` composables backed by Vue's reactivity, plus an optional [TanStack Query](https://tanstack.com/query) adapter.
+
+**Streaming-first.** A `stitch` can stream (`sse` / `stream` surfaces) — `useStitchStream` re-renders as each `delta` chunk arrives. That's the differentiator over plain request/response query libraries.
+
+These composables are a thin layer over [`@stitchapi/query-core`](../query-core), the framework-agnostic store that owns the reactive lifecycle. React / Svelte / Solid bindings are the same few lines against their own reactive primitive.
+
+## Install
+
+```sh
+pnpm add @stitchapi/vue @stitchapi/query-core stitchapi vue
+```
+
+`stitchapi` (`>=0.7.0`) and `vue` (`^3.4`) are peer dependencies. `@tanstack/vue-query` is **not** required — `queryOptions` returns a plain object.
+
+## `useStitch` — request / response
+
+```vue
+<script setup lang="ts">
+import { useStitch } from '@stitchapi/vue';
+import { stitch } from 'stitchapi';
+
+const props = defineProps<{ id: string }>();
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+});
+
+// `input` may be a value, a `ref`, or a getter — a getter re-fetches when its
+// structural key changes.
+const { data, isPending, isError, refetch } = useStitch(getUser, () => ({
+    params: { id: props.id },
+}));
+</script>
+
+<template>
+    <Spinner v-if="isPending" />
+    <Retry v-else-if="isError" @click="refetch" />
+    <h1 v-else>{{ data?.name }}</h1>
+</template>
+```
+
+The query is re-created (and re-fetched) when the stitch's name or a structural key of `input` changes. The in-flight run is aborted when the component's scope is disposed.
+
+## `useStitchStream` — live deltas
+
+```vue
+<script setup lang="ts">
+import { useStitchStream } from '@stitchapi/vue';
+import { sse } from 'stitchapi';
+
+const props = defineProps<{ prompt: string }>();
+const chat = sse({ url: 'https://api.example.com/chat' });
+
+const { chunks, isStreaming } = useStitchStream(chat, () => ({
+    body: { prompt: props.prompt },
+}));
+</script>
+
+<template>
+    <span v-for="(c, i) in chunks" :key="i">{{ c }}</span>
+    <Cursor v-if="isStreaming" />
+</template>
+```
+
+Same return shape as `useStitch`. `data` is the accumulated chunks (`mode: 'append'`, default) or the latest chunk (`mode: 'replace'`); `chunks` is the running list; `status` is `'streaming'` until the terminal `result`, then `'success'`.
+
+## Return shape
+
+Each field is a `ComputedRef`, so destructuring keeps reactivity (and `.value` is unwrapped automatically in templates):
+
+```ts
+interface UseStitchReturn<T> {
+    status: ComputedRef<'idle' | 'pending' | 'streaming' | 'success' | 'error'>;
+    data: ComputedRef<T | undefined>;
+    error: ComputedRef<unknown>;
+    chunks: ComputedRef<readonly unknown[]>;
+    isPending: ComputedRef<boolean>;
+    isError: ComputedRef<boolean>;
+    isSuccess: ComputedRef<boolean>;
+    isStreaming: ComputedRef<boolean>;
+    refetch: () => void;
+    cancel: () => void;
+}
+```
+
+## Optional: TanStack Query
+
+`queryOptions(stitch, input)` returns a plain `{ queryKey, queryFn }` object — no import of `@tanstack/vue-query` required, so it works even if you never install it.
+
+```ts
+import { queryOptions } from '@stitchapi/vue';
+import { useQuery } from '@tanstack/vue-query';
+
+const { data } = useQuery(queryOptions(getUser, { params: { id } }));
+```
+
+## License
+
+Apache-2.0

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,0 +1,70 @@
+{
+    "name": "@stitchapi/vue",
+    "version": "1.0.0-rc.2",
+    "type": "commonjs",
+    "description": "Vue 3 bindings for StitchAPI — reactive useStitch/useStitchStream composables over @stitchapi/query-core, plus an optional TanStack Query queryOptions helper. Streaming-first: re-render as `delta` chunks arrive.",
+    "main": "lib/index.js",
+    "module": "lib/index.mjs",
+    "types": "lib/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./lib/index.d.mts",
+                "default": "./lib/index.mjs"
+            },
+            "require": {
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
+            }
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "lib"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsup",
+        "test": "vitest run",
+        "check:types": "tsc --noEmit",
+        "prepack": "tsup",
+        "prepublishOnly": "node ../../scripts/check-release.mjs --changelog"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rejifald/StitchAPI.git",
+        "directory": "packages/vue"
+    },
+    "keywords": [
+        "stitchapi",
+        "vue",
+        "vue3",
+        "composables",
+        "reactivity",
+        "streaming",
+        "query",
+        "tanstack-query"
+    ],
+    "author": "Oleksandr Zhuravlov (rejifald@gmail.com)",
+    "license": "Apache-2.0",
+    "homepage": "https://stitchapi.dev",
+    "engines": {
+        "node": ">=18.18.0"
+    },
+    "peerDependencies": {
+        "@stitchapi/query-core": "^1.0.0-rc.1",
+        "stitchapi": "^1.0.0-rc.1",
+        "vue": "^3.4.0"
+    },
+    "devDependencies": {
+        "@stitchapi/query-core": "workspace:*",
+        "@types/node": "^22.10.0",
+        "stitchapi": "workspace:*",
+        "tsup": "^8.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.8",
+        "vue": "^3.4.0"
+    }
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,0 +1,308 @@
+// @stitchapi/vue — Vue 3 bindings for StitchAPI.
+//
+// These composables are a THIN layer over `@stitchapi/query-core`: that package
+// owns the reactive store (subscribe / getSnapshot / refetch / cancel), and Vue's
+// reactivity reads it through a single `shallowRef` holding the immutable
+// snapshot. Because all the behaviour lives in the framework-agnostic core, the
+// React / Svelte / Solid bindings are the same few lines against their own
+// reactive primitive.
+//
+// - `useStitch`       — the unary request/response composable.
+// - `useStitchStream` — the streaming composable: re-renders as `delta` chunks
+//                       arrive. This is the differentiator over plain
+//                       request/response query libraries.
+// - `queryOptions`    — an OPTIONAL TanStack Query adapter (returns a plain POJO,
+//                       so it needs no import of `@tanstack/vue-query`).
+import {
+    type CreateStitchQueryOptions,
+    type QueryInput,
+    type QueryOutput,
+    type StitchLike,
+    type StitchQuery,
+    type StitchQueryState,
+    createStitchQuery,
+} from '@stitchapi/query-core';
+import {
+    type ComputedRef,
+    type MaybeRefOrGetter,
+    computed,
+    onScopeDispose,
+    shallowRef,
+    toValue,
+    watch,
+} from 'vue';
+
+export type {
+    CreateStitchQueryOptions,
+    QueryInput,
+    QueryOutput,
+    StitchLike,
+    StitchQuery,
+    StitchQueryState,
+} from '@stitchapi/query-core';
+
+// ---------------------------------------------------------------------------
+// Composable result
+// ---------------------------------------------------------------------------
+
+/**
+ * What `useStitch` / `useStitchStream` return: each reactive state field as its
+ * own `ComputedRef` (so the object stays destructurable WITHOUT losing
+ * reactivity, the Vue idiom) plus the imperative `refetch` / `cancel` handles.
+ */
+export interface UseStitchReturn<T> {
+    readonly status: ComputedRef<StitchQueryState<T>['status']>;
+    /** The validated output (unary) or the latest streamed value (streaming). */
+    readonly data: ComputedRef<T | undefined>;
+    /** The thrown reason on failure. */
+    readonly error: ComputedRef<unknown>;
+    /** Accumulated `delta` chunks, in arrival order. */
+    readonly chunks: ComputedRef<readonly unknown[]>;
+    readonly isPending: ComputedRef<boolean>;
+    readonly isError: ComputedRef<boolean>;
+    readonly isSuccess: ComputedRef<boolean>;
+    readonly isStreaming: ComputedRef<boolean>;
+    /** Abort the in-flight run and re-run from scratch. */
+    refetch: () => void;
+    /** Abort the in-flight run, if any. */
+    cancel: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Shared driver
+// ---------------------------------------------------------------------------
+
+interface UseStitchOptions<T> extends CreateStitchQueryOptions<T> {}
+
+// A structural key of the input so an equal-shaped literal does not re-create the
+// handle, but `{ id: 1 }` → `{ id: 2 }` does. Mirrors `@stitchapi/react`.
+function defaultKey(input: unknown): string {
+    try {
+        return JSON.stringify(input ?? null);
+    } catch {
+        // Non-serialisable input (a function, a cyclic object) → opt out of
+        // structural keying; falling back to a fresh key re-creates each time.
+        return Math.random().toString(36);
+    }
+}
+
+// `input` and `options` may be passed as plain values, refs, or getters so a
+// composable in a `<script setup>` re-runs the call when they change. `toValue`
+// unwraps all three.
+function useStitchInternal<T>(
+    stitch: StitchLike<T, unknown>,
+    input: MaybeRefOrGetter<unknown>,
+    options: MaybeRefOrGetter<UseStitchOptions<T>>,
+    stream: boolean,
+): UseStitchReturn<T> {
+    // The single reactive cell every consumer reads through. The core hands out a
+    // NEW frozen snapshot only on a real change, so swapping the ref is cheap and
+    // never tears. `shallowRef` is deliberate: the snapshot is already immutable,
+    // so deep reactivity would only add overhead.
+    const snapshot = shallowRef<StitchQueryState<T>>(
+        // Seed with a synchronous read below once the first handle exists; this
+        // placeholder is replaced before any consumer can observe it.
+        undefined as unknown as StitchQueryState<T>,
+    );
+
+    let query: StitchQuery<T> | undefined;
+    let unsubscribe: (() => void) | undefined;
+
+    // (Re)build the handle for the current input/options. Tears down the previous
+    // one first so a superseded run can't keep publishing.
+    function build(): void {
+        unsubscribe?.();
+        query?.destroy();
+
+        const opts = toValue(options);
+        const resolvedInput = toValue(input);
+        query = createStitchQuery<T, unknown>(stitch, resolvedInput, {
+            stream,
+            ...(opts.mode ? { mode: opts.mode } : {}),
+            ...(opts.enabled !== undefined ? { enabled: opts.enabled } : {}),
+            ...(opts.onSuccess ? { onSuccess: opts.onSuccess } : {}),
+            ...(opts.onError ? { onError: opts.onError } : {}),
+        });
+
+        // Seed synchronously (the store may already be `pending`), then track.
+        snapshot.value = query.getSnapshot();
+        unsubscribe = query.subscribe(() => {
+            // `query` is non-null here — the listener can only fire while the
+            // handle that registered it is live.
+            snapshot.value = query!.getSnapshot();
+        });
+    }
+
+    build();
+
+    // Re-create the handle (and re-fetch) when a structural key of the input or
+    // the streaming-relevant options change. The stitch's stable `__config.name`
+    // joins the key so two stitches with the same input still differ.
+    const name = (stitch as { __config?: { name?: string } }).__config?.name;
+    const depKey = (): string => {
+        const opts = toValue(options);
+        return JSON.stringify([
+            name ?? '',
+            defaultKey(toValue(input)),
+            stream,
+            opts.mode ?? null,
+            opts.enabled ?? null,
+        ]);
+    };
+    watch(depKey, () => build());
+
+    // Drop listeners and abort the run when the owning scope (component / manual
+    // `effectScope`) is disposed.
+    onScopeDispose(() => {
+        unsubscribe?.();
+        query?.destroy();
+    });
+
+    const field = <K extends keyof StitchQueryState<T>>(
+        k: K,
+    ): ComputedRef<StitchQueryState<T>[K]> => computed(() => snapshot.value[k]);
+
+    return {
+        status: field('status'),
+        data: field('data'),
+        error: field('error'),
+        chunks: field('chunks'),
+        isPending: field('isPending'),
+        isError: field('isError'),
+        isSuccess: field('isSuccess'),
+        isStreaming: field('isStreaming'),
+        refetch: () => query?.refetch(),
+        cancel: () => query?.cancel(),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// useStitch — unary
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a stitch as a request/response query and re-render on its transitions.
+ *
+ * `input` and `options` accept a plain value, a `ref`, or a getter — change any
+ * of them and the query is re-created (and re-fetched) when a structural key
+ * shifts. The in-flight run is aborted when the scope is disposed.
+ *
+ * @example
+ * ```vue
+ * <script setup lang="ts">
+ * const { data, isPending, isError, refetch } = useStitch(getUser, () => ({
+ *     params: { id: props.id },
+ * }));
+ * </script>
+ *
+ * <template>
+ *   <Spinner v-if="isPending" />
+ *   <Error v-else-if="isError" @retry="refetch" />
+ *   <Profile v-else :user="data" />
+ * </template>
+ * ```
+ */
+export function useStitch<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    input: MaybeRefOrGetter<QueryInput<S>>,
+    options?: MaybeRefOrGetter<UseStitchOptions<QueryOutput<S>>>,
+): UseStitchReturn<QueryOutput<S>>;
+export function useStitch<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    input: MaybeRefOrGetter<Input>,
+    options?: MaybeRefOrGetter<UseStitchOptions<T>>,
+): UseStitchReturn<T>;
+export function useStitch<T>(
+    stitch: StitchLike<T, unknown>,
+    input: MaybeRefOrGetter<unknown>,
+    options: MaybeRefOrGetter<UseStitchOptions<T>> = {},
+): UseStitchReturn<T> {
+    return useStitchInternal<T>(stitch, input, options, false);
+}
+
+// ---------------------------------------------------------------------------
+// useStitchStream — streaming
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a streaming stitch (an `sse` / `stream` surface) and re-render as each
+ * `delta` chunk arrives. Same return shape as {@link useStitch}; `data` is the
+ * accumulated chunks (`mode: 'append'`, default) or the latest chunk
+ * (`mode: 'replace'`), and `chunks` is the running list. `status` is
+ * `'streaming'` until the terminal `result`, then `'success'`.
+ *
+ * @example
+ * ```vue
+ * <script setup lang="ts">
+ * const { chunks, isStreaming } = useStitchStream(chat, () => ({
+ *     body: { prompt: props.prompt },
+ * }));
+ * </script>
+ * ```
+ */
+export function useStitchStream<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    input: MaybeRefOrGetter<QueryInput<S>>,
+    options?: MaybeRefOrGetter<UseStitchOptions<QueryOutput<S>>>,
+): UseStitchReturn<QueryOutput<S>>;
+export function useStitchStream<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    input: MaybeRefOrGetter<Input>,
+    options?: MaybeRefOrGetter<UseStitchOptions<T>>,
+): UseStitchReturn<T>;
+export function useStitchStream<T>(
+    stitch: StitchLike<T, unknown>,
+    input: MaybeRefOrGetter<unknown>,
+    options: MaybeRefOrGetter<UseStitchOptions<T>> = {},
+): UseStitchReturn<T> {
+    return useStitchInternal<T>(stitch, input, options, true);
+}
+
+// ---------------------------------------------------------------------------
+// queryOptions — optional TanStack Query adapter
+// ---------------------------------------------------------------------------
+
+// IDENTICAL to `@stitchapi/react`'s `queryOptions` — a plain POJO with no
+// framework import, so it feeds `@tanstack/vue-query`'s `useQuery(options)`
+// (or any other) just the same.
+
+/** The plain object {@link queryOptions} returns — structurally compatible with
+ * TanStack Query's `useQuery(options)` without importing the library. */
+export interface StitchQueryOptions<T> {
+    queryKey: readonly unknown[];
+    queryFn: (ctx?: { signal?: AbortSignal }) => Promise<T>;
+}
+
+/**
+ * Build a TanStack-Query-compatible options object for a stitch, WITHOUT a hard
+ * dependency on `@tanstack/vue-query` — it just returns a POJO. Pass it straight
+ * to `useQuery`:
+ *
+ * ```ts
+ * import { useQuery } from '@tanstack/vue-query';
+ * import { queryOptions } from '@stitchapi/vue';
+ *
+ * const { data } = useQuery(queryOptions(getUser, { params: { id } }));
+ * ```
+ *
+ * The `queryFn` awaits the stitch (the validated output); the `queryKey` is the
+ * stitch's `name` (when present) plus the input, so TanStack caches per call.
+ */
+export function queryOptions<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    input: QueryInput<S>,
+): StitchQueryOptions<QueryOutput<S>>;
+export function queryOptions<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    input: Input,
+): StitchQueryOptions<T>;
+export function queryOptions<T>(
+    stitch: StitchLike<T, unknown>,
+    input: unknown,
+): StitchQueryOptions<T> {
+    const name = (stitch as { __config?: { name?: string } }).__config?.name;
+    return {
+        queryKey: [name ?? 'stitch', input ?? null],
+        queryFn: () => Promise.resolve(stitch(input)),
+    };
+}

--- a/packages/vue/test/composables.spec.ts
+++ b/packages/vue/test/composables.spec.ts
@@ -1,0 +1,248 @@
+// @stitchapi/vue composable behaviour, driven inside a manual `effectScope` —
+// no component mount, no jsdom. The composables read core through a `shallowRef`,
+// and the core publishes synchronously on each transition, so a `flush()` (one
+// awaited microtask) is enough to settle the fake stitch's resolved promises.
+// Driven by FAKE stitches — no engine, no network.
+import { queryOptions, useStitch, useStitchStream } from '../src';
+
+import type { StitchCallResult, StitchLike } from '@stitchapi/query-core';
+import type { StitchEvent } from 'stitchapi';
+import { describe, expect, test } from 'vitest';
+import { type EffectScope, effectScope, ref } from 'vue';
+
+// --- fakes -----------------------------------------------------------------
+
+function unaryStitch<T>(
+    settle: (input: unknown) => Promise<T>,
+    config?: { name?: string },
+): StitchLike<T> {
+    const fn = (input?: unknown): StitchCallResult<T> => {
+        const promise = settle(input);
+        return {
+            then: (onf, onr) => promise.then(onf, onr),
+            stream() {
+                return (async function* () {
+                    const value = await promise;
+                    yield {
+                        type: 'result',
+                        value,
+                        status: 200,
+                        attempts: 1,
+                        at: 0,
+                    } satisfies StitchEvent<T>;
+                })();
+            },
+        };
+    };
+    if (config) (fn as { __config?: unknown }).__config = config;
+    return fn;
+}
+
+function streamStitch<T>(events: StitchEvent<T>[]): StitchLike<T> {
+    return (): StitchCallResult<T> => {
+        const terminal = events.find((e) => e.type === 'result');
+        const value =
+            terminal && terminal.type === 'result'
+                ? terminal.value
+                : (undefined as T);
+        const promise = Promise.resolve(value);
+        return {
+            then: (onf, onr) => promise.then(onf, onr),
+            stream() {
+                return (async function* () {
+                    for (const e of events) {
+                        await Promise.resolve();
+                        yield e;
+                    }
+                })();
+            },
+        };
+    };
+}
+
+// Run `body` inside a disposable reactive scope so `onScopeDispose` fires on
+// teardown, exactly as a component unmount would drive it.
+function withScope<R>(body: () => R): { result: R; scope: EffectScope } {
+    const scope = effectScope();
+    const result = scope.run(body) as R;
+    return { result, scope };
+}
+
+// Let queued microtasks (the fake's resolved promises + the store's sync
+// publishes) drain. A handful of turns covers an async generator's per-yield
+// awaits.
+async function flush(turns = 6): Promise<void> {
+    for (let i = 0; i < turns; i++) await Promise.resolve();
+}
+
+// --- useStitch -------------------------------------------------------------
+
+describe('useStitch', () => {
+    test('transitions pending → success', async () => {
+        const stitch = unaryStitch(async () => ({ name: 'Ada' }));
+        const { result, scope } = withScope(() =>
+            useStitch(stitch, { params: { id: '1' } }),
+        );
+
+        // The store starts a run synchronously on creation.
+        expect(result.isPending.value).toBe(true);
+        expect(result.data.value).toBeUndefined();
+
+        await flush();
+        expect(result.isSuccess.value).toBe(true);
+        expect(result.data.value).toEqual({ name: 'Ada' });
+        scope.stop();
+    });
+
+    test('transitions to error on rejection', async () => {
+        const stitch = unaryStitch<{ name: string }>(async () => {
+            throw new Error('nope');
+        });
+        const { result, scope } = withScope(() => useStitch(stitch, {}));
+
+        await flush();
+        expect(result.isError.value).toBe(true);
+        expect((result.error.value as Error).message).toBe('nope');
+        scope.stop();
+    });
+
+    test('refetch re-runs the call', async () => {
+        let n = 0;
+        const stitch = unaryStitch(async () => ({ name: `v${++n}` }));
+        const { result, scope } = withScope(() => useStitch(stitch, {}));
+
+        await flush();
+        expect(result.data.value).toEqual({ name: 'v1' });
+
+        result.refetch();
+        await flush();
+        expect(result.data.value).toEqual({ name: 'v2' });
+        scope.stop();
+    });
+
+    test('changing input (reactive) re-fetches on a new structural key', async () => {
+        const stitch = unaryStitch(async (input) => ({
+            name: `id-${(input as { params: { id: string } }).params.id}`,
+        }));
+        const id = ref('1');
+        const { result, scope } = withScope(() =>
+            // Getter input so the `watch` on the structural key picks up changes.
+            useStitch(stitch, () => ({ params: { id: id.value } })),
+        );
+
+        await flush();
+        expect(result.data.value).toEqual({ name: 'id-1' });
+
+        id.value = '2';
+        await flush(); // let the `watch` callback rebuild + the new run settle
+        expect(result.data.value).toEqual({ name: 'id-2' });
+        scope.stop();
+    });
+
+    test('enabled:false starts idle and only runs on refetch', async () => {
+        const stitch = unaryStitch(async () => ({ name: 'lazy' }));
+        const { result, scope } = withScope(() =>
+            useStitch(stitch, {}, { enabled: false }),
+        );
+
+        await flush();
+        expect(result.status.value).toBe('idle');
+        expect(result.data.value).toBeUndefined();
+
+        result.refetch();
+        await flush();
+        expect(result.isSuccess.value).toBe(true);
+        expect(result.data.value).toEqual({ name: 'lazy' });
+        scope.stop();
+    });
+
+    test('onScopeDispose tears down: no publish after scope.stop()', async () => {
+        // A never-resolving stitch: if teardown leaks, a late resolve would flip
+        // state. We stop the scope mid-flight and assert state is frozen.
+        let release: (v: { name: string }) => void = () => {};
+        const stitch = unaryStitch<{ name: string }>(
+            () => new Promise((res) => (release = res)),
+        );
+        const { result, scope } = withScope(() => useStitch(stitch, {}));
+
+        expect(result.isPending.value).toBe(true);
+        scope.stop(); // fires onScopeDispose → destroy()
+        release({ name: 'too-late' });
+        await flush();
+        // destroy() invalidates the run token, so the resolution can't publish.
+        expect(result.isPending.value).toBe(true);
+        expect(result.data.value).toBeUndefined();
+    });
+});
+
+// --- useStitchStream -------------------------------------------------------
+
+describe('useStitchStream', () => {
+    test('re-renders as delta chunks arrive, then settles success', async () => {
+        const events: StitchEvent<number[]>[] = [
+            { type: 'delta', chunk: 1, at: 0 },
+            { type: 'delta', chunk: 2, at: 0 },
+            { type: 'delta', chunk: 3, at: 0 },
+            {
+                type: 'result',
+                value: [1, 2, 3],
+                status: 200,
+                attempts: 1,
+                at: 0,
+            },
+            { type: 'done', ok: true, ms: 1, attempts: 1, at: 0 },
+        ];
+        const { result, scope } = withScope(() =>
+            useStitchStream(streamStitch(events), undefined),
+        );
+
+        // First chunk lands → streaming with [1].
+        await flush(2);
+        expect(result.isStreaming.value).toBe(true);
+        expect(result.chunks.value).toEqual([1]);
+
+        // All chunks accumulate and the stream settles to success. The generator
+        // awaits a microtask per yield, so drain generously.
+        await flush(12);
+        expect(result.chunks.value).toEqual([1, 2, 3]);
+        expect(result.isSuccess.value).toBe(true);
+        scope.stop();
+    });
+
+    test('replace mode keeps only the latest chunk on data', async () => {
+        const events: StitchEvent<number>[] = [
+            { type: 'delta', chunk: 10, at: 0 },
+            { type: 'delta', chunk: 20, at: 0 },
+            { type: 'result', value: 20, status: 200, attempts: 1, at: 0 },
+        ];
+        const { result, scope } = withScope(() =>
+            useStitchStream(streamStitch(events), undefined, {
+                mode: 'replace',
+            }),
+        );
+
+        await flush(12);
+        expect(result.data.value).toBe(20);
+        expect(result.chunks.value).toEqual([]);
+        scope.stop();
+    });
+});
+
+// --- queryOptions ----------------------------------------------------------
+
+describe('queryOptions', () => {
+    test('returns a TanStack-shaped POJO with key + async queryFn', async () => {
+        const stitch = unaryStitch(async () => ({ ok: true }), {
+            name: 'getThing',
+        });
+        const opts = queryOptions(stitch, { params: { id: '7' } });
+        expect(opts.queryKey).toEqual(['getThing', { params: { id: '7' } }]);
+        await expect(opts.queryFn()).resolves.toEqual({ ok: true });
+    });
+
+    test('falls back to "stitch" when no __config.name', () => {
+        const stitch = unaryStitch(async () => 1);
+        const opts = queryOptions(stitch, null);
+        expect(opts.queryKey[0]).toBe('stitch');
+    });
+});

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,0 +1,35 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM"],
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "exactOptionalPropertyTypes": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "verbatimModuleSyntax": true,
+        "isolatedModules": true,
+
+        "types": ["node", "vitest/globals"],
+
+        // Resolve the workspace packages to their SOURCE so typecheck + tests
+        // don't depend on `stitchapi` / `@stitchapi/query-core` being built
+        // first. The published `exports` maps still point at `lib/`.
+        "baseUrl": ".",
+        "paths": {
+            "stitchapi/testing": ["../core/src/testing.ts"],
+            "stitchapi": ["../core/src/index.ts"],
+            "@stitchapi/query-core": ["../query-core/src/index.ts"]
+        }
+    },
+    "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/vue/tsup.config.ts
+++ b/packages/vue/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+// Single dual-format entry. `stitchapi` and `vue` are peer deps (externalised by
+// tsup); `@stitchapi/query-core` is a runtime dep and is also kept external so
+// the Vue bindings stay a thin layer over it.
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    minify: true,
+    outDir: 'lib',
+    clean: true,
+    external: ['@stitchapi/query-core'],
+});

--- a/packages/vue/vitest.config.ts
+++ b/packages/vue/vitest.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+// Alias the workspace packages to their SOURCE (more specific subpaths first), so
+// tests run without `stitchapi` / `@stitchapi/query-core` being built. Mirrors
+// tsconfig `paths`.
+const core = (p: string): string =>
+    fileURLToPath(new URL(`../core/src/${p}`, import.meta.url));
+const queryCore = (): string =>
+    fileURLToPath(new URL('../query-core/src/index.ts', import.meta.url));
+
+export default defineConfig({
+    resolve: {
+        alias: [
+            { find: /^stitchapi\/testing$/, replacement: core('testing.ts') },
+            { find: /^stitchapi$/, replacement: core('index.ts') },
+            { find: /^@stitchapi\/query-core$/, replacement: queryCore() },
+        ],
+    },
+    test: {
+        globals: true,
+        // Composables drive Vue's reactivity directly via `effectScope` — no DOM,
+        // no component mount — so the plain node env is enough.
+        environment: 'node',
+        include: ['test/**/*.spec.ts'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
     devDependencies:
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^4.3.0
-        version: 4.3.0(prettier@3.3.3)
+        version: 4.3.0(@vue/compiler-sfc@3.5.38)(prettier@3.3.3)
       fallow:
         specifier: ^2.99.0
         version: 2.99.0
@@ -582,6 +582,30 @@ importers:
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+
+  packages/vue:
+    devDependencies:
+      '@stitchapi/query-core':
+        specifier: workspace:*
+        version: link:../query-core
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.21
+      stitchapi:
+        specifier: workspace:*
+        version: link:../core
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      vue:
+        specifier: ^3.4.0
+        version: 3.5.38(typescript@5.9.3)
 
 packages:
 
@@ -2705,6 +2729,35 @@ packages:
   '@vitest/utils@4.1.8':
     resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
+  '@vue/compiler-core@3.5.38':
+    resolution: {integrity: sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==}
+
+  '@vue/compiler-dom@3.5.38':
+    resolution: {integrity: sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==}
+
+  '@vue/compiler-sfc@3.5.38':
+    resolution: {integrity: sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==}
+
+  '@vue/compiler-ssr@3.5.38':
+    resolution: {integrity: sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==}
+
+  '@vue/reactivity@3.5.38':
+    resolution: {integrity: sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==}
+
+  '@vue/runtime-core@3.5.38':
+    resolution: {integrity: sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==}
+
+  '@vue/runtime-dom@3.5.38':
+    resolution: {integrity: sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==}
+
+  '@vue/server-renderer@3.5.38':
+    resolution: {integrity: sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==}
+    peerDependencies:
+      vue: 3.5.38
+
+  '@vue/shared@3.5.38':
+    resolution: {integrity: sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==}
+
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
@@ -3384,6 +3437,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
@@ -3601,6 +3658,9 @@ packages:
 
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -6029,6 +6089,14 @@ packages:
       jsdom:
         optional: true
 
+  vue@3.5.38:
+    resolution: {integrity: sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -7608,7 +7676,7 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@trivago/prettier-plugin-sort-imports@4.3.0(prettier@3.3.3)':
+  '@trivago/prettier-plugin-sort-imports@4.3.0(@vue/compiler-sfc@3.5.38)(prettier@3.3.3)':
     dependencies:
       '@babel/generator': 7.17.7
       '@babel/parser': 7.29.7
@@ -7617,6 +7685,8 @@ snapshots:
       javascript-natural-sort: 0.7.1
       lodash: 4.18.1
       prettier: 3.3.3
+    optionalDependencies:
+      '@vue/compiler-sfc': 3.5.38
     transitivePeerDependencies:
       - supports-color
 
@@ -8166,6 +8236,60 @@ snapshots:
       '@vitest/pretty-format': 4.1.8
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  '@vue/compiler-core@3.5.38':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.38
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.38':
+    dependencies:
+      '@vue/compiler-core': 3.5.38
+      '@vue/shared': 3.5.38
+
+  '@vue/compiler-sfc@3.5.38':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.38
+      '@vue/compiler-dom': 3.5.38
+      '@vue/compiler-ssr': 3.5.38
+      '@vue/shared': 3.5.38
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.15
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.38':
+    dependencies:
+      '@vue/compiler-dom': 3.5.38
+      '@vue/shared': 3.5.38
+
+  '@vue/reactivity@3.5.38':
+    dependencies:
+      '@vue/shared': 3.5.38
+
+  '@vue/runtime-core@3.5.38':
+    dependencies:
+      '@vue/reactivity': 3.5.38
+      '@vue/shared': 3.5.38
+
+  '@vue/runtime-dom@3.5.38':
+    dependencies:
+      '@vue/reactivity': 3.5.38
+      '@vue/runtime-core': 3.5.38
+      '@vue/shared': 3.5.38
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.38(vue@3.5.38(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.38
+      '@vue/shared': 3.5.38
+      vue: 3.5.38(typescript@5.9.3)
+
+  '@vue/shared@3.5.38': {}
 
   abstract-logging@2.0.1: {}
 
@@ -8851,6 +8975,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   environment@1.1.0: {}
 
   error-ex@1.3.4:
@@ -9260,6 +9386,8 @@ snapshots:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -12225,6 +12353,16 @@ snapshots:
       jsdom: 25.0.1
     transitivePeerDependencies:
       - msw
+
+  vue@3.5.38(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.38
+      '@vue/compiler-sfc': 3.5.38
+      '@vue/runtime-dom': 3.5.38
+      '@vue/server-renderer': 3.5.38(vue@3.5.38(typescript@5.9.3))
+      '@vue/shared': 3.5.38
+    optionalDependencies:
+      typescript: 5.9.3
 
   w3c-keyname@2.2.8: {}
 


### PR DESCRIPTION
## What this adds

New package **@stitchapi/vue** — Vue 3 bindings for StitchAPI:

- **`useStitch(stitch, input, options?)`** — unary request/response composable.
- **`useStitchStream(stitch, input, options?)`** — streaming composable that re-renders as each `delta` chunk arrives.
- **`queryOptions(stitch, input)`** — the same POJO TanStack adapter as `@stitchapi/react` (no framework import).

Both composables back a single `shallowRef` from `@stitchapi/query-core`'s `subscribe`/`getSnapshot`, re-create the query handle via `watch` on a structural input/options key (so an equal-shaped literal does not re-fetch, but a changed key does), and dispose with `onScopeDispose` (`query.destroy()`). `input`/`options` accept a value, `ref`, or getter. The result exposes each state field as a `ComputedRef` so destructuring keeps reactivity, plus `refetch`/`cancel`.

## Rationale

Frontend reactive binding for the Vue ecosystem — a thin idiomatic layer over the framework-agnostic `@stitchapi/query-core` store, mirroring `@stitchapi/react`.

Part of the #197 integration backlog wave.

## Verification

Run from the worktree with the package's own scripts:

- `check:types` — **pass** (`tsc --noEmit`, strict tsconfig mirrored from `packages/react`, resolves `stitchapi`/`@stitchapi/query-core` to source).
- `build` — **pass** (`tsup`, dual CJS/ESM + `.d.ts`/`.d.mts`).
- `test` — **pass** (10/10, `vitest run` in **node env** — driven via `effectScope` + microtask flush with a fake stitch; no component mount, no jsdom).

## Caveats

- Tests assert reactive transitions by draining microtasks (the fake stitch resolves promises / yields generator events on the microtask queue) rather than mounting a component — matching `@stitchapi/query-core`'s own node-env approach.
- `@tanstack/vue-query` is intentionally **not** a peer dep; `queryOptions` returns a plain object so it works without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)