### PR TITLE
fix(test): template literal for trace-file path, drop plus-operands

### DIFF
--- a/packages/core/eslint-suppressions.json
+++ b/packages/core/eslint-suppressions.json
@@ -58,11 +58,6 @@
       "count": 2
     }
   },
-  "test/composition.spec.ts": {
-    "@typescript-eslint/restrict-plus-operands": {
-      "count": 1
-    }
-  },
   "test/graphql-and-headers.spec.ts": {
     "@typescript-eslint/no-unnecessary-condition": {
       "count": 2

--- a/packages/core/test/composition.spec.ts
+++ b/packages/core/test/composition.spec.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
 
 process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
-    'stitch-composition-' + process.pid + '.jsonl',
+    `stitch-composition-${process.pid}.jsonl`,
 );
 
 let server: MockServer;


### PR DESCRIPTION
## What

Removes one entry (`test/composition.spec.ts` → `@typescript-eslint/restrict-plus-operands`) from `packages/core/eslint-suppressions.json` by fixing the underlying issue rather than re-suppressing it.

## Why

The spec built its `STITCH_TRACE_FILE` path by concatenating a string with `process.pid` (a number):

```js
'stitch-composition-' + process.pid + '.jsonl'
```

`string + number` trips `restrict-plus-operands`.

## Fix

Use a template literal — the project already configures `restrict-template-expressions` with `allowNumber: true`, so interpolating a number is allowed and this is the idiomatic spelling:

```diff
-    'stitch-composition-' + process.pid + '.jsonl',
+    `stitch-composition-${process.pid}.jsonl`,
```

## Verification

- `pnpm check:lint` — clean (suppression removed, no new violation)
- `pnpm check:types` — clean
- `pnpm test` — 716 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)