### PR TITLE
test(expo): guard expoSecureStore key collision-resistance (padStart(4))

### DIFF
--- a/packages/expo/test/store.spec.ts
+++ b/packages/expo/test/store.spec.ts
@@ -47,4 +47,20 @@ describe('expoSecureStore', () => {
         expect(seen[0]).toMatch(/^[A-Za-z0-9._-]+$/);
         expect(seen[0]).toMatch(/^[0-9a-f]+$/);
     });
+
+    test('pads each code unit to 4 hex digits so distinct keys never collide', async () => {
+        const api = expoSecureStore(fakeSecureStore());
+        // Codes [1, 0] and [16] both hex to "10" under a NAIVE, unpadded
+        // per-code-unit encoding ("1"+"0" vs "10"). padStart(4) keeps them
+        // distinct ("00010000" vs "0010") — without it the second write would
+        // clobber the first.
+        const keyA = String.fromCharCode(1, 0);
+        const keyB = String.fromCharCode(16);
+
+        await api.set(keyA, 'first');
+        await api.set(keyB, 'second');
+
+        expect(await api.get(keyA)).toBe('first');
+        expect(await api.get(keyB)).toBe('second');
+    });
 });


### PR DESCRIPTION
## What

`packages/expo/src/store.ts` (`expoSecureStore`) hex-encodes engine keys into SecureStore's restricted charset (`[A-Za-z0-9._-]`), padding **each UTF-16 code unit to 4 hex digits** precisely so two distinct engine keys can never collide. The existing "encodes engine keys" test checks the output *charset* of one key, but never asserts that collision-resistance invariant.

## How

One test added to `store.spec.ts`: a round-trip with two keys — char codes `[1, 0]` and `[16]` — that both hex to `"10"` under a naive *unpadded* per-code-unit encoding. With `padStart(4)` they encode to `"00010000"` vs `"0010"`, so the two writes stay separate and each reads back its own value. Without the padding, the second write would clobber the first — this test would catch that regression.

`adapter.ts` (streaming + unary) and the full `StitchStore` contract (`verifyStoreContract`) are already covered; `index.ts` is re-exports and `native-modules.d.ts` is a type declaration, so this is the one genuine gap.

## Verification

- `pnpm --filter @stitchapi/expo test` → **5 passed** (1 new)
- `pnpm --filter @stitchapi/expo check:types` → clean
- `pnpm check:lint` → clean · `prettier --check` → clean
- pre-push hook (full CI gate) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)