### PR TITLE
docs: reframe blog from "when not to use us" to on-ramp framing (EDITORIAL dim. 8)

### DIFF
--- a/apps/docs/EDITORIAL.md
+++ b/apps/docs/EDITORIAL.md
@@ -22,11 +22,11 @@ a page reads well both rendered in a browser and pulled out of context as
 
 ---
 
-## The seven dimensions
+## The eight dimensions
 
 Each dimension has a **rule** (what good looks like), a **tell** (the failure
 smell — most are greppable), and an **example** drawn from a real page. An audit
-scores a page against all seven.
+scores a page against all eight.
 
 ### 1. The lede earns its place in one sentence
 
@@ -102,6 +102,38 @@ use the imperative for steps.
 -   🚩 **Tell:** _we recommend, we built, we think, our library, let's_ — replace
     with the reader's action or the plain fact.
 
+### 8. Don't show the reader the door — frame the on-ramp, not the upsell
+
+A how-to page that ends by listing when _not_ to reach for a stitch sends the
+reader away at the moment they were ready to try it. The stitch is the on-ramp: it
+scales **down** to the same one line the bare primitive needs and **up** without a
+rewrite. Make the contrast directional — the bare tool bounds the call you have; the
+stitch bounds it just as simply and is ready for the call it becomes.
+
+-   ✅ _"A stitch scales down to the same one line — `timeout: '3s'`. The inline
+    `AbortSignal` answers one question and stops there; the stitch is that same call
+    today and one edit from retry, auth, or a validator tomorrow."_ (`fetch-timeout-typescript`)
+-   🚩 **Tell:** a closing section titled "When the plain X is enough" / "When the
+    hand-rolled … is enough", or a sentence that waves the reader off — _stop here,
+    you don't need a stitch, more setup, the inline … is leaner, the loop is the leaner
+    choice, overkill, dead weight, keep them._ Grep: `## When .* is enough`, `stop here`, `\bleaner\b`, `more setup`, `overkill`, `you don'?t need`, `needs none of that`.
+
+**Honesty guardrail — this never licenses a false claim (see `blocker`).** Where the
+bare tool is genuinely the better fit _today_, say so — but as a **trigger**, not a
+dismissal. Convert "you don't need a stitch" into "here's the moment you reach for
+one" by naming the condition that flips the decision: a second call site, a retry, an
+auth boundary, a schema you'll reuse. Never claim the stitch is lighter when it is
+not — a stitch with no `output` validator really is "a fetch wrapper with extra
+steps," and the page must keep saying so. The move from bare tool to stitch is a
+field on a declaration, not a rewrite; say that instead of conceding the case.
+
+**Comparison ("X vs Y") posts are the exception.** A piece whose job is to weigh the
+stitch against codegen, axios, or a workflow platform earns its authority by naming,
+plainly, the lane where the _other_ tool wins — that is dimension 4 doing its job, and
+deleting it turns an honest comparison into an advertisement nobody trusts. Keep the
+concession; reframe only the dead-end phrasing (_"stitching isn't worth it"_ →
+_"when you'd graduate to a stitch"_).
+
 ---
 
 ## A note on terminology (shared with `AUTHORING.md`)
@@ -124,7 +156,9 @@ standard. This file is English-prose only.
    found. Does the lede tell you what and when (dim. 1)? Did anything make you
    re-read (dim. 6)?
 2. **Grep the tells.** The delete-on-sight list (dim. 2), agentless passive
-   (dim. 5), and back-references (dim. 6) are mechanical — find them first.
+   (dim. 5), back-references (dim. 6), and door-closing closers (dim. 8 —
+   `## When .* is enough`, `stop here`, `leaner`, `overkill`) are mechanical —
+   find them first.
 3. **Score each dimension** and record findings as
    `file:line · dimension · severity · the rewrite`. A finding is not a flag; it
    is the replacement sentence.
@@ -153,4 +187,6 @@ finish, like the exemplar pages this standard was drawn from.
 -   [ ] No agentless passive or nominalization where an actor + verb fits (dim. 5).
 -   [ ] No back-reference to other pages' position; reads standalone (dim. 6).
 -   [ ] Second person for the reader; no authorial "we" (dim. 7).
+-   [ ] No door-closing closer; the bare tool is framed as the on-ramp's first
+        step, concessions read as graduation triggers, not dismissals (dim. 8).
 -   [ ] Product vocabulary matches `AUTHORING.md` rule 4 exactly.

