### PR TITLE
feat(next): @stitchapi/next — Web-standard route-handler helpers

### DIFF
--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -46,6 +46,11 @@ an SSE helper, and an error bridge.
         href="/docs/integrations/hono"
         description="Edge/multi-runtime middleware with a per-request seam and an SSE bridge — Workers, Deno, Bun, Node."
     />
+    <Card
+        title="Next.js"
+        href="/docs/integrations/next"
+        description="Web-standard route-handler helpers — sseResponse (text/event-stream) and stitchErrorResponse (StitchError → Response)."
+    />
 </Cards>
 
 ## Frontend

--- a/apps/docs/content/docs/integrations/meta.json
+++ b/apps/docs/content/docs/integrations/meta.json
@@ -5,6 +5,7 @@
         "nestjs",
         "fastify",
         "hono",
+        "next",
         "react",
         "vue",
         "svelte",

--- a/apps/docs/content/docs/integrations/next.mdx
+++ b/apps/docs/content/docs/integrations/next.mdx
@@ -1,0 +1,90 @@
+---
+title: Next.js
+description: Web-standard helpers for Next App Router route handlers — sseResponse streams a stitch as text/event-stream, and stitchErrorResponse maps a StitchError to a Response.
+---
+
+Next App Router route handlers are **Web-standard**: they take a `Request` and return
+a `Response`. So a stitch already runs in one directly — define a [`seam`](/docs/concepts/event-stream)
+once and call it in the handler. `@stitchapi/next` adds the two bits you'd otherwise
+hand-roll on the Web platform: streaming a stitch as Server-Sent Events, and mapping a
+`StitchError` to a `Response`.
+
+It's built on Web standards only (`Response`, `ReadableStream`, `TextEncoder`) — no
+`next` import — so the same helpers also work in Remix, SvelteKit endpoints, Bun,
+Deno, and Workers.
+
+## Example
+
+```package-install
+@stitchapi/next stitchapi
+```
+
+`stitchapi` is the only peer dependency.
+
+## A route handler
+
+A non-streaming endpoint is the stitch plus the error helper — no per-route
+`try/catch` shape to invent:
+
+```ts
+// app/api/users/[id]/route.ts
+import { getUser } from '@/lib/api';
+
+import { isStitchError, stitchErrorResponse } from '@stitchapi/next';
+
+export async function GET(
+    _req: Request,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    const { id } = await params;
+    try {
+        return Response.json(await getUser({ params: { id } }));
+    } catch (err) {
+        if (isStitchError(err)) return stitchErrorResponse(err);
+        throw err;
+    }
+}
+```
+
+`stitchErrorResponse` maps a `StitchError` to `502` by default — the safe choice that
+never leaks the upstream's `401`/`404` semantics. Pass `{ status: (e) => e.status ?? 502 }`
+to propagate the upstream status instead.
+
+## Streaming with SSE
+
+`sseResponse` streams a stitch's events as `text/event-stream`. Each `delta` becomes
+one frame; an `error` event ends the stream with a named `event: error` frame; the
+terminal `result` closes it:
+
+```ts
+// app/api/chat/route.ts
+import { chat } from '@/lib/api';
+
+import { sseResponse } from '@stitchapi/next';
+
+export async function POST(request: Request) {
+    const { prompt } = await request.json();
+    return sseResponse(chat({ body: { prompt } }).stream(), {
+        data: (c) => String(c), // pull text out of each chunk
+        signal: request.signal, // abort the upstream if the client leaves
+    });
+}
+```
+
+Pass `request.signal` so a client disconnect aborts the upstream iterator rather than
+leaving it running.
+
+<Callout type="info">
+    On the client, pair a streaming route with
+    [`useStitchStream`](/docs/integrations/react) (or the Vue / Svelte / Angular
+    binding) to render tokens as they arrive.
+</Callout>
+
+## See also
+
+<Cards>
+    <Card title="Hono (edge)" href="/docs/integrations/hono" />
+    <Card title="React" href="/docs/integrations/react" />
+    <Card title="Request surfaces" href="/docs/reference/surfaces" />
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+</Cards>

