### PR TITLE
fix(stitch): honest drift-spec guard in normalizeOutput

### DIFF
--- a/packages/core/eslint-suppressions.json
+++ b/packages/core/eslint-suppressions.json
@@ -48,11 +48,6 @@
       "count": 1
     }
   },
-  "src/stitch.ts": {
-    "@typescript-eslint/no-unnecessary-condition": {
-      "count": 1
-    }
-  },
   "src/store.ts": {
     "@typescript-eslint/no-non-null-assertion": {
       "count": 3

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -98,7 +98,7 @@ function chainHooks(layers: Hooks[]): Hooks | undefined {
 
 function normalizeOutput(out: StitchConfig['output']): StitchConfig['output'] {
     if (!out) return undefined;
-    if ((out as DriftSpec).__kind === 'drift') return out;
+    if ((out as Partial<DriftSpec>).__kind === 'drift') return out;
     return toValidator(out);
 }
 


### PR DESCRIPTION
## What

Removes one entry (`src/stitch.ts` → `@typescript-eslint/no-unnecessary-condition`) from `packages/core/eslint-suppressions.json` by fixing the underlying issue rather than re-suppressing it.

## Why

`normalizeOutput` discriminates a `DriftSpec` from a plain output schema at runtime via `__kind === 'drift'`. But the assertion cast the value to `DriftSpec`, whose `__kind` is the **literal** `'drift'` — so `=== 'drift'` was statically always-true and the guard read as dead code (`no-unnecessary-condition`).

## Fix

Cast to `Partial<DriftSpec>` instead. `__kind` becomes `'drift' | undefined`, so the runtime check is honest again — it can actually be false for a non-drift schema — and the lint suppression is no longer needed.

```diff
-    if ((out as DriftSpec).__kind === 'drift') return out;
+    if ((out as Partial<DriftSpec>).__kind === 'drift') return out;
```

## Verification

- `pnpm check:lint` — clean (suppression removed, no new violation)
- `pnpm check:types` — clean (`tsc --noEmit` + test tsconfig)
- `pnpm test` — 715 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)