### PR TITLE
feat(core)!: add .inspect() — expose the raw body + drift findings (ADR 0016)

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -239,6 +239,12 @@ export const PLAYGROUND_INSTANCE_COMPLETIONS: Record<string, Completion[]> = {
             info: "Call and unwrap to the value, throwing a `StitchError` on failure. The named twin of `.safe()` (and an explicit spelling of the throwing bare call).",
         },
         {
+            label: "inspect",
+            type: "method",
+            detail: "(...args: [...Args<TIn>, opts?: InspectOptions]) => Promise<Inspection<TOut>>",
+            info: "Probe a fresh call and return an  — `{ value, raw, findings, status, error }` — **without throwing** (ADR 0016). Use it after the fact to ask \"the schema coerced/stripped this; what did the server actually send?\": `raw` is the pre-validation body, `findings` the soft + hard drift between it and `value`. `.inspect()` **always hits the network and bypasses the cache by default**, so it is a fresh probe — *not* an observer of what your cached `await` call did. Pass `{ cache: true }` to honour the cache policy (then `raw` is `null` on a hit). On a streaming surface `raw` is `null` too (no single buffered body). ⚠️ `raw` is unredacted and non-enumerable — read `wrapper.raw` deliberately; never log the whole wrapper.",
+        },
+        {
             label: "with",
             type: "method",
             detail: "(partial: P) => Stitch<TOut, RelaxKeys<TIn, keyof P>>",

--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -211,6 +211,13 @@ export const pages: Page[] = [
         kind: 'guide',
     },
     {
+        path: 'recipes/inspect-what-the-server-sent',
+        title: 'Inspect what the server actually sent',
+        description:
+            'Probe a fresh call with .inspect() to read the unredacted raw body next to the validated value and the drift findings diffed between them — without throwing — when you need to see what changed after the fact.',
+        kind: 'guide',
+    },
+    {
         path: 'recipes/watch-a-call-as-it-happens',
         title: 'Watch retries and throttling as they happen',
         description:

--- a/apps/docs/content/docs/recipes/inspect-what-the-server-sent.mdx
+++ b/apps/docs/content/docs/recipes/inspect-what-the-server-sent.mdx
@@ -1,0 +1,108 @@
+---
+title: 'Inspect what the server actually sent'
+description: 'Probe a fresh call with .inspect() to read the unredacted raw body next to the validated value and the drift findings diffed between them — without throwing — when you need to see what changed after the fact.'
+---
+
+## Task
+
+The schema coerced a field, filled a default, or stripped a key — and now you
+want to see what the server _actually_ sent. An `await getUser(...)` hands back
+only the validated value; the raw body and the soft drift findings rode the
+[event stream](/docs/concepts/event-stream) and are gone. You want both, on the
+resolved result, without consuming a stream and without throwing when the
+response breaks the contract.
+
+## Example
+
+`.inspect()` runs one fresh call and resolves to an `Inspection` —
+`{ value, raw, findings, status, error }`. It never throws: a hard contract
+violation comes back as `value: null` with `error` set, and `raw` / `findings` /
+`status` still populated.
+
+```ts twoslash
+// [!code fold:start]
+import { drift, stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const getUser = stitch({
+    baseUrl: 'https://demo.stitchapi.dev',
+    path: '/users/{id}',
+    unwrap: 'data',
+    output: drift(
+        z.object({ id: z.number(), name: z.string(), role: z.string() }),
+    ),
+});
+// [!code fold:end]
+const result = await getUser.inspect({ params: { id: 1 } });
+
+result.value; // the validated User (coerced/defaulted/stripped) — or null on a hard fail
+result.findings; // every drift finding: undeclared, coerced, defaulted, invalid
+result.status; // the HTTP status, so `raw` is interpretable (a 422 body reads unlike a 200)
+result.error; // a StitchError on a contract violation, else null — value/error are inverse
+
+// `raw` is the pre-validation body the findings are diffed against. Reach for it
+// deliberately (see the caveat below); here, only when something actually drifted.
+if (result.findings.length > 0) {
+    console.log('server sent:', result.raw);
+}
+```
+
+`value` is the same validated value `await getUser(...)` returns; `raw` is the
+body _before_ validation, the coordinate space each `finding.path` is anchored
+to. The pair is self-explaining: a `coerced` finding at `role` plus
+`result.raw.role` tells you exactly which wire value the schema rewrote.
+
+## How it works
+
+`.inspect()` consumes one run with the raw body retained and surfaces it on a
+**non-enumerable** field. The other four fields are ordinary properties; `raw`
+alone is hidden, so it cannot leak into a log by accident.
+
+<Callout type="warn">
+    **Anti-pattern:** don't log the whole wrapper — `raw` is **unredacted**, so
+    a stray token or PII in an undeclared field would land in your logs. Because
+    `raw` is non-enumerable, `JSON.stringify(result)`, `{...result}`, and trace
+    sinks all skip it; that protection only holds if you don't defeat it. Read
+    `result.raw` deliberately, at the one place you mean to.
+</Callout>
+
+<Callout type="warn">
+    **`.inspect()` always hits the network.** It is a fresh probe — it bypasses
+    the cache by default, reading and writing neither — so it is _not_ an observer
+    of what your cached `await` call did. Pass `{ cache: true }` to honour the
+    cache policy instead; on a cache hit the entry stores only `{ value, status }`,
+    so `raw` is then `null`.
+</Callout>
+
+```ts twoslash
+// [!code fold:start]
+import { stitch } from 'stitchapi';
+
+const getUser = stitch({
+    baseUrl: 'https://demo.stitchapi.dev',
+    path: '/users/{id}',
+    cache: { ttl: '60s' },
+});
+// [!code fold:end]
+// Honour the cache; on a hit, `raw` is null (the cache holds no raw body).
+const cached = await getUser.inspect({ params: { id: 1 } }, { cache: true });
+```
+
+`raw` is `null` on a [streaming surface](/docs/concepts/event-stream) too — the
+engine refuses to buffer an unbounded delta spine — while `findings` and `status`
+still populate; use `.stream()` for incremental inspection there.
+
+## See also
+
+<Cards>
+    <Card title="Drift detection" href="/docs/guides/validation/drift" />
+    <Card
+        title="Catch a breaking API change before your users do"
+        href="/docs/recipes/catch-a-breaking-api-change"
+    />
+    <Card
+        title="Watch retries and throttling as they happen"
+        href="/docs/recipes/watch-a-call-as-it-happens"
+    />
+    <Card title="STITCH_DRIFT" href="/docs/errors/stitch-drift" />
+</Cards>

--- a/apps/docs/content/docs/recipes/meta.json
+++ b/apps/docs/content/docs/recipes/meta.json
@@ -10,6 +10,7 @@
         "idempotent-writes",
         "catch-a-breaking-api-change",
         "catch-a-selector-rename",
+        "inspect-what-the-server-sent",
         "watch-a-call-as-it-happens",
         "mirror-a-paginated-api",
         "one-rate-limit-across-workers",

--- a/docs/adr/0016-inspect-raw-and-findings.md
+++ b/docs/adr/0016-inspect-raw-and-findings.md
@@ -1,0 +1,142 @@
+# ADR 0016 — `.inspect()`: expose the raw body + drift findings
+
+-   **Status:** Accepted (decided 2026-06-28; builds on [ADR 0015](./0015-schema-anchored-drift.md), merged in [#331](https://github.com/rejifald/StitchAPI/pull/331)). Implementation follows in the same PR line.
+-   **Date:** 2026-06-28
+-   **Tags:** drift, diagnostics, inspect, result-object, security, api-surface, accepted
+
+> [!NOTE]
+>
+> Numbering follows ADR 0015 (the drift redesign, PR #331). 0013/0014 (#328) are
+> also in flight; if a collision lands first, renumber at PR time — as 0015 did.
+
+> [!IMPORTANT]
+>
+> **Depends on [ADR 0015 — schema-anchored drift](./0015-schema-anchored-drift.md)**,
+> which must land first. 0015 makes a stitch return the **validated** value
+> (coerced/defaulted/stripped) and computes soft drift as
+> `diff(raw, validated)` (`classifyDiff` in `packages/core/src/diff.ts`). This ADR
+> is the follow-up 0015 itself flags ("expose the raw body + drift findings on a
+> non-enumerable result field"). It **sharpens** that bullet: 0015 lumped in
+> "stitch config, attempt #, and other diagnosis"; we hold the line at
+> `{ value, raw, findings, status, error }` and push config/attempts/timing to a
+> **separate enhanced-result-object** decision.
+
+## Context
+
+Under [0015](./0015-schema-anchored-drift.md):
+
+-   A stitch resolves to the **validated** value, so the **raw body is lost** to
+    an `await` consumer.
+-   Soft findings (`undeclared` / `coerced` / `defaulted`) ride the **event
+    stream only** (`{ type: 'drift', finding }`), so an `await` consumer never
+    sees them.
+
+For after-the-fact analysis — "the schema `coerced` `user.age`; what did the
+server actually send?" — you need both, on the resolved result, without
+consuming a stream. And because soft findings come from `diff(raw, validated)`,
+a finding's `path` resolves against `raw` — so exposing `raw` alongside
+`findings` makes the pair self-explanatory.
+
+**The value can't carry it.** The awaited value is the raw `T`
+([`stitch.ts`](../../packages/core/src/stitch.ts)) and is frequently a
+**primitive or array** — you cannot attach a property (Symbol or string) to a
+`number`. Object spread drops non-enumerable symbol props; array spread copies
+none. Attachment-on-the-value is out.
+
+## Decision
+
+Add a method on the stitch callable, beside `.safe` / `.unwrap` / `.stream`:
+
+```ts
+api.users.inspect(input): Promise<Inspection<T>>
+
+interface Inspection<T> {
+    value: T | null;          // validated value (per 0015); null iff `error` is set
+    raw: unknown;             // the pre-validation body findings are diffed against
+    findings: DriftFinding[]; // soft + hard findings (per 0015), incl. those that ride the stream
+    status: number;
+    error: StitchError | null;
+}
+```
+
+1.  **A method, not value-attachment.** The wrapper is always an object, so a
+    primitive/array `T` sits in `wrapper.value` — the attachment problem
+    evaporates. It joins the `.with()` re-bind list, composing with partial-input
+    binding for free.
+
+2.  **Scope = `{ value, raw, findings, status, error }`.** `status` rides along
+    because it makes `raw` interpretable (a `422` body reads nothing like a
+    `200`) and it is already on the result event. Attempt count, timing, and
+    config echo stay in the enhanced-result-object decision.
+
+3.  **Never throws — the `.safe()` of drift.** 0015's hard tier throws
+    (`invalid`/`error`); the failure path is exactly when raw matters most, so
+    `.inspect()` catches it: `{ value: null, error }` with `raw` and `findings`
+    still populated. `value` and `error` are **inverse** — `value` is `null` iff
+    `error` is set; otherwise `value` is the validated result.
+
+4.  **`raw` = the pre-validation body** — the left side of 0015's
+    `diff(raw, validated)`, the coordinate space `finding.path` is anchored to.
+    (Per 0015, in-schema `.transform()` pollutes the diff; reshaping belongs in
+    the pipeline `transform` stage, which runs _before_ validation. So `raw` is
+    the post-pipeline-transform body, matching what the diff already uses.)
+
+5.  **`raw` is a non-enumerable, unredacted field.** Redacting it would blind the
+    one tool meant to catch a stray token/PII in an undeclared field, so it is
+    **not** redacted. The real risk is _accidental_ leakage, which
+    non-enumerability closes: `JSON.stringify(wrapper)`, spread, and trace-walkers
+    skip it — you reach for `wrapper.raw` deliberately. This mirrors the existing
+    `__rawConfig` (non-enum, full) vs `__config` (redacted) split and the
+    `ERROR_SOURCE` discipline. The other fields stay enumerable.
+
+6.  **Baked into core, opt-in by call.** Not a subsystem like the cache/pipe
+    subpaths — 0015 already computes findings and holds `raw` at diff time, so the
+    marginal code is a `retainRaw` branch + a wrapper consumer. Ships always
+    (tiny); **retains `raw` in memory only when `.inspect()` is called**.
+
+7.  **Bypasses the cache, transparently, by default.** A cache hit (stores only
+    `{ value, status }`, no `raw`) defeats the purpose. `.inspect()` sets
+    `bypassCache` — reusing the engine's existing bypass branch — and does
+    **neither read nor write**, so it is side-effect-free and repeatable (a
+    write-back would warm the cache and mask the drift you are chasing).
+    `.inspect(input, { cache: true })` opts caching back in, with `raw: null` on a
+    hit. Bypass also keeps `.inspect()` out of single-flight coalescing — it runs
+    its own request, whose `raw` it can see.
+
+### Required engine change
+
+The hard-fail (contract-violation) path throws before surfacing the body. Carry
+`raw` on it — preferably pinned to the `StitchError` via the existing
+`ERROR_SOURCE` channel (non-enumerable, never serialized to traces) — so
+`.inspect()` recovers it on the failure case and the §5 posture comes for free.
+
+## Caveats (documented behaviour)
+
+-   **`.inspect()` diverges from `await`.** `await api.users(input)` may be a 0 ms
+    cache hit; `.inspect(input)` always hits the network. It is "probe a fresh
+    call now," not "observe what my cached call did."
+-   **Streaming surfaces:** `raw` is `null` (no single buffered body — the engine
+    refuses to buffer an unbounded delta spine). `findings` and `status` still
+    populate; use `.stream()` `delta`/`drift` events for incremental inspection.
+
+## Consequences
+
+-   One new method per stitch; one new exported type (`Inspection<T>`).
+-   No change to `await` / `.safe()` / `.unwrap()` types — `value` stays pure `T`.
+-   Cache-bypass-by-default makes `.inspect()` a network call; documented loudly.
+
+## Future work / Out of scope
+
+-   **Default redaction of `raw`** — ships unredacted-but-non-enumerable; revisit
+    with a `redact` option if an incident or demand justifies it.
+-   **`source: 'live' | 'cache' | 'stream'` discriminator** — would disambiguate
+    why `raw` is `null`; it is diagnostic metadata → the enhanced-result-object,
+    not here.
+-   **Array drift summarization in `classifyDiff`** — for an array-typed value,
+    summarize homogeneous drift as one finding (`detail: "all N elements: …"`,
+    optional sample index), per-element only on heterogeneity, so findings stay
+    proportional to distinct problems, not data size. This is a refinement to
+    **0015's `diff.ts`**, recommended alongside this work; `actual` retention here
+    keeps the full per-element detail recoverable regardless.
+-   **The enhanced result object** (config, attempts, timing) — a separate ADR;
+    this one holds the line.

--- a/packages/core/scripts/bundle-size.mjs
+++ b/packages/core/scripts/bundle-size.mjs
@@ -45,16 +45,24 @@ const KB = 1024;
 // for custom trace sinks) both sit on the core path; they push the entry to ~22.04 /
 // ~17.78 KB gzip. The +0.25 KB step restores the same tight headroom (~0.2 KB) the
 // gate is meant to keep.
+//
+// Budgets raised for `.inspect()` — ADR 0016 (22.25→22.65 / 18.0→18.30 KB): the
+// never-throwing raw-body + drift-findings probe is baked into the core path by design
+// (ADR 0016 Decision 6 — it reuses 0015's diff/findings, so it ships always, opt-in by
+// call, and cannot move to a subpath). The retainRaw/bypassCache run flags, the
+// `Inspection` wrapper consumer, and the contract-violation raw-pinning add ~0.19 / ~0.12
+// KB gzip (entry ~22.44 / stitch ~18.12). The step restores the same tight ~0.2 KB
+// headroom the gate is meant to hold.
 const SCENARIOS = [
     {
         name: 'stitchapi — whole entry',
         code: `export * from './index.mjs';`,
-        budget: 22.25 * KB,
+        budget: 22.65 * KB,
     },
     {
         name: 'import { stitch }',
         code: `export { stitch } from './index.mjs';`,
-        budget: 18.0 * KB,
+        budget: 18.3 * KB,
     },
 ];
 

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -35,6 +35,7 @@ import type {
     StitchStore,
     TraceSink,
 } from './types';
+import { StitchError } from './types';
 import {
     appendQueryString,
     buildQuery,
@@ -270,6 +271,69 @@ const hostKey = (req: AdapterRequest, cfg: ResolvedStitchConfig): string => {
 // never reaches a trace sink (which serialises via Object.entries / JSON.stringify, both of which
 // skip it), so the full `response` can't leak into a JSONL/console log. See `drain` in stitch.ts.
 export const ERROR_SOURCE = Symbol('stitch.errorSource');
+
+// A non-enumerable channel for the retained pre-validation body (`.inspect()`, ADR 0016). Like
+// ERROR_SOURCE, non-enumerable means a trace sink (Object.entries / JSON.stringify) never sees it, so
+// the unredacted body can't leak into a JSONL/console log. Rides the `result` event on the success
+// path and the pinned StitchError (via ERROR_SOURCE) on the hard-fail path; read by `.inspect()` only.
+export const RAW_BODY = Symbol('stitch.rawBody');
+
+// Per-call run flags (ADR 0016), threaded into `execute` by `.inspect()`. `retainRaw` retains the
+// pre-validation body and surfaces it on the terminal event; `bypassCache` skips the cache entirely
+// (neither read nor write). Both default off, so the await/safe/stream paths are byte-identical.
+export interface RunFlags {
+    retainRaw?: boolean;
+    bypassCache?: boolean;
+}
+
+// Mutable per-run state threaded through the run functions. `attempts` is the live attempt counter
+// the events stamp; `retainRaw` (ADR 0016) is the per-call request to surface the raw body.
+interface RunState {
+    attempts: number;
+    retainRaw?: boolean;
+}
+
+// Attach the retained raw body to a terminal `result` event on the non-enumerable RAW_BODY channel —
+// only when `.inspect()` asked for it (`state.retainRaw`). A no-op otherwise, so the await/safe path
+// yields a byte-identical event. The body never serialises into a trace sink (non-enumerable).
+function withRaw(ev: StitchEvent, state: RunState, raw: unknown): StitchEvent {
+    if (state.retainRaw)
+        Object.defineProperty(ev, RAW_BODY, { value: raw, enumerable: false });
+    return ev;
+}
+
+// The contract-violation (hard drift) error event. When `.inspect()` asked to retain the raw body,
+// pin a StitchError carrying it (on RAW_BODY) via the ERROR_SOURCE channel, so `.inspect()` recovers
+// the body the failure path would otherwise drop (ADR 0016, required engine change). Without
+// `retainRaw` the event is identical to before — no source pinned — so the await/safe path rebuilds
+// its own StitchError exactly as it did pre-0016.
+function contractViolationEvt(
+    name: string,
+    status: number,
+    state: RunState,
+    raw: unknown,
+): StitchEvent {
+    const evt: Extract<StitchEvent, { type: 'error' }> = {
+        type: 'error',
+        name,
+        message: 'contract violation (drift)',
+        status,
+        attempts: state.attempts,
+        at: now(),
+    };
+    if (state.retainRaw) {
+        const err = new StitchError('contract violation (drift)', {
+            status,
+            attempts: state.attempts,
+        });
+        Object.defineProperty(err, RAW_BODY, { value: raw, enumerable: false });
+        Object.defineProperty(evt, ERROR_SOURCE, {
+            value: err,
+            enumerable: false,
+        });
+    }
+    return evt;
+}
 
 function errEvt(err: unknown, name: string, attempts: number): StitchEvent {
     const e = err as { message?: string; status?: number };
@@ -527,7 +591,7 @@ async function drainErrorBody(body: unknown): Promise<unknown> {
 async function* attemptLoop(
     rt: Runtime,
     baseReq: AdapterRequest,
-    state: { attempts: number },
+    state: RunState,
     run: RunContext,
     budget?: TotalBudget,
 ): AsyncGenerator<StitchEvent, AdapterResponse> {
@@ -714,7 +778,7 @@ async function* attemptLoop(
 async function* attemptWithCircuit(
     rt: Runtime,
     baseReq: AdapterRequest,
-    state: { attempts: number },
+    state: RunState,
     run: RunContext,
     budget?: TotalBudget,
 ): AsyncGenerator<StitchEvent, AdapterResponse> {
@@ -785,7 +849,7 @@ function mergeInput(a: StitchInput, b: StitchInput): StitchInput {
 async function* paginated(
     rt: Runtime,
     input: StitchInput,
-    state: { attempts: number },
+    state: RunState,
     t0: number,
     run: RunContext,
     budget?: TotalBudget,
@@ -847,6 +911,9 @@ async function* paginated(
         pageInput = mergeInput(input, nextPartial);
     }
 
+    // The aggregated pages ARE the raw body the contract validates and drift diffs against (ADR
+    // 0015); `.inspect()` (ADR 0016) surfaces this array as `raw`.
+    const rawBody = acc;
     const { value: validated, findings } = await validateOutput(cfg, acc);
     let fatal = false;
     for (const finding of findings) {
@@ -854,25 +921,16 @@ async function* paginated(
         if (finding.level === 'error') fatal = true;
     }
     if (fatal) {
-        yield {
-            type: 'error',
-            name,
-            message: 'contract violation (drift)',
-            status: lastStatus,
-            attempts: state.attempts,
-            at: now(),
-        };
+        yield contractViolationEvt(name, lastStatus, state, rawBody);
         yield doneEvt(false, t0, state.attempts);
         return;
     }
 
-    yield {
-        type: 'result',
-        value: validated,
-        status: lastStatus,
-        attempts: state.attempts,
-        at: now(),
-    };
+    yield withRaw(
+        resultEvt(validated, lastStatus, state.attempts),
+        state,
+        rawBody,
+    );
     yield doneEvt(true, t0, state.attempts);
 }
 
@@ -1002,7 +1060,7 @@ async function* runFrom(
     rt: Runtime,
     baseReq: AdapterRequest,
     name: string,
-    state: { attempts: number },
+    state: RunState,
     t0: number,
     run: RunContext,
     budget?: TotalBudget,
@@ -1028,6 +1086,9 @@ async function* runFrom(
     let value: unknown = outcome.value;
     if (cfg.transform) value = await cfg.transform(value);
     if (cfg.unwrap) value = getPath(value, cfg.unwrap);
+    // The pre-validation body — the left side of 0015's `diff(raw, validated)`, the coordinate space a
+    // finding's `path` is anchored to. `.inspect()` (ADR 0016) surfaces it; otherwise it's discarded.
+    const rawBody = value;
     const { value: validated, findings } = await validateOutput(cfg, value);
     let fatal = false;
     for (const finding of findings) {
@@ -1035,20 +1096,13 @@ async function* runFrom(
         if (finding.level === 'error') fatal = true;
     }
     if (fatal) {
-        yield {
-            type: 'error',
-            name,
-            message: 'contract violation (drift)',
-            status: res.status,
-            attempts: state.attempts,
-            at: now(),
-        };
+        yield contractViolationEvt(name, res.status, state, rawBody);
         yield doneEvt(false, t0, state.attempts);
         return { ok: false };
     }
 
     value = validated; // serve the validated value — sound, matches the declared contract (ADR 0015)
-    yield resultEvt(value, res.status, state.attempts);
+    yield withRaw(resultEvt(value, res.status, state.attempts), state, rawBody);
     yield doneEvt(true, t0, state.attempts);
     const vary = res.headers['vary'];
     return vary !== undefined
@@ -1076,7 +1130,7 @@ async function* runStreaming(
     rt: Runtime,
     input: StitchInput,
     name: string,
-    state: { attempts: number },
+    state: RunState,
     t0: number,
     run: RunContext,
     budget?: TotalBudget,
@@ -1337,7 +1391,7 @@ async function* runOnce(
     rt: Runtime,
     input: StitchInput,
     name: string,
-    state: { attempts: number },
+    state: RunState,
     t0: number,
     run: RunContext,
     budget?: TotalBudget,
@@ -1362,7 +1416,7 @@ async function* runCached(
     ctl: CacheController,
     input: StitchInput,
     name: string,
-    state: { attempts: number },
+    state: RunState,
     t0: number,
     run: RunContext,
     budget?: TotalBudget,
@@ -1491,11 +1545,16 @@ export async function* execute(
     // `parentId` (a `cookieSession` login, a `pipe()` step). Stamped on the `start` event and
     // carried onto the trace-sink ctx by `tee` (stitch.ts).
     run: RunContext = newRunContext(),
+    // Per-call run flags (ADR 0016), set by `.inspect()`: `retainRaw` surfaces the pre-validation
+    // body on the terminal event; `bypassCache` skips the cache entirely (neither read nor write).
+    // Both default off, so every other consumer (await/safe/stream) is byte-identical.
+    flags?: RunFlags,
 ): AsyncGenerator<StitchEvent, void> {
     const { cfg } = rt;
     const name = nameOf(cfg);
     const t0 = now();
-    const state = { attempts: 0 };
+    const state: RunState = { attempts: 0 };
+    if (flags?.retainRaw) state.retainRaw = true;
     const budget = totalBudget(cfg, t0);
 
     try {
@@ -1521,7 +1580,10 @@ export async function* execute(
 
     // Cache lookup is OUTERMOST over the expensive chain but AFTER input validation, so a hit can
     // never tunnel an invalid call past the boundary and the key mirrors the resolved request.
-    const ctl = await ensureCache(rt);
+    // `.inspect()` bypasses it by default (ADR 0016): a hit stores only `{ value, status }` — no
+    // `raw` — so serving one defeats the probe; bypass runs the uncached path, which neither reads
+    // nor writes the cache and stays out of single-flight coalescing (it runs its own request).
+    const ctl = flags?.bypassCache ? null : await ensureCache(rt);
     if (ctl) {
         yield* runCached(rt, ctl, input, name, state, t0, run, budget);
         return;

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -312,12 +312,9 @@ function makeInspection<T>(
     error: StitchError | null,
 ): Inspection<T> {
     const wrapper = { value, findings, status, error } as Inspection<T>;
-    Object.defineProperty(wrapper, 'raw', {
-        value: raw,
-        enumerable: false,
-        writable: true,
-        configurable: true,
-    });
+    // `enumerable: false` is the whole point; the other descriptor flags default false (the wrapper
+    // is transient — nobody reassigns or reconfigures `raw`).
+    Object.defineProperty(wrapper, 'raw', { value: raw, enumerable: false });
     return wrapper;
 }
 

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -3,6 +3,8 @@
 // shared runtime + a trusted principal boundary — reach for `seam` (see seam.ts).
 import {
     ERROR_SOURCE,
+    RAW_BODY,
+    type RunFlags,
     type Runtime,
     cacheInvalidateBulk,
     cacheInvalidateExact,
@@ -20,11 +22,14 @@ import { graphqlSurface } from './surface';
 import { consoleSink, createTrace, exportsFromEnv, multiplex } from './trace';
 import {
     type Clock,
+    type DriftFinding,
     type DriftOptions,
     type DriftSpec,
     type HookContext,
     type Hooks,
     type InputSchemas,
+    type InspectOptions,
+    type Inspection,
     type RedactedStitchConfig,
     type ResolvedStitchConfig,
     type RunContext,
@@ -255,43 +260,104 @@ async function drain<T>(
     let error: Error | undefined;
     for await (const ev of gen) {
         if (ev.type === 'result') value = ev.value;
-        else if (ev.type === 'error') {
-            const source = (ev as { [ERROR_SOURCE]?: Error })[ERROR_SOURCE];
-            const res =
-                source === undefined
-                    ? undefined
-                    : (
-                          source as {
-                              response?: { body?: unknown; url?: string };
-                          }
-                      ).response;
-            // A pinned HTTP error (has `.response`, but is neither a StitchError nor a
-            // RateLimitError): rebuild as a StitchError carrying the response `body`/`url`. A
-            // RateLimitError keeps its class identity (re-surfaced unchanged) so the delegate-backoff
-            // caller still gets `retryAfterMs`/`response`.
-            if (
-                res !== undefined &&
-                !(source instanceof StitchError) &&
-                !(source instanceof RateLimitError)
-            ) {
-                error = new StitchError(ev.message, {
-                    status: ev.status,
-                    attempts: ev.attempts,
-                    body: res.body,
-                    url: res.url,
-                    cause: source,
-                });
-            } else {
-                error =
-                    source ??
-                    new StitchError(ev.message, {
-                        status: ev.status,
-                        attempts: ev.attempts,
-                    });
-            }
-        }
+        else if (ev.type === 'error') error = rebuildError(ev);
     }
     return error ? { error } : { value: value as T };
+}
+
+// Rebuild the terminal error from an `error` event, honouring the non-enumerable ERROR_SOURCE channel
+// (engine.ts). Three kinds ride it: a delegate-backoff RateLimitError is re-surfaced UNCHANGED (the
+// caller keeps its class identity + `retryAfterMs`/`response`); a plain HTTP error (`.response`, but
+// not a StitchError/RateLimitError) is flattened into a StitchError carrying the response `body`/`url`;
+// a contract-violation StitchError (pinned by `.inspect()`'s retain path) passes through. Absent a
+// source, build a StitchError from the event's `status`/`attempts`. Shared by `drain` and
+// `consumeInspect`.
+function rebuildError(ev: Extract<StitchEvent, { type: 'error' }>): Error {
+    const source = (ev as { [ERROR_SOURCE]?: Error })[ERROR_SOURCE];
+    const res =
+        source === undefined
+            ? undefined
+            : (source as { response?: { body?: unknown; url?: string } })
+                  .response;
+    if (
+        res !== undefined &&
+        !(source instanceof StitchError) &&
+        !(source instanceof RateLimitError)
+    ) {
+        return new StitchError(ev.message, {
+            status: ev.status,
+            attempts: ev.attempts,
+            body: res.body,
+            url: res.url,
+            cause: source,
+        });
+    }
+    return (
+        source ??
+        new StitchError(ev.message, {
+            status: ev.status,
+            attempts: ev.attempts,
+        })
+    );
+}
+
+// Build the `Inspection` wrapper (ADR 0016): every field enumerable EXCEPT `raw`, which is defined
+// non-enumerable so `JSON.stringify(wrapper)`, `{ ...wrapper }`, and trace walkers all skip the
+// unredacted body — you reach for `wrapper.raw` deliberately. Mirrors the `__rawConfig` discipline.
+function makeInspection<T>(
+    value: T | null,
+    raw: unknown,
+    findings: DriftFinding[],
+    status: number,
+    error: StitchError | null,
+): Inspection<T> {
+    const wrapper = { value, findings, status, error } as Inspection<T>;
+    Object.defineProperty(wrapper, 'raw', {
+        value: raw,
+        enumerable: false,
+        writable: true,
+        configurable: true,
+    });
+    return wrapper;
+}
+
+// `.inspect()` consumer (ADR 0016): drain ONE run and assemble the `Inspection` — never throws.
+// `findings` collect from every `drift` event; `value`/`status` from the terminal `result`; on a hard
+// failure `value` stays `null` and `error` is the rebuilt StitchError. `raw` rides the non-enumerable
+// RAW_BODY channel — on the `result` event for a success, on the pinned StitchError (recovered via
+// ERROR_SOURCE) for a contract violation; it stays `null` when not retained (streaming / cache hit).
+async function consumeInspect<T>(
+    gen: AsyncGenerator<StitchEvent<T>, void>,
+): Promise<Inspection<T>> {
+    const findings: DriftFinding[] = [];
+    let value: T | null = null;
+    let raw: unknown = null;
+    let status = 0;
+    let error: StitchError | null = null;
+    const readRaw = (carrier: object): void => {
+        const r = (carrier as { [RAW_BODY]?: unknown })[RAW_BODY];
+        if (r !== undefined) raw = r;
+    };
+    try {
+        for await (const ev of gen) {
+            if (ev.type === 'drift') findings.push(ev.finding);
+            else if (ev.type === 'result') {
+                value = ev.value;
+                status = ev.status;
+                readRaw(ev);
+            } else if (ev.type === 'error') {
+                if (ev.status !== undefined) status = ev.status;
+                const rebuilt = rebuildError(ev);
+                error = asStitchError(rebuilt);
+                readRaw(rebuilt);
+            }
+        }
+    } catch (e) {
+        // A stream that throws mid-drain (not an `error` event) still yields a never-throwing
+        // Inspection — surface the throw as `error`, leaving `value` null.
+        error = asStitchError(e);
+    }
+    return makeInspection<T>(value, raw, findings, status, error);
 }
 
 // Throwing consumer: `await stitch(...)` / `stitch.unwrap(...)`. Rejects with the StitchError.
@@ -482,10 +548,22 @@ export function makeStitch<T = unknown>(
     // One traced run for `input` under a given run identity (ADR 0007). `streamFn` mints a fresh
     // ROOT run per consumption; `pipe()` (stitchapi/pipe) supplies a CHILD run via `__runWith`, so a
     // step joins the pipe's chain (its events tee with parentId set).
-    const streamWith = (input: StitchInput, run: RunContext) =>
-        tee<T>(execute(rt, input, run) as never, rt.trace, name, run);
+    const streamWith = (
+        input: StitchInput,
+        run: RunContext,
+        flags?: RunFlags,
+    ) => tee<T>(execute(rt, input, run, flags) as never, rt.trace, name, run);
     const streamFn = (input?: StitchInput) =>
         streamWith(input ?? {}, newRunContext());
+    // `.inspect()` (ADR 0016): one fresh root run with the raw body retained and the cache bypassed by
+    // default (`{ cache: true }` opts caching back in). Consumed by the never-throwing `consumeInspect`.
+    const inspectFn = (input: StitchInput, opts?: InspectOptions) =>
+        consumeInspect<T>(
+            streamWith(input, newRunContext(), {
+                retainRaw: true,
+                bypassCache: !opts?.cache,
+            }),
+        );
 
     const result = (input?: StitchInput): StitchResult<T> => {
         const make = () => streamFn(input);
@@ -532,6 +610,8 @@ export function makeStitch<T = unknown>(
     stitchFn.stream = streamFn;
     stitchFn.safe = (input?: StitchInput) => consumeSafe<T>(streamFn(input));
     stitchFn.unwrap = (input?: StitchInput) => consume<T>(streamFn(input));
+    stitchFn.inspect = (input?: StitchInput, opts?: InspectOptions) =>
+        inspectFn(input ?? {}, opts);
     stitchFn.with = (partial: StitchInput) => {
         // bind partial input; the bound stitch reuses the same runtime (cookies/throttle persist)
         const bound = ((input?: StitchInput) =>
@@ -552,6 +632,8 @@ export function makeStitch<T = unknown>(
             consumeSafe<T>(streamFn(mergeInput(partial, input)));
         bound.unwrap = (input?: StitchInput) =>
             consume<T>(streamFn(mergeInput(partial, input)));
+        bound.inspect = (input?: StitchInput, opts?: InspectOptions) =>
+            inspectFn(mergeInput(partial, input), opts);
         bound.with = (more: StitchInput) =>
             stitchFn.with(mergeInput(partial, more));
         bound.__raw = (input?: StitchInput) =>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -770,6 +770,42 @@ export type SafeResult<T> =
     | { ok: true; data: T; error: null }
     | { ok: false; data: null; error: StitchError };
 
+/** Options for {@link Stitch.inspect} (ADR 0016). */
+export interface InspectOptions {
+    /**
+     * Honour the cache policy instead of bypassing it. Default `false` — `.inspect()` is a fresh
+     * network probe (neither reads nor writes the cache), so `raw` is always live. With `cache: true`
+     * a cache hit is allowed, but the cache stores only `{ value, status }` — so `raw` is `null` on
+     * a hit (it is only populated on a miss, where a live request actually ran).
+     */
+    cache?: boolean;
+}
+
+/**
+ * The result of {@link Stitch.inspect} (ADR 0016) — the validated value alongside the pre-validation
+ * raw body and the drift {@link DriftFinding}s diffed between them, plus the response `status`. It
+ * **never throws**: a hard contract violation comes back as `{ value: null, error }` with `raw`,
+ * `findings`, and `status` still populated. `value` and `error` are **inverse** — `value` is `null`
+ * iff `error` is set.
+ *
+ * ⚠️ `raw` is the UNREDACTED pre-validation body, exposed on a **non-enumerable** field: `JSON.stringify`,
+ * object spread, and trace walkers all skip it, so it can't leak by accident — reach for `wrapper.raw`
+ * deliberately, and never log the whole wrapper. `raw` is `null` on a streaming surface (no single
+ * buffered body) and on a cache hit.
+ */
+export interface Inspection<T> {
+    /** The validated value — coerced/defaulted/stripped per ADR 0015; `null` iff `error` is set. */
+    value: T | null;
+    /** The pre-validation body the findings are diffed against. Non-enumerable; `null` on streaming/cache-hit. */
+    raw: unknown;
+    /** Soft + hard drift findings (including those that ride the event stream), in emission order. */
+    findings: DriftFinding[];
+    /** HTTP status of the probed response — makes `raw` interpretable (a `422` body reads unlike a `200`). */
+    status: number;
+    /** The {@link StitchError} on a hard failure; `null` on success. */
+    error: StitchError | null;
+}
+
 export interface StitchResult<T> extends PromiseLike<T> {
     stream(): AsyncGenerator<StitchEvent<T>, void>;
     /** Consume the call without throwing — resolves to `{ ok, data, error }` (see {@link SafeResult}); shares the one run with `then`/`catch`/`finally`. */
@@ -802,6 +838,21 @@ export interface Stitch<TOut = unknown, TIn = StitchInput> {
      * of `.safe()` (and an explicit spelling of the throwing bare call).
      */
     unwrap(...args: Args<TIn>): Promise<TOut>;
+    /**
+     * Probe a fresh call and return an {@link Inspection} — `{ value, raw, findings, status, error }` —
+     * **without throwing** (ADR 0016). Use it after the fact to ask "the schema coerced/stripped this;
+     * what did the server actually send?": `raw` is the pre-validation body, `findings` the soft + hard
+     * drift between it and `value`.
+     *
+     * `.inspect()` **always hits the network and bypasses the cache by default**, so it is a fresh probe
+     * — *not* an observer of what your cached `await` call did. Pass `{ cache: true }` to honour the
+     * cache policy (then `raw` is `null` on a hit). On a streaming surface `raw` is `null` too (no single
+     * buffered body). ⚠️ `raw` is unredacted and non-enumerable — read `wrapper.raw` deliberately; never
+     * log the whole wrapper.
+     */
+    inspect(
+        ...args: [...Args<TIn>, opts?: InspectOptions]
+    ): Promise<Inspection<TOut>>;
     with<const P extends Partial<TIn>>(
         partial: P,
     ): Stitch<TOut, RelaxKeys<TIn, keyof P>>;

--- a/packages/core/test/inspect.spec.ts
+++ b/packages/core/test/inspect.spec.ts
@@ -1,0 +1,226 @@
+// `.inspect()` (ADR 0016): probe a fresh call and return an `Inspection<T>` —
+// `{ value, raw, findings, status, error }` — WITHOUT throwing. It surfaces the pre-validation `raw`
+// body alongside the validated `value` and the soft/hard drift `findings` diffed between them. These
+// exercise it end-to-end through the engine against a counting adapter:
+//   - primitive / array / object `T`: `value` + `raw` both populate;
+//   - coerced / defaulted / undeclared findings ride the wrapper; `raw` is the untouched body;
+//   - a hard contract violation returns `value: null` + `error` with `raw` + `findings` still set;
+//   - `raw` is NON-ENUMERABLE: `JSON.stringify(wrapper)` and `{ ...wrapper }` both exclude it;
+//   - the default `.inspect()` neither reads nor writes the cache (repeatable); `{ cache: true }`
+//     honours the policy and `raw` is `null` on a hit;
+//   - a streaming surface yields `raw: null` (no buffered body); `value` + `status` still populate.
+import { StitchError, drift, stitch } from '../src';
+import type { Adapter } from '../src';
+import { stream } from '../src/stream';
+import { asValidator } from './support/schema';
+import { streamAdapter, streamOf } from './support/streams';
+
+import { z } from 'zod';
+
+const URL = 'https://api.test/resource';
+
+// A counting adapter returning a fixed body — "the origin ran" is observable as a bumped count, so a
+// cache read/write is visible as a call that did / didn't reach the origin. `body` may be a thunk so a
+// route can vary per call (unused here; every test wants a stable body).
+function counting(
+    body: unknown,
+    opts?: { status?: number; headers?: Record<string, string> },
+): { adapter: Adapter; calls: () => number } {
+    let calls = 0;
+    const adapter: Adapter = async () => {
+        calls += 1;
+        return {
+            status: opts?.status ?? 200,
+            headers: opts?.headers ?? {},
+            body: typeof body === 'function' ? (body as () => unknown)() : body,
+        };
+    };
+    return { adapter, calls: () => calls };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Primitive T — `value` and `raw` are the primitive; a plain schema drifts nothing.
+// ---------------------------------------------------------------------------
+test('primitive T: value + raw are the primitive, no findings', async () => {
+    const { adapter } = counting(42);
+    const s = stitch({
+        url: URL,
+        adapter,
+        trace: false,
+        output: asValidator(z.number()),
+    });
+    const r = await s.inspect();
+    expect(r.value).toBe(42);
+    expect(r.raw).toBe(42);
+    expect(r.status).toBe(200);
+    expect(r.error).toBeNull();
+    expect(r.findings).toEqual([]);
+});
+
+// ---------------------------------------------------------------------------
+// 2. Array T — the attachment problem the ADR names (you can't pin a prop to an array): the wrapper
+//    holds it in `value`, with `raw` the same array.
+// ---------------------------------------------------------------------------
+test('array T: value + raw are the array', async () => {
+    const { adapter } = counting([{ id: 1 }, { id: 2 }]);
+    const s = stitch({
+        url: URL,
+        adapter,
+        trace: false,
+        output: asValidator(z.array(z.object({ id: z.number() }))),
+    });
+    const r = await s.inspect();
+    expect(r.value).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(r.raw).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(r.error).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// 3. Object T — coerced / defaulted / undeclared findings all ride the wrapper, and `raw` is the
+//    UNTOUCHED pre-validation body (string `n`, the stripped `extra`, no `m`).
+// ---------------------------------------------------------------------------
+test('object T: coerced + defaulted + undeclared findings ride the wrapper; raw is untouched', async () => {
+    const { adapter } = counting({ n: '42', extra: 'x' });
+    const s = stitch({
+        url: URL,
+        adapter,
+        trace: false,
+        output: drift(
+            z.object({ n: z.coerce.number(), m: z.number().default(5) }),
+        ),
+    });
+    const r = await s.inspect();
+    expect(r.value).toEqual({ n: 42, m: 5 }); // coerced + defaulted
+    expect(r.raw).toEqual({ n: '42', extra: 'x' }); // the body, untouched by validation
+    const changes = r.findings.map((f) => f.change);
+    expect(changes).toContain('coerced'); // n: string -> number
+    expect(changes).toContain('defaulted'); // m: default fired
+    expect(changes).toContain('undeclared'); // extra: stripped
+    expect(r.error).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// 4. Hard failure (contract violation) — never throws: `value: null` + a StitchError, with `raw` and
+//    the `invalid`/error finding still recovered (the failure path normally drops the body).
+// ---------------------------------------------------------------------------
+test('hard-fail: value null + error + raw + findings', async () => {
+    const { adapter } = counting({ id: '1' }); // schema wants a number
+    const s = stitch({
+        url: URL,
+        adapter,
+        trace: false,
+        output: asValidator(z.object({ id: z.number() })),
+    });
+    const r = await s.inspect();
+    expect(r.value).toBeNull();
+    expect(r.error).toBeInstanceOf(StitchError);
+    expect(r.raw).toEqual({ id: '1' });
+    expect(
+        r.findings.some((f) => f.change === 'invalid' && f.level === 'error'),
+    ).toBe(true);
+    expect(r.status).toBe(200);
+});
+
+// ---------------------------------------------------------------------------
+// 5. `raw` is non-enumerable — JSON.stringify and spread both drop it, the other fields survive.
+// ---------------------------------------------------------------------------
+test('raw is non-enumerable: JSON.stringify(wrapper) and { ...wrapper } both exclude raw', async () => {
+    const { adapter } = counting({ n: '42' });
+    const s = stitch({
+        url: URL,
+        adapter,
+        trace: false,
+        output: drift(z.object({ n: z.coerce.number() })),
+    });
+    const r = await s.inspect();
+    expect(r.raw).toEqual({ n: '42' }); // readable deliberately
+
+    const json = JSON.parse(JSON.stringify(r)) as Record<string, unknown>;
+    expect('raw' in json).toBe(false);
+    expect(json['value']).toEqual({ n: 42 }); // the other fields DO serialise
+
+    const spread = { ...r } as Record<string, unknown>;
+    expect('raw' in spread).toBe(false);
+    expect(spread['status']).toBe(200);
+});
+
+// ---------------------------------------------------------------------------
+// 6. Default `.inspect()` bypasses the cache — neither READ nor WRITE — and is repeatable.
+// ---------------------------------------------------------------------------
+test('default .inspect() neither reads nor writes the cache (repeatable)', async () => {
+    const { adapter, calls } = counting({ n: 1 });
+    const s = stitch({
+        url: URL,
+        adapter,
+        trace: false,
+        cache: { ttl: '60s', scope: 'app' },
+    });
+    // Two inspects → two live origin calls: it never serves a prior entry (no read) ...
+    await s.inspect();
+    await s.inspect();
+    expect(calls()).toBe(2);
+    // ... and never warmed one (no write): the next AWAIT is a miss (a third call) ...
+    expect(await s()).toEqual({ n: 1 });
+    expect(calls()).toBe(3);
+    // ... which DID warm the cache — proving the store was reachable all along, and that only
+    // `.inspect()` was holding off it: a second await is a hit, no fourth call.
+    expect(await s()).toEqual({ n: 1 });
+    expect(calls()).toBe(3);
+});
+
+// ---------------------------------------------------------------------------
+// 7. `{ cache: true }` honours the policy; on a hit `raw` is null (the cache stores no raw body).
+// ---------------------------------------------------------------------------
+test('{ cache: true }: a cache hit yields value but raw null', async () => {
+    const { adapter, calls } = counting({ n: 1 });
+    const s = stitch({
+        url: URL,
+        adapter,
+        trace: false,
+        cache: { ttl: '60s', scope: 'app' },
+    });
+    expect(await s()).toEqual({ n: 1 }); // warm the cache
+    expect(calls()).toBe(1);
+
+    const r = await s.inspect(undefined, { cache: true }); // served from cache
+    expect(calls()).toBe(1); // no new origin call — it read the entry
+    expect(r.value).toEqual({ n: 1 });
+    expect(r.raw).toBeNull(); // the cache holds { value, status }, never raw
+    expect(r.status).toBe(200);
+    expect(r.error).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// 8. Streaming surface — `raw` is null (the engine refuses to buffer the delta spine); `value`
+//    (the collected chunks) and `status` still populate.
+// ---------------------------------------------------------------------------
+test('streaming surface: raw is null; value (chunks) + status populate', async () => {
+    const s = stream({
+        url: 'https://x.test/s',
+        trace: false,
+        stream: { decode: 'lines' },
+        adapter: streamAdapter(streamOf(['a\n', 'b\n', 'c'])),
+    });
+    const r = await s.inspect();
+    expect(r.raw).toBeNull();
+    expect(r.value).toEqual(['a', 'b', 'c']);
+    expect(r.status).toBe(200);
+    expect(r.error).toBeNull();
+});
+
+// ---------------------------------------------------------------------------
+// 9. `.inspect()` joins the `.with()` re-bind list — a bound stitch inspects with the bound input.
+// ---------------------------------------------------------------------------
+test('.with(...).inspect() composes with partial-input binding', async () => {
+    const { adapter } = counting({ ok: true });
+    const s = stitch({
+        url: URL,
+        adapter,
+        trace: false,
+        output: asValidator(z.object({ ok: z.boolean() })),
+    }).with({ query: { page: 1 } });
+    const r = await s.inspect();
+    expect(r.value).toEqual({ ok: true });
+    expect(r.raw).toEqual({ ok: true });
+    expect(r.error).toBeNull();
+});


### PR DESCRIPTION
## What

Implements **ADR 0016 — `.inspect()`: expose the raw body + drift findings** (`docs/adr/0016-inspect-raw-and-findings.md`). Builds on ADR 0015 (schema-anchored drift, #331).

Adds `Stitch.inspect(input?, opts?: { cache?: boolean })` — beside `.safe`/`.unwrap`/`.stream` and in the `.with()` re-bind list. It runs **one fresh call** and resolves to an `Inspection<T>` **without throwing**:

```ts
interface Inspection<T> {
    value: T | null;          // validated value (per 0015); null iff `error` is set
    raw: unknown;             // pre-validation body the findings are diffed against
    findings: DriftFinding[]; // soft + hard findings, incl. those that ride the stream
    status: number;
    error: StitchError | null;
}
```

Use it after the fact to ask "the schema coerced/stripped this — what did the server actually send?": `value` is the validated result, `raw` the body it was diffed against, `findings` the drift between them.

## How

- **`raw` is non-enumerable** on the wrapper (`makeInspection`): `JSON.stringify(wrapper)`, `{ ...wrapper }`, and trace sinks all skip the unredacted body — you reach for `wrapper.raw` deliberately.
- **Never throws** (`consumeInspect` drains one run): on a hard contract violation, `value: null` + `error`, with `raw`/`findings`/`status` still populated.
- **Engine**: per-call `RunFlags { retainRaw, bypassCache }` threaded into `execute`; `retainRaw` rides `RunState`. `raw` surfaces on the `result` event via the non-enumerable `RAW_BODY` symbol (success) and on a pinned `StitchError` via the existing `ERROR_SOURCE` channel (contract-violation — the body the failure path used to drop). `bypassCache` routes to the uncached `runOnce` (neither reads nor writes; out of single-flight coalescing).
- **Cache**: bypassed by default (`raw` always live); `{ cache: true }` honours the policy and `raw` is `null` on a hit. **Streaming**: `raw` is `null` (no buffered delta spine); `findings`/`status` still populate.
- `drain` refactored to share `rebuildError` with `consumeInspect`. The `await`/`.safe()`/`.stream()` paths are byte-identical when the flags are off.

## Tests

`packages/core/test/inspect.spec.ts` (9): primitive/array/object `T`; coerced + defaulted + undeclared findings on the wrapper; hard-fail → `value:null` + `error` + `raw` + `findings`; `JSON.stringify` and spread both exclude `raw`; default `.inspect()` neither reads nor writes cache (repeatable); `{ cache: true }` hit → `raw` null; streaming → `raw` null; `.with().inspect()`.

## Docs

- Recipe `recipes/inspect-what-the-server-sent.mdx` — when to use it, the `Inspection<T>` shape, and the loud caveats (unredacted raw → don't log the whole wrapper; always-network/cache-bypass probe; null on streaming + cached hits). Wired into the manifest + sidebar.
- ADR 0016 added, flipped to **Accepted**.

## Verification

- Core: `tsc` (src + test) clean, ESLint clean, **full suite 1081 passed**.
- **Monorepo-wide typecheck** clean (integration packages' drift fixtures unaffected); pre-commit + pre-push gates green.
- **Docs build passes** (twoslash/Shiki compiled the new snippets); manifest sync test green.

## Out of scope (deferred per the ADR)

`source: 'live' | 'cache' | 'stream'` discriminator, default redaction of `raw`, `wireBody`, and the config/attempt/timing "enhanced result object".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
