### PR TITLE
fix(test): drop redundant optional chains after body cast

### DIFF
--- a/packages/core/eslint-suppressions.json
+++ b/packages/core/eslint-suppressions.json
@@ -58,11 +58,6 @@
       "count": 2
     }
   },
-  "test/graphql-and-headers.spec.ts": {
-    "@typescript-eslint/no-unnecessary-condition": {
-      "count": 2
-    }
-  },
   "test/support/mock-server.ts": {
     "@typescript-eslint/no-redundant-type-constituents": {
       "count": 1

--- a/packages/core/test/graphql-and-headers.spec.ts
+++ b/packages/core/test/graphql-and-headers.spec.ts
@@ -46,10 +46,10 @@ describe('GraphQL kind', () => {
 
         const call = server.calls('/graphql')[0];
         expect(call?.headers['apikey']).toBe('gql_tok');
-        expect((call?.body as { variables: unknown })?.variables).toEqual({
+        expect((call?.body as { variables: unknown }).variables).toEqual({
             id: 1,
         });
-        expect((call?.body as { query: string })?.query).toMatch(/thing/);
+        expect((call?.body as { query: string }).query).toMatch(/thing/);
     });
 
     test('.with({ variables }) carries GraphQL variables into the request', async () => {


### PR DESCRIPTION
## What

Removes one entry (`test/graphql-and-headers.spec.ts` → `@typescript-eslint/no-unnecessary-condition`, count 2) from `packages/core/eslint-suppressions.json` by fixing the underlying issue rather than re-suppressing it.

## Why

Two assertions read the request body via `(call?.body as { … })?.prop`. The `as` cast already asserts a non-nullish object shape, so the **trailing** `?.` is a no-op (`no-unnecessary-condition`). The inner `call?.body` is legitimate — `call` (from `server.calls('/graphql')[0]`) is genuinely `… | undefined`.

## Fix

Drop the two post-cast `?.`:

```diff
-        expect((call?.body as { variables: unknown })?.variables).toEqual({
+        expect((call?.body as { variables: unknown }).variables).toEqual({
             id: 1,
         });
-        expect((call?.body as { query: string })?.query).toMatch(/thing/);
+        expect((call?.body as { query: string }).query).toMatch(/thing/);
```

Behaviour is unchanged — the passing test proves the body is present at runtime.

## Verification

- `pnpm check:lint` — clean (suppression removed, no new violation)
- `pnpm check:types` — clean
- `pnpm test` — 717 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)