### PR TITLE
fix(serve): scrub secret query params in structured input on the SSE stream

### DIFF
--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -37,9 +37,11 @@ const REDACTED = '[REDACTED]';
 // Redact an event for delivery over an UNTRUSTED transport — the `stitch serve` SSE stream, which
 // is unauthenticated and may be fronted. Unlike the built-in sinks this PRESERVES the payload
 // (`delta`/`result` — a streaming consumer asked for it); it only scrubs the credential-bearing
-// metadata a `start` frame echoes back: URL credentials/secret query slots (via `scrubUrl`) and any
-// denylisted header value in `input.headers` (`authorization` / `cookie` / …). Every other event
-// type passes through untouched.
+// metadata a `start` frame echoes back: URL credentials + secret query values in the URL string
+// (via `scrubUrl`), the SAME secret query values in the structured `input.query` (via
+// `redactSecretQuery` — `scrubUrl` reaches only the URL string, so the parsed query must be
+// scrubbed too, exactly as the JSONL sink does), and any denylisted header value in `input.headers`
+// (`authorization` / `cookie` / …). Every other event type passes through untouched.
 export function redactEventForTransport(event: StitchEvent): StitchEvent {
     if (event.type !== 'start') return event;
     const headers = event.input.headers;
@@ -51,12 +53,16 @@ export function redactEventForTransport(event: StitchEvent): StitchEvent {
               ]),
           )
         : undefined;
+    const query = event.input.query;
+    const safeQuery = query ? redactSecretQuery(query) : undefined;
     return {
         ...event,
         url: scrubUrl(event.url),
-        input: safeHeaders
-            ? { ...event.input, headers: safeHeaders }
-            : event.input,
+        input: {
+            ...event.input,
+            ...(safeHeaders ? { headers: safeHeaders } : {}),
+            ...(safeQuery ? { query: safeQuery } : {}),
+        },
     };
 }
 

--- a/packages/core/test/serve.spec.ts
+++ b/packages/core/test/serve.spec.ts
@@ -122,6 +122,25 @@ test('SSE start frame scrubs credential headers the caller echoed (serve is unau
     expect(text).not.toContain('Bearer SECRET'); // the secret never rides the wire
 });
 
+test('SSE start frame scrubs a secret query param the caller echoed (structured input.query)', async () => {
+    api.route('GET', '/ping', { body: { ok: true } });
+    const res = await fetch(`${base}/stitch/ping`, {
+        method: 'POST',
+        headers: { accept: 'text/event-stream' },
+        body: JSON.stringify({ query: { api_key: 'SQLEAK', page: '2' } }),
+    });
+    const text = await res.text();
+    const start = parseSse(text).find((f) => f.event === 'start');
+    const echoed = (
+        start?.data?.['input'] as
+            | { query?: Record<string, unknown> }
+            | undefined
+    )?.query;
+    expect(echoed?.['api_key']).toBe('[REDACTED]'); // secret query value scrubbed before it leaves
+    expect(echoed?.['page']).toBe('2'); // non-secret query param preserved
+    expect(text).not.toContain('SQLEAK'); // the secret never rides the wire (url OR structured input)
+});
+
 test('an unknown stitch is a 404 with a listing message', async () => {
     const res = await fetch(`${base}/stitch/nope`, {
         method: 'POST',


### PR DESCRIPTION
## The bug (secret leak)

`redactEventForTransport` (`packages/core/src/trace.ts`) is the scrubber for the **`stitch serve` SSE stream** — an unauthenticated transport that, per its own doc, "is unauthenticated and may be fronted". On a `start` frame it scrubbed:

- ✅ URL credentials + secret query in the **URL string** (via `scrubUrl`)
- ✅ `authorization` / `cookie` / … in `input.headers`
- ❌ **secret values in the structured `input.query` — passed through untouched**

`scrubUrl` only rewrites the URL *string*. But the engine puts the raw call input on the `start` event (`startEvt`, `engine.ts:947`), so `input.query` still holds the plaintext secret, and `serve.ts:76` `JSON.stringify`s the whole event onto the SSE wire:

```
POST /stitch/ping  {"query":{"api_key":"SECRET"}}   (Accept: text/event-stream)
-> event: start
   data: {"url":"https://…?api_key=REDACTED",            // URL scrubbed ✅
          "input":{"query":{"api_key":"SECRET"}}}          // STRUCTURED query LEAKS ❌
```

Reachable in production via `call({ query: { api_key: '…' } })` (or a stitch's static secret query param) on any served stitch consumed over SSE.

### Why this is clearly a bug, not intended

The **local** JSONL sink (`prepareRecord`, same file) already redacts `input.query` via `redactSecretQuery`, with the explicit comment *"redact secret param values so the structured input can't leak what scrubUrl already stripped from `url`."* So the **more-sensitive remote SSE path was the *less*-protected one.** And `redactEventForTransport`'s own doc claimed it scrubbed "secret query slots (via `scrubUrl`)" — which `scrubUrl` does not deliver for the parsed query object.

## The fix

Run `input.query` through the **same `redactSecretQuery`** the JSONL sink uses, alongside the existing header scrub. Secret params (`api_key`, `access_token`, `*token*`, `*secret*`, … per `isSecretQueryKey`) become `[REDACTED]`; benign params (`page`, `sort`) are preserved for observability. The doc comment is corrected to state the structured query is scrubbed too. No new dependency, no behavior change for non-`start` events.

## Test

Adds `SSE start frame scrubs a secret query param the caller echoed (structured input.query)` to `serve.spec.ts` — a sibling of the existing header-scrub test. It drives the real `serve()` SSE path and asserts the secret query value is `[REDACTED]` on the wire, a benign param survives, and the raw secret string never appears in the response text. **Fails on `main`** (`api_key` rides the wire as the raw value), passes with the fix.

## Verification

- `pnpm check:types` ✅
- `pnpm check:lint` ✅
- `pnpm test` ✅ — 717 passed, 2 skipped (full suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)