### PR TITLE
test(express): cover SSE id option, default mapper object case, and multi-line frames

### DIFF
--- a/packages/express/test/express.spec.ts
+++ b/packages/express/test/express.spec.ts
@@ -218,6 +218,40 @@ describe('streamStitchSse writes SSE frames to res', () => {
         );
     });
 
+    test('the default data mapper sends a string verbatim and JSON-stringifies an object', async () => {
+        async function* events(): AsyncGenerator<StitchEvent<unknown>> {
+            yield { type: 'delta', chunk: 'plain', at: 1 };
+            yield { type: 'delta', chunk: { a: 1 }, at: 2 };
+        }
+        const res = mockRes();
+        await streamStitchSse(res as unknown as Response, events());
+
+        expect(res.body()).toBe('data: plain\n\ndata: {"a":1}\n\n');
+    });
+
+    test('the id option emits an id: line per frame with the zero-based index', async () => {
+        async function* events(): AsyncGenerator<StitchEvent<unknown>> {
+            yield { type: 'delta', chunk: 'a', at: 1 };
+            yield { type: 'delta', chunk: 'b', at: 2 };
+        }
+        const res = mockRes();
+        await streamStitchSse(res as unknown as Response, events(), {
+            id: (chunk, index) => `${String(chunk)}-${index}`,
+        });
+
+        expect(res.body()).toBe('id: a-0\ndata: a\n\nid: b-1\ndata: b\n\n');
+    });
+
+    test('a multi-line chunk gets one data: prefix per line (SSE spec)', async () => {
+        async function* events(): AsyncGenerator<StitchEvent<unknown>> {
+            yield { type: 'delta', chunk: 'line1\nline2', at: 1 };
+        }
+        const res = mockRes();
+        await streamStitchSse(res as unknown as Response, events());
+
+        expect(res.body()).toBe('data: line1\ndata: line2\n\n');
+    });
+
     test('a client disconnect aborts the upstream iterator (iterator.return is called)', async () => {
         let returned = false;
         // A stream that blocks after the first delta until torn down — exactly the shape of a real


### PR DESCRIPTION
## What

`packages/express/src/sse.ts` (`streamStitchSse`) was well covered (control filtering, error frame, custom data mapper + named event, disconnect teardown) but three branches of its `frame()` builder were untested.

## How

Three tests added to the existing SSE suite (reusing its `mockRes`):

- **`id` option**: emits an `id:` line per frame with the zero-based frame index (resumable streams) — `id: a-0\ndata: a\n\n…`.
- **Default data mapper**: a string chunk is sent verbatim, an object chunk is JSON-stringified (the existing mapper test always passed a custom mapper, so the default object path was never hit).
- **Multi-line chunk**: gets one `data:` prefix per line (SSE spec) — `data: line1\ndata: line2\n\n`.

## Verification

- `pnpm --filter @stitchapi/express test` → **14 passed** (3 new)
- `pnpm --filter @stitchapi/express check:types` → clean
- `pnpm check:lint` → clean · `prettier --check` → clean
- pre-push hook (full CI gate) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)