### PR TITLE
feat(cache): @stitchapi/swr + @stitchapi/rtk-query — stitch as a fetcher for SWR & RTK Query

### DIFF
--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -66,6 +66,16 @@ model.
         href="/docs/integrations/tanstack-query"
         description="Use a stitch as a queryFn with the framework-agnostic queryOptions(stitch, input) helper — no hard dependency."
     />
+    <Card
+        title="SWR"
+        href="/docs/integrations/swr"
+        description="useStitchSWR runs a stitch as an SWR fetcher — SWR owns caching and revalidation."
+    />
+    <Card
+        title="RTK Query"
+        href="/docs/integrations/rtk-query"
+        description="stitchQueryFn / stitchStreamUpdater slot a stitch into an RTK Query endpoint (incl. streaming)."
+    />
 </Cards>
 
 ## Observability

--- a/apps/docs/content/docs/integrations/meta.json
+++ b/apps/docs/content/docs/integrations/meta.json
@@ -9,6 +9,8 @@
         "vue",
         "svelte",
         "tanstack-query",
+        "swr",
+        "rtk-query",
         "pino",
         "stores"
     ]

--- a/apps/docs/content/docs/integrations/rtk-query.mdx
+++ b/apps/docs/content/docs/integrations/rtk-query.mdx
@@ -1,0 +1,90 @@
+---
+title: RTK Query
+description: stitchQueryFn turns a stitch into an RTK Query endpoint, and stitchStreamUpdater folds a streaming stitch into the cache — RTK Query keeps the cache, tags, and generated hooks.
+---
+
+Use `@stitchapi/rtk-query` when your app is already on
+[RTK Query](https://redux-toolkit.js.org/rtk-query/overview). RTK Query keeps
+owning the cache, tags, and generated hooks; the stitch stays the **typed,
+validated, traced** call. The adapters are plain functions (no React), so they
+work with both `@reduxjs/toolkit/query` and `@reduxjs/toolkit/query/react`. No
+`@stitchapi/query-core` — RTK Query is the store.
+
+## Example
+
+Install the adapter alongside core and Redux Toolkit:
+
+```package-install
+@stitchapi/rtk-query stitchapi @reduxjs/toolkit
+```
+
+`stitchapi` and `@reduxjs/toolkit` are peer dependencies.
+
+## `stitchQueryFn` — a stitch as an endpoint
+
+`stitchQueryFn(stitch)` returns an endpoint `queryFn`: `{ data }` with the validated
+output on success, or `{ error }` with a **serialisable** error on a throw (so
+Redux holds no non-serialisable value). `queryFn` bypasses the `baseQuery`, so
+`fakeBaseQuery()` is the natural base when every endpoint is a stitch:
+
+```ts
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
+import { stitchQueryFn } from '@stitchapi/rtk-query';
+import { stitch } from 'stitchapi';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+});
+
+export const api = createApi({
+    baseQuery: fakeBaseQuery(),
+    endpoints: (build) => ({
+        getUser: build.query({ queryFn: stitchQueryFn(getUser) }),
+    }),
+});
+
+export const { useGetUserQuery } = api;
+// useGetUserQuery({ params: { id } })
+```
+
+## `stitchStreamUpdater` — streaming into the cache
+
+RTK Query is the one cache library here that models streaming, via
+`onCacheEntryAdded`. `stitchStreamUpdater(stitch)` folds a streaming stitch's
+`delta` chunks into the cached array as they arrive. Seed the endpoint with an
+empty array through `queryFn`:
+
+```ts
+import { sse } from 'stitchapi/sse';
+import { stitchStreamUpdater } from '@stitchapi/rtk-query';
+
+const chat = sse({ url: 'https://api.example.com/chat' });
+
+// inside endpoints: (build) => ({ ... })
+chat: build.query<number[], { prompt: string }>({
+    queryFn: () => ({ data: [] }),
+    onCacheEntryAdded: stitchStreamUpdater<number>(chat),
+}),
+```
+
+The cached data is the accumulated chunks (`mode: 'append'`, default) or the latest
+chunk (`mode: 'replace'`). Streaming stops when the cache entry is removed (the last
+subscriber leaves).
+
+<Callout type="info">
+    Reach for these adapters when RTK Query already owns your view state and you
+    want a stitch as the endpoint. For StitchAPI to own the lifecycle directly,
+    use [`useStitch` / `useStitchStream`](/docs/integrations/react). The same
+    split applies to [TanStack Query](/docs/integrations/tanstack-query) and
+    [SWR](/docs/integrations/swr).
+</Callout>
+
+## See also
+
+<Cards>
+    <Card title="React" href="/docs/integrations/react" />
+    <Card title="TanStack Query" href="/docs/integrations/tanstack-query" />
+    <Card title="SWR" href="/docs/integrations/swr" />
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+</Cards>

--- a/apps/docs/content/docs/integrations/swr.mdx
+++ b/apps/docs/content/docs/integrations/swr.mdx
@@ -1,0 +1,88 @@
+---
+title: SWR
+description: useStitchSWR runs a stitch as an SWR fetcher, so SWR owns caching and revalidation while the stitch stays typed, validated, and traced.
+---
+
+Use `@stitchapi/swr` when your app is already on [SWR](https://swr.vercel.app) and
+you want a stitch as the fetcher. SWR keeps owning caching, deduping, and
+revalidation; the stitch stays the **typed, validated, traced** call. There is no
+`@stitchapi/query-core` here — SWR is the store.
+
+If you'd rather StitchAPI own the lifecycle directly — especially **streaming**,
+which SWR doesn't model — reach for `useStitchStream` in
+[`@stitchapi/react`](/docs/integrations/react) instead.
+
+## Example
+
+Install the adapter alongside core, SWR, and React:
+
+```package-install
+@stitchapi/swr stitchapi swr react
+```
+
+`stitchapi`, `swr`, and `react` are peer dependencies.
+
+## `useStitchSWR`
+
+Pass a stitch and its input; get SWR's own response back (`data`, `error`,
+`isLoading`, `isValidating`, `mutate`). The cache key is the stitch's name plus the
+input, so two components calling the same stitch with the same input dedupe to one
+request.
+
+```tsx
+import { useStitchSWR } from '@stitchapi/swr';
+import { stitch } from 'stitchapi';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+});
+
+function Profile({ id }: { id: string }) {
+    const { data, error, isLoading } = useStitchSWR(getUser, {
+        params: { id },
+    });
+    if (isLoading) return <Spinner />;
+    if (error) return <Retry />;
+    return <h1>{data?.name}</h1>;
+}
+```
+
+Pass SWR options as the third argument — they go straight through:
+
+```tsx
+useStitchSWR(getUser, { params: { id } }, { refreshInterval: 5000 });
+```
+
+## Conditional fetching &amp; `mutate`
+
+`swrKey(stitch, input)` returns the cache key, so you can use SWR's null-key
+conditional pattern or target a `mutate`:
+
+```tsx
+import { swrKey } from '@stitchapi/swr';
+import useSWR from 'swr';
+
+// Skip the request until `id` exists.
+const { data } = useSWR(id ? swrKey(getUser, { params: { id } }) : null, () =>
+    getUser({ params: { id } }),
+);
+```
+
+<Callout type="info">
+    `useStitchSWR` is for when SWR already owns your view state and you want a
+    stitch as the fetcher. For StitchAPI to own the lifecycle — and for
+    streaming — use [`useStitch` / `useStitchStream`](/docs/integrations/react).
+    The same split applies to [TanStack
+    Query](/docs/integrations/tanstack-query) and [RTK
+    Query](/docs/integrations/rtk-query).
+</Callout>
+
+## See also
+
+<Cards>
+    <Card title="React" href="/docs/integrations/react" />
+    <Card title="TanStack Query" href="/docs/integrations/tanstack-query" />
+    <Card title="RTK Query" href="/docs/integrations/rtk-query" />
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+</Cards>

--- a/packages/rtk-query/LICENSE
+++ b/packages/rtk-query/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/rtk-query/README.md
+++ b/packages/rtk-query/README.md
@@ -1,0 +1,57 @@
+# @stitchapi/rtk-query
+
+[RTK Query](https://redux-toolkit.js.org/rtk-query/overview) bindings for [StitchAPI](https://stitchapi.dev). Use a stitch inside an RTK Query endpoint: RTK Query keeps owning the cache, tags, and generated hooks, while the stitch stays the **typed, validated, traced** call.
+
+Reach for this when your app is already on Redux Toolkit / RTK Query. The adapters are plain functions (no React), so they work with both `@reduxjs/toolkit/query` and `@reduxjs/toolkit/query/react`.
+
+## Install
+
+```sh
+pnpm add @stitchapi/rtk-query stitchapi @reduxjs/toolkit
+```
+
+`stitchapi` and `@reduxjs/toolkit` (`^2`) are peer dependencies. There is **no** `@stitchapi/query-core` dependency — RTK Query is the store.
+
+## `stitchQueryFn` — a stitch as an endpoint
+
+`stitchQueryFn(stitch)` returns an endpoint `queryFn`: on success `{ data }` with the validated output, on a throw `{ error }` with a **serialisable** error (so Redux holds no non-serialisable value).
+
+```ts
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
+import { stitchQueryFn } from '@stitchapi/rtk-query';
+import { stitch } from 'stitchapi';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+});
+
+export const api = createApi({
+    baseQuery: fakeBaseQuery(),
+    endpoints: (build) => ({
+        getUser: build.query({ queryFn: stitchQueryFn(getUser) }),
+    }),
+});
+
+export const { useGetUserQuery } = api;
+// useGetUserQuery({ params: { id } })
+```
+
+`queryFn` bypasses the `baseQuery`, so `fakeBaseQuery()` is the natural base when every endpoint is a stitch; mix with a real `baseQuery` to keep both.
+
+## `stitchStreamUpdater` — streaming into the cache
+
+RTK Query is the one cache lib here that models streaming. `stitchStreamUpdater(stitch)` returns an endpoint `onCacheEntryAdded` that folds a streaming stitch's `delta` chunks into the cached array. Seed the endpoint with an empty array:
+
+```ts
+chat: build.query<number[], { prompt: string }>({
+    queryFn: () => ({ data: [] }),
+    onCacheEntryAdded: stitchStreamUpdater<number>(chat),
+}),
+```
+
+The cached data is the accumulated chunks (`mode: 'append'`, default) or the latest chunk (`mode: 'replace'`). Streaming stops when the cache entry is removed (the last component unsubscribes).
+
+## License
+
+Apache-2.0

--- a/packages/rtk-query/package.json
+++ b/packages/rtk-query/package.json
@@ -1,0 +1,66 @@
+{
+    "name": "@stitchapi/rtk-query",
+    "version": "1.0.0-rc.2",
+    "type": "commonjs",
+    "description": "RTK Query bindings for StitchAPI — stitchQueryFn turns a stitch into an RTK Query endpoint queryFn (error-normalized), and stitchStreamUpdater folds a streaming stitch into the cache via onCacheEntryAdded.",
+    "main": "lib/index.js",
+    "module": "lib/index.mjs",
+    "types": "lib/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./lib/index.d.mts",
+                "default": "./lib/index.mjs"
+            },
+            "require": {
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
+            }
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "lib"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsup",
+        "test": "vitest run",
+        "check:types": "tsc --noEmit",
+        "prepack": "tsup",
+        "prepublishOnly": "node ../../scripts/check-release.mjs --changelog"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rejifald/StitchAPI.git",
+        "directory": "packages/rtk-query"
+    },
+    "keywords": [
+        "stitchapi",
+        "rtk-query",
+        "redux-toolkit",
+        "redux",
+        "cache",
+        "query"
+    ],
+    "author": "Oleksandr Zhuravlov (rejifald@gmail.com)",
+    "license": "Apache-2.0",
+    "homepage": "https://stitchapi.dev",
+    "engines": {
+        "node": ">=18.18.0"
+    },
+    "peerDependencies": {
+        "@reduxjs/toolkit": "^2.0.0",
+        "stitchapi": "^1.0.0-rc.1"
+    },
+    "devDependencies": {
+        "@reduxjs/toolkit": "^2.2.0",
+        "@types/node": "^22.10.0",
+        "stitchapi": "workspace:*",
+        "tsup": "^8.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.8"
+    }
+}

