### PR TITLE
feat(solid): @stitchapi/solid — createStitch/createStitchStream over query-core

### DIFF
--- a/packages/solid/LICENSE
+++ b/packages/solid/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -18,8 +18,8 @@ pnpm add @stitchapi/solid @stitchapi/query-core stitchapi solid-js
 
 ```tsx
 import { createStitch } from '@stitchapi/solid';
-import { stitch } from 'stitchapi';
 import { Show } from 'solid-js';
+import { stitch } from 'stitchapi';
 
 const getUser = stitch({
     baseUrl: 'https://api.example.com',
@@ -32,7 +32,10 @@ function Profile(props: { id: string }) {
 
     return (
         <Show when={!user.state.isPending} fallback={<Spinner />}>
-            <Show when={!user.state.isError} fallback={<Retry onClick={user.refetch} />}>
+            <Show
+                when={!user.state.isError}
+                fallback={<Retry onClick={user.refetch} />}
+            >
                 <h1>{user.state.data?.name}</h1>
             </Show>
         </Show>
@@ -46,16 +49,20 @@ function Profile(props: { id: string }) {
 
 ```tsx
 import { createStitchStream } from '@stitchapi/solid';
-import { sse } from 'stitchapi';
 import { For } from 'solid-js';
+import { sse } from 'stitchapi';
 
 const chat = sse({ url: 'https://api.example.com/chat' });
 
 function Chat(props: { prompt: string }) {
-    const c = createStitchStream(chat, () => ({ body: { prompt: props.prompt } }));
+    const c = createStitchStream(chat, () => ({
+        body: { prompt: props.prompt },
+    }));
     return (
         <div>
-            <For each={c.state.chunks as string[]}>{(chunk) => <span>{chunk}</span>}</For>
+            <For each={c.state.chunks as string[]}>
+                {(chunk) => <span>{chunk}</span>}
+            </For>
             <Show when={c.state.isStreaming}>
                 <Cursor />
             </Show>
@@ -95,7 +102,9 @@ interface StitchStore<T> {
 import { queryOptions } from '@stitchapi/solid';
 import { createQuery } from '@tanstack/solid-query';
 
-const query = createQuery(() => queryOptions(getUser, { params: { id: id() } }));
+const query = createQuery(() =>
+    queryOptions(getUser, { params: { id: id() } }),
+);
 ```
 
 ## License

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,0 +1,103 @@
+# @stitchapi/solid
+
+Solid bindings for [StitchAPI](https://stitchapi.dev). `createStitch` / `createStitchStream` primitives that reconcile a Solid `createStore` from the query store, plus an optional [TanStack Query](https://tanstack.com/query) adapter.
+
+**Streaming-first.** A `stitch` can stream (`sse` / `stream` surfaces) — `createStitchStream` reconciles each `delta` chunk into the store as it arrives. That's the differentiator over plain request/response query libraries.
+
+These primitives are a thin layer over [`@stitchapi/query-core`](../query-core), the framework-agnostic store that owns the reactive lifecycle. React / Vue / Svelte / Solid bindings are the same few lines against their own reactive primitive.
+
+## Install
+
+```sh
+pnpm add @stitchapi/solid @stitchapi/query-core stitchapi solid-js
+```
+
+`stitchapi`, `@stitchapi/query-core`, and `solid-js` (`^1.8`) are peer dependencies. `@tanstack/solid-query` is an **optional** peer — only needed if you use `queryOptions`.
+
+## `createStitch` — request / response
+
+```tsx
+import { createStitch } from '@stitchapi/solid';
+import { stitch } from 'stitchapi';
+import { Show } from 'solid-js';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+});
+
+function Profile(props: { id: string }) {
+    // Pass an accessor so the query re-fetches when `props.id` changes.
+    const user = createStitch(getUser, () => ({ params: { id: props.id } }));
+
+    return (
+        <Show when={!user.state.isPending} fallback={<Spinner />}>
+            <Show when={!user.state.isError} fallback={<Retry onClick={user.refetch} />}>
+                <h1>{user.state.data?.name}</h1>
+            </Show>
+        </Show>
+    );
+}
+```
+
+`input` and `options` may be plain values (read once) or accessors (`() => props.id`, a signal getter) — when an accessor's value changes the handle is recreated and re-fetched. The in-flight run is aborted on scope teardown (`onCleanup`).
+
+## `createStitchStream` — live deltas
+
+```tsx
+import { createStitchStream } from '@stitchapi/solid';
+import { sse } from 'stitchapi';
+import { For } from 'solid-js';
+
+const chat = sse({ url: 'https://api.example.com/chat' });
+
+function Chat(props: { prompt: string }) {
+    const c = createStitchStream(chat, () => ({ body: { prompt: props.prompt } }));
+    return (
+        <div>
+            <For each={c.state.chunks as string[]}>{(chunk) => <span>{chunk}</span>}</For>
+            <Show when={c.state.isStreaming}>
+                <Cursor />
+            </Show>
+        </div>
+    );
+}
+```
+
+Same store shape as `createStitch`. `state.data` is the accumulated chunks (`mode: 'append'`, default) or the latest chunk (`mode: 'replace'`); `state.chunks` is the running list; `state.status` is `'streaming'` until the terminal `result`, then `'success'`.
+
+## Store shape
+
+```ts
+interface StitchStore<T> {
+    state: {
+        status: 'idle' | 'pending' | 'streaming' | 'success' | 'error';
+        data: T | undefined;
+        error: unknown;
+        chunks: readonly unknown[];
+        isPending: boolean;
+        isError: boolean;
+        isSuccess: boolean;
+        isStreaming: boolean;
+    };
+    refetch: () => void;
+    cancel: () => void;
+}
+```
+
+`state` is a Solid store proxy — read its fields inside JSX or an effect to track them fine-grained.
+
+## Optional: TanStack Query
+
+`queryOptions(stitch, input)` returns a plain `{ queryKey, queryFn }` object — no import of `@tanstack/solid-query` required, so it works even if you never install it.
+
+```tsx
+import { queryOptions } from '@stitchapi/solid';
+import { createQuery } from '@tanstack/solid-query';
+
+const query = createQuery(() => queryOptions(getUser, { params: { id: id() } }));
+```
+
+## License
+
+Apache-2.0

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,0 +1,75 @@
+{
+    "name": "@stitchapi/solid",
+    "version": "1.0.0-rc.2",
+    "type": "commonjs",
+    "description": "Solid bindings for StitchAPI — createStitch/createStitchStream primitives that reconcile a Solid store from the query-core reactive store. Streaming-first: re-render as `delta` chunks arrive. Plus an optional TanStack Query queryOptions helper.",
+    "main": "lib/index.js",
+    "module": "lib/index.mjs",
+    "types": "lib/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./lib/index.d.mts",
+                "default": "./lib/index.mjs"
+            },
+            "require": {
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
+            }
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "lib"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsup",
+        "test": "vitest run",
+        "check:types": "tsc --noEmit",
+        "prepack": "tsup",
+        "prepublishOnly": "node ../../scripts/check-release.mjs --changelog"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rejifald/StitchAPI.git",
+        "directory": "packages/solid"
+    },
+    "keywords": [
+        "stitchapi",
+        "solid",
+        "solid-js",
+        "createStore",
+        "streaming",
+        "query",
+        "tanstack-query"
+    ],
+    "author": "Oleksandr Zhuravlov (rejifald@gmail.com)",
+    "license": "Apache-2.0",
+    "homepage": "https://stitchapi.dev",
+    "engines": {
+        "node": ">=18.18.0"
+    },
+    "peerDependencies": {
+        "@stitchapi/query-core": "^1.0.0-rc.2",
+        "stitchapi": "^1.0.0-rc.1",
+        "solid-js": "^1.8.0",
+        "@tanstack/solid-query": "^5.0.0"
+    },
+    "peerDependenciesMeta": {
+        "@tanstack/solid-query": {
+            "optional": true
+        }
+    },
+    "devDependencies": {
+        "@stitchapi/query-core": "workspace:*",
+        "@types/node": "^22.10.0",
+        "solid-js": "^1.8.0",
+        "stitchapi": "workspace:*",
+        "tsup": "^8.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.8"
+    }
+}

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -1,0 +1,284 @@
+// @stitchapi/solid — Solid bindings for StitchAPI.
+//
+// These primitives are a THIN layer over `@stitchapi/query-core`: that package
+// owns the reactive store (subscribe / getSnapshot / refetch / cancel), and Solid
+// mirrors it into a `createStore` reconciled on each notification. Because all the
+// behaviour lives in the framework-agnostic core, the React / Vue / Svelte / Solid
+// bindings are the same few lines against their own reactive primitive.
+//
+// - `createStitch`       — the unary request/response primitive.
+// - `createStitchStream` — the streaming primitive: re-renders as `delta` chunks
+//                          arrive. This is the differentiator over plain
+//                          request/response query libraries.
+// - `queryOptions`       — an OPTIONAL TanStack Query adapter (returns a plain
+//                          POJO, so it needs no import of `@tanstack/solid-query`).
+import {
+    type CreateStitchQueryOptions,
+    type QueryInput,
+    type QueryOutput,
+    type StitchLike,
+    type StitchQuery,
+    type StitchQueryState,
+    createStitchQuery,
+} from '@stitchapi/query-core';
+import { createEffect, on, onCleanup } from 'solid-js';
+import { createStore, reconcile } from 'solid-js/store';
+
+export type {
+    CreateStitchQueryOptions,
+    QueryInput,
+    QueryOutput,
+    StitchLike,
+    StitchQuery,
+    StitchQueryState,
+} from '@stitchapi/query-core';
+
+// ---------------------------------------------------------------------------
+// Primitive result
+// ---------------------------------------------------------------------------
+
+/** What `createStitch` / `createStitchStream` return: the reactive store (a Solid
+ * proxy, so reading `store.data` inside an effect/JSX tracks it) plus the
+ * imperative `refetch` / `cancel` handles. */
+export interface StitchStore<T> {
+    /** The reactive state — a Solid store proxy. Read fields inside tracking
+     * scopes (effects, JSX) to re-run on change. */
+    readonly state: StitchQueryState<T>;
+    /** Abort the in-flight run and re-run from scratch. */
+    refetch: () => void;
+    /** Abort the in-flight run, if any. */
+    cancel: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Reactive inputs
+// ---------------------------------------------------------------------------
+
+/** A value or a zero-arg accessor of it — Solid's idiom for "static or reactive".
+ * Passing an accessor (a signal getter, or `() => props.x`) lets the primitive
+ * recreate the handle when the value changes; a plain value is read once. */
+export type MaybeAccessor<T> = T | (() => T);
+
+function access<T>(value: MaybeAccessor<T>): T {
+    return typeof value === 'function' ? (value as () => T)() : value;
+}
+
+export interface CreateStitchOptions<T> extends CreateStitchQueryOptions<T> {}
+
+// ---------------------------------------------------------------------------
+// Shared driver
+// ---------------------------------------------------------------------------
+
+// The store's seed value, read before the effect mirrors the first real snapshot
+// (the effect is non-deferred, so this is only ever visible for an instant). It
+// matches core's idle snapshot exactly so `state` is well-formed from the start.
+const IDLE_STATE: StitchQueryState<unknown> = {
+    status: 'idle',
+    data: undefined,
+    error: undefined,
+    chunks: [],
+    isPending: false,
+    isError: false,
+    isSuccess: false,
+    isStreaming: false,
+};
+
+function createStitchInternal<T>(
+    stitch: StitchLike<T, unknown>,
+    input: MaybeAccessor<unknown>,
+    options: MaybeAccessor<CreateStitchOptions<T>>,
+    stream: boolean,
+): StitchStore<T> {
+    // The Solid store we reconcile from the core query's snapshots. `reconcile`
+    // does a structural diff so only the fields that actually changed notify
+    // their dependents (mirrors core's identity-stable snapshots, fine-grained).
+    const [state, setState] = createStore<StitchQueryState<T>>(
+        IDLE_STATE as StitchQueryState<T>,
+    );
+
+    // Hold the latest `stitch` in a ref-like closure. A caller who passes an
+    // INLINE stitch hands a fresh function identity, which must NOT recreate the
+    // handle; the store always calls through this stable wrapper.
+    let liveStitch = stitch;
+    const stableStitch: StitchLike<T, unknown> = (arg?: unknown) =>
+        liveStitch(arg);
+
+    // The live query handle — reassigned by the effect on input/option changes.
+    let query: StitchQuery<T> | undefined;
+
+    // Recreate the handle whenever the tracked input / options change. `on`
+    // makes the dependencies explicit (and `defer: false` runs it immediately),
+    // so an inline stitch identity never enters the trigger.
+    createEffect(
+        on(
+            () => [access(input), access(options)] as const,
+            ([currentInput, currentOptions]) => {
+                liveStitch = stitch;
+                // Tear down the superseded handle before standing up the new one.
+                query?.destroy();
+
+                const { mode, enabled, onSuccess, onError } = currentOptions;
+                const handle = createStitchQuery<T, unknown>(
+                    stableStitch,
+                    currentInput,
+                    {
+                        stream,
+                        ...(mode ? { mode } : {}),
+                        ...(enabled !== undefined ? { enabled } : {}),
+                        ...(onSuccess ? { onSuccess } : {}),
+                        ...(onError ? { onError } : {}),
+                    },
+                );
+                query = handle;
+
+                // Mirror the snapshot into the store, then on every transition.
+                // `reconcile` keeps the proxy identity stable and only patches the
+                // changed fields.
+                setState(reconcile(handle.getSnapshot()));
+                const off = handle.subscribe(() => {
+                    setState(reconcile(handle.getSnapshot()));
+                });
+
+                // Drop the listener (and the handle) when this effect re-runs or
+                // the owning scope is disposed.
+                onCleanup(() => {
+                    off();
+                    handle.destroy();
+                });
+            },
+        ),
+    );
+
+    return {
+        state,
+        refetch: () => query?.refetch(),
+        cancel: () => query?.cancel(),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// createStitch — unary
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a stitch as a request/response query and reconcile its transitions into a
+ * Solid store. Read `store.state.data` / `store.state.isPending` inside JSX or an
+ * effect to re-render on change.
+ *
+ * `input` and `options` may be plain values (read once) or accessors (`() =>
+ * props.id`, a signal getter) — when an accessor's value changes the query handle
+ * is recreated and re-fetched. An inline stitch is safe: its function identity
+ * does NOT trigger a recreate. The in-flight run is aborted on scope teardown.
+ *
+ * @example
+ * ```tsx
+ * const user = createStitch(getUser, () => ({ params: { id: id() } }));
+ * return (
+ *   <Show when={!user.state.isPending} fallback={<Spinner />}>
+ *     {user.state.isError ? <Retry onClick={user.refetch} /> : <Profile data={user.state.data} />}
+ *   </Show>
+ * );
+ * ```
+ */
+export function createStitch<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    input: MaybeAccessor<QueryInput<S>>,
+    options?: MaybeAccessor<CreateStitchOptions<QueryOutput<S>>>,
+): StitchStore<QueryOutput<S>>;
+export function createStitch<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    input: MaybeAccessor<Input>,
+    options?: MaybeAccessor<CreateStitchOptions<T>>,
+): StitchStore<T>;
+export function createStitch<T>(
+    stitch: StitchLike<T, unknown>,
+    input: MaybeAccessor<unknown>,
+    options: MaybeAccessor<CreateStitchOptions<T>> = {},
+): StitchStore<T> {
+    return createStitchInternal<T>(stitch, input, options, false);
+}
+
+// ---------------------------------------------------------------------------
+// createStitchStream — streaming
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a streaming stitch (an `sse` / `stream` surface) and reconcile each `delta`
+ * chunk into the Solid store as it arrives. Same store shape as {@link
+ * createStitch}; `state.data` is the accumulated chunks (`mode: 'append'`,
+ * default) or the latest chunk (`mode: 'replace'`), and `state.chunks` is the
+ * running list. `state.status` is `'streaming'` until the terminal `result`, then
+ * `'success'`.
+ *
+ * @example
+ * ```tsx
+ * const chat = createStitchStream(stream, () => ({ body: { prompt: prompt() } }));
+ * return <Tokens chunks={chat.state.chunks} live={chat.state.isStreaming} />;
+ * ```
+ */
+export function createStitchStream<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    input: MaybeAccessor<QueryInput<S>>,
+    options?: MaybeAccessor<CreateStitchOptions<QueryOutput<S>>>,
+): StitchStore<QueryOutput<S>>;
+export function createStitchStream<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    input: MaybeAccessor<Input>,
+    options?: MaybeAccessor<CreateStitchOptions<T>>,
+): StitchStore<T>;
+export function createStitchStream<T>(
+    stitch: StitchLike<T, unknown>,
+    input: MaybeAccessor<unknown>,
+    options: MaybeAccessor<CreateStitchOptions<T>> = {},
+): StitchStore<T> {
+    return createStitchInternal<T>(stitch, input, options, true);
+}
+
+// ---------------------------------------------------------------------------
+// queryOptions — optional TanStack Query adapter
+// ---------------------------------------------------------------------------
+
+// IDENTICAL to `@stitchapi/react`'s `queryOptions` (no framework import) — the
+// POJO shape `@tanstack/solid-query`'s `createQuery(options)` consumes is the same
+// `{ queryKey, queryFn }` TanStack uses everywhere.
+
+/** The plain object {@link queryOptions} returns — structurally compatible with
+ * TanStack Query's `createQuery(options)` without importing the library. */
+export interface StitchQueryOptions<T> {
+    queryKey: readonly unknown[];
+    queryFn: (ctx?: { signal?: AbortSignal }) => Promise<T>;
+}
+
+/**
+ * Build a TanStack-Query-compatible options object for a stitch, WITHOUT a hard
+ * dependency on `@tanstack/solid-query` — it just returns a POJO. Pass it straight
+ * to `createQuery`:
+ *
+ * ```tsx
+ * import { createQuery } from '@tanstack/solid-query';
+ * import { queryOptions } from '@stitchapi/solid';
+ *
+ * const query = createQuery(() => queryOptions(getUser, { params: { id: id() } }));
+ * ```
+ *
+ * The `queryFn` awaits the stitch (the validated output); the `queryKey` is the
+ * stitch's `name` (when present) plus the input, so TanStack caches per call.
+ */
+export function queryOptions<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    input: QueryInput<S>,
+): StitchQueryOptions<QueryOutput<S>>;
+export function queryOptions<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    input: Input,
+): StitchQueryOptions<T>;
+export function queryOptions<T>(
+    stitch: StitchLike<T, unknown>,
+    input: unknown,
+): StitchQueryOptions<T> {
+    const name = (stitch as { __config?: { name?: string } }).__config?.name;
+    return {
+        queryKey: [name ?? 'stitch', input ?? null],
+        queryFn: () => Promise.resolve(stitch(input)),
+    };
+}

--- a/packages/solid/test/primitives.spec.ts
+++ b/packages/solid/test/primitives.spec.ts
@@ -1,0 +1,311 @@
+// @stitchapi/solid primitive behaviour, driven inside Solid's reactive scope in a
+// node env (no DOM). Driven by FAKE stitches — no engine, no network. We wrap each
+// assertion run in `createRoot` so the effects/cleanups have an owner, and dispose
+// it to exercise teardown.
+import {
+    type StitchStore,
+    createStitch,
+    createStitchStream,
+    queryOptions,
+} from '../src';
+
+import type { StitchCallResult, StitchLike } from '@stitchapi/query-core';
+import { createEffect, createRoot, createSignal } from 'solid-js';
+import type { StitchEvent } from 'stitchapi';
+import { describe, expect, test } from 'vitest';
+
+// --- fakes -----------------------------------------------------------------
+
+/** A unary stitch: resolves (or rejects) after a tick, ignoring streaming. */
+function unaryStitch<T>(
+    settle: (input: unknown) => Promise<T>,
+    config?: { name?: string },
+): StitchLike<T> {
+    const fn = (input?: unknown): StitchCallResult<T> => {
+        const promise = settle(input);
+        return {
+            then: (onf, onr) => promise.then(onf, onr),
+            stream() {
+                return (async function* () {
+                    const value = await promise;
+                    yield {
+                        type: 'result',
+                        value,
+                        status: 200,
+                        attempts: 1,
+                        at: 0,
+                    } satisfies StitchEvent<T>;
+                })();
+            },
+        };
+    };
+    if (config) (fn as { __config?: unknown }).__config = config;
+    return fn;
+}
+
+/** A streaming stitch: emits the given events from `.stream()`; `await` resolves
+ * to the terminal `result` value (mirrors core's `StitchResult`). */
+function streamStitch<T>(events: StitchEvent<T>[]): StitchLike<T> {
+    return (): StitchCallResult<T> => {
+        const terminal = events.find((e) => e.type === 'result');
+        const value =
+            terminal && terminal.type === 'result'
+                ? terminal.value
+                : (undefined as T);
+        const promise = Promise.resolve(value);
+        return {
+            then: (onf, onr) => promise.then(onf, onr),
+            stream() {
+                return (async function* () {
+                    for (const e of events) {
+                        // Yield on a microtask so listeners observe each delta.
+                        await Promise.resolve();
+                        yield e;
+                    }
+                })();
+            },
+        };
+    };
+}
+
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+const drain = (): Promise<void> => new Promise((r) => setTimeout(r, 10));
+
+/** Run `fn` inside a Solid root and return a `dispose` to tear it down. */
+function root<T>(fn: () => T): { value: T; dispose: () => void } {
+    let value!: T;
+    let dispose!: () => void;
+    createRoot((d) => {
+        dispose = d;
+        value = fn();
+    });
+    return { value, dispose };
+}
+
+// --- createStitch (unary) --------------------------------------------------
+
+describe('createStitch', () => {
+    test('reconciles pending → success into the store', async () => {
+        const stitch = unaryStitch(async () => ({ name: 'Ada' }));
+        const { value: store, dispose } = root(() =>
+            createStitch(stitch, { params: { id: '1' } }),
+        );
+
+        expect(store.state.status).toBe('pending');
+        expect(store.state.isPending).toBe(true);
+
+        await tick();
+        expect(store.state.status).toBe('success');
+        expect(store.state.isSuccess).toBe(true);
+        expect(store.state.data).toEqual({ name: 'Ada' });
+        dispose();
+    });
+
+    test('lands on error with the thrown reason', async () => {
+        const boom = new Error('nope');
+        const stitch = unaryStitch<{ name: string }>(async () => {
+            throw boom;
+        });
+        const { value: store, dispose } = root(() => createStitch(stitch, {}));
+
+        await tick();
+        expect(store.state.status).toBe('error');
+        expect(store.state.isError).toBe(true);
+        expect(store.state.error).toBe(boom);
+        dispose();
+    });
+
+    test('refetch re-runs the call', async () => {
+        let n = 0;
+        const stitch = unaryStitch(async () => ({ name: `v${++n}` }));
+        const { value: store, dispose } = root(() => createStitch(stitch, {}));
+
+        await tick();
+        expect(store.state.data).toEqual({ name: 'v1' });
+
+        store.refetch();
+        expect(store.state.status).toBe('pending');
+        await tick();
+        expect(store.state.data).toEqual({ name: 'v2' });
+        dispose();
+    });
+
+    test('a reactive input accessor recreates the handle and re-fetches', async () => {
+        const stitch = unaryStitch(async (input) => ({
+            name: `id-${(input as { params: { id: string } }).params.id}`,
+        }));
+
+        let store!: StitchStore<{ name: string }>;
+        let setId!: (v: string) => void;
+        const dispose = createRoot((d) => {
+            const [id, set] = createSignal('1');
+            setId = set;
+            store = createStitch(stitch, () => ({ params: { id: id() } }));
+            return d;
+        });
+
+        await tick();
+        expect(store.state.data).toEqual({ name: 'id-1' });
+
+        setId('2');
+        await tick();
+        expect(store.state.data).toEqual({ name: 'id-2' });
+        dispose();
+    });
+
+    test('cancel aborts the run: a late resolution does not publish success', async () => {
+        let resolveIt: (v: string) => void = () => {};
+        const stitch: StitchLike<string> = () => {
+            const promise = new Promise<string>((res) => {
+                resolveIt = res;
+            });
+            return {
+                then: (onf, onr) => promise.then(onf, onr),
+                stream() {
+                    return (async function* () {})() as never;
+                },
+            };
+        };
+        const { value: store, dispose } = root(() =>
+            createStitch(stitch, undefined),
+        );
+        expect(store.state.status).toBe('pending');
+
+        store.cancel();
+        resolveIt('late');
+        await tick();
+        expect(store.state.status).toBe('pending'); // never advanced
+        expect(store.state.data).toBeUndefined();
+        dispose();
+    });
+
+    test('disposing the root tears down the run (no publish after dispose)', async () => {
+        let resolveIt: (v: string) => void = () => {};
+        const stitch: StitchLike<string> = () => {
+            const promise = new Promise<string>((res) => {
+                resolveIt = res;
+            });
+            return {
+                then: (onf, onr) => promise.then(onf, onr),
+                stream() {
+                    return (async function* () {})() as never;
+                },
+            };
+        };
+        const { value: store, dispose } = root(() =>
+            createStitch(stitch, undefined),
+        );
+        dispose();
+        resolveIt('late');
+        await tick();
+        // The destroyed handle's late resolution is dropped — still pending.
+        expect(store.state.status).toBe('pending');
+        expect(store.state.data).toBeUndefined();
+    });
+});
+
+// --- createStitchStream ----------------------------------------------------
+
+describe('createStitchStream', () => {
+    test('reconciles delta chunks as they arrive, then settles success', async () => {
+        const events: StitchEvent<number[]>[] = [
+            { type: 'delta', chunk: 1, at: 0 },
+            { type: 'delta', chunk: 2, at: 0 },
+            { type: 'delta', chunk: 3, at: 0 },
+            {
+                type: 'result',
+                value: [1, 2, 3],
+                status: 200,
+                attempts: 1,
+                at: 0,
+            },
+            { type: 'done', ok: true, ms: 1, attempts: 1, at: 0 },
+        ];
+        const { value: store, dispose } = root(() =>
+            createStitchStream(streamStitch(events), undefined),
+        );
+
+        await drain();
+        expect(store.state.status).toBe('success');
+        expect(store.state.chunks).toEqual([1, 2, 3]);
+        expect(store.state.data).toEqual([1, 2, 3]);
+        dispose();
+    });
+
+    test('passes through streaming before success', async () => {
+        const events: StitchEvent<number>[] = [
+            { type: 'delta', chunk: 1, at: 0 },
+            { type: 'result', value: 99, status: 200, attempts: 1, at: 0 },
+        ];
+        const statuses: string[] = [];
+        const dispose = createRoot((d) => {
+            const store = createStitchStream(streamStitch(events), undefined, {
+                mode: 'replace',
+            });
+            // Track the status reactively: an effect re-runs on each reconcile.
+            createEffect(() => statuses.push(store.state.status));
+            return d;
+        });
+        await drain();
+        expect(statuses).toContain('streaming');
+        expect(statuses).toContain('success');
+        dispose();
+    });
+
+    test('replace mode keeps only the latest chunk as data', async () => {
+        const events: StitchEvent<number>[] = [
+            { type: 'delta', chunk: 10, at: 0 },
+            { type: 'delta', chunk: 20, at: 0 },
+            { type: 'result', value: 20, status: 200, attempts: 1, at: 0 },
+        ];
+        const { value: store, dispose } = root(() =>
+            createStitchStream(streamStitch(events), undefined, {
+                mode: 'replace',
+            }),
+        );
+        await drain();
+        expect(store.state.data).toBe(20);
+        expect(store.state.chunks).toEqual([]);
+        expect(store.state.status).toBe('success');
+        dispose();
+    });
+
+    test('a streamed error event lands on error status', async () => {
+        const events: StitchEvent<number>[] = [
+            { type: 'delta', chunk: 1, at: 0 },
+            {
+                type: 'error',
+                name: 'StitchError',
+                message: 'mid-stream failure',
+                attempts: 1,
+                at: 0,
+            },
+        ];
+        const { value: store, dispose } = root(() =>
+            createStitchStream(streamStitch(events), undefined),
+        );
+        await drain();
+        expect(store.state.status).toBe('error');
+        expect((store.state.error as Error).message).toBe('mid-stream failure');
+        dispose();
+    });
+});
+
+// --- queryOptions ----------------------------------------------------------
+
+describe('queryOptions', () => {
+    test('returns a TanStack-shaped POJO with key + async queryFn', async () => {
+        const stitch = unaryStitch(async () => ({ ok: true }), {
+            name: 'getThing',
+        });
+        const opts = queryOptions(stitch, { params: { id: '7' } });
+        expect(opts.queryKey).toEqual(['getThing', { params: { id: '7' } }]);
+        await expect(opts.queryFn()).resolves.toEqual({ ok: true });
+    });
+
+    test('falls back to "stitch" when no __config.name', () => {
+        const stitch = unaryStitch(async () => 1);
+        const opts = queryOptions(stitch, null);
+        expect(opts.queryKey[0]).toBe('stitch');
+    });
+});

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -1,0 +1,35 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM"],
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "exactOptionalPropertyTypes": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "verbatimModuleSyntax": true,
+        "isolatedModules": true,
+
+        "types": ["node", "vitest/globals"],
+
+        // Resolve the workspace packages to their SOURCE so typecheck + tests
+        // don't depend on `stitchapi` / `@stitchapi/query-core` being built
+        // first. The published `exports` maps still point at `lib/`.
+        "baseUrl": ".",
+        "paths": {
+            "stitchapi/testing": ["../core/src/testing.ts"],
+            "stitchapi": ["../core/src/index.ts"],
+            "@stitchapi/query-core": ["../query-core/src/index.ts"]
+        }
+    },
+    "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/solid/tsup.config.ts
+++ b/packages/solid/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+// Single dual-format entry. `stitchapi` and `solid-js` are peer deps (externalised
+// by tsup); `@stitchapi/query-core` is a runtime dep and is also kept external so
+// the Solid bindings stay a thin layer over it.
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    minify: true,
+    outDir: 'lib',
+    clean: true,
+    // `solid-js` AND its subpaths (`solid-js/store`) are the peer; the regex
+    // keeps them all external so we don't bundle Solid's runtime.
+    external: ['@stitchapi/query-core', /^solid-js(\/|$)/],
+});

--- a/packages/solid/vitest.config.ts
+++ b/packages/solid/vitest.config.ts
@@ -1,0 +1,38 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+// Alias the workspace packages to their SOURCE (more specific subpaths first), so
+// tests run without `stitchapi` / `@stitchapi/query-core` being built. Mirrors
+// tsconfig `paths`.
+const core = (p: string): string =>
+    fileURLToPath(new URL(`../core/src/${p}`, import.meta.url));
+const queryCore = (): string =>
+    fileURLToPath(new URL('../query-core/src/index.ts', import.meta.url));
+
+// Solid ships separate condition builds: the `node`/`server` build makes
+// `createEffect` a no-op (SSR), so we MUST resolve the reactive CLIENT build.
+// `['development', 'browser']` is Solid's documented test condition set — it loads
+// `dist/dev.js`, the real reactive runtime, even though the test `environment` is
+// `node` (we drive signals by hand, no DOM needed). A vitest node-env test runs
+// through Vite's SSR pipeline, so the conditions must be set on `ssr.resolve` (not
+// just `resolve`, which only governs the client graph).
+const reactiveConditions = ['development', 'browser'];
+
+const alias = [
+    { find: /^stitchapi\/testing$/, replacement: core('testing.ts') },
+    { find: /^stitchapi$/, replacement: core('index.ts') },
+    { find: /^@stitchapi\/query-core$/, replacement: queryCore() },
+];
+
+export default defineConfig({
+    resolve: { conditions: reactiveConditions, alias },
+    ssr: { resolve: { conditions: reactiveConditions } },
+    test: {
+        globals: true,
+        environment: 'node',
+        // Force Solid through the inline transform so the export conditions above
+        // pick the reactive build instead of node's default externalised require.
+        server: { deps: { inline: ['solid-js'] } },
+        include: ['test/**/*.spec.ts'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -583,6 +583,34 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
+  packages/solid:
+    dependencies:
+      '@tanstack/solid-query':
+        specifier: ^5.0.0
+        version: 5.101.0(solid-js@1.9.13)
+    devDependencies:
+      '@stitchapi/query-core':
+        specifier: workspace:*
+        version: link:../query-core
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.21
+      solid-js:
+        specifier: ^1.8.0
+        version: 1.9.13
+      stitchapi:
+        specifier: workspace:*
+        version: link:../core
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+
 packages:
 
   '@alloc/quick-lru@5.2.0':
@@ -2229,6 +2257,11 @@ packages:
     resolution: {integrity: sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/solid-query@5.101.0':
+    resolution: {integrity: sha512-XoPWynbaWquvSisMvUirakfD9OmLas1cOwt1gBDUTn8HC2CVkZm+O/jBgEa5SL5LrY6vxmWjzzskhXkywLfymw==}
+    peerDependencies:
+      solid-js: ^1.6.0
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5429,6 +5462,16 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+    engines: {node: '>=10'}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
@@ -5486,6 +5529,9 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  solid-js@1.9.13:
+    resolution: {integrity: sha512-6hJeJMOcEX8ktqjpDoJZEmld3ijvcvWBDtiXBm7f4332SiFN66QeAQI1REQshvyUoISsSeJ4PHDauKYbwao9JQ==}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -7577,6 +7623,11 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.101.0
       react: 19.2.7
+
+  '@tanstack/solid-query@5.101.0(solid-js@1.9.13)':
+    dependencies:
+      '@tanstack/query-core': 5.101.0
+      solid-js: 1.9.13
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -11530,6 +11581,12 @@ snapshots:
 
   semver@7.8.4: {}
 
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
+  seroval@1.5.4: {}
+
   set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
@@ -11638,6 +11695,12 @@ snapshots:
       unicode-emoji-modifier-base: 1.0.0
 
   slash@3.0.0: {}
+
+  solid-js@1.9.13:
+    dependencies:
+      csstype: 3.2.3
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
 
   sonic-boom@4.2.1:
     dependencies:


### PR DESCRIPTION
## What it adds

New package **@stitchapi/solid** — Solid bindings for StitchAPI, a thin layer over [`@stitchapi/query-core`](../query-core)'s framework-agnostic reactive store (the React package's own header notes the bindings are "the same few lines against their own external-store primitive").

- `createStitch(stitch, input, options?)` — unary request/response primitive.
- `createStitchStream(stitch, input, options?)` — streaming primitive; reconciles each `delta` chunk into the store as it arrives.
  Both reconcile a Solid `createStore` from the query's `subscribe`/`getSnapshot` (via `reconcile` for fine-grained diffing), recreate the handle through `createEffect(on(...))` when a reactive `input`/`options` accessor changes, and dispose the handle (`query.destroy()`) on `onCleanup`. They expose the reactive `state` plus imperative `refetch`/`cancel`.
- `queryOptions(stitch, input)` — the framework-free TanStack adapter POJO, IDENTICAL to react's (no framework import).

`input`/`options` accept Solid's value-or-accessor idiom (`MaybeAccessor<T>`) so a signal getter or `() => props.x` drives recreation/re-fetch; an inline stitch identity does NOT trigger a recreate (it calls through a stable wrapper).

## Rationale

Extends StitchAPI's frontend reactive-binding family to Solid, reusing the shared query-core store so streaming-first semantics (`delta` re-renders) come for free.

Part of the #197 integration backlog wave.

## Verification

Mirrors `packages/react` / `packages/query-core` layout, package.json, tsconfig, tsup, and code style. Tested in a **node env** inside `createRoot` with fake stitches (a callable returning a thenable that also has `.stream()` yielding `StitchEvent`s).

- `check:types` — **pass** (`tsc --noEmit`, strict + all ratchet flags)
- `build` — **pass** (`tsup`; dual CJS/ESM + dts; `solid-js`, `solid-js/store`, and `@stitchapi/query-core` kept external)
- `test` — **pass** (12/12; `vitest run`)

## Caveats

- A vitest node-env test runs through Vite's SSR pipeline, where Solid's default `node`/`server` export condition resolves the SSR build that makes `createEffect` a **no-op**. The package's `vitest.config.ts` therefore sets `ssr.resolve.conditions: ['development', 'browser']` and inlines `solid-js`, so tests exercise the real reactive runtime (no DOM needed — signals are driven by hand). This is test-only config and does not affect the published bundle, which leaves `solid-js` external for the host app to resolve normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)