### PR TITLE
fix(engine): fold variables (and signal/onProgress) when paginating

### DIFF
--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -779,13 +779,26 @@ async function* attemptWithCircuit(
     }
 }
 
+// Fold the paginator's next-page partial onto the base input. Kept in lock-step with the `.with()`
+// merge in stitch.ts: `variables` is a first-class StitchInput field (GraphQL's primary input, the
+// slot a cursor rides in `next: () => ({ variables: { after } })`), so it must merge like the rest —
+// dropping it stranded paginated GraphQL on page 1. `signal`/`onProgress` carry too so an aborted
+// paginated call still cancels mid-pagination. Omit a key entirely when neither side sets it
+// (exactOptionalPropertyTypes forbids `variables: undefined`).
 function mergeInput(a: StitchInput, b: StitchInput): StitchInput {
-    return {
+    const merged: StitchInput = {
         params: { ...(a.params ?? {}), ...(b.params ?? {}) },
         query: { ...(a.query ?? {}), ...(b.query ?? {}) },
         headers: { ...(a.headers ?? {}), ...(b.headers ?? {}) },
         body: b.body !== undefined ? b.body : a.body,
     };
+    if (a.variables ?? b.variables)
+        merged.variables = { ...(a.variables ?? {}), ...(b.variables ?? {}) };
+    const signal = b.signal ?? a.signal;
+    if (signal) merged.signal = signal;
+    const onProgress = b.onProgress ?? a.onProgress;
+    if (onProgress) merged.onProgress = onProgress;
+    return merged;
 }
 
 // Pagination: one logical call that follows pages until `paginate.next` returns undefined

--- a/packages/core/test/pagination.spec.ts
+++ b/packages/core/test/pagination.spec.ts
@@ -1,6 +1,6 @@
 // Pagination: one logical stitch call that follows pages and aggregates items. Each page is
 // a full request (so auth/retry/throttle apply) and emits a `paginate` progress event.
-import { stitch } from '../src';
+import { graphql, stitch } from '../src';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
 
@@ -62,6 +62,55 @@ test('emits a paginate progress event per page', async () => {
     }
     expect(pages.length).toBe(3);
     expect(result).toEqual([1, 2, 3, 4, 5]);
+});
+
+test('paginated GraphQL advances its cursor through the variables slot', async () => {
+    // The page is selected by the `after` VARIABLE the paginator threads back — exactly how a
+    // cursor-paginated GraphQL API works. If the engine drops `variables` when folding the next
+    // page's input, page 2 loses the cursor, re-fetches page 1, and loops until `max`.
+    interface GqlReq {
+        variables?: { after?: string };
+    }
+    const page = (
+        nodes: number[],
+        endCursor: string | undefined,
+        hasNextPage: boolean,
+    ) => ({ data: { users: { nodes, pageInfo: { endCursor, hasNextPage } } } });
+    server.route('POST', '/gql', {
+        body: (_i: number, req: { body: unknown }) => {
+            const after = (req.body as GqlReq).variables?.after;
+            if (!after) return page([1, 2], 'c1', true);
+            if (after === 'c1') return page([3, 4], undefined, false);
+            return page([], undefined, false);
+        },
+    });
+    const listUsers = graphql({
+        baseUrl: server.url,
+        path: '/gql',
+        query: 'query($after: String) { users(after: $after) { nodes pageInfo { endCursor hasNextPage } } }',
+        unwrap: 'data.users.nodes',
+        paginate: {
+            next: (body) => {
+                const pi = (
+                    body as {
+                        data: {
+                            users: {
+                                pageInfo: {
+                                    endCursor?: string;
+                                    hasNextPage: boolean;
+                                };
+                            };
+                        };
+                    }
+                ).data.users.pageInfo;
+                return pi.hasNextPage
+                    ? { variables: { after: pi.endCursor } }
+                    : undefined;
+            },
+        },
+    });
+    await expect(listUsers()).resolves.toEqual([1, 2, 3, 4]);
+    expect(server.callCount('/gql')).toBe(2); // two real requests; the cursor advanced
 });
 
 test('max caps the page loop (guards a runaway paginator)', async () => {


### PR DESCRIPTION
## The bug — paginated GraphQL never advances its cursor

The engine's pagination input-merge (`mergeInput`, `engine.ts:782`, used by `paginated()` at `engine.ts:855`) built only `{ params, query, headers, body }` — it **dropped the `variables` slot**.

For a cursor-paginated **GraphQL** call, the cursor rides in `variables`:

```ts
paginate: { next: (body) => hasNext ? { variables: { after: endCursor } } : undefined }
```

and the graphql surface packs the request body as `variables: input.variables ?? input.body ?? {}` (`surface.ts:119`). So when `mergeInput` discarded `variables`, **every page after the first re-ran the *initial* query with no `after`** — re-fetching page 1 over and over until `max` (default 50). Paginated GraphQL silently never walked past the first page.

### Clear precedent — the sibling merge was already fixed

There are two `mergeInput`s. The `.with()` one in `stitch.ts:361` was explicitly fixed for this exact bug, with a comment naming it:

> `variables` is a first-class StitchInput field (GraphQL's primary input). It was dropped here, so `.with({ variables })` silently lost them; merge it like the rest.

That fix never reached the engine's duplicate copy. This PR brings them back in lock-step.

## The fix

Align the engine's `mergeInput` with the canonical `stitch.ts` one:
- fold **`variables`** (the load-bearing fix — restores GraphQL cursoring),
- carry **`signal`/`onProgress`** so an aborted paginated call still cancels mid-pagination (these were stranded after page 1 too).

Keys are omitted when neither side sets them (`exactOptionalPropertyTypes`). (The two copies could later be unified into one shared helper so this can't drift again — left out here to keep the fix minimal.)

## Test

Adds `paginated GraphQL advances its cursor through the variables slot` to `pagination.spec.ts`. The mock server selects each page by the **`after` variable the paginator threads back** (not by call index — which is why the existing `graphql-paginated-errors` test missed this). It fails iff the cursor is dropped:

- **on `main`**: aggregate is `[1,2,1,2,…]` (page 1 repeated) over **50** calls.
- **with the fix**: `[1,2,3,4]` over **2** calls.

## Verification

- `pnpm check:types` ✅
- `pnpm check:lint` ✅
- `pnpm test` ✅ — 718 passed, 2 skipped (full suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)