### PR TITLE
test(fingerprint-typebox): extend the battery to more representable JSON shapes

### DIFF
--- a/packages/fingerprint-typebox/test/conformance.spec.ts
+++ b/packages/fingerprint-typebox/test/conformance.spec.ts
@@ -143,6 +143,30 @@ const fixtures: FingerprintFixtures = {
             label: 'union-string-number',
             schema: () => std(Type.Union([Type.String(), Type.Number()])),
         },
+        // Representable JSON-Schema shapes the original battery omitted — each
+        // exercises a distinct walker path and must hash to a unique value.
+        { label: 'null', schema: () => std(Type.Null()) },
+        { label: 'date', schema: () => std(Type.Date()) },
+        { label: 'bigint', schema: () => std(Type.BigInt()) },
+        { label: 'uint8array', schema: () => std(Type.Uint8Array()) },
+        {
+            label: 'tuple',
+            schema: () => std(Type.Tuple([Type.String(), Type.Number()])),
+        },
+        {
+            label: 'record',
+            schema: () => std(Type.Record(Type.String(), Type.Number())),
+        },
+        {
+            label: 'intersect',
+            schema: () =>
+                std(
+                    Type.Intersect([
+                        Type.Object({ a: Type.Number() }),
+                        Type.Object({ b: Type.String() }),
+                    ]),
+                ),
+        },
     ],
     abstain: [
         // A transform attaches an opaque Decode/Encode codec, invisible to the


### PR DESCRIPTION
## What

The TypeBox fingerprint walker handles any representable JSON-Schema node, but the conformance fixtures only covered string/number/integer/boolean/enum/literal/array/union/object — leaving several representable shapes unexercised.

## How

Extended the `distinct` fixtures battery in `conformance.spec.ts` so each must hash to a **unique, non-abstaining** value:

- `null` (`Type.Null()`), `date` (`Type.Date()`), `bigint` (`Type.BigInt()`), `uint8array` (`Type.Uint8Array()`)
- `tuple` (`Type.Tuple` → `items[]` array form), `record` (`Type.Record` → `patternProperties`), `intersect` (`Type.Intersect` → `allOf`)

Running confirms none of these abstain (they each carry a JSON-Schema discriminator) and all produce distinct fingerprints — pinning the walker's canonical-stringify path for these shapes.

## Verification

- `pnpm --filter @stitchapi/fingerprint-typebox test` → **3 passed** (expanded battery; all distinctness holds)
- `pnpm --filter @stitchapi/fingerprint-typebox check:types` → clean
- `pnpm check:lint` → clean · `prettier --check` → clean
- pre-push hook (full CI gate) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)