### PR TITLE
fix(test): drop redundant String() in mock-server header collection

### DIFF
--- a/packages/core/eslint-suppressions.json
+++ b/packages/core/eslint-suppressions.json
@@ -69,9 +69,6 @@
     },
     "@typescript-eslint/no-unnecessary-condition": {
       "count": 1
-    },
-    "@typescript-eslint/no-unnecessary-type-conversion": {
-      "count": 1
     }
   }
 }

--- a/packages/core/test/support/mock-server.ts
+++ b/packages/core/test/support/mock-server.ts
@@ -59,9 +59,7 @@ const parseCookies = (header: string | undefined): Record<string, string> => {
 const collectHeaders = (req: IncomingMessage): Record<string, string> => {
     const out: Record<string, string> = {};
     for (const [k, v] of Object.entries(req.headers)) {
-        out[k.toLowerCase()] = Array.isArray(v)
-            ? v.join(', ')
-            : String(v ?? '');
+        out[k.toLowerCase()] = Array.isArray(v) ? v.join(', ') : (v ?? '');
     }
     return out;
 };


### PR DESCRIPTION
## What

Removes one entry (`test/support/mock-server.ts` → `@typescript-eslint/no-unnecessary-type-conversion`) from `packages/core/eslint-suppressions.json` by fixing the underlying issue rather than re-suppressing it.

## Why

In `collectHeaders`, the non-array branch wrapped `v ?? ''` in `String(...)`:

```js
out[k.toLowerCase()] = Array.isArray(v) ? v.join(', ') : String(v ?? '');
```

After the `Array.isArray(v)` check, `v` is narrowed to `string | undefined`, so `v ?? ''` is already a `string` — the `String()` call is a no-op (`no-unnecessary-type-conversion`).

## Fix

Return `v ?? ''` directly; behaviour is identical.

```diff
-        out[k.toLowerCase()] = Array.isArray(v)
-            ? v.join(', ')
-            : String(v ?? '');
+        out[k.toLowerCase()] = Array.isArray(v) ? v.join(', ') : (v ?? '');
```

## Verification

- `pnpm check:lint` — clean (suppression removed, no new violation)
- `pnpm check:types` — clean
- `pnpm test` — 717 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)