### PR TITLE
docs(adr): design 0016's four deferrals — array summarization, raw redaction, enhanced result object (0017-0019, Proposed)

### DIFF
--- a/docs/adr/0017-array-drift-summarization.md
+++ b/docs/adr/0017-array-drift-summarization.md
@@ -1,0 +1,179 @@
+# ADR 0017 — Array drift summarization in `classifyDiff`
+
+-   **Status:** Proposed (designed 2026-06-28; refines [ADR 0015](./0015-schema-anchored-drift.md), merged in [#331](https://github.com/rejifald/StitchAPI/pull/331)). One of the four items [ADR 0016](./0016-inspect-raw-and-findings.md) deferred.
+-   **Date:** 2026-06-28
+-   **Tags:** drift, diff, findings, proportionality, correctness
+
+> [!NOTE]
+>
+> Numbering continues past 0016 (`.inspect()`, PR #334, in flight) and the
+> 0013/0014 pair (#328, in flight). If a lower number lands first, renumber at PR
+> time — as 0015/0016 did.
+
+> [!IMPORTANT]
+>
+> **Refines [ADR 0015](./0015-schema-anchored-drift.md)'s soft-drift layer**
+> (`classifyDiff` in [`packages/core/src/drift.ts`](../../packages/core/src/drift.ts),
+> over the structural `diff` in [`diff.ts`](../../packages/core/src/diff.ts)). It
+> depends only on 0015, which is **merged**. It is independent of `.inspect()`
+> (ADR 0016): the change is in the classify layer that feeds _both_ the `drift`
+> event stream and (once 0016 lands) `Inspection.findings`.
+
+## Context
+
+0015 computes soft drift as `diff(raw, validated)` and renders each diff op into
+a leveled `DriftFinding`. The diff is index-precise (array element `i` → numeric
+path segment `i`), but `renderPath` collapses every numeric segment to the `[]`
+grammar, and `classifyDiff` then dedupes by `change|path`:
+
+```ts
+const key = `${change}|${path}`;
+if (seen.has(key)) continue; // first finding wins; the rest are dropped
+```
+
+So a field stripped from 100 array elements becomes **one** `items[].x`
+`undeclared` finding rather than 100. That dedup is load-bearing — it keeps
+findings proportional to distinct problems, not data size — and 0015 already
+ships it. **This ADR is not "add array dedup"; it sharpens the dedup that
+exists.** Three gaps in the current first-wins collapse:
+
+1.  **No count.** The single finding does not say _how many_ elements drifted.
+    "`items[].x` undeclared" hides whether that is 1 element or 10 000.
+2.  **No drill-down coordinate.** Findings render `[]`, so a consumer cannot jump
+    to a concrete element to see the offending value.
+3.  **Silent heterogeneity loss — a correctness gap.** First-wins keys on
+    `change|path` _only_, so two genuinely different problems at the same
+    collapsed path are merged and one is dropped. If element 0 coerced
+    `string → number` and element 1 coerced `boolean → number`, both share
+    `coerced|items[].x`; the engine reports `string -> number` and **silently
+    discards** the `boolean -> number` problem. A heterogeneous array (the exact
+    variance 0015 tolerates at validation time) can hide a real distinct drift.
+
+Gap 3 is the reason to act now; gaps 1–2 are the ergonomic payoff that comes with
+the fix.
+
+## Decision
+
+Replace `classifyDiff`'s per-diff first-wins dedup with **group-then-summarize**.
+Group the diffs by `change|path` (the existing collapse key); within each group
+that came from an array (its rendered path contains `[]`), branch on homogeneity.
+
+### Homogeneity test
+
+Two diffs in a group are **the same problem** iff they would render the
+**identical `detail` string** (the output of `detailFor`). This is the right
+test because `detail` already encodes exactly the distinguishing facts and
+_nothing else_:
+
+| change       | `detail` shape                 | what makes elements differ   |
+| ------------ | ------------------------------ | ---------------------------- |
+| `coerced`    | `<kindOf old> -> <kindOf new>` | the wire-type transition     |
+| `undeclared` | `undeclared field (<kindOf>)`  | the stray value's kind       |
+| `defaulted`  | `default applied` (constant)   | nothing — always homogeneous |
+
+Defining homogeneity as `detail` equality keeps the test self-consistent with
+what a finding reports: elements collapse iff they'd say the same thing. (Note
+`detailFor` emits **kinds only, never values** — so neither the summary nor the
+per-variant findings ever leak a payload value, a property ADR 0018 leans on.)
+
+### Emitted shape
+
+-   **Homogeneous group** (one distinct `detail`): **one** finding.
+    -   `path` stays the `[]` grammar (`items[].x`) — dedup-stable and
+        `ignore`-compatible.
+    -   `detail` becomes **`all N elements: <detail>`** where `N` is the count of
+        affected elements.
+    -   add `sample` = a **concrete-index path** for the first occurrence
+        (`items[0].x`) so a consumer can drill into the real value.
+-   **Heterogeneous group** (>1 distinct `detail`): **one finding per distinct
+    `detail` variant**, each with its own `count` and `sample` concrete index.
+    Output stays proportional to _distinct problems_, degrading to one-per-element
+    only when every element genuinely differs (the honest worst case). This is
+    strictly stronger than ADR 0016's note ("per-element only on heterogeneity"):
+    per-variant subsumes per-element and never floods on a near-homogeneous array
+    with a single outlier.
+
+`ignore` (path-based) and `severity` (change-based) apply **after** grouping, to
+the summarized/variant findings — unchanged semantics, since all elements share
+the `[]` path and `change`.
+
+### Finding type
+
+`DriftFinding` gains **one** optional field, `sample?: string`:
+
+```ts
+interface DriftFinding {
+    level: DriftSeverity | 'error';
+    path: string; // unchanged: the [] grammar
+    change: SoftDriftChange | 'invalid';
+    detail: string; // now may read "all N elements: …"
+    sample?: string; // NEW: concrete-index path, e.g. "items[3].x" (array summaries only)
+}
+```
+
+The count `N` rides in the human-readable `detail` rather than as a structured
+field — it is legible there and avoids a second optional. `sample` _is_
+structured, because its sole job is to be a machine coordinate into `raw` (see
+below), where a parsed-from-prose index would be fragile.
+
+### Interaction with `.inspect()`'s full-raw retention (ADR 0016)
+
+Summarization deliberately drops per-element specifics _from the finding_, but
+loses nothing, because **`raw` is the source of truth**. `.inspect()` retains the
+entire untouched body (ADR 0016 §5), so every element's actual value is
+recoverable by indexing `inspection.raw` — `sample` (`items[3].x`) is a ready
+coordinate, and the `[]` path names the array to iterate. A summarized finding is
+an **index into `raw`, not a replacement for it.**
+
+The one honest limit: a **stream-only** consumer (no `.inspect()`, so `raw` is
+not retained — the engine refuses to buffer the spine) gets the summary, `count`,
+and `sample` but cannot recover per-element values. That matches 0016's existing
+streaming caveat and is documented, not hidden.
+
+## Alternatives considered
+
+-   **Keep first-wins dedup (status quo).** Rejected: silently drops
+    heterogeneous problems (gap 3) and reports no count/coordinate.
+-   **Always one finding per element (no collapse).** Rejected: findings scale
+    with data size, not distinct problems — floods on large arrays, the precise
+    failure 0015's `[]` dedup was built to prevent.
+-   **One finding per `change|path` always, just append a `count`.** Rejected:
+    fixes gaps 1–2 but not gap 3 — heterogeneous problems still merge and vanish.
+-   **Cap at the first K elements sampled.** Rejected: a silent cap; a divergent
+    element past K is missed — the no-silent-truncation principle. (If a future
+    bound is ever needed, it must be logged, not silent.)
+-   **Put `count`/`sample` in `diff.ts` (the structural diff).** Rejected: the
+    diff must stay index-precise so heterogeneity is _detectable_. Summarization
+    is a classify-layer concern; `diff.ts` is untouched.
+
+## Consequences
+
+-   `classifyDiff` gains a group/summarize pass; `diff.ts` unchanged.
+-   `DriftFinding` gains one optional `sample` — additive; existing consumers and
+    the `drift` event are unaffected.
+-   The existing "stripped field on 100 elements = 1 finding" test stays green,
+    now asserting `detail: "all 100 elements: …"` and `count`-in-detail.
+-   Heterogeneous arrays surface every distinct problem instead of the first —
+    a behavior change that can _increase_ finding count on genuinely mixed data
+    (the point).
+
+## Engine / type touch-points
+
+-   [`packages/core/src/drift.ts`](../../packages/core/src/drift.ts) —
+    `classifyDiff`: swap the per-diff `seen` loop for group-by-`change|path`, then
+    a `summarizeGroup` helper that branches on `detail` homogeneity; reuse
+    `detailFor` per variant. Apply `ignore`/`severity` after grouping.
+-   [`packages/core/src/types.ts`](../../packages/core/src/types.ts) —
+    `DriftFinding`: add `sample?: string`. Flows to `Inspection.findings` and the
+    `drift` event for free (same type).
+-   [`packages/core/src/diff.ts`](../../packages/core/src/diff.ts) — **no change**
+    (stays index-precise; precision is what makes heterogeneity detectable).
+-   Tests: homogeneous vs heterogeneous array cases; scalar-array coercion; the
+    single-outlier-in-a-large-array case (one variant finding + one summary, not a
+    flood).
+
+## Relationship to the other 0016 deferrals
+
+Stands **alone**. Different subsystem from the other three: this is the diff/
+classify layer (refining 0015), while ADR 0018 (`raw` redaction) and ADR 0019
+(enhanced result object) refine the `.inspect()` result surface (ADR 0016).

--- a/docs/adr/0018-inspect-raw-redaction.md
+++ b/docs/adr/0018-inspect-raw-redaction.md
@@ -1,0 +1,157 @@
+# ADR 0018 — `.inspect()`: an opt-in `redact` option for `raw`
+
+-   **Status:** Proposed (designed 2026-06-28; refines [ADR 0016](./0016-inspect-raw-and-findings.md), in flight as [#334](https://github.com/rejifald/StitchAPI/pull/334)). One of the four items ADR 0016 deferred.
+-   **Date:** 2026-06-28
+-   **Tags:** inspect, security, redaction, privacy, opt-in
+
+> [!NOTE]
+>
+> Numbering continues past 0016 (PR #334) and 0013/0014 (#328), both in flight.
+> Renumber at PR time if a lower number lands first — as 0015/0016 did.
+
+> [!IMPORTANT]
+>
+> **Depends on [ADR 0016](./0016-inspect-raw-and-findings.md)** (`.inspect()` and
+> the `Inspection<T>.raw` field), which must land first (PR #334). 0016 ships
+> `raw` **unredacted-but-non-enumerable** and flags the redaction option as future
+> work: "revisit with a `redact` option if an incident or demand justifies it."
+> This is that option.
+
+## Context
+
+0016 §5 makes `raw` the **unredacted** pre-validation body on a **non-enumerable**
+field. Non-enumerability closes _accidental_ leakage (`JSON.stringify`, spread,
+trace-walkers all skip it); the unredactedness is deliberate, because `raw` is
+**the one tool meant to catch a stray token or PII in an _undeclared_ field** —
+redact it and you blind exactly the thing it exists to surface.
+
+The demand is the deliberate-sharing case: a consumer who _wants_ to pipe
+`wrapper.raw` into a log line, a bug report, or a support ticket and needs the
+known-secret fields scrubbed first. The tension is real and names the whole
+design constraint: **redaction must serve safe sharing without ever becoming a
+false safety net that re-blinds the catch-a-stray-token tool.**
+
+## Decision
+
+Add an **opt-in, per-call** `redact` option to `.inspect()`. Default **off**.
+
+```ts
+interface InspectOptions {
+    cache?: boolean; // (ADR 0016)
+    redact?: boolean | string[]; // NEW — default false
+}
+```
+
+### 1. Where the config lives — per-call, on `InspectOptions`
+
+`.inspect()` is _already_ a deliberate, per-call probe ("reach for `wrapper.raw`
+deliberately"). Redaction is a property of **this inspection's output handling**
+— the consumer who forwards `raw` to a log is at the call site — not of the
+stitch's identity. So `redact` rides `InspectOptions`, beside `cache`.
+
+A stitch-level default is permitted as a secondary convenience (`drift`-config or
+a `defaultInspect` block), but the per-call option always overrides, and the
+default **everywhere** is off. We deliberately do **not** offer a process-wide
+"redact all `.inspect()`" toggle: that is precisely the silent-blinding footgun
+(someone flips it "for safety" and every probe in the codebase goes blind to the
+stray-token case). Per-call keeps any blinding **local and visible**.
+
+### 2. What the policy reuses — the existing secret-key denylist
+
+Redaction reuses the curated trace-redaction denylist already in
+[`util.ts`](../../packages/core/src/util.ts) — the `SECRET_QUERY_KEYS` /
+`SECRET_QUERY_STEMS` predicate (`isSecretQueryKey`) plus any caller
+`registerSecretQueryKey` registrations — rather than inventing a parallel list
+that would drift out of sync. A credential param name registered for URL
+scrubbing is then also caught when it echoes in a response body.
+
+The denylist is **query-key-named** today; the body case needs the same matcher
+under a body-neutral name:
+
+-   Promote the predicate to **`isSecretKey(name)`** in `util.ts`, keeping
+    `isSecretQueryKey` as an alias (the URL scrubbers keep their name).
+-   Add **`redactSecretsDeep(value, extra?)`** in `util.ts`: walk a plain value,
+    replace any object key matching `isSecretKey` (or the caller's `extra`
+    name/path patterns via the existing `matchPath`) with the existing
+    `URL_REDACTED = 'REDACTED'` sentinel. Returns a **deep clone** — never mutate
+    the engine's retained body.
+
+`redact: true` uses the shared denylist; `redact: string[]` adds extra key
+names / paths (reusing `matchPath`'s prefix/`*` grammar) on top of it.
+
+### 3. Name-based only — a sharing convenience, _not_ a leak guarantee
+
+Redaction here is **name-based**: it scrubs fields whose _key_ is known-secret. It
+deliberately does **not** attempt value-shape (regex JWT/bearer/PII) redaction.
+This is the crux:
+
+-   A name-based redactor **cannot** catch a token sitting in an innocently-named,
+    undeclared field — and that is **exactly the case `.inspect()` exists to let a
+    human find.** So redaction is scoped honestly as "scrub the fields I already
+    know are secret-named, so I can share the rest," **not** as a guarantee that
+    `raw` is now leak-free.
+-   That scoping _is the argument for opt-in._ An opt-in convenience cannot lull
+    you. An on-by-default "safety" net would: you'd believe `raw` is safe to log
+    while the dangerous case (token in a field not named like a secret) slips
+    through unredacted. **The default protection is non-enumerability** (accidental
+    leakage); `redact` is the deliberate-sharing escape hatch layered on top.
+
+### 4. Findings are computed before redaction
+
+The soft/hard diff runs on the **unredacted** body (findings need real values to
+classify), then `raw` is redacted for the result object. This is safe because
+`detailFor` emits **kinds only, never values** (`string -> number`,
+`undeclared field (string)`) — so `findings` never leak a secret even when
+`redact` is off. When `redact` is set, `.inspect()` places the **redacted clone**
+on `wrapper.raw` and drops the unredacted body (otherwise redaction is pointless);
+`source`/`status`/`findings` are unaffected.
+
+## Alternatives considered
+
+-   **Redact by default (opt-out).** Rejected: inverts the tool's purpose, creates
+    false confidence, and a name-based redactor can't catch the stray-token case
+    anyway — so a default-on net protects least where it matters most.
+-   **A new, body-specific secret denylist.** Rejected: duplicates the curated
+    `isSecretKey` list, would drift, and caller `registerSecretQueryKey`
+    registrations wouldn't carry over.
+-   **Value-shape (regex) redaction.** Rejected for v1: heuristic, false-positive
+    prone, and still cannot guarantee catching the field manual inspection exists
+    for. Could be a future additive `redact` mode if demand appears.
+-   **Process-wide / global redaction default.** Rejected as a mechanism: the
+    silent-blinding footgun. Allowed only as an explicit stitch-level default that
+    the per-call option overrides.
+-   **Redact in place on the retained body.** Rejected: corrupts the engine's
+    pristine `RAW_BODY`; redaction returns a clone.
+
+## Consequences
+
+-   `.inspect()` gains one optional `redact`; the default path is byte-identical
+    to 0016 (unredacted, non-enumerable).
+-   **No engine change.** Redaction lives entirely at the `.inspect()` assembly
+    site in `stitch.ts`; the engine keeps retaining the pristine body on
+    `RAW_BODY` (contrast 0016, which _did_ need the `RAW_BODY`/`ERROR_SOURCE`
+    engine plumbing).
+-   `util.ts` gains a reusable `redactSecretsDeep` + the `isSecretKey` rename;
+    the URL scrubbers are unchanged behind the alias.
+
+## Engine / type touch-points
+
+-   [`types.ts`](../../packages/core/src/types.ts) — `InspectOptions`: add
+    `redact?: boolean | string[]`. Update the `Inspection.raw` JSDoc to mention
+    the escape hatch.
+-   [`util.ts`](../../packages/core/src/util.ts) — rename the predicate to
+    `isSecretKey` (alias `isSecretQueryKey`); add `redactSecretsDeep(value, extra?)`
+    reusing it + `URL_REDACTED`.
+-   [`stitch.ts`](../../packages/core/src/stitch.ts) — the `.inspect()` consumer:
+    after recovering `raw` (`RAW_BODY`) and computing `findings`, if `redact` is
+    set, place `redactSecretsDeep(...)` on `wrapper.raw` instead of the raw body.
+-   `engine.ts` — **no change.**
+
+## Relationship to the other 0016 deferrals
+
+Stands **alone**. It is a focused security toggle on an _existing_ 0016 field,
+distinct from ADR 0019's _new_ result surface. Note the interaction: ADR 0019's
+`RunReport<T> extends Inspection<T>` inherits `raw`, so `redact` (and
+non-enumerability) cover the report's `raw` too; ADR 0019's _config echo_ uses a
+**separate** redaction path (the already-redacted `__config`, never
+`__rawConfig`) — these are two different mechanisms for two different surfaces.

--- a/docs/adr/0019-enhanced-result-object.md
+++ b/docs/adr/0019-enhanced-result-object.md
@@ -1,0 +1,199 @@
+# ADR 0019 — The enhanced result object (`.report()`) + the `source` discriminator
+
+-   **Status:** Proposed (designed 2026-06-28; extends [ADR 0016](./0016-inspect-raw-and-findings.md), in flight as [#334](https://github.com/rejifald/StitchAPI/pull/334)). Folds in **two** of the four items ADR 0016 deferred: the `source` discriminator and the enhanced result object.
+-   **Date:** 2026-06-28
+-   **Tags:** inspect, diagnostics, result-object, observability, privacy, api-surface
+
+> [!NOTE]
+>
+> Numbering continues past 0016 (PR #334) and 0013/0014 (#328), both in flight.
+> Renumber at PR time if a lower number lands first — as 0015/0016 did.
+
+> [!IMPORTANT]
+>
+> **Depends on [ADR 0016](./0016-inspect-raw-and-findings.md)** (`Inspection<T>`
+> and `.inspect()`), which must land first (PR #334). 0016 deliberately **held the
+> line** at `{ value, raw, findings, status, error }` and pushed attempt count,
+> timing, and config echo to "a separate ADR; this one holds the line." This is
+> that ADR. It also **revises** 0016's tentative placement of the `source`
+> discriminator (see §1).
+
+## Context
+
+0016 gives an `await`-style consumer the body and the drift. The remaining
+diagnostic questions are about the **run**, not the body: _How many attempts did
+it take? How long? Was it served from cache or a live request? What config
+actually resolved for this call?_ 0016 deliberately excluded these to keep
+`Inspection<T>` the minimal "raw + drift" object.
+
+It also left two related questions open:
+
+-   **`source: 'live' | 'cache' | 'stream'`** — disambiguates _why_ `raw` is
+    `null` (a cache hit vs. a streaming surface vs. a live miss). 0016 guessed this
+    belonged on "the enhanced-result-object, not here."
+-   **The enhanced result object** (config echo, attempts, timing) — its own
+    decision, "the largest."
+
+Most of the data already exists on the event spine (ADR 0007). This ADR audits
+what is free vs. what needs plumbing, and lands the surface.
+
+## Decision
+
+A two-layer split: `source` lands on the **minimal** `Inspection<T>` because it
+interprets an existing Inspection field; the heavier diagnostics land on a
+**new** `RunReport<T> extends Inspection<T>` returned by **`.report()`**.
+
+### 1. `source` goes on `Inspection<T>` — revising 0016's guess
+
+```ts
+interface Inspection<T> {
+    value: T | null;
+    raw: unknown;
+    findings: DriftFinding[];
+    status: number;
+    error: StitchError | null;
+    source: 'live' | 'cache' | 'stream'; // NEW
+}
+```
+
+0016 speculated `source` belonged on the enhanced object. On reflection that is
+incoherent: **`source` exists to explain why `raw` is `null`, and `raw` lives on
+`Inspection`.** The explainer must sit with the thing it explains. `source` is
+also _free_ — the engine already knows which branch ran (the
+`progress { phase: 'cache', detail: 'hit' | 'miss' }` event; the streaming
+surface is a separate `.inspect()` code path; live = a real request). So `source`
+is the one diagnostic that earns a place on the minimal object, and this ADR moves
+it there, superseding 0016's deferral note for this item.
+
+Semantics — `source` distinguishes the **structural** nulls from the live case:
+
+| `source`   | when                                 | `raw`                                  |
+| ---------- | ------------------------------------ | -------------------------------------- |
+| `'live'`   | a real request ran (miss, or bypass) | populated (unless redacted/0018)       |
+| `'cache'`  | `{ cache: true }` + a hit            | `null` (cache stores `{value,status}`) |
+| `'stream'` | a streaming surface                  | `null` (no single buffered body)       |
+
+Honest limit: `source` explains the **structural** nulls fully (cache/stream —
+`raw` _can never_ exist there). On `'live'`, `raw` is populated **except** when a
+transport error killed the request before any body arrived (then `raw` is `null`
+and `source` is still `'live'`). So the contract is "`source` tells you whether
+`raw` _could_ exist," not "`source === 'live'` ⟹ `raw !== null`." Documented, not
+hidden.
+
+### 2. The heavier diagnostics go on `RunReport<T>` via `.report()`
+
+```ts
+type CacheOutcome = 'hit' | 'hit (revalidated)' | 'miss' | 'bypass' | 'disabled';
+
+interface RunReport<T> extends Inspection<T> {
+    attempts: number;             // total incl. the first
+    timing: { ms: number; waited?: number }; // total wall ms; summed backoff/throttle wait
+    config: RedactedStitchConfig; // the REDACTED resolved config — never __rawConfig
+    cache: CacheOutcome;          // fine-grained cache outcome (source's detail)
+}
+
+// on the Stitch callable, beside .inspect():
+report(...args: [...Args<TIn>, opts?: InspectOptions]): Promise<RunReport<T>>;
+```
+
+`RunReport<T>` **extends** `Inspection<T>`: a report _is_ an inspection plus run
+diagnostics. So `.inspect()` stays 0016's minimal "raw + drift" tool, and
+`.report()` is the "explain this run" superset — one coherent type hierarchy, the
+0016 line held on the small object.
+
+### 3. Why a separate method, not an expanded `Inspection`
+
+-   **Expand `Inspection` with all fields** — rejected: re-breaks 0016's held line
+    and makes _every_ `.inspect()` pay the config-resolve-and-redact cost for data
+    most probes don't want. (We make a single exception for `source` — free, and
+    the interpretant of `raw`.)
+-   **Option-gated optional fields** (`.inspect(input, { trace: true })` populates
+    `attempts?`, `timing?`, …) — rejected: "sometimes-undefined" fields are a
+    typing wart; you can't tell "not asked for" from "genuinely empty." A distinct
+    return type is cleaner.
+-   **A separate `.report()` returning `RunReport<T> extends Inspection<T>`** —
+    chosen. Names the diagnostics concern, keeps `.inspect()` minimal, one type
+    hierarchy.
+
+Name: **`.report()`**. Rejected `.trace()` (collides with the existing trace sink
+— `trace.ts`, `TraceContext`, the JSONL/OTLP `trace`) and `.describe()`
+(overloaded with the static config-summary "describe what a stitch does"). A
+_report_ is the per-run dynamic artifact.
+
+### 4. Where the data lives — the plumbing audit
+
+| field                   | source on the spine                                 | new plumbing?                         |
+| ----------------------- | --------------------------------------------------- | ------------------------------------- |
+| `attempts`              | `StitchEvent.attempts` / `StitchError.attempts`     | none                                  |
+| `timing.ms`             | `done.ms`                                           | none                                  |
+| `timing.waited`         | Σ `progress.waitedMs` (throttle/retry/reconnect)    | none (derived)                        |
+| `source` / `cache`      | `progress { phase:'cache', detail }` + surface kind | none (derived)                        |
+| `config`                | `Stitch.__config` (already redacted, ADR 0002)      | redact the _resolved_ per-call config |
+| **per-attempt latency** | — not on the spine —                                | **needs engine spans → DEFERRED**     |
+
+The whole of `RunReport` v1 is buildable from the **existing event spine** plus
+the already-redacted `__config`. The single gap is **precise per-attempt request
+latency** (attempt N took X ms): the spine carries per-event `at` timestamps and
+`progress.waitedMs`, but not request-start/request-end per attempt. v1 reports
+total `ms` + total `waited` and **defers** per-attempt spans (they need the engine
+to stamp attempt boundaries). We do **not** fake per-attempt latency from `at`
+deltas — those deltas include validation/throttle time and would mislead.
+
+Contrast 0016, which needed engine changes (`RAW_BODY` / `ERROR_SOURCE`): this
+ADR's v1 needs **no new engine events** — it rides the spine.
+
+### 5. Privacy posture
+
+-   **`config` is the redacted `__config`, never `__rawConfig`.** `__rawConfig`
+    carries live auth/secrets; `__config` is the auth-stripped projection (ADR
+    0002). `RunReport.config` is the **resolved** per-call config (after `.with()`
+    binding and per-call `deepMerge`) run through the _same_ redaction projection
+    that produces `__config` — the one bit of new config-side work, and it MUST go
+    through that projection. Echoing `__rawConfig` is forbidden.
+-   **`raw` is inherited** from `Inspection`: non-enumerable, and ADR 0018's
+    `redact` option applies to it.
+-   Every other `RunReport` field (`attempts`, `timing`, `source`, `cache`,
+    `config`) is secret-free and **enumerable** — a report is safe to log _except_
+    don't expand `raw`. Same posture as `Inspection`.
+
+## Consequences
+
+-   `Inspection<T>` gains `source` (one enum, free); `RunReport<T>` + `.report()`
+    are net-new. No change to `await` / `.safe()` / `.unwrap()` / `.inspect()`
+    _value_ typing.
+-   Like `.inspect()`, `.report()` is a network probe (bypasses cache by default,
+    `{ cache: true }` to honor it) — same caveats as 0016.
+-   Per-attempt latency is explicitly absent in v1; flagged so its absence reads
+    as "deferred," not "covered."
+
+## Engine / type touch-points
+
+-   [`types.ts`](../../packages/core/src/types.ts) — add `source` to
+    `Inspection<T>`; add `RunReport<T> extends Inspection<T>`, `CacheOutcome`; add
+    `report(...)` to the `Stitch` interface. `InspectOptions` is shared (or a
+    `ReportOptions` alias).
+-   [`stitch.ts`](../../packages/core/src/stitch.ts) — a `.report()` consumer that
+    drains the event stream once (like `.inspect()`): collect `attempts` (terminal
+    event), `ms` (`done`), `waited` (Σ `progress.waitedMs`), `cache`/`source` (the
+    `phase:'cache'` detail + surface kind), `config` (resolved + redacted
+    `__config`). Add the `source` computation to the existing `.inspect()` consumer.
+-   [`config-summary.ts`](../../packages/core/src/config-summary.ts) — reuse the
+    redacted-config read-outs; reuse the `__rawConfig → __config` redaction
+    projection to produce the resolved per-call echo.
+-   `engine.ts` — **no new events for v1.** The only engine change (per-attempt
+    span stamping) is the _deferred_ item, out of scope here.
+
+## Relationship to the other 0016 deferrals
+
+-   **Folds in the `source` item** (0016 deferral #2) — landed on `Inspection`,
+    revising 0016's guess.
+-   **Overlaps ADR 0018**: `RunReport` inherits `raw`, so 0018's `redact` and
+    non-enumerability cover it; but `config` echo uses a _different_ redaction path
+    (the `__config` projection), so the two ADRs touch redaction in
+    non-overlapping places.
+-   **Independent of ADR 0017** (array drift summarization — the diff/classify
+    layer). `RunReport.findings` inherit 0017's summarized shape for free.
+
+This is the **largest** of the four and rightly its own ADR, with `source`
+merged in because `source` is the interpretant of `raw` and cannot stand on its
+own.


### PR DESCRIPTION
A design pass — **ADRs only, no implementation** — for the four items [ADR 0016](https://github.com/rejifald/StitchAPI/pull/334) deferred in its *Future work / Out of scope*. All three land as **Status: Proposed**.

## What's here

Four deferred items → **three ADRs** (one merge):

| ADR | Item(s) | Builds on |
|---|---|---|
| **0017 — Array drift summarization in `classifyDiff`** | Item 3 | refines 0015 (merged, #331) |
| **0018 — Opt-in `redact` option for `.inspect()`'s `raw`** | Item 2 | refines 0016 (#334) |
| **0019 — Enhanced result object (`.report()`/`RunReport`) + `source` discriminator** | Items 4 **+ 1** | extends 0016 (#334) |

**The one merge:** the `source` discriminator (item 1) folds into 0019. ADR 0016 *guessed* `source` belonged on the enhanced object; 0019 reverses that — `source` explains why `raw` is `null`, and `raw` lives on `Inspection`, so `source` lands on `Inspection` itself (it's free; the engine already knows the branch). The heavier diagnostics go on a separate `RunReport<T> extends Inspection<T>`.

## Decisions, in brief

- **0017** — 0015's existing `change|path` dedup already collapses homogeneous array drift, but with a **silent correctness gap**: first-wins drops *heterogeneous* problems at the same `[]` path. Decision: group-then-summarize; homogeneity = identical `detail` string; homogeneous → `"all N elements: …"` + `sample` index; heterogeneous → one finding per distinct variant. One new optional `DriftFinding.sample`. `diff.ts` stays index-precise.
- **0018** — Per-call `InspectOptions.redact`, **default off**, reusing the existing secret-key denylist (`isSecretKey`, renamed from `isSecretQueryKey`) + a new `redactSecretsDeep`. Name-based only, scoped as a *safe-sharing convenience, not a leak guarantee* — which is exactly why it stays opt-in. **No engine change.**
- **0019** — `source` on `Inspection`; `RunReport` via `.report()` carrying `attempts`, `timing`, redacted `config`, `cache`. The plumbing audit is the heart: everything except **per-attempt latency** is derivable from the existing event spine, so v1 needs **no new engine events**. `config` echo is the redacted `__config`, **never `__rawConfig`**.

## Numbering

Numbered **0017–0019** to dodge `0013/0014` (#328) and `0016` (#334), both in flight. Each carries the renumber-at-PR-time note, as 0015/0016 did.

## Verification

Pre-commit hook clean: Prettier unchanged, full workspace typecheck passed (docs are Markdown only — no code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)