### PR TITLE
docs(blog): "Axios Alternatives in 2026" + SEO editorial roadmap

### DIFF
--- a/apps/docs/content/blog/axios-alternatives.mdx
+++ b/apps/docs/content/blog/axios-alternatives.mdx
@@ -1,0 +1,85 @@
+---
+title: 'Axios Alternatives in 2026: Match the Tool to Your Actual Problem'
+description: People leave axios for two unrelated reasons — they want a lighter fetch wrapper, or they're tired of maintaining the retry/timeout/auth/validation glue around every call. Those point at different tools. Here's an honest map of the alternatives, and where a stitch fits.
+author: Oleksandr Zhuravlov
+date: '2026-06-28'
+tags: [axios, http, typescript, fetch, comparison, resilience]
+---
+
+You've decided to drop axios from a TypeScript project. Before you reach for the first library on a "best axios alternatives" list, separate the two reasons people make this move, because they point at different tools. Either you want a **smaller, modern fetch wrapper** — the same job axios does, with less weight and a native-`fetch` core — or you've realized the wrapper was never the point, and what you actually maintain is the **interceptor layer around it**: retries, timeouts, rate limiting, the auth token lifecycle, response validation. Pick the wrong category and you'll port your problem instead of solving it.
+
+## If you want a lighter fetch wrapper
+
+This is the common case, and the honest answer is that the field is good. Native `fetch` plus one of a few small libraries covers most of what axios did.
+
+-   **Native `fetch`.** It's everywhere in 2026 — browsers, Node, Deno, Bun, edge runtimes — with no dependency at all. The two gaps people hit: it doesn't reject on a non-2xx status (you check `response.ok` yourself), and retries, timeouts, and base-URL handling are yours to write. `AbortSignal.timeout()` covers the simplest timeout case.
+-   **[ky](https://github.com/sindresorhus/ky).** A tiny `fetch`-based client with retry, timeout, and hooks built in, written in TypeScript. It's the closest "axios feel" in a fraction of the size, and the default pick if you're browser-first and want batteries included.
+-   **[ofetch](https://github.com/unjs/ofetch).** Auto-parses JSON, throws on errors, retries, and runs the same in Node and the browser. It's the `fetch` layer under Nuxt, and a clean choice if you live in that ecosystem.
+
+If a smaller wrapper is genuinely all you need — you call a couple of well-behaved endpoints and the rest of the reliability story isn't yours to own — stop here. One of these is the right move, and the rest of this post is for a different problem.
+
+## If the wrapper was never the point
+
+Open the axios setup in a mature codebase and the `axios.create()` call is usually the small part. The bulk is interceptors: a retry-with-backoff that respects `Retry-After`, a request queue that keeps you under a rate limit, a per-request timeout, a token refresh on 401, and — if the team is careful — a hand-written check that the response actually has the shape the rest of the code assumes. None of the wrappers above remove that. They give you a nicer `fetch`; the glue is still yours to assemble and maintain per project.
+
+A stitch is the alternative for that problem, and it's a different category on purpose. **It isn't a smaller HTTP client — it's a layer above whichever one you keep.** `fetch` and axios become pluggable adapters underneath; a stitch sits on top and turns one endpoint into a typed, validated, resilient function. You declare the call and its policy once, as data:
+
+```ts
+import { stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const listOrders = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/orders',
+    output: z.object({ orders: z.array(Order) }),
+    retry: { attempts: 4, on: [429, 502, 503], respectRetryAfter: true },
+    throttle: { rate: '1/s', concurrency: 2, scope: 'host' },
+    timeout: { total: '30s', perAttempt: '10s' },
+});
+
+const { orders } = await listOrders(); // typed · validated · retried · throttled
+```
+
+Everything that was an interceptor is now a field. `retry` backs off and honors `Retry-After`. `throttle` is **proactive** — it keeps you under the limit before the 429s arrive, and `scope: 'host'` shares one limiter across every stitch hitting that host, so it stays correct even as you add calls ([proactive throttling beats reacting to 429s](/blog/proactive-throttling-vs-reactive-429s)). `timeout` is layered: a ceiling for the whole call and a separate budget per attempt.
+
+The `output` validator is the part axios never had. A stitch validates the **live** response on every call, so a shape mismatch is caught at the boundary as a typed error instead of surfacing as an `undefined` three layers downstream. Wrap the schema in `drift()` and each response is also diffed against its validated form, with every change leveled by severity — a renamed required field throws, a coercion the schema quietly absorbed surfaces as a `warn` on the event stream ([schema drift is a production bug](/blog/schema-drift-is-a-production-bug)). That's a class of failure an interceptor stack typically ships straight to production.
+
+Auth is a boundary too, not another interceptor: `bearer`, `apiKey`, `basic`, `cookieSession` with auto-login and re-login, and `oauth2` live on the stitch, and the secret resolves at call time. The caller gets data without ever holding the credential.
+
+## On dependency weight
+
+A reason teams cite for leaving axios is the supply-chain surface: it pulls a small tree of transitive dependencies, and every one of them is something you audit and trust. The lighter wrappers shrink that tree; native `fetch` removes it. StitchAPI's core is **zero-dependency** — nothing transitive to vet — and validator-agnostic, so you bring your own Standard Schema or Zod rather than inheriting a fixed one. If reducing what you install is part of why axios is leaving, it's worth weighing the whole tree, not just the top-level package.
+
+## The axis the older clients don't have
+
+If an AI agent is one of the callers, the category gap widens. A wrapper gives an agent importable code; it doesn't give it a front door. The same stitch is reachable four ways from one definition — an in-process function, a CLI command, an HTTP endpoint, and an MCP tool — so an agent calls the exact same validated, observable thing your code does, and gets a **capability, not a credential** ([stop writing `fetch()` in your agents](/blog/stop-writing-fetch-in-your-agents)). No axios alternative offers that, because it wasn't in scope for any of them.
+
+## A side-by-side
+
+| Axis                 | Fetch wrappers (ky, ofetch, native `fetch`) | A stitch (StitchAPI)                                    |
+| -------------------- | ------------------------------------------- | ------------------------------------------------------- |
+| **Category**         | a smaller HTTP client                       | a layer above `fetch`/axios (they're adapters)          |
+| **Retry / throttle** | retry built in; throttle is yours           | declared fields; throttle is proactive, host-scoped     |
+| **Timeouts**         | single timeout (or `AbortSignal`)           | layered — total + per-attempt                           |
+| **Response shape**   | typed by you, unchecked at runtime          | validated live on every call; leveled drift signals     |
+| **Auth**             | an interceptor you write                    | a boundary on the stitch; caller never holds the secret |
+| **Dependencies**     | small (or none, for native `fetch`)         | zero-dependency core, bring-your-own validator          |
+| **Agent surface**    | importable code; no built-in door           | function / CLI / HTTP / MCP from one definition         |
+
+## When a fetch wrapper is the right call
+
+This isn't a piece that ends with "so never use ky." There's a clear lane where a wrapper wins, and it's worth naming:
+
+-   **You call a few well-behaved endpoints.** No rate limits, no flakiness, no shifting shapes — most of a stitch's machinery would sit dormant, and a thin typed wrapper is less ceremony.
+-   **You won't write a schema.** A stitch's runtime guarantees come from its `output` validator. Skip it and you skip validation and drift, at which point a stitch is a fetch wrapper with extra steps — so use the actual wrapper.
+-   **You're already deep in an ecosystem.** If Nuxt gives you ofetch and it's working, switching layers for its own sake is churn, not progress.
+
+A stitch earns its keep on the opposite shape of problem: APIs that rate-limit, flake, or change shape without warning; heterogeneous surfaces — HTTP, GraphQL, SSE, an LLM endpoint — stitched under one model; and anywhere you want resilience, an auth boundary, and an agent front door declared on the primitive instead of assembled around a client per project.
+
+## Try it
+
+```bash
+npm i stitchapi
+```
+
+Declare one endpoint with a `retry` and an `output` schema, and watch the retry, the rate-limit handling, and the shape check that used to be three interceptors collapse into the declaration. The primitive itself is [The stitch](/docs/concepts/the-stitch), the policies live in [Retry](/docs/guides/resilience/retry), [Throttle](/docs/guides/resilience/throttle), and [Validation & drift](/docs/guides/validation/drift), and if you're coming from a generated client instead, there's [stitching vs. codegen](/blog/stitch-vs-codegen-api-clients).

--- a/docs/SEO-EDITORIAL-ROADMAP.md
+++ b/docs/SEO-EDITORIAL-ROADMAP.md
@@ -1,0 +1,119 @@
+# SEO Editorial Roadmap
+
+**Status:** living plan · **Created:** 2026-06-28 · **Scope:** `apps/docs` (docs site + `/blog`)
+**Companion:** [MESSAGING.md](./MESSAGING.md) · **Technical SEO shipped:** per-page structured data ([#332](https://github.com/rejifald/StitchAPI/pull/332)) + JSON-LD hardening ([#336](https://github.com/rejifald/StitchAPI/pull/336))
+
+> [!NOTE]
+>
+> This is a content plan, not a spec. It maps where organic-search upside is and
+> which posts capture it. Update the "Status" column on each pillar as posts ship.
+
+---
+
+## Diagnosis
+
+The docs are comprehensive and the blog (16 posts as of 2026-06-28) is high quality —
+but it skews **shareable**: thought-leadership and product-mechanism explainers framed
+in StitchAPI's own vocabulary ("the seam", "make-a-flaky-call-succeed"). That serves
+people who already found the project.
+
+The gap is **searchable content that captures existing demand** — readers searching the
+generic problem before they know StitchAPI exists. Three under-served intents:
+**comparisons** (consideration), **"how to [task] in TypeScript"** (implementation), and
+**definitions** (awareness + AI citation). Search order: capture demand first.
+
+## Content pillars
+
+| #   | Pillar                                        | Owns                                                          | Mode                               | Status                                                                                           |
+| --- | --------------------------------------------- | ------------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------ |
+| 1   | **Resilient API calls in TypeScript**         | retry / timeout / throttle / circuit-breaker / caching how-to | Searchable (implementation)        | mechanisms covered shareably; generic-query spokes missing                                       |
+| 2   | **Agent-native API access (MCP & code-mode)** | "give an agent a tool", MCP, code-mode, credential-safe       | Shareable → Searchable (awareness) | strong opinion pieces; awareness/definition layer missing                                        |
+| 3   | **Typed API clients without codegen**         | vs axios / ky / openapi-fetch / Orval, validation, drift      | Searchable (consideration)         | 2 comparisons exist; alternatives/"best" space open. **`axios-alternatives` shipped 2026-06-28** |
+| 4   | **One definition, every surface**             | function ↔ CLI ↔ HTTP ↔ MCP, framework integrations        | Shareable + use-case               | well covered — maintain, add integration use-cases                                               |
+
+Pillars 1–3 hold the SEO upside. Pillar 4 is the differentiation moat — keep feeding it,
+but it is not the traffic engine.
+
+## Priority topics (scored)
+
+Scoring model: Customer Impact (40%), Content-Market Fit (30%), Search Potential (20%),
+Resources (10%).
+
+| Topic (working title)                                                 | Pillar | Mode   | Stage          | Target query                | Impact | Fit | Search | Res | Total   |
+| --------------------------------------------------------------------- | ------ | ------ | -------------- | --------------------------- | ------ | --- | ------ | --- | ------- |
+| Axios alternatives in 2026 (zero-dep, typed, resilient) — **shipped** | 3      | Search | Consideration  | "axios alternatives"        | 9      | 9   | 9      | 7   | **8.8** |
+| How to retry a failed fetch in TypeScript (the right way)             | 1      | Search | Implementation | "retry fetch typescript"    | 9      | 9   | 8      | 8   | **8.7** |
+| Code mode vs tool calling: giving an agent many tools                 | 2      | Both   | Awareness      | "code mode mcp"             | 9      | 9   | 8      | 6   | **8.4** |
+| How to rate-limit / throttle API calls in Node & edge                 | 1      | Search | Implementation | "rate limit api calls node" | 8      | 9   | 8      | 7   | **8.2** |
+| Type-safe API client without OpenAPI codegen                          | 3      | Search | Consideration  | "type-safe api client"      | 8      | 9   | 8      | 7   | **8.1** |
+| How to add a timeout to fetch (total ≠ per-try)                       | 1      | Search | Implementation | "fetch timeout typescript"  | 8      | 8   | 8      | 9   | **8.0** |
+| Validate an API response with Zod / Standard Schema                   | 1/3    | Search | Implementation | "validate api response zod" | 8      | 9   | 7      | 7   | **7.9** |
+| What is schema drift? (glossary + how to detect it)                   | 3      | Both   | Awareness      | "what is schema drift"      | 7      | 9   | 7      | 8   | **7.6** |
+| How to call an API from a Claude / MCP agent safely                   | 2      | Search | Awareness      | "call api from llm agent"   | 8      | 8   | 7      | 6   | **7.5** |
+| Best way to handle pagination in TypeScript (into one array)          | 1      | Search | Implementation | "typescript paginate api"   | 7      | 8   | 7      | 8   | **7.4** |
+| Circuit breaker pattern in Node/TypeScript (glossary + impl)          | 1      | Search | Awareness      | "circuit breaker nodejs"    | 7      | 8   | 7      | 7   | **7.3** |
+| Hey API / Orval vs runtime stitching                                  | 3      | Search | Consideration  | "orval alternative"         | 7      | 8   | 7      | 7   | **7.3** |
+
+**The pattern for every searchable spoke:** rank for the _generic_ problem ("retry fetch
+in TypeScript"), teach it honestly and completely, _then_ show the one-line StitchAPI way.
+The product-framed version already exists in Recipes — these blog spokes are the
+keyword-framed front doors that link into them.
+
+## Topic cluster map
+
+```
+Pillar 1 — Resilient API calls in TypeScript  (HUB: /docs/guides/resilience/*)
+├── retry fetch in TypeScript        → /docs/recipes/make-a-flaky-call-succeed
+├── rate-limit / throttle API calls  → /docs/recipes/one-rate-limit-across-workers
+├── add a timeout to fetch           → /docs/errors/stitch-timeout
+├── circuit breaker in Node          → [blog] circuit-breakers-and-layered-timeouts
+└── paginate into one array          → /docs/recipes/paginate-into-one-array
+
+Pillar 2 — Agent-native API access  (HUB: /docs/agents)
+├── code mode vs tool calling        → [blog] one-tool-per-endpoint
+├── call an API from an MCP agent    → /docs/surfaces/mcp
+├── what is MCP / one server vs many → [blog] you-might-not-need-an-mcp-server-per-integration
+└── credential-safe agent tools      → [blog] auth-as-a-capability-not-a-credential
+
+Pillar 3 — Typed clients without codegen  (HUB: /docs/concepts/the-stitch)
+├── axios alternatives               → [blog] axios-alternatives  ✅ shipped
+├── type-safe client w/o OpenAPI     → /docs/guides/validation
+├── validate response with Zod       → /docs/guides/validation
+├── Hey API / Orval vs stitching     → [blog] stitch-vs-codegen-api-clients
+└── what is schema drift             → /docs/errors/stitch-drift
+
+Pillar 4 — One definition, every surface  (HUB: [blog] one-definition-four-front-doors)
+└── per-framework use-cases (Express/Hono/Next/React…) → /docs/integrations/*
+```
+
+Each blog spoke links **down** into the relevant Recipe/Guide/Error doc, and the doc
+links **back up** to the explainer — the interlinking compounds authority.
+
+## Quick wins (priority order)
+
+1. **Axios alternatives** — highest commercial intent; differentiates on zero-deps + the
+   "layer above fetch/axios" framing. **Shipped 2026-06-28** (`content/blog/axios-alternatives.mdx`).
+2. **"How to retry a failed fetch in TypeScript"** — evergreen, steady volume, near-zero
+   research cost (the mechanism already exists in the docs).
+3. **Code mode vs tool calling** — rides current MCP search momentum; the project already
+   holds the strongest opinion in the space.
+
+These are low-effort/high-return because the engineering content already lives in the
+docs — the work is re-framing around the search query.
+
+## Notes & guardrails
+
+-   **Honesty bar.** Every comparison names where the alternative wins (see the "when a
+    fetch wrapper is the right call" section in `axios-alternatives.mdx`). This is what
+    makes the posts credible and matches the [EDITORIAL.md](../apps/docs/EDITORIAL.md) standard.
+-   **No fabricated claims.** Do not assert specific third-party security incidents or
+    invented metrics; frame around verifiable properties (dependency tree, transitive
+    surface). Same reason the structured data omits fabricated `datePublished` dates.
+-   **Slugs stay evergreen.** Keep the target keyword in the slug (`axios-alternatives`),
+    carry the year in the title only, and refresh content yearly rather than re-slugging.
+
+## References
+
+-   TypeScript HTTP-client landscape 2026 — <https://reintech.io/blog/axios-vs-fetch-vs-ky-http-client-comparison-2026>
+-   Cloudflare, "Code Mode: the better way to use MCP" — <https://blog.cloudflare.com/code-mode/>
+-   Anthropic, "Code execution with MCP" — <https://www.anthropic.com/engineering/code-execution-with-mcp>


### PR DESCRIPTION
## What

Two content deliverables from the SEO content-strategy pass:

1. **`apps/docs/content/blog/axios-alternatives.mdx`** — the top quick-win searchable post, targeting the consideration-stage query *"axios alternatives"*. The blog so far skews shareable (thought-leadership, mechanism explainers); this is the first post written to capture existing search demand.
2. **`docs/SEO-EDITORIAL-ROADMAP.md`** — the living content plan it came from: 4 pillars, scored priority topics, topic-cluster map, quick-wins, and honesty guardrails.

## The post's angle

Rather than a generic listicle, it splits the **two unrelated reasons** people leave axios — wanting a lighter fetch wrapper vs. being tired of maintaining the interceptor glue — and routes each to the right tool. It covers ky / ofetch / native `fetch` fairly, then positions a stitch as a *different category* (a layer above `fetch`/axios, not beside them), with an explicit **"when a fetch wrapper is the right call"** section so the comparison stays credible per [EDITORIAL.md](apps/docs/EDITORIAL.md).

Dependency-weight framing uses only **verifiable** properties (transitive surface, zero-dep core) — no unverified third-party security-incident claims, consistent with the repo's no-fabricated-signals stance.

## Verification

- `fumadocs-mdx` codegen accepts the frontmatter (title/description/author/quoted ISO date/tags).
- `check:docs-links` passes; all `/docs/...` and `/blog/...` links resolve (folder-only routes like `/docs/guides/resilience` avoided — linked concrete sub-pages instead).
- Rendered locally: `/blog/axios-alternatives` returns 200, body + code blocks render, and the post is auto-included in `sitemap.xml`.
- `check:types`, format pass (pre-commit hook green).

Follow-up to the structured-data work (#332, #336).

🤖 Generated with [Claude Code](https://claude.com/claude-code)