### PR TITLE
feat(docs): add a blog section + 16 launch articles

### DIFF
--- a/apps/docs/app/(home)/blog/[slug]/page.tsx
+++ b/apps/docs/app/(home)/blog/[slug]/page.tsx
@@ -1,0 +1,84 @@
+import { getMDXComponents } from '@/components/mdx';
+import { blogSource, formatPostDate } from '@/lib/blog';
+import { appName, siteUrl } from '@/lib/shared';
+
+import { DocsBody } from 'fumadocs-ui/layouts/docs/page';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+export default async function BlogPostPage(
+    props: PageProps<'/blog/[slug]'>,
+) {
+    const { slug } = await props.params;
+    const post = blogSource.getPage([slug]);
+    if (!post) notFound();
+
+    const MDX = post.data.body;
+
+    return (
+        <main className="container mx-auto max-w-3xl px-4 py-16">
+            <Link
+                href="/blog"
+                className="text-fd-muted-foreground hover:text-fd-foreground mb-8 inline-block text-sm transition-colors"
+            >
+                ← Back to blog
+            </Link>
+            <article>
+                <header className="mb-10">
+                    <h1 className="mb-3 text-4xl font-semibold tracking-tight">
+                        {post.data.title}
+                    </h1>
+                    <p className="text-fd-muted-foreground text-sm">
+                        <span>{post.data.author}</span>
+                        <span aria-hidden> · </span>
+                        <time dateTime={post.data.date}>
+                            {formatPostDate(post.data.date)}
+                        </time>
+                    </p>
+                </header>
+                <DocsBody>
+                    <MDX components={getMDXComponents()} />
+                </DocsBody>
+            </article>
+        </main>
+    );
+}
+
+export function generateStaticParams() {
+    return blogSource.generateParams().map((params) => ({
+        // The flat blog has a single slug segment; fumadocs hands back
+        // `{ slug: string[] }`, so flatten it to this route's `{ slug: string }`.
+        slug: params.slug?.[0] ?? '',
+    }));
+}
+
+export async function generateMetadata(
+    props: PageProps<'/blog/[slug]'>,
+): Promise<Metadata> {
+    const { slug } = await props.params;
+    const post = blogSource.getPage([slug]);
+    if (!post) notFound();
+
+    const canonical = `${siteUrl}/blog/${slug}`;
+
+    return {
+        title: post.data.title,
+        description: post.data.description,
+        alternates: { canonical },
+        openGraph: {
+            type: 'article',
+            url: canonical,
+            siteName: appName,
+            title: post.data.title,
+            description: post.data.description,
+            authors: [post.data.author],
+            publishedTime: post.data.date,
+        },
+        twitter: {
+            card: 'summary_large_image',
+            title: post.data.title,
+            description: post.data.description,
+        },
+    };
+}

