### PR TITLE
test(core): guard the public API export surface (src/index.ts)

### DIFF
--- a/packages/core/test/public-api-surface.spec.ts
+++ b/packages/core/test/public-api-surface.spec.ts
@@ -1,0 +1,64 @@
+// The public API surface of the package (src/index.ts). smoke.spec.ts exercises `stitch` end-to-end
+// but nothing pins the EXPORT surface itself, so an accidental removal/rename of a public symbol
+// would slip past the test suite (only attw/build catches it, late). This guards the contract: the
+// documented value exports are present and of the expected kind.
+import * as api from '../src';
+import type { AdapterResponse } from '../src/types';
+
+// Every documented function/guard export (systemClock is an object; the error classes are below).
+const FUNCTIONS = [
+    'stitch',
+    'drift',
+    'graphql',
+    'seam',
+    'bearer',
+    'apiKey',
+    'basic',
+    'cookieSession',
+    'oauth2',
+    'env',
+    'optionalEnv',
+    'secretsFile',
+    'secretFrom',
+    'fetchAdapter',
+    'axiosAdapter',
+    'xhrAdapter',
+    'createTrace',
+    'consoleSink',
+    'fileSink',
+    'multiplex',
+    'loggerSink',
+    'otlpTrace',
+    'otlpHttpExporter',
+    'toOtlpJson',
+    'toValidator',
+    'memoryStore',
+    'isStitch',
+    'isSeam',
+] as const;
+
+describe('public API surface (src/index.ts)', () => {
+    test.each(FUNCTIONS)('exports %s as a function', (name) => {
+        expect(typeof (api as Record<string, unknown>)[name]).toBe('function');
+    });
+
+    test('exports the built-in surfaces with their stable ids', () => {
+        expect(api.httpSurface.id).toBe('http');
+        expect(api.graphqlSurface.id).toBe('graphql');
+    });
+
+    test('exports systemClock with the Clock shape', () => {
+        expect(typeof api.systemClock.now).toBe('function');
+        expect(typeof api.systemClock.sleep).toBe('function');
+        expect(typeof api.systemClock.setTimer).toBe('function');
+        expect(typeof api.systemClock.clearTimer).toBe('function');
+    });
+
+    test('exports the error classes (both extend Error)', () => {
+        const response: AdapterResponse = { status: 429, headers: {}, body: {} };
+        const rate = new api.RateLimitError({ status: 429, response });
+        expect(rate).toBeInstanceOf(Error);
+        expect(rate.status).toBe(429);
+        expect(new api.StitchError('x')).toBeInstanceOf(Error);
+    });
+});

--- a/packages/core/test/public-api-surface.spec.ts
+++ b/packages/core/test/public-api-surface.spec.ts
@@ -55,7 +55,11 @@ describe('public API surface (src/index.ts)', () => {
     });
 
     test('exports the error classes (both extend Error)', () => {
-        const response: AdapterResponse = { status: 429, headers: {}, body: {} };
+        const response: AdapterResponse = {
+            status: 429,
+            headers: {},
+            body: {},
+        };
         const rate = new api.RateLimitError({ status: 429, response });
         expect(rate).toBeInstanceOf(Error);
         expect(rate.status).toBe(429);


### PR DESCRIPTION
## What

Adds `packages/core/test/public-api-surface.spec.ts` — a guard on the package's public **export surface** (`src/index.ts`).

## Why

`smoke.spec.ts` exercises `stitch` end-to-end, but nothing pins the export surface itself — an accidental removal/rename of a public symbol would slip past the test suite (only `attw`/build catches it, late). This guards the contract:

- **every documented function/guard export** is present and a function (`stitch`, `drift`, `graphql`, `seam`, the auth helpers, the three adapters, the trace sinks, `toValidator`, `memoryStore`, `isStitch`, `isSeam`);
- `httpSurface`/`graphqlSurface` carry their **stable ids**;
- `systemClock` has the **Clock shape** (`now`/`sleep`/`setTimer`/`clearTimer`);
- `RateLimitError` and `StitchError` are constructable and **extend Error**.

## Result

Pure coverage gap fill — **no behaviour change**. Full gate passes:

- `pnpm check:types` ✓
- `pnpm check:lint` ✓
- `pnpm test` — 859 passed (+31 new), 2 skipped ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)