### PR TITLE
refactor(docs): harden JSON-LD injection with a shared jsonLdHtml helper

### DIFF
--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -1,4 +1,5 @@
 import { getMDXComponents } from '@/components/mdx';
+import { jsonLdHtml } from '@/lib/json-ld';
 import { appName, gitConfig } from '@/lib/shared';
 import { getPageImage, getPageMarkdownUrl, source } from '@/lib/source';
 import { docsStructuredData } from '@/lib/structured-data';
@@ -30,7 +31,7 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
             <script
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{
-                    __html: JSON.stringify(docsStructuredData(page)),
+                    __html: jsonLdHtml(docsStructuredData(page)),
                 }}
             />
             <DocsPage toc={page.data.toc} full={page.data.full}>

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,5 +1,6 @@
 import './global.css';
 
+import { jsonLdHtml } from '@/lib/json-ld';
 import { appName, gitConfig, siteUrl } from '@/lib/shared';
 
 import 'fumadocs-twoslash/twoslash.css';
@@ -137,7 +138,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
             <body className="flex flex-col min-h-screen">
                 <script
                     type="application/ld+json"
-                    dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+                    dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
                 />
                 <RootProvider>
                     <Banner

--- a/apps/docs/lib/json-ld.ts
+++ b/apps/docs/lib/json-ld.ts
@@ -1,0 +1,21 @@
+/**
+ * Serialize a JSON-LD value for embedding in a
+ * `<script type="application/ld+json" dangerouslySetInnerHTML>`.
+ *
+ * Why `dangerouslySetInnerHTML` at all: React HTML-escapes string children
+ * (`<` → `&lt;`, `&` → `&amp;`, …). Inside a JSON-LD script the body must stay
+ * verbatim JSON for a crawler to parse it, so the escaped form is corrupt. Writing
+ * the raw body is the Next.js-recommended pattern for JSON-LD — there is no
+ * escaping-free alternative (the Metadata API does not cover arbitrary scripts).
+ *
+ * Why the `<` escape: `JSON.stringify` does NOT escape `<`, so a literal
+ * `</script>` appearing in any field (e.g. a doc title) would close the tag early
+ * and allow markup injection — the one real vector here. Replacing every `<` with
+ * the sequence backslash-u-003c (a JSON-valid escape for `<`) keeps the structured
+ * data byte-for-byte valid while making tag breakout impossible. Content is
+ * build-time and first-party, so
+ * this is defense-in-depth rather than a patched hole — but it costs nothing.
+ */
+export function jsonLdHtml(data: unknown): string {
+    return JSON.stringify(data).replace(/</g, '\\u003c');
+}


### PR DESCRIPTION
## What

Both the site-level (`app/layout.tsx`) and per-page (`app/docs/[[...slug]]/page.tsx`) JSON-LD embedded raw `JSON.stringify` output via `dangerouslySetInnerHTML`. This centralizes that into a single [`lib/json-ld.ts`](apps/docs/lib/json-ld.ts) `jsonLdHtml()` helper that also **escapes `<`**.

## Why

`JSON.stringify` does **not** escape `<`, so a literal `</script>` in any serialized field (e.g. a doc title) could close the `<script>` tag early and inject markup. Content here is build-time and first-party, so this is **defense-in-depth** rather than a patched hole — but the fix is free and it's the canonical [Next.js JSON-LD](https://nextjs.org/docs/app/guides/json-ld) hardening.

`jsonLdHtml()` replaces every `<` with its JSON-valid `<` escape: the body stays byte-for-byte valid JSON (round-trips through `JSON.parse`), but tag breakout becomes impossible.

### Why `dangerouslySetInnerHTML` at all (documented in the helper)

React HTML-escapes string children, which corrupts the verbatim JSON a crawler must parse. Writing the raw body is the Next.js-recommended pattern for JSON-LD — the Metadata API doesn't cover arbitrary scripts, and `next/script`/libraries use the same API underneath. The helper's doc comment captures this rationale in one place.

## Verification

- Unit-level proof: a `</script><script>` payload in a field serializes to `</script><script>` (no literal `</script>` survives) and still `JSON.parse`s back to the original value.
- `check:types`, `check:lint`, `prettier --check` all pass (pre-commit hook green).

Follow-up to #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)