--- a/packages/next/LICENSE
+++ b/packages/next/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -1,0 +1,69 @@
+# @stitchapi/next
+
+[Next.js](https://nextjs.org) helpers for [StitchAPI](https://stitchapi.dev).
+
+Next App Router route handlers are Web-standard — they take a `Request` and return a `Response` — so a stitch already runs in one directly: define a `seam` once and call it in the handler. What's worth a helper is the two bits you'd otherwise hand-roll on the Web platform:
+
+-   **`sseResponse(stitch.stream())`** — turn a streaming stitch into a `text/event-stream` `Response`.
+-   **`stitchErrorResponse(err)`** — map a thrown `StitchError` to a `Response` with a safe status.
+
+Built on Web standards only (`Response`, `ReadableStream`, `TextEncoder`) — **no `next` import** — so the same helpers also work in Remix, SvelteKit endpoints, Bun, Deno, and Workers.
+
+## Install
+
+```sh
+pnpm add @stitchapi/next stitchapi
+```
+
+`stitchapi` is the only peer dependency.
+
+## A route handler
+
+A non-streaming endpoint is just the stitch plus the error helper:
+
+```ts
+// app/api/users/[id]/route.ts
+import { getUser } from '@/lib/api';
+
+import { isStitchError, stitchErrorResponse } from '@stitchapi/next';
+
+export async function GET(
+    _req: Request,
+    { params }: { params: Promise<{ id: string }> },
+) {
+    const { id } = await params;
+    try {
+        return Response.json(await getUser({ params: { id } }));
+    } catch (err) {
+        if (isStitchError(err)) return stitchErrorResponse(err);
+        throw err;
+    }
+}
+```
+
+`stitchErrorResponse` maps a `StitchError` to `502` by default (never leaking the upstream's status); pass `{ status: (e) => e.status ?? 502 }` to propagate it.
+
+## Streaming with SSE
+
+`sseResponse` streams a stitch's events as `text/event-stream`. Each `delta` becomes one frame; an `error` event ends with a named `event: error` frame:
+
+```ts
+// app/api/chat/route.ts
+import { chat } from '@/lib/api';
+
+import { sseResponse } from '@stitchapi/next';
+
+export async function POST(request: Request) {
+    const { prompt } = await request.json();
+    return sseResponse(chat({ body: { prompt } }).stream(), {
+        data: (c) => String(c), // pull text out of each chunk
+        signal: request.signal, // abort the upstream if the client leaves
+    });
+}
+```
+
+Pass `request.signal` so a client disconnect tears the stitch down rather than leaving it running.
+
+## License
+
+Apache-2.0

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,0 +1,64 @@
+{
+    "name": "@stitchapi/next",
+    "version": "1.0.0-rc.2",
+    "type": "commonjs",
+    "description": "Next.js helpers for StitchAPI — stream a stitch as an SSE Response and map a StitchError to a Response, for App Router route handlers (and any Web-standard fetch handler).",
+    "main": "lib/index.js",
+    "module": "lib/index.mjs",
+    "types": "lib/index.d.ts",
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./lib/index.d.mts",
+                "default": "./lib/index.mjs"
+            },
+            "require": {
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
+            }
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "lib"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsup",
+        "test": "vitest run",
+        "check:types": "tsc --noEmit",
+        "prepack": "tsup",
+        "prepublishOnly": "node ../../scripts/check-release.mjs --changelog"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rejifald/StitchAPI.git",
+        "directory": "packages/next"
+    },
+    "keywords": [
+        "stitchapi",
+        "next",
+        "nextjs",
+        "route-handler",
+        "sse",
+        "app-router"
+    ],
+    "author": "Oleksandr Zhuravlov (rejifald@gmail.com)",
+    "license": "Apache-2.0",
+    "homepage": "https://stitchapi.dev",
+    "engines": {
+        "node": ">=18.18.0"
+    },
+    "peerDependencies": {
+        "stitchapi": "^1.0.0-rc.1"
+    },
+    "devDependencies": {
+        "@types/node": "^22.10.0",
+        "stitchapi": "workspace:*",
+        "tsup": "^8.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.8"
+    }
+}

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1,0 +1,193 @@
+// @stitchapi/next — Next.js helpers for StitchAPI.
+//
+// Next App Router route handlers are Web-standard: they take a `Request` and return
+// a `Response`. So a stitch already runs in one directly — `const api = seam(...)`,
+// then call it in the handler. What's worth a helper is the two bits you'd otherwise
+// hand-roll on the Web platform:
+//
+// - `sseResponse(stitch.stream())` — turn a streaming stitch into a `text/event-stream`
+//   `Response` (the Web-standard twin of `@stitchapi/express`'s `streamStitchSse`,
+//   which targets a Node `ServerResponse`).
+// - `stitchErrorResponse(err)` — map a thrown `StitchError` to a `Response` with a
+//   safe status (default 502), so a route handler needs no bespoke error shaping.
+//
+// Built on Web standards (`Response`, `ReadableStream`, `TextEncoder`) only — no
+// `next` import — so the same helpers work in Next route handlers, Remix, SvelteKit
+// endpoints, Bun, Deno, and Workers. `stitchapi` is the only peer dependency.
+import type { StitchEvent } from 'stitchapi';
+
+// ---------------------------------------------------------------------------
+// SSE Response
+// ---------------------------------------------------------------------------
+
+/** Anything `sseResponse` can drive: a stitch `.stream()` generator, or any event
+ * iterable. */
+export type StitchEventSource<T> =
+    | AsyncIterable<StitchEvent<T>>
+    | AsyncGenerator<StitchEvent<T>, void>;
+
+export interface SseResponseOptions {
+    /**
+     * Map a `delta` chunk to the SSE frame `data`. Default: the chunk itself (a
+     * string as-is; anything else `JSON.stringify`-ed). Use it to pull text out of a
+     * structured chunk, e.g. `data: (c) => c.choices[0].delta.content`.
+     */
+    data?: (chunk: unknown) => string;
+    /** Emit an `event:` line per frame (the SSE event name). Default: unnamed. */
+    event?: string;
+    /** Provide an `id:` line per frame (the SSE last-event id), for resumable streams. */
+    id?: (chunk: unknown, index: number) => string;
+    /** Extra response headers (merged over the SSE defaults). */
+    headers?: Record<string, string>;
+    /** Abort the upstream iterator when this fires — pass the route handler's
+     * `request.signal` so a client disconnect tears the stitch down. */
+    signal?: AbortSignal;
+}
+
+// One delta chunk → an SSE frame. A multi-line payload is split so every line gets
+// its own `data:` prefix (the SSE spec joins them with `\n`); the frame ends blank.
+function frame(
+    chunk: unknown,
+    index: number,
+    options: SseResponseOptions,
+): string {
+    const payload = options.data
+        ? options.data(chunk)
+        : typeof chunk === 'string'
+          ? chunk
+          : JSON.stringify(chunk);
+    let out = '';
+    if (options.event) out += `event: ${options.event}\n`;
+    if (options.id) out += `id: ${options.id(chunk, index)}\n`;
+    for (const line of payload.split('\n')) out += `data: ${line}\n`;
+    return `${out}\n`;
+}
+
+/**
+ * Stream a stitch's events as a `text/event-stream` `Response`. Each `delta` becomes
+ * one frame; an `error` event ends the stream with a named `event: error` frame; the
+ * terminal `result`/`done` closes it.
+ *
+ * ```ts
+ * // app/api/chat/route.ts
+ * import { sseResponse } from '@stitchapi/next';
+ *
+ * export async function POST(request: Request) {
+ *     const { prompt } = await request.json();
+ *     return sseResponse(chat({ body: { prompt } }).stream(), {
+ *         data: (c) => String(c),
+ *         signal: request.signal, // abort the upstream if the client leaves
+ *     });
+ * }
+ * ```
+ */
+export function sseResponse<T>(
+    source: StitchEventSource<T>,
+    options: SseResponseOptions = {},
+): Response {
+    const encoder = new TextEncoder();
+    let index = 0;
+    const stream = new ReadableStream<Uint8Array>({
+        async start(controller) {
+            try {
+                for await (const event of source) {
+                    if (options.signal?.aborted) break;
+                    if (event.type === 'delta') {
+                        controller.enqueue(
+                            encoder.encode(
+                                frame(event.chunk, index++, options),
+                            ),
+                        );
+                    } else if (event.type === 'error') {
+                        controller.enqueue(
+                            encoder.encode(
+                                `event: error\ndata: ${JSON.stringify({
+                                    name: event.name,
+                                    message: event.message,
+                                    ...(event.status !== undefined
+                                        ? { status: event.status }
+                                        : {}),
+                                })}\n\n`,
+                            ),
+                        );
+                        break;
+                    }
+                    // 'result' / 'done' / 'start' / 'progress' → not framed; the stream
+                    // ends when the iterator does.
+                }
+            } catch (reason) {
+                controller.enqueue(
+                    encoder.encode(
+                        `event: error\ndata: ${JSON.stringify({
+                            message:
+                                reason instanceof Error
+                                    ? reason.message
+                                    : String(reason),
+                        })}\n\n`,
+                    ),
+                );
+            } finally {
+                controller.close();
+            }
+        },
+    });
+
+    return new Response(stream, {
+        headers: {
+            'content-type': 'text/event-stream; charset=utf-8',
+            'cache-control': 'no-cache, no-transform',
+            connection: 'keep-alive',
+            ...options.headers,
+        },
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Error Response
+// ---------------------------------------------------------------------------
+
+/** The error a stitch throws on failure: a branded `Error` with the upstream status. */
+export type StitchError = Error & { status?: number };
+
+/** True when `err` is the error a stitch throws on failure (`name === 'StitchError'`). */
+export function isStitchError(err: unknown): err is StitchError {
+    return err instanceof Error && err.name === 'StitchError';
+}
+
+export interface ErrorResponseOptions {
+    /**
+     * The HTTP status for the mapped failure. Default `502` for a `StitchError` (an
+     * upstream gateway failure) and `500` otherwise — the safe default never leaks an
+     * upstream's `401`/`404` semantics to your client. Override with a number, or a
+     * function: propagate the upstream status with `(e) => e.status ?? 502`.
+     */
+    status?: number | ((err: StitchError) => number);
+    /** Shape the JSON body. Default `{ error: err.message }`. */
+    body?: (err: StitchError, status: number) => unknown;
+}
+
+/**
+ * Map a thrown error to a JSON `Response`. Use it in a route handler's `catch`:
+ *
+ * ```ts
+ * try {
+ *     return Response.json(await getUser({ params: { id } }));
+ * } catch (err) {
+ *     if (isStitchError(err)) return stitchErrorResponse(err);
+ *     throw err;
+ * }
+ * ```
+ */
+export function stitchErrorResponse(
+    err: unknown,
+    options: ErrorResponseOptions = {},
+): Response {
+    const e: StitchError = err instanceof Error ? err : new Error(String(err));
+    const fallback = isStitchError(err) ? 502 : 500;
+    const status =
+        typeof options.status === 'function'
+            ? options.status(e)
+            : (options.status ?? fallback);
+    const body = options.body ? options.body(e, status) : { error: e.message };
+    return Response.json(body, { status });
+}

--- a/packages/next/test/next.spec.ts
+++ b/packages/next/test/next.spec.ts
@@ -1,0 +1,106 @@
+// @stitchapi/next behaviour — Web-standard Response helpers driven with fake event
+// sources and errors. No engine, no Next.
+import { isStitchError, sseResponse, stitchErrorResponse } from '../src';
+
+import type { StitchEvent } from 'stitchapi';
+import { describe, expect, test } from 'vitest';
+
+async function* events(
+    ...evs: StitchEvent[]
+): AsyncGenerator<StitchEvent, void> {
+    for (const e of evs) {
+        await Promise.resolve();
+        yield e;
+    }
+}
+
+const delta = (chunk: unknown): StitchEvent => ({
+    type: 'delta',
+    chunk,
+    at: 0,
+});
+const result = (value: unknown): StitchEvent => ({
+    type: 'result',
+    value,
+    status: 200,
+    attempts: 1,
+    at: 0,
+});
+const done: StitchEvent = { type: 'done', ok: true, ms: 1, attempts: 1, at: 0 };
+
+function stitchError(message: string, status?: number): Error {
+    const e = new Error(message) as Error & { status?: number };
+    e.name = 'StitchError';
+    if (status !== undefined) e.status = status;
+    return e;
+}
+
+// --- sseResponse -----------------------------------------------------------
+
+describe('sseResponse', () => {
+    test('streams each delta as an SSE frame and sets the content type', async () => {
+        const res = sseResponse(
+            events(delta('a'), delta('b'), result(['a', 'b']), done),
+        );
+        expect(res.headers.get('content-type')).toBe(
+            'text/event-stream; charset=utf-8',
+        );
+        const body = await res.text();
+        expect(body).toBe('data: a\n\ndata: b\n\n');
+    });
+
+    test('a `data` mapper pulls text out of a structured chunk', async () => {
+        const res = sseResponse(events(delta({ text: 'hi' }), done), {
+            data: (c) => (c as { text: string }).text,
+        });
+        expect(await res.text()).toBe('data: hi\n\n');
+    });
+
+    test('an error event ends the stream with a named error frame', async () => {
+        const res = sseResponse(
+            events(delta('a'), {
+                type: 'error',
+                name: 'StitchError',
+                message: 'boom',
+                status: 500,
+                attempts: 1,
+                at: 0,
+            }),
+        );
+        const body = await res.text();
+        expect(body).toContain('data: a\n\n');
+        expect(body).toContain('event: error');
+        expect(body).toContain('"message":"boom"');
+    });
+});
+
+// --- stitchErrorResponse ---------------------------------------------------
+
+describe('stitchErrorResponse', () => {
+    test('a StitchError maps to 502 by default with a JSON body', async () => {
+        const res = stitchErrorResponse(stitchError('upstream down', 503));
+        expect(res.status).toBe(502);
+        expect(res.headers.get('content-type')).toContain('application/json');
+        expect(await res.json()).toEqual({ error: 'upstream down' });
+    });
+
+    test('status can propagate the upstream status', async () => {
+        const res = stitchErrorResponse(stitchError('rate limited', 429), {
+            status: (e) => e.status ?? 502,
+        });
+        expect(res.status).toBe(429);
+    });
+
+    test('a non-StitchError defaults to 500', async () => {
+        const res = stitchErrorResponse(new Error('oops'));
+        expect(res.status).toBe(500);
+    });
+});
+
+describe('isStitchError', () => {
+    test('matches the branded error only', () => {
+        expect(isStitchError(stitchError('x'))).toBe(true);
+        expect(isStitchError(new Error('x'))).toBe(false);
+        expect(isStitchError('x')).toBe(false);
+    });
+});

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM"],
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "exactOptionalPropertyTypes": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "verbatimModuleSyntax": true,
+        "isolatedModules": true,
+
+        "types": ["node", "vitest/globals"],
+
+        "baseUrl": ".",
+        "paths": {
+            "stitchapi/testing": ["../core/src/testing.ts"],
+            "stitchapi": ["../core/src/index.ts"]
+        }
+    },
+    "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/next/tsup.config.ts
+++ b/packages/next/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+// Single dual-format entry. `stitchapi` is the only peer dep; everything else is a
+// Web-standard global (Response, ReadableStream, TextEncoder).
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    minify: true,
+    outDir: 'lib',
+    clean: true,
+    external: ['stitchapi'],
+});

