### PR TITLE
test(fingerprint-valibot): extend the battery to the less-common Valibot types

### DIFF
--- a/packages/fingerprint-valibot/test/conformance.spec.ts
+++ b/packages/fingerprint-valibot/test/conformance.spec.ts
@@ -98,6 +98,55 @@ const fixtures: FingerprintFixtures = {
             label: 'union-snb',
             schema: () => v.union([v.string(), v.number(), v.boolean()]),
         },
+        // Less-common Valibot types the original battery omitted — each exercises
+        // a distinct type-dispatch branch and must fingerprint to a unique value.
+        { label: 'bigint', schema: () => v.bigint() },
+        { label: 'date', schema: () => v.date() },
+        { label: 'symbol', schema: () => v.symbol() },
+        { label: 'null', schema: () => v.null_() },
+        { label: 'undefined', schema: () => v.undefined_() },
+        { label: 'void', schema: () => v.void_() },
+        { label: 'nan', schema: () => v.nan() },
+        { label: 'any', schema: () => v.any() },
+        { label: 'unknown', schema: () => v.unknown() },
+        { label: 'never', schema: () => v.never() },
+        { label: 'nullable', schema: () => v.nullable(v.string()) },
+        { label: 'nullish', schema: () => v.nullish(v.string()) },
+        {
+            label: 'tuple',
+            schema: () => v.tuple([v.string(), v.number()]),
+        },
+        {
+            label: 'record',
+            schema: () => v.record(v.string(), v.number()),
+        },
+        { label: 'map', schema: () => v.map(v.string(), v.number()) },
+        { label: 'set', schema: () => v.set(v.number()) },
+        { label: 'enum', schema: () => v.enum_({ A: 'x', B: 'y' }) },
+        {
+            label: 'variant',
+            schema: () =>
+                v.variant('t', [
+                    v.object({ t: v.literal('a') }),
+                    v.object({ t: v.literal('b') }),
+                ]),
+        },
+        {
+            label: 'intersect',
+            schema: () =>
+                v.intersect([
+                    v.object({ a: v.number() }),
+                    v.object({ b: v.string() }),
+                ]),
+        },
+        {
+            label: 'strict-object',
+            schema: () => v.strictObject({ id: v.number() }),
+        },
+        {
+            label: 'loose-object',
+            schema: () => v.looseObject({ id: v.number() }),
+        },
     ],
     abstain: [
         // Opaque predicate (check) → cannot capture the logic.


### PR DESCRIPTION
## What

`valibotFingerprinter` handles a large Valibot schema-type set, but the conformance fixtures only covered string/number/boolean/object/picklist/literal/array/union — leaving ~21 type-dispatch branches unexercised.

## How

Extended the `distinct` fixtures battery in `conformance.spec.ts` (so the shared `verifyFingerprintContract` proves each fingerprints to a **unique, non-abstaining** value):

`bigint`, `date`, `symbol`, `null_`, `undefined_`, `void_`, `nan`, `any`, `unknown`, `never`, `nullable`, `nullish`, `tuple`, `record`, `map`, `set`, `enum_`, `variant`, `intersect`, `strictObject`, `looseObject`.

This pins the walker's discrimination for the full type set (each maps to a distinct code, so a regression that collapsed two types would now fail the pairwise-distinctness check).

## Verification

- `pnpm --filter @stitchapi/fingerprint-valibot test` → **3 passed** (the contract now runs the expanded battery; all distinctness holds)
- `pnpm --filter @stitchapi/fingerprint-valibot check:types` → clean
- `pnpm check:lint` → clean · `prettier --check` → clean
- pre-push hook (full CI gate) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)