### PR TITLE
feat(angular): @stitchapi/angular — injectStitch/injectStitchStream (signals + RxJS) over query-core

### DIFF
--- a/apps/docs/content/docs/integrations/angular.mdx
+++ b/apps/docs/content/docs/integrations/angular.mdx
@@ -1,0 +1,206 @@
+---
+title: Angular
+description: injectStitch and injectStitchStream expose a stitch's lifecycle as both Angular signals and an RxJS observable over the framework-agnostic @stitchapi/query-core store — plus an optional TanStack Query adapter.
+---
+
+Use `@stitchapi/angular` when you call stitches from Angular components and want the
+call's lifecycle — pending / success / error, cancellation, refetch, and
+**streaming re-renders** — managed for you. `injectStitch` is the request/response
+function; `injectStitchStream` re-renders as each `delta` chunk arrives, which is
+the differentiator over plain request/response query libraries.
+
+Every result is exposed **two ways from one shared execution**: fine-grained
+**signals** (`data()`, `isPending()`, …) for templates and `computed`, and an RxJS
+**observable** (`state$`) for the `async` pipe and operators. Both are a thin layer
+over [`@stitchapi/query-core`](#the-shared-store-stitchapiquery-core), the
+framework-agnostic store that owns the reactive lifecycle.
+
+## Example
+
+Install the bindings, the store, core, and Angular:
+
+```package-install
+@stitchapi/angular @stitchapi/query-core stitchapi @angular/core
+```
+
+`stitchapi`, `@angular/core`, and `rxjs` are peer dependencies;
+`@tanstack/angular-query-experimental` is an **optional** peer, needed only for the
+`queryOptions` adapter below.
+
+## `injectStitch` — request / response
+
+Call `injectStitch` in an injection context (a component field initializer). Pass
+the input as a **signal or getter** (`() => this.id()`) so the query re-fetches
+when it changes — Angular signal inputs are the natural source. Read the result's
+signals in the template; the in-flight run is aborted when the component is
+destroyed.
+
+```ts
+import { Component, input } from '@angular/core';
+import { injectStitch } from '@stitchapi/angular';
+import { stitch } from 'stitchapi';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+});
+
+@Component({
+    selector: 'app-profile',
+    template: `
+        @if (user.isPending()) {
+            <app-spinner />
+        } @else if (user.isError()) {
+            <button (click)="user.refetch()">Retry</button>
+        } @else {
+            <h1>{{ user.data()?.name }}</h1>
+        }
+    `,
+})
+export class ProfileComponent {
+    readonly id = input.required<string>();
+    // `id` is a signal — passing a getter re-fetches when it changes.
+    readonly user = injectStitch(getUser, () => ({
+        params: { id: this.id() },
+    }));
+}
+```
+
+## `injectStitchStream` — live deltas
+
+For a streaming stitch (an [`sse`](/docs/reference/surfaces) or `stream` surface),
+`injectStitchStream` updates as each chunk arrives. `chunks()` is the running list,
+`data()` is the accumulated array (`mode: 'append'`, default) or the latest chunk
+(`mode: 'replace'`), and `status()` is `'streaming'` until the terminal `result`,
+then `'success'`:
+
+```ts
+import { Component, input } from '@angular/core';
+import { injectStitchStream } from '@stitchapi/angular';
+import { sse } from 'stitchapi/sse';
+
+const chat = sse({ url: 'https://api.example.com/chat' });
+
+@Component({
+    selector: 'app-chat',
+    template: `
+        @for (c of tokens.chunks(); track $index) {
+            <span>{{ c }}</span>
+        }
+        @if (tokens.isStreaming()) {
+            <app-cursor />
+        }
+    `,
+})
+export class ChatComponent {
+    readonly prompt = input.required<string>();
+    readonly tokens = injectStitchStream(chat, () => ({
+        body: { prompt: this.prompt() },
+    }));
+}
+```
+
+Both functions return the same shape — `data`, `error`, `status`, `chunks`, and the
+`isPending` / `isError` / `isSuccess` / `isStreaming` flags (each a `Signal`), the
+`state$` observable, plus `refetch` and `cancel`.
+
+## The observable: `state$`
+
+Prefer RxJS? The same state is a multicast `Observable<StitchQueryState<T>>` on
+`state$`, sharing the one query execution with the signals. Read it with the
+`async` pipe:
+
+```ts
+import { AsyncPipe } from '@angular/common';
+import { Component, input } from '@angular/core';
+import { injectStitch } from '@stitchapi/angular';
+
+@Component({
+    selector: 'app-profile',
+    imports: [AsyncPipe],
+    template: `
+        @if (state$ | async; as s) {
+            @if (s.isSuccess) {
+                <h1>{{ s.data?.name }}</h1>
+            }
+        }
+    `,
+})
+export class ProfileComponent {
+    readonly id = input.required<string>();
+    readonly state$ = injectStitch(getUser, () => ({
+        params: { id: this.id() },
+    })).state$;
+}
+```
+
+## The shared store: `@stitchapi/query-core`
+
+The bindings hold almost no logic. All of it — running the call under an
+`AbortController`, publishing status transitions, folding `delta` chunks into
+state, `cancel()` by aborting, `refetch()` by re-running — lives in
+`@stitchapi/query-core`'s `createStitchQuery`, a `subscribe` / `getSnapshot`
+handle with **no framework imports** and **no `node:*`**, so it is browser- and
+edge-safe. Angular bridges it to an observable and derives the signals from that:
+
+```ts twoslash
+import { createStitchQuery } from '@stitchapi/query-core';
+import { stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const listUsers = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users',
+    output: z.array(z.object({ id: z.number(), name: z.string() })),
+});
+
+const query = createStitchQuery(listUsers, { query: { q: 'ada' } });
+const unsubscribe = query.subscribe(() => {
+    const snapshot = query.getSnapshot();
+    if (snapshot.isSuccess) console.log(snapshot.data);
+});
+```
+
+Because the whole reactive lifecycle lives in the store and not the binding, the
+[React](/docs/integrations/react), [Vue](/docs/integrations/vue), and
+[Svelte](/docs/integrations/svelte) bindings are the same few lines against their
+own reactive primitive — Angular's are `toSignal` + `toObservable`.
+
+## Optional: TanStack Query
+
+Already on [TanStack Query](/docs/integrations/tanstack-query)?
+`queryOptions(stitch, input)` returns a plain `{ queryKey, queryFn }` object you
+pass straight to `injectQuery` — it imports nothing from
+`@tanstack/angular-query-experimental`, so it works even if you never install it:
+
+```ts
+import { Component, input } from '@angular/core';
+import { queryOptions } from '@stitchapi/angular';
+import { injectQuery } from '@tanstack/angular-query-experimental';
+
+@Component({ selector: 'app-profile', template: `...` })
+export class ProfileComponent {
+    readonly id = input.required<string>();
+    readonly user = injectQuery(() =>
+        queryOptions(getUser, { params: { id: this.id() } }),
+    );
+}
+```
+
+<Callout type="info">
+    Reach for `queryOptions` when TanStack Query already owns your view state
+    and you want a stitch as the `queryFn`; reach for `injectStitch` /
+    `injectStitchStream` when you want StitchAPI to own the lifecycle directly —
+    especially for streaming, which `injectQuery` does not model. See the
+    [TanStack Query guide](/docs/integrations/tanstack-query) for how the two
+    layers split.
+</Callout>
+
+## See also
+
+<Cards>
+    <Card title="React" href="/docs/integrations/react" />
+    <Card title="Vue" href="/docs/integrations/vue" />
+    <Card title="Svelte" href="/docs/integrations/svelte" />
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+</Cards>

--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -50,16 +50,31 @@ an SSE helper, and an error bridge.
 
 ## Frontend
 
-The hooks and composables are a thin layer over the shared `@stitchapi/query-core`
-store, so updates are tearing-free and **streaming-first** — the view re-renders as
-each `delta` chunk arrives, which plain request/response query libraries don't
-model.
+Each binding is a thin layer over the shared `@stitchapi/query-core` store, so
+updates are tearing-free and **streaming-first** — the view re-renders as each
+`delta` chunk arrives, which plain request/response query libraries don't model.
+One core, one binding per framework's own reactive primitive.
 
 <Cards>
     <Card
         title="React"
         href="/docs/integrations/react"
-        description="Tearing-free useStitch / useStitchStream hooks over query-core, plus an optional TanStack Query adapter."
+        description="Tearing-free useStitch / useStitchStream hooks built on useSyncExternalStore."
+    />
+    <Card
+        title="Vue"
+        href="/docs/integrations/vue"
+        description="useStitch / useStitchStream composables backed by Vue 3 reactivity (refs)."
+    />
+    <Card
+        title="Svelte"
+        href="/docs/integrations/svelte"
+        description="stitchStore / stitchStreamStore — real Svelte stores, on Svelte 4 and 5."
+    />
+    <Card
+        title="Angular"
+        href="/docs/integrations/angular"
+        description="injectStitch / injectStitchStream exposed as both signals and an RxJS observable."
     />
     <Card
         title="TanStack Query"
@@ -80,6 +95,19 @@ model.
 
 For OpenTelemetry, core exports an OTLP trace bridge directly — see the
 [OTLP guide](/docs/guides/observability/otlp).
+
+## State &amp; storage
+
+Attach a `StitchStore` to move a stitch's throttle counters, sessions, and cache
+into a shared backend — fleet-wide, with no call-site change.
+
+<Cards>
+    <Card
+        title="Distributed stores"
+        href="/docs/integrations/stores"
+        description="Redis (+ Upstash edge), Cloudflare Workers KV, and Deno KV drivers — with the atomic-incr trade-off that decides which fits."
+    />
+</Cards>
 
 ## See also
 

--- a/apps/docs/content/docs/integrations/meta.json
+++ b/apps/docs/content/docs/integrations/meta.json
@@ -8,6 +8,7 @@
         "react",
         "vue",
         "svelte",
+        "angular",
         "tanstack-query",
         "pino",
         "stores"

--- a/packages/angular/LICENSE
+++ b/packages/angular/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,0 +1,124 @@
+# @stitchapi/angular
+
+Angular bindings for [StitchAPI](https://stitchapi.dev). `injectStitch` / `injectStitchStream` expose a stitch's lifecycle as **both Angular signals and an RxJS observable** from one shared execution, plus an optional [TanStack Query](https://tanstack.com/query) adapter.
+
+**Streaming-first.** A `stitch` can stream (`sse` / `stream` surfaces) — `injectStitchStream` surfaces each `delta` chunk as it arrives. That's the differentiator over plain request/response query libraries.
+
+These functions are a thin layer over [`@stitchapi/query-core`](../query-core), the framework-agnostic store that owns the reactive lifecycle. React / Vue / Svelte / Solid bindings are the same few lines against their own reactive primitive.
+
+## Install
+
+```sh
+pnpm add @stitchapi/angular @stitchapi/query-core stitchapi @angular/core rxjs
+```
+
+`stitchapi`, `@angular/core` (`>=16`), and `rxjs` (`>=7`) are peer dependencies. `@tanstack/angular-query-experimental` is an **optional** peer — only needed if you use `queryOptions`.
+
+## `injectStitch` — request / response
+
+Call it in an injection context (a component field initializer). Pass the input as a **signal or getter** so the query re-fetches when it changes; read the result's signals in the template.
+
+```ts
+import { Component, input } from '@angular/core';
+import { injectStitch } from '@stitchapi/angular';
+import { stitch } from 'stitchapi';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+});
+
+@Component({
+    selector: 'app-profile',
+    template: `
+        @if (user.isPending()) {
+            <app-spinner />
+        } @else if (user.isError()) {
+            <button (click)="user.refetch()">Retry</button>
+        } @else {
+            <h1>{{ user.data()?.name }}</h1>
+        }
+    `,
+})
+export class ProfileComponent {
+    readonly id = input.required<string>();
+    readonly user = injectStitch(getUser, () => ({
+        params: { id: this.id() },
+    }));
+}
+```
+
+The query is recreated (and re-fetched) when the input signal changes. The in-flight run is aborted when the component is destroyed.
+
+## `injectStitchStream` — live deltas
+
+```ts
+import { Component, input } from '@angular/core';
+import { injectStitchStream } from '@stitchapi/angular';
+import { sse } from 'stitchapi/sse';
+
+const chat = sse({ url: 'https://api.example.com/chat' });
+
+@Component({
+    selector: 'app-chat',
+    template: `
+        @for (c of tokens.chunks(); track $index) {
+            <span>{{ c }}</span>
+        }
+        @if (tokens.isStreaming()) {
+            <app-cursor />
+        }
+    `,
+})
+export class ChatComponent {
+    readonly prompt = input.required<string>();
+    readonly tokens = injectStitchStream(chat, () => ({
+        body: { prompt: this.prompt() },
+    }));
+}
+```
+
+Same shape as `injectStitch`. `data()` is the accumulated chunks (`mode: 'append'`, default) or the latest chunk (`mode: 'replace'`); `chunks()` is the running list; `status()` is `'streaming'` until the terminal `result`, then `'success'`.
+
+## Both signals and an observable
+
+Every result exposes the same state two ways, from **one shared query execution**:
+
+```ts
+interface InjectStitchResult<T> {
+    // signals
+    state: Signal<StitchQueryState<T>>;
+    data: Signal<T | undefined>;
+    error: Signal<unknown>;
+    status: Signal<'idle' | 'pending' | 'streaming' | 'success' | 'error'>;
+    chunks: Signal<readonly unknown[]>;
+    isPending: Signal<boolean>;
+    isError: Signal<boolean>;
+    isSuccess: Signal<boolean>;
+    isStreaming: Signal<boolean>;
+    // observable — for the async pipe / RxJS operators
+    state$: Observable<StitchQueryState<T>>;
+    // imperative
+    refetch: () => void;
+    cancel: () => void;
+}
+```
+
+Read `user.data()` in a template, or `user.state$ | async` if you prefer RxJS — both reflect the same run.
+
+## Optional: TanStack Query
+
+`queryOptions(stitch, input)` returns a plain `{ queryKey, queryFn }` object — no import of `@tanstack/angular-query-experimental` required, so it works even if you never install it.
+
+```ts
+import { injectQuery } from '@tanstack/angular-query-experimental';
+import { queryOptions } from '@stitchapi/angular';
+
+readonly user = injectQuery(() =>
+    queryOptions(getUser, { params: { id: this.id() } }),
+);
+```
+
+## License
+
+Apache-2.0

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,0 +1,83 @@
+{
+    "name": "@stitchapi/angular",
+    "version": "1.0.0-rc.2",
+    "type": "commonjs",
+    "description": "Angular bindings for StitchAPI — injectStitch/injectStitchStream expose a stitch's lifecycle as both signals and an RxJS observable over @stitchapi/query-core. Streaming-first: re-render as `delta` chunks arrive. Plus an optional TanStack Query queryOptions helper.",
+    "main": "lib/index.js",
+    "module": "lib/index.mjs",
+    "types": "lib/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./lib/index.d.mts",
+                "default": "./lib/index.mjs"
+            },
+            "require": {
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
+            }
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "lib"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsup",
+        "test": "vitest run",
+        "check:types": "tsc --noEmit",
+        "prepack": "tsup",
+        "prepublishOnly": "node ../../scripts/check-release.mjs --changelog"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rejifald/StitchAPI.git",
+        "directory": "packages/angular"
+    },
+    "keywords": [
+        "stitchapi",
+        "angular",
+        "signals",
+        "rxjs",
+        "streaming",
+        "query",
+        "tanstack-query"
+    ],
+    "author": "Oleksandr Zhuravlov (rejifald@gmail.com)",
+    "license": "Apache-2.0",
+    "homepage": "https://stitchapi.dev",
+    "engines": {
+        "node": ">=18.18.0"
+    },
+    "peerDependencies": {
+        "@angular/core": ">=16.0.0",
+        "@stitchapi/query-core": "^1.0.0-rc.2",
+        "@tanstack/angular-query-experimental": ">=5.0.0",
+        "rxjs": ">=7.0.0",
+        "stitchapi": "^1.0.0-rc.1"
+    },
+    "peerDependenciesMeta": {
+        "@tanstack/angular-query-experimental": {
+            "optional": true
+        }
+    },
+    "devDependencies": {
+        "@angular/common": "^19.2.0",
+        "@angular/compiler": "^19.2.0",
+        "@angular/core": "^19.2.0",
+        "@angular/platform-browser": "^19.2.0",
+        "@angular/platform-browser-dynamic": "^19.2.0",
+        "@stitchapi/query-core": "workspace:*",
+        "@types/node": "^22.10.0",
+        "jsdom": "^25.0.1",
+        "rxjs": "^7.8.0",
+        "stitchapi": "workspace:*",
+        "tsup": "^8.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.8",
+        "zone.js": "~0.15.0"
+    }
+}

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,0 +1,329 @@
+// @stitchapi/angular — Angular bindings for StitchAPI.
+//
+// These functions are a THIN layer over `@stitchapi/query-core`: that package
+// owns the reactive store (subscribe / getSnapshot / refetch / cancel), and
+// Angular consumes it as BOTH a signal and an RxJS observable, from one shared
+// execution. Because all the behaviour lives in the framework-agnostic core, the
+// React / Vue / Svelte / Solid bindings are the same few lines against their own
+// reactive primitive.
+//
+// - `injectStitch`       — the unary request/response primitive.
+// - `injectStitchStream` — the streaming primitive: emits as `delta` chunks
+//                          arrive. This is the differentiator over plain
+//                          request/response query libraries.
+// - `queryOptions`       — an OPTIONAL TanStack Query adapter (returns a plain
+//                          POJO, so it needs no import of the Angular adapter).
+//
+// The observable is the bridge off the store; the signal is derived from it via
+// `toSignal`, so a single query feeds both. `state$` and the signals share one
+// execution (multicast), and the run is torn down with the injection context.
+import {
+    DestroyRef,
+    Injector,
+    type Signal,
+    assertInInjectionContext,
+    computed,
+    inject,
+} from '@angular/core';
+import {
+    takeUntilDestroyed,
+    toObservable,
+    toSignal,
+} from '@angular/core/rxjs-interop';
+import {
+    type CreateStitchQueryOptions,
+    type QueryInput,
+    type QueryOutput,
+    type StitchLike,
+    type StitchQuery,
+    type StitchQueryState,
+    type StitchQueryStatus,
+    createStitchQuery,
+} from '@stitchapi/query-core';
+import { Observable, of } from 'rxjs';
+import { shareReplay, switchMap } from 'rxjs/operators';
+
+export type {
+    CreateStitchQueryOptions,
+    QueryInput,
+    QueryOutput,
+    StitchLike,
+    StitchQuery,
+    StitchQueryState,
+    StitchQueryStatus,
+} from '@stitchapi/query-core';
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+
+/** A value, a `Signal` of it, or a zero-arg getter — Angular's idiom for "static
+ * or reactive". Passing a signal/getter recreates the query (and re-fetches) when
+ * the tracked value changes; a plain value is read once. */
+export type InjectInput<T> = T | Signal<T> | (() => T);
+
+export interface InjectStitchOptions<T> extends CreateStitchQueryOptions<T> {
+    /** Injection context to use when `injectStitch` is called outside one (e.g. a
+     * test, or a non-injection callback). Defaults to the ambient context. */
+    injector?: Injector;
+}
+
+/** What `injectStitch` / `injectStitchStream` return: the reactive state exposed
+ * BOTH as fine-grained signals AND as an RxJS observable (`state$`), from one
+ * shared query execution, plus the imperative `refetch` / `cancel` handles. */
+export interface InjectStitchResult<T> {
+    /** The whole snapshot as a signal — read `state().data` etc. in a template or
+     * `computed`. */
+    readonly state: Signal<StitchQueryState<T>>;
+    /** The validated output (unary) or the latest streamed value (streaming). */
+    readonly data: Signal<T | undefined>;
+    /** The thrown reason on failure. */
+    readonly error: Signal<unknown>;
+    /** The lifecycle status. */
+    readonly status: Signal<StitchQueryStatus>;
+    /** Accumulated `delta` chunks, in arrival order. */
+    readonly chunks: Signal<readonly unknown[]>;
+    /** `status === 'pending'`. */
+    readonly isPending: Signal<boolean>;
+    /** `status === 'error'`. */
+    readonly isError: Signal<boolean>;
+    /** `status === 'success'`. */
+    readonly isSuccess: Signal<boolean>;
+    /** `status === 'streaming'`. */
+    readonly isStreaming: Signal<boolean>;
+    /** The same state as an observable — for the `async` pipe / RxJS consumers.
+     * Multicast: it shares the one query execution with the signals above. */
+    readonly state$: Observable<StitchQueryState<T>>;
+    /** Abort the in-flight run and re-run from scratch. */
+    refetch: () => void;
+    /** Abort the in-flight run, if any. */
+    cancel: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Shared driver
+// ---------------------------------------------------------------------------
+
+// The store's seed value, surfaced before the first real snapshot (an instant).
+// It matches core's idle snapshot exactly so the signals are well-formed from the
+// start.
+const IDLE_STATE: StitchQueryState<unknown> = {
+    status: 'idle',
+    data: undefined,
+    error: undefined,
+    chunks: [],
+    isPending: false,
+    isError: false,
+    isSuccess: false,
+    isStreaming: false,
+};
+
+/** Turn the reactive (or static) input into an observable of the current value.
+ * A signal/getter becomes a `toObservable(computed(...))` that re-emits on change;
+ * a plain value becomes a single-shot `of(value)`. */
+function inputObservable<I>(
+    input: InjectInput<I>,
+    injector: Injector,
+): Observable<I> {
+    if (typeof input === 'function') {
+        // A Signal is itself a getter, so both `Signal<I>` and `() => I` flow
+        // through here; `computed` tracks any signals read inside.
+        const source = computed(() => (input as () => I)());
+        return toObservable(source, { injector });
+    }
+    return of(input as I);
+}
+
+function injectStitchInternal<T>(
+    stitch: StitchLike<T, unknown>,
+    input: InjectInput<unknown>,
+    options: InjectStitchOptions<T>,
+    stream: boolean,
+): InjectStitchResult<T> {
+    if (!options.injector) assertInInjectionContext(injectStitch);
+    const injector = options.injector ?? inject(Injector);
+    const destroyRef = injector.get(DestroyRef);
+
+    const { mode, enabled, onSuccess, onError } = options;
+    const coreOptions: CreateStitchQueryOptions<T> & { stream: boolean } = {
+        stream,
+        ...(mode ? { mode } : {}),
+        ...(enabled !== undefined ? { enabled } : {}),
+        ...(onSuccess ? { onSuccess } : {}),
+        ...(onError ? { onError } : {}),
+    };
+
+    // The live query handle, captured for the imperative refetch/cancel. It is
+    // reassigned whenever the input changes (switchMap tears down the old one).
+    let current: StitchQuery<T> | undefined;
+
+    const state$ = inputObservable(input, injector).pipe(
+        // Recreate the handle on each input value; the inner Observable owns the
+        // store subscription and tears the handle down on unsubscribe.
+        switchMap(
+            (value) =>
+                new Observable<StitchQueryState<T>>((subscriber) => {
+                    const handle = createStitchQuery<T, unknown>(
+                        stitch,
+                        value,
+                        coreOptions,
+                    );
+                    current = handle;
+                    subscriber.next(handle.getSnapshot());
+                    const off = handle.subscribe(() =>
+                        subscriber.next(handle.getSnapshot()),
+                    );
+                    return () => {
+                        off();
+                        handle.destroy();
+                        if (current === handle) current = undefined;
+                    };
+                }),
+        ),
+        // Complete (and tear down the store) when the injection context dies.
+        takeUntilDestroyed(destroyRef),
+        // One execution shared by the signal AND any `async`-pipe consumers.
+        shareReplay({ bufferSize: 1, refCount: true }),
+    );
+
+    const state = toSignal(state$, {
+        initialValue: IDLE_STATE as StitchQueryState<T>,
+        injector,
+    });
+
+    return {
+        state,
+        data: computed(() => state().data),
+        error: computed(() => state().error),
+        status: computed(() => state().status),
+        chunks: computed(() => state().chunks),
+        isPending: computed(() => state().isPending),
+        isError: computed(() => state().isError),
+        isSuccess: computed(() => state().isSuccess),
+        isStreaming: computed(() => state().isStreaming),
+        state$,
+        refetch: () => current?.refetch(),
+        cancel: () => current?.cancel(),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// injectStitch — unary
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a stitch as a request/response query, exposed as Angular signals and an
+ * RxJS observable from one shared execution. Call it in an injection context
+ * (a component/directive field initializer, or `runInInjectionContext`); read
+ * `result.data()` in a template, or `result.state$ | async`.
+ *
+ * `input` may be a plain value (read once) or a `Signal` / getter (`() =>
+ * this.id()`) — when its value changes the query is recreated and re-fetched.
+ * The in-flight run is aborted when the injection context is destroyed.
+ *
+ * @example
+ * ```ts
+ * readonly user = injectStitch(getUser, () => ({ params: { id: this.id() } }));
+ * // template: @if (user.isPending()) { ... } @else { {{ user.data()?.name }} }
+ * ```
+ */
+export function injectStitch<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    input: InjectInput<QueryInput<S>>,
+    options?: InjectStitchOptions<QueryOutput<S>>,
+): InjectStitchResult<QueryOutput<S>>;
+export function injectStitch<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    input: InjectInput<Input>,
+    options?: InjectStitchOptions<T>,
+): InjectStitchResult<T>;
+export function injectStitch<T>(
+    stitch: StitchLike<T, unknown>,
+    input: InjectInput<unknown>,
+    options: InjectStitchOptions<T> = {},
+): InjectStitchResult<T> {
+    return injectStitchInternal<T>(stitch, input, options, false);
+}
+
+// ---------------------------------------------------------------------------
+// injectStitchStream — streaming
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a streaming stitch (an `sse` / `stream` surface) and surface each `delta`
+ * chunk as it arrives, as signals and an observable. Same shape as {@link
+ * injectStitch}; `data()` is the accumulated chunks (`mode: 'append'`, default)
+ * or the latest chunk (`mode: 'replace'`), `chunks()` is the running list, and
+ * `status()` is `'streaming'` until the terminal `result`, then `'success'`.
+ *
+ * @example
+ * ```ts
+ * readonly chat = injectStitchStream(stream, () => ({ body: { prompt: this.prompt() } }));
+ * // template: @for (c of chat.chunks(); track $index) { <span>{{ c }}</span> }
+ * ```
+ */
+export function injectStitchStream<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    input: InjectInput<QueryInput<S>>,
+    options?: InjectStitchOptions<QueryOutput<S>>,
+): InjectStitchResult<QueryOutput<S>>;
+export function injectStitchStream<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    input: InjectInput<Input>,
+    options?: InjectStitchOptions<T>,
+): InjectStitchResult<T>;
+export function injectStitchStream<T>(
+    stitch: StitchLike<T, unknown>,
+    input: InjectInput<unknown>,
+    options: InjectStitchOptions<T> = {},
+): InjectStitchResult<T> {
+    return injectStitchInternal<T>(stitch, input, options, true);
+}
+
+// ---------------------------------------------------------------------------
+// queryOptions — optional TanStack Query adapter
+// ---------------------------------------------------------------------------
+
+// IDENTICAL to the other bindings' `queryOptions` (no framework import) — the
+// POJO shape `@tanstack/angular-query-experimental`'s `injectQuery(() => ...)`
+// consumes is the same `{ queryKey, queryFn }` TanStack uses everywhere.
+
+/** The plain object {@link queryOptions} returns — structurally compatible with
+ * TanStack Query's options without importing the library. */
+export interface StitchQueryOptions<T> {
+    queryKey: readonly unknown[];
+    queryFn: (ctx?: { signal?: AbortSignal }) => Promise<T>;
+}
+
+/**
+ * Build a TanStack-Query-compatible options object for a stitch, WITHOUT a hard
+ * dependency on `@tanstack/angular-query-experimental` — it just returns a POJO:
+ *
+ * ```ts
+ * import { injectQuery } from '@tanstack/angular-query-experimental';
+ * import { queryOptions } from '@stitchapi/angular';
+ *
+ * readonly user = injectQuery(() => queryOptions(getUser, { params: { id: this.id() } }));
+ * ```
+ *
+ * The `queryFn` awaits the stitch (the validated output); the `queryKey` is the
+ * stitch's `name` (when present) plus the input, so TanStack caches per call.
+ */
+export function queryOptions<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    input: QueryInput<S>,
+): StitchQueryOptions<QueryOutput<S>>;
+export function queryOptions<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    input: Input,
+): StitchQueryOptions<T>;
+export function queryOptions<T>(
+    stitch: StitchLike<T, unknown>,
+    input: unknown,
+): StitchQueryOptions<T> {
+    const name = (stitch as { __config?: { name?: string } }).__config?.name;
+    return {
+        queryKey: [name ?? 'stitch', input ?? null],
+        queryFn: () => Promise.resolve(stitch(input)),
+    };
+}

