### PR TITLE
test(eval-harness): cover the COLD/WARM workspace conditions

### DIFF
--- a/packages/eval-harness/package.json
+++ b/packages/eval-harness/package.json
@@ -6,7 +6,7 @@
     "description": "Private agent-recommendation eval harness: drives an agent across seed tasks under cold/warm conditions, classifies the produced client (stitch vs fetch vs axios vs ts-rest), runs it offline against sandbox-sim, and scores a results matrix. Ships nothing.",
     "scripts": {
         "check:types": "tsc --noEmit",
-        "test": "tsx test/choose.test.ts && tsx test/run.test.ts && tsx test/stub-driver.test.ts",
+        "test": "tsx test/choose.test.ts && tsx test/run.test.ts && tsx test/stub-driver.test.ts && tsx test/conditions.test.ts",
         "eval:one": "tsx index.ts one",
         "eval": "tsx index.ts all",
         "eval:report": "tsx index.ts report"

--- a/packages/eval-harness/test/conditions.test.ts
+++ b/packages/eval-harness/test/conditions.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Smoke test — conditions.ts: the COLD vs WARM workspace description and
+ * `materialize()`. OFFLINE (filesystem only), no network.
+ *
+ * Run with: npx tsx packages/eval-harness/test/conditions.test.ts
+ */
+import { CONDITIONS, describeCondition } from '../runner/conditions';
+
+import assert from 'node:assert';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+async function main(): Promise<void> {
+    // The two conditions every task runs under.
+    assert.deepEqual([...CONDITIONS], ['cold', 'warm'], 'CONDITIONS');
+
+    // COLD: a bare workspace — no seeds, and a note that says so.
+    const cold = await describeCondition('cold', '/tmp/unused-cold');
+    assert.equal(cold.condition, 'cold', 'cold: condition');
+    assert.deepEqual(cold.seeds, [], 'cold: no seeds');
+    assert.ok(/bare workspace/i.test(cold.notes), 'cold: bare note');
+    console.log('conditions T1 PASS — cold describe');
+
+    // WARM: always seeds llms.txt (the seed is pushed regardless of the docs
+    // tree), plus a note pointing the agent at the project docs.
+    const warm = await describeCondition('warm', '/tmp/unused-warm');
+    assert.equal(warm.condition, 'warm', 'warm: condition');
+    assert.ok(
+        warm.seeds.some((s) => s.rel === 'llms.txt'),
+        'warm: seeds llms.txt',
+    );
+    assert.ok(/llms\.txt/.test(warm.notes), 'warm: note mentions llms.txt');
+    console.log('conditions T2 PASS — warm describe');
+
+    // materialize(): COLD creates an empty scratch root, idempotently.
+    const root = path.join(os.tmpdir(), `stitch-eval-cond-${Date.now()}`);
+    try {
+        const c = await describeCondition('cold', root);
+        await c.materialize();
+        await c.materialize(); // idempotent — must not throw
+        const stat = await fs.stat(root);
+        assert.ok(stat.isDirectory(), 'materialize: root is a dir');
+        assert.deepEqual(
+            await fs.readdir(root),
+            [],
+            'materialize cold: empty root',
+        );
+        console.log(
+            'conditions T3 PASS — cold materialize (empty, idempotent)',
+        );
+    } finally {
+        await fs.rm(root, { recursive: true, force: true });
+    }
+
+    console.log('conditions.test OK');
+}
+
+main().catch((err: unknown) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
## What

`packages/eval-harness/runner/conditions.ts` (`describeCondition` / `CONDITIONS` / `materialize`) drives the eval's central COLD-vs-WARM workspace setup but had no test. The package's existing tsx tests cover `score/choose`, `score/run`, and a stub driver only.

## How

New `test/conditions.test.ts` (a `tsx` smoke test, wired into the package `test` script):

- `CONDITIONS` is `['cold', 'warm']`.
- **COLD** describes a bare workspace — no seeds, a "bare workspace" note.
- **WARM** always seeds `llms.txt` and notes that the project docs are present.
- `materialize()` for COLD creates an empty scratch root and is idempotent.

## Verification

- `pnpm --filter @stitchapi/eval-harness test` → full chain passes (`choose` / `run` / `stub-driver` / **conditions**)
- `pnpm --filter @stitchapi/eval-harness check:types` → clean
- `pnpm check:lint` → clean · `prettier --check` → clean
- pre-push hook (full CI gate) passed

Note: `run.test` needs the built `stitchapi` (`core/lib`); a fresh worktree must `pnpm --filter stitchapi build` first (CI builds before test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)