### PR TITLE
feat(docs): render npm nav link as an icon to match GitHub

### DIFF
--- a/apps/docs/app/(home)/components/primitives.tsx
+++ b/apps/docs/app/(home)/components/primitives.tsx
@@ -71,6 +71,19 @@ export function GithubIcon({ className }: { className?: string }) {
     );
 }
 
+export function NpmIcon({ className }: { className?: string }) {
+    return (
+        <svg
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+            className={cn('size-4', className)}
+        >
+            <path d="M1.763 0C.786 0 0 .786 0 1.763v20.474C0 23.214.786 24 1.763 24h20.474c.977 0 1.763-.786 1.763-1.763V1.763C24 .786 23.214 0 22.237 0zM5.13 5.323l13.837.019-.009 13.836h-3.464l.01-10.382h-3.456L12.04 19.17H5.113z" />
+        </svg>
+    );
+}
+
 const buttonBase =
     'inline-flex items-center justify-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-colors';
 

--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -1,5 +1,6 @@
 import { gitConfig } from './shared';
 
+import { NpmIcon } from '@/app/(home)/components/primitives';
 import { Logo } from '@/components/logo';
 
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
@@ -24,6 +25,9 @@ export function baseOptions(): BaseLayoutProps {
                 url: '/playground',
             },
             {
+                type: 'icon',
+                label: 'npm',
+                icon: <NpmIcon />,
                 text: 'npm',
                 url: 'https://www.npmjs.com/package/stitchapi',
                 external: true,


### PR DESCRIPTION
## What

The docs site nav had **GitHub** as an icon button in the right-side secondary cluster, but **npm** sat in the primary nav as plain text alongside Docs / Blog / Playground. Since both are "where the project lives" affordances, this groups them: npm now renders as a matching icon button next to GitHub.

## How

- Add a hand-rolled `NpmIcon` SVG next to the existing `GithubIcon` in [primitives.tsx](apps/docs/app/(home)/components/primitives.tsx) — same `viewBox`, `fill="currentColor"`, `size-4`. (lucide-react dropped brand icons, which is exactly why `GithubIcon` is custom too.)
- Convert the npm entry in [layout.shared.tsx](apps/docs/lib/layout.shared.tsx) from a text link to a Fumadocs `type: 'icon'` link (`secondary` defaults true → renders in the GitHub cluster).

## Verification

- `check:lint` and `check:types` pass (full pre-commit hook ran format + monorepo typecheck + docs build).
- Ran the docs dev server rooted in the worktree and confirmed via SSR HTML: the npm anchor now carries the **identical** icon-button classes and `aria-label` as the GitHub anchor, sits in the secondary cluster, and the old primary-nav text "npm" link is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)