### PR TITLE
test(elysia): cover streamStitchSse mapper, event label, framing, and error paths

### DIFF
--- a/packages/elysia/test/sse.spec.ts
+++ b/packages/elysia/test/sse.spec.ts
@@ -1,0 +1,177 @@
+// Focused tests for @stitchapi/elysia's `streamStitchSse`. The integration
+// `elysia.spec.ts` only exercises the basic delta→`data:` path and the
+// error-event frame. This drives the helper directly with hand-rolled
+// `StitchEvent` generators — it takes just the source and returns a Web-standard
+// `Response`, so no Elysia app is needed — to cover the untested surface: the
+// DEFAULT data mapper, the `event:` label, the `onError` callback, control
+// events not being forwarded, the throw-mid-stream catch path, the SSE-spec
+// multi-line `data:` framing, and the response headers.
+import { streamStitchSse } from '../src';
+
+import type { StitchEvent } from 'stitchapi';
+import { describe, expect, test } from 'vitest';
+
+/** An async event source over a fixed list, yielding on a microtask per event. */
+async function* gen(events: StitchEvent[]): AsyncGenerator<StitchEvent, void> {
+    for (const e of events) {
+        await Promise.resolve();
+        yield e;
+    }
+}
+
+/** The `data:` lines of an SSE body, in order. */
+function dataLines(body: string): string[] {
+    return body
+        .split('\n')
+        .filter((l) => l.startsWith('data:'))
+        .map((l) => l.trimEnd());
+}
+
+describe('streamStitchSse — delta mapping', () => {
+    test('the default data mapper sends a string verbatim and JSON-stringifies an object', async () => {
+        const res = streamStitchSse(
+            gen([
+                { type: 'delta', chunk: 'hello', at: 0 },
+                { type: 'delta', chunk: { a: 1 }, at: 0 },
+                { type: 'done', ok: true, ms: 1, attempts: 1, at: 0 },
+            ]),
+        );
+
+        const body = await res.text();
+        expect(body).toContain('data: hello');
+        expect(body).toContain('data: {"a":1}');
+    });
+
+    test('the event option labels each delta message', async () => {
+        const res = streamStitchSse(
+            gen([
+                { type: 'delta', chunk: 't1', at: 0 },
+                { type: 'done', ok: true, ms: 1, attempts: 1, at: 0 },
+            ]),
+            { event: 'token' },
+        );
+
+        const body = await res.text();
+        expect(body).toContain('event: token');
+        expect(body).toContain('data: t1');
+    });
+
+    test('a custom data mapper pulls text out of a structured chunk', async () => {
+        const res = streamStitchSse(
+            gen([
+                { type: 'delta', chunk: { text: 'pulled' }, at: 0 },
+                { type: 'done', ok: true, ms: 1, attempts: 1, at: 0 },
+            ]),
+            { data: (chunk) => (chunk as { text: string }).text },
+        );
+
+        const body = await res.text();
+        expect(body).toContain('data: pulled');
+    });
+
+    test('a multi-line chunk gets one data: prefix per line (SSE spec)', async () => {
+        const res = streamStitchSse(
+            gen([
+                { type: 'delta', chunk: 'line1\nline2', at: 0 },
+                { type: 'done', ok: true, ms: 1, attempts: 1, at: 0 },
+            ]),
+        );
+
+        const body = await res.text();
+        expect(body).toContain('data: line1\ndata: line2');
+    });
+});
+
+describe('streamStitchSse — control events', () => {
+    test('start/progress/result/done are consumed but not forwarded — only deltas reach the client', async () => {
+        const res = streamStitchSse(
+            gen([
+                {
+                    type: 'start',
+                    name: 'x',
+                    method: 'GET',
+                    url: 'https://api.test/x',
+                    input: {},
+                    at: 0,
+                },
+                { type: 'progress', phase: 'request', attempt: 1, at: 0 },
+                { type: 'delta', chunk: 'only-this', at: 0 },
+                {
+                    type: 'result',
+                    value: { leak: 'SHOULD-NOT-APPEAR' },
+                    status: 200,
+                    attempts: 1,
+                    at: 0,
+                },
+                { type: 'done', ok: true, ms: 1, attempts: 1, at: 0 },
+            ]),
+        );
+
+        const body = await res.text();
+        expect(dataLines(body)).toEqual(['data: only-this']);
+        expect(body).not.toContain('SHOULD-NOT-APPEAR');
+    });
+});
+
+describe('streamStitchSse — error paths', () => {
+    test('an error event writes an event: error frame, invokes onError, and stops forwarding', async () => {
+        let captured: unknown;
+        const res = streamStitchSse(
+            gen([
+                { type: 'delta', chunk: 'a', at: 0 },
+                {
+                    type: 'error',
+                    name: 'StitchError',
+                    message: 'upstream failed',
+                    attempts: 1,
+                    at: 0,
+                },
+                { type: 'delta', chunk: 'never', at: 0 },
+            ]),
+            {
+                onError: (e) => {
+                    captured = e;
+                },
+            },
+        );
+
+        const body = await res.text();
+        expect(body).toContain('data: a');
+        expect(body).toContain('event: error');
+        expect(body).toContain('upstream failed');
+        expect(body).not.toContain('never');
+        expect((captured as Error).message).toBe('upstream failed');
+    });
+
+    test('a throw mid-stream is caught: onError fires and a final event: error frame is written', async () => {
+        let captured: unknown;
+        async function* boom(): AsyncGenerator<StitchEvent, void> {
+            yield { type: 'delta', chunk: 'a', at: 0 };
+            throw new Error('stream blew up');
+        }
+
+        const res = streamStitchSse(boom(), {
+            onError: (e) => {
+                captured = e;
+            },
+        });
+
+        const body = await res.text();
+        expect(body).toContain('data: a');
+        expect(body).toContain('event: error');
+        expect(body).toContain('stream blew up');
+        expect((captured as Error).message).toBe('stream blew up');
+    });
+});
+
+describe('streamStitchSse — response', () => {
+    test('returns a text/event-stream Response', async () => {
+        const res = streamStitchSse(
+            gen([{ type: 'done', ok: true, ms: 1, attempts: 1, at: 0 }]),
+        );
+        expect(res.headers.get('content-type')).toBe('text/event-stream');
+        expect(res.headers.get('cache-control')).toContain('no-cache');
+        // Drain so the stream is not left dangling.
+        await res.text();
+    });
+});


