### PR TITLE
chore(release): 1.0.0-rc.3 — the integration ecosystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,48 @@ npm release are grouped under the in-development version that introduced them.
 
 ## [Unreleased]
 
+## [1.0.0-rc.3] — 2026-06-21
+
+### Added — the integration ecosystem
+
+The first wave of `@stitchapi/*` ecosystem adapters — a stitch now drops into the
+framework, runtime, and store you already use, each a thin typed seam over the
+same core runtime (no new concepts; streaming-first where it applies):
+
+-   **Server frameworks:** `@stitchapi/elysia`, `@stitchapi/express`,
+    `@stitchapi/fastify`, `@stitchapi/hono`, and `@stitchapi/next` — a
+    request-scoped seam on the context/`req`, an SSE bridge for a streaming
+    stitch, and `StitchError`→HTTP mapping. The Fetch-only adapters (`hono`,
+    `elysia`, `next`) stay edge/multi-runtime safe.
+-   **Client & UI bindings:** `@stitchapi/react`, `@stitchapi/vue`,
+    `@stitchapi/svelte`, `@stitchapi/solid`, and `@stitchapi/angular` —
+    tearing-free `useStitch`/`useStitchStream` (and the framework-native
+    equivalents) that re-render as `delta` chunks arrive, over the new shared
+    `@stitchapi/query-core` reactive store, plus an optional TanStack Query
+    `queryOptions` helper. `@stitchapi/react-native` adds the streaming XHR
+    transport bare RN lacks and an AsyncStorage `StitchStore`, and
+    `@stitchapi/expo` layers `expo/fetch` streaming and a secure-store token
+    store on top.
+-   **Data-fetching libraries:** `@stitchapi/swr` (`useStitchSWR`) and
+    `@stitchapi/rtk-query` (`stitchQueryFn` + `stitchStreamUpdater`) hand
+    caching/revalidation to the host library while the stitch stays typed,
+    validated, and traced.
+-   **State stores:** `@stitchapi/cloudflare-kv` (Workers KV) and
+    `@stitchapi/deno-kv` (atomic `incr` for distributed throttle) join
+    `@stitchapi/redis` as edge-/runtime-native `StitchStore` backends.
+-   **Auth:** `@stitchapi/aws-sigv4` — an `AuthStrategy` that signs each request
+    with AWS SigV4 over edge-safe Web Crypto (AWS APIs, S3-compatible stores, any
+    SigV4-protected endpoint).
+-   **Observability:** `@stitchapi/pino` and `@stitchapi/sentry` `TraceSink`s map
+    the stitch event stream to structured logs and breadcrumbs/error capture —
+    metadata-only, safe on a secret-bearing seam.
+-   **AI:** `@stitchapi/vercel-ai` exposes a stitch as a Vercel AI SDK `tool()`
+    the model can call — it gets validated data, never the credential.
+
+Each ships `publishConfig.access: public`, a README, and a LICENSE. A new package's
+first publish is a one-time bootstrap (OIDC cannot publish a brand-new name); it
+rides the OIDC publish workflow thereafter — see [`docs/RELEASING.md`](docs/RELEASING.md).
+
 ### Added — a published testing story
 
 -   **Mocking kit on `stitchapi/testing`:** helpers for testing your own stitches
@@ -192,6 +234,7 @@ causality push:
 -   **Playground:** the browser Worker runner, handler registration, incremental
     streaming, and the trace → Mermaid DAG wiring.
 
-[Unreleased]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.2...HEAD
+[Unreleased]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.3...HEAD
+[1.0.0-rc.3]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.2...v1.0.0-rc.3
 [1.0.0-rc.2]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.1...v1.0.0-rc.2
 [1.0.0-rc.1]: https://github.com/rejifald/StitchAPI/compare/v0.7.0...v1.0.0-rc.1

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/angular",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Angular bindings for StitchAPI — injectStitch/injectStitchStream expose a stitch's lifecycle as both signals and an RxJS observable over @stitchapi/query-core. Streaming-first: re-render as `delta` chunks arrive. Plus an optional TanStack Query queryOptions helper.",
     "main": "lib/index.js",

--- a/packages/aws-sigv4/package.json
+++ b/packages/aws-sigv4/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/aws-sigv4",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "AWS Signature V4 request signing for StitchAPI — an AuthStrategy that signs each request with SigV4 (Web Crypto, edge-safe), for AWS APIs, S3-compatible stores, and any SigV4-protected endpoint.",
     "main": "lib/index.js",

