### PR TITLE
test(rtk-query): cover error serialisation drops and stream eviction

### DIFF
--- a/packages/rtk-query/test/rtk-query.spec.ts
+++ b/packages/rtk-query/test/rtk-query.spec.ts
@@ -86,6 +86,42 @@ describe('stitchQueryFn', () => {
         // The error is a plain serialisable object (safe for Redux state).
         expect(result.error && typeof result.error).toBe('object');
     });
+
+    test('keeps primitive own fields but DROPS non-primitive ones (Redux-serialisable)', async () => {
+        class RichError extends Error {
+            override name = 'StitchError';
+            status = 502; // primitive → carried
+            response = { headers: { secret: 'x' } }; // object → dropped
+        }
+        const qfn = stitchQueryFn(
+            unaryStitch(async () => {
+                throw new RichError('bad gateway');
+            }),
+        );
+        const result = await qfn({});
+
+        expect(result.error).toEqual({
+            name: 'StitchError',
+            message: 'bad gateway',
+            status: 502,
+        });
+        // A non-serialisable object field must never reach Redux state.
+        expect(result.error && 'response' in result.error).toBe(false);
+    });
+
+    test('serialises a non-Error throw via String(reason)', async () => {
+        const qfn = stitchQueryFn(
+            unaryStitch(async () => {
+                // eslint-disable-next-line @typescript-eslint/only-throw-error
+                throw 'plain string failure';
+            }),
+        );
+        const result = await qfn({});
+        expect(result.error).toEqual({
+            name: 'Error',
+            message: 'plain string failure',
+        });
+    });
 });
 
 // --- stitchStreamUpdater ---------------------------------------------------
@@ -111,6 +147,30 @@ describe('stitchStreamUpdater', () => {
             mode: 'replace',
         })(undefined, api);
         expect(data).toEqual([3]);
+    });
+
+    test('stops when the cache entry is removed, even if the stream never ends', async () => {
+        const data: number[] = [];
+        const api: CacheLifecycleApi<number[]> = {
+            updateCachedData: (recipe) => recipe(data),
+            cacheDataLoaded: Promise.resolve({ data }),
+            // The entry is evicted (component unmounted) — this must win the race.
+            cacheEntryRemoved: Promise.resolve(),
+        };
+        // A stitch whose stream never completes on its own.
+        const neverEnding: StreamableStitchLike<number> = () => ({
+            then: (onf) => Promise.resolve(undefined as never).then(onf),
+            stream() {
+                return (async function* () {
+                    await new Promise<void>(() => {});
+                })();
+            },
+        });
+
+        // Must resolve via cacheEntryRemoved rather than hang on the live stream.
+        await expect(
+            stitchStreamUpdater<number>(neverEnding)(undefined, api),
+        ).resolves.toBeUndefined();
     });
 });
 


### PR DESCRIPTION
## What

`@stitchapi/rtk-query` proved `{data}`/`{error}` and a `StitchError`'s primitive `status` field, but three behaviours were untested.

## How

Three tests added to the existing `rtk-query.spec.ts`:

- **`serializeError` drops non-primitive own fields**: it keeps `name`/`message` plus primitive own props (`status`) but **drops** an object prop (`response`), so Redux state never holds a non-serialisable value.
- **Non-`Error` throw**: a thrown string serialises to `{ name: 'Error', message: String(reason) }`.
- **`stitchStreamUpdater` eviction**: it stops when the cache entry is removed (the `cacheEntryRemoved` `Promise.race` wins) even if the underlying stream never ends — otherwise an unmounted component would leak a live stream.

While here I also examined **vercel-ai** — `stitchExecute`/`stitchTool` are already fully covered (all branches), so no PR there.

## Verification

- `pnpm --filter @stitchapi/rtk-query test` → **8 passed** (3 new)
- `pnpm --filter @stitchapi/rtk-query check:types` → clean
- `pnpm check:lint` → clean · `prettier --check` → clean
- pre-push hook (full CI gate) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)