### PR TITLE
docs: add Contributing links to private package READMEs

### DIFF
--- a/packages/completions-plugin/README.md
+++ b/packages/completions-plugin/README.md
@@ -1,0 +1,47 @@
+# @stitchapi/completions-plugin
+
+Private, ships-nothing build tool for the docs **playground**. A webpack plugin
+that generates the CodeMirror completions map from StitchAPI's own TypeScript
+source at build time, so the playground's autocomplete never drifts from the
+real API.
+
+**Discovery rule.** For every exported `*Config` interface in a package's
+`src/**/*.ts`, if the derived function name (`StitchConfig → stitch`) is also
+exported from `src/index.ts`, it becomes a completion entry automatically. A new
+primitive shows up in the playground the moment it ships — no hand-maintained
+list.
+
+## Usage
+
+Wire `PlaygroundCompletionsPlugin` into the docs app's webpack config
+(`apps/docs/next.config.mjs`), pointing it at the packages to scan and the
+generated output file:
+
+```js
+import { PlaygroundCompletionsPlugin } from '@stitchapi/completions-plugin';
+
+new PlaygroundCompletionsPlugin({
+    packages: [resolve(repoRoot, 'packages/core')],
+    outputFile: '/abs/path/to/playground-completions.generated.ts',
+});
+```
+
+The plugin regenerates the map on webpack's `beforeCompile` hook. If generation
+throws it logs and continues, leaving the last good file in place rather than
+failing the build.
+
+The same generator is exposed directly as `generatePlaygroundCompletions(opts)`
+for the standalone `gen:completions` script the CI drift guard runs.
+
+## Develop
+
+```sh
+pnpm --filter @stitchapi/completions-plugin test          # node:test codegen suite
+```
+
+CI regenerates the committed completions artifact and fails if it drifted (see
+the `verify` job in [`.github/workflows/verify.yml`](../../.github/workflows/verify.yml)).
+
+## Contributing
+
+Issues and pull requests are welcome — see the [contributing guide](../../CONTRIBUTING.md) for local setup, the verify gate, and how to open a PR against `main`.

--- a/packages/eval-harness/README.md
+++ b/packages/eval-harness/README.md
@@ -111,3 +111,7 @@ pnpm --filter @stitchapi/eval-harness eval:report --driver claude --model <model
 A real run literally writes the WARM seed docs into a per-cell scratch dir, runs
 the CLI there, collects the produced `*.ts`, and scores it through the same
 offline pipeline as the stub.
+
+## Contributing
+
+Issues and pull requests are welcome — see the [contributing guide](../../CONTRIBUTING.md) for local setup, the verify gate, and how to open a PR against `main`.

--- a/packages/sandbox-sim/README.md
+++ b/packages/sandbox-sim/README.md
@@ -1,3 +1,7 @@
 # @stitchapi/sandbox-sim
 
 Isomorphic fake-API simulator for the StitchAPI playground. Provides a handler registry and adapters that allow snippets to run identically in both browser (Web Worker) and server (isolated-vm) tiers without hitting a real network.
+
+## Contributing
+
+Issues and pull requests are welcome — see the [contributing guide](../../CONTRIBUTING.md) for local setup, the verify gate, and how to open a PR against `main`.


### PR DESCRIPTION
## What

Companion to #333 (which linked `CONTRIBUTING.md` from the **published** integration READMEs). This brings the three **private/internal** packages to the same consistency bar:

- `@stitchapi/eval-harness` — add a `## Contributing` section
- `@stitchapi/sandbox-sim` — add a `## Contributing` section
- `@stitchapi/completions-plugin` — had **no README at all**; add one (grounded in its `index.mjs`/`codegen.mjs`: the webpack plugin that generates the playground's CodeMirror completions from TypeScript source at build time) ending with the same Contributing link

## Why

#333 deliberately scoped itself to published packages and left these untouched. Per follow-up request, every package README should now reference the root [`CONTRIBUTING.md`](../../CONTRIBUTING.md). These packages are `private: true` and aren't submitted to ecosystem/"awesome" lists — this is purely in-repo consistency.

## Verification

- `pnpm check:format` — ✅ all files match Prettier style
- `pnpm check:docs-links` — ✅ 104 routes, all `/docs/...` links resolve
- All `../../CONTRIBUTING.md` and the new `../../.github/workflows/verify.yml` relative links verified to resolve
- pre-commit hooks (format, typecheck across 35 projects) — ✅ green

🤖 Generated with [Claude Code](https://claude.com/claude-code)