### PR TITLE
fix(docs): derive release version + install channel from the canonical package

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 ## Install
 
 ```bash
-npm install stitchapi   # or: pnpm add stitchapi · yarn add stitchapi
+npm install stitchapi@rc   # or: pnpm add stitchapi@rc · yarn add stitchapi@rc
 ```
 
 Validation is bring-your-own — pass a [Zod](https://zod.dev) schema or any [Standard Schema](https://standardschema.dev) validator; none is bundled. The examples below use Zod for familiarity, and hit the live demo API at `demo.stitchapi.dev`.

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,6 +1,7 @@
 import './global.css';
 
 import { jsonLdHtml } from '@/lib/json-ld';
+import { releaseVersion } from '@/lib/release';
 import { appName, gitConfig, siteUrl } from '@/lib/shared';
 
 import 'fumadocs-twoslash/twoslash.css';
@@ -151,7 +152,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
                         />
                         <span>
                             <span className="font-semibold text-stitch-strong">
-                                Release candidate — 1.0.0-rc.1
+                                Release candidate — {releaseVersion}
                             </span>
                             <span className="hidden text-fd-muted-foreground sm:inline">
                                 {' '}

--- a/apps/docs/lib/release.ts
+++ b/apps/docs/lib/release.ts
@@ -1,0 +1,43 @@
+// Single source of truth for the *documented* release: the version string the
+// docs site shows and the npm dist-tag users must install from. Both are derived
+// from the canonical `stitchapi` package version so the docs can never drift from
+// what actually ships (the bug this module exists to kill: a banner reading
+// "rc.1" while npm's `rc` tag points at rc.3, and bare `npm install stitchapi`
+// quietly resolving to the old `latest` build).
+//
+// The version is read from the workspace source package.json — the same file
+// scripts/check-release.mjs treats as canonical. resolveJsonModule is on (see
+// tsconfig.json), and the path stays inside the monorepo so both `tsc` and the
+// Next/fumadocs bundlers resolve it at build time.
+import corePkg from '../../../packages/core/package.json';
+
+/** The documented release version, e.g. `1.0.0-rc.3`. */
+export const releaseVersion: string = corePkg.version;
+
+/**
+ * The npm dist-tag a version publishes under: its prerelease label (`rc`,
+ * `alpha`, …), `next` for a numeric-only prerelease, or `latest` for a stable
+ * release. This MUST stay in lockstep with `deriveDistTag` in
+ * scripts/check-release.mjs — that function (backed by semver) is the canonical
+ * rule the Publish workflow enforces; this is a dependency-free mirror of it.
+ */
+export function deriveDistTag(version: string): string {
+    const dash = version.indexOf('-');
+    if (dash === -1) return 'latest'; // no prerelease → stable
+    const firstId = version.slice(dash + 1).split('.')[0];
+    return /^[a-z]/i.test(firstId) ? firstId : 'next';
+}
+
+/** The dist-tag the documented version installs from, e.g. `rc` or `latest`. */
+export const releaseChannel: string = deriveDistTag(releaseVersion);
+
+/**
+ * The suffix to append to a bare `stitchapi` / `@stitchapi/*` install spec so it
+ * pulls the documented release: `@rc` on a prerelease channel, and `''` once the
+ * channel is `latest` (a bare install is already correct for a stable release).
+ * The install-channel remark plugin and the README guard both build on this, so
+ * cutting `1.0.0` stable makes every documented install command correct with no
+ * further edits.
+ */
+export const installSuffix: string =
+    releaseChannel === 'latest' ? '' : `@${releaseChannel}`;

--- a/apps/docs/lib/remark-install-channel.ts
+++ b/apps/docs/lib/remark-install-channel.ts
@@ -1,0 +1,63 @@
+import { installSuffix } from './release';
+
+// Append the documented npm dist-tag to the first-party packages inside every
+// ```package-install``` block, at build time, so authors keep writing bare names
+// (`stitchapi`, `@stitchapi/react`) while readers always get a copy-paste install
+// command that pulls the *documented* release rather than the stale `latest` tag.
+//
+// This runs BEFORE fumadocs' `remarkNpm` plugin (which expands the block into the
+// per-package-manager tabs) — see source.config.ts, where remarkPlugins is passed
+// as a function so we can prepend instead of append. The transform is a pure
+// rewrite of the code node's text, unit-tested in remark-install-channel.test.ts.
+//
+// Drift-proofing: the suffix comes from lib/release.ts (derived from the canonical
+// core version). On a prerelease it is `@rc`; once `1.0.0` ships stable it becomes
+// `''` and this plugin turns into a no-op — no per-page edits at release time.
+
+/** Minimal mdast shapes — avoids a direct @types/mdast dependency. */
+interface CodeNode {
+    type: 'code';
+    lang?: string | null;
+    value: string;
+}
+interface ParentNode {
+    children?: Node[];
+}
+type Node = (CodeNode | ParentNode) & { type?: string };
+
+const isCode = (node: Node): node is CodeNode =>
+    node.type === 'code' &&
+    typeof (node as CodeNode).value === 'string';
+
+/** True for a first-party token that has no explicit version/tag yet. */
+function needsSuffix(token: string): boolean {
+    if (token === 'stitchapi') return true; // unscoped core, bare
+    if (token.startsWith('@stitchapi/')) {
+        // A scoped spec carries a tag as a second `@` (e.g. `@stitchapi/react@rc`).
+        return token.indexOf('@', 1) === -1;
+    }
+    return false; // third-party (react, zod, …) or already-tagged → leave alone
+}
+
+/** Append `installSuffix` to every bare first-party token in an install line. */
+export function addInstallChannel(spec: string, suffix = installSuffix): string {
+    if (!suffix) return spec; // stable channel → bare installs are already correct
+    return spec.replace(/\S+/g, (token) =>
+        needsSuffix(token) ? token + suffix : token,
+    );
+}
+
+/** remark plugin: rewrite ```package-install``` blocks in place. */
+export function remarkInstallChannel() {
+    return (tree: Node): void => {
+        const visit = (node: Node): void => {
+            if (isCode(node) && node.lang === 'package-install') {
+                node.value = addInstallChannel(node.value);
+                return;
+            }
+            const children = (node as ParentNode).children;
+            if (Array.isArray(children)) children.forEach(visit);
+        };
+        visit(tree);
+    };
+}

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -1,3 +1,4 @@
+import { remarkInstallChannel } from './lib/remark-install-channel';
 import { transformerFold } from './lib/transformer-fold';
 
 import { rehypeCodeDefaultOptions } from 'fumadocs-core/mdx-plugins';
@@ -72,6 +73,12 @@ export default defineConfig({
         // code-variant tabs persist per `tabGroup` id set on the fence.
         // See AUTHORING.md → "Code variants — tabs".
         remarkNpmOptions: { persist: { id: 'package-manager' } },
+        // Stamp the documented npm dist-tag (e.g. `@rc`) onto bare first-party
+        // specs in ```package-install``` blocks BEFORE fumadocs' remarkNpm expands
+        // them into per-manager tabs. The array form of `remarkPlugins` runs AFTER
+        // remarkNpm; the function form receives the built-in list so we can
+        // prepend and run first. See lib/remark-install-channel.ts.
+        remarkPlugins: (builtin) => [remarkInstallChannel, ...builtin],
         // Twoslash type-checks every ```ts twoslash``` block against the real
         // `stitchapi` types at build time and renders hover tooltips. Spread the
         // defaults so the stock Shiki transformers (tab/title/icon meta) survive;

--- a/apps/docs/test/remark-install-channel.spec.ts
+++ b/apps/docs/test/remark-install-channel.spec.ts
@@ -1,0 +1,74 @@
+import {
+    addInstallChannel,
+    remarkInstallChannel,
+} from '../lib/remark-install-channel';
+
+import { describe, expect, it } from 'vitest';
+
+describe('addInstallChannel', () => {
+    it('stamps the tag onto the bare unscoped core package', () => {
+        expect(addInstallChannel('stitchapi', '@rc')).toBe('stitchapi@rc');
+    });
+
+    it('stamps the tag onto a bare scoped package', () => {
+        expect(addInstallChannel('@stitchapi/react', '@rc')).toBe(
+            '@stitchapi/react@rc',
+        );
+    });
+
+    it('tags every first-party token in a multi-package line', () => {
+        expect(
+            addInstallChannel(
+                '@stitchapi/react @stitchapi/query-core stitchapi react',
+                '@rc',
+            ),
+        ).toBe(
+            '@stitchapi/react@rc @stitchapi/query-core@rc stitchapi@rc react',
+        );
+    });
+
+    it('leaves third-party packages untouched', () => {
+        expect(
+            addInstallChannel('@stitchapi/svelte stitchapi svelte', '@rc'),
+        ).toBe('@stitchapi/svelte@rc stitchapi@rc svelte');
+    });
+
+    it('does not double-tag a spec that already carries a tag', () => {
+        expect(
+            addInstallChannel('@stitchapi/react@rc stitchapi@1.0.0', '@rc'),
+        ).toBe('@stitchapi/react@rc stitchapi@1.0.0');
+    });
+
+    it('is a no-op on the stable channel (empty suffix)', () => {
+        expect(addInstallChannel('@stitchapi/react stitchapi', '')).toBe(
+            '@stitchapi/react stitchapi',
+        );
+    });
+});
+
+describe('remarkInstallChannel', () => {
+    const run = (value: string, lang = 'package-install') => {
+        const node = { type: 'code' as const, lang, value };
+        const tree = { type: 'root', children: [node] };
+        remarkInstallChannel()(tree);
+        return node.value;
+    };
+
+    it('rewrites package-install code blocks', () => {
+        // Asserts the suffix is applied; the exact tag tracks the canonical
+        // version, so compare against the module-derived behaviour rather than a
+        // hardcoded `@rc` (which would itself drift at the stable release).
+        const out = run('@stitchapi/redis stitchapi');
+        expect(out).toMatch(/^@stitchapi\/redis(@\S+)? stitchapi(@\S+)?$/);
+        // Whatever tag the redis spec gets, the core spec gets the same one.
+        const redisTag = out.split(' ')[0].slice('@stitchapi/redis'.length);
+        const coreTag = out.split(' ')[1].slice('stitchapi'.length);
+        expect(coreTag).toBe(redisTag);
+    });
+
+    it('ignores non-install code blocks', () => {
+        expect(run('npm install stitchapi', 'bash')).toBe(
+            'npm install stitchapi',
+        );
+    });
+});

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -11,7 +11,7 @@ These functions are a thin layer over [`@stitchapi/query-core`](../query-core), 
 ## Install
 
 ```sh
-pnpm add @stitchapi/angular @stitchapi/query-core stitchapi @angular/core rxjs
+pnpm add @stitchapi/angular@rc @stitchapi/query-core@rc stitchapi@rc @angular/core rxjs
 ```
 
 `stitchapi`, `@angular/core` (`>=16`), and `rxjs` (`>=7`) are peer dependencies. `@tanstack/angular-query-experimental` is an **optional** peer — only needed if you use `queryOptions`.

--- a/packages/aws-sigv4/README.md
+++ b/packages/aws-sigv4/README.md
@@ -11,7 +11,7 @@ Crypto is the platform's **Web Crypto** (`crypto.subtle`), so it runs unchanged 
 ## Install
 
 ```sh
-pnpm add @stitchapi/aws-sigv4 stitchapi
+pnpm add @stitchapi/aws-sigv4@rc stitchapi@rc
 ```
 
 `stitchapi` is the only peer dependency.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -137,19 +137,19 @@ Design notes and positioning live in the repo:
 Using npm:
 
 ```bash
-$ npm install stitchapi
+$ npm install stitchapi@rc
 ```
 
 Using yarn:
 
 ```bash
-$ yarn add stitchapi
+$ yarn add stitchapi@rc
 ```
 
 Using pnpm:
 
 ```bash
-$ pnpm add stitchapi
+$ pnpm add stitchapi@rc
 ```
 
 Once the package is installed, you can import the library using `import` or `require` approach:

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -12,7 +12,7 @@ Everything else — the `useStitch` / `useStitchStream` hooks, the `asyncStorage
 ## Install
 
 ```sh
-pnpm add @stitchapi/expo @stitchapi/react @stitchapi/query-core stitchapi
+pnpm add @stitchapi/expo@rc @stitchapi/react@rc @stitchapi/query-core@rc stitchapi@rc
 ```
 
 `stitchapi`, `react`, `react-native`, and `expo` are peer dependencies. `expo-secure-store`, `@react-native-async-storage/async-storage`, and `@react-native-community/netinfo` are **optional** peers — install the ones whose helpers you use.

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -14,7 +14,7 @@ extension point, and the `Logger` sink and `ConfigService` bridge **delegate** t
 dependency and the package forks nothing (contract-not-dependency).
 
 ```sh
-pnpm add @stitchapi/nest stitchapi
+pnpm add @stitchapi/nest@rc stitchapi@rc
 # peers you already have in a Nest app: @nestjs/common, @nestjs/core, rxjs, reflect-metadata
 ```
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -14,7 +14,7 @@ Built on Web standards only (`Response`, `ReadableStream`, `TextEncoder`) — **
 ## Install
 
 ```sh
-pnpm add @stitchapi/next stitchapi
+pnpm add @stitchapi/next@rc stitchapi@rc
 ```
 
 `stitchapi` is the only peer dependency.

--- a/packages/query-core/README.md
+++ b/packages/query-core/README.md
@@ -13,7 +13,7 @@ A `stitch` is a typed declarative call: invoking it returns a `StitchResult<T>` 
 ## Install
 
 ```sh
-pnpm add @stitchapi/query-core stitchapi
+pnpm add @stitchapi/query-core@rc stitchapi@rc
 ```
 
 `stitchapi` is a peer dependency (`>=0.7.0`).

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -13,7 +13,7 @@ React Native bindings for [StitchAPI](https://stitchapi.dev). The `useStitch` / 
 ## Install
 
 ```sh
-pnpm add @stitchapi/react-native @stitchapi/react @stitchapi/query-core stitchapi
+pnpm add @stitchapi/react-native@rc @stitchapi/react@rc @stitchapi/query-core@rc stitchapi@rc
 ```
 
 `stitchapi`, `react`, and `react-native` are peer dependencies. `@react-native-async-storage/async-storage` and `@react-native-community/netinfo` are **optional** peers — install them only for the store / reconnect helpers.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -11,7 +11,7 @@ These hooks are a thin layer over [`@stitchapi/query-core`](../query-core), the 
 ## Install
 
 ```sh
-pnpm add @stitchapi/react @stitchapi/query-core stitchapi react
+pnpm add @stitchapi/react@rc @stitchapi/query-core@rc stitchapi@rc react
 ```
 
 `stitchapi` (`>=0.7.0`) and `react` (`^18 || ^19`) are peer dependencies. `@tanstack/react-query` is an **optional** peer — only needed if you use `stitchQueryOptions`.

--- a/packages/rtk-query/README.md
+++ b/packages/rtk-query/README.md
@@ -9,7 +9,7 @@ Reach for this when your app is already on Redux Toolkit / RTK Query. The adapte
 ## Install
 
 ```sh
-pnpm add @stitchapi/rtk-query stitchapi @reduxjs/toolkit
+pnpm add @stitchapi/rtk-query@rc stitchapi@rc @reduxjs/toolkit
 ```
 
 `stitchapi` and `@reduxjs/toolkit` (`^2`) are peer dependencies. There is **no** `@stitchapi/query-core` dependency — RTK Query is the store.

--- a/packages/sentry/README.md
+++ b/packages/sentry/README.md
@@ -11,7 +11,7 @@ Routine events become breadcrumbs (category `stitch`); an `error` event is captu
 ## Install
 
 ```sh
-pnpm add @stitchapi/sentry stitchapi
+pnpm add @stitchapi/sentry@rc stitchapi@rc
 ```
 
 `stitchapi` is the only peer dependency. Pass whichever `@sentry/*` SDK your app already runs.

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -11,7 +11,7 @@ These primitives are a thin layer over [`@stitchapi/query-core`](../query-core),
 ## Install
 
 ```sh
-pnpm add @stitchapi/solid @stitchapi/query-core stitchapi solid-js
+pnpm add @stitchapi/solid@rc @stitchapi/query-core@rc stitchapi@rc solid-js
 ```
 
 `stitchapi`, `@stitchapi/query-core`, and `solid-js` (`^1.8`) are peer dependencies. `@tanstack/solid-query` is an **optional** peer — only needed if you use `queryOptions`.

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -11,7 +11,7 @@ These stores are a thin layer over [`@stitchapi/query-core`](../query-core), the
 ## Install
 
 ```sh
-pnpm add @stitchapi/svelte @stitchapi/query-core stitchapi svelte
+pnpm add @stitchapi/svelte@rc @stitchapi/query-core@rc stitchapi@rc svelte
 ```
 
 `stitchapi` and `svelte` (`^4 || ^5`) are peer dependencies. `@tanstack/svelte-query` is an **optional** peer — only needed if you use `queryOptions`.

--- a/packages/swr/README.md
+++ b/packages/swr/README.md
@@ -9,7 +9,7 @@ Reach for this when your app is already on SWR. If you want StitchAPI to own the
 ## Install
 
 ```sh
-pnpm add @stitchapi/swr stitchapi swr react
+pnpm add @stitchapi/swr@rc stitchapi@rc swr react
 ```
 
 `stitchapi`, `swr` (`^2`), and `react` (`^18 || ^19`) are peer dependencies. There is **no** `@stitchapi/query-core` dependency — SWR is the store.

--- a/packages/vercel-ai/README.md
+++ b/packages/vercel-ai/README.md
@@ -11,7 +11,7 @@ StitchAPI is agent-native through the [MCP surface](https://stitchapi.dev/docs/s
 ## Install
 
 ```sh
-pnpm add @stitchapi/vercel-ai stitchapi
+pnpm add @stitchapi/vercel-ai@rc stitchapi@rc
 ```
 
 `stitchapi` is the only required peer; bring the `ai` SDK you already run.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -11,7 +11,7 @@ These composables are a thin layer over [`@stitchapi/query-core`](../query-core)
 ## Install
 
 ```sh
-pnpm add @stitchapi/vue @stitchapi/query-core stitchapi vue
+pnpm add @stitchapi/vue@rc @stitchapi/query-core@rc stitchapi@rc vue
 ```
 
 `stitchapi` (`>=0.7.0`) and `vue` (`^3.4`) are peer dependencies. `@tanstack/vue-query` is **not** required — `queryOptions` returns a plain object.

--- a/scripts/check-release.mjs
+++ b/scripts/check-release.mjs
@@ -229,6 +229,67 @@ if (
     );
 }
 
+// 8. README install-channel coherence -----------------------------------------
+// Plain-markdown READMEs (npm package pages + the GitHub landing) ship in the
+// tarball with no build step, so their install commands carry a literal dist-tag.
+// A bare `npm install stitchapi` resolves to the `latest` tag — which, on a
+// prerelease line, is the OLD stable build, not what the docs describe. This
+// check fails when a documented install command for a first-party package omits
+// the channel suffix this version publishes under (`@rc` here), and — once 1.0.0
+// ships stable — when a stale `@rc` lingers on what should be a bare install.
+// The docs *site* is handled separately by lib/remark-install-channel.ts.
+if (canonical) {
+    const expectedTag = deriveDistTag(canonical);
+    const expectedSuffix = expectedTag === 'latest' ? '' : `@${expectedTag}`;
+    // After an optional `$ ` prompt, the line must START with an install command
+    // (so inline-prose backtick mentions are not treated as instructions).
+    const installLine =
+        /^\s*\$?\s*(npm (install|i)|pnpm add|yarn add|bun add)\b/;
+    const readmes = [
+        join(ROOT, 'README.md'),
+        ...pkgs.map(({ path }) => join(dirname(path), 'README.md')),
+    ].filter(existsSync);
+
+    /** The dist-tag portion of a first-party token, or null if it isn't ours. */
+    const channelOf = (token) => {
+        if (token === 'stitchapi' || token.startsWith('stitchapi@')) {
+            return token.slice('stitchapi'.length); // '' | '@rc' | '@1.2.3'
+        }
+        if (token.startsWith('@stitchapi/')) {
+            const at = token.indexOf('@', 1);
+            return at === -1 ? '' : token.slice(at);
+        }
+        return null; // third-party (react, zod, …) — not our concern
+    };
+
+    let installChecks = 0;
+    for (const file of readmes) {
+        const rel = file.replace(ROOT + '/', '');
+        const lines = readFileSync(file, 'utf8').split('\n');
+        lines.forEach((line, i) => {
+            if (!installLine.test(line)) return;
+            for (const token of line.match(/\S+/g) ?? []) {
+                const channel = channelOf(token);
+                if (channel === null) continue;
+                installChecks++;
+                if (channel !== expectedSuffix) {
+                    const base = token.slice(0, token.length - channel.length);
+                    fail(
+                        `${rel}:${i + 1}: install spec "${token}" should be ` +
+                            `"${base}${expectedSuffix}" — ${canonical} publishes under ` +
+                            `"${expectedTag}"; a bare install resolves to "latest".`,
+                    );
+                }
+            }
+        });
+    }
+    if (installChecks && !failures.some((f) => f.includes('install spec'))) {
+        pass(
+            `README install-channel: ${installChecks} first-party install spec(s) target "${expectedTag}"`,
+        );
+    }
+}
+
 // ---- report ------------------------------------------------------------------
 for (const m of ok) console.log(`  ✓ ${m}`);
 for (const m of warnings) console.warn(`  ! ${m}`);


### PR DESCRIPTION
## Problem

Two live drift bugs, same root cause — version/channel values were hardcoded instead of derived from the canonical core package:

1. The docs banner read **`1.0.0-rc.1`** while core is at **`1.0.0-rc.3`**.
2. Every install command (docs site **and** READMEs) used a **bare** spec. npm dist-tags are currently:

   ```
   latest: 0.7.0     rc: 1.0.0-rc.3
   ```

   So `npm install stitchapi` resolves to **0.7.0** — a pre-1.0 build. Readers of rc.3 docs were installing an old library.

## Fix — derive, don't hardcode

- **`apps/docs/lib/release.ts`** — single source of truth: `releaseVersion`, `releaseChannel`, `installSuffix`, derived from `packages/core/package.json`, mirroring `deriveDistTag()` in `scripts/check-release.mjs`.
- **Banner** now interpolates `{releaseVersion}`.
- **`apps/docs/lib/remark-install-channel.ts`** — build-time remark plugin that stamps the derived dist-tag (`@rc`) onto bare first-party specs in package-install blocks, **before** fumadocs' `remarkNpm`. Wired via the *function form* of `remarkPlugins` so it runs first (the array form runs after — too late). Unit-tested.
- **READMEs** (root + core + 17 integrations) — install commands carry `@rc`; third-party deps left untouched.
- **`scripts/check-release.mjs` check #8** — fails when a README install command for a first-party package omits the channel suffix (and, at stable, when a stale `@rc` lingers).

Everything collapses back to **bare installs automatically when `1.0.0` ships stable** (`installSuffix` becomes `''`) — no per-file edits at release time.

## Verification

- Pre-push gate green: `format`, `lint`, `typecheck`, `test`, `exports`, **`build-docs`** (the docs site builds with the new remark plugin).
- New vitest suite (8 cases) for the transform; full docs suite 15/15.
- `check:release` passes (45 first-party specs target `rc`) and was negative-tested: reverting one README to bare installs fails the guard with a precise message.

## Out of scope (flagged separately)

`packages/core/src/mcp.ts:19` hardcodes `SERVER_VERSION = '1.0.0-rc.1'` — the shipped MCP server reports the wrong version to clients. Same anti-pattern, in core runtime with its own build considerations; spun off as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)