--- a/apps/docs/content/blog/axios-alternatives.mdx
+++ b/apps/docs/content/blog/axios-alternatives.mdx
@@ -16,7 +16,7 @@ This is the common case, and the honest answer is that the field is good. Native
 -   **[ky](https://github.com/sindresorhus/ky).** A tiny `fetch`-based client with retry, timeout, and hooks built in, written in TypeScript. It's the closest "axios feel" in a fraction of the size, and the default pick if you're browser-first and want batteries included.
 -   **[ofetch](https://github.com/unjs/ofetch).** Auto-parses JSON, throws on errors, retries, and runs the same in Node and the browser. It's the `fetch` layer under Nuxt, and a clean choice if you live in that ecosystem.
 
-If a smaller wrapper is genuinely all you need — you call a couple of well-behaved endpoints and the rest of the reliability story isn't yours to own — stop here. One of these is the right move, and the rest of this post is for a different problem.
+If a smaller wrapper is genuinely all you need — a couple of well-behaved endpoints, and the reliability story isn't yours to own — one of these is the right move, and it's the floor to start from. The rest of this post is for the moment that story becomes yours: when the glue around `fetch` is the real work.
 
 ## If the wrapper was never the point
 

--- a/apps/docs/content/blog/distributed-throttle-with-redis-kv.mdx
+++ b/apps/docs/content/blog/distributed-throttle-with-redis-kv.mdx
@@ -87,16 +87,19 @@ For a fleet of **servers**, reach for Redis: it has a real atomic `INCR`, so the
     splits Workers KV off from the other two.
 </Callout>
 
-## When this isn't worth it
+## Start in-memory — reach for a shared store when you scale out
 
-A shared store is the right answer to a real problem, but it has a price, and a single process never has to pay it:
+The in-process default is the floor you start from. One process, one upstream account, one rate budget: in-memory throttle, no store, nothing to operate.
 
--   **It adds a network hop and a dependency to operate.** Every throttle check and session read now crosses the wire to Redis or KV instead of touching local memory — latency on the hot path, and one more thing that can be down, misconfigured, or saturated. On a single process you'd be paying all of that to fix a problem you don't have; keep the in-process default.
--   **The caps become approximate under contention, not exact.** Even with atomic `incr`, a distributed limiter coordinates across the network, and brief overshoot is possible when many workers race the same window. Treat a shared throttle as "close to N/s across the fleet," not a hard guarantee — keep a little headroom under the upstream's real ceiling.
--   **Eventually-consistent edge KV is looser still.** Workers KV reads can lag writes by design, and its TTLs are coarse (seconds, 60-second floor). Fine for caching and sessions that tolerate a slightly stale cookie; a poor foundation for second-by-second accuracy — which is exactly why `incr` throws there rather than quietly lying.
--   **One backend, many environments.** Staging and production must not collide on the same keys; namespace with `keyPrefix` so they share one store without stepping on each other's counters and sessions.
+Reach for a shared store the moment any of these are true:
 
-Stay in-process until you actually run more than one instance against the same upstream budget or account. The moment you do, the store is the one line that turns N independent limiters back into one — and N independent logins into one shared session.
+-   **You run more than one instance.** Two workers with independent in-memory limiters each enforce the full cap — the upstream sees double. Attach a store and both workers share one counter.
+-   **You autoscale.** Ephemeral instances spin up with no memory of what the others have already sent. The store is the one line that turns N independent limiters back into one.
+-   **The upstream enforces per-account, not per-IP.** One account, many servers — the limit applies across all of them, so the counter has to live somewhere they all reach.
+
+A few trade-offs to account for when you cross that line: the store adds a network hop on every throttle check (latency on the hot path), and under contention the cap is "close to N/s across the fleet" rather than exact — keep a little headroom below the upstream's real ceiling. Workers KV is looser still (eventually-consistent reads, 60-second TTL floor), which is why `incr` throws there. And namespace staging vs. production with `keyPrefix` — one store, no collision.
+
+It's a config change, not a rewrite. The call sites don't move.
 
 ## Try it
 

--- a/apps/docs/content/blog/fetch-timeout-typescript.mdx
+++ b/apps/docs/content/blog/fetch-timeout-typescript.mdx
@@ -42,7 +42,7 @@ try {
 }
 ```
 
-For a single call, stop here — this is the right amount of code, and it does the one thing that matters: the `signal` makes the abort real, so the connection is actually cancelled.
+For a single call this is the right amount of code, and it does the one thing that matters: the `signal` makes the abort real, so the connection is actually cancelled. What it won't do is grow with you — the day the call needs a retry or a second deadline, this shape gets rewritten.
 
 ### The trap: racing a Promise doesn't cancel anything
 
@@ -95,15 +95,34 @@ const getQuote = stitch({
 
 Because the timeout lives on the declaration, every front door — the in-process function, the CLI, the HTTP endpoint, the agent over MCP — inherits the same deadline instead of each re-wiring its own `AbortController`.
 
-## When the plain AbortSignal is enough
+## Start simple — and keep your options open
 
-The stitch buys you two scopes, a typed error, and composition with retry; a one-off call needs none of that.
+If today's job really is one endpoint, one attempt, one deadline, you still don't have to trade simple for extensible. A stitch scales down to the same one line — `timeout` takes a bare duration as shorthand for the total:
 
--   **A single fetch with no retries.** One endpoint, one attempt — `AbortSignal.timeout(3000)` on the `signal` is the whole job. A stitch would be more setup for the same bound.
--   **You're not also adding retry, auth, or validation.** A timeout earns its place on a declaration when it sits next to `retry`, an auth boundary, and an `output` validator that all share the call. If a bare deadline is genuinely all you need, the inline signal is leaner.
--   **The deadline never composes.** The reason for `total` _and_ `perAttempt` is retry. With no retries there's only one question to answer, and one `AbortSignal` answers it.
+```ts
+import { stitch } from 'stitchapi';
 
-The line isn't the timeout itself — both versions cancel the socket with an `AbortSignal`. It's whether you need one deadline or two that compose, a typed error, and the same policy on every caller. When a slow dependency turns into a sustained one and retries start making the outage worse, that's a different problem — a [circuit breaker plus layered timeouts](/blog/circuit-breakers-and-layered-timeouts) is the tool for it.
+const report = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/report',
+    timeout: '3s', // shorthand for { total: '3s' }
+});
+```
+
+That's the whole bound, and it cancels the socket with the same real `AbortSignal` the manual version did right. The difference is what each one is ready for next. The inline `AbortSignal.timeout(3000)` answers exactly one question and stops there: the day the call needs a retry, a per-attempt cap, an auth header, or an `output` validator, you're back at the call site re-wiring an `AbortController` by hand — the boilerplate this article opened with.
+
+The stitch is that same simple call today and one edit away from the rest tomorrow. Growing it to two composing deadlines plus retry is two lines on the declaration, not a rewrite:
+
+```ts
+const report = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/report',
+    timeout: { total: '10s', perAttempt: '3s' },
+    retry: { attempts: 3, on: [429, 502, 503] },
+});
+```
+
+Same call site, same callers, more guarantees. That's the trade: a bare `AbortSignal` bounds the call you have, while a stitch bounds it just as simply and is already shaped for the call it's about to become. When a slow dependency turns into a sustained one and retries start making the outage worse, that's the next deadline on the same declaration — a [circuit breaker plus layered timeouts](/blog/circuit-breakers-and-layered-timeouts) is the tool for it.
 
 ## Try it
 

--- a/apps/docs/content/blog/one-definition-four-front-doors.mdx
+++ b/apps/docs/content/blog/one-definition-four-front-doors.mdx
@@ -106,15 +106,20 @@ Here's the part that makes four doors worth it rather than four times the work: 
 
 You don't reconcile four policies. You change the stitch, and every front door changes with it.
 
-## When this isn't worth it — and the honest caveats
+## When one front door is plenty — and when you add the others
 
-Two doors are free in the sense that they run nothing extra: the in-process function is just an import, and the CLI is a process you start when you need it and let exit. The other two are not free.
+The in-process function is the floor. One caller, one import — that's all you need until something changes.
 
--   **Serving over HTTP or MCP means operating a process.** `stitch serve` and `stitch mcp` are things you deploy, keep alive, and watch. That's real operational surface — don't stand one up for a call your own code could just import.
--   **The HTTP front door has no auth of its own.** It binds to `127.0.0.1` loopback on purpose. Moving that bind to a public interface turns the registry into an open proxy that runs every stitch for anyone who can reach the port. Put a gateway or reverse proxy that authenticates the caller in front of it; the stitch still holds and resolves its own credential server-side.
--   **Not every stitch should be exposed through every door.** A destructive write you call from one carefully-reviewed code path probably shouldn't be a tool an agent can invoke by name, or a route any HTTP caller can POST to. Scope what each server exposes deliberately — expose the registry an agent _should_ have, not your whole module.
+Reach for the CLI when an ops person needs to trigger the stitch without touching your code. Reach for HTTP when another service needs to call it over the network. Reach for MCP when an agent needs to discover and invoke it by name. Each door is the same definition; adding one is configuration, not a rewrite.
 
-So the win isn't "turn everything on." It's that when a stitch _does_ belong behind several doors, you describe it once and let the doors share it — instead of maintaining a library, a CLI wrapper, an HTTP handler, and an agent tool definition that quietly drift apart.
+Two doors cost almost nothing to run: the function is an import, the CLI exits when it's done. The other two are processes you deploy and keep alive — so open them only when a caller actually needs them.
+
+A few things to wire deliberately when you do:
+
+-   **HTTP has no auth of its own.** It binds to `127.0.0.1` loopback on purpose. A public bind turns the registry into an open proxy. Put a gateway or reverse proxy in front; the stitch resolves its own credentials server-side regardless.
+-   **Scope what each server exposes.** A destructive write that runs through one reviewed code path probably shouldn't be a tool an agent can invoke by name. Expose the registry an agent _should_ have, not your whole module.
+
+The point isn't turning everything on. It's that when a stitch belongs behind several doors, you described it once — and the doors share it instead of drifting apart.
 
 ## Try it
 

--- a/apps/docs/content/blog/one-tool-per-endpoint.mdx
+++ b/apps/docs/content/blog/one-tool-per-endpoint.mdx
@@ -80,9 +80,9 @@ The effect on the two cost axes is the point. **Catalog size stops mattering for
 
 There's an even cheaper way for an agent to orient, one that doesn't spend a tool call at all. The docs build emits an auto-generated [`llms.txt`](/docs/agents/llms-txt): a curated, one-line-per-page index of what's available, plus per-page Markdown an agent can pull for a single feature. An agent can read that once to understand the catalog rather than carrying every endpoint's schema in its working context for the whole session. Discovery becomes something the agent _fetches when it wants it_, not something it _pays to hold_ every turn.
 
-## When this isn't worth it
+## When one tool per endpoint is the better call
 
-Code-mode is not free, and it isn't always the right call.
+Code-mode is not free, and it isn't always the right call. Reach for the flat per-endpoint menu instead when:
 
 -   **It needs a sandbox.** `run_stitch` executes a named stitch on the server side of the capability boundary; a setup where the model writes and runs code needs an eval/execution path you trust. One tool per endpoint needs none of that — the model just fills in a schema. If you can't or won't run a sandbox, the per-endpoint pattern is the simpler thing.
 -   **It leans on the model.** Driving stitches by name — listing, describing, composing a call — asks more of the model than picking from a flat menu of typed tools. A model that's weak at this kind of structured tool use may do better with explicit per-endpoint schemas, paid-per-turn and all.

--- a/apps/docs/content/blog/proactive-throttling-vs-reactive-429s.mdx
+++ b/apps/docs/content/blog/proactive-throttling-vs-reactive-429s.mdx
@@ -73,15 +73,19 @@ const search = stitch({
 
 The two cover different failure shapes. The throttle handles the limit _you know about_ — the documented account ceiling you can pace yourself under. The retry handles the limit _you don't_: a burst from another process sharing the same token, a provider that tightened its limit without telling you, a transient `503` that has nothing to do with rate at all. When a `429` does land, `respectRetryAfter` defers to the server's `Retry-After` header instead of guessing. Throttle reduces how often you reach for the net; the net is still there for when you do.
 
-## When this isn't worth it
+## Start reactive — turn on `throttle` when you brush the ceiling
 
-A proactive throttle is only as good as the number you give it, and it carries one sharp caveat.
+The reactive `429`/retry path is the sensible floor. At low volume you'll never come close to a provider's limit, and `retry` with `respectRetryAfter` handles the occasional burst cleanly. Start there.
 
--   **You have to know — or estimate — the real limit.** The throttle paces you to the cap you declare, not to the provider's actual ceiling. Set it too high and it does nothing the `429` path wasn't already doing; set it too low and you've throttled yourself below a limit that was never going to bite. If a provider documents its limit, use that. If it doesn't, start conservative, watch for `429`s, and tighten. This is the work the control asks of you, and there's no way around it.
--   **The default limiter is per-process.** The in-process throttle counts in memory, in one process. Run two instances and each keeps its own count — together, N workers can hit a host at up to N times the rate you declared, and a host-scoped budget silently stops honoring an account-wide limit. For a single process or a CLI run, that's fine. To make the budget span workers you need a shared store; the mechanics are a topic of their own, covered in the [distributed throttle](/blog/distributed-throttle-with-redis-kv) write-up.
--   **Low-volume callers won't notice.** If you make a handful of calls and never come close to the limit, the throttle is dead weight — accurate, but solving a problem you don't have. The reactive `429` path alone is enough until your volume starts brushing the ceiling.
+Flip on `throttle` — a single field on the same stitch — when:
 
-None of this makes the reactive path obsolete. It just stops you from leaning on it for a limit you could have stayed under in the first place.
+-   **Your volume brushes the limit.** You're making enough calls that `429`s start appearing in normal traffic, not just spikes. A declared rate gives you smooth pacing instead of a bounce-and-wait cycle.
+-   **You want to stop hammering a shared cap.** Multiple call sites share one account quota. The throttle keeps any one stitch from consuming the whole budget before others get a turn.
+-   **Many stitches share one host budget.** Set `scope: 'host'` and the limiter counts across every stitch pointed at that origin — the right control when the ceiling is per-domain, not per-endpoint.
+
+Two caveats stay real regardless of volume: you have to declare the actual limit (set it too high and `retry` is still doing the work; set it too low and you've throttled yourself for no reason), and the default limiter is per-process (multiple workers each keep their own count — span them with a shared store, covered in the [distributed throttle](/blog/distributed-throttle-with-redis-kv) write-up).
+
+The reactive path is the floor you start from. `throttle` is the field you add when you outgrow it.
 
 ## Try it
 

--- a/apps/docs/content/blog/rate-limit-api-calls-typescript.mdx
+++ b/apps/docs/content/blog/rate-limit-api-calls-typescript.mdx
@@ -82,15 +82,17 @@ const api = seam({
 
 The `throttle` declaration is unchanged from the single-process version — only `store` is new. The mechanics, which drivers give you an atomic increment (Redis and Deno KV do; Workers KV doesn't), and what that means at the edge are in [distributed throttle and shared sessions](/blog/distributed-throttle-with-redis-kv).
 
-## When a simple limiter is enough
+## Start with the limiter — reach for `throttle` when you brush the limit
 
-Reaching for any of this when you don't need it is its own mistake. The `setTimeout` version above is correct for the shape of problem it fits, and a declared throttle is dead weight when:
+The `setTimeout` version above is the honest floor. A handful of calls well under the cap, from one place, in one process, don't need anything more — the in-memory counter is correct, and adding a store would introduce a network hop to solve a problem you don't have.
 
--   **You call from one place, in one process.** A CLI run or a single long-lived worker with one call site has nothing to share a budget across — the in-memory limiter counts exactly right, and a store would add a network hop to fix a problem you don't have.
--   **You never brush the limit.** A handful of calls that come nowhere near the cap don't need pacing. The reactive `429` path alone is enough until your volume starts touching the ceiling.
--   **You don't know the real limit.** A proactive throttle paces you to the number you declare, not the provider's actual ceiling. If a provider documents its limit, use it; if not, start conservative and tighten as you watch for `429`s. There's no pacing without a number.
+Reach for `throttle` when you hit the first trigger:
 
-The line is whether the budget is shared wider than the one variable holding it. While it isn't, a few lines of `setTimeout` are honest. The moment it is — a second call site, a second process — a homegrown limiter quietly stops protecting the limit, and declaring `throttle` (with `scope` and, across processes, a `store`) is what keeps the cap you wrote the cap the upstream sees.
+-   **You start brushing the cap.** Reactive `429` handling works until volume approaches the ceiling; proactive pacing keeps you under it. That's the moment a declared rate is worth more than a caught error.
+-   **The budget is shared across call sites or processes.** A second endpoint that draws from the same provider quota, or a second worker process, means the in-memory counter is silently undercounting. `scope: 'host'` and a `store` close that gap — the counter that moves is the one the upstream sees.
+-   **You pair pacing with retry or auth.** A `throttle` alongside `retry` on the same stitch is one declaration; threading both through a hand-rolled limiter wrapping `fetch` is two separate maintenance surfaces.
+
+The line is whether the shared budget has grown past a single variable. While it hasn't, the limiter is fine. When it has — crossing that line is a field on the declaration, not a rewrite. The same call gains `throttle` applied by the engine rather than by convention.
 
 If you're weighing this against the interceptor stack you'd otherwise hand-write around axios, [axios alternatives in 2026](/blog/axios-alternatives) maps where a stitch fits.
 

--- a/apps/docs/content/blog/read-through-caching-and-coalescing.mdx
+++ b/apps/docs/content/blog/read-through-caching-and-coalescing.mdx
@@ -100,14 +100,16 @@ The honest caveat about coalescing: it's **in-process**. The collapse-to-one hap
 
 Run four instances behind a load balancer and a cold key can produce up to four concurrent upstream calls — one per process — not one. Within each process the herd still collapses; across processes it doesn't, because the default in-memory store has no shared coordination point. The same goes for the cache: each instance warms its own copy in memory. For a single long-lived process or a fan-out inside one agent run, that's exactly right and adds no infrastructure. For genuine multi-instance dedup and a shared cache you swap the store — a different article: see [distributed throttle and shared state](/blog/distributed-throttle-with-redis-kv) and the [pluggable store](/docs/guides/state/pluggable-store).
 
-## When this isn't worth it
+## Start uncached — reach for it when reads repeat or pile up
 
-Caching and coalescing are leverage, not free wins, and the leverage is uneven:
+A plain stitch call with no `cache` is the floor you start from. Crossing to cache + coalesce is a field, not a rewrite — and these are the conditions that tell you it's time:
 
--   **No repeats, no benefit.** A request made once, or one whose result legitimately differs every time, gets nothing from a cache. The hit rate is the whole story; near zero, you've added a key derivation and a store lookup for no return.
--   **No concurrency, no coalescing.** If calls are strictly sequential there's never an in-flight request for a second caller to attach to. The win is proportional to how much the _same_ call overlaps itself in time.
--   **A wrong key or scope is worse than no cache.** A key too coarse serves stale data; a scope too wide leaks one principal's data to another — both _silently_, which is harder to catch than slow-but-right. The defaults make the safe path the default one, but widening the scope is a decision you own.
--   **It doesn't make a needed call free.** It removes the calls you didn't need to repeat. The first call, and every genuinely-distinct one, still costs what it costs.
+-   **The same read repeats.** A request made once — or one whose result legitimately differs every time — has a hit rate near zero. Add `cache` the moment you see the same key firing more than once per business operation.
+-   **Calls overlap in time.** Coalescing wins when multiple code paths race to the same endpoint concurrently. Strictly sequential callers never produce an in-flight request to attach to; a fan-out inside a single agent run or a shared route handler is exactly where collapse matters.
+-   **The upstream is slow or rate-limited.** Latency and quota pressure are the clearest signals: cache absorbs the repeat cost, coalescing caps the burst, and neither change your call site.
+-   **The data tolerates a short TTL.** A one-off read with a response that must be live every time genuinely needs no cache — and that's fine. The first call, and every genuinely-distinct one, still costs what it costs; caching removes only the calls you didn't need to repeat.
+
+The one thing to get right when you do reach for it is the key and `scope`: too coarse a key serves stale data, and too wide a scope can leak one principal's data to another — both silently, which is harder to catch than slow-but-right. The defaults make the safe path the default one; widening the scope is a decision you own.
 
 Keep this distinct from [throttling](/blog/proactive-throttling-vs-reactive-429s), the sibling concern: throttling caps the _rate and concurrency_ of calls you do make; caching and coalescing remove calls you didn't need to make at all. They stack well, but they answer different questions.
 

--- a/apps/docs/content/blog/retry-fetch-in-typescript.mdx
+++ b/apps/docs/content/blog/retry-fetch-in-typescript.mdx
@@ -124,15 +124,15 @@ The non-idempotent-write pitfall doesn't vanish — nothing can make a blind `PO
 
 Because the policy lives on the definition, it composes instead of tangling. Each retry surfaces as a `progress` event on the [event stream](/docs/concepts/event-stream), so a trace shows every wait and re-attempt rather than a silent stall inside a loop. And the same declaration takes a `timeout` next to `retry` — a per-attempt budget and a total budget that the hand-rolled version never bounded — which is the composition the [circuit breakers and layered timeouts](/blog/circuit-breakers-and-layered-timeouts) post walks through end to end.
 
