### PR TITLE
docs: stop gen:docs clobbering hand-maintained integrations sidebar

### DIFF
--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -68,6 +68,11 @@ export const sections: Section[] = [
     { path: 'guides/observability', title: 'Observability' },
     { path: 'guides/state', title: 'State & stores' },
     { path: 'surfaces', title: 'Surfaces', icon: 'Layers' },
+    // `integrations` meta.json is HAND-MAINTAINED and NOT regenerated: it is
+    // hand-curated to mirror the README package table, and the generator skips
+    // it (see HAND_MAINTAINED_SECTIONS in scripts/generate-skeleton.mjs).
+    // Pages added under `integrations/` in the `pages` array below do NOT drive
+    // its sidebar — edit content/docs/integrations/meta.json directly.
     { path: 'integrations', title: 'Integrations', icon: 'Plug' },
     { path: 'agents', title: 'For agents', icon: 'Bot' },
     { path: 'reference', title: 'Reference', icon: 'Code' },
@@ -387,6 +392,11 @@ export const pages: Page[] = [
     },
 
     // ── Integrations ────────────────────────────────────────────────────────
+    // NOTE: integrations/meta.json is hand-maintained and NOT generated (see the
+    // `integrations` entry in `sections` above). This single entry exists only so
+    // the section is represented here; the live sidebar lists 21 hand-ordered
+    // pages. Do not rely on the generator to reproduce that list — adding entries
+    // here will not change the sidebar.
     {
         path: 'integrations/nestjs',
         title: 'NestJS',

--- a/apps/docs/scripts/generate-skeleton.mjs
+++ b/apps/docs/scripts/generate-skeleton.mjs
@@ -101,14 +101,30 @@ if (
 const stockTest = join(CONTENT, 'test.mdx');
 if (existsSync(stockTest)) rmSync(stockTest);
 
-// 2. meta.json per section (always rewritten — it is derived from the manifest).
+// Sections whose meta.json is HAND-MAINTAINED and intentionally NOT derived
+// from the manifest. The generator skips them — rewriting would clobber edits.
+//
+// `integrations`: its sidebar is hand-curated to mirror the README package
+// table (21 pages today, each added one-per-PR straight into its meta.json) and
+// the manifest deliberately carries only a single `integrations/nestjs` entry.
+// `childrenOf()` emits a flat `pages` array and cannot express Fumadocs
+// `---Group---` separators, so the generator could never reproduce this layout —
+// it leaves the file alone instead. Keep this paired with the note on the
+// `integrations` entry in content.manifest.ts.
+const HAND_MAINTAINED_SECTIONS = new Set(['integrations']);
+
+// 2. meta.json per section (rewritten from the manifest — it is derived —
+//    except hand-maintained sections, which are left untouched).
+let metaWritten = 0;
 for (const s of sections) {
+    if (HAND_MAINTAINED_SECTIONS.has(s.path)) continue;
     const dir = s.path ? join(CONTENT, s.path) : CONTENT;
     mkdirSync(dir, { recursive: true });
     const meta = { title: s.title };
     if (s.icon) meta.icon = s.icon;
     meta.pages = childrenOf(s.path);
     writeFileSync(join(dir, 'meta.json'), `${JSON.stringify(meta, null, 4)}\n`);
+    metaWritten += 1;
 }
 
 // 3. Stub .mdx per page (only if absent — never clobber written content).
@@ -126,5 +142,5 @@ for (const p of pages) {
 }
 
 console.log(
-    `skeleton: ${sections.length} meta.json, ${created} stub(s) created, ${skipped} existing page(s) kept`,
+    `skeleton: ${metaWritten} meta.json, ${created} stub(s) created, ${skipped} existing page(s) kept`,
 );


### PR DESCRIPTION
## Problem

`apps/docs/scripts/generate-skeleton.mjs` (run via `pnpm gen:docs`) rewrites every section's `meta.json` from `apps/docs/content.manifest.ts`, emitting a flat `pages` array. But `apps/docs/content/docs/integrations/meta.json` is **hand-maintained** — hand-curated to mirror the README package table, listing 21 integration pages added one-per-PR — while the manifest carries only a single `integrations/nestjs` entry.

Consequence: running `pnpm gen:docs` would overwrite `integrations/meta.json` down to `{ "title": "Integrations", "icon": "Plug", "pages": ["nestjs"] }`, **dropping 20 pages** from the sidebar. The generator's `childrenOf()` has no way to express the grouped/ordered layout, so it could never reproduce the file anyway. (`gen:docs` is manual — not wired into CI/lefthook — so this hasn't fired yet.)

## Fix (option a)

Exclude `integrations` from the generator via a `HAND_MAINTAINED_SECTIONS` set, and document the divergence with paired comments in both files. Chosen over teaching the generator to emit `---Group---` separators because the live file is a hand-curated flat list maintained per-PR — making the manifest the source of truth would fight that workflow and require separator support the generator lacks.

## Verification

- After `pnpm gen:docs`, `git diff` on `integrations/meta.json` is **empty** (idempotent across re-runs); the generator now writes 15 meta.json instead of 16.
- The change is surgical — every other section's generation is byte-for-byte unchanged.
- Both edited files pass `prettier --check`.

## ⚠️ Out of scope — broader drift flagged separately

While verifying, I found `gen:docs` would *also* silently drop real committed pages from **8 other sections** (a whole 15-page `recipes` section + the root `description`, `guides/testing`, and 6 individual pages) because the manifest is stale across the docs tree — and the two-way-sync test the manifest header promises was never written. That needs per-section decisions + new tests, so it's tracked as a follow-up rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)