--- a/packages/rtk-query/src/index.ts
+++ b/packages/rtk-query/src/index.ts
@@ -1,0 +1,186 @@
+// @stitchapi/rtk-query — use a stitch inside an RTK Query endpoint.
+//
+// For apps already on [RTK Query](https://redux-toolkit.js.org/rtk-query/overview):
+// RTK Query keeps owning the cache, tags, and generated hooks, while the stitch
+// stays the typed, validated, traced call. No `@stitchapi/query-core` — RTK Query
+// is the store. The adapters are plain functions (no React), so they work with the
+// React and the framework-agnostic entry points alike.
+//
+// - `stitchQueryFn`      — a stitch as an endpoint `queryFn` (error normalised to a
+//                          serialisable shape Redux can hold).
+// - `stitchStreamUpdater` — fold a streaming stitch's `delta` chunks into the cache
+//                          via an endpoint `onCacheEntryAdded` — RTK Query is the one
+//                          cache lib here that models streaming.
+import type { Stitch, StitchEvent } from 'stitchapi';
+
+// ---------------------------------------------------------------------------
+// The structural call contract
+// ---------------------------------------------------------------------------
+
+/** A callable returning an awaitable validated output (the unary surface). */
+export type StitchLike<T, Input = unknown> = (input?: Input) => PromiseLike<T>;
+
+/** A callable whose result is also streamable (`sse` / `stream` surfaces). */
+export type StreamableStitchLike<T, Input = unknown> = (
+    input?: Input,
+) => PromiseLike<T> & { stream(): AsyncIterable<StitchEvent<T>> };
+
+/** The validated output type of a stitch (or `StitchLike`). */
+export type QueryOutput<S> =
+    S extends Stitch<infer O, infer _I>
+        ? O
+        : S extends StitchLike<infer O2, infer _I2>
+          ? O2
+          : unknown;
+
+/** The input type of a stitch (or `StitchLike`). */
+export type QueryInput<S> =
+    S extends Stitch<infer _O, infer I>
+        ? I
+        : S extends StitchLike<infer _O2, infer I2>
+          ? I2
+          : unknown;
+
+// ---------------------------------------------------------------------------
+// stitchQueryFn
+// ---------------------------------------------------------------------------
+
+/** A serialisable representation of a thrown reason, safe to hold in Redux state:
+ * the error's `name` and `message` plus any primitive own fields (e.g. a
+ * `StitchError`'s `status`). */
+export interface StitchQueryFnError {
+    readonly name: string;
+    readonly message: string;
+    readonly [key: string]: unknown;
+}
+
+/** RTK Query's `queryFn` return shape (`{ data } | { error }`), stated
+ * structurally so it composes with `build.query({ queryFn })`. */
+export type QueryFnResult<Data> =
+    | { data: Data; error?: undefined }
+    | { data?: undefined; error: StitchQueryFnError };
+
+function isPrimitive(v: unknown): boolean {
+    return (
+        v === null ||
+        v === undefined ||
+        typeof v === 'string' ||
+        typeof v === 'number' ||
+        typeof v === 'boolean'
+    );
+}
+
+function serializeError(reason: unknown): StitchQueryFnError {
+    if (reason instanceof Error) {
+        const extra: Record<string, unknown> = {};
+        const own = reason as unknown as Record<string, unknown>;
+        for (const key of Object.keys(reason)) {
+            const value = own[key];
+            if (isPrimitive(value)) extra[key] = value;
+        }
+        return { name: reason.name, message: reason.message, ...extra };
+    }
+    return { name: 'Error', message: String(reason) };
+}
+
+/**
+ * Turn a stitch into an RTK Query endpoint `queryFn`. On success it returns
+ * `{ data }` with the validated output; on a throw it returns `{ error }` with a
+ * serialisable error (so Redux holds no non-serialisable value). Pair it with
+ * `fakeBaseQuery()` (or any `baseQuery` — `queryFn` bypasses it):
+ *
+ * ```ts
+ * import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
+ * import { stitchQueryFn } from '@stitchapi/rtk-query';
+ *
+ * export const api = createApi({
+ *     baseQuery: fakeBaseQuery(),
+ *     endpoints: (build) => ({
+ *         getUser: build.query({ queryFn: stitchQueryFn(getUser) }),
+ *     }),
+ * });
+ * // → api.useGetUserQuery({ params: { id } })
+ * ```
+ */
+export function stitchQueryFn<S extends StitchLike<unknown, never>>(
+    stitch: S,
+): (input: QueryInput<S>) => Promise<QueryFnResult<QueryOutput<S>>>;
+export function stitchQueryFn<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+): (input: Input) => Promise<QueryFnResult<T>>;
+export function stitchQueryFn<T>(
+    stitch: StitchLike<T, unknown>,
+): (input: unknown) => Promise<QueryFnResult<T>> {
+    return async (input: unknown): Promise<QueryFnResult<T>> => {
+        try {
+            return { data: (await stitch(input)) as T };
+        } catch (reason) {
+            return { error: serializeError(reason) };
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
+// stitchStreamUpdater
+// ---------------------------------------------------------------------------
+
+/** How a streaming endpoint folds `delta` chunks into its cached array. */
+export interface StreamUpdaterOptions {
+    /** `'append'` (default) pushes every chunk; `'replace'` keeps only the latest. */
+    readonly mode?: 'append' | 'replace';
+}
+
+/** The slice of RTK Query's cache-lifecycle API that {@link stitchStreamUpdater}
+ * uses — stated structurally so no RTK generics leak into the signature. */
+export interface CacheLifecycleApi<Data> {
+    updateCachedData(updateRecipe: (draft: Data) => void): void;
+    cacheDataLoaded: Promise<unknown>;
+    cacheEntryRemoved: Promise<void>;
+}
+
+/**
+ * Build an endpoint `onCacheEntryAdded` that streams a stitch's `delta` chunks
+ * into the cached array as they arrive — RTK Query is the one cache lib here that
+ * models streaming. Seed the endpoint with an empty array via `queryFn`:
+ *
+ * ```ts
+ * chat: build.query<number[], { prompt: string }>({
+ *     queryFn: () => ({ data: [] }),
+ *     onCacheEntryAdded: stitchStreamUpdater(chat),
+ * }),
+ * ```
+ *
+ * The cached data is the accumulated chunks (`mode: 'append'`, default) or the
+ * latest chunk (`mode: 'replace'`). Streaming stops when the cache entry is removed.
+ */
+export function stitchStreamUpdater<Chunk, Input = unknown>(
+    stitch: StreamableStitchLike<unknown, Input>,
+    options?: StreamUpdaterOptions,
+): (input: Input, api: CacheLifecycleApi<Chunk[]>) => Promise<void>;
+export function stitchStreamUpdater<Chunk>(
+    stitch: StreamableStitchLike<unknown, unknown>,
+    options: StreamUpdaterOptions = {},
+): (input: unknown, api: CacheLifecycleApi<Chunk[]>) => Promise<void> {
+    const mode = options.mode ?? 'append';
+    return async (
+        input: unknown,
+        api: CacheLifecycleApi<Chunk[]>,
+    ): Promise<void> => {
+        // Wait for the initial (seeded) cache value before patching it.
+        await api.cacheDataLoaded;
+
+        const consume = (async () => {
+            for await (const event of stitch(input).stream()) {
+                if (event.type !== 'delta') continue;
+                const chunk = event.chunk as Chunk;
+                api.updateCachedData((draft) => {
+                    if (mode === 'replace') draft.length = 0;
+                    draft.push(chunk);
+                });
+            }
+        })();
+
+        // Stop streaming when the entry is evicted (component unmounts).
+        await Promise.race([consume, api.cacheEntryRemoved]);
+    };
+}

--- a/packages/rtk-query/test/rtk-query.spec.ts
+++ b/packages/rtk-query/test/rtk-query.spec.ts
@@ -1,0 +1,149 @@
+// @stitchapi/rtk-query behaviour. The adapters are plain framework-agnostic
+// functions, so they are driven directly (no Redux store) — plus one real
+// `createApi` to prove they compose. Driven by FAKE stitches: no engine, no network.
+import { stitchQueryFn, stitchStreamUpdater } from '../src';
+import type {
+    CacheLifecycleApi,
+    StitchLike,
+    StreamableStitchLike,
+} from '../src';
+
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query';
+import type { StitchEvent } from 'stitchapi';
+import { describe, expect, test } from 'vitest';
+
+// --- fakes -----------------------------------------------------------------
+
+function unaryStitch<T>(settle: (input: unknown) => Promise<T>): StitchLike<T> {
+    return (input?: unknown): PromiseLike<T> => ({
+        then: (onf, onr) => settle(input).then(onf, onr),
+    });
+}
+
+function streamStitch<T>(events: StitchEvent<T>[]): StreamableStitchLike<T> {
+    return () => {
+        const terminal = events.find((e) => e.type === 'result');
+        const value =
+            terminal && terminal.type === 'result'
+                ? terminal.value
+                : (undefined as T);
+        const promise = Promise.resolve(value);
+        return {
+            then: (onf, onr) => promise.then(onf, onr),
+            stream() {
+                return (async function* () {
+                    for (const e of events) {
+                        await Promise.resolve();
+                        yield e;
+                    }
+                })();
+            },
+        };
+    };
+}
+
+/** A mock of the slice of RTK's cache-lifecycle API the updater uses, backed by a
+ * real array so we can assert what got pushed. `cacheEntryRemoved` never resolves. */
+function mockCache<T>(seed: T[]): {
+    data: T[];
+    api: CacheLifecycleApi<T[]>;
+} {
+    const data = seed;
+    return {
+        data,
+        api: {
+            updateCachedData: (recipe) => recipe(data),
+            cacheDataLoaded: Promise.resolve({ data }),
+            cacheEntryRemoved: new Promise<void>(() => {}),
+        },
+    };
+}
+
+// --- stitchQueryFn ---------------------------------------------------------
+
+describe('stitchQueryFn', () => {
+    test('returns { data } with the validated output on success', async () => {
+        const qfn = stitchQueryFn(unaryStitch(async () => ({ name: 'Ada' })));
+        await expect(qfn({ params: { id: '1' } })).resolves.toEqual({
+            data: { name: 'Ada' },
+        });
+    });
+
+    test('returns { error } with a serialisable reason on a throw', async () => {
+        class StitcheyError extends Error {
+            override name = 'StitchError';
+            status = 404;
+        }
+        const qfn = stitchQueryFn<{ name: string }>(
+            unaryStitch(async () => {
+                throw new StitcheyError('not found');
+            }),
+        );
+        const result = await qfn({});
+        expect(result).toEqual({
+            error: { name: 'StitchError', message: 'not found', status: 404 },
+        });
+        // The error is a plain serialisable object (safe for Redux state).
+        expect(result.error && typeof result.error).toBe('object');
+    });
+});
+
+// --- stitchStreamUpdater ---------------------------------------------------
+
+describe('stitchStreamUpdater', () => {
+    const events: StitchEvent<number>[] = [
+        { type: 'delta', chunk: 1, at: 0 },
+        { type: 'delta', chunk: 2, at: 0 },
+        { type: 'delta', chunk: 3, at: 0 },
+        { type: 'result', value: 3, status: 200, attempts: 1, at: 0 },
+        { type: 'done', ok: true, ms: 1, attempts: 1, at: 0 },
+    ];
+
+    test('append mode pushes every delta chunk into the cached array', async () => {
+        const { data, api } = mockCache<number>([]);
+        await stitchStreamUpdater<number>(streamStitch(events))(undefined, api);
+        expect(data).toEqual([1, 2, 3]);
+    });
+
+    test('replace mode keeps only the latest chunk', async () => {
+        const { data, api } = mockCache<number>([]);
+        await stitchStreamUpdater<number>(streamStitch(events), {
+            mode: 'replace',
+        })(undefined, api);
+        expect(data).toEqual([3]);
+    });
+});
+
+// --- composition with createApi -------------------------------------------
+
+describe('createApi composition', () => {
+    test('both adapters slot into a real endpoint definition', () => {
+        const api = createApi({
+            baseQuery: fakeBaseQuery(),
+            endpoints: (build) => ({
+                getUser: build.query<{ name: string }, { id: string }>({
+                    queryFn: stitchQueryFn(
+                        unaryStitch(async () => ({ name: 'Ada' })),
+                    ),
+                }),
+                chat: build.query<number[], void>({
+                    queryFn: () => ({ data: [] }),
+                    onCacheEntryAdded: stitchStreamUpdater<number>(
+                        streamStitch([
+                            { type: 'delta', chunk: 1, at: 0 },
+                            {
+                                type: 'result',
+                                value: 1,
+                                status: 200,
+                                attempts: 1,
+                                at: 0,
+                            },
+                        ]),
+                    ),
+                }),
+            }),
+        });
+        expect(api.reducerPath).toBe('api');
+        expect(typeof api.reducer).toBe('function');
+    });
+});

--- a/packages/rtk-query/tsconfig.json
+++ b/packages/rtk-query/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM"],
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "exactOptionalPropertyTypes": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "verbatimModuleSyntax": true,
+        "isolatedModules": true,
+
+        "types": ["node", "vitest/globals"],
+
+        "baseUrl": ".",
+        "paths": {
+            "stitchapi/testing": ["../core/src/testing.ts"],
+            "stitchapi": ["../core/src/index.ts"]
+        }
+    },
+    "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/rtk-query/tsup.config.ts
+++ b/packages/rtk-query/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+// Single dual-format entry. `@reduxjs/toolkit` and `stitchapi` are peer deps
+// (externalised by tsup) — this package bundles no runtime of its own.
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    minify: true,
+    outDir: 'lib',
+    clean: true,
+    external: [/^@reduxjs\/toolkit/, 'stitchapi'],
+});

