### PR TITLE
fix(docs): resync content manifest with meta.json and guard the IA against drift

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -75,6 +75,13 @@ jobs:
             # lefthook pre-commit `completions` job, enforced in CI.
             - run: pnpm --filter @stitchapi/docs gen:completions
             - run: git diff --exit-code "apps/docs/app/(home)/playground/playground-completions.generated.ts"
+            # Docs IA drift guard: content.manifest.ts is the source of truth for the sidebar,
+            # but pages get added straight into the per-folder meta.json files, so the manifest
+            # silently rots and a stray `gen:docs` would delete real pages. Regenerate and fail
+            # if any meta.json drifted from the manifest (two-way sync is also unit-tested in
+            # apps/docs/test/content-manifest.spec.ts). Mirrors the completions gate above.
+            - run: pnpm --filter @stitchapi/docs gen:docs
+            - run: git diff --exit-code apps/docs/content/docs
             # Render gate: `tsc` type-checks the docs but never renders a page, so a
             # broken AutoTypeTable path/name, an unregistered MDX component, or a
             # generator throw all pass type-check and only fail at build. Building the

--- a/apps/docs/AUTHORING.md
+++ b/apps/docs/AUTHORING.md
@@ -23,6 +23,14 @@ machine-readable `llms.mdx`.
     emit folders, each `meta.json`, and a stub `.mdx` per page.
     **A page that isn't in the manifest doesn't exist; a manifest entry with no
     file is a bug.** Don't reorganize the tree by hand — change the manifest.
