### PR TITLE
docs(editorial): prose-quality standard + surgical pass across docs & READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 > [!NOTE]
 >
-> **StitchAPI is at `1.0.0-rc.2`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is very welcome.
+> **StitchAPI is at `1.0.0-rc.3`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is welcome.
 
 ---
 

--- a/apps/docs/AUTHORING.md
+++ b/apps/docs/AUTHORING.md
@@ -2,6 +2,11 @@
 
 This is the contract for writing docs pages. Read it before you write one.
 
+This guide governs **structure** — templates, sections, twoslash, tabs, the
+manifest. How the prose _reads_ — voice, economy, how a claim is shown rather than
+asserted — is the separate, equally-mandatory contract in
+[`EDITORIAL.md`](./EDITORIAL.md). A page must pass both.
+
 It matters more than a usual style guide because the first content pass ships
 the **structure only** — every page starts life as a generated stub. There is no
 finished page to copy yet, so **this guide plus [`content.manifest.ts`](./content.manifest.ts)

--- a/apps/docs/EDITORIAL.md
+++ b/apps/docs/EDITORIAL.md
@@ -1,0 +1,156 @@
+# The editorial standard for StitchAPI prose
+
+This is the contract for how a docs page _reads_. [`AUTHORING.md`](./AUTHORING.md)
+governs the **structure** of a page — which template, which sections, twoslash,
+tabs, the manifest. This governs the **prose** that fills it.
+
+The two are orthogonal and both mandatory: a page can pass every structural rule
+in `AUTHORING.md` — correct template, green twoslash, valid `See also` — and still
+be a bad article, because the sentences hedge, the lede warms up, or a claim is
+asserted instead of shown. This file is what catches that.
+
+It is not an aspiration. The voice below is **reverse-engineered from the pages
+that already read well** — [`concepts/the-stitch`](./content/docs/concepts/the-stitch.mdx),
+[`guides/resilience/retry`](./content/docs/guides/resilience/retry.mdx),
+[`integrations/react`](./content/docs/integrations/react.mdx). The job of this
+standard is to make that voice repeatable and its absence auditable, so every new
+page matches the best existing one instead of regressing to a generic style.
+
+Audience, like `AUTHORING.md`: human writers **and** agents. Each rule is chosen so
+a page reads well both rendered in a browser and pulled out of context as
+`llms.mdx`.
+
+---
+
+## The seven dimensions
+
+Each dimension has a **rule** (what good looks like), a **tell** (the failure
+smell — most are greppable), and an **example** drawn from a real page. An audit
+scores a page against all seven.
+
+### 1. The lede earns its place in one sentence
+
+The first sentence states **what this is and when you reach for it** — nothing
+before it. It is also the agent's relevance signal in `llms.mdx`, so it cannot
+spend a clause warming up.
+
+-   ✅ _"Add `retry` when an API returns transient failures — rate limits and gateway
+    hiccups — and you want the stitch to wait and try again instead of surfacing the
+    first error."_ (`retry.mdx`)
+-   🚩 **Tell:** opens with "In this guide…", "This page covers…", "StitchAPI
+    provides…", or a bare definition with no _when_. Grep: `^In this`, `^This (page|guide|section)`, `provides a way to`.
+
+### 2. Economy — every sentence is load-bearing
+
+Long sentences are allowed when each clause adds information; the page above runs
+forty-word sentences that all carry weight. What is not allowed is filler — words
+that survive their own deletion.
+
+-   🚩 **Tell — delete-on-sight words:** _simply, just (as a softener), basically,
+    in order to (→ "to"), it's worth noting, of course, note that, actually, very,
+    really, powerful, robust, seamless, easily, leverage, utilize (→ "use")._
+-   🚩 **Tell:** a sentence whose removal changes nothing. If you can cut it and the
+    reader loses no fact, cut it.
+
+### 3. Show the mechanism, not the adjective
+
+A claim is demonstrated by naming the behavior, never asserted with a praise word.
+"Resilient" is earned by writing _retry, timeout, circuit breaker_ next to it — or
+it is not earned at all.
+
+-   ✅ _"`fetch` hands back opaque bytes."_ — the weakness is the mechanism, not an
+    adjective.
+-   🚩 **Tell:** _powerful / elegant / intuitive / blazing-fast / first-class /
+    best-in-class_ with no `code` or concrete behavior in the same sentence.
+
+### 4. Define by contrast — "X, not Y"
+
+The strongest explanations on the site fix a concept by saying what it is _instead
+of_. Use a bold parallel lead-in for a run of such claims.
+
+-   ✅ _"**Declarative, not an imperative wrapper.** … **Atomic, not spec-first.** …
+    **One primitive, two facades.**"_ (`the-stitch.mdx`)
+-   🚩 **Tell:** a feature list with no foil — the reader is told what it does but
+    never what it replaces or refuses to be.
+
+### 5. Concrete subject, active verb
+
+A named actor does the thing. "The engine decides how to carry it out," not "it is
+decided how the call should be carried out." Prefer verbs over nominalizations.
+
+-   🚩 **Tell:** agentless passive — _is provided, is handled, can be configured, is
+    performed_ — with no actor. Nominalizations: _the configuration of, the
+    validation of, the resolution of_ (→ "configuring", "validating", "resolving").
+
+### 6. Cohesion without back-reference
+
+Each paragraph follows from the last _within the page_, but the page never leans on
+its own position in the sidebar. No "as we saw above" — restate the one-line premise
+in a clause and link. This is the prose face of `AUTHORING.md` rule 5
+(self-contained pages): the page must read standalone as `llms.mdx`.
+
+-   🚩 **Tell:** _as we saw, as mentioned, recall that, continuing from, in the
+    previous section, above/below_ (as a content reference). Grep: `as (we saw|mentioned)`, `previous (section|page)`, `recall that`.
+
+### 7. Second person, purposeful
+
+"You" addresses the reader's task. Avoid "we" for the authors and avoid the
+product speaking in the first person; say what _you_ (the reader) get or do, and
+use the imperative for steps.
+
+-   ✅ _"you narrow or widen it per stitch."_ (`retry.mdx`)
+-   🚩 **Tell:** _we recommend, we built, we think, our library, let's_ — replace
+    with the reader's action or the plain fact.
+
+---
+
+## A note on terminology (shared with `AUTHORING.md`)
+
+`AUTHORING.md` rule 4 already fixes the product vocabulary — "stitch" lowercase,
+"capability, not credential", "the event stream", never "SDK"/"client"/"endpoint
+wrapper". That rule is **load-bearing for prose too**: an audit treats a vocabulary
+slip (calling a stitch a "client") as a dimension-3 failure, because the wrong noun
+asserts the wrong mental model. Don't re-litigate the vocabulary here — enforce it.
+
+For **Ukrainian and other localized prose**, terminology is a different and larger
+problem (transliterate vs. translate vs. keep-in-English), governed by its own
+standard. This file is English-prose only.
+
+---
+
+## How to audit a page
+
+1. **Read it once as a reader**, top to bottom, as if it were the only page you
+   found. Does the lede tell you what and when (dim. 1)? Did anything make you
+   re-read (dim. 6)?
+2. **Grep the tells.** The delete-on-sight list (dim. 2), agentless passive
+   (dim. 5), and back-references (dim. 6) are mechanical — find them first.
+3. **Score each dimension** and record findings as
+   `file:line · dimension · severity · the rewrite`. A finding is not a flag; it
+   is the replacement sentence.
+
+### Severity
+
+-   **`blocker`** — the prose states something false or contradicts the code/example
+    on the page. Fix before anything else; this is also a correctness bug.
+-   **`major`** — violates dimensions 1–4. The reader is slowed or misled: a lede
+    that buries the _when_, a claim asserted not shown, filler thick enough to
+    obscure the point.
+-   **`minor`** — violates dimensions 5–7. Polish: a passive that wants an actor, a
+    stray "we", an avoidable back-reference.
+
+A page is **done** when it has no `blocker` or `major` findings and reads, start to
+finish, like the exemplar pages this standard was drawn from.
+
+---
+
+## Definition of done (per page, prose)
+
+-   [ ] Lede states what + when in the first sentence; no warm-up (dim. 1).
+-   [ ] No delete-on-sight filler; every sentence is load-bearing (dim. 2).
+-   [ ] Every quality claim is shown by a named mechanism, not an adjective (dim. 3).
+-   [ ] Key concepts are framed "X, not Y" where a foil exists (dim. 4).
+-   [ ] No agentless passive or nominalization where an actor + verb fits (dim. 5).
+-   [ ] No back-reference to other pages' position; reads standalone (dim. 6).
+-   [ ] Second person for the reader; no authorial "we" (dim. 7).
+-   [ ] Product vocabulary matches `AUTHORING.md` rule 4 exactly.