--- a/packages/cloudflare-kv/package.json
+++ b/packages/cloudflare-kv/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/cloudflare-kv",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Cloudflare Workers KV-backed StitchStore for StitchAPI — edge cache + shared sessions/tokens. Bring your own KV namespace binding. (incr → use a Durable Object store.)",
     "main": "lib/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "stitchapi",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Turn any API into a typed, resilient function. A declarative stitch takes one endpoint — HTTP, GraphQL, SSE, LLM, even a shell command — and hands back a callable with auth, retries, validation, and drift built in. No server, no codegen, no config files. Callable from code, the CLI, or an AI agent over MCP — agents get a capability, not your credentials. Zero deps.",
     "main": "lib/index.js",

--- a/packages/deno-kv/package.json
+++ b/packages/deno-kv/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/deno-kv",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Deno KV-backed StitchStore for StitchAPI — distributed throttle + shared sessions/tokens with atomic incr. Bring your own Deno.Kv handle.",
     "main": "lib/index.js",

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/elysia",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Elysia plugin for StitchAPI — put a request-scoped seam on the context, stream a stitch's SSE output, and map Stitch errors to HTTP. Web-standard (Fetch-only, no node:*).",
     "main": "lib/index.js",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/expo",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Expo bindings for StitchAPI — expoFetchAdapter (streaming over expo/fetch, no polyfills), an expo-secure-store-backed StitchStore for encrypted tokens, and the re-exported useStitch/useStitchStream hooks, AsyncStorage store, and AppState/NetInfo refetch helpers from @stitchapi/react-native.",
     "main": "lib/index.js",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/express",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Express middleware for StitchAPI — attach a request-scoped seam to req, stream a stitch's SSE output, and map Stitch errors to HTTP. Express 4 & 5.",
     "main": "lib/index.js",

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fastify",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Fastify plugin for StitchAPI — decorate the app/request with a seam, request-scoped principal (AsyncLocalStorage), and SSE + error + Pino-logger bridges.",
     "main": "lib/index.js",

--- a/packages/fingerprint-arktype/package.json
+++ b/packages/fingerprint-arktype/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-arktype",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for ArkType — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-effect/package.json
+++ b/packages/fingerprint-effect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-effect",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for Effect Schema — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-typebox/package.json
+++ b/packages/fingerprint-typebox/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-typebox",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for TypeBox — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-valibot/package.json
+++ b/packages/fingerprint-valibot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-valibot",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for Valibot — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-zod/package.json
+++ b/packages/fingerprint-zod/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-zod",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for Zod — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/hono",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Hono middleware + helpers for StitchAPI — put a seam on the request context, stream a stitch's SSE output, and map Stitch errors to HTTP. Edge/multi-runtime (Fetch-only, no node:*).",
     "main": "lib/index.js",

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/nest",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "First-class NestJS integration for StitchAPI — StitchModule.forRoot/forFeature/forFeatureScoped, injectable stitches, Logger + ConfigService bridges, an exception filter and an SSE bridge (ADR 0006).",
     "main": "lib/index.js",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/next",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Next.js helpers for StitchAPI — stream a stitch as an SSE Response and map a StitchError to a Response, for App Router route handlers (and any Web-standard fetch handler).",
     "main": "lib/index.js",

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/pino",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Pino TraceSink for StitchAPI — bridge the stitch event stream to a Pino logger as structured, metadata-only log records.",
     "main": "lib/index.js",

--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/query-core",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Framework-agnostic reactive query store for StitchAPI — a subscribe/getSnapshot store wrapping a stitch call (unary + streaming deltas). The shared core behind @stitchapi/react and future Vue/Svelte/Solid bindings.",
     "main": "lib/index.js",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/react-native",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "React Native bindings for StitchAPI — a streaming-capable XHR transport adapter (the streaming `fetch` bare RN lacks), an AsyncStorage-backed StitchStore for persistent sessions/tokens, AppState/NetInfo refetch helpers, and the re-exported useStitch/useStitchStream hooks.",
     "main": "lib/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/react",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "React bindings for StitchAPI — tearing-free useStitch/useStitchStream hooks over useSyncExternalStore, plus an optional TanStack Query queryOptions helper. Streaming-first: re-render as `delta` chunks arrive.",
     "main": "lib/index.js",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/redis",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Redis-backed StitchStore for StitchAPI — distributed throttle + shared sessions/tokens. Bring your own ioredis, node-redis, or Upstash (edge HTTP Redis) client.",
     "main": "lib/index.js",

