### PR TITLE
test(fingerprint-effect): cover the keyword AST tags the battery omitted

### DIFF
--- a/packages/fingerprint-effect/test/conformance.spec.ts
+++ b/packages/fingerprint-effect/test/conformance.spec.ts
@@ -77,6 +77,17 @@ const fixtures: FingerprintFixtures = {
             schema: std(() => S.Record({ key: S.String, value: S.Number })),
         },
         { label: 'empty-struct', schema: std(() => S.Struct({})) },
+        // Keyword AST tags the original battery omitted — each exercises a
+        // distinct case and must hash to a unique value. (bigint/symbol use the
+        // *FromSelf keywords; the plain S.BigInt/S.Symbol are transforms → abstain.)
+        { label: 'bigint', schema: std(() => S.BigIntFromSelf) },
+        { label: 'symbol', schema: std(() => S.SymbolFromSelf) },
+        { label: 'undefined', schema: std(() => S.Undefined) },
+        { label: 'void', schema: std(() => S.Void) },
+        { label: 'unknown', schema: std(() => S.Unknown) },
+        { label: 'any', schema: std(() => S.Any) },
+        { label: 'object', schema: std(() => S.Object) },
+        { label: 'never', schema: std(() => S.Never) },
     ],
     abstain: [
         {


### PR DESCRIPTION
## What

The Effect Schema fingerprint walker dispatches on the AST `_tag`, but the conformance fixtures only covered `String`/`Number`/`Boolean`/`Literal`/`Union`/`TupleType`/`Enums`/`TypeLiteral` (struct/record/empty) — leaving eight keyword tags unexercised.

## How

Extended the `distinct` fixtures battery in `conformance.spec.ts` so each must hash to a **unique** value:

`bigint`, `symbol`, `undefined`, `void`, `unknown`, `any`, `object`, `never`.

`bigint`/`symbol` use the `*FromSelf` keywords (`S.BigIntFromSelf` / `S.SymbolFromSelf`) — the plain `S.BigInt`/`S.Symbol` are string↔value transforms, which the strategy correctly **abstains** on, so those wouldn't reach the keyword case.

## Verification

- `pnpm --filter @stitchapi/fingerprint-effect test` → **3 passed** (expanded battery; all distinctness holds, none abstain)
- `pnpm --filter @stitchapi/fingerprint-effect check:types` → clean
- `pnpm check:lint` → clean · `prettier --check` → clean
- pre-push hook (full CI gate) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)