### PR TITLE
fix(mcp): derive MCP server version from package.json (kill version drift)

### DIFF
--- a/packages/core/src/mcp.ts
+++ b/packages/core/src/mcp.ts
@@ -16,7 +16,11 @@ import type { Readable, Writable } from 'node:stream';
 
 const PROTOCOL_VERSION = '2025-06-18';
 const SERVER_NAME = 'stitchapi';
-const SERVER_VERSION = '1.0.0-rc.1';
+// Derived at build time from packages/core/package.json `version` via an esbuild
+// `define` (see tsup.config.ts / vitest.config.ts and src/version.d.ts), so the
+// version the MCP server reports can never drift from the published release. An
+// explicit `info.version` from the caller still wins (see `createMcpServer`).
+const SERVER_VERSION = __PKG_VERSION__;
 
 export interface JsonRpcMessage {
     jsonrpc: '2.0';

--- a/packages/core/src/version.d.ts
+++ b/packages/core/src/version.d.ts
@@ -1,0 +1,10 @@
+// Build-time constant: the canonical `stitchapi` package version, injected by
+// esbuild `define` so the shipped library never hardcodes (and never drifts from)
+// the real release. The value is the `version` field of packages/core/package.json,
+// stringified at build time:
+//   - tsup.config.ts defines it for both the library and CLI bundles
+//   - vitest.config.ts defines it so the test run sees the same value
+// `tsc` only needs to know the identifier exists and is a string — it does not
+// perform the substitution. There is no runtime fallback by design: every path
+// that executes this code (tsup output, vitest) performs the `define`.
+declare const __PKG_VERSION__: string;

--- a/packages/core/test/mcp.spec.ts
+++ b/packages/core/test/mcp.spec.ts
@@ -6,10 +6,21 @@ import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
 import { asValidator } from './support/schema';
 
+import { readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PassThrough, type Readable } from 'node:stream';
 import { z } from 'zod';
+
+// The canonical version, read straight from package.json on disk (NOT the build-time
+// `__PKG_VERSION__` define) so this asserts the reported version actually tracks the
+// published release rather than testing the define against itself. vitest runs with
+// packages/core as the cwd.
+const PKG_VERSION = (
+    JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8')) as {
+        version: string;
+    }
+).version;
 
 process.env['STITCH_TRACE_FILE'] = join(
     tmpdir(),
@@ -65,11 +76,24 @@ test('initialize advertises tools capability and server info', async () => {
     const result = res?.result as {
         protocolVersion: string;
         capabilities: { tools?: unknown };
-        serverInfo: { name: string };
+        serverInfo: { name: string; version: string };
     };
     expect(result.protocolVersion).toBe('x'); // echoes the client's version
     expect(result.capabilities.tools).toBeDefined();
     expect(result.serverInfo.name).toBe('stitchapi');
+    // The reported version is derived from package.json at build time, so it can
+    // never drift from the published release (the bug this guards against).
+    expect(result.serverInfo.version).toBe(PKG_VERSION);
+});
+
+test('an explicit info.version overrides the derived package version', async () => {
+    const custom = createMcpServer({}, { version: '9.9.9-custom' });
+    const res = await custom.handle(
+        req('initialize', { protocolVersion: 'x' }),
+    );
+    const result = res?.result as { serverInfo: { version: string } };
+    expect(result.serverInfo.version).toBe('9.9.9-custom');
+    expect(result.serverInfo.version).not.toBe(PKG_VERSION);
 });
 
 test('tools/list returns the single code-mode tool (+ discovery + describe)', async () => {

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,4 +1,13 @@
+import { version } from './package.json';
+
 import { defineConfig } from 'tsup';
+
+// Inject the canonical package version as a build-time constant so the shipped
+// library never hardcodes it (and never drifts from the published release). Used
+// by src/mcp.ts for the version the MCP server reports; declared for `tsc` in
+// src/version.d.ts and mirrored in vitest.config.ts so the test run sees it too.
+// This stays a literal substitution — package.json is NOT pulled into the bundle.
+const define = { __PKG_VERSION__: JSON.stringify(version) };
 
 // Two bundles from one source tree:
 //   lib/index.{js,mjs} (+ .d.ts) — the library (function surface), dual-format + types
@@ -37,13 +46,17 @@ export default defineConfig([
         dts: true,
         outDir: 'lib',
         clean: true,
+        define,
     },
     {
+        // The CLI bundle pulls in src/mcp.ts (via serveStdio), so it needs the
+        // same version define.
         entry: ['src/cli.ts'],
         format: ['cjs'],
         minify: true,
         dts: false,
         outDir: 'lib',
         clean: false,
+        define,
     },
 ]);

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,6 +1,12 @@
+import { version } from './package.json';
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+    // Mirror the tsup `define` so the test run sees the same build-time version
+    // constant the shipped bundle does (src/mcp.ts → SERVER_VERSION). Kept in
+    // lockstep with tsup.config.ts; sourced from the canonical package.json.
+    define: { __PKG_VERSION__: JSON.stringify(version) },
     test: {
         globals: true,
         environment: 'node',


### PR DESCRIPTION
## Problem

`packages/core/src/mcp.ts` hardcoded `const SERVER_VERSION = '1.0.0-rc.1'`, used at `version: info.version ?? SERVER_VERSION` as the version the StitchAPI MCP server reports to clients. The package is at `1.0.0-rc.3`, so MCP clients were told the wrong version — the same version-drift class just fixed for the docs site.

## Fix

Derive the version from the canonical `packages/core/package.json` `version` field via a build-time `__PKG_VERSION__` constant injected by esbuild `define`, so it can never drift again.

- **`tsup.config.ts`** — `define: { __PKG_VERSION__: JSON.stringify(version) }` on **both** bundles (the CLI bundle pulls in `mcp.ts` via `serveStdio`). Only the version *string literal* is injected; the whole `package.json` is **not** bundled (verified: no `keywords`/`description` metadata appears in `lib/`).
- **`vitest.config.ts`** — mirrors the `define` so the test run sees the same value.
- **`src/version.d.ts`** — declares the global so `tsc` is happy (no runtime fallback by design: every execution path — tsup output, vitest — performs the `define`).
- **`src/mcp.ts`** — `SERVER_VERSION = __PKG_VERSION__`. `info.version ?? SERVER_VERSION` semantics preserved: an explicit caller-provided version still wins.

## Tests

Extended `test/mcp.spec.ts`:
- `initialize` now asserts `serverInfo.version` equals the on-disk `package.json` version (read via `fs`, **not** the define, so the assertion is genuinely drift-proof).
- New test: an explicit `info.version` overrides the derived version.

## Verification

- `pnpm check:types` ✅ · `pnpm test` (1080 pass) ✅ · `pnpm check:lint` ✅
- `pnpm build` → `lib/mcp.js`, `lib/mcp.mjs`, `lib/cli.js` all contain the injected `1.0.0-rc.3`; no stale `1.0.0-rc.1` remains; no `package.json` metadata inlined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)