### PR TITLE
feat(graphql): send operationName with GraphQL requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ npm release are grouped under the in-development version that introduced them.
 
 ## [Unreleased]
 
+### Added
+
+-   **GraphQL `operationName`.** The `graphql` surface now sends `operationName`
+    alongside `{ query, variables }`, derived from the first named operation in
+    the document (anonymous documents omit it, matching `graphql-request`). A new
+    `operationName` config key overrides the derived value for multi-operation
+    documents, or suppresses the field entirely with `''`. This restores parity
+    with conventional GraphQL clients so servers, logs, APM, and request mocks
+    that key on the operation name see it again.
+
 ## [1.0.0-rc.3] — 2026-06-21
 
 ### Added — the integration ecosystem

--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -84,6 +84,12 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             info: "GraphQL query string (`kind: 'graphql'`).",
         },
         {
+            label: "operationName",
+            type: "property",
+            detail: "string",
+            info: "GraphQL `operationName` sent alongside `query` + `variables` (`kind: 'graphql'`). Omit to derive it from the first named operation in `query`; set it explicitly to override (e.g. a multi-operation document) or pass `''` to suppress the field entirely.",
+        },
+        {
             label: "input",
             type: "property",
             detail: "InputSchemas",

--- a/packages/core/src/surface.ts
+++ b/packages/core/src/surface.ts
@@ -102,30 +102,26 @@ export interface Surface<TInput = StitchInput, TResult = unknown> {
 /** The default surface: a plain JSON-over-HTTP call. Selected whenever `kind` is omitted. */
 export const httpSurface: Surface = { id: 'http' };
 
-// Derive the GraphQL `operationName` the way graphql clients (e.g. graphql-request) do: the name
-// token of the first named operation in the document. Anonymous documents (`{ ... }`, or `query (
-// $id: ID) { ... }` with variables but no name) yield `undefined`, so no `operationName` is sent.
-// A literal keyword in a field/comment can't match — the keyword must be a word-boundary-delimited
-// `query|mutation|subscription` followed by whitespace and a name. Pass `cfg.operationName` to
-// override (a multi-operation document, or `''` to suppress).
-const OPERATION_NAME_RE =
-    /(?:^|[^_0-9A-Za-z])(?:query|mutation|subscription)\s+([_A-Za-z][_0-9A-Za-z]*)/;
-function deriveOperationName(query: string): string | undefined {
-    return OPERATION_NAME_RE.exec(query)?.[1];
-}
-
 /**
  * GraphQL-over-HTTP. Its behaviour lives entirely in these hooks (ADR 0005 Stage 4): `buildRequest`
  * packs `{ query, variables, operationName? }` as JSON and forces POST; `interpret` treats a 200
  * carrying `errors` as a failure. The `data` unwrap is a plain config key the `graphql(...)` helper
  * / `seam.graphql()` set (the engine applies it after `interpret`), as is the `/graphql` default
  * path.
+ *
+ * `operationName` is derived the way graphql clients (e.g. graphql-request) do: the name token of
+ * the first named operation. The keyword must be on a `\b` word boundary and followed by whitespace
+ * and a name (`\w+`), so a field/type that merely starts with a keyword can't match; anonymous
+ * documents (`{ ... }`, or `query ($id: ID) { ... }` with no name) yield no key. Set
+ * `cfg.operationName` to override (a multi-operation document, or `''` to suppress).
  */
 export const graphqlSurface: Surface = {
     id: 'graphql',
     buildRequest: (cfg, input, base) => {
         const query = cfg.query ?? '';
-        const operationName = cfg.operationName ?? deriveOperationName(query);
+        const operationName =
+            cfg.operationName ??
+            /\b(?:query|mutation|subscription)\s+(\w+)/.exec(query)?.[1];
         return {
             ...base,
             method: (cfg.method ?? 'POST').toUpperCase(),

--- a/packages/core/src/surface.ts
+++ b/packages/core/src/surface.ts
@@ -102,23 +102,43 @@ export interface Surface<TInput = StitchInput, TResult = unknown> {
 /** The default surface: a plain JSON-over-HTTP call. Selected whenever `kind` is omitted. */
 export const httpSurface: Surface = { id: 'http' };
 
+// Derive the GraphQL `operationName` the way graphql clients (e.g. graphql-request) do: the name
+// token of the first named operation in the document. Anonymous documents (`{ ... }`, or `query (
+// $id: ID) { ... }` with variables but no name) yield `undefined`, so no `operationName` is sent.
+// A literal keyword in a field/comment can't match — the keyword must be a word-boundary-delimited
+// `query|mutation|subscription` followed by whitespace and a name. Pass `cfg.operationName` to
+// override (a multi-operation document, or `''` to suppress).
+const OPERATION_NAME_RE =
+    /(?:^|[^_0-9A-Za-z])(?:query|mutation|subscription)\s+([_A-Za-z][_0-9A-Za-z]*)/;
+function deriveOperationName(query: string): string | undefined {
+    return OPERATION_NAME_RE.exec(query)?.[1];
+}
+
 /**
  * GraphQL-over-HTTP. Its behaviour lives entirely in these hooks (ADR 0005 Stage 4): `buildRequest`
- * packs `{ query, variables }` as JSON and forces POST; `interpret` treats a 200 carrying `errors`
- * as a failure. The `data` unwrap is a plain config key the `graphql(...)` helper / `seam.graphql()`
- * set (the engine applies it after `interpret`), as is the `/graphql` default path.
+ * packs `{ query, variables, operationName? }` as JSON and forces POST; `interpret` treats a 200
+ * carrying `errors` as a failure. The `data` unwrap is a plain config key the `graphql(...)` helper
+ * / `seam.graphql()` set (the engine applies it after `interpret`), as is the `/graphql` default
+ * path.
  */
 export const graphqlSurface: Surface = {
     id: 'graphql',
-    buildRequest: (cfg, input, base) => ({
-        ...base,
-        method: (cfg.method ?? 'POST').toUpperCase(),
-        bodyType: 'json',
-        body: {
-            query: cfg.query ?? '',
-            variables: input.variables ?? input.body ?? {},
-        },
-    }),
+    buildRequest: (cfg, input, base) => {
+        const query = cfg.query ?? '';
+        const operationName = cfg.operationName ?? deriveOperationName(query);
+        return {
+            ...base,
+            method: (cfg.method ?? 'POST').toUpperCase(),
+            bodyType: 'json',
+            body: {
+                query,
+                variables: input.variables ?? input.body ?? {},
+                // Only carry the key when a name is known — anonymous documents omit it, matching
+                // graphql-request and keeping the body clean. `cfg.operationName: ''` suppresses it.
+                ...(operationName ? { operationName } : {}),
+            },
+        };
+    },
     interpret: (res) => {
         const errs = (
             res.body as { errors?: { message?: string }[] } | null | undefined

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -553,6 +553,12 @@ export interface StitchConfig {
     headers?: Record<string, string>;
     /** GraphQL query string (`kind: 'graphql'`). */
     query?: string;
+    /**
+     * GraphQL `operationName` sent alongside `query` + `variables` (`kind: 'graphql'`). Omit to
+     * derive it from the first named operation in `query`; set it explicitly to override (e.g. a
+     * multi-operation document) or pass `''` to suppress the field entirely.
+     */
+    operationName?: string;
     /** Schemas validating params, query, body, headers, and (GraphQL) variables before the request. */
     input?: InputSchemas;
     /**

--- a/packages/core/test/surface-graphql-hooks.spec.ts
+++ b/packages/core/test/surface-graphql-hooks.spec.ts
@@ -15,7 +15,9 @@ import type {
     StitchInput,
 } from '../src/types';
 
-const cfg = (o: { query?: string; method?: string } = {}): StitchConfig => o;
+const cfg = (
+    o: { query?: string; method?: string; operationName?: string } = {},
+): StitchConfig => o;
 
 const base: AdapterRequest = {
     url: 'https://api.test/graphql',
@@ -75,6 +77,79 @@ describe('graphqlSurface.buildRequest', () => {
     test('honours and upper-cases a configured method', () => {
         const req = build(cfg({ query: 'q', method: 'put' }), {});
         expect(req.method).toBe('PUT');
+    });
+
+    test('derives operationName from the first named operation in the query', () => {
+        const req = build(
+            cfg({
+                query: 'query findScene($id: ID!) { scene(id: $id) { id } }',
+            }),
+            { variables: { id: 's1' } },
+        );
+        expect(req.body).toEqual({
+            query: 'query findScene($id: ID!) { scene(id: $id) { id } }',
+            variables: { id: 's1' },
+            operationName: 'findScene',
+        });
+    });
+
+    test('derives the name across mutation/subscription too', () => {
+        expect(
+            (
+                build(
+                    cfg({ query: 'mutation Login($p: P!) { login(p: $p) }' }),
+                    {},
+                ).body as {
+                    operationName?: string;
+                }
+            ).operationName,
+        ).toBe('Login');
+        expect(
+            (
+                build(cfg({ query: 'subscription OnTick { tick }' }), {})
+                    .body as {
+                    operationName?: string;
+                }
+            ).operationName,
+        ).toBe('OnTick');
+    });
+
+    test('omits operationName for an anonymous document (shorthand or unnamed query)', () => {
+        for (const query of [
+            '{ thing }',
+            'query($id: ID) { thing(id: $id) }',
+        ]) {
+            const body = build(cfg({ query }), {}).body as Record<
+                string,
+                unknown
+            >;
+            expect('operationName' in body).toBe(false);
+        }
+    });
+
+    test('an explicit cfg.operationName overrides the derived name', () => {
+        const body = build(
+            cfg({ query: 'query A { a } query B { b }', operationName: 'B' }),
+            {},
+        ).body as { operationName?: string };
+        expect(body.operationName).toBe('B');
+    });
+
+    test('cfg.operationName of "" suppresses the field even for a named query', () => {
+        const body = build(
+            cfg({ query: 'query Named { x }', operationName: '' }),
+            {},
+        ).body as Record<string, unknown>;
+        expect('operationName' in body).toBe(false);
+    });
+
+    test('does not mistake a field or type named like a keyword for the operation', () => {
+        // `queryStatus` field + `query` keyword: only the real operation `Dash` is picked up.
+        const body = build(
+            cfg({ query: 'query Dash { queryStatus mutationCount }' }),
+            {},
+        ).body as { operationName?: string };
+        expect(body.operationName).toBe('Dash');
     });
 });
 


### PR DESCRIPTION
## What

The `graphql` surface packed only `{ query, variables }` into the request body, silently dropping the `operationName` that conventional GraphQL clients (e.g. `graphql-request`) send. This PR derives and sends `operationName`, and adds an `operationName` config key for explicit control.

## Why

Anything downstream that keys on the operation name saw nothing:

- **Servers** that route/authorize/persist-query by operation name.
- **Access logs & APM traces** that label GraphQL spans by operation.
- **Request mocks/fixtures** that match on `operationName`.

This surfaced from a real consumer: a project migrated its StashDB client from `graphql-request` to StitchAPI, and its mock fixtures keyed on `bodyContains: { operationName: "findScene" }` stopped matching — because StitchAPI never sent the field. Restoring it brings StitchAPI to parity with the clients those tools were built around.

## How

- `graphqlSurface.buildRequest` now computes `operationName = cfg.operationName ?? deriveOperationName(query)` and includes it in the body **only when a name is known** (anonymous documents omit the key, matching `graphql-request` — no `operationName: null` noise).
- `deriveOperationName` is a zero-dep regex (the runtime has no `graphql` dependency and stays dependency-free) that picks the name token of the first named `query`/`mutation`/`subscription`. A field, type, or fragment that merely starts with a keyword can't match — the keyword must be word-boundary-delimited and followed by whitespace + a name.
- New `StitchConfig.operationName` key: override the derived value (multi-operation documents) or suppress the field with `''`.

## Behavior / compatibility

- **Backward compatible for anonymous documents** — body shape is unchanged when there's no named operation.
- For named operations the body gains an `operationName` field. This also changes the cache key for those requests (the canonical request includes the body), which is correct — it's a one-time key shift.

## Tests

Extended `surface-graphql-hooks.spec.ts`: derivation for query/mutation/subscription, anonymous-document omission, explicit override, `''` suppression, and the keyword-lookalike-field guard. Full `packages/core` suite (1086 tests), typecheck, and lint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)