### PR DESCRIPTION
## What

`packages/elysia/src/sse.ts` (`streamStitchSse`) was only partially tested. The integration `elysia.spec.ts` exercised the basic delta→`data:` path and the upstream-error frame, leaving several branches uncovered.

## How

New `packages/elysia/test/sse.spec.ts` drives `streamStitchSse` directly with hand-rolled `StitchEvent` generators (it takes just the source and returns a Web-standard `Response`, so no Elysia app is needed). It covers:

- **Default data mapper**: a string chunk verbatim, an object chunk JSON-stringified.
- **`event:` option** labels each delta message.
- **Multi-line chunk** gets one `data:` prefix per line (the `frame()` SSE-spec helper).
- **Control events** (`start`/`progress`/`result`/`done`) are consumed but **not** forwarded — only deltas reach the client, and a `result` value never hits the wire.
- An **`error` event** writes an `event: error` frame, invokes `onError`, and stops forwarding.
- A **throw mid-stream** is caught: `onError` fires and a final `event: error` frame is written.
- The Response is `text/event-stream` with a `no-cache` control header.

`plugin.ts` and `error.ts` were already well covered (502 default, status override, `errorHandler:false`, `isStitchError`), so this PR targets the SSE module.

## Verification

- `pnpm --filter @stitchapi/elysia test` → **18 passed** (8 new)
- `pnpm --filter @stitchapi/elysia check:types` → clean
- `pnpm check:lint` → clean · `prettier --check` → clean
- pre-push hook (full CI gate) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)