### PR TITLE
ci(publish): fail-fast preflight gate on release tag/version mismatch

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,7 +24,35 @@ concurrency:
     cancel-in-progress: false
 
 jobs:
+    # Fast fail-first gate. Before the ~15-min verify + e2e gates run (let alone a
+    # publish), reject a release whose tag does not match the version in the commit it
+    # points at. This catches the classic mistake of cutting the release tag on a commit
+    # from *before* the version-bump PR merged (e.g. tagging `main`'s old tip): the tag
+    # then carries an rc.3 label over an rc.2 tree, which previously only surfaced at the
+    # publish step's `check-release --release-tag` after the whole gate had already run.
+    # The publish job keeps that authoritative check as defense-in-depth; this just fails
+    # in seconds with a fix-it message.
+    preflight:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version-file: .nvmrc
+            - name: Release tag must match the tagged commit's version
+              run: |
+                  set -euo pipefail
+                  TAG="${{ github.event.release.tag_name }}"
+                  VERSION="$(node -p "require('./packages/core/package.json').version")"
+                  if [ "$TAG" != "v$VERSION" ]; then
+                      echo "::error title=Release tag/version mismatch::Release tag '$TAG' points at a commit whose package version is 'v$VERSION'. The tag was almost certainly cut on a commit from before the version-bump PR merged. Re-point it to the bumped commit — \`git tag -f $TAG <bump-commit> && git push -f origin $TAG\` — or delete and re-create the release on that commit, then re-run."
+                      exit 1
+                  fi
+                  echo "✓ release tag $TAG matches package version v$VERSION"
+
     verify:
+        needs: preflight
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
@@ -52,6 +80,7 @@ jobs:
     # playground DAG. A release waits on it so we never publish a broken browser
     # sandbox. Mirrors the `e2e` job in verify.yml.
     e2e:
+        needs: preflight
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -118,10 +118,14 @@ npm dist-tag add stitchapi@1.0.0 latest
 
 ## CI & authentication (OIDC trusted publishing)
 
--   `npm-publish.yml` triggers on `release: created`, runs the full verify gate
-    (`check:format` → `lint` → `types` → `test:coverage` → `exports` →
-    `check:release`) + the browser e2e gate, then publishes. Node version comes from
-    [`.nvmrc`](../.nvmrc).
+-   `npm-publish.yml` triggers on `release: created`. A fast **`preflight`** job runs
+    first and gates everything else: it rejects in seconds a release whose tag does not
+    match the version in the commit it points at (the classic "tagged `main` before the
+    bump PR merged" mistake), so the long gates never run on a doomed release. Then the
+    full verify gate (`check:format` → `lint` → `types` → `test:coverage` → `exports` →
+    `check:release`) + the browser e2e gate run, and finally it publishes — the publish
+    job re-runs `check-release --release-tag` as the authoritative final guard. Node
+    version comes from [`.nvmrc`](../.nvmrc).
 -   **No npm token.** The publish job authenticates with **OIDC trusted publishing**:
     it requests an `id-token: write` permission, mints a short-lived token, and npm
     exchanges it for publish rights — nothing to store, rotate, or leak. It then runs


### PR DESCRIPTION
## Why

The `1.0.0-rc.3` publish run [failed](https://github.com/rejifald/StitchAPI/actions/workflows/npm-publish.yml) with:

```
✗ release tag v1.0.0-rc.3 != package version 1.0.0-rc.2
```

[#318](https://github.com/rejifald/StitchAPI/pull/318) merged fine (main → rc.3 at `116efe7`), but the release tag `v1.0.0-rc.3` was cut on the **pre-merge** commit `9de6ee2` (still rc.2). The guardrail caught it correctly — **but only at the publish step, after the full ~15-min verify + e2e gates had already run.**

## What

- New **`preflight`** job, first in the pipeline, that `verify` and `e2e` (and transitively `publish-npm`) depend on. It compares `github.event.release.tag_name` to the version in the tagged commit and fails in seconds with an actionable message when they diverge — no install, no build.
- `publish-npm` keeps the authoritative `check-release --release-tag` as defense-in-depth.
- RELEASING.md updated to document the gate.

## Verification

- YAML parses; job graph is `preflight → {verify, e2e} → publish-npm`.
- Gate logic simulated both ways: rc.3-tag-on-rc.2-tree → exit 1; rc.3-tag-on-rc.3-tree → exit 0.
- `prettier --check` ✓

## Note

This prevents *recurrence*. To actually ship rc.3, the tag must be re-pointed to the bumped commit and the release re-fired (the 21 new packages are now on npm at rc.2, so the brand-new-name bootstrap blocker is cleared — but their Trusted Publishers must be attached for the OIDC publish to authenticate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)