### PR TITLE
ci(publish): attempt every package and report all publish failures

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -129,11 +129,20 @@ jobs:
             # uploads that tarball authenticated by the workflow's id-token — no NODE_AUTH_TOKEN.
             # A version already on the registry is skipped, so a re-run after a partial publish is
             # idempotent. `--provenance` attaches a signed build-provenance attestation.
+            #
+            # The loop does NOT abort on the first package that fails — it attempts every package,
+            # then exits non-zero with the full list of failures. A single missing/mismatched npm
+            # Trusted Publisher (ENEEDAUTH/E403) on one package would otherwise mask the state of
+            # all the packages after it, turning a release into a blind one-at-a-time grind. Each
+            # `npm publish` runs under an `if` so its failure is recorded, not fatal (errexit is
+            # exempt inside an `if` condition); successful publishes still land, and the re-run
+            # skips them.
             - name: Publish (OIDC trusted publishing)
               run: |
                   set -euo pipefail
                   TAG="${{ steps.release.outputs.tag }}"
                   OUT="$(mktemp -d)"
+                  published=() skipped=() failed=()
                   for d in packages/*/; do
                       d="${d%/}"
                       if [ "$(node -p "require('./$d/package.json').private === true")" = "true" ]; then
@@ -143,10 +152,30 @@ jobs:
                       version="$(node -p "require('./$d/package.json').version")"
                       if npm view "$name@$version" version >/dev/null 2>&1; then
                           echo "✓ skip $name@$version (already on the registry)"
+                          skipped+=("$name")
                           continue
                       fi
-                      (cd "$d" && pnpm pack --pack-destination "$OUT" >/dev/null)
                       tgz="$OUT/$(echo "$name" | sed 's/@//; s#/#-#')-$version.tgz"
+                      if ! (cd "$d" && pnpm pack --pack-destination "$OUT" >/dev/null); then
+                          echo "::error::pack failed for $name@$version"
+                          failed+=("$name")
+                          continue
+                      fi
                       echo "→ publishing $name@$version under dist-tag '$TAG'"
-                      npm publish "$tgz" --provenance --tag "$TAG"
+                      if npm publish "$tgz" --provenance --tag "$TAG"; then
+                          echo "✓ published $name@$version"
+                          published+=("$name")
+                      else
+                          echo "::warning::publish failed for $name@$version (likely a missing/mismatched npm Trusted Publisher)"
+                          failed+=("$name")
+                      fi
                   done
+                  echo "── publish summary ────────────────────────────────────"
+                  echo "  published (${#published[@]}): ${published[*]:-—}"
+                  echo "  skipped   (${#skipped[@]}): ${skipped[*]:-—}"
+                  echo "  failed    (${#failed[@]}): ${failed[*]:-—}"
+                  if [ "${#failed[@]}" -gt 0 ]; then
+                      echo "::error title=Publish incomplete::${#failed[@]} package(s) failed to publish: ${failed[*]}. ENEEDAUTH/E403 here almost always means that package's npm Trusted Publisher is missing or doesn't match — it must be GitHub Actions, repo rejifald/StitchAPI, workflow npm-publish.yml, no environment. Fix those on npmjs.com, then re-run this job; already-published packages are skipped, so the re-run only retries the failures."
+                      exit 1
+                  fi
+                  echo "✓ all publishable packages are on the registry at $TAG"


### PR DESCRIPTION
## Why

The rc.3 publish keeps dying on the **first** package — `@stitchapi/angular` → `ENEEDAUTH` (a missing/mismatched npm Trusted Publisher). The loop runs under `set -euo pipefail`, so that first failure aborts everything, hiding whether the other 20 new packages are also broken. Diagnosing this one re-run at a time (each ~5 min) is painful and slow.

## What

The publish loop now **attempts every package** and collects failures instead of aborting:

- Each `npm publish` (and `pnpm pack`) runs under an `if` — errexit is exempt inside an `if` condition, so a failure is recorded, not fatal.
- Successful publishes still land (and the re-run skips already-published versions — unchanged idempotency).
- At the end it prints a `published / skipped / failed` summary and, if anything failed, exits 1 with a `::error::` naming **every** failed package and the likely Trusted-Publisher fix.

Net effect: one run gives the complete list of packages whose Trusted Publisher still needs fixing, instead of revealing them one corpse at a time.

## Verification

- YAML parses; `prettier --check` ✓
- Bash logic simulated under `bash -e` / `set -euo pipefail`: a mid-loop failure does **not** stop later packages, the summary is correct, exit code is 1 when any package fails and 0 when none do, and empty-array access is safe under `set -u`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)