--- a/packages/rtk-query/vitest.config.ts
+++ b/packages/rtk-query/vitest.config.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+// Alias `stitchapi` to its SOURCE so tests run without it being built first.
+const core = (p: string): string =>
+    fileURLToPath(new URL(`../core/src/${p}`, import.meta.url));
+
+export default defineConfig({
+    resolve: {
+        alias: [
+            { find: /^stitchapi\/testing$/, replacement: core('testing.ts') },
+            { find: /^stitchapi$/, replacement: core('index.ts') },
+        ],
+    },
+    test: {
+        globals: true,
+        // The adapters are framework-agnostic plain functions — no DOM needed.
+        environment: 'node',
+        include: ['test/**/*.spec.ts'],
+    },
+});

--- a/packages/swr/LICENSE
+++ b/packages/swr/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/swr/README.md
+++ b/packages/swr/README.md
@@ -1,0 +1,60 @@
+# @stitchapi/swr
+
+[SWR](https://swr.vercel.app) bindings for [StitchAPI](https://stitchapi.dev). `useStitchSWR` runs a stitch as an SWR fetcher, so SWR keeps owning caching, deduping, and revalidation while the stitch stays the **typed, validated, traced** call.
+
+Reach for this when your app is already on SWR. If you want StitchAPI to own the lifecycle directly — especially **streaming** (`useStitchStream`), which SWR doesn't model — use [`@stitchapi/react`](../react) instead.
+
+## Install
+
+```sh
+pnpm add @stitchapi/swr stitchapi swr react
+```
+
+`stitchapi`, `swr` (`^2`), and `react` (`^18 || ^19`) are peer dependencies. There is **no** `@stitchapi/query-core` dependency — SWR is the store.
+
+## `useStitchSWR`
+
+```tsx
+import { useStitchSWR } from '@stitchapi/swr';
+import { stitch } from 'stitchapi';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+});
+
+function Profile({ id }: { id: string }) {
+    const { data, error, isLoading } = useStitchSWR(getUser, {
+        params: { id },
+    });
+    if (isLoading) return <Spinner />;
+    if (error) return <Retry />;
+    return <h1>{data?.name}</h1>;
+}
+```
+
+The return value is SWR's own `SWRResponse` — `data`, `error`, `isLoading`, `isValidating`, `mutate`. Pass SWR options as the third argument:
+
+```tsx
+useStitchSWR(getUser, { params: { id } }, { refreshInterval: 5000 });
+```
+
+The cache key is the stitch's `name` plus the input, so two components calling the same stitch with the same input **dedupe** to one request.
+
+## Conditional fetching & `mutate`
+
+`swrKey(stitch, input)` returns that key, for SWR's null-key conditional pattern or a targeted `mutate`:
+
+```tsx
+import { swrKey } from '@stitchapi/swr';
+import useSWR from 'swr';
+
+// Skip the request until `id` exists.
+const { data } = useSWR(id ? swrKey(getUser, { params: { id } }) : null, () =>
+    getUser({ params: { id } }),
+);
+```
+
+## License
+
+Apache-2.0

--- a/packages/swr/package.json
+++ b/packages/swr/package.json
@@ -1,0 +1,72 @@
+{
+    "name": "@stitchapi/swr",
+    "version": "1.0.0-rc.2",
+    "type": "commonjs",
+    "description": "SWR bindings for StitchAPI — useStitchSWR runs a stitch as an SWR fetcher, so SWR owns caching and revalidation while the stitch stays typed, validated, and traced.",
+    "main": "lib/index.js",
+    "module": "lib/index.mjs",
+    "types": "lib/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./lib/index.d.mts",
+                "default": "./lib/index.mjs"
+            },
+            "require": {
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
+            }
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "lib"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsup",
+        "test": "vitest run",
+        "check:types": "tsc --noEmit",
+        "prepack": "tsup",
+        "prepublishOnly": "node ../../scripts/check-release.mjs --changelog"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rejifald/StitchAPI.git",
+        "directory": "packages/swr"
+    },
+    "keywords": [
+        "stitchapi",
+        "swr",
+        "react",
+        "cache",
+        "fetcher",
+        "query"
+    ],
+    "author": "Oleksandr Zhuravlov (rejifald@gmail.com)",
+    "license": "Apache-2.0",
+    "homepage": "https://stitchapi.dev",
+    "engines": {
+        "node": ">=18.18.0"
+    },
+    "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "stitchapi": "^1.0.0-rc.1",
+        "swr": "^2.0.0"
+    },
+    "devDependencies": {
+        "@testing-library/react": "^16.1.0",
+        "@types/node": "^22.10.0",
+        "@types/react": "^19.0.0",
+        "jsdom": "^25.0.1",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "stitchapi": "workspace:*",
+        "swr": "^2.2.5",
+        "tsup": "^8.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.8"
+    }
+}

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -1,0 +1,127 @@
+// @stitchapi/swr — use a stitch as an SWR fetcher.
+//
+// Unlike `@stitchapi/react` (which OWNS the call lifecycle via query-core), this is
+// a thin adapter for apps already standardised on [SWR](https://swr.vercel.app):
+// SWR keeps owning caching, deduping, and revalidation, while the stitch stays the
+// typed, validated, traced fetcher. No `@stitchapi/query-core` — SWR is the store.
+//
+// - `useStitchSWR` — the hook: `useSWR` with the stitch as the fetcher.
+// - `swrKey`       — the cache key a stitch+input maps to, for manual `useSWR`,
+//                    conditional fetching (`enabled ? swrKey(...) : null`), or
+//                    global `mutate`.
+//
+// SWR models request/response only — for streaming (`sse` / `stream` surfaces)
+// reach for `useStitchStream` from `@stitchapi/react` instead.
+import type { Stitch } from 'stitchapi';
+import useSWR, { type SWRConfiguration, type SWRResponse } from 'swr';
+
+// ---------------------------------------------------------------------------
+// The structural call contract
+// ---------------------------------------------------------------------------
+
+/** A callable that, given its input, returns an awaitable validated output. The
+ * real `Stitch` satisfies this; so does a plain fake in a test. SWR only needs the
+ * awaitable side, so — unlike the reactive bindings — there is no `.stream()`. */
+export type StitchLike<T, Input = unknown> = (input?: Input) => PromiseLike<T>;
+
+/** The validated output type of a stitch (or `StitchLike`). */
+export type QueryOutput<S> =
+    S extends Stitch<infer O, infer _I>
+        ? O
+        : S extends StitchLike<infer O2, infer _I2>
+          ? O2
+          : unknown;
+
+/** The input type of a stitch (or `StitchLike`). */
+export type QueryInput<S> =
+    S extends Stitch<infer _O, infer I>
+        ? I
+        : S extends StitchLike<infer _O2, infer I2>
+          ? I2
+          : unknown;
+
+// ---------------------------------------------------------------------------
+// swrKey
+// ---------------------------------------------------------------------------
+
+/** The SWR cache key a stitch+input maps to: the stitch's `name` (when present)
+ * plus the input, so SWR caches and dedupes per call. */
+export type StitchSWRKey = readonly [name: string, input: unknown];
+
+/**
+ * Build the SWR key for a stitch call — use it for conditional fetching or a
+ * targeted `mutate`:
+ *
+ * ```ts
+ * import useSWR from 'swr';
+ * import { swrKey } from '@stitchapi/swr';
+ *
+ * // Skip the request until `id` exists (SWR's null-key convention).
+ * const { data } = useSWR(id ? swrKey(getUser, { params: { id } }) : null, () =>
+ *     getUser({ params: { id } }),
+ * );
+ * ```
+ */
+export function swrKey<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    input: QueryInput<S>,
+): StitchSWRKey;
+export function swrKey<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    input: Input,
+): StitchSWRKey;
+export function swrKey<T>(
+    stitch: StitchLike<T, unknown>,
+    input: unknown,
+): StitchSWRKey {
+    const name = (stitch as { __config?: { name?: string } }).__config?.name;
+    return [name ?? 'stitch', input ?? null];
+}
+
+// ---------------------------------------------------------------------------
+// useStitchSWR
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a stitch through SWR. Returns SWR's own response (`data`, `error`,
+ * `isLoading`, `isValidating`, `mutate`) — SWR owns caching and revalidation; the
+ * stitch is the validated fetcher. The cache key is {@link swrKey}, so two calls
+ * with the same stitch + input dedupe.
+ *
+ * ```tsx
+ * import { useStitchSWR } from '@stitchapi/swr';
+ *
+ * function Profile({ id }: { id: string }) {
+ *     const { data, error, isLoading } = useStitchSWR(getUser, { params: { id } });
+ *     if (isLoading) return <Spinner />;
+ *     if (error) return <Retry />;
+ *     return <h1>{data?.name}</h1>;
+ * }
+ * ```
+ *
+ * Pass SWR options as the third argument (`{ revalidateOnFocus, refreshInterval,
+ * … }`). For conditional fetching use {@link swrKey} with a bare `useSWR`.
+ */
+export function useStitchSWR<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    input: QueryInput<S>,
+    config?: SWRConfiguration<QueryOutput<S>>,
+): SWRResponse<QueryOutput<S>>;
+export function useStitchSWR<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    input: Input,
+    config?: SWRConfiguration<T>,
+): SWRResponse<T>;
+export function useStitchSWR<T>(
+    stitch: StitchLike<T, unknown>,
+    input: unknown,
+    config?: SWRConfiguration<T>,
+): SWRResponse<T> {
+    // The stitch is the fetcher; SWR caches by `swrKey`. `Promise.resolve` lifts
+    // the stitch's thenable result into a real Promise for SWR.
+    return useSWR<T>(
+        swrKey(stitch, input),
+        () => Promise.resolve(stitch(input)),
+        config,
+    );
+}

