### PR TITLE
test(svelte): cover onSuccess / onError passthrough to the underlying query

### DIFF
--- a/packages/svelte/test/stores.spec.ts
+++ b/packages/svelte/test/stores.spec.ts
@@ -174,6 +174,43 @@ describe('stitchStore', () => {
     test('useStitch is an alias of stitchStore', () => {
         expect(useStitch).toBe(stitchStore);
     });
+
+    test('forwards onSuccess to the underlying query (fires on success after subscribe)', async () => {
+        let received: unknown;
+        const store = stitchStore(
+            unaryStitch(async () => ({ id: 7 })),
+            {},
+            {
+                onSuccess: (d) => {
+                    received = d;
+                },
+            },
+        );
+        const { unsubscribe } = collect(store); // first subscriber starts the run
+        await flush();
+        expect(received).toEqual({ id: 7 });
+        unsubscribe();
+    });
+
+    test('forwards onError to the underlying query', async () => {
+        let received: unknown;
+        const boom = new Error('nope');
+        const store = stitchStore<{ id: number }>(
+            unaryStitch(async () => {
+                throw boom;
+            }),
+            {},
+            {
+                onError: (e) => {
+                    received = e;
+                },
+            },
+        );
+        const { unsubscribe } = collect(store);
+        await flush();
+        expect(received).toBe(boom);
+        unsubscribe();
+    });
 });
 
 // --- stitchStreamStore (streaming) -----------------------------------------


### PR DESCRIPTION
## What

`@stitchapi/svelte`'s suite covered lazy-start-on-subscribe, abort-on-last-unsubscribe, `refetch`, `enabled: false`, streaming, and the `use*` aliases — but `makeStore` also forwards the `onSuccess`/`onError` options into `createStitchQuery`, which had no test.

## How

Two tests added to the `stitchStore` suite (reusing the `collect`/`flush` helpers):

- **`onSuccess`** fires with the resolved value once the first subscriber starts the deferred run.
- **`onError`** fires with the thrown reason.

## Verification

- `pnpm --filter @stitchapi/svelte test` → **13 passed** (2 new)
- `pnpm --filter @stitchapi/svelte check:types` → clean
- `pnpm check:lint` → clean · `prettier --check` → clean
- pre-push hook (full CI gate) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)