### PR TITLE
docs(blog): consistent query-lib naming + drop the Try it section

### DIFF
--- a/apps/docs/content/blog/stitch-in-react-vue-svelte-solid.mdx
+++ b/apps/docs/content/blog/stitch-in-react-vue-svelte-solid.mdx
@@ -87,7 +87,7 @@ readonly user = injectStitch(getUser, () => ({ params: { id: this.id() } }));
 // the same state as an observable:        user.state$   // async pipe + RxJS operators
 ```
 
-Refs, stores, store proxies, signals, observables — different surfaces, but the same `status` / `chunks` / `isStreaming` underneath, because one query-core sits behind every binding. The exact signatures — and the optional TanStack Query adapter each one ships — live in the per-framework guides.
+Refs, stores, store proxies, signals, observables — different surfaces, but the same `status` / `chunks` / `isStreaming` underneath, because one query-core sits behind every binding. The exact signatures — and the optional TanStack Query adapter each one ships — live in the per-framework guides: [React](/docs/integrations/react), [Vue](/docs/integrations/vue), [Svelte](/docs/integrations/svelte), [Solid](/docs/integrations/solid), and [Angular](/docs/integrations/angular).
 
 ## It composes with the data layer you already have
 
@@ -103,15 +103,5 @@ So the decision isn't "stitch bindings _or_ my query library." It's which layer 
 
 Two honest caveats:
 
--   **If a query library already owns your view state, you may not need the binding's hooks at all.** Going through `@stitchapi/swr`, `@stitchapi/rtk-query`, or the TanStack Query adapter can be the simpler path — let that layer manage state and let the stitch be the `queryFn`.
+-   **If a query library already owns your view state, you may not need the binding's hooks at all.** Going through SWR, RTK Query, or TanStack Query can be the simpler path — let that layer manage state and let the stitch be the `queryFn`.
 -   **A one-shot call doesn't need a binding.** For a fire-once call outside a reactive view, `await stitch(...)` is enough; the binding earns its keep only when a component has to react to loading, error, drift, or streaming state over time.
-
-## Try it
-
-Install the core plus the binding for your framework — React, here:
-
-```bash
-npm i stitchapi @stitchapi/query-core @stitchapi/react
-```
-
-The per-framework guides have the exact signatures: [React](/docs/integrations/react), [Vue](/docs/integrations/vue), [Svelte](/docs/integrations/svelte), [Solid](/docs/integrations/solid), and [Angular](/docs/integrations/angular).


### PR DESCRIPTION
Two follow-ups on the **Stitch in Your UI** post ([`stitch-in-react-vue-svelte-solid`](apps/docs/content/blog/stitch-in-react-vue-svelte-solid.mdx)), on top of #324.

### 1. Consistent query-library naming

The "if a query library owns your view state" caveat listed `@stitchapi/swr`, `@stitchapi/rtk-query`, **or the TanStack Query adapter** — two package names plus one brand-named adapter. The asymmetry is real: `@stitchapi/swr` and `@stitchapi/rtk-query` are published packages, but **there is no `@stitchapi/tanstack-query`** — TanStack support is an adapter each framework binding ships (`{ queryKey, queryFn }`). Since there's no package to name, the consistent fix is to use the **library brand names for all three** (SWR, RTK Query, TanStack Query) in that recap. The precise package names still appear in the "It composes" section above, where the swr/rtk-query-vs-adapter distinction is explained.

### 2. Drop the "Try it" section

Removed it as redundant. Its one load-bearing part — the per-framework doc links — moves up into the "same state" coda, so the post closes on the honest caveats instead of an install recap.

Content-only. `prettier --check` clean; `check:docs-links` passes (all five integration links still resolve from their new home in the coda).

🤖 Generated with [Claude Code](https://claude.com/claude-code)