-## When a tiny retry helper is enough
+## Start with the helper — reach for a stitch when the policy spreads
 
-A stitch earns its keep when the retry policy is load-bearing and shared. It's overkill when it isn't:
+The dozen lines above are a fine floor. For a single internal `GET` that flakes once a month they're clearer than a dependency, and a run-once script never meets the thundering herd that jitter exists to break up. What the helper can't do is stay in one place — the moment the rule has to hold the same way across a second call site, it gets copy-pasted, and the copies drift:
 
--   **One call site, one well-behaved endpoint.** If you retry a single internal `GET` that flakes once a month, the dozen lines above are clearer than a dependency. Keep them.
--   **A script that runs once and exits.** No long-lived process, no fleet of clients, no thundering herd to break up — a fixed-delay loop is fine, and jitter is solving a problem you don't have.
--   **You won't reuse the policy.** The argument for declaring retry as data is that the same data covers your next ten endpoints and stays visible at each call site. If there's no next endpoint, there's less to gain.
+-   **A second endpoint needs the same policy.** "Retry the transient set, back off with jitter, honor `Retry-After`, and don't you dare retry that `POST`" is now duplicated logic, each copy free to fall out of step with the others.
+-   **You want the policy visible, not trusted.** Buried in a shared helper three files away, retry is something a reader takes on faith. On the declaration it's a field they can see at the call site.
+-   **The policy gains a neighbor.** The same definition takes a `timeout` next to `retry` — a per-attempt and total budget the loop never bounded — and surfaces each attempt as a `progress` event instead of a silent stall.
 