--- a/packages/swr/test/swr.spec.tsx
+++ b/packages/swr/test/swr.spec.tsx
@@ -1,0 +1,105 @@
+// @stitchapi/swr behaviour, driven through SWR in a jsdom env with React Testing
+// Library. Driven by FAKE stitches — no engine, no network. Each render wraps SWR
+// in a fresh in-memory cache so tests don't share state.
+import { swrKey, useStitchSWR } from '../src';
+import type { StitchLike } from '../src';
+
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
+import { type ReactNode, createElement } from 'react';
+import { SWRConfig } from 'swr';
+import { describe, expect, test } from 'vitest';
+
+// --- fakes -----------------------------------------------------------------
+
+/** A unary stitch: resolves (or rejects) after a tick. SWR only needs the
+ * awaitable side, so the fake is just a thenable. */
+function unaryStitch<T>(
+    settle: (input: unknown) => Promise<T>,
+    config?: { name?: string },
+): StitchLike<T> {
+    const fn = (input?: unknown): PromiseLike<T> => ({
+        then: (onf, onr) => settle(input).then(onf, onr),
+    });
+    if (config) (fn as { __config?: unknown }).__config = config;
+    return fn;
+}
+
+/** Wrap children in an isolated SWR cache (fresh Map per test). */
+function wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+        SWRConfig,
+        { value: { provider: () => new Map(), dedupingInterval: 0 } },
+        children,
+    );
+}
+
+// --- swrKey ----------------------------------------------------------------
+
+describe('swrKey', () => {
+    test('uses __config.name + input', () => {
+        const stitch = unaryStitch(async () => 1, { name: 'getThing' });
+        expect(swrKey(stitch, { params: { id: '7' } })).toEqual([
+            'getThing',
+            { params: { id: '7' } },
+        ]);
+    });
+
+    test('falls back to "stitch" and normalises undefined input to null', () => {
+        const stitch = unaryStitch(async () => 1);
+        expect(swrKey(stitch, undefined)).toEqual(['stitch', null]);
+    });
+});
+
+// --- useStitchSWR ----------------------------------------------------------
+
+describe('useStitchSWR', () => {
+    test('fetches through the stitch and exposes the validated data', async () => {
+        const getUser = unaryStitch(async () => ({ name: 'Ada' }));
+        const { result } = renderHook(
+            () => useStitchSWR(getUser, { params: { id: '1' } }),
+            { wrapper },
+        );
+
+        expect(result.current.isLoading).toBe(true);
+        await waitFor(() =>
+            expect(result.current.data).toEqual({ name: 'Ada' }),
+        );
+        expect(result.current.error).toBeUndefined();
+    });
+
+    test('surfaces a thrown reason on SWR `error`', async () => {
+        const boom = new Error('nope');
+        const getUser = unaryStitch<{ name: string }>(async () => {
+            throw boom;
+        });
+        const { result } = renderHook(() => useStitchSWR(getUser, {}), {
+            wrapper,
+        });
+
+        await waitFor(() => expect(result.current.error).toBe(boom));
+        expect(result.current.data).toBeUndefined();
+    });
+
+    test('dedupes two components with the same stitch + input', async () => {
+        let calls = 0;
+        const getUser = unaryStitch(async () => {
+            calls++;
+            return { name: 'Ada' };
+        });
+
+        function Twice() {
+            const a = useStitchSWR(getUser, { params: { id: '1' } });
+            const b = useStitchSWR(getUser, { params: { id: '1' } });
+            return createElement(
+                'div',
+                null,
+                `${a.data?.name ?? ''}|${b.data?.name ?? ''}`,
+            );
+        }
+
+        render(createElement(Twice), { wrapper });
+        await waitFor(() => screen.getByText('Ada|Ada'));
+        // One shared cache entry → the fetcher runs once for both hooks.
+        expect(calls).toBe(1);
+    });
+});