--- a/packages/rtk-query/package.json
+++ b/packages/rtk-query/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/rtk-query",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "RTK Query bindings for StitchAPI — stitchQueryFn turns a stitch into an RTK Query endpoint queryFn (error-normalized), and stitchStreamUpdater folds a streaming stitch into the cache via onCacheEntryAdded.",
     "main": "lib/index.js",

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/sentry",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "A Sentry TraceSink for StitchAPI — maps the stitch event stream to Sentry breadcrumbs, and captures error events with the call's context. Metadata-only, safe on a secret-bearing seam.",
     "main": "lib/index.js",

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/shell",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Run a static local command as a StitchAPI surface — Node-only, injection-proof by construction (static binary + argv array + no shell). ADR 0008.",
     "main": "lib/index.js",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/solid",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Solid bindings for StitchAPI — createStitch/createStitchStream primitives that reconcile a Solid store from the query-core reactive store. Streaming-first: re-render as `delta` chunks arrive. Plus an optional TanStack Query queryOptions helper.",
     "main": "lib/index.js",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/svelte",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Svelte bindings for StitchAPI — stitchStore/stitchStreamStore Svelte stores over @stitchapi/query-core (unary + streaming deltas), plus an optional TanStack-shaped queryOptions helper. Works on Svelte 4 and 5.",
     "main": "lib/index.js",

--- a/packages/swr/package.json
+++ b/packages/swr/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/swr",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "SWR bindings for StitchAPI — useStitchSWR runs a stitch as an SWR fetcher, so SWR owns caching and revalidation while the stitch stays typed, validated, and traced.",
     "main": "lib/index.js",

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/vercel-ai",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Vercel AI SDK adapter for StitchAPI — expose a stitch as a tool() the model can call. It runs the typed, validated, traced stitch as the tool's execute; the model gets validated data, never the credential.",
     "main": "lib/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/vue",
-    "version": "1.0.0-rc.2",
+    "version": "1.0.0-rc.3",
     "type": "commonjs",
     "description": "Vue 3 bindings for StitchAPI — reactive useStitch/useStitchStream composables over @stitchapi/query-core, plus an optional TanStack Query queryOptions helper. Streaming-first: re-render as `delta` chunks arrive.",
     "main": "lib/index.js",


### PR DESCRIPTION
## What

Lockstep version bump **`1.0.0-rc.2` → `1.0.0-rc.3`** across all 30 publishable packages, plus the CHANGELOG entry documenting the first wave of `@stitchapi/*` ecosystem adapters.

## Why

`rc.3` is the first release to ship the integration ecosystem — 21 new adapter packages added since `rc.2` (server frameworks, client/UI bindings, data-fetching libs, state stores, auth, observability, AI). They were merged without a grouped CHANGELOG entry; this release gives them one.

## Changes

- **Version fields only** moved to `1.0.0-rc.3` in all 30 publishable `packages/*/package.json`. Caret sibling peer ranges (`^1.0.0-rc.1` / `^1.0.0-rc.2`) already admit `rc.3`, so per [`docs/RELEASING.md`](docs/RELEASING.md) they stay put (peer ranges widen only on a major bump).
- **CHANGELOG.md**: promoted `[Unreleased]` → `[1.0.0-rc.3] — 2026-06-21`, added the *"the integration ecosystem"* section, refreshed compare links.

## Verification

- `pnpm check:release --changelog --tag rc` ✓ — lockstep (30 @ rc.3), peer coherence (39 ranges admit rc.3), scoped access, dist-tag → `rc`, CHANGELOG entry present, LICENSE+README in all 30
- `prettier --check` ✓
- CI verify + e2e gates run on this PR

## ⚠️ Deploy note — the 21 new packages need a one-time bootstrap

OIDC trusted publishing **cannot publish a brand-new package name**. These 21 packages have never been on npm, so their **first** publish must be a manual interactive-2FA bootstrap (`npm login` → `pnpm -r publish --tag rc`), after which a Trusted Publisher is attached on npmjs.com and they ride `npm-publish.yml` like `stitchapi`/`nest`/`redis`. See [`docs/RELEASING.md` → *Bootstrapping a new package's first publish*](docs/RELEASING.md). The GitHub-release-triggered workflow alone will **not** deploy them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)