--- a/apps/docs/app/(home)/blog/[slug]/page.tsx
+++ b/apps/docs/app/(home)/blog/[slug]/page.tsx
@@ -7,9 +7,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
-export default async function BlogPostPage(
-    props: PageProps<'/blog/[slug]'>,
-) {
+export default async function BlogPostPage(props: PageProps<'/blog/[slug]'>) {
     const { slug } = await props.params;
     const post = blogSource.getPage([slug]);
     if (!post) notFound();

--- a/apps/docs/app/(home)/blog/page.tsx
+++ b/apps/docs/app/(home)/blog/page.tsx
@@ -1,0 +1,64 @@
+import { formatPostDate, getSortedPosts, postSlug } from '@/lib/blog';
+import { appName } from '@/lib/shared';
+
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+    title: 'Blog',
+    description: `Notes from the ${appName} team on API stitching, agent-native integrations, and cutting AI cost.`,
+};
+
+export default function BlogIndexPage() {
+    const posts = getSortedPosts();
+
+    return (
+        <main className="container mx-auto max-w-3xl px-4 py-16">
+            <header className="mb-12">
+                <h1 className="mb-3 text-4xl font-semibold tracking-tight">
+                    Blog
+                </h1>
+                <p className="text-fd-muted-foreground text-lg">
+                    Notes on API stitching, agent-native integrations, and
+                    cutting AI cost.
+                </p>
+            </header>
+
+            {posts.length === 0 ? (
+                <p className="text-fd-muted-foreground">No posts yet.</p>
+            ) : (
+                <ul className="flex flex-col gap-10">
+                    {posts.map((post) => (
+                        <li
+                            key={post.url}
+                            className="border-fd-border border-b pb-10 last:border-b-0"
+                        >
+                            <article className="flex flex-col gap-2">
+                                <h2 className="text-2xl font-semibold tracking-tight">
+                                    <Link
+                                        href={`/blog/${postSlug(post)}`}
+                                        className="hover:text-fd-primary transition-colors"
+                                    >
+                                        {post.data.title}
+                                    </Link>
+                                </h2>
+                                <p className="text-fd-muted-foreground text-sm">
+                                    <span>{post.data.author}</span>
+                                    <span aria-hidden> · </span>
+                                    <time dateTime={post.data.date}>
+                                        {formatPostDate(post.data.date)}
+                                    </time>
+                                </p>
+                                {post.data.description ? (
+                                    <p className="text-fd-muted-foreground">
+                                        {post.data.description}
+                                    </p>
+                                ) : null}
+                            </article>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </main>
+    );
+}

--- a/apps/docs/app/(home)/blog/rss.xml/route.ts
+++ b/apps/docs/app/(home)/blog/rss.xml/route.ts
@@ -1,0 +1,58 @@
+import { getSortedPosts, postSlug } from '@/lib/blog';
+import { appName, siteUrl } from '@/lib/shared';
+
+// Static export: the feed is generated at build time, not per request.
+export const revalidate = false;
+
+const escapeXml = (value: string): string =>
+    value.replace(/[<>&'"]/g, (char) => {
+        switch (char) {
+            case '<':
+                return '&lt;';
+            case '>':
+                return '&gt;';
+            case '&':
+                return '&amp;';
+            case "'":
+                return '&apos;';
+            case '"':
+                return '&quot;';
+            default:
+                return char;
+        }
+    });
+
+export function GET() {
+    const blogUrl = `${siteUrl}/blog`;
+    const posts = getSortedPosts();
+
+    const items = posts
+        .map((post) => {
+            const link = `${blogUrl}/${postSlug(post)}`;
+            const pubDate = new Date(post.data.date).toUTCString();
+            return `        <item>
+            <title>${escapeXml(post.data.title)}</title>
+            <link>${escapeXml(link)}</link>
+            <description>${escapeXml(post.data.description ?? '')}</description>
+            <pubDate>${pubDate}</pubDate>
+            <guid isPermaLink="true">${escapeXml(link)}</guid>
+        </item>`;
+        })
+        .join('\n');
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+    <channel>
+        <title>${escapeXml(`${appName} Blog`)}</title>
+        <link>${escapeXml(blogUrl)}</link>
+        <description>${escapeXml(`Notes from the ${appName} team on API stitching, agent-native integrations, and cutting AI cost.`)}</description>
+        <language>en</language>
+${items}
+    </channel>
+</rss>
+`;
+
+    return new Response(xml, {
+        headers: { 'Content-Type': 'application/xml' },
+    });
+}

--- a/apps/docs/app/sitemap.ts
+++ b/apps/docs/app/sitemap.ts
@@ -1,4 +1,5 @@
-import { siteUrl } from '@/lib/shared';
+import { getSortedPosts, postSlug } from '@/lib/blog';
+import { blogRoute, siteUrl } from '@/lib/shared';
 import { source } from '@/lib/source';
 
 import type { MetadataRoute } from 'next';
@@ -23,6 +24,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
             lastModified,
             changeFrequency: 'weekly' as const,
             priority: 0.8,
+        })),
+        {
+            url: absolute(blogRoute),
+            lastModified,
+            changeFrequency: 'weekly' as const,
+            priority: 0.7,
+        },
+        ...getSortedPosts().map((post) => ({
+            url: absolute(`${blogRoute}/${postSlug(post)}`),
+            lastModified,
+            changeFrequency: 'monthly' as const,
+            priority: 0.6,
         })),
     ];
 }

--- a/apps/docs/content/blog/cut-llm-costs-from-both-ends.mdx
+++ b/apps/docs/content/blog/cut-llm-costs-from-both-ends.mdx
@@ -27,9 +27,9 @@ So the bill grows along two axes you don't control well: the **size of your tool
 
 StitchAPI's **code-mode** inverts this. Instead of enumerating every endpoint as a tool, you expose one small, fixed set:
 
-- `run_stitch` — execute a snippet that calls the stitches it needs
-- `list_stitches` — discover what's available, on demand
-- `describe_stitch` — pull the detail for one stitch, only when the model actually needs it
+-   `run_stitch` — execute a snippet that calls the stitches it needs
+-   `list_stitches` — discover what's available, on demand
+-   `describe_stitch` — pull the detail for one stitch, only when the model actually needs it
 
 The model writes a short TypeScript snippet that calls the stitches by name, and discovers their shapes _on demand_ instead of being handed the whole catalog up front. Conceptually:
 
@@ -55,17 +55,19 @@ The fixed three-tool surface is the same whether you have four stitches or four 
 There's a discovery channel for this that doesn't even cost a tool call: StitchAPI auto-generates an `llms.txt` describing your stitches in a compact, agent-readable form. An agent can read that once to orient, rather than carrying every schema in its working context for the whole session.
 
 <Callout type="info">
-The context savings scale with the size of your catalog and the length of your loops. A two-tool, single-shot call won't notice. A forty-tool agent grinding through a twenty-step loop will.
+    The context savings scale with the size of your catalog and the length of
+    your loops. A two-tool, single-shot call won't notice. A forty-tool agent
+    grinding through a twenty-step loop will.
 </Callout>
 
 ## Axis B — the redundant-call tax
 
 The second leak is on the far end of the request: paid upstream calls your agent didn't need to make. These are declared right on the stitch, so they apply no matter who pulls the trigger.
 
-- **Read-through caching + in-process request coalescing.** A cached read skips the upstream call entirely. Coalescing is the underrated half: identical concurrent calls collapse to _one_ paid upstream request. For a fan-out agent that kicks off the same lookup — or the same model prompt — across ten parallel branches, that's ten paid calls becoming one.
-- **Throttle.** Concurrency and rate caps put a ceiling on a runaway loop's spend. A model stuck in a retry spiral can't quietly run up a four-figure bill against a metered endpoint.
-- **Circuit breaker.** When a provider is already down, the breaker fast-fails instead of paying for a wall of doomed retries against it.
-- **Idempotency keys.** A retried write settles once, not twice — no duplicate paid side effects.
+-   **Read-through caching + in-process request coalescing.** A cached read skips the upstream call entirely. Coalescing is the underrated half: identical concurrent calls collapse to _one_ paid upstream request. For a fan-out agent that kicks off the same lookup — or the same model prompt — across ten parallel branches, that's ten paid calls becoming one.
+-   **Throttle.** Concurrency and rate caps put a ceiling on a runaway loop's spend. A model stuck in a retry spiral can't quietly run up a four-figure bill against a metered endpoint.
+-   **Circuit breaker.** When a provider is already down, the breaker fast-fails instead of paying for a wall of doomed retries against it.
+-   **Idempotency keys.** A retried write settles once, not twice — no duplicate paid side effects.
 
 Here's a stitch declaring a cached, throttled read:
 
@@ -97,25 +99,25 @@ So the savings don't depend on _who_ calls. A human running the stitch from the 
 
 The biggest wins, honestly stated:
 
-- **Long, multi-step agent loops** — the context tax is per turn, so loop length multiplies it.
-- **Fan-out / parallel tool calls** — coalescing turns N identical concurrent calls into one paid call.
-- **Large tool catalogs** — code-mode's flat three-tool surface is where the per-turn schema cost would otherwise pile up.
+-   **Long, multi-step agent loops** — the context tax is per turn, so loop length multiplies it.
+-   **Fan-out / parallel tool calls** — coalescing turns N identical concurrent calls into one paid call.
+-   **Large tool catalogs** — code-mode's flat three-tool surface is where the per-turn schema cost would otherwise pile up.
 
 And the caveats, because overclaiming helps no one:
 
-- **Caching only helps idempotent reads.** A cache in front of a write, or a read whose result legitimately changes every call, buys you nothing — and you shouldn't pretend it does.
-- **Context savings scale with catalog size and loop length, not every workload.** A single tool answering a single question won't see the per-turn schema savings, because there was never a fat catalog to re-send.
-- **None of this makes a needed call free.** It removes the calls you didn't need and the schemas you re-sent for no reason. The work your agent genuinely has to do still costs what it costs.
+-   **Caching only helps idempotent reads.** A cache in front of a write, or a read whose result legitimately changes every call, buys you nothing — and you shouldn't pretend it does.
+-   **Context savings scale with catalog size and loop length, not every workload.** A single tool answering a single question won't see the per-turn schema savings, because there was never a fat catalog to re-send.
+-   **None of this makes a needed call free.** It removes the calls you didn't need and the schemas you re-sent for no reason. The work your agent genuinely has to do still costs what it costs.
 
 ## Where to go next
 
 If you want the mechanics:
 
-- [Use StitchAPI from an agent](/docs/agents) — the agent entry point, and how invocation works without handing over a credential.
-- [run_stitch & code-mode](/docs/agents/run-stitch-tool) — the one-tool surface behind Axis A.
-- [Point an agent at llms.txt](/docs/agents/llms-txt) — the zero-tool-call discovery channel.
-- [Throttle](/docs/guides/resilience/throttle) and [Circuit breaker](/docs/guides/resilience/circuit-breaker) — the spend caps behind Axis B.
-- [Idempotency keys](/docs/guides/resilience/idempotency) — so a retried write doesn't double-charge.
+-   [Use StitchAPI from an agent](/docs/agents) — the agent entry point, and how invocation works without handing over a credential.
+-   [run_stitch & code-mode](/docs/agents/run-stitch-tool) — the one-tool surface behind Axis A.
+-   [Point an agent at llms.txt](/docs/agents/llms-txt) — the zero-tool-call discovery channel.
+-   [Throttle](/docs/guides/resilience/throttle) and [Circuit breaker](/docs/guides/resilience/circuit-breaker) — the spend caps behind Axis B.
+-   [Idempotency keys](/docs/guides/resilience/idempotency) — so a retried write doesn't double-charge.
 
 Or just start:
 

--- a/apps/docs/content/blog/cut-llm-costs-from-both-ends.mdx
+++ b/apps/docs/content/blog/cut-llm-costs-from-both-ends.mdx
@@ -1,0 +1,126 @@
+---
+title: Cut your LLM bill from both ends
+description: StitchAPI attacks AI cost on two axes — the tokens you spend describing tools to a model, and the redundant upstream calls your agents make. Here's the mechanism behind each.
+author: Oleksandr Zhuravlov
+date: '2026-06-25'
+tags: [ai, agents, cost, mcp]
+---
+
+Most advice on cutting AI costs lands in one of two buckets: compress your prompts, or switch to a cheaper model. Both help. Both also leave the structural cost untouched — the part of your bill that scales with how your agents are _wired_, not with how cleverly you phrase a system prompt.
+
+There are two places that structural cost leaks, and they sit on opposite ends of the request. StitchAPI is API stitching: you declare an endpoint once — its types, auth, and resilience — and call it like a local function, from code, the CLI, plain HTTP, or an AI agent over MCP. Because the cost-shaping lives in that one declaration, both leaks close as a property of how you _declare_ an integration, not an optimization you bolt on afterward.
+
+## The two places the money leaks
+
+1. **The context tax.** The tokens you pay to describe your tools to the model — on _every_ turn of a multi-step loop.
+2. **The redundant-call tax.** The paid upstream calls your agent makes that it didn't actually need to make: duplicate fan-out, retries against a dead provider, a runaway loop hammering the same endpoint.
+
+The first is an input-token problem. The second is an upstream-spend problem. Neither is fixed by a cheaper model. Let's take them in turn.
+
+## Axis A — the context tax
+
+The common way to give a model access to an API is one tool per endpoint. It's the path of least resistance: each endpoint becomes a tool with its own JSON schema, and the model picks from the menu.
+
+The problem is where that menu lives. Every tool's schema is re-sent in the model's context on _every_ step of the agent loop. Forty endpoints means forty schemas, re-paid on turn 1, turn 2, turn 3, and so on for the length of the loop. The catalog is fixed cost you pay per turn, whether or not the model touches a given tool that turn.
+
+So the bill grows along two axes you don't control well: the **size of your tool catalog** and the **length of your agent loops**. Add the 41st integration and every future turn gets a little more expensive, forever.
+
+StitchAPI's **code-mode** inverts this. Instead of enumerating every endpoint as a tool, you expose one small, fixed set:
+
+- `run_stitch` — execute a snippet that calls the stitches it needs
+- `list_stitches` — discover what's available, on demand
+- `describe_stitch` — pull the detail for one stitch, only when the model actually needs it
+
+The model writes a short TypeScript snippet that calls the stitches by name, and discovers their shapes _on demand_ instead of being handed the whole catalog up front. Conceptually:
+
+```ts
+// Before — one tool per endpoint, every schema re-sent each turn:
+//   tools: [
+//     getUser, listUsers, createUser, updateUser, deleteUser,
+//     getOrder, listOrders, createOrder, refundOrder,
+//     ... 40 more, all in context, every turn ...
+//   ]
+
+// After — one execution tool + on-demand discovery:
+//   tools: [run_stitch, list_stitches, describe_stitch]
+//
+// The model calls list_stitches once, describe_stitch for the few it
+// needs, then writes a snippet:
+const user = await runStitch('getUser', { params: { id: 7 } });
+const orders = await runStitch('listOrders', { query: { userId: user.id } });
+```
+
+The fixed three-tool surface is the same whether you have four stitches or four hundred. Adding the 41st API costs roughly zero additional context per turn — the model learns about it through `list_stitches` only on the turns it cares.
+
+There's a discovery channel for this that doesn't even cost a tool call: StitchAPI auto-generates an `llms.txt` describing your stitches in a compact, agent-readable form. An agent can read that once to orient, rather than carrying every schema in its working context for the whole session.
+
+<Callout type="info">
+The context savings scale with the size of your catalog and the length of your loops. A two-tool, single-shot call won't notice. A forty-tool agent grinding through a twenty-step loop will.
+</Callout>
+
+## Axis B — the redundant-call tax
+
+The second leak is on the far end of the request: paid upstream calls your agent didn't need to make. These are declared right on the stitch, so they apply no matter who pulls the trigger.
+
+- **Read-through caching + in-process request coalescing.** A cached read skips the upstream call entirely. Coalescing is the underrated half: identical concurrent calls collapse to _one_ paid upstream request. For a fan-out agent that kicks off the same lookup — or the same model prompt — across ten parallel branches, that's ten paid calls becoming one.
+- **Throttle.** Concurrency and rate caps put a ceiling on a runaway loop's spend. A model stuck in a retry spiral can't quietly run up a four-figure bill against a metered endpoint.
+- **Circuit breaker.** When a provider is already down, the breaker fast-fails instead of paying for a wall of doomed retries against it.
+- **Idempotency keys.** A retried write settles once, not twice — no duplicate paid side effects.
+
+Here's a stitch declaring a cached, throttled read:
+
+```ts
+import { stitch } from 'stitchapi';
+
+const search = stitch('https://api.example.com/search', {
+    // Read-through cache; identical concurrent calls coalesce into one.
+    cache: { ttl: '5m', coalesce: true },
+    // Bound the spend: at most 5 in flight, 20 calls/sec.
+    throttle: { concurrency: 5, rate: { limit: 20, per: '1s' } },
+});
+
+// Ten parallel branches asking the same thing => one paid upstream call.
+const results = await Promise.all(
+    Array.from({ length: 10 }, () => search({ query: { q: 'stitchapi' } })),
+);
+```
+
+None of that is agent-specific. It's the same machinery you'd want around any expensive call — it just happens to matter a lot more when the caller is a model that will cheerfully retry, fan out, and loop.
+
+## Declared, not bolted on
+
+The reason both axes close at once is that they're properties of the stitch _definition_, not of any one caller. A stitch has four front doors — an in-process function, a CLI command, an HTTP endpoint, and an MCP tool — and the cache, the throttle, the breaker, the idempotency key live on the definition behind all four.
+
+So the savings don't depend on _who_ calls. A human running the stitch from the CLI gets the same coalescing as an agent calling it over MCP. You declare the cost behavior once; every surface inherits it.
+
+## When it matters most — and when it doesn't
+
+The biggest wins, honestly stated:
+
+- **Long, multi-step agent loops** — the context tax is per turn, so loop length multiplies it.
+- **Fan-out / parallel tool calls** — coalescing turns N identical concurrent calls into one paid call.
+- **Large tool catalogs** — code-mode's flat three-tool surface is where the per-turn schema cost would otherwise pile up.
+
+And the caveats, because overclaiming helps no one:
+
+- **Caching only helps idempotent reads.** A cache in front of a write, or a read whose result legitimately changes every call, buys you nothing — and you shouldn't pretend it does.
+- **Context savings scale with catalog size and loop length, not every workload.** A single tool answering a single question won't see the per-turn schema savings, because there was never a fat catalog to re-send.
+- **None of this makes a needed call free.** It removes the calls you didn't need and the schemas you re-sent for no reason. The work your agent genuinely has to do still costs what it costs.
+
+## Where to go next
+
+If you want the mechanics:
+
+- [Use StitchAPI from an agent](/docs/agents) — the agent entry point, and how invocation works without handing over a credential.
+- [run_stitch & code-mode](/docs/agents/run-stitch-tool) — the one-tool surface behind Axis A.
+- [Point an agent at llms.txt](/docs/agents/llms-txt) — the zero-tool-call discovery channel.
+- [Throttle](/docs/guides/resilience/throttle) and [Circuit breaker](/docs/guides/resilience/circuit-breaker) — the spend caps behind Axis B.
+- [Idempotency keys](/docs/guides/resilience/idempotency) — so a retried write doesn't double-charge.
+
+Or just start:
+
+```bash
+npm i stitchapi
+```
+
+Declare one endpoint, point an agent at it, and watch the two taxes shrink at the same time.

--- a/apps/docs/lib/blog.ts
+++ b/apps/docs/lib/blog.ts
@@ -1,0 +1,41 @@
+import { blogRoute } from './shared';
+
+import { blog } from 'collections/server';
+import { loader } from 'fumadocs-core/source';
+
+// The blog is its own fumadocs source, rooted at `/blog`, kept separate from the
+// docs source (and the docs IA drift guard) on purpose. Posts are flat under
+// `content/blog`, so a page's single slug segment is the URL slug.
+export const blogSource = loader({
+    baseUrl: blogRoute,
+    source: blog.toFumadocsSource(),
+});
+
+export type BlogPost = (typeof blogSource)['$inferPage'];
+
+/**
+ * Every post, newest first. `date` is an ISO date string validated in
+ * `source.config.ts`, so a lexicographic compare already orders correctly; we
+ * parse to `Date` defensively in case a post uses a fuller timestamp.
+ */
+export function getSortedPosts(): BlogPost[] {
+    return [...blogSource.getPages()].sort(
+        (a, b) =>
+            new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
+    );
+}
+
+/** The single-segment URL slug for a post (e.g. `cut-llm-costs-from-both-ends`). */
+export function postSlug(post: BlogPost): string {
+    return post.slugs[0] ?? '';
+}
+
+/** Format an ISO date string for display, e.g. "June 25, 2026". */
+export function formatPostDate(date: string): string {
+    return new Date(date).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        timeZone: 'UTC',
+    });
+}

--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -16,6 +16,10 @@ export function baseOptions(): BaseLayoutProps {
                 url: '/docs',
             },
             {
+                text: 'Blog',
+                url: '/blog',
+            },
+            {
                 text: 'Playground',
                 url: '/playground',
             },

--- a/apps/docs/lib/shared.ts
+++ b/apps/docs/lib/shared.ts
@@ -8,6 +8,8 @@ export const docsRoute = '/docs';
 export const docsImageRoute = '/og/docs';
 export const docsContentRoute = '/llms.mdx/docs';
 
+export const blogRoute = '/blog';
+
 // GitHub repository, used for "edit on GitHub" / source links.
 export const gitConfig = {
     user: 'rejifald',

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -4,6 +4,7 @@ import { rehypeCodeDefaultOptions } from 'fumadocs-core/mdx-plugins';
 import { metaSchema, pageSchema } from 'fumadocs-core/source/schema';
 import { defineConfig, defineDocs } from 'fumadocs-mdx/config';
 import { transformerTwoslash } from 'fumadocs-twoslash';
+import { z } from 'zod';
 
 // You can customize Zod schemas for frontmatter and `meta.json` here
 // see https://fumadocs.dev/docs/mdx/collections
@@ -14,6 +15,49 @@ export const docs = defineDocs({
         postprocess: {
             includeProcessedMarkdown: true,
         },
+    },
+    meta: {
+        schema: metaSchema,
+    },
+});
+
+// A SEPARATE collection from `docs`, with its own `content/blog` tree, so it
+// stays clear of the docs IA drift guard (content.manifest.ts + the skeleton
+// generator + content-manifest.spec.ts), which is scoped to `content/docs`.
+//
+// Blog posts carry the standard page frontmatter (title/description) plus
+// author + date + optional tags. Extending `pageSchema` keeps the blog in sync
+// with however the docs page schema evolves rather than re-declaring it.
+// `date` is an ISO date string (`YYYY-MM-DD`); we keep it a string the loader
+// can sort lexicographically and parse with `new Date(...)` for display. The
+// YAML parser turns an unquoted `date: 2026-06-25` into a `Date`, so coerce it
+// back to an ISO date string before validating — quoting in frontmatter is
+// preferred, but this keeps an unquoted date from breaking the build.
+//
+// NOTE: `source.config.ts` may only export collections — keep the schema inline
+// (fumadocs-mdx rejects any other export from this file).
+export const blog = defineDocs({
+    dir: 'content/blog',
+    docs: {
+        schema: pageSchema.extend({
+            author: z.string(),
+            date: z.preprocess(
+                (value) =>
+                    value instanceof Date
+                        ? value.toISOString().slice(0, 10)
+                        : value,
+                z
+                    .string()
+                    .refine(
+                        (value) => !Number.isNaN(new Date(value).getTime()),
+                        {
+                            message:
+                                'Invalid date — use an ISO date like 2026-06-25',
+                        },
+                    ),
+            ),
+            tags: z.array(z.string()).optional(),
+        }),
     },
     meta: {
         schema: metaSchema,


### PR DESCRIPTION
## What

Adds a blog section to the StitchAPI docs site, plus the first post.

- **Blog collection** — a new `blog` collection in `apps/docs/source.config.ts` (dir `content/blog`), kept **separate** from the `docs` collection so it stays clear of the docs IA drift guard (`content.manifest.ts` + `scripts/generate-skeleton.mjs` + `test/content-manifest.spec.ts`, all scoped to `content/docs`). Frontmatter extends fumadocs' `pageSchema` with `author`, `date` (ISO date string), and optional `tags`.
- **Blog source** — `apps/docs/lib/blog.ts` exposes `blogSource` (baseUrl `/blog`) with `getSortedPosts()` (newest first), `postSlug`, and `formatPostDate` helpers. A `blogRoute = '/blog'` constant was added to `apps/docs/lib/shared.ts`.
- **Routes** (all under the `(home)` route group, so posts get marketing chrome, not the docs sidebar):
  - `/blog` — index listing every post (title, author, formatted date, description), newest first, with page metadata.
  - `/blog/[slug]` — single post; `generateStaticParams`, canonical URL + OpenGraph metadata, renders the MDX body with the project's `getMDXComponents` inside fumadocs' `DocsBody`, `notFound()` for unknown slugs.
  - `/blog/rss.xml` — RSS 2.0 feed (sibling static segment of `[slug]`), one `<item>` per post, XML entities escaped.
- **Nav link** — a `Blog` link added after `Docs` in `baseOptions()`.
- **Sitemap** — `/blog` and each post URL added to `app/sitemap.ts`.
- **First post** — `content/blog/cut-llm-costs-from-both-ends.mdx` ("Cut your LLM bill from both ends"), ~1100 words. Illustrative code uses plain ` ```ts ` fences (no `twoslash`) so they aren't type-checked at build time, per the repo's code-fence rule.

## How to preview

```
pnpm --filter @stitchapi/docs dev
```

Then open `/blog`, click through to the post, and check `/blog/rss.xml`.

## Validation

All run from `apps/docs`:

- `check:types` — passing
- `check:lint` — passing
- `test` (7 tests, incl. the IA/drift guard) — passing
- `gen:docs` then `git diff` on `content/docs` — clean (CI drift gate stays green)
- `pnpm run build` — full production build succeeds; `/blog`, `/blog/cut-llm-costs-from-both-ends`, and `/blog/rss.xml` all prerender

## Notes

- The blog needs no `meta.json` — the flat collection builds green without one.
- The `date` frontmatter is quoted (and the schema also coerces a YAML-parsed `Date` back to an ISO string) so an unquoted date can't break the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)