--- a/packages/swr/tsconfig.json
+++ b/packages/swr/tsconfig.json
@@ -1,0 +1,32 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM"],
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "jsx": "react-jsx",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "exactOptionalPropertyTypes": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "verbatimModuleSyntax": true,
+        "isolatedModules": true,
+
+        "types": ["node", "vitest/globals"],
+
+        "baseUrl": ".",
+        "paths": {
+            "stitchapi/testing": ["../core/src/testing.ts"],
+            "stitchapi": ["../core/src/index.ts"]
+        }
+    },
+    "include": ["src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]
+}

--- a/packages/swr/tsup.config.ts
+++ b/packages/swr/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+// Single dual-format entry. `react`, `swr`, and `stitchapi` are peer deps
+// (externalised by tsup) — this package bundles no runtime of its own.
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    minify: true,
+    outDir: 'lib',
+    clean: true,
+    external: ['react', 'swr', 'stitchapi'],
+});

--- a/packages/swr/vitest.config.ts
+++ b/packages/swr/vitest.config.ts
@@ -1,0 +1,20 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+// Alias `stitchapi` to its SOURCE so tests run without it being built first.
+const core = (p: string): string =>
+    fileURLToPath(new URL(`../core/src/${p}`, import.meta.url));
+
+export default defineConfig({
+    resolve: {
+        alias: [
+            { find: /^stitchapi\/testing$/, replacement: core('testing.ts') },
+            { find: /^stitchapi$/, replacement: core('index.ts') },
+        ],
+    },
+    test: {
+        globals: true,
+        environment: 'jsdom',
+        include: ['test/**/*.spec.ts', 'test/**/*.spec.tsx'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -637,6 +637,27 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
+  packages/rtk-query:
+    devDependencies:
+      '@reduxjs/toolkit':
+        specifier: ^2.2.0
+        version: 2.12.0(react@19.2.7)
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.21
+      stitchapi:
+        specifier: workspace:*
+        version: link:../core
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+
   packages/sandbox-sim:
     devDependencies:
       '@types/node':
@@ -713,6 +734,42 @@ importers:
       svelte:
         specifier: ^5.0.0
         version: 5.56.3(@typescript-eslint/types@8.61.0)
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+
+  packages/swr:
+    devDependencies:
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.21
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.17
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+      react:
+        specifier: ^19.0.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.7(react@19.2.7)
+      stitchapi:
+        specifier: workspace:*
+        version: link:../core
+      swr:
+        specifier: ^2.2.5
+        version: 2.4.1(react@19.2.7)
       tsup:
         specifier: ^8.3.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
@@ -2002,6 +2059,17 @@ packages:
     peerDependencies:
       '@redis/client': ^5.12.1
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2290,6 +2358,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@sveltejs/acorn-typescript@1.0.10':
     resolution: {integrity: sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==}
@@ -4439,6 +4510,9 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@11.1.8:
+    resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -5694,6 +5768,14 @@ packages:
     resolution: {integrity: sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==}
     engines: {node: '>= 18.19.0'}
 
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
@@ -5745,6 +5827,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -6098,6 +6183,11 @@ packages:
     resolution: {integrity: sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==}
     engines: {node: '>=18'}
 
+  swr@2.4.1:
+    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -6393,6 +6483,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
@@ -7808,6 +7903,17 @@ snapshots:
     dependencies:
       '@redis/client': 5.12.1
 
+  '@reduxjs/toolkit@2.12.0(react@19.2.7)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.8
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.2.0
+    optionalDependencies:
+      react: 19.2.7
+
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -7992,6 +8098,8 @@ snapshots:
   '@sindresorhus/is@4.6.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
     dependencies:
@@ -10568,6 +10676,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@11.1.8: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -12072,6 +12182,12 @@ snapshots:
       - '@node-rs/xxhash'
       - '@opentelemetry/api'
 
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
   reflect-metadata@0.2.2: {}
 
   reflect.getprototypeof@1.0.10:
@@ -12171,6 +12287,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  reselect@5.2.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -12665,6 +12783,12 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
+  swr@2.4.1(react@19.2.7):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
   symbol-tree@3.2.4: {}
 
   tailwind-merge@3.6.0: {}
@@ -13011,6 +13135,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.17
+
+  use-sync-external-store@1.6.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   uuid@14.0.0: {}
 


### PR DESCRIPTION
## What

Two adapter packages extending the **"bring your own cache layer; a stitch is the validated, traced fetcher"** pattern — already shipped for TanStack Query via `queryOptions` — to the other two dominant React caching libraries. Both **own caching**; neither depends on `@stitchapi/query-core`.

### `@stitchapi/swr` (180 B)
- `useStitchSWR(stitch, input, config?)` — `useSWR` with the stitch as fetcher; returns SWR's own response (`data`/`error`/`isLoading`/`mutate`), dedupes by key.
- `swrKey(stitch, input)` — the cache key, for SWR's null-key conditional pattern or a targeted `mutate`.

### `@stitchapi/rtk-query` (712 B)
- `stitchQueryFn(stitch)` — a stitch as an endpoint `queryFn`, error normalized to a **serializable** shape Redux can hold.
- `stitchStreamUpdater(stitch)` — fold a streaming stitch's `delta` chunks into the cache via `onCacheEntryAdded` (RTK Query is the **one** cache lib here that models streaming).

## Why this fits

Same rationale as the existing TanStack Query adapter: a user already standardized on SWR or RTK Query can adopt a stitch as their fetcher without switching cache libs. These are **adapter tier** (React, cache-layer) — not a new seam, and not a reason to adopt either lib. Neither was in the original backlog. The `useStitch`/`useStitchStream` lifecycle-owning hooks (in `@stitchapi/react`) remain the answer when you *don't* already have a cache lib.

## Tested & documented

- **SWR**: 5 specs — `renderHook` + an isolated `SWRConfig` cache (jsdom): fetch→data, error surfacing, dedupe, `swrKey`. ✅
- **RTK Query**: 5 specs — adapters driven directly + a real `createApi` composition (node): `{data}`/`{error}`, append/replace streaming, endpoint construction. ✅
- `check:types` ✅, `tsup` builds ✅ (both tiny).
- Docs: [`integrations/swr.mdx`](apps/docs/content/docs/integrations/swr.mdx) + [`integrations/rtk-query.mdx`](apps/docs/content/docs/integrations/rtk-query.mdx), registered in `meta.json`, cards added to the integrations index. `check-docs-links` ✅ (92 routes), prettier ✅, Shiki renders all fences ✅. Plain `ts`/`tsx` doc fences (not twoslash) → **no `build:typed-deps` change**.

> Note: trivially overlaps `meta.json` / `index.mdx` with the open Angular PR #218 (both append to the integrations nav) — a one-line union resolve whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)