### PR TITLE
test(vue): cover onSuccess / onError passthrough to the underlying query

### DIFF
--- a/packages/vue/test/composables.spec.ts
+++ b/packages/vue/test/composables.spec.ts
@@ -173,6 +173,47 @@ describe('useStitch', () => {
         expect(result.isPending.value).toBe(true);
         expect(result.data.value).toBeUndefined();
     });
+
+    test('forwards onSuccess to the underlying query', async () => {
+        let received: unknown;
+        const { scope } = withScope(() =>
+            useStitch(
+                unaryStitch(async () => ({ id: 7 })),
+                {},
+                {
+                    onSuccess: (d) => {
+                        received = d;
+                    },
+                },
+            ),
+        );
+
+        await flush();
+        expect(received).toEqual({ id: 7 });
+        scope.stop();
+    });
+
+    test('forwards onError to the underlying query', async () => {
+        let received: unknown;
+        const boom = new Error('nope');
+        const { scope } = withScope(() =>
+            useStitch<{ id: number }>(
+                unaryStitch(async () => {
+                    throw boom;
+                }),
+                {},
+                {
+                    onError: (e) => {
+                        received = e;
+                    },
+                },
+            ),
+        );
+
+        await flush();
+        expect(received).toBe(boom);
+        scope.stop();
+    });
 });
 
 // --- useStitchStream -------------------------------------------------------


### PR DESCRIPTION
## What

`@stitchapi/vue`'s composable suite covered the lifecycle, reactive-input refetch, `enabled: false`, `onScopeDispose` teardown, and streaming — but `useStitch` also forwards the `onSuccess`/`onError` options into `createStitchQuery`, which had no test.

## How

Two tests added to the `useStitch` suite (reusing the `withScope`/`flush` harness):

- **`onSuccess`** fires with the resolved value.
- **`onError`** fires with the thrown reason.

## Verification

- `pnpm --filter @stitchapi/vue test` → **12 passed** (2 new)
- `pnpm --filter @stitchapi/vue check:types` → clean
- `pnpm check:lint` → clean · `prettier --check` → clean
- pre-push hook (full CI gate) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)