### PR TITLE
docs(integrations): add an Integrations landing page

### DIFF
--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -1,0 +1,103 @@
+---
+title: Integrations
+description: First-party companion packages that bridge a stitch to the framework, frontend, logger, and store you already run — each a thin layer over a stable seam, never a re-implementation.
+---
+
+A stitch is plain TypeScript with no framework and no `node:*`, so it already runs
+anywhere. The packages here are the **companions**: thin bridges that wire a stitch
+into the tool you already run — a backend framework, a frontend's reactivity, your
+logger, your store — so its lifecycle, principal, streaming, and telemetry line up
+with the host instead of being bolted on.
+
+Each one is small on purpose. They plug into a handful of **stable seams**, so a
+new integration is ~100 lines over an existing contract, not a rewrite — and every
+companion is proven against the same conformance kits the core ships:
+
+-   **Backend seam** — lifecycle, request-scoped principal (`seam.as(user)`), an
+    SSE→response bridge, and an error→HTTP mapping, identical across frameworks.
+-   **Reactive store** — [`@stitchapi/query-core`](/docs/integrations/react) owns a
+    framework-agnostic `subscribe` / `getSnapshot` store; each frontend binding is a
+    few lines against its own primitive.
+-   **[`TraceSink`](/docs/guides/observability/trace-sinks)** — forward the typed
+    [event stream](/docs/concepts/event-stream) to the logger or telemetry pipeline
+    you already run.
+-   **[`StitchStore`](/docs/guides/state/pluggable-store)** — move throttle counters,
+    sessions, and cache into a shared backend so they go fleet-wide with no call-site
+    change.
+
+## Backend frameworks
+
+Attach a `seam` to your server: one shared client with a request-scoped principal,
+an SSE helper, and an error bridge.
+
+<Cards>
+    <Card
+        title="NestJS"
+        href="/docs/integrations/nestjs"
+        description="A module + injectable seam, request-scoped principal, and an exception filter that maps StitchError to HTTP."
+    />
+    <Card
+        title="Fastify"
+        href="/docs/integrations/fastify"
+        description="A plugin with a request-scoped principal, SSE reply bridge, and an error handler — wired to Fastify's lifecycle and logger."
+    />
+    <Card
+        title="Hono"
+        href="/docs/integrations/hono"
+        description="Edge/multi-runtime middleware with a per-request seam and an SSE bridge — Workers, Deno, Bun, Node."
+    />
+</Cards>
+
+## Frontend
+
+The hooks and composables are a thin layer over the shared `@stitchapi/query-core`
+store, so updates are tearing-free and **streaming-first** — the view re-renders as
+each `delta` chunk arrives, which plain request/response query libraries don't
+model.
+
+<Cards>
+    <Card
+        title="React"
+        href="/docs/integrations/react"
+        description="Tearing-free useStitch / useStitchStream hooks over query-core, plus an optional TanStack Query adapter."
+    />
+    <Card
+        title="TanStack Query"
+        href="/docs/integrations/tanstack-query"
+        description="Use a stitch as a queryFn with the framework-agnostic queryOptions(stitch, input) helper — no hard dependency."
+    />
+</Cards>
+
+## Observability
+
+<Cards>
+    <Card
+        title="Pino"
+        href="/docs/integrations/pino"
+        description="Forward the event stream to a Pino logger as structured, leveled records — metadata-only, safe on a secret-bearing seam."
+    />
+</Cards>
+
+For OpenTelemetry, core exports an OTLP trace bridge directly — see the
+[OTLP guide](/docs/guides/observability/otlp).
+
+## See also
+
+<Cards>
+    <Card
+        title="The event stream"
+        href="/docs/concepts/event-stream"
+        description="The typed events every companion forwards or renders."
+    />
+    <Card
+        title="Pluggable store"
+        href="/docs/guides/state/pluggable-store"
+        description="The StitchStore seam that makes throttle, sessions, and cache fleet-wide."
+    />
+    <Card
+        title="Standard Schema"
+        href="/docs/guides/validation/standard-schema"
+        description="Bring Zod, Valibot, or ArkType for validation and inferred types."
+    />
+    <Card title="The stitch primitive" href="/docs/concepts/the-stitch" />
+</Cards>


### PR DESCRIPTION
## What

Adds [`integrations/index.mdx`](apps/docs/content/docs/integrations/index.mdx) — a landing page for the integrations section, which currently has none. `recipes/`, `agents/`, `errors/`, and `getting-started/` all have an index; `/docs/integrations` did not.

The page leads with the **why** — companions are cheap because they plug into a small set of stable seams (backend seam · `query-core` reactive store · `TraceSink` · `StitchStore`), not bespoke rewrites — then cards the currently-published integrations grouped by kind:

- **Backend frameworks** — NestJS, Fastify, Hono
- **Frontend** — React, TanStack Query
- **Observability** — Pino (+ pointer to the OTLP guide)

## Conflict-free with the in-flight docs PRs

Adds **`index.mdx` only — no `meta.json` change**. Per the `recipes`/`agents` precedent the section root is implicit (not listed in `pages`), so this does not touch the same lines as [#214](https://github.com/rejifald/StitchAPI/pull/214) (vue/svelte) or [#215](https://github.com/rejifald/StitchAPI/pull/215) (stores). Cards for vue/svelte/stores — and for Express/Elysia/Solid — are intentionally deferred so every link resolves on `main` today; they're a one-line-each follow-up as each page merges.

## Verification

- `node scripts/check-docs-links.mjs` → ✓ all `/docs/...` links resolve (87 routes)
- `prettier --check` → ✓ clean
- No code fences on this page (pure prose + `<Cards>`), so no twoslash/Shiki surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)