### PR TITLE
fix(cache): tag bigint cache-key token so it can't collide with a string

### DIFF
--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -36,8 +36,11 @@ function stable(value: unknown): string {
     if (t === 'number')
         return Number.isFinite(value) ? JSON.stringify(value) : 'null';
     if (t === 'boolean') return value ? 'true' : 'false';
-    if (t === 'bigint')
-        return JSON.stringify(`${(value as bigint).toString()}n`);
+    // A type tag (`bigint:`) — NOT a JSON-stringified `"…n"` — so a bigint never collides with a
+    // plain string of the same digits-plus-`n` (`42n` ≠ the string `'42n'`). The tag's leading
+    // letter also keeps it clear of every other token shape (quoted strings, bare numbers,
+    // `true`/`false`/`null`), so `42n` still stays distinct from the number `42`.
+    if (t === 'bigint') return `bigint:${(value as bigint).toString()}`;
     if (t === 'undefined') return 'null'; // only reached for an array hole; objects drop it
     if (value instanceof Date) return JSON.stringify(value.toISOString());
     if (Array.isArray(value))
@@ -118,8 +121,10 @@ export interface RequestDescriptor {
 }
 
 /** The frozen key-schema version. Folded into the hashed content AND prefixed onto the stored
- *  key, so any canonicalisation change is a mass self-healing miss, never a stale-key hit. */
-export const KEY_VERSION = 'k1';
+ *  key, so any canonicalisation change is a mass self-healing miss, never a stale-key hit.
+ *  `k2`: bigint canonicalisation changed from `"<n>n"` to the `bigint:<n>` type tag (it had
+ *  collided with the plain string `"<n>n"`), so old bigint-bearing keys must miss, not cross-hit. */
+export const KEY_VERSION = 'k2';
 
 function canonicalRequest(
     d: RequestDescriptor,

--- a/packages/core/test/cache-internals.spec.ts
+++ b/packages/core/test/cache-internals.spec.ts
@@ -58,6 +58,19 @@ describe('deriveCacheKey canonicalisation', () => {
         expect(a).not.toBe(b);
     });
 
+    test('a bigint does not collide with its plain-string form', () => {
+        // `42n` (bigint) and `'42n'` (string) are distinct values that can produce distinct wire
+        // requests — a bigint query/param goes on the wire as `42`, the string as `42n`. The
+        // canonicaliser must keep them apart so one is never served the other's cached response.
+        const big = deriveCacheKey(GET({ body: { v: 42n } }), undefined);
+        const str = deriveCacheKey(GET({ body: { v: '42n' } }), undefined);
+        expect(big).not.toBe(str);
+        // …and a bigint must still NOT collide with the equivalent number (`42n` ≠ `42`),
+        // which is the distinction the original `…n` suffix was reaching for.
+        const num = deriveCacheKey(GET({ body: { v: 42 } }), undefined);
+        expect(big).not.toBe(num);
+    });
+
     test('null is kept; undefined is treated as absent', () => {
         const withNull = deriveCacheKey(GET({ body: { a: null } }), undefined);
         const empty = deriveCacheKey(GET({ body: {} }), undefined);


### PR DESCRIPTION
## The bug

The derived-key cache canonicaliser (`stable()` in `packages/core/src/cache.ts`) encoded a `bigint` as `JSON.stringify(`${n}n`)` — i.e. the JSON string `"<n>n"`. A plain **string** value `'<n>n'` encodes to the byte-identical token, so a bigint and that string derive the **same** cache key:

```ts
deriveCacheKey(GET({ body: { v: 42n }   }))  // token "42n"  ┐ same
deriveCacheKey(GET({ body: { v: '42n' } }))  // token "42n"  ┘ key
// both -> 4b948eb2c8104f3fc550a64e4f77021d
```

These are distinct request values that can produce **distinct wire requests** — a bigint query/param goes on the wire as `42` (`String(42n)`), the string as `42n`. So the collision lets one request be served the other's cached response, which is exactly the cross-value hit a key-derivation primitive must avoid (`stable()`'s contract is "collide only for semantically-identical requests").

The bug is original to the cache module (#80) and uncovered by the existing `deriveCacheKey` canonicalisation tests (they only compared distinct *strings*/numbers).

> Note on `Date`: `stable()` also encodes a `Date` as its ISO string, which *does* collide with the equivalent ISO string — but that is **correct**, because a `Date` in a request serialises to exactly that ISO string on the wire, so the two requests are genuinely identical. Only the bigint case is a bug; this PR leaves `Date` untouched.

## The fix

Emit a `bigint:<n>` **type tag** instead of `"<n>n"`. Its leading letter keeps it clear of every other token shape (quoted strings always start with `"`, bare numbers with a digit/`-`, and `true`/`false`/`null`), so `42n` now stays distinct from **both** the string `'42n'` and the number `42` (the number distinction is what the original `…n` suffix was reaching for, and it is preserved).

`KEY_VERSION` is bumped `k1` → `k2` per the module's documented contract (`cache.ts:120`): a canonicalisation change is a key-schema bump — a one-time mass self-healing **miss**, never a stale-key hit — so any pre-existing bigint-bearing entry misses rather than cross-hitting after upgrade. No test or stored artifact hardcodes the version.

## Test

Adds `a bigint does not collide with its plain-string form` to `cache-internals.spec.ts`, asserting `42n` ≠ `'42n'` **and** `42n` ≠ `42`. It fails on `main` (both keys `4b948eb2…`) and passes with the fix.

## Verification

- `pnpm check:types` ✅
- `pnpm check:lint` ✅
- `pnpm test` ✅ — 716 passed, 2 skipped (one unrelated pre-existing wall-clock window-boundary flake in `stream.spec.ts:399` that passes 3/3 in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)