### PR TITLE
test(solid): cover reactive options recreate and onSuccess passthrough

### DIFF
--- a/packages/solid/test/primitives.spec.ts
+++ b/packages/solid/test/primitives.spec.ts
@@ -202,6 +202,54 @@ describe('createStitch', () => {
         expect(store.state.status).toBe('pending');
         expect(store.state.data).toBeUndefined();
     });
+
+    test('a reactive options accessor recreates the handle (enabled flips false → true)', async () => {
+        let calls = 0;
+        const stitch = unaryStitch(async () => {
+            calls += 1;
+            return 'v';
+        });
+
+        let store!: StitchStore<string>;
+        let setEnabled!: (v: boolean) => void;
+        const dispose = createRoot((d) => {
+            const [enabled, set] = createSignal(false);
+            setEnabled = set;
+            store = createStitch(stitch, undefined, () => ({
+                enabled: enabled(),
+            }));
+            return d;
+        });
+
+        // enabled:false → idle, the stitch never ran.
+        expect(store.state.status).toBe('idle');
+        expect(calls).toBe(0);
+
+        // Flipping the reactive OPTION recreates the handle with enabled:true.
+        setEnabled(true);
+        expect(store.state.status).toBe('pending');
+        await tick();
+        expect(store.state.status).toBe('success');
+        expect(store.state.data).toBe('v');
+        expect(calls).toBe(1);
+        dispose();
+    });
+
+    test('forwards onSuccess to the underlying query', async () => {
+        let received: unknown;
+        const stitch = unaryStitch(async () => ({ id: 7 }));
+        const { dispose } = root(() =>
+            createStitch(stitch, undefined, {
+                onSuccess: (d) => {
+                    received = d;
+                },
+            }),
+        );
+
+        await tick();
+        expect(received).toEqual({ id: 7 });
+        dispose();
+    });
 });
 
 // --- createStitchStream ----------------------------------------------------


### PR DESCRIPTION
## What

`@stitchapi/solid`'s suite covered the reactive **input** recreate path, `cancel`, and root-dispose teardown — but the driver's effect also tracks `access(options)` and forwards `onSuccess`/`onError`, neither of which was tested.

## How

Two tests added to the `createStitch` suite (reusing the `createRoot`/`createSignal`/`tick` harness):

- **Reactive options recreate**: flipping a reactive `enabled` accessor false → true recreates the handle — the store goes `idle` → `pending` → `success` and the stitch runs exactly once.
- **`onSuccess` passthrough**: `createStitch(..., { onSuccess })` forwards the callback to the underlying query, which fires with the resolved value.

## Verification

- `pnpm --filter @stitchapi/solid test` → **14 passed** (2 new)
- `pnpm --filter @stitchapi/solid check:types` → clean
- `pnpm check:lint` → clean · `prettier --check` → clean
- pre-push hook (full CI gate) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)