### PR TITLE
test(react): cover enabled:false gate and inline-stitch identity stability

### DIFF
--- a/packages/react/test/hooks.spec.tsx
+++ b/packages/react/test/hooks.spec.tsx
@@ -136,6 +136,78 @@ describe('useStitch', () => {
         });
         await waitFor(() => expect(screen.getByText('id-2')).toBeDefined());
     });
+
+    test('enabled:false stays idle and never invokes the stitch', async () => {
+        let calls = 0;
+        const stitch = unaryStitch(async () => {
+            calls += 1;
+            return { name: 'Ada' };
+        });
+
+        function Comp(): React.ReactElement {
+            const { status, isPending } = useStitch(
+                stitch,
+                { params: { id: '1' } },
+                { enabled: false },
+            );
+            return (
+                <span data-testid="status">
+                    {status}
+                    {isPending ? '!' : ''}
+                </span>
+            );
+        }
+        render(<Comp />);
+
+        // The gate holds the store at idle — no pending, no run.
+        expect(screen.getByTestId('status').textContent).toBe('idle');
+        // Flush microtasks: an eager run would have called the stitch by now.
+        await Promise.resolve();
+        expect(calls).toBe(0);
+    });
+
+    test('a fresh stitch identity each render does not re-fetch (no loop)', async () => {
+        let calls = 0;
+        const settle = async (): Promise<{ name: string }> => {
+            calls += 1;
+            return { name: `call-${calls}` };
+        };
+
+        function Comp(): React.ReactElement {
+            const [, force] = React.useState(0);
+            // `unaryStitch(settle)` mints a new function identity on every
+            // render. With the structural input unchanged, that identity churn
+            // must NOT key a fresh run — otherwise each run's notify would
+            // re-render and re-create, looping forever.
+            const { data } = useStitch(unaryStitch(settle), {
+                params: { id: '1' },
+            });
+            return (
+                <div>
+                    <span data-testid="name">{data?.name ?? '...'}</span>
+                    <button onClick={() => force((n) => n + 1)}>
+                        rerender
+                    </button>
+                </div>
+            );
+        }
+        render(<Comp />);
+        await waitFor(() =>
+            expect(screen.getByTestId('name').textContent).toBe('call-1'),
+        );
+
+        act(() => {
+            screen.getByText('rerender').click();
+        });
+        act(() => {
+            screen.getByText('rerender').click();
+        });
+
+        // Two extra renders (new stitch identity each), same structural key →
+        // still exactly one run.
+        expect(calls).toBe(1);
+        expect(screen.getByTestId('name').textContent).toBe('call-1');
+    });
 });
 
 // --- useStitchStream -------------------------------------------------------


### PR DESCRIPTION
## What

Closes two gaps in `@stitchapi/react`'s hook test suite (`packages/react/test/hooks.spec.tsx`). The suite already covered the happy paths, error state, `refetch`, input-change refetch, streaming (append + replace), and `queryOptions`. Two documented behaviours had **no** test:

1. **`enabled: false`** — the gate must hold the store at `idle` and never invoke the stitch.
2. **Inline-stitch identity stability** — a stitch passed inline (a fresh function identity every render) must **not** re-create the query when the structural input is unchanged. This is the loop-prevention guarantee the source explicitly calls out: otherwise each run's `notify` → re-render → re-create → run, forever. The existing "changing input re-fetches" test asserts the positive direction; this PR adds the inverse.

## How

Both tests reuse the existing fake stitches (no engine, no network) and the suite's render-based style (`render` + `screen` + `act`). The inline-identity test counts stitch invocations across two forced re-renders and asserts it stays at exactly one run.

## Verification

- `pnpm --filter @stitchapi/react test` → **10 passed**
- `pnpm --filter @stitchapi/react check:types` → clean
- `pnpm check:lint` → clean (only `core`/`docs` define a lint script; both Done)
- `prettier --check` → clean
- pre-push hook (full CI gate) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)