### PR TITLE
test(fingerprint-arktype): extend the battery to more domains, keywords, composites

### DIFF
--- a/packages/fingerprint-arktype/test/conformance.spec.ts
+++ b/packages/fingerprint-arktype/test/conformance.spec.ts
@@ -64,6 +64,18 @@ const fixtures: FingerprintFixtures = {
         { label: 'enum-abc', schema: () => type('"a"|"b"|"c"') }, // enum variant added
         { label: 'tuple-sn', schema: () => type(['string', 'number']) },
         { label: 'tuple-ns', schema: () => type(['number', 'string']) }, // order-significant
+        // Domains / keywords / composites the original battery omitted — each
+        // exercises a distinct walker path and must hash to a unique value.
+        { label: 'bigint', schema: () => type('bigint') },
+        { label: 'symbol', schema: () => type('symbol') },
+        { label: 'date', schema: () => type('Date') },
+        { label: 'string-email', schema: () => type('string.email') },
+        { label: 'string-uuid', schema: () => type('string.uuid') },
+        { label: 'record', schema: () => type({ '[string]': 'number' }) },
+        {
+            label: 'intersection',
+            schema: () => type({ a: 'number' }).and({ b: 'string' }),
+        },
     ],
     abstain: [
         // Morph (.pipe): JSON carries a non-deterministic opaque `$ark.fn` ref.


### PR DESCRIPTION
## What

The ArkType fingerprint walker canonicalizes `t.json` for any deterministic, morph-free type, but the conformance fixtures covered only string/number/boolean/literal/object/array/union/enum/tuple/nullable — leaving several representable types unexercised.

## How

Extended the `distinct` fixtures battery in `conformance.spec.ts` so each must hash to a **unique, non-abstaining** value:

- domains: `bigint`, `symbol`, `Date`
- keyword-constrained strings: `string.email`, `string.uuid`
- composites: `record` (index signature `{ '[string]': 'number' }`), `intersection` (`.and`)

Running confirms none abstain (no `$ark.fn`/`default` in their `.json`) and all produce distinct fingerprints.

## Verification

- `pnpm --filter @stitchapi/fingerprint-arktype test` → **3 passed** (expanded battery; all distinctness holds)
- `pnpm --filter @stitchapi/fingerprint-arktype check:types` → clean
- `pnpm check:lint` → clean · `prettier --check` → clean
- pre-push hook (full CI gate) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)