--- a/packages/angular/test/bindings.spec.ts
+++ b/packages/angular/test/bindings.spec.ts
@@ -1,0 +1,267 @@
+// @stitchapi/angular behaviour, driven inside Angular's TestBed injection context
+// in a jsdom env. Driven by FAKE stitches — no engine, no network. Each binding is
+// created in `TestBed.runInInjectionContext`, and the module is reset between tests
+// to exercise context teardown.
+import { injectStitch, injectStitchStream, queryOptions } from '../src';
+
+import { ApplicationRef, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import type { StitchCallResult, StitchLike } from '@stitchapi/query-core';
+import type { StitchEvent } from 'stitchapi';
+import { afterEach, describe, expect, test } from 'vitest';
+
+// --- fakes -----------------------------------------------------------------
+
+/** A unary stitch: resolves (or rejects) after a tick, ignoring streaming. */
+function unaryStitch<T>(
+    settle: (input: unknown) => Promise<T>,
+    config?: { name?: string },
+): StitchLike<T> {
+    const fn = (input?: unknown): StitchCallResult<T> => {
+        const promise = settle(input);
+        return {
+            then: (onf, onr) => promise.then(onf, onr),
+            stream() {
+                return (async function* () {
+                    const value = await promise;
+                    yield {
+                        type: 'result',
+                        value,
+                        status: 200,
+                        attempts: 1,
+                        at: 0,
+                    } satisfies StitchEvent<T>;
+                })();
+            },
+        };
+    };
+    if (config) (fn as { __config?: unknown }).__config = config;
+    return fn;
+}
+
+/** A streaming stitch: emits the given events from `.stream()`; `await` resolves
+ * to the terminal `result` value (mirrors core's `StitchResult`). */
+function streamStitch<T>(events: StitchEvent<T>[]): StitchLike<T> {
+    return (): StitchCallResult<T> => {
+        const terminal = events.find((e) => e.type === 'result');
+        const value =
+            terminal && terminal.type === 'result'
+                ? terminal.value
+                : (undefined as T);
+        const promise = Promise.resolve(value);
+        return {
+            then: (onf, onr) => promise.then(onf, onr),
+            stream() {
+                return (async function* () {
+                    for (const e of events) {
+                        await Promise.resolve();
+                        yield e;
+                    }
+                })();
+            },
+        };
+    };
+}
+
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+const drain = (): Promise<void> => new Promise((r) => setTimeout(r, 15));
+
+/** Run a factory in the TestBed injection context. */
+function run<T>(fn: () => T): T {
+    return TestBed.runInInjectionContext(fn);
+}
+
+/** Flush Angular's effect queue (so a signal-driven `toObservable` re-emits). */
+function flush(): void {
+    TestBed.inject(ApplicationRef).tick();
+}
+
+afterEach(() => {
+    TestBed.resetTestingModule();
+});
+
+// --- injectStitch (unary) --------------------------------------------------
+
+describe('injectStitch', () => {
+    test('moves pending → success across the signals', async () => {
+        const stitch = unaryStitch(async () => ({ name: 'Ada' }));
+        const result = run(() => injectStitch(stitch, { params: { id: '1' } }));
+
+        expect(result.status()).toBe('pending');
+        expect(result.isPending()).toBe(true);
+
+        await tick();
+        expect(result.status()).toBe('success');
+        expect(result.isSuccess()).toBe(true);
+        expect(result.data()).toEqual({ name: 'Ada' });
+    });
+
+    test('lands on error with the thrown reason', async () => {
+        const boom = new Error('nope');
+        const stitch = unaryStitch<{ name: string }>(async () => {
+            throw boom;
+        });
+        const result = run(() => injectStitch(stitch, {}));
+
+        await tick();
+        expect(result.status()).toBe('error');
+        expect(result.isError()).toBe(true);
+        expect(result.error()).toBe(boom);
+    });
+
+    test('refetch re-runs the call', async () => {
+        let n = 0;
+        const stitch = unaryStitch(async () => ({ name: `v${++n}` }));
+        const result = run(() => injectStitch(stitch, {}));
+
+        await tick();
+        expect(result.data()).toEqual({ name: 'v1' });
+
+        result.refetch();
+        expect(result.status()).toBe('pending');
+        await tick();
+        expect(result.data()).toEqual({ name: 'v2' });
+    });
+
+    test('a reactive signal input recreates the handle and re-fetches', async () => {
+        const stitch = unaryStitch(async (input) => ({
+            name: `id-${(input as { params: { id: string } }).params.id}`,
+        }));
+        const id = signal('1');
+        const result = run(() =>
+            injectStitch(stitch, () => ({ params: { id: id() } })),
+        );
+
+        await tick();
+        expect(result.data()).toEqual({ name: 'id-1' });
+
+        id.set('2');
+        flush(); // let the input signal's toObservable re-emit
+        await tick();
+        expect(result.data()).toEqual({ name: 'id-2' });
+    });
+
+    test('cancel aborts the run: a late resolution does not publish success', async () => {
+        let resolveIt: (v: string) => void = () => {};
+        const stitch: StitchLike<string> = () => {
+            const promise = new Promise<string>((res) => {
+                resolveIt = res;
+            });
+            return {
+                then: (onf, onr) => promise.then(onf, onr),
+                stream() {
+                    return (async function* () {})() as never;
+                },
+            };
+        };
+        const result = run(() => injectStitch(stitch, undefined));
+        expect(result.status()).toBe('pending');
+
+        result.cancel();
+        resolveIt('late');
+        await tick();
+        expect(result.status()).toBe('pending'); // never advanced
+        expect(result.data()).toBeUndefined();
+    });
+});
+
+// --- injectStitchStream ----------------------------------------------------
+
+describe('injectStitchStream', () => {
+    test('reconciles delta chunks as they arrive, then settles success', async () => {
+        const events: StitchEvent<number[]>[] = [
+            { type: 'delta', chunk: 1, at: 0 },
+            { type: 'delta', chunk: 2, at: 0 },
+            { type: 'delta', chunk: 3, at: 0 },
+            {
+                type: 'result',
+                value: [1, 2, 3],
+                status: 200,
+                attempts: 1,
+                at: 0,
+            },
+            { type: 'done', ok: true, ms: 1, attempts: 1, at: 0 },
+        ];
+        const result = run(() =>
+            injectStitchStream(streamStitch(events), undefined),
+        );
+
+        await drain();
+        expect(result.status()).toBe('success');
+        expect(result.chunks()).toEqual([1, 2, 3]);
+        expect(result.data()).toEqual([1, 2, 3]);
+    });
+
+    test('replace mode keeps only the latest chunk as data', async () => {
+        const events: StitchEvent<number>[] = [
+            { type: 'delta', chunk: 10, at: 0 },
+            { type: 'delta', chunk: 20, at: 0 },
+            { type: 'result', value: 20, status: 200, attempts: 1, at: 0 },
+        ];
+        const result = run(() =>
+            injectStitchStream(streamStitch(events), undefined, {
+                mode: 'replace',
+            }),
+        );
+        await drain();
+        expect(result.data()).toBe(20);
+        expect(result.chunks()).toEqual([]);
+        expect(result.status()).toBe('success');
+    });
+
+    test('a streamed error event lands on error status', async () => {
+        const events: StitchEvent<number>[] = [
+            { type: 'delta', chunk: 1, at: 0 },
+            {
+                type: 'error',
+                name: 'StitchError',
+                message: 'mid-stream failure',
+                attempts: 1,
+                at: 0,
+            },
+        ];
+        const result = run(() =>
+            injectStitchStream(streamStitch(events), undefined),
+        );
+        await drain();
+        expect(result.status()).toBe('error');
+        expect((result.error() as Error).message).toBe('mid-stream failure');
+    });
+});
+
+// --- the observable surface ------------------------------------------------
+
+describe('state$', () => {
+    test('emits the same snapshots as the signals (one shared execution)', async () => {
+        const stitch = unaryStitch(async () => ({ ok: true }));
+        const result = run(() => injectStitch(stitch, {}));
+
+        const statuses: string[] = [];
+        const sub = result.state$.subscribe((s) => statuses.push(s.status));
+
+        await tick();
+        expect(statuses).toContain('success');
+        // The observable mirrors the signal — same terminal state.
+        expect(result.isSuccess()).toBe(true);
+        sub.unsubscribe();
+    });
+});
+
+// --- queryOptions ----------------------------------------------------------
+
+describe('queryOptions', () => {
+    test('returns a TanStack-shaped POJO with key + async queryFn', async () => {
+        const stitch = unaryStitch(async () => ({ ok: true }), {
+            name: 'getThing',
+        });
+        const opts = queryOptions(stitch, { params: { id: '7' } });
+        expect(opts.queryKey).toEqual(['getThing', { params: { id: '7' } }]);
+        await expect(opts.queryFn()).resolves.toEqual({ ok: true });
+    });
+
+    test('falls back to "stitch" when no __config.name', () => {
+        const stitch = unaryStitch(async () => 1);
+        const opts = queryOptions(stitch, null);
+        expect(opts.queryKey[0]).toBe('stitch');
+    });
+});

--- a/packages/angular/test/setup.ts
+++ b/packages/angular/test/setup.ts
@@ -1,0 +1,15 @@
+// One-time Angular test-environment bootstrap (zone.js + the JIT testing
+// platform), so `TestBed` works under vitest's node/jsdom runner.
+import '@angular/compiler';
+import { getTestBed } from '@angular/core/testing';
+import {
+    BrowserDynamicTestingModule,
+    platformBrowserDynamicTesting,
+} from '@angular/platform-browser-dynamic/testing';
+import 'zone.js';
+import 'zone.js/testing';
+
+getTestBed().initTestEnvironment(
+    BrowserDynamicTestingModule,
+    platformBrowserDynamicTesting(),
+);

--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -1,0 +1,35 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM"],
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "exactOptionalPropertyTypes": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "verbatimModuleSyntax": true,
+        "isolatedModules": true,
+
+        "experimentalDecorators": true,
+        "useDefineForClassFields": false,
+
+        "types": ["node", "vitest/globals"],
+
+        "baseUrl": ".",
+        "paths": {
+            "stitchapi/testing": ["../core/src/testing.ts"],
+            "stitchapi": ["../core/src/index.ts"],
+            "@stitchapi/query-core": ["../query-core/src/index.ts"]
+        }
+    },
+    "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/angular/tsup.config.ts
+++ b/packages/angular/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+// Single dual-format entry. `@angular/*`, `rxjs`, and `stitchapi` are peer deps
+// (externalised by tsup); `@stitchapi/query-core` is a runtime dep and is also
+// kept external so the Angular bindings stay a thin layer over it.
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    minify: true,
+    outDir: 'lib',
+    clean: true,
+    // Keep Angular and RxJS (and their subpaths, e.g. `@angular/core/rxjs-interop`,
+    // `rxjs/operators`) external so we never bundle a framework runtime.
+    external: ['@stitchapi/query-core', /^@angular\//, /^rxjs(\/|$)/],
+});

