### PR TITLE
docs(blog): three searchable SEO quick-win posts (retry, code-mode, throttle)

### DIFF
--- a/apps/docs/content/blog/code-mode-vs-tool-calling.mdx
+++ b/apps/docs/content/blog/code-mode-vs-tool-calling.mdx
@@ -1,0 +1,64 @@
+---
+title: 'Code Mode vs Tool Calling: Giving an Agent Many Tools Without Flooding Its Context'
+description: Tool calling hands the model one schema per endpoint and re-sends every one each turn; code mode hands it a small typed API and lets it discover the rest on demand. Here's what the two patterns actually are, and how StitchAPI exposes code mode as three fixed tools.
+author: Oleksandr Zhuravlov
+date: '2026-06-28'
+tags: [ai, agents, mcp, code-mode, context, tokens]
+---
+
+Reach for **code mode** when an agent needs access to many tools and you don't want every tool's schema sitting in the model's context on every turn. It's an industry pattern, not a StitchAPI invention — the same idea shows up wherever a model is given more capabilities than fit comfortably in a per-turn tool list. This post defines code mode against the pattern it replaces, **tool calling**, then shows the concrete three-tool shape StitchAPI uses.
+
+## Tool calling: one schema per endpoint, re-sent every turn
+
+The default way to give a model an API is **tool calling**: each endpoint becomes a named tool with its own JSON schema describing its parameters and result, and the model picks from the menu. `getUser`, `listOrders`, `createOrder`, `refundOrder` — one tool each. The model reads the menu, fills in a schema, and the runtime executes the call.
+
+The catch is _where the menu lives_. Tool schemas aren't sent once and remembered; they're part of the model's context, and the context is rebuilt on every step of the loop. So every tool's schema is re-sent on turn 1, turn 2, turn 3, and on for the whole length of the loop — whether or not the model touches that tool that turn. Forty endpoints means forty schemas in context on every step, including the steps where the model only reads a result and thinks. The tool list is a fixed per-turn cost that grows with the catalog and multiplies with the loop.
+
+## Code mode: a small typed API the model writes against
+
+**Code mode** inverts the arrangement. Instead of enumerating every endpoint as a tool, you give the model a small, fixed surface — often a single execution tool — and let it _write code_ or _name a call_ against that surface. The endpoints don't live in the standing tool list; the model discovers them when it needs them, through calls it makes on the turns it cares about.
+
+The contrast is the whole point. **Discovery on demand, not a menu re-sent every turn.** Tool calling pays for the full catalog on every step; code mode pays for discovery only on the steps that discover. The schemas the model carries each turn describe the fixed surface and nothing else, so the standing context stays flat as the catalog behind it grows from four endpoints to four hundred.
+
+## How StitchAPI does it: three fixed tools
+
+StitchAPI exposes code mode over MCP as exactly three tools, no matter how many stitches sit behind them:
+
+-   `run_stitch` — execute a stitch by name, passing `{ name, input }`
+-   `list_stitches` — discover the available stitch names, methods, and paths, on demand
+-   `describe_stitch` — pull one stitch's shape (its input slots, output, auth _scheme_, policies) only when the model is about to use it
+
+The agent orients first, then runs by name. These are plain MCP tool calls — there's no per-endpoint schema being re-sent:
+
+```json
+{ "name": "list_stitches", "input": {} }
+```
+
+```json
+{
+    "name": "run_stitch",
+    "input": { "name": "getUser", "input": { "params": { "id": 7 } } }
+}
+```
+
+The inner `input` is the stitch's own input — `{ params?, query?, body?, headers? }` — and the call runs against the upstream API behind a capability boundary. The agent names a capability; the runtime holds the credential. `describe_stitch` even reports the auth _scheme_ (`bearer`, `apiKey`, …) without ever exposing the token, so the model can reason about a call it isn't trusted to see the secret for.
+
+Map it back onto the two costs. The per-turn surface is **a constant three** — adding the 41st stitch costs roughly zero additional standing tokens, because the tool list still describes three tools. Loop length still multiplies that surface, but three tools across twenty turns is a small, flat number, not forty schemas across twenty turns. Discovery moved out of the standing context and into `list_stitches` and `describe_stitch` calls the model makes only when it needs them.
+
+## When one tool per endpoint is fine
+
+Code mode earns its keep on large catalogs and long loops. Below that, tool calling is the simpler thing, and overselling code mode helps no one:
+
+-   **A small, fixed catalog.** Two or three endpoints, a single-shot call — there was never a fat menu to re-send. Two schemas sent once is cheaper than standing up an execution surface and asking the model to discover and name calls.
+-   **You want a curated menu.** Sometimes the named-tool-per-action shape _is_ the interface you want the model to see: a small, deliberately authored set of tools beats "discover, then call." If a tight tool surface is the product, build it as tool calling.
+-   **The model is weak at structured tool use.** Driving stitches by name — listing, describing, composing a call — asks more of the model than picking from a flat menu of typed tools. A model that struggles with that may do better with explicit per-endpoint schemas, paid-per-turn and all.
+
+For the deeper opinion on the catalog-tax math and why the per-endpoint reflex compounds, see [Why your agent shouldn't get one tool per endpoint](/blog/one-tool-per-endpoint). The architectural cousin — when to stop running a separate MCP server for each service — is [You might not need an MCP server per integration](/blog/you-might-not-need-an-mcp-server-per-integration). And if you're picking an HTTP layer underneath all this, [axios alternatives in 2026](/blog/axios-alternatives) maps the field.
+
+## Try it
+
+```bash
+npm i stitchapi
+```
+
+Declare your endpoints once, point an agent at the three-tool surface, and watch the per-turn tool list stop growing. See [Use StitchAPI from an agent](/docs/agents) for the entry point and the capability boundary, [run_stitch & code-mode](/docs/agents/run-stitch-tool) for the three tools in full, and [capability, not credential](/docs/concepts/capability-not-credential) for why the agent calls without seeing the secret.

--- a/apps/docs/content/blog/rate-limit-api-calls-typescript.mdx
+++ b/apps/docs/content/blog/rate-limit-api-calls-typescript.mdx
@@ -1,0 +1,103 @@
+---
+title: 'How to Rate-Limit and Throttle API Calls in TypeScript (Node and Edge)'
+description: Rate (calls per unit time) and concurrency (in-flight cap) are different controls, and the usual setTimeout queue breaks the moment a second call site or process shares the limit. Here's how to pace calls correctly in TypeScript, and how a stitch declares it as data.
+author: Oleksandr Zhuravlov
+date: '2026-06-28'
+tags: [throttle, rate-limits, http, typescript, resilience]
+---
+
+You need to rate-limit outbound API calls in TypeScript when an upstream caps how fast you may call it and you'd rather pace under that cap than bounce off it. The first thing to get right is that "rate-limit" is two different controls, and most homegrown limiters only implement one.
+
+## Rate is not concurrency
+
+These two answer different questions, and conflating them is the most common bug in a hand-rolled limiter.
+
+-   **Rate** is _how fast_ — calls per unit time. "Five per second" is a pace: roughly one call every 200ms. It governs the gap between successive requests, not how many are open at once.
+-   **Concurrency** is _how many at once_ — the in-flight cap. "At most two" means a third call waits until one of the first two returns, no matter how quickly that happens.
+
+They're orthogonal. An upstream that tolerates a steady stream but falls over on fifty simultaneous sockets wants a concurrency cap. One that counts requests in a window and returns `429` past the count wants a rate cap. Most real limits are both, and a limiter that only spaces calls in time will still open a hundred sockets the instant they're all due.
+
+## The naive limiter, and where it breaks
+
+The first version everyone writes is a `setTimeout` between calls or a small promise queue:
+
+```ts
+let last = 0;
+
+async function paced<T>(fn: () => Promise<T>): Promise<T> {
+    const wait = Math.max(0, last + 200 - Date.now());
+    if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+    last = Date.now();
+    return fn();
+}
+```
+
+This holds one call site to roughly 5/s. It breaks the moment reality is bigger than one function:
+
+-   **Multiple call sites.** Two modules each keep their own `last`, and the upstream sees the sum. Three of them at 5/s apiece is 15/s against a host that allows five — and you're back to meeting `429`s in production.
+-   **No concurrency cap.** It spaces _starts_ but never counts in-flight requests. Slow responses pile up, and you breach a concurrency limit the timer never modeled.
+-   **Multiple processes.** Scale to three instances behind a load balancer, or a dozen serverless isolates, and each keeps its own `last` in its own memory. Your real upstream rate is N times your cap, where N is however many copies happen to be running.
+
+Every one of these is the same root issue: the budget lives in one variable in one place, and the limit it's protecting is shared somewhere wider.
+
+## Pace before you send, don't wait for the 429
+
+There's a second axis underneath the mechanics: _when_ you find the limit. The reactive approach is to fire as fast as your code produces calls, and when one returns `429`, back off and honor `Retry-After`. It works as a backstop, but by the time the `429` lands you've already spent the round trip and earned a rejection. Pacing yourself **under** the limit before requests leave is the proactive approach — fewer wasted trips, no rejection latency. The full argument for why proactive beats reactive, and how the two compose, is in [proactive throttling beats reacting to 429s](/blog/proactive-throttling-vs-reactive-429s).
+
+## The stitch way: declare the throttle as data
+
+A stitch is one API call turned into a typed function, and its rate limit is a field on that declaration, not a queue you assemble around the call. You name the pace and the cap; the stitch holds you to them before any request leaves.
+
+```ts
+import { stitch } from 'stitchapi';
+
+const search = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/search',
+    throttle: { rate: '5/s', concurrency: 2, scope: 'host' },
+});
+
+const results = await search({ query: 'shoes' }); // paced and bounded
+```
+
+`rate` is a string like `'5/s'` — a minimum spacing between successive calls, not a token bucket that lets a burst through. `concurrency` caps simultaneous in-flight calls; set either on its own or both together. When a call has to wait its turn it isn't a silent stall — the stitch emits a `progress` event with phase `throttled`, so a queued call shows up on the event stream instead of looking like a hang.
+
+`scope` is the answer to the multiple-call-sites problem. The default `'stitch'` gives each stitch its own budget; `'host'` pools one budget across every stitch hitting the same host — which is how a provider actually counts, since a rate limit is per account or per host, almost never per endpoint. Set `scope: 'host'` and three stitches against `api.example.com` draw from one `5/s` budget no matter which one a caller reaches for. Host-scoped pooling works in-process with no extra setup.
+
+## Multiple processes: the distributed story
+
+`scope: 'host'` shares a budget across stitches in one process; it does nothing across processes, because the counters live in memory. Run more than one instance against the same upstream budget and you're back to N times your cap. The fix isn't a different limiter — it's a different place to keep the counters. Attach a shared `store` to move them off-box, so every instance pointed at the same store draws from one budget:
+
+```ts
+import { fromIoredis, redisStore } from '@stitchapi/redis';
+import Redis from 'ioredis';
+import { seam } from 'stitchapi';
+
+const api = seam({
+    baseUrl: 'https://api.example.com',
+    throttle: { rate: '5/s', concurrency: 4, scope: 'host' },
+    store: redisStore(fromIoredis(new Redis(process.env.REDIS_URL))),
+});
+```
+
+The `throttle` declaration is unchanged from the single-process version — only `store` is new. The mechanics, which drivers give you an atomic increment (Redis and Deno KV do; Workers KV doesn't), and what that means at the edge are in [distributed throttle and shared sessions](/blog/distributed-throttle-with-redis-kv).
+
+## When a simple limiter is enough
+
+Reaching for any of this when you don't need it is its own mistake. The `setTimeout` version above is correct for the shape of problem it fits, and a declared throttle is dead weight when:
+
+-   **You call from one place, in one process.** A CLI run or a single long-lived worker with one call site has nothing to share a budget across — the in-memory limiter counts exactly right, and a store would add a network hop to fix a problem you don't have.
+-   **You never brush the limit.** A handful of calls that come nowhere near the cap don't need pacing. The reactive `429` path alone is enough until your volume starts touching the ceiling.
+-   **You don't know the real limit.** A proactive throttle paces you to the number you declare, not the provider's actual ceiling. If a provider documents its limit, use it; if not, start conservative and tighten as you watch for `429`s. There's no pacing without a number.
+
+The line is whether the budget is shared wider than the one variable holding it. While it isn't, a few lines of `setTimeout` are honest. The moment it is — a second call site, a second process — a homegrown limiter quietly stops protecting the limit, and declaring `throttle` (with `scope` and, across processes, a `store`) is what keeps the cap you wrote the cap the upstream sees.
+
+If you're weighing this against the interceptor stack you'd otherwise hand-write around axios, [axios alternatives in 2026](/blog/axios-alternatives) maps where a stitch fits.
+
+## Try it
+
+```bash
+npm i stitchapi
+```
+
+Declare a `throttle` on a stitch, set `scope: 'host'` to share the budget the way the provider counts, and pace under the limit instead of bouncing off it. The full field list and `scope` semantics are in the [Throttle guide](/docs/guides/resilience/throttle).

--- a/apps/docs/content/blog/retry-fetch-in-typescript.mdx
+++ b/apps/docs/content/blog/retry-fetch-in-typescript.mdx
@@ -1,0 +1,143 @@
+---
+title: 'How to Retry a Failed Fetch in TypeScript (the Right Way)'
+description: Native fetch has no retry, and the while-loop everyone copies retries the wrong things — non-idempotent writes, dead 4xx, no backoff. Here's a correct hand-rolled retry in plain TypeScript, the four pitfalls it has to dodge, and the one-line declarative version.
+author: Oleksandr Zhuravlov
+date: '2026-06-28'
+tags: [retry, fetch, typescript, resilience, http]
+---
+
+A call to `fetch` fails once with a `503`, the data was there a second ago, and a single retry would have saved the request — but native `fetch` has no retry, so the error surfaces straight to your caller. You reach for the obvious fix: wrap it in a loop. That loop is where most retry code goes wrong, because retrying correctly means deciding _what_ to retry, _how long_ to wait, and _when to stop_ — and the naive version answers all three badly.
+
+## Why `fetch` gives you nothing
+
+`fetch` rejects only on a network error — DNS failure, dropped connection, an aborted signal. A `429` or a `503` is a perfectly resolved promise with `response.ok === false`. So before you can retry anything you have to decide what counts as a failure, because the runtime won't tell you. That's the first thing a retry has to get right and the first thing a `try/catch` around `fetch` gets wrong: it never fires for the status codes you most want to retry.
+
+## The loop everyone writes first
+
+Here's the version that shows up in most codebases. It runs, and it's better than nothing:
+
+```ts
+async function fetchWithRetry(url: string, attempts = 3): Promise<Response> {
+    let lastError: unknown;
+    for (let i = 0; i < attempts; i++) {
+        try {
+            const res = await fetch(url);
+            if (res.ok) return res;
+            lastError = new Error(`HTTP ${res.status}`);
+        } catch (err) {
+            lastError = err;
+        }
+    }
+    throw lastError;
+}
+```
+
+It loops, it catches both rejection modes, it surfaces the last error. And it's wrong in four ways that only show up under load or against a misbehaving server — exactly when you needed the retry to be right.
+
+## The four pitfalls
+
+**No backoff means a thundering herd.** The loop above retries with no wait at all, hammering a struggling server as fast as the event loop allows. Add a fixed delay and you've fixed the rate but not the synchronization: when a dependency blips, every client that was mid-call retries on the _same_ schedule, so the recovering server gets a synchronized wall of traffic on each tick. The fix is exponential backoff — double the wait each attempt — plus **jitter**, a random spread on each delay so a thousand clients don't line up on the same millisecond.
+
+**Retrying a 4xx that will never succeed.** A `400` is a malformed request; a `401` is a missing credential; a `404` is a wrong path. None of them get better by trying again — retrying only delays the inevitable error by three round-trips and adds load for nothing. Retry the transient set (`429`, `502`, `503`, `504`) and let the rest fail fast.
+
+**Retrying a non-idempotent write.** This is the dangerous one. A `POST` that creates an order can time out _after_ the server committed the write but _before_ the response reached you. Retry it and you've created two orders. A retry policy that doesn't know which calls are safe to repeat will silently double-apply side effects under exactly the network conditions that triggered the retry. Reads are safe; blind writes are not.
+
+**Ignoring `Retry-After`.** When a server returns a `429` or a `503` it often tells you precisely when to come back, in a `Retry-After` header — either delta-seconds or an HTTP-date. Your computed backoff is a guess; that header is the answer. Ignoring it means you retry too early (and get rate-limited again) or too late (and wait longer than asked).
+
+## A correct-ish hand-rolled retry
+
+Fold all four in and the helper grows teeth. This one backs off exponentially with jitter, retries only a transient set, honors `Retry-After`, and stays a `GET` so repeating it is safe:
+
+```ts
+const RETRYABLE = new Set([429, 502, 503, 504]);
+
+function parseRetryAfter(res: Response): number | null {
+    const header = res.headers.get('retry-after');
+    if (!header) return null;
+    const seconds = Number(header);
+    if (!Number.isNaN(seconds)) return seconds * 1000;
+    const date = Date.parse(header);
+    return Number.isNaN(date) ? null : Math.max(0, date - Date.now());
+}
+
+async function fetchWithRetry(
+    url: string,
+    { attempts = 3, baseMs = 200, maxMs = 10_000 } = {},
+): Promise<Response> {
+    let lastError: unknown;
+    for (let i = 0; i < attempts; i++) {
+        try {
+            const res = await fetch(url);
+            if (res.ok) return res;
+            if (!RETRYABLE.has(res.status)) return res; // dead 4xx — fail fast
+            lastError = new Error(`HTTP ${res.status}`);
+
+            if (i < attempts - 1) {
+                const serverWait = parseRetryAfter(res);
+                const expo = Math.min(maxMs, baseMs * 2 ** i);
+                const jittered = Math.random() * expo;
+                await new Promise((r) => setTimeout(r, serverWait ?? jittered));
+            }
+        } catch (err) {
+            lastError = err;
+            if (i < attempts - 1) {
+                await new Promise((r) =>
+                    setTimeout(
+                        r,
+                        Math.random() * Math.min(maxMs, baseMs * 2 ** i),
+                    ),
+                );
+            }
+        }
+    }
+    throw lastError;
+}
+```
+
+That's the honest minimum, and it's a lot more than a `for` loop. It also still doesn't compose with a timeout (a hung attempt blocks the whole budget), it doesn't bound the _total_ time across attempts, and the moment you have a second endpoint you copy-paste it or thread the differences through arguments. The logic that decides whether to retry is now tangled into the function that makes the call.
+
+## The declarative version
+
+The retry policy isn't really code — it's data: a count, a status set, a backoff curve, a flag for `Retry-After`. A stitch lets you say exactly that data and keeps the deciding logic out of your call site. You declare the call once, with its retry policy as a field:
+
+```ts
+import { stitch } from 'stitchapi';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    retry: {
+        attempts: 3,
+        on: [429, 503],
+        backoff: 'expo-jitter',
+        baseMs: 200,
+        respectRetryAfter: true,
+    },
+});
+
+const user = await getUser({ id: '42' }); // retried, backed off, Retry-After honored
+```
+
+Every pitfall above is now a named field. `attempts` is the **total** number of tries including the first, so `attempts: 3` means up to two retries. `on` lists the status codes that trigger a retry — defaulting to the transient set `[429, 502, 503, 504]`, which is what keeps a dead `4xx` from being retried at all. `backoff: 'expo-jitter'` doubles the delay each attempt and spreads it randomly to break up the herd, paced from `baseMs` and clamped to `maxMs`; `'expo'` and `'fixed'` are there when you want a different curve. And `respectRetryAfter: true` uses the server's `Retry-After` header in place of the computed backoff when the response carries one.
+
+The non-idempotent-write pitfall doesn't vanish — nothing can make a blind `POST` retry safe — but it stops being a silent default. Adding `retry` to a write is a deliberate line you write, and the [retry guide](/docs/guides/resilience/retry) flags it: pair it with an idempotency key so the server collapses the duplicate, or leave retry off. The policy is declared where you can see it, not buried in a shared helper three files away.
+
+Because the policy lives on the definition, it composes instead of tangling. Each retry surfaces as a `progress` event on the [event stream](/docs/concepts/event-stream), so a trace shows every wait and re-attempt rather than a silent stall inside a loop. And the same declaration takes a `timeout` next to `retry` — a per-attempt budget and a total budget that the hand-rolled version never bounded — which is the composition the [circuit breakers and layered timeouts](/blog/circuit-breakers-and-layered-timeouts) post walks through end to end.
+
+## When a tiny retry helper is enough
+
+A stitch earns its keep when the retry policy is load-bearing and shared. It's overkill when it isn't:
+
+-   **One call site, one well-behaved endpoint.** If you retry a single internal `GET` that flakes once a month, the dozen lines above are clearer than a dependency. Keep them.
+-   **A script that runs once and exits.** No long-lived process, no fleet of clients, no thundering herd to break up — a fixed-delay loop is fine, and jitter is solving a problem you don't have.
+-   **You won't reuse the policy.** The argument for declaring retry as data is that the same data covers your next ten endpoints and stays visible at each call site. If there's no next endpoint, there's less to gain.
+
+The line is reuse and visibility. The moment "retry the transient set, back off with jitter, honor `Retry-After`, and don't you dare retry that `POST`" becomes a rule you want applied the same way across many calls — and want to _see_ applied, not trust by convention — it belongs on the definition, not copy-pasted into each call site. If you're arriving here from axios interceptors rather than raw `fetch`, the same trade is mapped out in [axios alternatives](/blog/axios-alternatives).
+
+## Try it
+
+```bash
+npm i stitchapi
+```
+
+Declare one endpoint with a `retry` field and the loop, the backoff math, the status-code allowlist, and the `Retry-After` parsing collapse into five lines of policy you can read at a glance. The full option list — every `backoff` curve, `baseMs`, `maxMs`, and the idempotency caveat — lives in [Retry & backoff](/docs/guides/resilience/retry).


### PR DESCRIPTION
## What

Three more blog posts from the [SEO editorial roadmap](docs/SEO-EDITORIAL-ROADMAP.md), each targeting a generic search query and routing it into the docs:

| Post | Target query | Stage |
|---|---|---|
| `retry-fetch-in-typescript.mdx` | "retry fetch typescript" | Implementation |
| `code-mode-vs-tool-calling.mdx` | "code mode mcp" | Awareness |
| `rate-limit-api-calls-typescript.mdx` | "rate limit api calls node" | Implementation |

Each teaches the generic problem honestly first, then shows the StitchAPI way, and includes an honest "when the simple tool is enough" section. Differentiated from the existing opinion pieces (`one-tool-per-endpoint`, `proactive-throttling-vs-reactive-429s`) and cross-linked to them.

## How they were produced

Drafted by subagents, each briefed with [EDITORIAL.md](apps/docs/EDITORIAL.md) and the **real API source docs** (the resilience guides + agent docs) to ground every example. Then verified on the main thread — not trusted blind:

- **No fabricated API fields** — grep-audited every `retry`/`throttle`/agent-tool token in the posts against the source docs (`expo-jitter`, `baseMs`, `maxMs`, `respectRetryAfter`, `rate`, `concurrency`, `scope`, `store`, `redisStore`, `seam`, `run_stitch`/`list_stitches`/`describe_stitch` — all real).
- **Links resolve** — `check:docs-links` passes; every `/docs/...` and `/blog/...` link confirmed (bare folder routes avoided).
- **Frontmatter valid** — `fumadocs-mdx` codegen accepts all three.
- **Render + discoverability** — all three return 200 locally and appear in `sitemap.xml`.
- **Prose** — EDITORIAL filler-word audit clean.
- `check:types` + format pass (pre-commit hook green).

Follow-up to #332, #336, #338.

🤖 Generated with [Claude Code](https://claude.com/claude-code)