### PR TITLE
test(sentry): cover captureErrors:false and the error-level captureDrift guard

### DIFF
--- a/packages/sentry/test/sentry.spec.ts
+++ b/packages/sentry/test/sentry.spec.ts
@@ -125,6 +125,38 @@ describe('sentrySink', () => {
         expect(b.captures).toHaveLength(1);
     });
 
+    test('captureErrors:false still breadcrumbs the error but does not capture it as an issue', () => {
+        const { sentry, breadcrumbs, captures } = mockSentry();
+        sentrySink(sentry, { captureErrors: false }).handle(ev.error, ctx);
+
+        // The error trail is preserved, but the framework owns the issue.
+        expect(captures).toHaveLength(0);
+        expect(breadcrumbs).toHaveLength(1);
+        expect(breadcrumbs[0]!.level).toBe('error');
+    });
+
+    test('captureDrift only captures an error-level finding — a warn-level drift is breadcrumbed only', () => {
+        const driftWarn: StitchEvent = {
+            type: 'drift',
+            finding: {
+                path: '$.user.age',
+                level: 'warn',
+                change: 'type-changed',
+            },
+            at: 0,
+        };
+        const { sentry, breadcrumbs, captures } = mockSentry();
+        sentrySink(sentry, { captureDrift: true }).handle(driftWarn, ctx);
+
+        // captureDrift is gated on an error-level finding; a warn drift only crumbs.
+        expect(captures).toHaveLength(0);
+        expect(breadcrumbs).toHaveLength(1);
+        expect(breadcrumbs[0]).toMatchObject({
+            category: 'stitch.drift',
+            level: 'warning',
+        });
+    });
+
     test('delta and info events are never sent (raw data / announcements)', () => {
         const { sentry, breadcrumbs, captures } = mockSentry();
         const sink = sentrySink(sentry);


### PR DESCRIPTION
## What

`@stitchapi/sentry`'s `sentrySink` had solid coverage (default error capture, breadcrumb levels, lifecycle toggle, error-level drift capture, metadata-only redaction), but two option branches were untested.

## How

Two tests added to the existing `sentry.spec.ts`:

- **`captureErrors: false`** — the error is still breadcrumbed (the trail is preserved for any later issue) but **not** captured as a Sentry issue, for apps whose framework already reports the error.
- **`captureDrift` is gated on an error-level finding** — a `warn`-level drift with `captureDrift: true` is breadcrumbed only (level `warning`), never captured. The existing test only covered the error-level finding.

## Verification

- `pnpm --filter @stitchapi/sentry test` → **8 passed** (2 new)
- `pnpm --filter @stitchapi/sentry check:types` → clean
- `pnpm check:lint` → clean · `prettier --check` → clean
- pre-push hook (full CI gate) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)