### PR TITLE
test(react-native): cover the streaming-polyfill guard (polyfills.ts)

### DIFF
--- a/packages/react-native/test/polyfills.spec.ts
+++ b/packages/react-native/test/polyfills.spec.ts
@@ -1,0 +1,66 @@
+// Unit tests for @stitchapi/react-native's streaming-polyfill guard
+// (`polyfills.ts`), which no spec touched. Both functions take an injectable
+// `scope`, so we exercise the required-globals check with fake scopes — and the
+// default-scope path against Node's globals — without monkeypatching globalThis.
+import { assertStreamingPolyfills, hasStreamingPolyfills } from '../src';
+
+import { describe, expect, test } from 'vitest';
+
+/** A scope where every streaming global is present. */
+const allPresent = (): Record<string, unknown> => ({
+    TextEncoder: class {},
+    TextDecoder: class {},
+    ReadableStream: class {},
+});
+
+describe('hasStreamingPolyfills', () => {
+    test('true when TextEncoder, TextDecoder, and ReadableStream are all present', () => {
+        expect(hasStreamingPolyfills(allPresent())).toBe(true);
+    });
+
+    test('false when a required global is absent', () => {
+        // ReadableStream missing entirely.
+        expect(
+            hasStreamingPolyfills({
+                TextEncoder: class {},
+                TextDecoder: class {},
+            }),
+        ).toBe(false);
+    });
+
+    test('treats a global explicitly set to undefined as missing', () => {
+        expect(
+            hasStreamingPolyfills({
+                TextEncoder: undefined,
+                TextDecoder: class {},
+                ReadableStream: class {},
+            }),
+        ).toBe(false);
+    });
+
+    test('the default scope is globalThis, which Node provides', () => {
+        expect(hasStreamingPolyfills()).toBe(true);
+    });
+});
+
+describe('assertStreamingPolyfills', () => {
+    test('does not throw when every streaming global is present', () => {
+        expect(() => assertStreamingPolyfills(allPresent())).not.toThrow();
+    });
+
+    test('throws naming the missing globals and the install hint', () => {
+        // Only TextEncoder present → TextDecoder + ReadableStream missing, in
+        // REQUIRED order.
+        const scope: Record<string, unknown> = { TextEncoder: class {} };
+        expect(() => assertStreamingPolyfills(scope)).toThrow(
+            /TextDecoder, ReadableStream/,
+        );
+        expect(() => assertStreamingPolyfills(scope)).toThrow(
+            /react-native-polyfill-globals\/auto/,
+        );
+    });
+
+    test('the default scope (globalThis) does not throw in Node', () => {
+        expect(() => assertStreamingPolyfills()).not.toThrow();
+    });
+});


### PR DESCRIPTION
## What

`packages/react-native/src/polyfills.ts` (`assertStreamingPolyfills` / `hasStreamingPolyfills`) had **no** test coverage. It's the guard that turns a cryptic "ReadableStream is not defined" deep in the stream decoder into one actionable install message on bare Hermes.

## How

New `packages/react-native/test/polyfills.spec.ts`. Both functions take an injectable `scope`, so the tests use fake scopes (plus the default `globalThis` path) — no monkeypatching:

- **`hasStreamingPolyfills`**: `true` when `TextEncoder`/`TextDecoder`/`ReadableStream` are all present, `false` when one is absent, and a global explicitly set to `undefined` counts as missing.
- **`assertStreamingPolyfills`**: does not throw when present; otherwise throws naming the missing globals (in `REQUIRED` order) and the `react-native-polyfill-globals/auto` install hint.
- The **default scope** is `globalThis`, which Node provides — so the no-arg calls report present / do not throw.

`adapter.ts`, `lifecycle.ts`, and `store.ts` already have dedicated specs; `index.ts` is re-exports and `native-modules.d.ts` is a declaration, so this closes the package's last gap.

## Verification

- `pnpm --filter @stitchapi/react-native test` → **22 passed** (7 new)
- `pnpm --filter @stitchapi/react-native check:types` → clean
- `pnpm check:lint` → clean · `prettier --check` → clean
- pre-push hook (full CI gate) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)