### PR TITLE
feat(observability): @stitchapi/sentry — a Sentry TraceSink

### DIFF
--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -91,6 +91,11 @@ One core, one binding per framework's own reactive primitive.
         href="/docs/integrations/pino"
         description="Forward the event stream to a Pino logger as structured, leveled records — metadata-only, safe on a secret-bearing seam."
     />
+    <Card
+        title="Sentry"
+        href="/docs/integrations/sentry"
+        description="Map the event stream to Sentry breadcrumbs and capture error events with the call's context."
+    />
 </Cards>
 
 For OpenTelemetry, core exports an OTLP trace bridge directly — see the

--- a/apps/docs/content/docs/integrations/meta.json
+++ b/apps/docs/content/docs/integrations/meta.json
@@ -11,6 +11,7 @@
         "angular",
         "tanstack-query",
         "pino",
+        "sentry",
         "stores"
     ]
 }

--- a/apps/docs/content/docs/integrations/sentry.mdx
+++ b/apps/docs/content/docs/integrations/sentry.mdx
@@ -1,0 +1,77 @@
+---
+title: Sentry
+description: A Sentry TraceSink that maps the stitch event stream to breadcrumbs and captures error events with the call's context — metadata-only, safe on a secret-bearing seam.
+---
+
+The logger sinks ([`@stitchapi/pino`](/docs/integrations/pino), core's `loggerSink`)
+and the [OTLP bridge](/docs/guides/observability/otlp) cover logs and traces;
+[Sentry](https://sentry.io)'s model is different — a trail of **breadcrumbs**
+leading up to a **captured error**. `@stitchapi/sentry` is a
+[`TraceSink`](/docs/guides/observability/trace-sinks) that maps the stitch
+[event stream](/docs/concepts/event-stream) onto it: routine events become
+breadcrumbs, and an `error` event is captured as a Sentry issue with the call's
+context — so the breadcrumb trail attaches automatically.
+
+**Bring your own Sentry.** The sink imports no SDK — it talks to a small structural
+surface that `@sentry/node`, `@sentry/browser`, `@sentry/react`, and friends all
+satisfy. There's no `@sentry/*` dependency.
+
+## Example
+
+```package-install
+@stitchapi/sentry stitchapi
+```
+
+`stitchapi` is the only peer dependency; pass whichever `@sentry/*` SDK you already
+run.
+
+## Usage
+
+`sentrySink(Sentry)` returns a `TraceSink`. Pass it as a seam's `trace` and every
+call now reports through Sentry:
+
+```ts
+import * as Sentry from '@sentry/node';
+import { sentrySink } from '@stitchapi/sentry';
+import { seam } from 'stitchapi';
+
+const api = seam({
+    baseUrl: 'https://api.example.com',
+    trace: sentrySink(Sentry),
+});
+```
+
+The same sink works on a single stitch — `stitch({ trace: sentrySink(Sentry) })`.
+
+## What it sends
+
+| Event                          | Sentry                                                               |
+| ------------------------------ | -------------------------------------------------------------------- |
+| `error`                        | `captureMessage` (level `error`) + an error breadcrumb               |
+| `progress` (`retry`/`circuit`) | breadcrumb, level `warning`                                          |
+| `progress` (throttle/paginate) | breadcrumb, level `debug`                                            |
+| `drift`                        | breadcrumb (level follows the finding); captured with `captureDrift` |
+| `start` / `result` / `done`    | breadcrumb only when `lifecycle: true` (off by default)              |
+| `delta` / `info`               | **never sent** (raw response data / strategy announcements)          |
+
+Options: `{ lifecycle?, captureErrors?, captureDrift? }`.
+
+<Callout type="warn">
+    **Metadata only, by design.** A custom `TraceSink` receives the **raw**
+    event — core only redacts inside its own built-in sinks. So this sink sends
+    only the stitch name, method, **redacted URL** (the query string is stripped
+    — it can carry `?api_key=…`), status, attempt counts, drift
+    path/level/change, phase, and timing. It never sends `event.input` (its
+    headers still hold the live `authorization` / `cookie`), the response
+    `value`, or a `delta` chunk — safe on a secret-bearing seam regardless of
+    core's trace redaction.
+</Callout>
+
+## See also
+
+<Cards>
+    <Card title="Pino" href="/docs/integrations/pino" />
+    <Card title="Trace sinks" href="/docs/guides/observability/trace-sinks" />
+    <Card title="OpenTelemetry (OTLP)" href="/docs/guides/observability/otlp" />
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+</Cards>

--- a/packages/sentry/LICENSE
+++ b/packages/sentry/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/sentry/README.md
+++ b/packages/sentry/README.md
@@ -1,0 +1,51 @@
+# @stitchapi/sentry
+
+A [Sentry](https://sentry.io) `TraceSink` for [StitchAPI](https://stitchapi.dev). The logger sinks (`@stitchapi/pino`, core's `loggerSink`) and the OTLP bridge cover logs and traces; Sentry's model is different — a trail of **breadcrumbs** leading up to a **captured error**. This sink maps the stitch [event stream](https://stitchapi.dev/docs/concepts/event-stream) onto it.
+
+Routine events become breadcrumbs (category `stitch`); an `error` event is captured as a Sentry issue with the call's context, so the breadcrumb trail attaches automatically.
+
+**Bring your own Sentry.** The sink imports no SDK — it talks to a small structural surface that `@sentry/node`, `@sentry/browser`, `@sentry/react`, and friends all satisfy. So there's no `@sentry/*` dependency, and a test double is a drop-in.
+
+## Install
+
+```sh
+pnpm add @stitchapi/sentry stitchapi
+```
+
+`stitchapi` is the only peer dependency. Pass whichever `@sentry/*` SDK your app already runs.
+
+## Usage
+
+```ts
+import * as Sentry from '@sentry/node';
+import { sentrySink } from '@stitchapi/sentry';
+import { seam } from 'stitchapi';
+
+const api = seam({
+    baseUrl: 'https://api.example.com',
+    trace: sentrySink(Sentry),
+});
+```
+
+The same sink works on a single stitch — `stitch({ trace: sentrySink(Sentry) })`.
+
+## What it sends
+
+| Event                          | Sentry                                                               |
+| ------------------------------ | -------------------------------------------------------------------- |
+| `error`                        | `captureMessage` (level `error`) + an error breadcrumb               |
+| `progress` (`retry`/`circuit`) | breadcrumb, level `warning`                                          |
+| `progress` (throttle/paginate) | breadcrumb, level `debug`                                            |
+| `drift`                        | breadcrumb (level follows the finding); captured with `captureDrift` |
+| `start` / `result` / `done`    | breadcrumb only when `lifecycle: true` (off by default)              |
+| `delta` / `info`               | **never sent** (raw response data / strategy announcements)          |
+
+Options: `{ lifecycle?, captureErrors?, captureDrift? }`.
+
+## Safe on a secret-bearing seam
+
+> A custom `TraceSink` receives the **raw** event — core only redacts inside its own built-in sinks. This sink therefore sends **metadata only**: the stitch name, method, **redacted URL** (query stripped — it can carry `?api_key=…`), status, attempt counts, drift path/level/change, phase, and timing. It never sends `event.input` (headers still hold the live `authorization`/`cookie`), the response `value`, or a `delta` chunk.
+
+## License
+
+Apache-2.0

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -1,0 +1,64 @@
+{
+    "name": "@stitchapi/sentry",
+    "version": "1.0.0-rc.2",
+    "type": "commonjs",
+    "description": "A Sentry TraceSink for StitchAPI — maps the stitch event stream to Sentry breadcrumbs, and captures error events with the call's context. Metadata-only, safe on a secret-bearing seam.",
+    "main": "lib/index.js",
+    "module": "lib/index.mjs",
+    "types": "lib/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./lib/index.d.mts",
+                "default": "./lib/index.mjs"
+            },
+            "require": {
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
+            }
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "lib"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsup",
+        "test": "vitest run",
+        "check:types": "tsc --noEmit",
+        "prepack": "tsup",
+        "prepublishOnly": "node ../../scripts/check-release.mjs --changelog"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rejifald/StitchAPI.git",
+        "directory": "packages/sentry"
+    },
+    "keywords": [
+        "stitchapi",
+        "sentry",
+        "tracesink",
+        "observability",
+        "breadcrumbs",
+        "error-monitoring"
+    ],
+    "author": "Oleksandr Zhuravlov (rejifald@gmail.com)",
+    "license": "Apache-2.0",
+    "homepage": "https://stitchapi.dev",
+    "engines": {
+        "node": ">=18.18.0"
+    },
+    "peerDependencies": {
+        "stitchapi": "^1.0.0-rc.1"
+    },
+    "devDependencies": {
+        "@types/node": "^22.10.0",
+        "stitchapi": "workspace:*",
+        "tsup": "^8.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.8"
+    }
+}

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -1,0 +1,250 @@
+// @stitchapi/sentry — a Sentry TraceSink for StitchAPI.
+//
+// The logger sinks (`@stitchapi/pino`, core's `loggerSink`) and the OTLP bridge
+// cover logs and traces; Sentry's model is different — a trail of **breadcrumbs**
+// leading up to a **captured error**. This sink maps the stitch event stream onto
+// that: routine events become breadcrumbs (category `stitch`), and an `error` event
+// is captured as a Sentry issue with the call's context — so the breadcrumb trail is
+// attached automatically.
+//
+// Bring your own Sentry. The sink imports no SDK — it talks to a tiny structural
+// {@link SentryLike} surface that `@sentry/node`, `@sentry/browser`, `@sentry/react`,
+// and friends all satisfy (`import * as Sentry from '@sentry/node'`). So there is no
+// `@sentry/*` dependency, and a test double is a drop-in.
+//
+// SECURITY: a custom TraceSink receives the RAW event — core only redacts inside its
+// own built-in sinks. So this sends **metadata only** (name, method, redacted URL,
+// status, attempt counts, drift path/level/change, phase, timing) and NEVER
+// `event.input` (its headers carry the live `authorization`/`cookie`), `event.value`,
+// or a `delta` chunk. The URL query string is dropped (it can carry `?api_key=…`).
+import type { StitchEvent, TraceContext, TraceSink } from 'stitchapi';
+
+// ---------------------------------------------------------------------------
+// Sentry contract (structural — any @sentry/* SDK satisfies it)
+// ---------------------------------------------------------------------------
+
+/** Sentry severity levels. */
+export type SentryLevel = 'fatal' | 'error' | 'warning' | 'info' | 'debug';
+
+/** A Sentry breadcrumb (the subset this sink sets). */
+export interface SentryBreadcrumb {
+    category?: string;
+    message?: string;
+    level?: SentryLevel;
+    type?: string;
+    data?: Record<string, unknown>;
+}
+
+/** The capture context this sink passes to `captureMessage`. */
+export interface SentryCaptureContext {
+    level?: SentryLevel;
+    tags?: Record<string, string | number | boolean>;
+    extra?: Record<string, unknown>;
+}
+
+/** The minimal slice of a Sentry SDK this sink calls — declared structurally so a
+ * real `@sentry/node` / `@sentry/browser` / `@sentry/react` namespace, a Hub, and a
+ * plain test double are all interchangeable. */
+export interface SentryLike {
+    addBreadcrumb(breadcrumb: SentryBreadcrumb): void;
+    captureMessage(
+        message: string,
+        context?: SentryCaptureContext | SentryLevel,
+    ): unknown;
+}
+
+/** Options for {@link sentrySink}. */
+export interface SentrySinkOptions {
+    /**
+     * Breadcrumb the happy-path lifecycle (`start` / `result` / `done`). Default
+     * `false` — these are noisy in Sentry, where breadcrumbs matter most just before
+     * an error. Retries, circuit trips, and drift findings are always breadcrumbed.
+     */
+    lifecycle?: boolean;
+    /**
+     * Capture `error` events as Sentry issues via `captureMessage`. Default `true`.
+     * Set `false` to only leave breadcrumbs (e.g. when your framework already reports
+     * the error to Sentry and you just want the stitch trail).
+     */
+    captureErrors?: boolean;
+    /**
+     * Also capture an **error-level** `drift` finding (a breaking API change) as its
+     * own Sentry issue, not just a breadcrumb. Default `false`.
+     */
+    captureDrift?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/** Drop the query string (it may carry secrets, e.g. `?api_key=…`). */
+function redactUrl(url: string): string {
+    const q = url.indexOf('?');
+    return q === -1 ? url : `${url.slice(0, q)}?…`;
+}
+
+const DRIFT_TO_SENTRY: Record<string, SentryLevel> = {
+    error: 'error',
+    warn: 'warning',
+    info: 'debug',
+};
+
+/** Build the metadata-only breadcrumb for an event, or `null` to skip it. */
+function breadcrumbFor(
+    name: string,
+    event: StitchEvent,
+    lifecycle: boolean,
+): SentryBreadcrumb | null {
+    switch (event.type) {
+        case 'start':
+            return lifecycle
+                ? {
+                      category: 'stitch',
+                      level: 'info',
+                      message: `→ ${name} ${event.method} ${redactUrl(event.url)}`,
+                      data: { method: event.method, url: redactUrl(event.url) },
+                  }
+                : null;
+        case 'progress':
+            return {
+                category: 'stitch',
+                level:
+                    event.phase === 'retry' || event.phase === 'circuit'
+                        ? 'warning'
+                        : 'debug',
+                message: `· ${name} ${event.phase}#${event.attempt}`,
+                data: {
+                    phase: event.phase,
+                    attempt: event.attempt,
+                    ...(event.waitedMs !== undefined
+                        ? { waitedMs: event.waitedMs }
+                        : {}),
+                },
+            };
+        case 'drift': {
+            const f = event.finding;
+            return {
+                category: 'stitch.drift',
+                level: DRIFT_TO_SENTRY[f.level] ?? 'debug',
+                message: `drift ${name} ${f.path} ${f.change}`,
+                data: {
+                    path: f.path,
+                    level: f.level,
+                    change: f.change,
+                    ...(f.detail !== undefined ? { detail: f.detail } : {}),
+                },
+            };
+        }
+        case 'result':
+            return lifecycle
+                ? {
+                      category: 'stitch',
+                      level: 'info',
+                      message: `← ${name} ${event.status} (${event.attempts} attempt(s))`,
+                      data: { status: event.status, attempts: event.attempts },
+                  }
+                : null;
+        case 'error':
+            // Always breadcrumb the error too, so it shows in the trail of any later issue.
+            return {
+                category: 'stitch',
+                level: 'error',
+                message: `✗ ${name} ${event.name}: ${event.message}`,
+                data: {
+                    ...(event.status !== undefined
+                        ? { status: event.status }
+                        : {}),
+                    attempts: event.attempts,
+                },
+            };
+        case 'done':
+            return lifecycle
+                ? {
+                      category: 'stitch',
+                      level: 'debug',
+                      message: `done ${name} (${event.ok ? 'ok' : 'failed'}, ${event.ms}ms)`,
+                      data: {
+                          ok: event.ok,
+                          ms: event.ms,
+                          attempts: event.attempts,
+                      },
+                  }
+                : null;
+        default:
+            // 'info' (strategy announcement) + 'delta' (raw response data) → never sent.
+            return null;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// the sink
+// ---------------------------------------------------------------------------
+
+/**
+ * A {@link TraceSink} that forwards the stitch event stream to Sentry: routine events
+ * become breadcrumbs, and an `error` event is captured as an issue with the call's
+ * context (so the breadcrumb trail attaches). Bring any `@sentry/*` SDK:
+ *
+ * ```ts
+ * import * as Sentry from '@sentry/node';
+ * import { seam } from 'stitchapi';
+ * import { sentrySink } from '@stitchapi/sentry';
+ *
+ * const api = seam({ baseUrl: 'https://api.example.com', trace: sentrySink(Sentry) });
+ * ```
+ *
+ * The same sink works on a single stitch (`stitch({ trace: sentrySink(Sentry) })`).
+ */
+export function sentrySink(
+    sentry: SentryLike,
+    options: SentrySinkOptions = {},
+): TraceSink {
+    const lifecycle = options.lifecycle ?? false;
+    const captureErrors = options.captureErrors ?? true;
+    const captureDrift = options.captureDrift ?? false;
+
+    return {
+        handle(event: StitchEvent, ctx: TraceContext): void {
+            const crumb = breadcrumbFor(ctx.name, event, lifecycle);
+            if (crumb) sentry.addBreadcrumb(crumb);
+
+            if (event.type === 'error' && captureErrors) {
+                sentry.captureMessage(
+                    `${ctx.name}: ${event.name} — ${event.message}`,
+                    {
+                        level: 'error',
+                        tags: {
+                            stitch: ctx.name,
+                            ...(event.status !== undefined
+                                ? { status: event.status }
+                                : {}),
+                        },
+                        extra: {
+                            attempts: event.attempts,
+                            ...(ctx.runId ? { runId: ctx.runId } : {}),
+                        },
+                    },
+                );
+            } else if (
+                event.type === 'drift' &&
+                event.finding.level === 'error' &&
+                captureDrift
+            ) {
+                sentry.captureMessage(
+                    `${ctx.name}: drift ${event.finding.path} ${event.finding.change}`,
+                    {
+                        level: 'warning',
+                        tags: { stitch: ctx.name, drift: event.finding.change },
+                        extra: {
+                            path: event.finding.path,
+                            ...(event.finding.detail !== undefined
+                                ? { detail: event.finding.detail }
+                                : {}),
+                        },
+                    },
+                );
+            }
+        },
+    };
+}

--- a/packages/sentry/test/sentry.spec.ts
+++ b/packages/sentry/test/sentry.spec.ts
@@ -1,0 +1,147 @@
+// @stitchapi/sentry behaviour, driven with hand-built StitchEvents against a mock
+// Sentry SDK (the structural SentryLike). No engine, no real Sentry.
+import { sentrySink } from '../src';
+import type {
+    SentryBreadcrumb,
+    SentryCaptureContext,
+    SentryLevel,
+    SentryLike,
+} from '../src';
+
+import type { StitchEvent, TraceContext } from 'stitchapi';
+import { describe, expect, test } from 'vitest';
+
+function mockSentry() {
+    const breadcrumbs: SentryBreadcrumb[] = [];
+    const captures: {
+        message: string;
+        context: SentryCaptureContext | SentryLevel | undefined;
+    }[] = [];
+    const sentry: SentryLike = {
+        addBreadcrumb: (b) => breadcrumbs.push(b),
+        captureMessage: (message, context) => {
+            captures.push({ message, context });
+            return 'event-id';
+        },
+    };
+    return { sentry, breadcrumbs, captures };
+}
+
+const ctx: TraceContext = { name: 'getUser', runId: 'run-1' };
+
+const ev = {
+    start: {
+        type: 'start',
+        name: 'getUser',
+        method: 'GET',
+        url: 'https://api.example.com/users?api_key=SUPERSECRET',
+        input: {} as never,
+        at: 0,
+    },
+    progressRetry: { type: 'progress', phase: 'retry', attempt: 1, at: 0 },
+    progressThrottle: {
+        type: 'progress',
+        phase: 'throttled',
+        attempt: 1,
+        waitedMs: 50,
+        at: 0,
+    },
+    driftError: {
+        type: 'drift',
+        finding: { path: '$.user.name', level: 'error', change: 'missing' },
+        at: 0,
+    },
+    result: {
+        type: 'result',
+        value: { secret: 'X' },
+        status: 200,
+        attempts: 1,
+        at: 0,
+    },
+    error: {
+        type: 'error',
+        name: 'StitchError',
+        message: 'boom',
+        status: 500,
+        attempts: 2,
+        at: 0,
+    },
+    delta: { type: 'delta', chunk: 'SUPERSECRET-TOKEN', at: 0 },
+    info: { type: 'info', topic: 'auth', detail: 'bearer', at: 0 },
+} satisfies Record<string, StitchEvent>;
+
+describe('sentrySink', () => {
+    test('captures an error event as a message with stitch context, plus a breadcrumb', () => {
+        const { sentry, breadcrumbs, captures } = mockSentry();
+        sentrySink(sentry).handle(ev.error, ctx);
+
+        expect(captures).toHaveLength(1);
+        expect(captures[0]!.message).toBe('getUser: StitchError — boom');
+        expect(captures[0]!.context).toMatchObject({
+            level: 'error',
+            tags: { stitch: 'getUser', status: 500 },
+            extra: { attempts: 2, runId: 'run-1' },
+        });
+        // The error is also breadcrumbed so it shows in the trail of any later issue.
+        expect(breadcrumbs).toHaveLength(1);
+        expect(breadcrumbs[0]!.level).toBe('error');
+    });
+
+    test('retry → warning breadcrumb; routine wait → debug breadcrumb', () => {
+        const { sentry, breadcrumbs } = mockSentry();
+        const sink = sentrySink(sentry);
+        sink.handle(ev.progressRetry, ctx);
+        sink.handle(ev.progressThrottle, ctx);
+        expect(breadcrumbs.map((b) => b.level)).toEqual(['warning', 'debug']);
+        expect(breadcrumbs[1]!.data).toMatchObject({
+            phase: 'throttled',
+            waitedMs: 50,
+        });
+    });
+
+    test('lifecycle is off by default, on when enabled', () => {
+        const off = mockSentry();
+        sentrySink(off.sentry).handle(ev.start, ctx);
+        sentrySink(off.sentry).handle(ev.result, ctx);
+        expect(off.breadcrumbs).toHaveLength(0);
+
+        const on = mockSentry();
+        sentrySink(on.sentry, { lifecycle: true }).handle(ev.start, ctx);
+        expect(on.breadcrumbs).toHaveLength(1);
+    });
+
+    test('error-level drift is breadcrumbed; captured only with captureDrift', () => {
+        const a = mockSentry();
+        sentrySink(a.sentry).handle(ev.driftError, ctx);
+        expect(a.breadcrumbs).toHaveLength(1);
+        expect(a.breadcrumbs[0]).toMatchObject({
+            category: 'stitch.drift',
+            level: 'error',
+        });
+        expect(a.captures).toHaveLength(0);
+
+        const b = mockSentry();
+        sentrySink(b.sentry, { captureDrift: true }).handle(ev.driftError, ctx);
+        expect(b.captures).toHaveLength(1);
+    });
+
+    test('delta and info events are never sent (raw data / announcements)', () => {
+        const { sentry, breadcrumbs, captures } = mockSentry();
+        const sink = sentrySink(sentry);
+        sink.handle(ev.delta, ctx);
+        sink.handle(ev.info, ctx);
+        expect(breadcrumbs).toHaveLength(0);
+        expect(captures).toHaveLength(0);
+    });
+
+    test('metadata only: no secret query, no input/value/chunk reaches Sentry', () => {
+        const { sentry, breadcrumbs, captures } = mockSentry();
+        const sink = sentrySink(sentry, { lifecycle: true });
+        for (const e of Object.values(ev)) sink.handle(e, ctx);
+
+        const dump = JSON.stringify({ breadcrumbs, captures });
+        expect(dump).not.toContain('SUPERSECRET'); // query value + delta chunk
+        expect(dump).not.toContain('api_key=');
+        expect(dump).toContain('?…'); // the start URL is present but query-stripped
+    });
+});

--- a/packages/sentry/tsconfig.json
+++ b/packages/sentry/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM"],
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "exactOptionalPropertyTypes": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "verbatimModuleSyntax": true,
+        "isolatedModules": true,
+
+        "types": ["node", "vitest/globals"],
+
+        "baseUrl": ".",
+        "paths": {
+            "stitchapi/testing": ["../core/src/testing.ts"],
+            "stitchapi": ["../core/src/index.ts"]
+        }
+    },
+    "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/sentry/tsup.config.ts
+++ b/packages/sentry/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+// Single dual-format entry. `stitchapi` is the only peer dep; the Sentry SDK is
+// passed in structurally (never imported), so nothing else is external.
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    minify: true,
+    outDir: 'lib',
+    clean: true,
+    external: ['stitchapi'],
+});

--- a/packages/sentry/vitest.config.ts
+++ b/packages/sentry/vitest.config.ts
@@ -1,0 +1,20 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+// Alias `stitchapi` to its SOURCE so tests run without it being built first.
+const core = (p: string): string =>
+    fileURLToPath(new URL(`../core/src/${p}`, import.meta.url));
+
+export default defineConfig({
+    resolve: {
+        alias: [
+            { find: /^stitchapi\/testing$/, replacement: core('testing.ts') },
+            { find: /^stitchapi$/, replacement: core('index.ts') },
+        ],
+    },
+    test: {
+        globals: true,
+        environment: 'node',
+        include: ['test/**/*.spec.ts'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,6 +698,24 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/sentry:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.21
+      stitchapi:
+        specifier: workspace:*
+        version: link:../core
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+
   packages/shell:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## What

The logger sinks (`@stitchapi/pino`, core's `loggerSink`) and the OTLP bridge cover logs and traces — but **Sentry's model is different**: a trail of **breadcrumbs** leading up to a **captured error**. `@stitchapi/sentry` maps the stitch event stream onto it.

- **`sentrySink(sentry, options?)`** → a `TraceSink`. Routine events become breadcrumbs (category `stitch`); an `error` event is captured via `captureMessage` with the call's context, so the breadcrumb trail attaches automatically.
- **SDK-agnostic**: a structural `SentryLike` means `@sentry/node` / `@sentry/browser` / `@sentry/react` / … all satisfy it — **no `@sentry/*` dependency**, and a test double is a drop-in.
- Options: `{ lifecycle? (default off), captureErrors? (default on), captureDrift? (default off) }`.

## Safe on a secret-bearing seam

Mirrors `@stitchapi/pino`'s discipline: a custom `TraceSink` gets the **raw** event, so this sends **metadata only** — name, method, **redacted URL** (query stripped), status, attempts, drift path/level/change, phase, timing — never `event.input` (its headers hold the live `authorization`/`cookie`), the response `value`, or a `delta` chunk. **A test asserts no secret query value or delta payload reaches Sentry.**

## Tested & documented

- **6 tests**: error capture + tags, retry→warning / routine→debug breadcrumbs, lifecycle gating, drift capture opt-in, delta/info never sent, and the redaction assertion. ✅
- `check:types` ✅, `tsup` ✅, prettier ✅, `check-docs-links` ✅ (92 routes).
- Docs: [`integrations/sentry.mdx`](apps/docs/content/docs/integrations/sentry.mdx) + a Sentry card in the index Observability group.

**2 of 4** (SigV4 ✅ #220 · Sentry ✅ here · Next.js · Vercel AI SDK to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)