### PR TITLE
test(core): unit-test resolveTrace + redactConfig (stitch helpers)

### DIFF
--- a/packages/core/test/stitch-helpers.spec.ts
+++ b/packages/core/test/stitch-helpers.spec.ts
@@ -37,7 +37,11 @@ describe('redactConfig', () => {
                 baseUrl: 'https://api.test',
                 path: '/x',
                 method: 'GET',
-                store: { get: () => undefined, set: () => undefined, incr: () => 1 },
+                store: {
+                    get: () => undefined,
+                    set: () => undefined,
+                    incr: () => 1,
+                },
                 adapter: () => Promise.resolve({}),
                 clock: systemClock,
                 auth: { scheme: { type: 'http', scheme: 'bearer' } },

--- a/packages/core/test/stitch-helpers.spec.ts
+++ b/packages/core/test/stitch-helpers.spec.ts
@@ -1,0 +1,69 @@
+// Two pure helpers in src/stitch.ts that no spec exercises directly (compose is covered by
+// composition.spec et al.): resolveTrace and the security-critical redactConfig.
+//   resolveTrace — false → a no-op sink; 'console' → the console sink; a sink object → returned by
+//                  reference; undefined → the ambient default. All are TraceSinks.
+//   redactConfig — produces the public __config: it STRIPS the live store/auth/adapter/clock handles,
+//                  re-derives `authScheme` from the live auth (never trusting an externally-set one),
+//                  and normalises the live Surface `kind` to its id string; the rest survives.
+import { systemClock } from '../src';
+import { redactConfig, resolveTrace } from '../src/stitch';
+import type { ResolvedStitchConfig, TraceSink } from '../src/types';
+
+const asResolved = (o: Record<string, unknown>): ResolvedStitchConfig => o;
+
+describe('resolveTrace', () => {
+    test('returns a provided sink by reference', () => {
+        const sink: TraceSink = { handle: () => undefined };
+        expect(resolveTrace(sink)).toBe(sink);
+    });
+
+    test('false yields a distinct no-op sink', () => {
+        const sink: TraceSink = { handle: () => undefined };
+        const t = resolveTrace(false);
+        expect(typeof t.handle).toBe('function');
+        expect(t).not.toBe(sink);
+    });
+
+    test("'console' and undefined each yield a TraceSink", () => {
+        expect(typeof resolveTrace('console').handle).toBe('function');
+        expect(typeof resolveTrace(undefined).handle).toBe('function');
+    });
+});
+
+describe('redactConfig', () => {
+    test('strips live handles, re-derives authScheme, and normalises kind to its id', () => {
+        const redacted = redactConfig(
+            asResolved({
+                baseUrl: 'https://api.test',
+                path: '/x',
+                method: 'GET',
+                store: { get: () => undefined, set: () => undefined, incr: () => 1 },
+                adapter: () => Promise.resolve({}),
+                clock: systemClock,
+                auth: { scheme: { type: 'http', scheme: 'bearer' } },
+                authScheme: { type: 'apiKey' }, // externally set — must be overwritten, not trusted
+                kind: { id: 'graphql' }, // a live Surface
+            }),
+        );
+        // live, secret-bearing handles are gone
+        expect('store' in redacted).toBe(false);
+        expect('auth' in redacted).toBe(false);
+        expect('adapter' in redacted).toBe(false);
+        expect('clock' in redacted).toBe(false);
+        // authScheme re-derived from the live auth (NOT the externally-set value)
+        expect(redacted.authScheme).toEqual({ type: 'http', scheme: 'bearer' });
+        // the live Surface is normalised to its id string
+        expect(redacted.kind).toBe('graphql');
+        // the rest survives
+        expect(redacted.baseUrl).toBe('https://api.test');
+        expect(redacted.path).toBe('/x');
+    });
+
+    test('omits authScheme and kind when there is no auth / no surface', () => {
+        const redacted = redactConfig(
+            asResolved({ baseUrl: 'https://api.test', path: '/y' }),
+        );
+        expect('authScheme' in redacted).toBe(false);
+        expect('kind' in redacted).toBe(false);
+    });
+});


### PR DESCRIPTION
## What

Adds `packages/core/test/stitch-helpers.spec.ts` — two pure helpers in `src/stitch.ts` that no spec exercises directly (`compose` is already covered by `composition.spec` et al.).

## Why

**`resolveTrace`** — `false` → a no-op sink; a provided sink is returned **by reference**; `'console'` and `undefined` each yield a `TraceSink`.

**`redactConfig`** — the security boundary that builds the public `__config`: it **strips** the live `store`/`auth`/`adapter`/`clock` handles, **re-derives `authScheme`** from the live auth (never trusting an externally-set one), and normalises the live Surface `kind` to its **id string**; the rest survives, and `authScheme`/`kind` are omitted when there's no auth/surface.

## Result

Pure coverage gap fill — **no behaviour change**. Full gate passes:

- `pnpm check:types` ✓
- `pnpm check:lint` ✓
- `pnpm test` — 867 passed (+5 new), 2 skipped ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)