--- a/apps/docs/content/docs/agents/index.mdx
+++ b/apps/docs/content/docs/agents/index.mdx
@@ -9,8 +9,8 @@ stitch and gets back structured, validated, traceable data without ever touching
 the secret — and it works through **one context-frugal tool**, not one tool per
 endpoint, so adding APIs never floods the model's context window.
 
-The rest of this section is three things an agent does with a stitch: it invokes
-them, it authors them, and it reasons over them.
+An agent does three things with a stitch: invokes it, authors it, and reasons
+over it — one subsection each.
 
 ## Invoke
 

--- a/apps/docs/content/docs/agents/run-stitch-tool.mdx
+++ b/apps/docs/content/docs/agents/run-stitch-tool.mdx
@@ -128,7 +128,7 @@ import { z } from 'zod';
 
 const getUser = stitch({
     baseUrl: 'https://api.example.com',
-    path: '/users/:id',
+    path: '/users/{id}',
     output: z.object({ id: z.number(), name: z.string() }),
 });
 ```

--- a/apps/docs/content/docs/concepts/principles.mdx
+++ b/apps/docs/content/docs/concepts/principles.mdx
@@ -45,10 +45,10 @@ declaration _is_ the runtime; there is nothing to commit, diff, and regenerate.
 
 Cross-cutting concerns — `baseUrl`, auth, `unwrap`, retry, throttle, timeout —
 are named, shareable values you compose, not a central config object far from the
-call site — and nothing is inherited implicitly: no config file, no ambient
-defaults, no global a stitch silently reads, so everything that shapes a call was
-composed into it explicitly and you can read one stitch and know exactly what it
-does. `extends` folds fragments into a stitch. You share a plain fragment
+call site. Nothing is inherited implicitly: no config file, no ambient defaults,
+no global a stitch silently reads. Everything that shapes a call was composed into
+it explicitly, so you can read one stitch and know exactly what it does. `extends`
+folds fragments into a stitch. You share a plain fragment
 instead of re-typing config, and a stitch is itself a composable value others can
 extend. (For a whole shared surface — shared runtime plus a trusted principal
 boundary — a `seam` owns the fragment instead.)

--- a/apps/docs/content/docs/guides/state/distributed-throttle.mdx
+++ b/apps/docs/content/docs/guides/state/distributed-throttle.mdx
@@ -54,7 +54,8 @@ stitch name or host.
 
 <Callout type="info">
     The same shared store also backs auth sessions, so one store gives you both
-    a fleet-wide rate budget and a shared session — see Shared sessions.
+    a fleet-wide rate budget and a shared session — see [Shared
+    sessions](/docs/guides/state/shared-sessions).
 </Callout>
 
 ## See also

--- a/apps/docs/content/docs/guides/testing/mocking.mdx
+++ b/apps/docs/content/docs/guides/testing/mocking.mdx
@@ -322,7 +322,7 @@ await p; // { ok: true } — with zero real waiting
 `advance(ms)` fires every backoff/pacing/timeout due at or before the new time, in
 order, and `pending()` reports the timers still waiting. The default is the real
 `systemClock` (exported from the main entry), so this changes nothing until you
-inject a clock; you can also supply your own object implementing `Clock`. Note that
+inject a clock; you can also supply your own object implementing `Clock`.
 `timeout.total` and event timestamps stay on wall-clock.
 
 ## See also

--- a/apps/docs/content/docs/integrations/next.mdx
+++ b/apps/docs/content/docs/integrations/next.mdx
@@ -4,7 +4,7 @@ description: Web-standard helpers for Next App Router route handlers — sseResp
 ---
 
 Next App Router route handlers are **Web-standard**: they take a `Request` and return
-a `Response`. So a stitch already runs in one directly — define a [`seam`](/docs/concepts/event-stream)
+a `Response`. So a stitch already runs in one directly — define a [`seam`](/docs/concepts/the-stitch)
 once and call it in the handler. `@stitchapi/next` adds the two bits you'd otherwise
 hand-roll on the Web platform: streaming a stitch as Server-Sent Events, and mapping a
 `StitchError` to a `Response`.

--- a/apps/docs/content/docs/integrations/stores.mdx
+++ b/apps/docs/content/docs/integrations/stores.mdx
@@ -8,7 +8,7 @@ the process-local pieces of a stitch — its
 [rate-limit counters](/docs/guides/state/distributed-throttle), its
 [auth sessions and tokens](/docs/guides/state/shared-sessions), and its response
 cache — into **fleet-wide** state, with **no change to the call site**. Core ships
-no backend; you attach one of these drivers to a [`seam`](/docs/concepts/event-stream)
+no backend; you attach one of these drivers to a [`seam`](/docs/concepts/the-stitch)
 and every worker shares the same counters and sessions.
 
 Each driver is a thin peer-dependency (or zero-dependency) package that imports no

--- a/apps/docs/content/docs/recipes/catch-a-breaking-api-change.mdx
+++ b/apps/docs/content/docs/recipes/catch-a-breaking-api-change.mdx
@@ -40,7 +40,7 @@ the repo); every call after compares the response and emits leveled findings.
 brand-new fields default to `info` (`onNew`). `warn` and `info` findings do
 **not** throw — they ride the [event stream](/docs/concepts/event-stream) as
 `drift` events, so you can [watch a field erode](/docs/recipes/watch-a-call-as-it-happens)
-before it breaks. This is the opposite end from plain
+before it breaks. Drift sits at the opposite end from plain
 [validation](/docs/guides/validation/validation), which rejects one malformed
 response hard, here and now.
 

--- a/apps/docs/content/docs/reference/events.mdx
+++ b/apps/docs/content/docs/reference/events.mdx
@@ -19,7 +19,7 @@ import type { StitchEvent } from 'stitchapi';
 
 ## The events
 
-A union table can render sparsely, so here is each of the seven variants and its
+A union table can render sparsely, so here is each of the eight variants and its
 fields. Every event carries an `at` field — a millisecond timestamp.
 
 -   **`start`** — the request is about to go out. Fields: `name` (the stitch
@@ -27,6 +27,9 @@ fields. Every event carries an `at` field — a millisecond timestamp.
 -   **`progress`** — a lifecycle beat within an attempt. Fields: `phase` (a
     `ProgressPhase`), `attempt` (1-based), `detail?`, `waitedMs?` (set when the
     phase involved a wait, e.g. `throttled` or `retry`), `at`.
+-   **`info`** — an auth strategy announcing a decision it made (e.g. which env
+    var a `bearer` token resolved from, or that `oauth2` fetched a token); it
+    never carries the secret itself. Fields: `topic`, `detail?`, `at`.
 -   **`drift`** — a single contract-drift observation against the response.
     Fields: `finding` (a `DriftFinding` with `level`, `path`, `change`,
     `detail?`), `at`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,11 +4,9 @@
 
 > [!NOTE]
 >
-> **StitchAPI is at `1.0.0-rc.2`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is very welcome.
+> **StitchAPI is at `1.0.0-rc.3`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is welcome.
 
 **Turn any REST, GraphQL, SSE, or LLM API into a typed, resilient function.** Its one primitive — a **stitch** — takes a single endpoint and hands you back a callable: declare the endpoint's contract once (input, output, auth, resilience) and call it like a local function. No server, no codegen, no config files — only explicit composition. The same definition your code calls, the CLI runs and an AI agent can invoke without ever touching a credential.
-
-The name StitchAPI combines the words “stitch” and “API,” reflecting its core purpose: to “stitch” or seamlessly connect any JSON-based API into your project. The term “stitch” conveys the idea of binding or linking various APIs into a unified system within your project.
 
 **Full documentation, guides, and a live playground live at [stitchapi.dev](https://stitchapi.dev).**
 

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -8,7 +8,7 @@ Stitch errors to HTTP — three thin bridges between StitchAPI's backend primiti
 (the `seam`, ADR 0002) and Express's `req`/`res`.
 
 Express has no plugin/lifecycle/logger structure to bridge (cf.
-[`@stitchapi/fastify`](https://stitchapi.dev)), so this is the **shallow**
+[`@stitchapi/fastify`](https://stitchapi.dev/docs/integrations/fastify)), so this is the **shallow**
 binding: a request handler, an SSE writer, and an error-handling middleware.
 Works on Express 4 and 5.
 

--- a/packages/sandbox-sim/README.md
+++ b/packages/sandbox-sim/README.md
@@ -1,3 +1,3 @@
 # @stitchapi/sandbox-sim
 
-Isomorphic fake-API simulator for the StitchAPI playground. Provides a handler registry and adapters that allow snippets to run identically in both browser (Web Worker) and server (isolated-vm) tiers without hitting a real network. Handlers are added in S2–S4; fetch-shim adapters are completed in S5.
+Isomorphic fake-API simulator for the StitchAPI playground. Provides a handler registry and adapters that allow snippets to run identically in both browser (Web Worker) and server (isolated-vm) tiers without hitting a real network.


### PR DESCRIPTION
## What

Adds **`apps/docs/EDITORIAL.md`** — a prose-quality contract that complements the existing structural `AUTHORING.md` — and dogfoods it across **all 106 doc pages + 33 READMEs**.

`AUTHORING.md` governs *structure* (templates, twoslash, tabs, the manifest). `EDITORIAL.md` governs how the *prose* reads, in seven greppable dimensions reverse-engineered from the pages that already read best (`the-stitch`, `retry`, `react`):

1. Lede states what + when in one sentence
2. Economy — every sentence load-bearing (delete-on-sight filler list)
3. Show the mechanism, not the adjective
4. Define by contrast — "X, not Y"
5. Concrete subject, active verb
6. Cohesion without back-reference
7. Second person, purposeful

Each dimension ships with a failure "tell" and a severity model, so the standard doubles as an auditable checklist.

## The audit

Run at a **surgical bar** — most pages passed untouched; this is a small diff by design. The prose pass also flushed out genuine **correctness bugs**:

- **`reference/events.mdx`** — omitted the `info` `StitchEvent` variant (said "seven"; the union has eight) and contradicted its own `AutoTypeTable`. Added it, with the accurate description from the type's TSDoc.
- **`agents/run-stitch-tool.mdx`** — path used Express `:id` instead of RFC 6570 `{id}`.
- **`integrations/stores.mdx` + `integrations/next.mdx`** — the word `seam` linked to the unrelated event-stream page → repointed to `the-stitch`.
- **`README.md` + `packages/core/README.md`** — both still claimed `1.0.0-rc.2` (shipped `rc.3`).
- **`guides/state/distributed-throttle.mdx`** — "see Shared sessions" had no link.
- **`packages/sandbox-sim/README.md`** — removed stale `S2–S5` sprint notation.
- **`packages/core/README.md`** — cut circular "the name combines stitch + API" filler.

Plus pure-prose minors (a 60-word run-on split, "Note that"/"very" filler, agentless subjects named).

## Follow-up flagged

`seam` has **no dedicated docs page** — the links above point at `the-stitch` as a stopgap. Worth its own concept/guide page wired into the content manifest.

## Verification

Pre-commit + pre-push gates all green: `typecheck`, `check:docs-links` (102 routes resolve), `check:readme`, `prettier`, and the full **`build-docs` (twoslash)** build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
