### PR TITLE
fix(diagram/mcp): show post-response stages in real engine order

### DIFF
--- a/packages/core/src/config-summary.ts
+++ b/packages/core/src/config-summary.ts
@@ -45,9 +45,11 @@ export function pipelineStages(
                 ? `paginate (max ${cfg.paginate.max ?? 50})`
                 : 'paginate',
         );
-    if (cfg.output) stages.push('validate');
+    // Post-response order matches the engine (engine.ts): transform → unwrap → validate. The body
+    // is transformed, then the unwrap path is read, then the result is validated against `output`.
     if (cfg.transform) stages.push('transform');
     if (cfg.unwrap) stages.push(`unwrap: ${cfg.unwrap}`);
+    if (cfg.output) stages.push('validate');
     if (cfg.cache) stages.push('cache');
     stages.push('result');
     return stages;

--- a/packages/core/src/diagram.ts
+++ b/packages/core/src/diagram.ts
@@ -1,7 +1,7 @@
 // `stitch diagram` — render a Mermaid flowchart of each stitch's SHAPE from its definition
 // (`__config`), not from a run. A glance-able "what does this stitch do": the configured request
 // pipeline — throttle, the request, retry, a non-http surface's interpret step, pagination,
-// validation, transform, unwrap, cache — in engine order. A trace-driven DAG of what actually ran
+// transform, unwrap, validation, cache — in engine order. A trace-driven DAG of what actually ran
 // is a separate, future capability (it needs composition causality the flat event stream does not
 // yet emit). Auth is intentionally absent: it is redacted from `__config` (ADR 0002), so a stitch
 // cannot leak which credential it holds — not even its scheme — through this view.

--- a/packages/core/test/diagram.spec.ts
+++ b/packages/core/test/diagram.spec.ts
@@ -36,13 +36,34 @@ describe('toMermaid', () => {
 
     test('a stitch chains its configured pipeline stages in order', () => {
         const { diagram } = toMermaid(sampleRegistry());
-        // getUser: call -> request -> retry -> validate -> unwrap -> result (no throttle/cache).
+        // getUser: call -> request -> retry -> unwrap -> validate -> result (no throttle/cache).
         expect(diagram).toContain('(["call"]) -->');
         expect(diagram).toContain('GET https://api.example.com/users/{id}');
         expect(diagram).toContain('retry');
         expect(diagram).toContain('validate');
         expect(diagram).toContain('unwrap: data');
         expect(diagram).toContain('(["result"])');
+    });
+
+    test('post-response stages render in engine order: transform -> unwrap -> validate', () => {
+        // The engine processes the response body transform → unwrap → validate (engine.ts), and the
+        // diagram's contract is "the configured request pipeline … in engine order". So the diagram
+        // must place validate LAST of the three, not first.
+        const { diagram } = toMermaid({
+            proc: stitch({
+                baseUrl: 'https://api.example.com',
+                path: '/x',
+                transform: (b) => b,
+                unwrap: 'data',
+                output: z.object({ id: z.number() }),
+            }),
+        });
+        const iTransform = diagram.indexOf('transform');
+        const iUnwrap = diagram.indexOf('unwrap: data');
+        const iValidate = diagram.indexOf('validate');
+        expect(iTransform).toBeGreaterThanOrEqual(0);
+        expect(iUnwrap).toBeGreaterThan(iTransform); // unwrap after transform
+        expect(iValidate).toBeGreaterThan(iUnwrap); // validate after unwrap
     });
 
     test('a bare stitch is just call -> request -> result', () => {

--- a/packages/core/test/mcp.spec.ts
+++ b/packages/core/test/mcp.spec.ts
@@ -184,6 +184,12 @@ test('tools/call describe_stitch teaches a stitch shape without running it', asy
         body: false,
     });
     expect(shape.output).toMatchObject({ validated: true, unwrap: 'data' });
+    // the pipeline lists stages in engine order: the engine unwraps THEN validates, so the
+    // 'unwrap' stage must precede 'validate' (not the reverse).
+    expect(shape.pipeline.indexOf('unwrap: data')).toBeGreaterThanOrEqual(0);
+    expect(shape.pipeline.indexOf('unwrap: data')).toBeLessThan(
+        shape.pipeline.indexOf('validate'),
+    );
     // a Mermaid flowchart string is included for the diagram view
     expect(shape.diagram).toContain('flowchart');
     // policies reflect the configured retry/timeout (no throttle/cache)


### PR DESCRIPTION
## The bug

The shared `pipelineStages` (`config-summary.ts`) — the "what does this stitch do" stage list used by **both** `stitch diagram` (the Mermaid flowchart) and the **MCP `describe_stitch`** view (the `pipeline` array a stitch teaches an agent) — listed the post-response stages as:

```
validate → transform → unwrap
```

The engine runs them in the **opposite** order (`engine.ts`): the body is **transform**ed, then the **unwrap** path is read, then the result is **validate**d against `output`:

```js
if (cfg.transform) value = await cfg.transform(value);
if (cfg.unwrap)    value = getPath(value, cfg.unwrap);
const findings = await validateOutput(cfg, value);
```

So both the diagram and the MCP teaching view showed the wrong execution order — directly contradicting the documented contract ("the configured request pipeline … **in engine order**"). For `describe_stitch`, that means an LLM agent introspecting a stitch is taught that validation happens *before* unwrap, which is backwards.

This was independently flagged by two separate audits (the diagram view and, earlier, the mcp view).

## The fix

A recent refactor already de-duplicated diagram's `stagesFor` and mcp's `pipelineOf` into the single shared `pipelineStages` ("kept in one leaf so the two stay in lockstep"). The order just has to be corrected there once, and **both** views are fixed:

```js
if (cfg.transform) stages.push('transform');
if (cfg.unwrap)    stages.push(`unwrap: ${cfg.unwrap}`);
if (cfg.output)    stages.push('validate');
```

Also fixes the stale "validation, transform, unwrap" listing in `diagram.ts`'s header comment.

## Tests

- `diagram.spec.ts`: a stitch with `transform` + `unwrap` + `output` must render `transform` before `unwrap` before `validate` (by string index).
- `mcp.spec.ts`: `describe_stitch`'s `pipeline` array must list `unwrap` before `validate`.

Both fail on the prior order (diagram: `validate` at 143 vs `unwrap` at 196; mcp: `unwrap` at index 4 vs `validate` at 3) and pass with the fix. The pre-existing per-stage `toContain` checks never pinned the relative order, so the bug was untested.

## Verification

- `pnpm check:types` ✅
- `pnpm check:lint` ✅
- `pnpm test` ✅ — 718 passed, 2 skipped (full suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)