### PR TITLE
fix(docs): add npm link to home page footer

### DIFF
--- a/apps/docs/app/(home)/components/cta.tsx
+++ b/apps/docs/app/(home)/components/cta.tsx
@@ -1,7 +1,7 @@
 import { BrandBackdrop } from './brand-backdrop';
 import { PrimaryButton } from './primitives';
 
-import { gitConfig } from '@/lib/shared';
+import { gitConfig, npmUrl } from '@/lib/shared';
 
 import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
@@ -54,6 +54,14 @@ export function Footer() {
                         className="transition-colors hover:text-fd-foreground"
                     >
                         GitHub
+                    </a>
+                    <a
+                        href={npmUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="transition-colors hover:text-fd-foreground"
+                    >
+                        npm
                     </a>
                     <Link
                         href="/docs/reference/stitch"

--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -1,4 +1,4 @@
-import { gitConfig } from './shared';
+import { gitConfig, npmUrl } from './shared';
 
 import { NpmIcon } from '@/app/(home)/components/primitives';
 import { Logo } from '@/components/logo';
@@ -29,7 +29,7 @@ export function baseOptions(): BaseLayoutProps {
                 label: 'npm',
                 icon: <NpmIcon />,
                 text: 'npm',
-                url: 'https://www.npmjs.com/package/stitchapi',
+                url: npmUrl,
                 external: true,
             },
         ],

--- a/apps/docs/lib/shared.ts
+++ b/apps/docs/lib/shared.ts
@@ -10,6 +10,8 @@ export const docsContentRoute = '/llms.mdx/docs';
 
 export const blogRoute = '/blog';
 
+export const npmUrl = 'https://www.npmjs.com/package/stitchapi';
+
 // GitHub repository, used for "edit on GitHub" / source links.
 export const gitConfig = {
     user: 'rejifald',


### PR DESCRIPTION
## Summary

- Adds an `npm` link to the home page footer alongside the existing GitHub and Docs links
- Extracts `npmUrl` into `lib/shared.ts` as a single source of truth
- Updates `lib/layout.shared.tsx` (nav icon) to use the shared constant instead of the hardcoded string

🤖 Generated with [Claude Code](https://claude.com/claude-code)