+    `test/content-manifest.spec.ts` and a CI `gen:docs` diff gate enforce this
+    two-way sync, so a drifted manifest fails the build.
+    -   **Exception — hand-maintained sections:** a section listed in
+        `HAND_MAINTAINED_SECTIONS` (e.g. `integrations`, whose pages are added
+        per-PR as each `@stitchapi/*` package ships) curates its own `meta.json`
+        and page set. The generator skips it and the sync test exempts its pages,
+        so for those folders you edit `meta.json` by hand and the manifest stays
+        out of it.
 -   **Machine-readable output is automatic:** Fumadocs emits `llms.txt`,
     `llms-full.txt`, and a per-page `llms.mdx` from your content. You never write
     these — but [rule 5](#authoring-rules) exists because of them.

--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -2,14 +2,17 @@
  * StitchAPI docs — content manifest.
  *
  * The single source of truth for the documentation information architecture.
- * The skeleton generator (`scripts/generate-skeleton.ts`, added next) reads this
- * to emit the folder tree, each `meta.json` (label + page order), and a stub
- * `.mdx` per page using the template for its `kind`.
+ * The skeleton generator (`scripts/generate-skeleton.mjs`) reads this to emit
+ * the folder tree, each `meta.json` (label + page order), and a stub `.mdx`
+ * per page using the template for its `kind`.
  *
- * Invariants (a test will enforce the first one):
+ * Invariants (enforced by `test/content-manifest.spec.ts`, plus a CI gate that
+ * re-runs `gen:docs` and fails on any diff):
  *  - Two-way sync: every `.mdx` under `content/docs` is listed here, and every
  *    entry here has a file. No orphan pages, no undocumented pages. This is the
  *    same anti-drift rule the runtime sells, applied to the docs themselves.
+ *    Exception: sections in `HAND_MAINTAINED_SECTIONS` curate their own
+ *    `meta.json` and page set, so their pages live outside this manifest.
  *  - `description` is mandatory and is a real sentence — it feeds search,
  *    `llms.txt`, and an agent's relevance decision when the page is pulled as
  *    standalone `llms.mdx`. Never ship a placeholder.
@@ -35,6 +38,11 @@ export interface Section {
     path: string;
     /** Sidebar group label — becomes the folder `meta.json` `title`. */
     title: string;
+    /**
+     * Optional folder-level blurb — becomes the `meta.json` `description`.
+     * Currently only the root section carries one (it feeds the docs home).
+     */
+    description?: string;
     /** Optional lucide icon name (the lucide-icons source plugin is enabled). */
     icon?: string;
 }
@@ -56,8 +64,14 @@ export interface Page {
  * entry; the root entry orders the top-level groups.
  */
 export const sections: Section[] = [
-    { path: '', title: 'Documentation' },
+    {
+        path: '',
+        title: 'Documentation',
+        description:
+            'API stitching: turn any API into a typed, resilient function — declare an endpoint once and call it like a local function from your code, the CLI, or an agent, without ever touching a credential.',
+    },
     { path: 'getting-started', title: 'Getting started', icon: 'Rocket' },
+    { path: 'recipes', title: 'Recipes', icon: 'ChefHat' },
     { path: 'concepts', title: 'Concepts', icon: 'Lightbulb' },
     { path: 'guides', title: 'Guides', icon: 'BookOpen' },
     { path: 'guides/authoring', title: 'Authoring & composition' },
@@ -67,12 +81,26 @@ export const sections: Section[] = [
     { path: 'guides/validation', title: 'Validation & drift' },
     { path: 'guides/observability', title: 'Observability' },
     { path: 'guides/state', title: 'State & stores' },
+    { path: 'guides/testing', title: 'Testing' },
     { path: 'surfaces', title: 'Surfaces', icon: 'Layers' },
     { path: 'integrations', title: 'Integrations', icon: 'Plug' },
     { path: 'agents', title: 'For agents', icon: 'Bot' },
     { path: 'reference', title: 'Reference', icon: 'Code' },
     { path: 'errors', title: 'Errors & pitfalls', icon: 'TriangleAlert' },
 ];
+
+/**
+ * Sections whose `meta.json` and page set are curated by hand, NOT generated
+ * from this manifest. The skeleton generator skips them (never rewrites their
+ * `meta.json`) and the two-way-sync test exempts their pages. Use this only for
+ * a section whose page set churns independently of this file — e.g.
+ * integrations, where every shipped `@stitchapi/*` package adds its own page
+ * per-PR. The section entry still lives in `sections` (above) so the generator
+ * keeps it in its parent's sidebar order.
+ */
+export const HAND_MAINTAINED_SECTIONS: ReadonlySet<string> = new Set([
+    'integrations',
+]);
 
 /**
  * Every page, grouped by section in reading order. The generator preserves this
@@ -115,6 +143,113 @@ export const pages: Page[] = [
         title: 'Migration notes',
         description:
             'Three spec-correct behaviors — lowercase header names, %20 query spaces, and template-narrowed stitch types — that differ from a naive baseline and surprise migrators.',
+        kind: 'guide',
+    },
+
+    // ── Recipes ─────────────────────────────────────────────────────────────
+    {
+        path: 'recipes/index',
+        title: 'Recipes',
+        description:
+            'Working examples of common tasks — each one the whole thing in a single block, with links down to the guides for depth.',
+        kind: 'landing',
+    },
+    {
+        path: 'recipes/typed-json-round-trip',
+        title: 'Send JSON and get a typed result back',
+        description:
+            'POST a validated body and read a typed, runtime-validated result — input checked before the request, output checked after.',
+        kind: 'guide',
+    },
+    {
+        path: 'recipes/define-an-entity-once',
+        title: 'Define an entity once, derive every request shape',
+        description:
+            'Declare a resource schema once and derive the create body, update body, and query filter with your validator’s own .omit()/.partial()/.pick() — no StitchAPI-specific schema layer.',
+        kind: 'guide',
+    },
+    {
+        path: 'recipes/paginate-into-one-array',
+        title: 'Loop a cursor API into one array',
+        description:
+            'Follow nextCursor across every page and aggregate the items — no manual while-loop, cursor bookkeeping, or concat.',
+        kind: 'guide',
+    },
+    {
+        path: 'recipes/make-a-flaky-call-succeed',
+        title: 'Make a flaky call succeed on its own',
+        description:
+            'Add retry with backoff so transient 429s and 5xxs recover without your code noticing.',
+        kind: 'guide',
+    },
+    {
+        path: 'recipes/survive-a-flaky-dependency',
+        title: 'Keep a failing dependency from taking you down',
+        description:
+            'Compose timeout, retry, and a circuit breaker so a degraded upstream fails fast instead of hanging every caller.',
+        kind: 'guide',
+    },
+    {
+        path: 'recipes/idempotent-writes',
+        title: 'Retry a write without double-charging',
+        description:
+            'Attach an idempotency key so a retried POST settles once, not twice.',
+        kind: 'guide',
+    },
+    {
+        path: 'recipes/catch-a-breaking-api-change',
+        title: 'Catch a breaking API change before your users do',
+        description:
+            'Wrap output with drift to compare every response against a committed snapshot and flag dropped fields, type flips, and new keys by severity.',
+        kind: 'guide',
+    },
+    {
+        path: 'recipes/catch-a-selector-rename',
+        title: 'Catch a silent selector rename in scraped HTML',
+        description:
+            'Scrape an HTML page into a structured object with transform, then drift the structured shape so a markup or selector rename becomes a loud contract error instead of a silently missing field.',
+        kind: 'guide',
+    },
+    {
+        path: 'recipes/watch-a-call-as-it-happens',
+        title: 'Watch retries and throttling as they happen',
+        description:
+            "Iterate a stitch's event stream instead of awaiting it, and observe every retry, pause, and drift in real time.",
+        kind: 'guide',
+    },
+    {
+        path: 'recipes/mirror-a-paginated-api',
+        title: 'Mirror a paginated API to NDJSON',
+        description:
+            'Pull every page of a cursor-paginated, OAuth2-protected endpoint — with retry and throttle on each page — and write the rows as newline-delimited JSON.',
+        kind: 'guide',
+    },
+    {
+        path: 'recipes/one-rate-limit-across-workers',
+        title: 'Share one rate limit across every worker',
+        description:
+            'Point the throttle at a shared store so a whole fleet draws from a single rate budget instead of N× the limit.',
+        kind: 'guide',
+    },
+    {
+        path: 'recipes/auth-as-a-capability',
+        title: 'Authenticate without the token touching your code',
+        description:
+            'Declare auth on the stitch so callers get a capability, not a credential — the secret is read per call and never returned.',
+        kind: 'guide',
+    },
+    {
+        path: 'recipes/expose-a-stitch-to-an-agent',
+        title: 'Let an agent call your API without handing it the key',
+        description:
+            'Expose your stitches over MCP through one run_stitch tool — the agent invokes a capability and never sees the credential.',
+        kind: 'guide',
+    },
+    {
+        path: 'recipes/one-stitch-every-surface',
+        title: 'Call one stitch as a function, a CLI command, and an agent tool',
+        description:
+            'One definition, four front doors — in-process, shell, HTTP, and MCP — with nothing about the stitch changing.',
         kind: 'guide',
     },
 
@@ -170,6 +305,13 @@ export const pages: Page[] = [
             'Pre-bind part of a call and reuse the same runtime so cookies, throttle, and sessions persist.',
         kind: 'guide',
     },
+    {
+        path: 'guides/authoring/hooks',
+        title: 'Hooks',
+        description:
+            'Observe a call as it runs — onRequest, onResponse, onError, onRetry — and where each fires relative to auth, retry, throttle, and timeout.',
+        kind: 'guide',
+    },
 
     // ── Guides · Auth ───────────────────────────────────────────────────────
     {
@@ -221,6 +363,13 @@ export const pages: Page[] = [
         title: 'Retry & backoff',
         description:
             'Retry on configurable status codes with expo/jitter/fixed backoff and respect for Retry-After.',
+        kind: 'guide',
+    },
+    {
+        path: 'guides/resilience/accept-status',
+        title: 'Accept status',
+        description:
+            'Declare statuses that are a normal result, not an error — an accepted non-2xx flows through transform/unwrap/validate instead of throwing.',
         kind: 'guide',
     },
     {
@@ -284,6 +433,13 @@ export const pages: Page[] = [
         path: 'guides/data/body-encoding',
         title: 'Body encoding',
         description: 'Send request bodies as json, form, or multipart.',
+        kind: 'guide',
+    },
+    {
+        path: 'guides/data/url-shaping',
+        title: 'URL shaping',
+        description:
+            'RFC 6570 path templates and qs-style nested query serialization — how params and query become the URL.',
         kind: 'guide',
     },
     {
@@ -356,6 +512,15 @@ export const pages: Page[] = [
         kind: 'guide',
     },
 
+    // ── Guides · Testing ────────────────────────────────────────────────────
+    {
+        path: 'guides/testing/mocking',
+        title: 'Testing',
+        description:
+            'Mock the transport to test a stitch definition, or swap in a fake stitch to test code that calls one — from stitchapi/testing.',
+        kind: 'guide',
+    },
+
     // ── Surfaces ────────────────────────────────────────────────────────────
     {
         path: 'surfaces/function',
@@ -387,13 +552,9 @@ export const pages: Page[] = [
     },
 
     // ── Integrations ────────────────────────────────────────────────────────
-    {
-        path: 'integrations/nestjs',
-        title: 'NestJS',
-        description:
-            'Wire stitches into a NestJS app with StitchModule — injectable stitches, a Logger trace bridge, ConfigService-backed secrets, and request-scoped multi-tenancy.',
-        kind: 'guide',
-    },
+    // Hand-maintained (see HAND_MAINTAINED_SECTIONS): the integrations pages
+    // live in content/docs/integrations/meta.json, added per-PR as each
+    // @stitchapi/* package ships. Intentionally absent from this manifest.
 
     // ── For agents ──────────────────────────────────────────────────────────
     {
@@ -415,6 +576,13 @@ export const pages: Page[] = [
         title: 'Author from one example',
         description:
             'Have an agent emit a stitch declaration from a single curl, HAR, or doc snippet.',
+        kind: 'guide',
+    },
+    {
+        path: 'agents/adopt-in-your-project',
+        title: 'Adopt in your project',
+        description:
+            'Drop a rule into your repo so any agent reaches for a typed stitch instead of a hand-rolled fetch — by hand, or with npx stitch init.',
         kind: 'guide',
     },
     {
@@ -447,10 +615,24 @@ export const pages: Page[] = [
         kind: 'reference',
     },
     {
+        path: 'reference/surfaces',
+        title: 'Request surfaces',
+        description:
+            'http, graphql, sse, stream, and download — the request styles a stitch can speak, each a subpath import riding one engine.',
+        kind: 'reference',
+    },
+    {
         path: 'reference/helpers',
         title: 'Helpers',
         description:
             'fetchAdapter, createTrace, multiplex, the OTLP exporters, memoryStore, and toValidator.',
+        kind: 'reference',
+    },
+    {
+        path: 'reference/conformance-kits',
+        title: 'Conformance kits',
+        description:
+            'Prove a custom adapter, store, or trace sink implements its seam — from stitchapi/testing, in your own CI.',
         kind: 'reference',
     },
     {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -14,6 +14,7 @@
         "build:core": "pnpm --filter stitchapi build",
         "build:typed-deps": "pnpm --filter stitchapi --filter @stitchapi/nest --filter @stitchapi/pino --filter @stitchapi/query-core --filter @stitchapi/react --filter @stitchapi/fastify --filter @stitchapi/hono build",
         "build:sandbox": "node scripts/gen-stitch-completions.mjs && node ../../docs/sandbox/runtime/build-sandbox-worker.mjs",
+        "test": "vitest run",
         "test:e2e": "playwright test",
         "test:e2e:install": "playwright install chromium"
     },
@@ -65,6 +66,7 @@
         "eslint-config-next": "16.2.7",
         "postcss": "^8.5.15",
         "tailwindcss": "^4.3.0",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.8"
     }
 }

--- a/apps/docs/scripts/generate-skeleton.mjs
+++ b/apps/docs/scripts/generate-skeleton.mjs
@@ -8,8 +8,26 @@
 // meta.json is always rewritten (it is derived). The scaffold's stock
 // index.mdx / test.mdx are removed on first run.
 //
+// Sections in HAND_MAINTAINED_SECTIONS are skipped entirely — their meta.json
+// and page set are curated by hand (e.g. integrations), so they keep their
+// sidebar slot via `sections` but their meta.json is never regenerated here.
+//
+// `meta.json` is governed by Prettier (it is NOT in .prettierignore), so the
+// serializer below matches Prettier's output exactly: objects always break, and
+// the `pages` array stays inline when the line fits in 80 columns and breaks one
+// item per line otherwise. Keeping codegen Prettier-stable means `gen:docs` is a
+// no-op on a synced tree — re-running produces no diff (enforced in CI).
+//
+// The meta-building helpers (childrenOf / metaForSection / serializeMeta) are
+// exported and pure; importing this module runs no side effects. The file-system
+// work happens in main(), which runs only when the file is executed directly.
+//
 // Run: node scripts/generate-skeleton.mjs   (from apps/docs)
-import { pages, sections } from '../content.manifest.ts';
+import {
+    HAND_MAINTAINED_SECTIONS,
+    pages,
+    sections,
+} from '../content.manifest.ts';
 
 import {
     existsSync,
@@ -24,9 +42,10 @@ import { fileURLToPath } from 'node:url';
 const here = dirname(fileURLToPath(import.meta.url));
 const CONTENT = resolve(here, '..', 'content', 'docs');
 
+const PRINT_WIDTH = 80;
+
 const parentOf = (p) => (p.includes('/') ? p.slice(0, p.lastIndexOf('/')) : '');
 const baseOf = (p) => (p.includes('/') ? p.slice(p.lastIndexOf('/') + 1) : p);
-const yaml = (s) => JSON.stringify(s); // JSON strings are valid YAML double-quoted scalars
 
 // Per-kind stub: an optional lead line + the template's required headings.
 // Plain markdown only (no MDX comments / JSX) so Prettier and the MDX build
@@ -72,12 +91,13 @@ function stubBody(kind) {
 }
 
 function stub(p) {
-    return `---\ntitle: ${yaml(p.title)}\ndescription: ${yaml(p.description)}\n---\n\n${stubBody(p.kind)}`;
+    const fm = `---\ntitle: ${JSON.stringify(p.title)}\ndescription: ${JSON.stringify(p.description)}\n---`;
+    return `${fm}\n\n${stubBody(p.kind)}`;
 }
 
 // Ordered immediate children of a folder (subfolders first, then leaf pages),
 // excluding the folder's own index — that is the folder's landing page.
-function childrenOf(folderPath) {
+export function childrenOf(folderPath) {
     const subfolders = sections
         .filter((s) => s.path !== '' && parentOf(s.path) === folderPath)
         .map((s) => baseOf(s.path));
@@ -90,41 +110,92 @@ function childrenOf(folderPath) {
     return [...subfolders, ...leaves];
 }
 
-// 1. Drop scaffold cruft so the manifest's `index` can take over the docs home.
-const stockIndex = join(CONTENT, 'index.mdx');
-if (
-    existsSync(stockIndex) &&
-    /Hello World|start writing/.test(readFileSync(stockIndex, 'utf8'))
-) {
-    rmSync(stockIndex);
-}
-const stockTest = join(CONTENT, 'test.mdx');
-if (existsSync(stockTest)) rmSync(stockTest);
-
-// 2. meta.json per section (always rewritten — it is derived from the manifest).
-for (const s of sections) {
-    const dir = s.path ? join(CONTENT, s.path) : CONTENT;
-    mkdirSync(dir, { recursive: true });
-    const meta = { title: s.title };
-    if (s.icon) meta.icon = s.icon;
-    meta.pages = childrenOf(s.path);
-    writeFileSync(join(dir, 'meta.json'), `${JSON.stringify(meta, null, 4)}\n`);
+// The meta.json object for a section: title, then the optional description and
+// icon, then the ordered children. Key order is the committed file order.
+export function metaForSection(section) {
+    const meta = { title: section.title };
+    if (section.description) meta.description = section.description;
+    if (section.icon) meta.icon = section.icon;
+    meta.pages = childrenOf(section.path);
+    return meta;
 }
 
-// 3. Stub .mdx per page (only if absent — never clobber written content).
-let created = 0;
-let skipped = 0;
-for (const p of pages) {
-    const file = join(CONTENT, `${p.path}.mdx`);
-    mkdirSync(dirname(file), { recursive: true });
-    if (existsSync(file)) {
-        skipped += 1;
-        continue;
+// Serialize a meta object the way Prettier would (4-space JSON; the `pages`
+// array inline if it fits in PRINT_WIDTH, else one item per line). `pages` is
+// always the last key, so its inline form carries no trailing comma.
+export function serializeMeta(meta) {
+    const entries = Object.entries(meta);
+    const lines = ['{'];
+    entries.forEach(([key, value], i) => {
+        const tail = i < entries.length - 1 ? ',' : '';
+        const k = JSON.stringify(key);
+        if (Array.isArray(value)) {
+            const inline = `[${value.map((v) => JSON.stringify(v)).join(', ')}]`;
+            const oneLine = `    ${k}: ${inline}${tail}`;
+            if (oneLine.length <= PRINT_WIDTH) {
+                lines.push(oneLine);
+            } else {
+                lines.push(`    ${k}: [`);
+                value.forEach((v, j) => {
+                    const c = j < value.length - 1 ? ',' : '';
+                    lines.push(`        ${JSON.stringify(v)}${c}`);
+                });
+                lines.push(`    ]${tail}`);
+            }
+        } else {
+            lines.push(`    ${k}: ${JSON.stringify(value)}${tail}`);
+        }
+    });
+    lines.push('}');
+    return `${lines.join('\n')}\n`;
+}
+
+function main() {
+    // 1. Drop scaffold cruft so the manifest's `index` can take over the home.
+    const stockIndex = join(CONTENT, 'index.mdx');
+    if (
+        existsSync(stockIndex) &&
+        /Hello World|start writing/.test(readFileSync(stockIndex, 'utf8'))
+    ) {
+        rmSync(stockIndex);
     }
-    writeFileSync(file, stub(p));
-    created += 1;
+    const stockTest = join(CONTENT, 'test.mdx');
+    if (existsSync(stockTest)) rmSync(stockTest);
+
+    // 2. meta.json per section (always rewritten — it is derived from the
+    // manifest), except hand-maintained sections, which own their own file.
+    let metas = 0;
+    for (const s of sections) {
+        if (HAND_MAINTAINED_SECTIONS.has(s.path)) continue;
+        const dir = s.path ? join(CONTENT, s.path) : CONTENT;
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, 'meta.json'), serializeMeta(metaForSection(s)));
+        metas += 1;
+    }
+
+    // 3. Stub .mdx per page (only if absent — never clobber written content).
+    let created = 0;
+    let skipped = 0;
+    for (const p of pages) {
+        const file = join(CONTENT, `${p.path}.mdx`);
+        mkdirSync(dirname(file), { recursive: true });
+        if (existsSync(file)) {
+            skipped += 1;
+            continue;
+        }
+        writeFileSync(file, stub(p));
+        created += 1;
+    }
+
+    console.log(
+        `skeleton: ${metas} meta.json, ${created} stub(s) created, ${skipped} existing page(s) kept`,
+    );
 }
 
-console.log(
-    `skeleton: ${sections.length} meta.json, ${created} stub(s) created, ${skipped} existing page(s) kept`,
-);
+// Run the file-system work only when executed directly, not when imported.
+if (
+    process.argv[1] &&
+    resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+    main();
+}

--- a/apps/docs/test/content-manifest.spec.ts
+++ b/apps/docs/test/content-manifest.spec.ts
@@ -1,0 +1,161 @@
+import {
+    HAND_MAINTAINED_SECTIONS,
+    type Section,
+    pages,
+    sections,
+} from '../content.manifest';
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// The anti-drift gate the manifest header promises. `content.manifest.ts` is the
+// source of truth for the docs IA, but pages were being added straight into the
+// per-folder `meta.json` files, so the manifest silently rotted and a stray
+// `gen:docs` would have deleted real pages. These tests fail the moment the
+// manifest and the on-disk content disagree.
+//
+// Byte-level idempotency (re-running `gen:docs` produces no diff, including
+// Prettier formatting) is enforced by the CI gate in .github/workflows/verify.yml
+// that runs the real generator and `git diff --exit-code`. The
+// "matches what the manifest would generate" test below is the formatting-
+// independent semantic half of that, runnable in `pnpm test`.
+
+const DOCS_ROOT = resolve(fileURLToPath(import.meta.url), '..', '..');
+const CONTENT = resolve(DOCS_ROOT, 'content', 'docs');
+
+interface MetaJson {
+    title: string;
+    description?: string;
+    icon?: string;
+    pages: string[];
+}
+
+/** Absolute paths of every file ending in `suffix` under `dir`. */
+function walk(dir: string, suffix: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...walk(full, suffix));
+        else if (entry.name.endsWith(suffix)) out.push(full);
+    }
+    return out;
+}
+
+/** content/docs-relative manifest path for an .mdx file: posix, no extension. */
+const toManifestPath = (absMdx: string): string =>
+    relative(CONTENT, absMdx)
+        .split(sep)
+        .join('/')
+        .replace(/\.mdx$/, '');
+
+const isUnderHandMaintained = (p: string): boolean =>
+    [...HAND_MAINTAINED_SECTIONS].some((h) => p === h || p.startsWith(`${h}/`));
+
+const parentOf = (p: string): string =>
+    p.includes('/') ? p.slice(0, p.lastIndexOf('/')) : '';
+const baseOf = (p: string): string =>
+    p.includes('/') ? p.slice(p.lastIndexOf('/') + 1) : p;
+
+// Mirror of generate-skeleton.mjs's childrenOf. Kept honest by the CI `gen:docs`
+// diff gate, which runs the real generator — if this drifts from it, that gate
+// reds. (Can't import the generator directly: it's an .mjs whose `.ts`-extension
+// import would trip `tsc`'s allowImportingTsExtensions in `check:types`.)
+function childrenOf(folderPath: string): string[] {
+    const subfolders = sections
+        .filter((s) => s.path !== '' && parentOf(s.path) === folderPath)
+        .map((s) => baseOf(s.path));
+    const leaves = pages
+        .filter(
+            (p) =>
+                parentOf(p.path) === folderPath && baseOf(p.path) !== 'index',
+        )
+        .map((p) => baseOf(p.path));
+    return [...subfolders, ...leaves];
+}
+
+const metaPathFor = (section: Section): string =>
+    section.path
+        ? join(CONTENT, section.path, 'meta.json')
+        : join(CONTENT, 'meta.json');
+
+describe('content manifest ↔ content/docs two-way sync', () => {
+    const diskPages = walk(CONTENT, '.mdx').map(toManifestPath);
+    const manifestPaths = new Set(pages.map((p) => p.path));
+
+    it('lists every .mdx on disk (except hand-maintained sections)', () => {
+        const undocumented = diskPages
+            .filter((p) => !manifestPaths.has(p) && !isUnderHandMaintained(p))
+            .sort();
+        expect(
+            undocumented,
+            `undocumented pages — add to content.manifest.ts:\n${undocumented.join('\n')}`,
+        ).toEqual([]);
+    });
+
+    it('has a file on disk for every manifest page', () => {
+        const orphans = pages
+            .filter((p) => !existsSync(join(CONTENT, `${p.path}.mdx`)))
+            .map((p) => p.path)
+            .sort();
+        expect(
+            orphans,
+            `manifest entries with no .mdx file:\n${orphans.join('\n')}`,
+        ).toEqual([]);
+    });
+
+    it('never lists a page that lives under a hand-maintained section', () => {
+        const stray = pages
+            .filter((p) => isUnderHandMaintained(p.path))
+            .map((p) => p.path);
+        expect(stray).toEqual([]);
+    });
+
+    it('has an existing folder for every manifest section', () => {
+        const missing = sections
+            .map((s) => (s.path ? join(CONTENT, s.path) : CONTENT))
+            .filter((dir) => !existsSync(dir));
+        expect(missing).toEqual([]);
+    });
+
+    it('declares a section for every folder that owns a meta.json', () => {
+        const declared = new Set(sections.map((s) => s.path));
+        const undeclared = walk(CONTENT, 'meta.json')
+            .map((f) => relative(CONTENT, f).split(sep).slice(0, -1).join('/'))
+            .filter((p) => !declared.has(p) && !HAND_MAINTAINED_SECTIONS.has(p))
+            .sort();
+        expect(
+            undeclared,
+            `folders with a meta.json but no section entry:\n${undeclared.join('\n')}`,
+        ).toEqual([]);
+    });
+});
+
+describe('committed meta.json is what the manifest would generate', () => {
+    it('every generator-owned meta.json matches the manifest (title, order, blurb)', () => {
+        for (const section of sections) {
+            if (HAND_MAINTAINED_SECTIONS.has(section.path)) continue;
+            const file = metaPathFor(section);
+            const actual: unknown = JSON.parse(readFileSync(file, 'utf8'));
+            const expected: MetaJson = {
+                title: section.title,
+                ...(section.description
+                    ? { description: section.description }
+                    : {}),
+                ...(section.icon ? { icon: section.icon } : {}),
+                pages: childrenOf(section.path),
+            };
+            expect(
+                actual,
+                `stale meta.json (re-run \`pnpm gen:docs\`): ${relative(CONTENT, file)}`,
+            ).toEqual(expected);
+        }
+    });
+
+    it('leaves hand-maintained sections out of generation but on disk', () => {
+        for (const path of HAND_MAINTAINED_SECTIONS) {
+            expect(existsSync(join(CONTENT, path, 'meta.json'))).toBe(true);
+        }
+    });
+});

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+// Docs-IA guardrail tests only (test/**/*.spec.ts) — manifest ↔ content/docs
+// two-way sync and gen:docs idempotency. The Playwright e2e suite is separate
+// (`test:e2e`), and Next/Fumadocs rendering is covered by the build gate.
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: 'node',
+        include: ['test/**/*.spec.ts'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   docs/sandbox:
     dependencies:
@@ -11381,7 +11384,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.8)':
     dependencies:
@@ -11411,6 +11414,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -16790,7 +16801,6 @@ snapshots:
       terser: 5.48.0
       tsx: 4.22.4
       yaml: 2.9.0
-    optional: true
 
   vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
@@ -16817,6 +16827,36 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.21
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.9.3
       '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
       jsdom: 25.0.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Why

`apps/docs/content.manifest.ts` is the source of truth for the docs sidebar IA, but pages had been added straight into the per-folder `meta.json` files for months, so the manifest **silently rotted**. `gen:docs` is manual (not wired into CI), so the drift never fired — but running it on a clean tree would have **silently deleted real, committed pages** from the sidebars:

- the entire `recipes/` section (15 `.mdx` + its `meta.json`)
- the `guides/testing/` section
- the root `meta.json` `description`
- `agents/adopt-in-your-project`, `guides/authoring/hooks`, `guides/data/url-shaping`, `guides/resilience/accept-status`, `reference/surfaces`, `reference/conformance-kits`

Root cause: the manifest header claimed "a test will enforce" two-way sync, but **no such test was ever written**.

## What

**Re-sync the manifest** so the generator reproduces the committed `meta.json` files byte-for-byte:
- Added the `recipes` and `guides/testing` sections, the root `description`, and the six dropped pages. Descriptions are the real frontmatter sentences.
- Added `HAND_MAINTAINED_SECTIONS` (single-sourced in the manifest, consumed by both the generator and the test). **`integrations` is excluded** — its 24 pages are added per-PR as each `@stitchapi/*` package ships, so it curates its own `meta.json`; the generator skips it but keeps its sidebar slot.
- Gave the generator a **Prettier-stable `meta.json` serializer** (objects break; the `pages` array stays inline when it fits in 80 cols, else one item per line) so codegen output matches the committed, Prettier-governed files exactly. Exported the pure helpers and gated the FS work behind a direct-run check.

**Lock the door so it can't rot again:**
- `apps/docs/test/content-manifest.spec.ts` (vitest) — the two-way-sync test the header always promised: fails when any `.mdx` under `content/docs` is absent from the manifest or vice versa, plus a formatting-independent "committed `meta.json` matches the manifest" check. Hand-maintained sections are exempted. Wired vitest into `apps/docs` (`test` script + devDep).
- CI gate in `verify.yml` (mirrors the existing `gen:completions` pattern): re-runs `gen:docs` then `git diff --exit-code apps/docs/content/docs`, so byte-level drift fails the build.
- Documented the hand-maintained exception in `AUTHORING.md`.

## Verification

- `pnpm gen:docs` then `git diff apps/docs/content/docs` → **empty** ✅
- `pnpm --filter @stitchapi/docs test` → 7 passing; a stray `.mdx` makes it fail with an actionable message, removing it restores green (negative-tested) ✅
- `check:format`, `eslint`, `tsc --noEmit` (full `check:types`) all clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)