### PR TITLE
test(swr): cover SWR config passthrough (the third argument)

### DIFF
--- a/packages/swr/test/swr.spec.tsx
+++ b/packages/swr/test/swr.spec.tsx
@@ -102,4 +102,25 @@ describe('useStitchSWR', () => {
         // One shared cache entry → the fetcher runs once for both hooks.
         expect(calls).toBe(1);
     });
+
+    test('forwards the SWR config (third argument) to useSWR', async () => {
+        const getUser = unaryStitch(async () => ({ name: 'fresh' }));
+        const { result } = renderHook(
+            () =>
+                useStitchSWR(
+                    getUser,
+                    { params: { id: '1' } },
+                    { fallbackData: { name: 'cached' } },
+                ),
+            { wrapper },
+        );
+
+        // `fallbackData` is a config option, so its presence proves the third
+        // argument reached useSWR: the cached value shows immediately…
+        expect(result.current.data).toEqual({ name: 'cached' });
+        // …then the stitch fetcher revalidates to the fresh value.
+        await waitFor(() =>
+            expect(result.current.data).toEqual({ name: 'fresh' }),
+        );
+    });
 });


### PR DESCRIPTION
## What

`@stitchapi/swr` covered `swrKey` (both branches) and `useStitchSWR`'s data / error / dedupe paths, but the documented **third argument** — the SWR config forwarded to `useSWR` — had no test.

## How

One test added to the existing `swr.spec.tsx`, driving the config through `fallbackData`: the cached value (`{ name: 'cached' }`) shows immediately — proving the config object reached `useSWR` — and then the stitch fetcher revalidates to the fresh value (`{ name: 'fresh' }`).

## Verification

- `pnpm --filter @stitchapi/swr test` → **6 passed** (1 new)
- `pnpm --filter @stitchapi/swr check:types` → clean
- `pnpm check:lint` → clean · `prettier --check` → clean
- pre-push hook (full CI gate) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)