### PR TITLE
docs(seam): give the seam construct its own concept + authoring guide

### DIFF
--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -262,6 +262,13 @@ export const pages: Page[] = [
         kind: 'concept',
     },
     {
+        path: 'concepts/the-seam',
+        title: 'The seam',
+        description:
+            'The shared-runtime primitive a set of stitches belong to — one store, vault, throttle bucket, and trace sink behind a shared base config and a trusted principal boundary.',
+        kind: 'concept',
+    },
+    {
         path: 'concepts/event-stream',
         title: 'The event stream',
         description:
@@ -296,6 +303,13 @@ export const pages: Page[] = [
         title: 'extends',
         description:
             'Layer fragments — strings, objects, or other stitches — with deep-merge to compose configuration.',
+        kind: 'guide',
+    },
+    {
+        path: 'guides/authoring/seam',
+        title: 'seam',
+        description:
+            'Group stitches under one shared runtime — store, vault, throttle bucket, and trace sink — behind a shared base config, and bind per-principal sessions with seam.as().',
         kind: 'guide',
     },
     {

--- a/apps/docs/content/docs/concepts/meta.json
+++ b/apps/docs/content/docs/concepts/meta.json
@@ -3,6 +3,7 @@
     "icon": "Lightbulb",
     "pages": [
         "the-stitch",
+        "the-seam",
         "event-stream",
         "capability-not-credential",
         "principles"

--- a/apps/docs/content/docs/concepts/principles.mdx
+++ b/apps/docs/content/docs/concepts/principles.mdx
@@ -154,8 +154,8 @@ exported as a spec.
 -   **Atomic stitches** are the [stitch](/docs/concepts/the-stitch) itself: one
     endpoint, no spec, no codegen, no server.
 -   **Composition over configuration** is what [`extends`](/docs/guides/authoring/extends)
-    expresses — a plain fragment is what it composes (a `seam` owns one for a whole
-    shared surface).
+    expresses — a plain fragment is what it composes (a [`seam`](/docs/concepts/the-seam)
+    owns one for a whole shared surface).
 -   **One source of truth** shows up at runtime as [leveled drift](/docs/guides/validation/drift),
     the same anti-drift rule this documentation follows.
 -   **Agent-native** is spelled out across [capability, not credential](/docs/concepts/capability-not-credential),

--- a/apps/docs/content/docs/concepts/the-seam.mdx
+++ b/apps/docs/content/docs/concepts/the-seam.mdx
@@ -1,0 +1,75 @@
+---
+title: 'The seam'
+description: 'The shared-runtime primitive a set of stitches belong to — one store, vault, throttle bucket, and trace sink behind a shared base config and a trusted principal boundary.'
+---
+
+A seam is the second primitive StitchAPI is built on: a long-lived surface that stitches _belong to_. Where a stitch is one call, a seam is the shared runtime behind a whole set of them — one store, one auth vault, one throttle bucket, one trace sink — fronted by a shared base config and a trusted principal boundary.
+
+## Why it's shaped this way
+
+A single API is rarely one call. You wrap a handful of endpoints against the same host, with the same auth, the same rate limit, and the same place you want traces to land. The question a seam answers is what those stitches should _share_ — and the answer is more than configuration.
+
+**A fragment shares config; a seam shares runtime.** A plain object folded in through [`extends`](/docs/guides/authoring/extends) is data: every stitch that extends it gets its _own_ copy — its own throttle counter, its own cookie jar, its own cached tokens. That is the right default, but it can't express "these five stitches draw from one rate budget" or "these share a login". A seam can, because it isn't a fragment the stitches copy — it is the live runtime they all _point at_. One throttle bucket pools the budget across every member; one vault lets a session captured by one stitch serve the next call; one trace sink sees the whole surface as a single stream.
+
+```ts twoslash
+import { bearer, env, seam } from 'stitchapi';
+import { z } from 'zod';
+
+const User = z.object({
+    id: z.number(),
+    name: z.string(),
+    email: z.string(),
+    role: z.enum(['admin', 'member', 'viewer']),
+});
+
+// One seam: the shared base every member inherits, and the runtime they share.
+const api = seam({
+    baseUrl: 'https://demo.stitchapi.dev',
+    auth: bearer(env('API_TOKEN')),
+    retry: { attempts: 3, on: [429, 503] },
+});
+
+// Members are stitches that belong to the seam — they extend its config and
+// share its store, throttle bucket, vault, and trace sink.
+const getUser = api.stitch({
+    path: '/users/{id}',
+    unwrap: 'data',
+    output: User,
+});
+const listUsers = api.stitch({
+    path: '/users',
+    unwrap: 'data',
+    output: User.array(),
+});
+```
+
+**The decisive job is the trusted principal boundary.** `seam.as(id)` derives a handle whose members carry that principal — and the principal lives in the _closure_, never in a call's input. A caller invokes a stitch the same way it always does; it cannot name a different principal, because there is no field on the call to name one. Auth is scoped per principal (separate sessions, no bleed between tenants), while the throttle stays shared (one bucket across every principal, so the whole surface still honours one rate limit). That split — isolated identity, pooled budget — is exactly what a multi-tenant server wants, and the seam enforces it by where it holds the principal, not by a check the caller could forget.
+
+**Lifecycle belongs to the root, not the per-request handle.** `flush`, `close`, and `invalidate` act on the runtime _every_ principal shares, so they live on the root seam alone. A handle from `seam.as(...)` is deliberately lifecycle-free: the least-trusted, per-request caller can derive its own identity but can never flush the trace sink, close the shared store, or bust the cache out from under the rest of the surface.
+
+## How it relates
+
+A seam is the surface-scale companion to the per-call [stitch](/docs/concepts/the-stitch): you still author and call stitches the same way, but they now belong to something.
+
+It owns the fragment that [`extends`](/docs/guides/authoring/extends) composes — reach for a plain fragment when stitches share only config, and a seam when they share _runtime_. Building and using one is the job of the [seam guide](/docs/guides/authoring/seam).
+
+Its principal boundary is [capability, not credential](/docs/concepts/capability-not-credential) at surface scale: the secret never leaves the runtime, and now the _identity_ the secret authenticates is bound in the closure too. The shared runtime is also what makes the state features work across a whole surface rather than one call — a [distributed throttle](/docs/guides/state/distributed-throttle) and [shared sessions](/docs/guides/state/shared-sessions) are a seam pointed at a [shared store](/docs/guides/state/pluggable-store).
+
+Because the seam is surface-agnostic, it can [mint members of any surface](/docs/reference/surfaces) — `http`, `graphql`, `sse`, `stream`, `download` — from the one shared runtime. And it is the object the [framework integrations](/docs/integrations) build once per app and bind a principal to per request.
+
+## See also
+
+<Cards>
+    <Card title="The stitch primitive" href="/docs/concepts/the-stitch" />
+    <Card title="Guide: seam" href="/docs/guides/authoring/seam" />
+    <Card title="extends" href="/docs/guides/authoring/extends" />
+    <Card
+        title="Capability, not credential"
+        href="/docs/concepts/capability-not-credential"
+    />
+    <Card
+        title="Distributed throttle"
+        href="/docs/guides/state/distributed-throttle"
+    />
+    <Card title="Shared sessions" href="/docs/guides/state/shared-sessions" />
+</Cards>

--- a/apps/docs/content/docs/concepts/the-stitch.mdx
+++ b/apps/docs/content/docs/concepts/the-stitch.mdx
@@ -48,6 +48,7 @@ And because the declaration is the runtime, one stitch is reachable through more
 ## See also
 
 <Cards>
+    <Card title="The seam" href="/docs/concepts/the-seam" />
     <Card title="The event stream" href="/docs/concepts/event-stream" />
     <Card
         title="Capability, not credential"

--- a/apps/docs/content/docs/guides/authoring/extends.mdx
+++ b/apps/docs/content/docs/guides/authoring/extends.mdx
@@ -43,12 +43,13 @@ last layer that sets one.
 <Callout type="info">
     A fragment is just a plain object you drop into `extends`. For a whole
     shared surface — shared _runtime_ and a trusted principal boundary, not just
-    config — reach for a `seam`.
+    config — reach for a [`seam`](/docs/guides/authoring/seam).
 </Callout>
 
 ## See also
 
 <Cards>
     <Card title="stitch()" href="/docs/guides/authoring/stitch" />
+    <Card title="seam" href="/docs/guides/authoring/seam" />
     <Card title="Reference: config types" href="/docs/reference/config-types" />
 </Cards>

--- a/apps/docs/content/docs/guides/authoring/meta.json
+++ b/apps/docs/content/docs/guides/authoring/meta.json
@@ -1,4 +1,4 @@
 {
     "title": "Authoring & composition",
-    "pages": ["stitch", "extends", "with", "hooks"]
+    "pages": ["stitch", "extends", "seam", "with", "hooks"]
 }

--- a/apps/docs/content/docs/guides/authoring/seam.mdx
+++ b/apps/docs/content/docs/guides/authoring/seam.mdx
@@ -1,0 +1,98 @@
+---
+title: seam
+description: Group stitches under one shared runtime — store, vault, throttle bucket, and trace sink — behind a shared base config, and bind per-principal sessions with seam.as().
+---
+
+Use `seam` when several stitches hit the same API and should share one runtime — one throttle budget, one store, one trace sink, one auth vault — instead of each carrying its own copy of the config. Build it once, then create members with `.stitch()` and `.graphql()`.
+
+## Example
+
+```ts twoslash
+import { bearer, env, seam } from 'stitchapi';
+import { z } from 'zod';
+
+const User = z.object({
+    id: z.number(),
+    name: z.string(),
+    email: z.string(),
+    role: z.enum(['admin', 'member', 'viewer']),
+});
+
+// Build the seam once: its config is the base every member inherits, and its
+// runtime — store, vault, throttle bucket, trace sink — is shared across them.
+const api = seam({
+    baseUrl: 'https://demo.stitchapi.dev',
+    auth: bearer(env('API_TOKEN')),
+    retry: { attempts: 3, on: [429, 503] },
+});
+
+// Members are stitches that belong to the seam.
+const getUser = api.stitch({
+    path: '/users/{id}',
+    unwrap: 'data',
+    output: User,
+});
+const listUsers = api.stitch({
+    path: '/users',
+    unwrap: 'data',
+    output: User.array(),
+});
+
+const user = await getUser({ params: { id: 7 } });
+```
+
+## Options
+
+A seam takes the same fields a stitch does — `baseUrl`, `auth`, `retry`, `throttle`, `timeout`, `store`, `trace`, and the rest — as the base its members extend, plus a `secretStore` for a hardened auth vault. See [Reference → Config types](/docs/reference/config-types) for every field.
+
+**Members extend the base; a member's own throttle stacks on the seam's.** Anything a member declares layers on top of the shared config — and a member's own `throttle` is _tighten-only_: it gates only that stitch on top of the shared bucket, so it can be stricter than the seam's budget but never escape it.
+
+**Per-principal sessions — `seam.as(id)`.** Derive a handle whose members carry a principal. The handle binds that principal in the closure, never in the call's input, so a caller can't name another one. Each principal gets its own sessions; the throttle bucket stays shared.
+
+```ts twoslash
+import { seam } from 'stitchapi';
+
+const api = seam({ baseUrl: 'https://demo.stitchapi.dev' });
+
+// One handle per request — bind the caller's identity, then create members.
+const forTenant = api.as('tenant-42');
+const getUser = forTenant.stitch({ path: '/users/{id}', unwrap: 'data' });
+```
+
+<Callout type="warn">
+    **Anti-pattern:** don't build a fresh `seam` per request — you'd get a new
+    store, throttle bucket, and vault each time, so nothing pools or persists.
+    Build the seam **once at startup** and derive a per-request identity with
+    `seam.as(req.user.id)` instead.
+</Callout>
+
+**Lifecycle — `flush` / `close` / `invalidate`.** These act on the shared runtime, so they live on the root seam only (a `seam.as(...)` handle is lifecycle-free). `close()` flushes the trace sink and closes the shared store on shutdown; `invalidate()` bulk-evicts the cache across members.
+
+```ts twoslash
+import { seam } from 'stitchapi';
+
+const api = seam({ baseUrl: 'https://demo.stitchapi.dev' });
+// ... build members, serve requests ...
+
+await api.close(); // flush the trace sink, close the shared store
+```
+
+## See also
+
+<Cards>
+    <Card title="Concept: the seam" href="/docs/concepts/the-seam" />
+    <Card title="extends" href="/docs/guides/authoring/extends" />
+    <Card
+        title=".with() partial application"
+        href="/docs/guides/authoring/with"
+    />
+    <Card
+        title="Distributed throttle"
+        href="/docs/guides/state/distributed-throttle"
+    />
+    <Card title="Shared sessions" href="/docs/guides/state/shared-sessions" />
+    <Card
+        title="The pluggable store"
+        href="/docs/guides/state/pluggable-store"
+    />
+</Cards>

--- a/apps/docs/content/docs/integrations/next.mdx
+++ b/apps/docs/content/docs/integrations/next.mdx
@@ -4,7 +4,7 @@ description: Web-standard helpers for Next App Router route handlers — sseResp
 ---
 
 Next App Router route handlers are **Web-standard**: they take a `Request` and return
-a `Response`. So a stitch already runs in one directly — define a [`seam`](/docs/concepts/the-stitch)
+a `Response`. So a stitch already runs in one directly — define a [`seam`](/docs/concepts/the-seam)
 once and call it in the handler. `@stitchapi/next` adds the two bits you'd otherwise
 hand-roll on the Web platform: streaming a stitch as Server-Sent Events, and mapping a
 `StitchError` to a `Response`.

--- a/apps/docs/content/docs/integrations/stores.mdx
+++ b/apps/docs/content/docs/integrations/stores.mdx
@@ -8,7 +8,7 @@ the process-local pieces of a stitch — its
 [rate-limit counters](/docs/guides/state/distributed-throttle), its
 [auth sessions and tokens](/docs/guides/state/shared-sessions), and its response
 cache — into **fleet-wide** state, with **no change to the call site**. Core ships
-no backend; you attach one of these drivers to a [`seam`](/docs/concepts/the-stitch)
+no backend; you attach one of these drivers to a [`seam`](/docs/concepts/the-seam)
 and every worker shares the same counters and sessions.
 
 Each driver is a thin peer-dependency (or zero-dependency) package that imports no

--- a/apps/docs/content/docs/reference/surfaces.mdx
+++ b/apps/docs/content/docs/reference/surfaces.mdx
@@ -97,7 +97,7 @@ for await (const ev of logs.stream()) {
 
 Streaming members open on the same auth/retry/throttle spine, with one twist:
 opening a stream **charges the rate limiter once** but **never holds a
-concurrency slot**, so a long-lived connection can't pin a [seam](/docs/concepts/the-stitch)'s
+concurrency slot**, so a long-lived connection can't pin a [seam](/docs/concepts/the-seam)'s
 concurrency budget.
 
 ## Validating streamed values


### PR DESCRIPTION
## What

The `seam` construct had no dedicated docs page, so `[`seam`]` links pointed at `/docs/concepts/the-stitch` (and earlier `/docs/concepts/event-stream`) as a stopgap. This gives it a home and repoints the construct-sense links.

Per the request, the page set is **both** a concept and an authoring guide, split why/how the way `the-stitch` and `guides/authoring/stitch` already are:

- **[`concepts/the-seam`](apps/docs/content/docs/concepts/the-seam.mdx)** (concept) — *what a seam is and why*: shared runtime (one store, vault, throttle bucket, trace sink), the trusted principal boundary via `seam.as()`, and root-only lifecycle. Mirrors `the-stitch`.
- **[`guides/authoring/seam`](apps/docs/content/docs/guides/authoring/seam.mdx)** (guide) — *how to define and use one*: members, per-principal sessions, tighten-only member throttle, lifecycle, `secretStore`, plus an inline build-once **Anti-pattern**.

## Changes

- Added both pages to [`content.manifest.ts`](apps/docs/content.manifest.ts) (the IA source of truth); regenerated the affected `meta.json` files via `gen:docs`.
- Repointed **construct-sense** `seam` links to the new pages: `integrations/stores`, `integrations/next`, `reference/surfaces`, `concepts/principles` → the-seam; the `extends` callout → the guide.
- Left the **generic swap-point sense** ("the transport is a seam" in `guides/testing/mocking`) pointing at `the-stitch` — that's the pluggable-contract meaning, not the `seam()` construct.
- Cross-linked from `the-stitch` and `extends` so the new pages aren't stranded (AUTHORING rule 7).

## Authoring

Written per `AUTHORING.md` and dogfooded against the new `EDITORIAL.md`'s seven dimensions (removed delete-on-sight filler, converted agentless passives to active subject+verb, X-not-Y framing, second person). All examples use the canonical roster on `demo.stitchapi.dev`.

## Verification

- `test/content-manifest.spec.ts` — 7/7 pass.
- `pnpm gen:docs` — idempotent, no diff.
- Pre-commit: format + lint + typecheck green. Pre-push: full `build-docs` (Twoslash) green — every snippet type-checks against the real `stitchapi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)