--- a/packages/next/vitest.config.ts
+++ b/packages/next/vitest.config.ts
@@ -1,0 +1,20 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+const core = (p: string): string =>
+    fileURLToPath(new URL(`../core/src/${p}`, import.meta.url));
+
+export default defineConfig({
+    resolve: {
+        alias: [
+            { find: /^stitchapi\/testing$/, replacement: core('testing.ts') },
+            { find: /^stitchapi$/, replacement: core('index.ts') },
+        ],
+    },
+    test: {
+        globals: true,
+        // Web-standard Response/ReadableStream are Node globals (undici) — no DOM needed.
+        environment: 'node',
+        include: ['test/**/*.spec.ts'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,6 +582,24 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
 
+  packages/next:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.21
+      stitchapi:
+        specifier: workspace:*
+        version: link:../core
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
+
   packages/pino:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## What

Next App Router route handlers are **Web-standard** (`Request` → `Response`), so a stitch already runs in one directly — define a `seam` and call it in the handler. This adds the two bits you'd otherwise hand-roll on the Web platform:

- **`sseResponse(stitch.stream(), opts)`** — stream a stitch as a `text/event-stream` `Response` (the Web-standard twin of `@stitchapi/express`'s `streamStitchSse`, which targets a Node `ServerResponse`). Each `delta` → one frame; an `error` event → a named `event: error` frame; pass `request.signal` to abort the upstream on client disconnect.
- **`stitchErrorResponse(err, opts)`** + `isStitchError` — map a `StitchError` to a JSON `Response` (default `502`; never leaks the upstream status).

## Honest scoping

I flagged this could be a thin package or a recipe. Because Next handlers are Web-standard and `seam.as(...)` works in them directly, the package is deliberately small — just the SSE/error bridges that genuinely warrant code. It's built on **Web standards only (no `next` import)**, so it also works in Remix, SvelteKit endpoints, Bun, Deno, and Workers.

## Tested & documented

- **7 tests**: SSE framing (delta frames, `data` mapper, error frame, content-type), error mapping (502 default, status propagation, non-StitchError → 500), `isStitchError`. ✅
- `check:types` ✅, `tsup` ✅, prettier ✅, `check-docs-links` ✅ (92 routes).
- Docs: [`integrations/next.mdx`](apps/docs/content/docs/integrations/next.mdx) + an index card in Backend frameworks. Peer: `stitchapi` only.

**3 of 4** (SigV4 ✅ #220 · Sentry ✅ #221 · Next.js ✅ here · Vercel AI SDK to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)