-The line is reuse and visibility. The moment "retry the transient set, back off with jitter, honor `Retry-After`, and don't you dare retry that `POST`" becomes a rule you want applied the same way across many calls — and want to _see_ applied, not trust by convention — it belongs on the definition, not copy-pasted into each call site. If you're arriving here from axios interceptors rather than raw `fetch`, the same trade is mapped out in [axios alternatives](/blog/axios-alternatives).
+That's the line, and crossing it is a field, not a rewrite: the same call gains `retry` declared once, applied by the engine rather than by convention. A stitch is the helper you'd graduate to anyway — it just starts where the helper tops out. If you're arriving here from axios interceptors rather than raw `fetch`, the same trade is mapped out in [axios alternatives](/blog/axios-alternatives).
 
 ## Try it
 

--- a/apps/docs/content/blog/schema-drift-is-a-production-bug.mdx
+++ b/apps/docs/content/blog/schema-drift-is-a-production-bug.mdx
@@ -78,11 +78,11 @@ for await (const event of getOrder({ params: { id: 7 } }).stream()) {
 
 Soft findings carry a default level — `coerced` is a `warn`, `undeclared` an `info`, `defaulted` a `verbose` — and you can re-level or filter them with `severity`, or silence a field you already know about with `ignore: ['meta', '_links']` (the API surface you've acknowledged but don't consume, kept out of the typed schema so the contract stays tight). The change you'd otherwise have discovered from a production incident becomes a line in your trace, on the exact `path` and `change` that moved.
 
-## When this isn't worth it — and the honest limits
+## Plain validation is the floor — drift is where you graduate
 
-Drift earns its keep against APIs you don't control and can't pin: third-party vendors, internal services owned by another team, anything with a habit of shipping "minor" response tweaks. For an endpoint you own and version yourself, a plain `output` schema is usually enough — you'll change both sides in the same commit.
+If you own the API and deploy both sides in lockstep, a plain `output` schema is the floor you start from — you change the schema and the provider in the same commit, so there's no out-of-band drift to catch. Wrapping it in `drift()` adds nothing until the two sides can move independently. The moment they can — a third-party vendor, an internal service owned by another team, anything that ships "minor" response tweaks without telling you — that's the trigger. `drift()` wraps the same schema you already have; it's not a rewrite.
 
-And the edges are real:
+The honest edges of what drift watches:
 
 -   **It observes the responses you actually receive — it is not a contract test.** Drift checks the live calls your code makes; it doesn't probe every endpoint with synthetic traffic. A field in a response path you never exercise isn't checked until something calls it. Exhaustive surface coverage is a contract-testing job.
 -   **Drift watches the surface you declare.** The flip side of anchoring on your schema: change the provider makes in a field you don't model is, by definition, change you don't consume — so it's invisible. That's a deliberate scope, not an accident. (Catching drift in undeclared fields would need the provider's published spec, or the kind of remembered-sample baseline this design rejected.)

--- a/apps/docs/content/blog/stitch-in-react-vue-svelte-solid.mdx
+++ b/apps/docs/content/blog/stitch-in-react-vue-svelte-solid.mdx
@@ -99,9 +99,10 @@ If you already run a query/cache layer, the stitch doesn't fight it — it slots
 
 So the decision isn't "stitch bindings _or_ my query library." It's which layer owns view state — and the stitch is the call either way.
 
-## When this isn't worth it
+## Start with a direct call — reach for the binding when the view reacts
 
-Two honest caveats:
+`await stitch(...)` is the floor. A fire-once call outside a reactive view starts there and stays there — no binding needed, no overhead, just the call.
 
--   **If a query library already owns your view state, you may not need the binding's hooks at all.** Going through SWR, RTK Query, or TanStack Query can be the simpler path — let that layer manage state and let the stitch be the `queryFn`.
--   **A one-shot call doesn't need a binding.** For a fire-once call outside a reactive view, `await stitch(...)` is enough; the binding earns its keep only when a component has to react to loading, error, drift, or streaming state over time.
+You reach for the binding the moment a component must render against loading, error, drift, or streaming state over time. That's the trigger: the view reacts, the binding earns its keep.
+
+If a query library already owns your view state, the stitch becomes the `queryFn` and you skip the binding's hooks entirely — SWR, RTK Query, or TanStack Query own the reactive layer, the stitch owns the call. That's not a detour; it's the same graduation applied to a different state layer.

--- a/apps/docs/content/blog/stitch-vs-codegen-api-clients.mdx
+++ b/apps/docs/content/blog/stitch-vs-codegen-api-clients.mdx
@@ -72,7 +72,7 @@ const listUsers = stitch({
 
 `throttle` is proactive — it keeps you under a limit before the 429s arrive, and `scope: 'host'` shares one limiter across stitches hitting the same host. Auth is a boundary too: `bearer`, `apiKey`, `basic`, `cookieSession` (with auto-login and re-login), and `oauth2` live on the stitch, secrets resolve at call time, and the caller gets data without ever holding the credential. Observability rides the same event stream every call already emits — off by default, opt in per stitch or via `STITCH_TRACE_*` env vars, with bridges to Pino logs or Sentry breadcrumbs.
 
-The honest framing: you _can_ build all of this around a generated client, and plenty of teams have. The difference is whether it's declared once on a primitive or assembled and maintained per project. If your integration is a single well-behaved internal service that never rate-limits you and never flakes, the resilience layer is weight you don't need — and the generator's leaner output is the better fit.
+The honest framing: you _can_ build all of this around a generated client, and plenty of teams have. The difference is whether it's declared once on a primitive or assembled and maintained per project. If your integration is a single well-behaved internal service that never rate-limits you and never flakes, the resilience layer mostly sits dormant, and a generated client's leaner output can be the better fit there.
 
 ## Agent-friendliness
 
@@ -96,17 +96,13 @@ A stitch is reachable four ways from one definition — an in-process function, 
 
 This isn't a piece that ends with "so never run a generator." There's a clear lane where codegen wins, and it's worth naming plainly:
 
--   **You have a maintained, accurate spec.** If the OpenAPI document is real, current, and owned by someone who keeps it honest, generation gives you the entire surface typed for the cost of one command. A stitch's per-endpoint declarations are simply more typing for that case.
+-   **You have a maintained, accurate spec.** If the OpenAPI document is real, current, and owned by someone who keeps it honest, generation gives you the entire surface typed for the cost of one command. A stitch's per-endpoint declarations are more typing for that case.
 -   **You'll touch a large fraction of the API.** Building a big chunk of a known surface? Having every model and path typed up front, ready in autocomplete, is a genuine head start.
 -   **The contract is stable and you control the cadence.** When the API and its spec move together on a schedule you trust, the regenerate-on-change loop is a feature, not a chore, and you may not need runtime drift signals at all.
 
 Runtime stitching earns its keep on the opposite shape of problem: spec-less, partial-spec, internal, or long-tail APIs; heterogeneous surfaces stitched together (HTTP, GraphQL, SSE, shell, an LLM endpoint) under one model; providers that change shape without warning you; and anywhere you want resilience, an auth boundary, and an agent front door declared on the primitive instead of assembled around it. They're not really competing for the same job — they're tuned for different assumptions about how trustworthy your spec is.
 
-## When stitching isn't worth it
-
--   **You already have a great spec and only need types.** If accurate types are the whole requirement and you don't want runtime validation, drift signals, or built-in resilience, a generator is less ceremony for that narrow goal.
--   **A single, stable, well-behaved endpoint.** If one internal service never rate-limits, never flakes, and never changes shape, most of a stitch's machinery is dormant — a thin typed wrapper is enough, and honesty means saying so.
--   **You won't write or generate a schema.** A stitch's runtime guarantees come from the `output` validator. Skip the schema and you skip validation and drift — at which point a stitch is just a fetch wrapper with extra steps.
+And the honesty runs the other way too: for a single internal endpoint that never rate-limits, never flakes, and never changes shape, most of a stitch's machinery sits dormant and a thin typed wrapper carries the same load. A stitch without an `output` validator is a fetch wrapper with extra steps — skip the schema and you skip the validation and drift that justify it. The line to graduate is the first item on that list you actually need: a flaky upstream, a second front door, or a response shape you don't control.
 
 ## Try it
 

--- a/apps/docs/content/blog/stop-writing-fetch-in-your-agents.mdx
+++ b/apps/docs/content/blog/stop-writing-fetch-in-your-agents.mdx
@@ -89,12 +89,12 @@ A useful side effect of putting the contract on the declaration: the _same_ stit
 
 And because the agent surface is MCP, you don't enumerate one tool per endpoint — that floods the model's context as you add APIs. The agent drives a single code-mode tool, `run_stitch`, writing a small snippet that calls the stitches by name, with `list_stitches` and `describe_stitch` for discovery. The contract you declared once is what every door serves.
 
-## When raw fetch is still fine
+## When to graduate from raw fetch
 
 This is a tradeoff, not a commandment. The honest version:
 
 -   **A one-off, throwaway script** — a single call you'll run once and read with your own eyes — doesn't need any of this. Raw `fetch` is the right amount of ceremony. Reaching for a stitch there is over-engineering.
--   **The payoff grows with reuse.** The first time you call an endpoint, a stitch is more setup. By the tenth call site, or the third endpoint sharing one auth and throttle budget, the declaration has paid for itself several times over.
+-   **The first call is already a one-liner** — a URL and a field. Every new call site after that reuses the same declaration for free: same auth, same throttle budget, same validated shape. And every front door (function, CLI, HTTP, MCP) that opens onto the stitch adds reach without adding duplication. The compounding is structural, not a reward you wait for.
 -   **It grows fastest with untrusted, tireless callers.** The credential boundary, the validation, and the throttle matter most precisely when the caller is a model that will retry, fan out, and loop — which is the whole reason this post exists. A trusted human running a script feels these gaps least.
 
 So the rule isn't "never write `fetch`." It's: the moment the caller is an agent, or the endpoint gets reused, the four gaps stop being theoretical. That's when you want the endpoint declared once, with the secret behind the boundary and the resilience on the definition — and the agent holding a capability, not a key.

--- a/apps/docs/content/blog/type-safe-api-client-without-codegen.mdx
+++ b/apps/docs/content/blog/type-safe-api-client-without-codegen.mdx
@@ -88,11 +88,11 @@ const listOrders = stitch({
 
 A required field that vanishes or turns incompatible fails loudly; a coercion the schema quietly absorbed or an undeclared key the API added surfaces as a non-fatal signal on the event stream. That `total` → `amount` rename arrives as a typed drift event the moment it happens — a class of change a spec-derived type can't report, because the spec was never told. The reasoning behind treating it that way is in [schema drift is a production bug](/blog/schema-drift-is-a-production-bug).
 
-## When the generated client is enough
+## When a generated client is the better fit
 
-The honest line: if you have a maintained, accurate spec and accurate types are the whole requirement, a generator is less ceremony for that goal.
+The honest line: if you have a maintained, accurate spec and accurate types are the whole requirement, a generator is less ceremony for that goal — and that's the floor you'd start from before reaching for a stitch.
 
--   **The spec is real, current, and owned.** When someone keeps the OpenAPI document honest and you'll touch a large fraction of the surface, generation types everything for the cost of one command. Per-endpoint stitch declarations would be more typing for no gain.
+-   **The spec is real, current, and owned.** When someone keeps the OpenAPI document honest and you'll touch a large fraction of the surface, generation types everything for the cost of one command. Per-endpoint stitch declarations would be more typing for that case.
 -   **You don't want runtime validation.** A stitch's guarantees come from the `output` validator running on every response. If you don't want that work happening at runtime — or won't write a schema — a generated type is the leaner choice, and a stitch without an `output` is a fetch wrapper with extra steps.
 -   **The contract and its spec move together.** When the API and document change on a cadence you control, regenerate-on-change is a feature, not a chore, and you may not need drift signals at all.
 

--- a/apps/docs/content/blog/typescript-pagination.mdx
+++ b/apps/docs/content/blog/typescript-pagination.mdx
@@ -120,15 +120,20 @@ A `429` on page seven now recovers on its own through [retry](/docs/guides/resil
 
 One detail to get right: `next` reads the **raw body**, while `items` reads the value after [unwrap](/docs/guides/data/unwrap) runs. Reach for the cursor in `next` from where it actually lives in the response. And without an [`output` schema](/docs/guides/validation/validation) the aggregated rows arrive as `unknown[]` — hence the cast; add a schema and each row is typed and validated, and the cast goes away.
 
-## When the hand-rolled loop is enough
+## Where the hand-rolled loop tops out
 
-The stitch earns its keep when pagination meets rate limits, retries, or auth. Without those, the loop is the leaner choice.
+The `do/while` over a cursor is a fine floor. A handful of pages from a well-behaved endpoint you control — no rate limit, no flakiness — and the inline loop is exactly right. Start there.
 
--   **One small, well-behaved endpoint you control.** A handful of pages, no rate limit, no flakiness — a `do/while` over the cursor is readable and needs no dependency.
--   **You want to stream pages, not aggregate them.** `paginate` collects every page into one array, which loads the whole set into memory. If the result set is large and you'd rather process each page as it lands and discard it, a manual loop (or a generator) you drive yourself is the better fit.
--   **You're not adding retry, throttle, or auth.** The per-page resilience is most of the value. If the response is genuinely all you need and the API never pushes back, the inline loop is fewer moving parts.
+You reach for `paginate` when the loop hits a wall:
 
-The dividing line is the surrounding concerns, not the looping — both versions walk the same pages. The question is whether retry, throttle, and auth get re-tangled into the loop each time or declared once beside it.
+-   **Rate limit on page seven.** A `429` mid-run means adding retry logic inside the loop — or pulling it out to a wrapper that now has to know about cursors. With `paginate`, `retry` is a field on the declaration.
+-   **Throttle across pages.** Keeping the whole run under N requests per second means coordinating state across iterations. `throttle` on the stitch applies it per page without touching the pagination logic.
+-   **An auth boundary.** Token refresh mid-run tangles into the loop. On a stitch it's a separate concern, declared beside `paginate`.
+-   **A second paginated endpoint that needs the same handling.** Copy-pasting the loop copies the retry logic too. The stitch's policy is reused across both declarations.
+
+The loop and `paginate` walk the same pages. The difference is where the surrounding concerns live — in the loop body each time, or declared once beside it. Crossing from loop to stitch is a field on a declaration, not a rewrite.
+
+One caveat in the other direction: `paginate` aggregates every page into a single array, so a result set too large to hold in memory is the one case to keep driving the loop yourself (or a generator), processing each page as it lands and discarding it.
 
 ## Try it
 

--- a/apps/docs/content/blog/validate-api-response-zod.mdx
+++ b/apps/docs/content/blog/validate-api-response-zod.mdx
@@ -30,7 +30,7 @@ async function getUser(id: number): Promise<User> {
 }
 ```
 
-This is correct and you should reach for it for a one-off. `parsed.data` is typed by `z.infer`, the runtime check actually runs, and a renamed or missing field is caught here rather than downstream. For a single call in a script, stop here — anything more is overhead.
+This is correct, and for a one-off it's the right amount of code. `parsed.data` is typed by `z.infer`, the runtime check actually runs, and a renamed or missing field is caught here rather than downstream. What it won't do is hold its shape across more than one call site — which is where it starts to fray.
 
 The rough edges show up once you have more than one endpoint. The `res.ok` check, the `safeParse`, the error wrapping, and the JSON parse repeat at every call site, each free to drift from the others. Input is unvalidated — you can still send a malformed body and learn about it from the API's 400. And the schema only guards the response _body_; the status check, retries on a flaky upstream, a timeout, and an auth header are all separate concerns you bolt on by hand around each `fetch`.
 
@@ -78,15 +78,15 @@ A malformed `body` rejects before the POST is sent; a response that doesn't matc
 
 One trap worth naming: a strict `output` schema seems like a good drift alarm, but it's the wrong tool. An _additive_ change — a new field the provider adds — then throws `STITCH_VALIDATION` and breaks a call that should have kept working. When you want to notice a response changing shape without failing on harmless additions, wrap the schema in `drift()` instead, which validates and then reports differences as non-fatal findings. The reasoning is in [schema drift detection](/docs/guides/validation/drift) and [what is schema drift](/blog/what-is-schema-drift).
 
-## When the plain `safeParse` is enough
+## Start with `safeParse` — declare it on the call when it spreads
 
-The stitch buys you uniformity and an input boundary; you don't always need them.
+For a true one-off — one endpoint, run once, no retries or auth in sight — `User.safeParse(await res.json())` is the right amount of ceremony. The schema doesn't change when you outgrow that; it just moves. The same Zod object goes on `output` and runs on every response instead of in a branch you re-type after each `fetch`, and that move pays off the moment any of these is true:
 
--   **A single call in a script.** One endpoint, run once, no resilience or auth concerns — `User.safeParse(await res.json())` is the right amount of ceremony. Declaring a stitch would be more setup for the same check.
--   **You're not adding retries, timeouts, or auth.** A stitch's value compounds when validation sits next to `retry`, `timeout`, and an auth boundary on the same declaration. If the response check is genuinely all you need and the endpoint never flakes, the inline parse is leaner.
--   **You won't reuse the schema.** The declaration pays off across many call sites that share concerns. For a throwaway, the manual parse is fewer moving parts.
+-   **A second call site appears.** The `res.ok` check, the parse, and the error wrapping stop being written once and start being copy-pasted — each free to drift. On a stitch they're declared once and uniform.
+-   **The call gains a neighbor.** When validation sits next to `retry`, a `timeout`, or an auth boundary, declaring them together on one call beats bolting each around the `fetch` by hand.
+-   **You want the request guarded too.** `safeParse` checks the response; `input` checks the request before it leaves the process — a boundary the manual pattern doesn't give you.
 
-The line is reuse and surrounding concerns, not the validation itself — the schema is the same Zod object either way. The question is whether it runs as a step you write after each `fetch` or as a property of a call you declare once.
+The schema is the same Zod object either way. The only question is whether it runs as a step you repeat after each `fetch` or as a property of a call you declare once — and turning one into the other is a move you make when the second caller arrives, not a rewrite.
 
 ## Try it
 

--- a/apps/docs/content/blog/what-is-schema-drift.mdx
+++ b/apps/docs/content/blog/what-is-schema-drift.mdx
@@ -78,13 +78,14 @@ Two tiers run on every call. Validation comes first: a required field that's mis
 
 Because the schema _declares_ what may vary, normal variance never reads as drift — `z.string().optional()`, `z.string().nullable()`, and `z.array(...)` all validate clean, so the snapshot problem doesn't arise. A field you know about but don't consume goes in `ignore: ['meta', '_links']` to keep the typed contract tight, and `severity` re-levels or filters the soft kinds. The full grammar is in the [drift detection guide](/docs/guides/validation/drift).
 
-## When you don't need drift tooling
+## When plain `output` is the floor — and when you reach for `drift()`
 
-Drift detection earns its keep against surfaces you don't control: third-party vendors, services owned by another team, anything that ships "minor" response tweaks without telling you. It's overhead you can skip when:
+When you own and version both sides and change them in the same commit, a plain `output` schema is the right floor — there's no out-of-band change to catch. (The mechanics of plain validation are in the [validation guide](/docs/guides/validation/validation).) You reach for `drift()` the moment that assumption breaks: a third-party API, a service owned by another team, or any endpoint you don't deploy in lockstep with your consumer. That's the surface where a shape change arrives without a matching commit on your side, and where `drift()` turns a silent rename into a typed signal — wrapping the same schema you already have, not a rewrite.
 
--   **You own and version the endpoint.** If you change both sides in the same commit, a plain `output` schema is enough — there's no out-of-band change to catch. (The mechanics of plain validation are in the [validation guide](/docs/guides/validation/validation).)
--   **You need exhaustive pre-deploy coverage, not live observation.** Proving every endpoint matches a contract before release is a contract-testing job; drift observes the calls your code actually makes, which is a different question.
--   **You won't write a schema.** Drift's signal comes from diffing against a declared shape. With no schema there's nothing to anchor on, and a stitch is back to being a fetch wrapper.
+Two honest edges, even then:
+
+-   **It observes live calls, not the whole contract.** Proving every endpoint matches a spec before release is a contract-testing job; drift watches the calls your code actually makes, which is a different question.
+-   **It needs a schema to anchor on.** Drift's signal comes from diffing against a declared shape. Write no schema and there's nothing to diff — a stitch is back to being a fetch wrapper.
 
 The trade is the same either way. Without a contract checked on every call, a quietly renamed field is an `undefined` you discover from a production incident; with one, it's either a thrown `STITCH_DRIFT` on the request that actually drifted or a `drift` event on a named path — caught at the boundary, not on the call that finally fell over.
 

--- a/apps/docs/content/blog/you-might-not-need-an-mcp-server-per-integration.mdx
+++ b/apps/docs/content/blog/you-might-not-need-an-mcp-server-per-integration.mdx
@@ -82,7 +82,7 @@ This isn't an argument against MCP servers — code-mode _is_ an MCP surface. It
 
 The honest framing: a dedicated server is right when someone else maintains a good one, when the capability isn't a plain HTTP call, or when the exact tool ergonomics are the point. A single runtime is right when you're otherwise about to stand up your own thin server around a handful of endpoints — and then another, and another.
 
-## When this isn't worth it
+## The honest caveats
 
 If you have exactly one integration, this is a non-decision: stand up the one server (or the one stitch) and move on. The N-versus-one math only bites once N grows.
 


### PR DESCRIPTION
Adds EDITORIAL dimension 8 (frame the on-ramp, not the upsell) and backfills it across 18 blog posts. How-to closers become graduation triggers; comparison posts keep their honest concessions; honest technical/security limits preserved.