### PR TITLE
fix(xhr-adapter): reject a pre-aborted signal instead of sending the request

### DIFF
--- a/packages/core/src/xhr-adapter.ts
+++ b/packages/core/src/xhr-adapter.ts
@@ -121,11 +121,21 @@ export function xhrAdapter(XHR?: XhrLikeCtor): Adapter {
             };
 
             if (req.signal) {
-                if (req.signal.aborted) xhr.abort();
-                else
-                    req.signal.addEventListener('abort', () => {
+                // A pre-aborted signal must REJECT here, not `xhr.abort()`: calling abort() before
+                // send() fires NO `abort` event (WHATWG XHR dispatches it only once the send() flag
+                // is set), so `onabort` would never run and the cancelled request would be sent
+                // anyway. Reject and return so `send()` below never fires.
+                if (req.signal.aborted) {
+                    reject(new Error('xhrAdapter: aborted'));
+                    return;
+                }
+                req.signal.addEventListener(
+                    'abort',
+                    () => {
                         xhr.abort();
-                    });
+                    },
+                    { once: true },
+                );
             }
 
             xhr.send(body ?? null);

--- a/packages/core/test/xhr-adapter.spec.ts
+++ b/packages/core/test/xhr-adapter.spec.ts
@@ -141,4 +141,57 @@ describe('xhrAdapter (ADR 0005 Decision 9)', () => {
             }),
         ).rejects.toThrow(/stream/i);
     });
+
+    test('a pre-aborted signal rejects without sending the request', async () => {
+        // A fake that models REAL XHR abort semantics: `abort()` dispatches an `abort` event ONLY
+        // once a request is in flight (the send() flag is set). `abort()` BEFORE `send()` is a
+        // no-op event-wise — which is exactly why a pre-aborted signal must be handled by
+        // rejecting, not by calling `abort()` and then sending anyway. `send()` fires `onload`
+        // (a real server answering), so a cancelled request that slips through RESOLVES.
+        class RealAbortXHR {
+            static last: RealAbortXHR | undefined;
+            sentFlag = false;
+            responseType = '';
+            status = 0;
+            response: unknown = new ArrayBuffer(0);
+            upload = { onprogress: null as ((e: XhrProgress) => void) | null };
+            onload: (() => void) | null = null;
+            onerror: (() => void) | null = null;
+            onabort: (() => void) | null = null;
+            onprogress: ((e: XhrProgress) => void) | null = null;
+            constructor() {
+                RealAbortXHR.last = this;
+            }
+            open(): void {
+                /* no-op fake */
+            }
+            setRequestHeader(): void {
+                /* no-op fake */
+            }
+            getAllResponseHeaders(): string {
+                return 'content-type: application/json\r\n';
+            }
+            abort(): void {
+                if (this.sentFlag) this.onabort?.(); // no `abort` event before send()
+            }
+            send(): void {
+                this.sentFlag = true;
+                this.status = 200;
+                this.onload?.();
+            }
+        }
+
+        const ac = new AbortController();
+        ac.abort(); // already aborted before the call
+        await expect(
+            xhrAdapter(RealAbortXHR as unknown as XhrLikeCtor)({
+                url: 'http://h/u',
+                method: 'GET',
+                headers: {},
+                signal: ac.signal,
+            }),
+        ).rejects.toThrow(/abort/i);
+        // The cancelled request must never go out.
+        expect(RealAbortXHR.last?.sentFlag).toBe(false);
+    });
 });


### PR DESCRIPTION
## The bug

`xhrAdapter` ignores an **already-aborted** `signal` and sends the request anyway.

On entry it did:

```ts
if (req.signal) {
    if (req.signal.aborted) xhr.abort();   // before send()
    else req.signal.addEventListener('abort', () => xhr.abort());
}
xhr.send(body ?? null);                     // ← runs unconditionally
```

Per [WHATWG XHR](https://xhr.spec.whatwg.org/#the-abort()-method), `abort()` dispatches an `abort` event **only once the send() flag is set** (a request is in flight). Calling `abort()` *before* `send()` is an event-wise no-op, so `xhr.onabort` never fires, the Promise never rejects — and then `xhr.send()` dispatches the request the caller already cancelled. `onload` later **resolves** it with a real response.

Net effect: a stitch called with a pre-aborted signal (e.g. `call({ signal })` where the signal already fired) silently performs the request and returns a result, instead of cancelling.

## The fix

On a pre-aborted signal, **reject and return** before `send()` — reusing the same `xhrAdapter: aborted` error the mid-flight abort path (`onabort`) produces, so both abort paths behave identically. The live abort listener also gains `{ once: true }`, matching the abort-cleanup convention used everywhere else in the repo (`engine.ts`, `resilience.ts`, `postmessage.ts`, …).

```ts
if (req.signal) {
    if (req.signal.aborted) { reject(new Error('xhrAdapter: aborted')); return; }
    req.signal.addEventListener('abort', () => { xhr.abort(); }, { once: true });
}
xhr.send(body ?? null);
```

## Why the existing tests missed it

The spec's `FakeXHR.abort()` fired `onabort` **unconditionally** — unlike a real XHR — so it masked the pre-send no-op, and no existing test passed a `signal` at all. The new test (`a pre-aborted signal rejects without sending the request`) uses a fake that models real semantics: `abort()` dispatches `abort` only after `send()`, and `send()` fires `onload` (a server answering). It asserts the call **rejects** and **never sends**. On `main` it resolves with status 200 (bug); with the fix it rejects and `sentFlag` stays `false`.

## Verification

- `pnpm check:types` ✅
- `pnpm check:lint` ✅
- `pnpm test` ✅ — 718 passed, 2 skipped (full suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)