### PR TITLE
docs(integrations): page for @stitchapi/elysia

### DIFF
--- a/apps/docs/content/docs/integrations/elysia.mdx
+++ b/apps/docs/content/docs/integrations/elysia.mdx
@@ -1,0 +1,138 @@
+---
+title: Elysia
+description: An Elysia plugin for StitchAPI — a principal-bound seam on the request context, an SSE bridge with streamStitchSse returning a Response, and stitch errors mapped to HTTP via the plugin's onError.
+---
+
+Use `@stitchapi/elysia` when you serve an API with [Elysia](https://elysiajs.com).
+`.use()` the plugin and every request gets a principal-bound `seam` on its context,
+plus two bridges into Elysia's Web-standard world: an SSE writer and a stitch-error
+→ HTTP mapping.
+
+<Callout type="info">
+    **Web-standard by construction.** Elysia is Bun-first, but the plugin
+    imports only `elysia` and `stitchapi` — there are **no `node:*` imports**,
+    so it runs unchanged on Bun, Node, Deno, and the edge.
+</Callout>
+
+## Example
+
+Install the package alongside core and Elysia:
+
+```package-install
+@stitchapi/elysia stitchapi elysia
+```
+
+Build (and own) the seam once at startup, then `.use()` the plugin. With a
+`principal` resolver, each request's context `stitch` is a `seam.as(id)` handle — a
+principal-bound seam with separate auth sessions per principal over one shared
+throttle. A `.derive` runs per request and puts it on the context, so a handler
+reads it straight off the destructured context:
+
+```ts
+import { stitch } from '@stitchapi/elysia';
+import { Elysia } from 'elysia';
+import { seam } from 'stitchapi';
+import { z } from 'zod';
+
+const api = seam({ baseUrl: 'https://api.example.com' });
+
+const app = new Elysia()
+    .use(
+        stitch({
+            seam: api,
+            principal: ({ request }) =>
+                request.headers.get('x-tenant') ?? undefined,
+        }),
+    )
+    .get('/me', ({ stitch }) =>
+        stitch.stitch({
+            path: '/me',
+            output: z.object({ id: z.string(), name: z.string() }),
+        })(),
+    );
+```
+
+The principal lives in the closure, never in a call argument, so a handler can
+never name another identity. Returning `undefined` falls back to the unbound root
+seam for that request (e.g. anonymous). **Borrow, don't own:** the plugin never
+calls `seam.close()` — you build the seam at startup and `await api.close()` on
+shutdown.
+
+## Streaming — `streamStitchSse`
+
+Stream a streaming/SSE stitch's `.stream()` to the client by returning the
+`text/event-stream` `Response` `streamStitchSse` builds. Each `delta` becomes a
+`data:` message; a terminal `error` (or a throw) becomes a final `event: error`
+message; control events are consumed but not forwarded; and a client disconnect
+cancels the body and aborts the upstream stitch stream.
+
+```ts
+import { stitch, streamStitchSse } from '@stitchapi/elysia';
+import { Elysia } from 'elysia';
+import { seam } from 'stitchapi';
+import { sseSurface } from 'stitchapi/sse';
+
+const api = seam({ baseUrl: 'https://api.example.com' });
+
+const app = new Elysia()
+    .use(stitch({ seam: api }))
+    .get('/chat', ({ stitch, query }) => {
+        const chat = stitch.stitch({ kind: sseSurface, path: '/v1/messages' });
+        return streamStitchSse(chat.stream({ body: { prompt: query.q } }), {
+            data: (chunk) => (chunk as { data: string }).data,
+        });
+    });
+```
+
+<Callout type="warn">
+    **Anti-pattern:** return the `streamStitchSse` `Response` as the handler's
+    result — don't also set `set.status` / `set.headers` or return a second
+    value from the same handler. The helper builds the complete
+    `text/event-stream` response (status, headers, and the frame body); a
+    competing write corrupts the stream.
+</Callout>
+
+## Errors
+
+A failed stitch throws a `StitchError` carrying the upstream `status`. The plugin
+registers an `.onError` that maps it to an HTTP response (`502` by default, so an
+upstream's status is never leaked) and lets every other error fall through to
+Elysia's default handling — so handlers need no try/catch:
+
+```ts
+import { stitch } from '@stitchapi/elysia';
+import { Elysia } from 'elysia';
+import { seam } from 'stitchapi';
+
+const api = seam({ baseUrl: 'https://api.example.com' });
+
+const app = new Elysia().use(
+    stitch({
+        seam: api,
+        // the default is a safe 502; propagate the upstream status instead:
+        errorHandler: { status: (e) => e.status ?? 502 },
+    }),
+);
+```
+
+Set `errorHandler: false` to register none and wire your own with `stitchOnError`
+(an `.onError`-compatible mapper) or `stitchErrorResponse(err, options)` (a one-off
+`StitchError` → `Response`); `isStitchError` narrows an unknown error first.
+
+<Callout type="info">
+    On Bun clusters and other multi-runtime deployments, pair the seam with a
+    shared [store](/docs/guides/state/pluggable-store) so throttle and sessions
+    are fleet-wide rather than per-process.
+</Callout>
+
+## See also
+
+<Cards>
+    <Card title="Hono" href="/docs/integrations/hono" />
+    <Card title="Fastify" href="/docs/integrations/fastify" />
+    <Card title="The stitch primitive" href="/docs/concepts/the-stitch" />
+    <Card
+        title="The pluggable store"
+        href="/docs/guides/state/pluggable-store"
+    />
+</Cards>

--- a/apps/docs/content/docs/integrations/meta.json
+++ b/apps/docs/content/docs/integrations/meta.json
@@ -5,6 +5,7 @@
         "nestjs",
         "fastify",
         "hono",
+        "elysia",
         "next",
         "react",
         "vue",


### PR DESCRIPTION
## What

Adds the **Elysia** integration page (`apps/docs/content/docs/integrations/elysia.mdx`) and wires it into the integrations nav. `@stitchapi/elysia` was a published package with no docs page.

The page documents the plugin's three bridges between a StitchAPI `seam` and Elysia's Web-standard request lifecycle:

- **`stitch()` plugin** — a `.derive` puts a request-scoped, principal-bound seam on the context (`({ stitch }) => stitch.stitch('/path')()`); separate auth sessions per principal over one shared throttle. Borrow-don't-own: the plugin never closes the seam.
- **`streamStitchSse`** — turns a stitch's `.stream()` into a `text/event-stream` `Response` you return straight from a handler, cancelling the body / aborting upstream on disconnect. Includes an inline **anti-pattern** callout: the helper owns the whole Response — don't also set `set.status`/`set.headers`.
- **Error mapping** — the plugin's `.onError` maps a thrown `StitchError` to HTTP (502 by default, so an upstream's status is never leaked). `errorHandler: false` opts out in favor of `stitchOnError` / `stitchErrorResponse`.

## Conventions followed

- Modeled on `integrations/hono.mdx` (closest sibling — Web-standard, edge-capable backend plugin), cross-linking Hono, Fastify, and the pluggable store.
- Examples use plain `` ```ts `` fences — the current integration-page convention (as on the merged sentry/next/vercel-ai pages) — so `@stitchapi/elysia` stays out of the docs typecheck graph. No `build:typed-deps` / `apps/docs` devDep changes.
- `prettier --write` applied; neutral naming + `api.example.com`; mandatory `See also`.

## Verification

- `pnpm --filter @stitchapi/docs gen:completions` → no diff.
- `pnpm check:docs-links` → ✓ 100 routes, every `/docs/...` link resolves.
- `prettier --check` on the changed files → clean.
- `pnpm --filter @stitchapi/docs build` (render gate) → ✓ all pages generated, TypeScript clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)