--- a/packages/angular/vitest.config.ts
+++ b/packages/angular/vitest.config.ts
@@ -1,0 +1,33 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+// Alias the workspace packages to their SOURCE (more specific subpaths first), so
+// tests run without `stitchapi` / `@stitchapi/query-core` being built. Mirrors
+// tsconfig `paths`.
+const core = (p: string): string =>
+    fileURLToPath(new URL(`../core/src/${p}`, import.meta.url));
+const queryCore = (): string =>
+    fileURLToPath(new URL('../query-core/src/index.ts', import.meta.url));
+
+export default defineConfig({
+    resolve: {
+        alias: [
+            { find: /^stitchapi\/testing$/, replacement: core('testing.ts') },
+            { find: /^stitchapi$/, replacement: core('index.ts') },
+            { find: /^@stitchapi\/query-core$/, replacement: queryCore() },
+        ],
+    },
+    test: {
+        globals: true,
+        // Angular's TestBed needs a DOM; jsdom is enough (we drive signals by
+        // hand, no rendering).
+        environment: 'jsdom',
+        // Initialise the Angular test environment once (zone.js + TestBed).
+        setupFiles: ['./test/setup.ts'],
+        include: ['test/**/*.spec.ts'],
+        // Angular and RxJS ship ESM with package `exports`; force vitest to
+        // transform them so their entry points (incl. `@angular/core/rxjs-interop`)
+        // resolve under the node test runner.
+        server: { deps: { inline: [/^@angular\//, /^rxjs/, /^zone\.js/] } },
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,55 @@ importers:
         specifier: ^19.2.7
         version: 19.2.7
 
+  packages/angular:
+    dependencies:
+      '@tanstack/angular-query-experimental':
+        specifier: '>=5.0.0'
+        version: 5.101.0(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))
+    devDependencies:
+      '@angular/common':
+        specifier: ^19.2.0
+        version: 19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/compiler':
+        specifier: ^19.2.0
+        version: 19.2.25
+      '@angular/core':
+        specifier: ^19.2.0
+        version: 19.2.25(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/platform-browser':
+        specifier: ^19.2.0
+        version: 19.2.25(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))
+      '@angular/platform-browser-dynamic':
+        specifier: ^19.2.0
+        version: 19.2.25(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.25)(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.25(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1)))
+      '@stitchapi/query-core':
+        specifier: workspace:*
+        version: link:../query-core
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.21
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+      rxjs:
+        specifier: ^7.8.0
+        version: 7.8.2
+      stitchapi:
+        specifier: workspace:*
+        version: link:../core
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+      zone.js:
+        specifier: ~0.15.0
+        version: 0.15.1
+
   packages/cloudflare-kv:
     devDependencies:
       '@types/node':
@@ -755,6 +804,44 @@ packages:
 
   '@andrewbranch/untar.js@1.0.3':
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
+
+  '@angular/common@19.2.25':
+    resolution: {integrity: sha512-WteFLyfDPvilzpSGHk64bqowa4NnHdbjNl1xXeGr038fgTjp0l0NdiUPqeDtYT4pf5lWl6477pPoQN7o//NyyQ==}
+    engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
+    peerDependencies:
+      '@angular/core': 19.2.25
+      rxjs: ^6.5.3 || ^7.4.0
+
+  '@angular/compiler@19.2.25':
+    resolution: {integrity: sha512-GGEeTTd/DV71E07K0u5753bxXozc6Z7iWaCZJDW7xiA7hdHCwrYBMz1PVUJAtXcxf4wTdiXQR48kw8/YHYnDAw==}
+    engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
+
+  '@angular/core@19.2.25':
+    resolution: {integrity: sha512-j7/irbbdO4rmZfRXS+sphCerzgcRlpGFwxHc/76Ual+ckwJG0MPsNFkllz2SIEZzE1EZkmIunGrHbjeRBJjyvg==}
+    engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
+    peerDependencies:
+      rxjs: ^6.5.3 || ^7.4.0
+      zone.js: ~0.15.0
+
+  '@angular/platform-browser-dynamic@19.2.25':
+    resolution: {integrity: sha512-T6LK+NH6VR0bNKepN6urSHPE86OxbIMvgm855W06YjXvK7cMotPCC+N10zv7M8zQRZtQ7WBkY0EGpC8qLrao0g==}
+    engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
+    peerDependencies:
+      '@angular/common': 19.2.25
+      '@angular/compiler': 19.2.25
+      '@angular/core': 19.2.25
+      '@angular/platform-browser': 19.2.25
+
+  '@angular/platform-browser@19.2.25':
+    resolution: {integrity: sha512-UF7cyBnMF3puA/cGy3MXbiPB2Rlw0Umf78XH664Iwqsb37A+TxqzOPaByXsNTIbpV6/h28yO3dMvDVFT3aOvOA==}
+    engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0}
+    peerDependencies:
+      '@angular/animations': 19.2.25
+      '@angular/common': 19.2.25
+      '@angular/core': 19.2.25
+    peerDependenciesMeta:
+      '@angular/animations':
+        optional: true
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
@@ -2391,11 +2478,20 @@ packages:
   '@tailwindcss/postcss@4.3.0':
     resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
 
+  '@tanstack/angular-query-experimental@5.101.0':
+    resolution: {integrity: sha512-UTqugLpQPEkFgdqyhA7VlsGbsyhB+h73RyYVpNVGXzqL8N4dlsrzWND1KrD1Oa4Uce4k1hSkIisS+5EmzPKeHA==}
+    peerDependencies:
+      '@angular/common': '>=16.0.0'
+      '@angular/core': '>=16.0.0'
+
   '@tanstack/query-core@5.101.0':
     resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
 
   '@tanstack/query-core@5.90.2':
     resolution: {integrity: sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==}
+
+  '@tanstack/query-devtools@5.101.0':
+    resolution: {integrity: sha512-MVqw17k08RQtGGLEL654+dX/btbX9p/8WjkznO//zusLTMaObxi3Q+MoFwGVkC9K3tqjn8qrrNhJevXx4fJTeQ==}
 
   '@tanstack/react-query@5.101.0':
     resolution: {integrity: sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==}
@@ -6638,6 +6734,9 @@ packages:
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
+  zone.js@0.15.1:
+    resolution: {integrity: sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -6646,6 +6745,36 @@ snapshots:
   '@alloc/quick-lru@5.2.0': {}
 
   '@andrewbranch/untar.js@1.0.3': {}
+
+  '@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)':
+    dependencies:
+      '@angular/core': 19.2.25(rxjs@7.8.2)(zone.js@0.15.1)
+      rxjs: 7.8.2
+      tslib: 2.8.1
+
+  '@angular/compiler@19.2.25':
+    dependencies:
+      tslib: 2.8.1
+
+  '@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1)':
+    dependencies:
+      rxjs: 7.8.2
+      tslib: 2.8.1
+      zone.js: 0.15.1
+
+  '@angular/platform-browser-dynamic@19.2.25(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@19.2.25)(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@19.2.25(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1)))':
+    dependencies:
+      '@angular/common': 19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/compiler': 19.2.25
+      '@angular/core': 19.2.25(rxjs@7.8.2)(zone.js@0.15.1)
+      '@angular/platform-browser': 19.2.25(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))
+      tslib: 2.8.1
+
+  '@angular/platform-browser@19.2.25(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))':
+    dependencies:
+      '@angular/common': 19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/core': 19.2.25(rxjs@7.8.2)(zone.js@0.15.1)
+      tslib: 2.8.1
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
@@ -8070,9 +8199,20 @@ snapshots:
       postcss: 8.5.15
       tailwindcss: 4.3.0
 
+  '@tanstack/angular-query-experimental@5.101.0(@angular/common@19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))':
+    dependencies:
+      '@angular/common': 19.2.25(@angular/core@19.2.25(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
+      '@angular/core': 19.2.25(rxjs@7.8.2)(zone.js@0.15.1)
+      '@tanstack/query-core': 5.101.0
+    optionalDependencies:
+      '@tanstack/query-devtools': 5.101.0
+
   '@tanstack/query-core@5.101.0': {}
 
   '@tanstack/query-core@5.90.2': {}
+
+  '@tanstack/query-devtools@5.101.0':
+    optional: true
 
   '@tanstack/react-query@5.101.0(react@19.2.7)':
     dependencies:
@@ -13226,5 +13366,7 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.4.3: {}
+
+  zone.js@0.15.1: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## What

A first-party Angular binding, completing mainstream reactive-framework coverage (React/Vue/Svelte/Solid → **+ Angular**). Thin layer over `@stitchapi/query-core`, same shared-core pattern as the others.

Exposes a stitch's lifecycle **both ways from one shared execution** (as requested — equal first-class):
- **Signals** — `data()`, `isPending()`, `status()`, … (via `toSignal`), for templates and `computed`.
- **RxJS observable** — `state$` (multicast), for the `async` pipe and operators.

`injectStitch` (request/response) and `injectStitchStream` (streaming `delta`s), plus a `queryOptions` POJO for `@tanstack/angular-query-experimental`.

## Design

The **observable is the bridge** off the store (`switchMap` over the input → a per-query `Observable` owning the `subscribe`/`destroy`), then the **signal is derived** via `toSignal`. One query feeds both, and it sidesteps Angular's signal-write-in-effect rules across v16–19. A `Signal`/getter input recreates the query (re-fetch); the run tears down with the injection context (`takeUntilDestroyed`). **Pure functions, no decorators/templates** → `tsup` build (~1.5 KB), no ng-packagr.

## Tested & documented

- **11 specs** via `TestBed.runInInjectionContext` + fake stitches (vitest/jsdom): pending→success→error, refetch, reactive signal input, cancel, streaming append/replace/error, `state$` parity, `queryOptions` — all pass locally.
- `check:types` ✅, `tsup` build ✅.
- Docs: [`integrations/angular.mdx`](apps/docs/content/docs/integrations/angular.mdx), registered in `meta.json`. The integrations index gets the Angular card **and** is backfilled with the now-live Vue/Svelte cards + a *State & storage* card for the distributed-stores page (the index had only the original six).
- `check-docs-links` ✅ (91 routes), prettier ✅, Shiki renders all fences ✅. Component examples use plain `ts` fences (not twoslash), so **no `build:typed-deps` change** needed.

## Peer deps

`@angular/core` `>=16`, `rxjs` `>=7`, `stitchapi`; optional `@tanstack/angular-query-experimental`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)