### PR TITLE
fix(validator): capture narrowed safeParse to drop non-null assertion

### DIFF
--- a/packages/core/eslint-suppressions.json
+++ b/packages/core/eslint-suppressions.json
@@ -53,11 +53,6 @@
       "count": 3
     }
   },
-  "src/validator.ts": {
-    "@typescript-eslint/no-non-null-assertion": {
-      "count": 1
-    }
-  },
   "test/cli.spec.ts": {
     "@typescript-eslint/no-unsafe-return": {
       "count": 2

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -52,11 +52,12 @@ export function toValidator(schema: unknown): Validator | undefined {
 
     // Zod (v3): has safeParse
     const zodLike = schema as { safeParse?: (v: unknown) => ZodResult };
-    if (typeof zodLike.safeParse === 'function') {
+    const { safeParse } = zodLike;
+    if (typeof safeParse === 'function') {
         return withSource(
             {
                 async validate(value) {
-                    const r = zodLike.safeParse!(value);
+                    const r = safeParse(value);
                     if (r.success) return { ok: true, value: r.data };
                     return {
                         ok: false,


### PR DESCRIPTION
## What

Removes one entry (`src/validator.ts` → `@typescript-eslint/no-non-null-assertion`) from `packages/core/eslint-suppressions.json` by fixing the underlying issue rather than re-suppressing it.

## Why

`toValidator` guards `typeof zodLike.safeParse === 'function'`, but the actual call lives inside a nested `async validate` closure. TypeScript's narrowing from the `typeof` check does **not** flow into that closure (the property could, in theory, be reassigned between the guard and the deferred call), so the call required a `!` non-null assertion to compile.

## Fix

Destructure `safeParse` into a `const` and narrow **that** local instead. A `const`'s narrowing is preserved into closures (it can't be reassigned), so the call is statically known-defined and the assertion is unnecessary.

```diff
-    if (typeof zodLike.safeParse === 'function') {
+    const { safeParse } = zodLike;
+    if (typeof safeParse === 'function') {
         return withSource(
             {
                 async validate(value) {
-                    const r = zodLike.safeParse!(value);
+                    const r = safeParse(value);
```

## Verification

- `pnpm check:lint` — clean (suppression removed, no new violation)
- `pnpm check:types` — clean (`tsc --noEmit` + test tsconfig)
- `pnpm test` — 716 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)