### PR TITLE
feat(contract): API meta-contract + ratchet + early renames (P2–P14, P20/P21) — 1/3

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -61,6 +61,10 @@ jobs:
             # to a real page (catches a dead link like the removed fluent-builder page or a section
             # with no index). Static scan — no build needed.
             - run: pnpm check:docs-links
+            # API meta-contract ratchet (docs/CONTRACT.md): fails on a NEW naming/typing/
+            # shorthand/duration violation in the published surface, baselined against
+            # scripts/contract-violations.baseline.json. Tool-free source scan — no build.
+            - run: pnpm check:contract
             # Release coherence: version lockstep + prerelease-aware peer ranges +
             # scoped publishConfig.access, LICENSE/README presence, so a bad bump fails
             # the PR, not the publish.

--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -116,7 +116,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
         {
             label: "paginate",
             type: "property",
-            detail: "{ /** * Given the previous page's raw body and how many pages were fetched, return the * input (merged over the original) for the next page, or `undefined` to stop. */ next: ( prevBody: unknown, pagesFetched: number, ) => StitchInput | undefined; /** Pull the array from each unwrapped page. Default: the value if it is an array. */ items?: (value: unknown) => unknown[]; /** Safety cap on pages. Default 50. */ pages?: number; /** @deprecated Renamed to `pages` (CONTRACT.md P4). Read until the 1.0 GA cut. */ max?: number; }",
+            detail: "PaginateOptions",
             info: "Auto-loop pages, aggregating items, with auth/retry/throttle applied to every page.",
         },
         {
@@ -159,7 +159,6 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "rateLimit",
             type: "property",
             detail: "{ /** Surface rate-limit outcomes instead of retrying/throttling them. Default `false`. */ delegate?: boolean; /** Statuses treated as a rate-limit signal. Default `[429]`. */ on?: number[]; }",
-            info: "Delegate backoff to the host (issue #145). When `delegate: true`, a rate-limit response (status in `on`, default `[429]`) is **not** retried internally and the built-in `throttle` is **bypassed** for the call — instead the outcome surfaces as a (carrying `status`, the `retryAfterMs` parsed from `Retry-After`, and the raw `response`) on the awaited path, and as an `error` event with `retryAfterMs` on `.stream()`. Use this when an OUTER gate/circuit owns the backoff (its own `Retry-After` hook, a DB-persisted budget) and StitchAPI's internal retry+throttle would double-count against it. ⚠️ In delegate mode the `throttle` config becomes **inert** for this stitch (the host owns the gate). A `circuit` block, if also set, still applies — the host may layer both. Non-rate-limit failures (5xx, etc.) behave exactly as today unless their status is listed in `on`. Validation, templating, transform/unwrap, and drift on the success path are unchanged.",
         },
         {
             label: "idempotency",

--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -164,8 +164,8 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
         {
             label: "idempotency",
             type: "property",
-            detail: "IdempotencyOptions",
-            info: "Inject a stable Idempotency-Key header on writes so safe retries don't duplicate.",
+            detail: "boolean | AtLeastOne<IdempotencyOptions>",
+            info: "Inject a stable Idempotency-Key header on writes so safe retries don't duplicate. `true` enables it with defaults (header `Idempotency-Key`, a random uuid per call); the object form customizes it and **must** set at least one field — the opaque `idempotency: {}` is rejected (CONTRACT.md P20).",
         },
         {
             label: "cache",

--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -170,7 +170,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
         {
             label: "cache",
             type: "property",
-            detail: "number | string | CacheConfig",
+            detail: "number | string | CacheOptions",
             info: "Read-through response cache + in-process coalescing (ADR 0003). Off unless set; the engine is loaded lazily from the `stitchapi/cache` subpath only when this block is present. A bare number (ms) or duration string is shorthand for the TTL — `cache: '1m'` ≡ `cache: { ttl: '1m' }` (still subject to the fingerprint / `version` rules before an entry is actually stored).",
         },
         {

--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -116,7 +116,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
         {
             label: "paginate",
             type: "property",
-            detail: "{ /** * Given the previous page's raw body and how many pages were fetched, return the * input (merged over the original) for the next page, or `undefined` to stop. */ next: ( prevBody: unknown, pagesFetched: number, ) => StitchInput | undefined; /** Pull the array from each unwrapped page. Default: the value if it is an array. */ items?: (value: unknown) => unknown[]; /** Safety cap on pages. Default 50. */ max?: number; }",
+            detail: "{ /** * Given the previous page's raw body and how many pages were fetched, return the * input (merged over the original) for the next page, or `undefined` to stop. */ next: ( prevBody: unknown, pagesFetched: number, ) => StitchInput | undefined; /** Pull the array from each unwrapped page. Default: the value if it is an array. */ items?: (value: unknown) => unknown[]; /** Safety cap on pages. Default 50. */ pages?: number; /** @deprecated Renamed to `pages` (CONTRACT.md P4). Read until the 1.0 GA cut. */ max?: number; }",
             info: "Auto-loop pages, aggregating items, with auth/retry/throttle applied to every page.",
         },
         {

--- a/apps/docs/content/blog/idempotency-keys-safe-retries.mdx
+++ b/apps/docs/content/blog/idempotency-keys-safe-retries.mdx
@@ -57,13 +57,13 @@ const charge = stitch({
     baseUrl: 'https://api.example.com',
     path: '/charges',
     retry: { attempts: 3, on: [429, 502, 503, 504], backoff: 'expo-jitter' },
-    idempotency: {},
+    idempotency: true,
 });
 
 const result = await charge({ body: { amount: 4200, ref: 'inv_88' } });
 ```
 
-`idempotency: {}` does the work the loop did, correctly. It generates a random uuid **once per logical call** and reuses it across that call's retries, sending it as the `Idempotency-Key` header. One `await charge(...)` settles one charge, even when the engine retries it twice under the hood. The server sees one token, dedupes the replay, and returns the committed result.
+`idempotency: true` does the work the loop did, correctly. It generates a random uuid **once per logical call** and reuses it across that call's retries, sending it as the `Idempotency-Key` header. One `await charge(...)` settles one charge, even when the engine retries it twice under the hood. The server sees one token, dedupes the replay, and returns the committed result.
 
 `retry` and `idempotency` are deliberately separate fields because they answer separate questions. `retry` decides _when to try again_ — which statuses, how many attempts, how to back off. `idempotency` decides _what makes two attempts the same write_. Pair them on every write: a retry without a key double-applies, a key without a retry never gets exercised.
 
@@ -85,19 +85,19 @@ const createOrder = stitch({
     path: '/orders',
     retry: { attempts: 3 },
     idempotency: {
-        key: (input) => `order-${(input.body as { ref: string }).ref}`,
+        keyOf: (input) => `order-${(input.body as { ref: string }).ref}`,
     },
 });
 ```
 
-`key` receives the call input and returns the token. `input.body` is typed `unknown` — the engine cannot know your payload shape — so narrow it before reading a property — `(input.body as { ref: string }).ref` casts it inline. Now both clicks produce `order-inv_88`, the server sees one token, and the second submission collapses into the first.
+`keyOf` receives the call input and returns the token. `input.body` is typed `unknown` — the engine cannot know your payload shape — so narrow it before reading a property — `(input.body as { ref: string }).ref` casts it inline. Now both clicks produce `order-inv_88`, the server sees one token, and the second submission collapses into the first.
 
 The rule splits cleanly:
 
-| Goal                                                        | Key strategy                                                     |
-| ----------------------------------------------------------- | ---------------------------------------------------------------- |
-| Collapse a retry of one call                                | `idempotency: {}` (random, per-call)                             |
-| Collapse two separate submissions of the same logical write | `idempotency: { key: (input) => ... }` derived from shared input |
+| Goal                                                        | Key strategy                                                       |
+| ----------------------------------------------------------- | ------------------------------------------------------------------ |
+| Collapse a retry of one call                                | `idempotency: true` (random, per-call)                             |
+| Collapse two separate submissions of the same logical write | `idempotency: { keyOf: (input) => ... }` derived from shared input |
 
 If the duplicates have nothing in common to hash, no key can join them — that is a fact about your data, not a gap in the feature.
 
@@ -116,7 +116,7 @@ const createOrder = stitch({
     retry: { attempts: 3 },
     idempotency: {
         header: 'X-Request-Id',
-        key: (input) => `order-${(input.body as { ref: string }).ref}`,
+        keyOf: (input) => `order-${(input.body as { ref: string }).ref}`,
     },
 });
 ```
@@ -129,7 +129,7 @@ An idempotency key is a contract, not a guarantee. It works only when the **serv
 
 ## Where this scales
 
-The `charge` stitch with `idempotency: {}` is the smallest safe write you can declare: a method, a URL, a retry policy, a key. When the duplicate you care about stops being a retry and becomes a double-clicked button, you add one field — `key` — and the same declaration now collapses submissions too. Same call site, same `await`, no rewrite of the surrounding handler.
+The `charge` stitch with `idempotency: true` is the smallest safe write you can declare: a method, a URL, a retry policy, a key. When the duplicate you care about stops being a retry and becomes a double-clicked button, you add one field — `keyOf` — and the same declaration now collapses submissions too. Same call site, same `await`, no rewrite of the surrounding handler.
 
 From there the same config object carries `timeout: { total: '30s', perAttempt: '10s' }`, an `output` schema to validate the response, and `auth: bearer(env('API_TOKEN'))` so the token resolves at call time and the caller never holds it. Each is one more field on the write you already have, bounding one more failure mode of the same call.
 

--- a/apps/docs/content/blog/read-through-caching-and-coalescing.mdx
+++ b/apps/docs/content/blog/read-through-caching-and-coalescing.mdx
@@ -81,7 +81,7 @@ const listAnnouncements = stitch({
         ttl: '1h',
         scope: 'app', // shared across principals — see below
         vary: ['accept-language'], // fold a header into the key
-        maxEntries: 500,
+        entries: 500,
     },
 });
 ```
@@ -155,4 +155,4 @@ Keep this distinct from [throttling](/blog/proactive-throttling-vs-reactive-429s
 stitchapi
 ```
 
-Add `cache: '5m'` to one read-heavy stitch, fan a few identical calls at it, and watch them collapse to a single upstream request. The full configuration surface — `ttl`, `scope`, `vary`, `maxEntries`, the stitch-level `sensitive` flag, and the fingerprinting rules — lives in the [docs](/docs).
+Add `cache: '5m'` to one read-heavy stitch, fan a few identical calls at it, and watch them collapse to a single upstream request. The full configuration surface — `ttl`, `scope`, `vary`, `entries`, the stitch-level `sensitive` flag, and the fingerprinting rules — lives in the [docs](/docs).

--- a/apps/docs/content/blog/typescript-pagination.mdx
+++ b/apps/docs/content/blog/typescript-pagination.mdx
@@ -57,7 +57,7 @@ const allUsers = stitch({
             return cursor ? { query: { cursor } } : undefined;
         },
         items: (value) => (value as { results: unknown[] }).results,
-        max: 20,
+        pages: 20,
     },
 });
 
@@ -110,7 +110,7 @@ const mirror = stitch({
             return cursor ? { query: { cursor } } : undefined;
         },
         items: (value) => (value as { results: unknown[] }).results,
-        max: 100,
+        pages: 100,
     },
 });
 

--- a/apps/docs/content/docs/errors/rate-limit.mdx
+++ b/apps/docs/content/docs/errors/rate-limit.mdx
@@ -5,8 +5,8 @@ description: 'The delegate-backoff error: a rate-limit response surfaced for an 
 
 ## What you'll see
 
-A stitch with [`rateLimit: { delegate: true }`](/docs/guides/resilience/delegate-backoff)
-that gets a rate-limit response (status in `rateLimit.on`, default `[429]`)
+A stitch with [`throttle: { delegate: true }`](/docs/guides/resilience/delegate-backoff)
+that gets a rate-limit response (status in `throttle.on`, default `[429]`)
 rejects with a **`RateLimitError`** instead of retrying. Unlike most failures,
 this is _not_ a `StitchError` — it's its own exported class, so you can catch it
 specifically and hand the signal to whatever owns your backoff:
@@ -17,7 +17,7 @@ import { RateLimitError, stitch } from 'stitchapi';
 const fetchPage = stitch({
     baseUrl: 'https://api.example.com',
     path: '/pages/{id}',
-    rateLimit: { delegate: true },
+    throttle: { delegate: true },
 });
 
 try {
@@ -34,7 +34,7 @@ try {
 `RateLimitError` carries:
 
 -   **`status`** — the rate-limit status (e.g. `429`, or whatever you listed in
-    `rateLimit.on`).
+    `throttle.on`).
 -   **`retryAfterMs`** — the wait the server asked for, parsed from `Retry-After`
     (delta-seconds **or** an HTTP-date) into milliseconds; `undefined` when the
     header is absent or unparseable.
@@ -65,7 +65,7 @@ purpose.
     `RateLimitError` (so `retryAfterMs` is still reachable via the cause).
 -   **Reconsider whether to delegate.** If nothing outside StitchAPI actually
     owns the backoff, you probably want internal handling instead — drop
-    `rateLimit` and use [retry](/docs/guides/resilience/retry) +
+    `throttle.delegate` and use [retry](/docs/guides/resilience/retry) +
     [throttle](/docs/guides/resilience/throttle).
 
 ## Related

--- a/apps/docs/content/docs/guides/auth/cookie-session.mdx
+++ b/apps/docs/content/docs/guides/auth/cookie-session.mdx
@@ -77,7 +77,7 @@ never crashes the call.
 
 ```ts twoslash
 import { cookieSession, env, stitch } from 'stitchapi';
-import type { AuthFailureInfo, RefreshResult } from 'stitchapi';
+import type { AuthFailureResult, RefreshResult } from 'stitchapi';
 
 // Your own durable store — a row in a database, a Redis hash, anything.
 declare const sessionState: {
@@ -107,7 +107,7 @@ const me = stitch({
             if (ok) await sessionState.markActive();
         },
         // Categorise a failure and drive your own recovery loop.
-        onAuthFailure: async (info: AuthFailureInfo) => {
+        onAuthFailure: async (info: AuthFailureResult) => {
             switch (info.category) {
                 case 'rate-limited':
                     // Back off until the server says we may retry.

--- a/apps/docs/content/docs/guides/data/pagination.mdx
+++ b/apps/docs/content/docs/guides/data/pagination.mdx
@@ -22,7 +22,7 @@ const allUsers = stitch({
             return cursor ? { query: { cursor } } : undefined;
         },
         items: (value) => (value as { results: unknown[] }).results,
-        max: 20,
+        pages: 20,
     },
 });
 ```

--- a/apps/docs/content/docs/guides/resilience/accept-status.mdx
+++ b/apps/docs/content/docs/guides/resilience/accept-status.mdx
@@ -76,7 +76,7 @@ const call = stitch({
 ```
 
 `acceptStatus` is orthogonal to
-[`rateLimit.delegate`](/docs/guides/resilience/delegate-backoff), which surfaces a
+[`throttle.delegate`](/docs/guides/resilience/delegate-backoff), which surfaces a
 `RateLimitError` on rate-limit statuses earlier and is unaffected by this option.
 
 ## When you still want the error body

--- a/apps/docs/content/docs/guides/resilience/delegate-backoff.mdx
+++ b/apps/docs/content/docs/guides/resilience/delegate-backoff.mdx
@@ -28,7 +28,7 @@ declare const outerGate: { penalize(ms: number): void };
 const fetchPage = stitch({
     baseUrl: 'https://api.example.com',
     path: '/pages/{id}',
-    rateLimit: { delegate: true }, // surface 429s; don't retry or throttle them
+    throttle: { delegate: true }, // surface 429s; don't retry or throttle them
 });
 
 try {
@@ -72,7 +72,7 @@ declare const outerGate: { penalize(ms: number): void };
 const fetchPage = stitch({
     baseUrl: 'https://api.example.com',
     path: '/pages/{id}',
-    rateLimit: { delegate: true },
+    throttle: { delegate: true },
 });
 
 for await (const ev of fetchPage.stream({ params: { id: '42' } })) {
@@ -101,7 +101,7 @@ block, if you also set one, still applies — you can let the host layer both.
 
 <Callout type="info">
     Delegate mode and internal retry-on-rate-limit are mutually exclusive _for
-    the delegated statuses_: a status in `rateLimit.on` is surfaced, never
+    the delegated statuses_: a status in `throttle.on` is surfaced, never
     retried, even if it also appears in `retry.on`.
 </Callout>
 

--- a/apps/docs/content/docs/guides/resilience/idempotency.mdx
+++ b/apps/docs/content/docs/guides/resilience/idempotency.mdx
@@ -20,7 +20,7 @@ const charge = stitch({
     method: 'POST',
     baseUrl: 'https://api.example.com',
     path: '/charges',
-    idempotency: {},
+    idempotency: true,
 });
 
 // Custom: derive a stable key from the input. `body` is `unknown`, so narrow it.

--- a/apps/docs/content/docs/recipes/mirror-a-paginated-api.mdx
+++ b/apps/docs/content/docs/recipes/mirror-a-paginated-api.mdx
@@ -40,7 +40,7 @@ const mirror = stitch({
             return cursor ? { query: { cursor } } : undefined;
         },
         items: (value) => (value as { results: unknown[] }).results,
-        max: 100,
+        pages: 100,
     },
 });
 

--- a/apps/docs/content/docs/recipes/paginate-into-one-array.mdx
+++ b/apps/docs/content/docs/recipes/paginate-into-one-array.mdx
@@ -27,7 +27,7 @@ const allUsers = stitch({
             return cursor ? { query: { cursor } } : undefined;
         },
         items: (value) => (value as { results: unknown[] }).results,
-        max: 20,
+        pages: 20,
     },
 });
 

--- a/apps/docs/content/docs/reference/auth-strategies.mdx
+++ b/apps/docs/content/docs/reference/auth-strategies.mdx
@@ -40,7 +40,7 @@ and re-logs in on a status code or a soft 200 wall.
 
 <AutoTypeTable
     path="../../packages/core/src/auth.ts"
-    name="CookieSessionOpts"
+    name="CookieSessionOptions"
 />
 
 ## oauth2
@@ -48,7 +48,7 @@ and re-logs in on a status code or a soft 200 wall.
 Performs the `client_credentials` grant, caches the access token, refreshes it
 before expiry, and attaches it as `Authorization: Bearer …`.
 
-<AutoTypeTable path="../../packages/core/src/auth.ts" name="OAuth2Opts" />
+<AutoTypeTable path="../../packages/core/src/auth.ts" name="OAuth2Options" />
 
 ## env
 

--- a/apps/docs/eslint.config.mjs
+++ b/apps/docs/eslint.config.mjs
@@ -10,6 +10,10 @@ const eslintConfig = defineConfig([
         'next-env.d.ts',
         '.source/**',
         'scripts/**',
+        // Generated bundle of the core runtime for the live playground (build:sandbox). It
+        // carries core's source comments verbatim — including `eslint-disable` directives for
+        // rules this app's flat config doesn't load — so it must never be linted as app source.
+        'public/sandbox/**',
     ]),
 ]);
 

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -322,6 +322,52 @@ re-export/field alias pinned by an identity test, removed at the **1.0 GA cut**
 (extending ADR 0012's precedent from symbols to fields). Widening
 (`number → number | string`, P17) is non-breaking and needs no alias.
 
+### P20 · No empty-object config; enable-with-defaults is a scalar
+
+The empty object `{}` **MUST NOT** be a valid value at a config slot. Where `{}` would
+carry meaning — "enable this capability with all defaults" — the capability **MUST**
+express that case as a **scalar** (`true` for a toggle; the dominant field's value for a
+single-field envelope, per P12) and **MUST** type its object form so the empty object is
+a **compile error**: `boolean | AtLeastOne<Options>` (a toggle) or
+`Scalar | AtLeastOne<Options>`. The object form is then reserved for real customization
+(≥1 field); the all-defaults case is the scalar.
+
+_Why:_ `idempotency: {}` reads as a no-op but silently **enables** idempotency with
+defaults — a meaningful value hidden behind the most opaque possible spelling. `true`
+says what `{}` means; rejecting `{}` removes the trap. This is the enforcement teeth for
+[P13](#p13--boolean-toggle-means-enable-with-defaults) (which _offers_ `true`) — P20
+also _forbids_ `{}`. It refines [P15](#p15--required-fields-are-deliberate-and-get-a-namedpositional-shorthand--not-silent-defaults):
+an all-optional envelope is still internally `{}`-constructible, but at the **slot** the
+all-defaults case is the scalar, not `{}`.
+
+_Helper:_ `AtLeastOne<T>` = a value with at least one property of `T` set (`{}` matches
+none of its per-key-required variants, so it is rejected).
+
+_Violations:_ `idempotency?: IdempotencyOptions` (so `idempotency: {}` is legal — **fixed
+here**); the other all-optional bare-`*Options` slots accept `{}` too: `multipart`,
+`stream`, `sse`, `throttle`, `hooks`, `input` (each → `Scalar | AtLeastOne<Options>` per
+P12/P13; lint **R6** flags them).
+
+### P21 · Every contract has an extension seam
+
+No consumer-facing contract may be a closed dead end. Every capability **MUST** be
+extensible **without forking core** — through a plugin interface (`Surface`, `Adapter`,
+`StitchStore`, `TraceSink`, `AuthStrategy`, `Validator`/`SchemaLike`), config composition
+(`extends` fragments), or a documented escape hatch. A new behaviour is added as a
+**pluggable seam**, never a hard-coded branch a host cannot reach. When P20 tightens an
+envelope, this rule guarantees the door stays open: there is always a way to extend.
+
+_Why:_ strictness without an escape hatch paints consumers into a corner. The two rules
+are a pair — P20 says "the envelope is exact," P21 says "but the system is open." A
+capability that can only be configured the one way core shipped, with no seam to extend
+it, is a contract bug.
+
+_Existing seams (the bar a new capability must clear):_ surfaces are `Surface` plugins
+(HTTP/GraphQL/SSE/shell/LLM are all the same seam); transport is a swappable `Adapter`;
+state is a pluggable `StitchStore`; observability is any `TraceSink`; auth is any
+`AuthStrategy`; validation is any Standard-Schema `Validator`; and every stitch composes
+via `extends` fragments. A new capability that exposes none of these is the violation.
+
 ---
 
 ## 6. Migration backlog (proposed renames — confirm during sweep)
@@ -392,7 +438,8 @@ cut; the lint skips the deprecated members so each rename ratchets the baseline 
 -   Rules implemented today (high-precision, source-text level): **R1** banned type-name
     suffix (P3), **R2** any `*Ms`-suffixed duration field, input or emitted (P17),
     **R3** function-typed `key` (P6), **R4** `scope: 'stitch'|'host'` overload (P2),
-    **R5** same identifier exported by ≥2 published packages (P9).
+    **R5** same identifier exported by ≥2 published packages (P9), **R6** a `StitchConfig`
+    slot typed as a bare all-optional `*Options` bag that accepts `{}` (P20).
 -   Deferred to a type-aware phase (needs the TS checker, not regex): full
     same-name-different-**shape** detection, duration-type conformance, default-value
     inversion (P8). Tracked as comments in the lint.

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -359,6 +359,11 @@ New shorthand/toggle slots to **add** (additive, non-breaking): `stream`, `multi
 `sse`, `.inspect()` scalars (P12); `idempotency` boolean (P13-toggle);
 `throttle` string (P14).
 
+**Shipped (migration in progress):** `ThrottleOptions.scope`→`pool` (P2) and
+`IdempotencyOptions.key`/`CacheConfig.key`→`keyOf` (P6) have landed under `@deprecated`
+aliases (read until the GA cut); the runtime prefers the new field
+(`pool ?? scope`, `keyOf ?? key`) and the lint no longer flags the deprecated members.
+
 ---
 
 ## 7. Enforcement

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -359,10 +359,16 @@ New shorthand/toggle slots to **add** (additive, non-breaking): `stream`, `multi
 `sse`, `.inspect()` scalars (P12); `idempotency` boolean (P13-toggle);
 `throttle` string (P14).
 
-**Shipped (migration in progress):** `ThrottleOptions.scope`→`pool` (P2) and
-`IdempotencyOptions.key`/`CacheConfig.key`→`keyOf` (P6) have landed under `@deprecated`
-aliases (read until the GA cut); the runtime prefers the new field
-(`pool ?? scope`, `keyOf ?? key`) and the lint no longer flags the deprecated members.
+**Shipped (migration in progress)** — all under `@deprecated` aliases read until the GA
+cut; the lint skips the deprecated members so each rename ratchets the baseline down:
+
+-   **P2** `ThrottleOptions.scope`→`pool`; runtime prefers `pool ?? scope`.
+-   **P6** `IdempotencyOptions.key`/`CacheOptions.key`→`keyOf`; runtime prefers `keyOf ?? key`.
+-   **P3** suffix renames (type-only, zero runtime): `CacheConfig`→`CacheOptions`,
+    `OAuth2Opts`→`OAuth2Options`, `CookieSessionOpts`→`CookieSessionOptions`,
+    `McpServerInfo`→`McpServerOptions`, `LlmConfig`→`LlmOptions`,
+    `SignV4Params`→`SignV4Options`, and the read-back `AuthFailureInfo`→`AuthFailureResult`.
+    (`OAuth2Opts`/`CookieSessionOpts` are auth-internal — renamed without an alias.)
 
 ---
 

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -31,7 +31,7 @@ Four forks were decided by the maintainer on adoption; the rules below assume th
 | --- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
 | D1  | Success-payload field name | **`data`** (align with axios / React Query / SWR / RTK Query, which every hook package wraps; `SafeResult` already uses it). Stream increments keep **`chunk`**; the Standard-Schema validation layer keeps spec-mandated **`value`/`issues`**. | [P5](#p5--one-success-field-one-failure-field) |
 | D2  | Cap-word convention        | **Bare nouns, no `max-` prefix**, for **count** caps (`attempts`, `entries`, `pages`, `failures`, `concurrency`). `max-` is retained only where it bounds a continuous **magnitude** and a bare noun would be ambiguous (a delay ceiling).      | [P4](#p4--one-cap-vocabulary)                  |
-| D3  | Duration style             | **`number \| string`** (`'5s'` or raw ms) for every consumer-authored duration, parsed by one `parseDuration`. **Drop the `Ms` suffix from inputs**; reserve `Ms` for emitted telemetry only.                                                   | [P17](#p17--one-canonical-duration-form)       |
+| D3  | Duration style             | **ms is the one house unit; drop the `Ms` suffix _everywhere_** (input and emitted; the unit lives in JSDoc). Consumer-authored durations additionally accept **`number \| string`** (`'5s'` or raw ms) via one `parseDuration`.                | [P17](#p17--one-canonical-duration-form)       |
 | D4  | Home of the contract       | **This `CONTRACT.md` (living doc) + an enforcement lint** in the verify gate.                                                                                                                                                                   | [§7](#7-enforcement)                           |
 
 ---
@@ -225,9 +225,9 @@ A capability whose primary act is an on-switch **MUST** accept **`boolean | Opti
 where `true` = enable-with-documented-defaults; it **MUST NOT** require an object
 literal merely to switch on.
 
-_Apply to:_ `idempotency?: boolean | IdempotencyOptions`,
-`rateLimit?: boolean | RateLimitOptions` (`true ≡ { delegate: true }`),
-`inspect(input, true)`. `sse.reconnect: true` already sets the precedent.
+_Apply to:_ `idempotency?: boolean | IdempotencyOptions` and `inspect(input, true)`.
+`sse.reconnect: true` already sets the precedent. (Rate-limit delegation becomes a
+`throttle` mode after the P14 fold, not its own toggle.)
 
 ### P14 · Multi-field envelopes are named, exported, and MAY shorthand their dominant field
 
@@ -236,8 +236,11 @@ interface (never an anonymous inline shape), so it can be imported, extended, an
 referenced. A multi-field envelope **MAY** still offer a scalar shorthand for an
 **unambiguously dominant** field (this is **not** the single-field collapse of P12).
 
-_Violations:_ `paginate` (`{ next; items?; max? }`) and `rateLimit`
-(`{ delegate?; on? }`) are anonymous → extract `PaginateOptions`, `RateLimitOptions`.
+_Violations:_ `paginate` (`{ next; items?; max? }`) is anonymous → extract
+`PaginateOptions`. `rateLimit` (`{ delegate?; on? }`) is anonymous **and** a near-synonym
+of `throttle` → **fold it into the `throttle` envelope** (`delegate` / `on` become
+throttle modes), collapsing two top-level keys into one and turning the buried "delegate
+makes throttle inert" interaction into a within-envelope rule.
 _Allowed example:_ `throttle?: string | ThrottleOptions` where `'2/s' ≡ { rate: '2/s' }`
 — `rate` dominates although `concurrency` also exists (so this is a P14 dominant-field
 shorthand, not a P12 collapse).
@@ -278,22 +281,24 @@ result interface is `UseStitchResult` / `UseStitchReturn` / `InjectStitchResult`
 
 ### P17 · One canonical duration form
 
-Per **D3**, every **consumer-authored** duration **MUST** accept
-**`number | string`** (raw ms or a token like `'5s'`/`'1m'`), parsed by one shared
-`parseDuration`, and **MUST** drop the `Ms` name suffix. The `Ms` suffix is **reserved
-for emitted/telemetry/wire** durations, which are always raw ms.
+Per **D3**, **ms is the single house time unit** and **no duration field carries the
+`Ms` suffix** — input or emitted. Every **consumer-authored** duration additionally
+**MUST** accept **`number | string`** (raw ms or a token like `'5s'`/`'1m'`), parsed by
+one shared `parseDuration`. Every **emitted** duration is a raw-ms `number`; its unit is
+stated in its JSDoc, not its name.
 
 _Why:_ every JS-native time API (`Date.now()`, `setTimeout`, `performance.now()`) is
-**already ms**, so a bare number on an input is unambiguously ms and the `Ms` suffix
-is redundant noise; accepting `'5s'` on top of it is pure ergonomic gain. The suffix
-earns its place only on emitted numbers, where it documents the unit a reader can't
-otherwise infer.
+**already ms**, so ms is the unambiguous default and the suffix is redundant noise
+everywhere. On inputs, accepting `'5s'` on top is pure ergonomic gain (and a `Ms` name
+on a field that takes `'5s'` would be a lie). On outputs, one uniform de-suffixed
+vocabulary beats a split convention; the JSDoc carries the unit.
 
-_Violations (inputs to widen + de-suffix):_ `RetryOptions.baseMs`/`maxMs`,
+_Violations (inputs — widen + de-suffix):_ `RetryOptions.baseMs`/`maxMs`,
 `CircuitOptions.cooldownMs`/`halfOpenAfterMs`, `ReconnectOptions.backoffMs`,
 `OAuth2Opts.refreshSkewMs`, `CookieSessionOpts.ttlMs`, store-contract `ttlMs`.
-_Telemetry to keep/normalize as `*Ms`:_ `StitchEvent.waitedMs` / `retryAfterMs`;
-rename bare `StitchEvent.done.ms` → `doneMs` and `SseEvent.retry` → `retryMs`.
+_Violations (emitted — de-suffix):_ `StitchEvent` `waitedMs`→`waited`,
+`retryAfterMs`→`retryAfter`, the `done` event's `ms`→`elapsed`; `SseEvent.retry` stays
+(already bare; it mirrors the SSE `retry:` wire field); `MockResponse.delayMs`→`delay`.
 _Unit hazard (the exception to "all JS time is ms"):_ a few fields are **seconds**
 because they mirror a wire format — `MockResponse.retryAfter` and the HTTP
 `Retry-After` header (delta-seconds), Cloudflare KV `expirationTtl`. Every
@@ -305,10 +310,10 @@ at the adapter edge and is named with its true unit (`expirationSeconds`,
 
 A duck-type that mirrors a foreign SDK **MUST** keep that SDK's spelling (so it
 structurally matches). StitchAPI's **own normalized** contracts (`StitchStore`,
-`RedisDriver`) **MUST** use one house vocabulary: `ttlMs` (always ms; convert foreign
-units at the edge), `delete` (not `del`), `close(): Promise<void>` (async, per P11),
-with one optionality per parameter (`ttlMs` MUST NOT be optional on `set` but required
-on `incr`).
+`RedisDriver`) **MUST** use one house vocabulary: `ttl` (ms — the house unit, no suffix
+per P17; convert foreign units at the edge), `delete` (not `del`),
+`close(): Promise<void>` (async, per P11), with one optionality per parameter (`ttl`
+MUST NOT be optional on `set` but required on `incr`).
 
 ### P19 · No pre-GA hard break
 
@@ -324,33 +329,34 @@ re-export/field alias pinned by an identity test, removed at the **1.0 GA cut**
 Not normative. The rule is the law; these are the proposed target spellings the sweep
 will apply under `@deprecated` aliases (P18). Severity = consumer blast radius.
 
-| Sev  | Current                                                               | Proposed                                | Rule |
-| ---- | --------------------------------------------------------------------- | --------------------------------------- | ---- |
-| High | `SafeResult.data` ↔ `Inspection.value` ↔ `StitchEvent.result.value` | `data` everywhere                       | P5   |
-| High | `IdempotencyOptions.key`, `CacheConfig.key` (fn)                      | `keyOf`                                 | P6   |
-| High | `ThrottleOptions.scope` (`'stitch'｜'host'`)                          | `pool`                                  | P2   |
-| High | `retry.on`, `rateLimit.on` (`number[]`)                               | `number[] ｜ (status)=>boolean`         | P7   |
-| High | `StitchStore`/`StitchLike`/`RequestSeam` cross-pkg clashes            | hoist or qualify                        | P9   |
-| High | `queryOptions` bare in vue/solid/svelte/angular                       | `stitchQueryOptions`                    | P16  |
-| Med  | `CacheConfig` →                                                       | `CacheOptions`                          | P3   |
-| Med  | `OAuth2Opts`, `CookieSessionOpts`                                     | `OAuth2Options`, `CookieSessionOptions` | P3   |
-| Med  | `McpServerInfo`, `SignV4Params`                                       | `…Options`                              | P3   |
-| Med  | `StitchQueryOptions` (a result)                                       | `StitchQueryResult`                     | P3   |
-| Med  | `ReconnectOptions.maxAttempts`                                        | `attempts`                              | P4   |
-| Med  | `CacheConfig.maxEntries`                                              | `entries`                               | P4   |
-| Med  | `CircuitOptions.failureThreshold`                                     | `failures`                              | P4   |
-| Med  | `paginate.max`                                                        | `pages`                                 | P4   |
-| Med  | `*Ms` input durations (`cooldownMs`, `backoffMs`, `baseMs`, …)        | de-suffix + `number｜string`            | P17  |
-| Med  | `paginate`, `rateLimit` inline shapes                                 | `PaginateOptions`, `RateLimitOptions`   | P14  |
-| Med  | SSE helper `sendStitchSse`/`stitchSse`                                | `streamStitchSse`                       | P16  |
-| Med  | error-options `StitchErrorHandlerOptions`/`ToHttpExceptionOptions`    | `StitchErrorOptions` (+ `body`)         | P16  |
-| Low  | `RedisDriver.del`, `…quit`, sync `close`                              | `delete`, async `close`                 | P18  |
-| Low  | `SchemaFingerprint.value`                                             | `token`                                 | P5   |
-| Low  | `bodyKind` (from-curl)                                                | `bodyType`                              | P1   |
-| Low  | `StitchEvent.done.ms`, `SseEvent.retry`                               | `doneMs`, `retryMs`                     | P17  |
+| Sev  | Current                                                               | Proposed                                                       | Rule   |
+| ---- | --------------------------------------------------------------------- | -------------------------------------------------------------- | ------ |
+| High | `SafeResult.data` ↔ `Inspection.value` ↔ `StitchEvent.result.value` | `data` everywhere                                              | P5     |
+| High | `IdempotencyOptions.key`, `CacheConfig.key` (fn)                      | `keyOf`                                                        | P6     |
+| High | `ThrottleOptions.scope` (`'stitch'｜'host'`)                          | `pool`                                                         | P2     |
+| High | `rateLimit` (separate top-level key) vs `throttle`                    | fold into one `throttle` envelope (`delegate` / `on` as modes) | P2/P14 |
+| High | `retry.on` + rate-limit `on` (`number[]`)                             | `number[] ｜ (status)=>boolean`                                | P7     |
+| High | `StitchStore`/`StitchLike`/`RequestSeam` cross-pkg clashes            | hoist or qualify                                               | P9     |
+| High | `queryOptions` bare in vue/solid/svelte/angular                       | `stitchQueryOptions`                                           | P16    |
+| Med  | `CacheConfig` →                                                       | `CacheOptions`                                                 | P3     |
+| Med  | `OAuth2Opts`, `CookieSessionOpts`                                     | `OAuth2Options`, `CookieSessionOptions`                        | P3     |
+| Med  | `McpServerInfo`, `SignV4Params`                                       | `…Options`                                                     | P3     |
+| Med  | `StitchQueryOptions` (a result)                                       | `StitchQueryResult`                                            | P3     |
+| Med  | `ReconnectOptions.maxAttempts`                                        | `attempts`                                                     | P4     |
+| Med  | `CacheConfig.maxEntries`                                              | `entries`                                                      | P4     |
+| Med  | `CircuitOptions.failureThreshold`                                     | `failures`                                                     | P4     |
+| Med  | `paginate.max`                                                        | `pages`                                                        | P4     |
+| Med  | `*Ms` duration inputs (`cooldownMs`, `backoffMs`, `ttlMs`, …)         | de-suffix + `number｜string`                                   | P17    |
+| Med  | `paginate` inline shape                                               | `PaginateOptions`                                              | P14    |
+| Med  | SSE helper `sendStitchSse`/`stitchSse`                                | `streamStitchSse`                                              | P16    |
+| Med  | error-options `StitchErrorHandlerOptions`/`ToHttpExceptionOptions`    | `StitchErrorOptions` (+ `body`)                                | P16    |
+| Low  | `RedisDriver.del`, `…quit`, sync `close`                              | `delete`, async `close`                                        | P18    |
+| Low  | `SchemaFingerprint.value`                                             | `token`                                                        | P5     |
+| Low  | `bodyKind` (from-curl)                                                | `bodyType`                                                     | P1     |
+| Low  | emitted `*Ms` (`waitedMs`, `retryAfterMs`, done `ms`)                 | de-suffix (`waited`, `retryAfter`, `elapsed`); units → JSDoc   | P17    |
 
 New shorthand/toggle slots to **add** (additive, non-breaking): `stream`, `multipart`,
-`sse`, `.inspect()` scalars (P12); `idempotency`, `rateLimit` booleans (P13-toggle);
+`sse`, `.inspect()` scalars (P12); `idempotency` boolean (P13-toggle);
 `throttle` string (P14).
 
 ---
@@ -369,7 +375,7 @@ New shorthand/toggle slots to **add** (additive, non-breaking): `stream`, `multi
     ESLint-suppression ratchet: the gate never blocks unrelated work, but the surface can
     only get more consistent, never less.
 -   Rules implemented today (high-precision, source-text level): **R1** banned type-name
-    suffix (P3), **R2** `*Ms`-suffixed field inside an `*Options` input bag (P17),
+    suffix (P3), **R2** any `*Ms`-suffixed duration field, input or emitted (P17),
     **R3** function-typed `key` (P6), **R4** `scope: 'stitch'|'host'` overload (P2),
     **R5** same identifier exported by ≥2 published packages (P9).
 -   Deferred to a type-aware phase (needs the TS checker, not regex): full

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -369,6 +369,10 @@ cut; the lint skips the deprecated members so each rename ratchets the baseline 
     `McpServerInfo`→`McpServerOptions`, `LlmConfig`→`LlmOptions`,
     `SignV4Params`→`SignV4Options`, and the read-back `AuthFailureInfo`→`AuthFailureResult`.
     (`OAuth2Opts`/`CookieSessionOpts` are auth-internal — renamed without an alias.)
+-   **P4** caps → bare nouns: `ReconnectOptions.maxAttempts`→`attempts`,
+    `CacheOptions.maxEntries`→`entries`, `paginate.max`→`pages`; runtime prefers the new
+    field. (`CircuitOptions.failureThreshold`→`failures` is deferred to the P17 CircuitOptions
+    overhaul, where its required-ness + `cooldownMs`/`halfOpenAfterMs` are handled together.)
 
 ---
 

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -1,0 +1,390 @@
+# StitchAPI API Meta-Contract
+
+> **Status:** Living normative document. Adopted 2026-06-29.
+> **Scope:** every consumer-facing contract in the published surface — `stitchapi`
+> core + its subpaths (`/serve`, `/mcp`, `/registry`, `/testing`, `/fingerprint`)
+> and every `@stitchapi/*` package.
+> **Relationship to ADRs:** this governs **field- and shape-level** conventions
+> (naming, typing, shorthand, envelopes). It **complements** and does not supersede
+> [ADR 0012](adr/0012-integration-symbol-naming.md), which governs cross-package
+> **symbol** naming; ADR 0012 rules are referenced, not restated. Enforced by
+> [`scripts/check-contract.mjs`](../scripts/check-contract.mjs) (a ratchet, see
+> [§7](#7-enforcement)).
+
+This contract exists so the public API reads as **one coherent thing**: a consumer
+who has learned one corner of StitchAPI can predict the rest. It turns patterns that
+already exist locally in the core (`retry: 3`, `timeout: '5s'`, `cache: '1m'`) into
+global law, and pins the cross-cutting vocabulary so the same word never means two
+things.
+
+The rules are **normative** (MUST / SHOULD / MUST NOT). The per-field rename
+proposals in [§6](#6-migration-backlog) are the **backlog**, not part of the
+normative text — exact target spellings are confirmed during the migration sweep.
+
+---
+
+## 0. Resolved decisions
+
+Four forks were decided by the maintainer on adoption; the rules below assume them.
+
+| #   | Decision                   | Resolution                                                                                                                                                                                                                                      | Drives                                         |
+| --- | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| D1  | Success-payload field name | **`data`** (align with axios / React Query / SWR / RTK Query, which every hook package wraps; `SafeResult` already uses it). Stream increments keep **`chunk`**; the Standard-Schema validation layer keeps spec-mandated **`value`/`issues`**. | [P5](#p5--one-success-field-one-failure-field) |
+| D2  | Cap-word convention        | **Bare nouns, no `max-` prefix**, for **count** caps (`attempts`, `entries`, `pages`, `failures`, `concurrency`). `max-` is retained only where it bounds a continuous **magnitude** and a bare noun would be ambiguous (a delay ceiling).      | [P4](#p4--one-cap-vocabulary)                  |
+| D3  | Duration style             | **`number \| string`** (`'5s'` or raw ms) for every consumer-authored duration, parsed by one `parseDuration`. **Drop the `Ms` suffix from inputs**; reserve `Ms` for emitted telemetry only.                                                   | [P17](#p17--one-canonical-duration-form)       |
+| D4  | Home of the contract       | **This `CONTRACT.md` (living doc) + an enforcement lint** in the verify gate.                                                                                                                                                                   | [§7](#7-enforcement)                           |
+
+---
+
+## 1. The serialization gate (the load-bearing invariant)
+
+**P0 · `__config` round-trips as JSON; sugar is the only non-serializable layer.**
+
+This is the existing contract that everything else hangs off
+([`types.ts` `RedactedStitchConfig`](../packages/core/src/types.ts), ADR 0005
+Decision 11). It is restated first because every shorthand and envelope rule below
+must preserve it.
+
+-   The public, redacted `__config` a stitch/seam exposes — read by `diagram`, `mcp`,
+    `cli`, `config-summary`, and `export --openapi` — **MUST be plain JSON-serializable
+    data**: no functions, no live handles, no sugar forms.
+-   Every scalar/boolean/string **shorthand MUST be normalized** to its canonical
+    envelope field by `compose()` **before it reaches `__config`** (a `retry: 3` is
+    `{ attempts: 3 }` on `__config`, never `3`).
+-   Every **function-valued field is sugar** and lives **off** `__config` (on the
+    non-enumerable `__rawConfig`), exactly as `auth` / `store` / `adapter` / the live
+    `Surface` already do. This explicitly includes the key-derivation functions
+    ([`keyOf`](#p6--key-is-a-string-keyof-is-a-function)) — they are sugar, not a
+    blessed `__config` exception.
+
+> **Why first:** the program of adding shorthands (P12–P15) is safe **only** because
+> normalization keeps `__config` stable. A shorthand that leaked its scalar form onto
+> `__config` would break introspection. P0 is the budget the rest of the contract
+> spends.
+
+---
+
+## 2. Naming — short, one word, one meaning
+
+### P1 · One word, one concept, one value-space
+
+A public field or symbol **MUST** be the shortest unambiguous token for its concept
+(prefer one word), and that token **MUST** denote exactly one concept and one
+value-space across the entire surface.
+
+_Current violations:_ `key` is a `string` namespace in `CircuitOptions` but a
+`(input) => string` in `IdempotencyOptions` / `CacheConfig`; `query` is a GraphQL
+document string in `StitchConfig` but URL params in `StitchInput` / `InputSchemas`;
+`on` is retry-trigger statuses **and** rate-limit-signal statuses; `bodyKind`
+(`from-curl`) vs `bodyType` (everywhere else) for one `'json'|'form'` concept.
+
+### P2 · Don't reuse one word for genuinely different concepts — rename one
+
+When two fields legitimately mean **different** things, they **MUST NOT** share a
+name even if each is individually defensible; rename one so a reader never has to know
+they differ.
+
+_Canonical case:_ `scope` is a **pool** axis (`'stitch'|'host'`) in `ThrottleOptions`
+and a **tenancy** axis (`'principal'|'app'`) in `CacheConfig`/`CookieSessionOpts`.
+These are real, distinct concepts → **`throttle.scope` is renamed to `pool`**, freeing
+`scope` to mean tenancy everywhere. (This is a rename, **not** an assertion that they
+were the same concept.)
+
+### P3 · One suffix system
+
+A type's role **MUST** be predictable from its suffix:
+
+| Role                        | Suffix            | MUST NOT use                              |
+| --------------------------- | ----------------- | ----------------------------------------- |
+| Consumer-input envelope     | `*Options`        | `*Config`, `*Opts`, `*Info`, `*Params`    |
+| Produced / read-back shape  | `*Result`         | `*Return`, `*Response`, `*State`, `*Info` |
+| Duck-typed foreign contract | `*Like` (or none) | —                                         |
+
+`*Options` **MUST NOT** appear on a returned value.
+_Violations:_ `CacheConfig`, `OAuth2Opts`, `CookieSessionOpts`, `McpServerInfo`,
+`SignV4Params`; `StitchQueryOptions` is actually a `{ queryKey, queryFn }` **result**.
+_Carve-out:_ `StitchConfig`/`SeamConfig`/`RedactedStitchConfig` keep `*Config` as the
+one well-known top-level authoring type family (the thing you literally call
+`stitch(config)` with); the ban targets the **sibling capability bags**.
+
+### P4 · One cap vocabulary
+
+Per **D2**, a **count** upper-bound is a **bare plural noun** — `attempts`, `entries`,
+`pages`, `failures`, `concurrency` — never `max`-prefixed, never `*Threshold`, never a
+bare `max`. A **magnitude** ceiling (a delay) MAY keep `max` when a bare noun would be
+ambiguous. Plural **`attempts`** = a running total; singular **`attempt`** = the
+current index.
+
+_Violations:_ `ReconnectOptions.maxAttempts` (→ `attempts`), `CacheConfig.maxEntries`
+(→ `entries`), `CircuitOptions.failureThreshold` (→ `failures`), `paginate.max`
+(→ `pages`), `deno-kv maxIncrRetries`.
+
+---
+
+## 3. Typing — predictable and consistent
+
+### P5 · One success field, one failure field
+
+Per **D1**, every StitchAPI **runtime** result/event envelope **MUST** expose its
+success payload as **`data`** and its failure payload as **`error`**.
+
+-   Streaming increments keep **`chunk`** (`StitchEvent.delta.chunk`) — `data` is the
+    terminal/aggregated payload, `chunk` is an increment.
+-   The **Standard-Schema validation layer** (`ValidationResult` / `StandardResult`)
+    keeps **`value`** / **`issues`** — that is the external Standard-Schema spec, not
+    ours to rename.
+-   `value` **MUST NOT** be overloaded for non-payload tokens (e.g. rename
+    `SchemaFingerprint.value` → `token`).
+
+_Violations:_ success is `data` in `SafeResult` but `value` in `Inspection` /
+`StitchEvent.result`; those two move to `data`.
+
+### P6 · `key` is a string; `keyOf` is a function
+
+A field named **`key` MUST be a string** identifier/namespace. A key-**derivation**
+function **MUST** be named **`keyOf`** (a `(input) => string`) and **MUST NOT** be
+called `key`.
+
+_Violations:_ `IdempotencyOptions.key`, `CacheConfig.key` (both `(input) => string`)
+→ `keyOf`. `CircuitOptions.key` and `StitchStore.get/set/incr(key)` are correct as-is.
+
+### P7 · Status-classification parity
+
+Any field that answers "does this HTTP status match?" **MUST** share one shape:
+**`number[] | ((status: number) => boolean)`**. Any list-shaped field whose
+single-value case is common **MUST** accept **`T | T[]`** and normalize internally.
+
+_Violations:_ `acceptStatus` takes a predicate but `retry.on` / `rateLimit.on` are
+`number[]`-only (widen them); `acceptStatus: 404` should be legal (today needs
+`[404]`); `DriftOptions.ignore`, `refreshOn` are list-only while `DriftOptions.severity`
+already widens `'warn' ≡ ['warn']` — make widening uniform.
+
+### P8 · Same concept → same default across packages
+
+A field reused across packages **MUST** carry the same default, or the divergence
+**MUST** be reconciled deliberately and documented — never left as a silent inversion.
+
+_Violations:_ `PinoSinkOptions.lifecycle` defaults `true` but `SentrySinkOptions.lifecycle`
+defaults `false`; `OAuth2Opts.tenancy` defaults `'app'` but `CookieSessionOpts.scope`
+defaults `'principal'` (same tenancy concept, two names **and** inverted defaults — fix
+both under P2).
+
+### P9 · Unique-by-shape exported types
+
+An exported type identifier **MUST** denote one structural contract across all
+packages. A genuinely per-framework shape **MUST** be framework-qualified
+(`SolidStitchStore` vs `SvelteStitchStore`, ADR 0012 rule 6); a shared shape **MUST**
+be hoisted into `query-core`/`core` and re-exported.
+
+_Violations:_ `StitchStore<T>` means two incompatible things in `@stitchapi/solid`
+(nested `.state`) vs `@stitchapi/svelte` (a `Readable`); `StitchLike` is redefined
+three ways across `query-core` / `swr` / `rtk-query`; `RequestSeam` (express/elysia)
+vs `HonoRequestSeam` vs `StitchHost` (fastify/nest) for the per-request seam;
+`StitchError` vs `StitchErrorLike` for one runtime shape.
+
+### P10 · Error-class taxonomy parity
+
+Every thrown error type (`StitchError`, `RateLimitError`, and per-package re-exports)
+**MUST** guarantee the same field set (`status?`, `attempts`, `body?`, `url?`, and a
+stable discriminator) so a consumer can branch on any thrown error uniformly.
+
+### P11 · Async/sync signature parity
+
+The same verb **MUST** keep the same sync/async shape across every surface and adapter.
+A `close()` is `() => Promise<void>` everywhere; a verb is not sync in one driver and
+async in another.
+
+_Violation:_ `DenoKvLike.close` is synchronous while every other store `close` returns
+`Promise<void>`.
+
+---
+
+## 4. Shorthands & envelopes (the preferred authoring model)
+
+> The maintainer's model: **every capability is a config object (an envelope), and an
+> envelope with one dominant field also accepts that field's scalar as shorthand.** > `retry`/`timeout`/`cache` already prove it; the rest of the surface MUST follow.
+> Every shorthand normalizes to the canonical field per **P0**.
+
+### P12 · Envelope + scalar shorthand
+
+Every capability **MUST** be expressible as a config object. An envelope whose
+meaningful surface is a **single dominant field MUST** also accept that field's scalar
+at its `StitchConfig` slot.
+
+| Slot                      | Today              | MUST also accept                            | Shorthand              |
+| ------------------------- | ------------------ | ------------------------------------------- | ---------------------- |
+| `retry` `timeout` `cache` | ✅                 | —                                           | done                   |
+| `stream`                  | `StreamOptions`    | `StreamDecode \| StreamOptions`             | `stream: 'ndjson'`     |
+| `multipart`               | `MultipartOptions` | `MultipartNesting \| MultipartOptions`      | `multipart: 'dot'`     |
+| `sse`                     | `{ reconnect }`    | `boolean \| ReconnectOptions \| SseOptions` | `sse: true`            |
+| `.inspect()`              | `{ cache }`        | `boolean \| InspectOptions`                 | `inspect(input, true)` |
+
+### P13 · Boolean toggle means enable-with-defaults
+
+A capability whose primary act is an on-switch **MUST** accept **`boolean | Options`**,
+where `true` = enable-with-documented-defaults; it **MUST NOT** require an object
+literal merely to switch on.
+
+_Apply to:_ `idempotency?: boolean | IdempotencyOptions`,
+`rateLimit?: boolean | RateLimitOptions` (`true ≡ { delegate: true }`),
+`inspect(input, true)`. `sse.reconnect: true` already sets the precedent.
+
+### P14 · Multi-field envelopes are named, exported, and MAY shorthand their dominant field
+
+A config sub-object with more than one field **MUST** be a named, exported `*Options`
+interface (never an anonymous inline shape), so it can be imported, extended, and
+referenced. A multi-field envelope **MAY** still offer a scalar shorthand for an
+**unambiguously dominant** field (this is **not** the single-field collapse of P12).
+
+_Violations:_ `paginate` (`{ next; items?; max? }`) and `rateLimit`
+(`{ delegate?; on? }`) are anonymous → extract `PaginateOptions`, `RateLimitOptions`.
+_Allowed example:_ `throttle?: string | ThrottleOptions` where `'2/s' ≡ { rate: '2/s' }`
+— `rate` dominates although `concurrency` also exists (so this is a P14 dominant-field
+shorthand, not a P12 collapse).
+
+### P15 · Required fields are deliberate and get a named/positional shorthand — not silent defaults
+
+An `*Options` envelope **SHOULD** be `{}`-constructible (every field optional with a
+documented default). Where a field is **required by design** because a silent default
+is a footgun, it **MUST** stay required and the envelope **MUST** offer a scalar/
+positional shorthand naming the required value(s).
+
+-   `CircuitOptions.failures`/`cooldown` **stay required** (a breaker with invisible
+    thresholds fails open/closed silently) — add a positional shorthand instead.
+-   `CacheOptions.ttl` **stays required** — its shorthand `cache: '1m'` already names it.
+
+> This corrects the audit draft, which tried to defend `ttl`-required while attacking
+> `circuit`-required. Required-with-a-named-shorthand is the **one** acceptable form of
+> a non-`{}` envelope.
+
+---
+
+## 5. Cross-cutting
+
+### P16 · Cross-surface & cross-package parity
+
+A concept **MUST** use the same field name, shorthand, and envelope on every surface
+(`stitch` / `seam` / `pipe`) and every framework package, varying only the
+framework-idiomatic verb (`use` / `create` / `inject`). New config fields are added to
+`StitchConfig` and **projected** (`SeamConfig = Omit<StitchConfig, …>` is the model),
+never re-declared per surface. ADR 0012's `stitchQueryOptions` rename **MUST** be
+applied to all five TanStack adapters, not react only.
+
+_Violations:_ SSE helper is `streamStitchSse` / `sendStitchSse` / `stitchSse`;
+error-options is `StitchErrorHandlerOptions` / `StitchErrorOptions` /
+`ToHttpExceptionOptions` (with `body` present in some, absent in others); the hook
+result interface is `UseStitchResult` / `UseStitchReturn` / `InjectStitchResult` /
+`StitchStore`; `queryOptions` is still bare in vue/solid/svelte/angular.
+
+### P17 · One canonical duration form
+
+Per **D3**, every **consumer-authored** duration **MUST** accept
+**`number | string`** (raw ms or a token like `'5s'`/`'1m'`), parsed by one shared
+`parseDuration`, and **MUST** drop the `Ms` name suffix. The `Ms` suffix is **reserved
+for emitted/telemetry/wire** durations, which are always raw ms.
+
+_Why:_ every JS-native time API (`Date.now()`, `setTimeout`, `performance.now()`) is
+**already ms**, so a bare number on an input is unambiguously ms and the `Ms` suffix
+is redundant noise; accepting `'5s'` on top of it is pure ergonomic gain. The suffix
+earns its place only on emitted numbers, where it documents the unit a reader can't
+otherwise infer.
+
+_Violations (inputs to widen + de-suffix):_ `RetryOptions.baseMs`/`maxMs`,
+`CircuitOptions.cooldownMs`/`halfOpenAfterMs`, `ReconnectOptions.backoffMs`,
+`OAuth2Opts.refreshSkewMs`, `CookieSessionOpts.ttlMs`, store-contract `ttlMs`.
+_Telemetry to keep/normalize as `*Ms`:_ `StitchEvent.waitedMs` / `retryAfterMs`;
+rename bare `StitchEvent.done.ms` → `doneMs` and `SseEvent.retry` → `retryMs`.
+_Unit hazard (the exception to "all JS time is ms"):_ a few fields are **seconds**
+because they mirror a wire format — `MockResponse.retryAfter` and the HTTP
+`Retry-After` header (delta-seconds), Cloudflare KV `expirationTtl`. Every
+StitchAPI-_authored_ duration stays ms; a field that must speak a foreign unit converts
+at the adapter edge and is named with its true unit (`expirationSeconds`,
+`retryAfterSeconds`) so the unit is never silent.
+
+### P18 · Adapter mirrors keep upstream spelling; house contracts use house vocabulary
+
+A duck-type that mirrors a foreign SDK **MUST** keep that SDK's spelling (so it
+structurally matches). StitchAPI's **own normalized** contracts (`StitchStore`,
+`RedisDriver`) **MUST** use one house vocabulary: `ttlMs` (always ms; convert foreign
+units at the edge), `delete` (not `del`), `close(): Promise<void>` (async, per P11),
+with one optionality per parameter (`ttlMs` MUST NOT be optional on `set` but required
+on `incr`).
+
+### P19 · No pre-GA hard break
+
+Every rename, narrowing, or removal mandated here **MUST** ship a `@deprecated`
+re-export/field alias pinned by an identity test, removed at the **1.0 GA cut**
+(extending ADR 0012's precedent from symbols to fields). Widening
+(`number → number | string`, P17) is non-breaking and needs no alias.
+
+---
+
+## 6. Migration backlog (proposed renames — confirm during sweep)
+
+Not normative. The rule is the law; these are the proposed target spellings the sweep
+will apply under `@deprecated` aliases (P18). Severity = consumer blast radius.
+
+| Sev  | Current                                                               | Proposed                                | Rule |
+| ---- | --------------------------------------------------------------------- | --------------------------------------- | ---- |
+| High | `SafeResult.data` ↔ `Inspection.value` ↔ `StitchEvent.result.value` | `data` everywhere                       | P5   |
+| High | `IdempotencyOptions.key`, `CacheConfig.key` (fn)                      | `keyOf`                                 | P6   |
+| High | `ThrottleOptions.scope` (`'stitch'｜'host'`)                          | `pool`                                  | P2   |
+| High | `retry.on`, `rateLimit.on` (`number[]`)                               | `number[] ｜ (status)=>boolean`         | P7   |
+| High | `StitchStore`/`StitchLike`/`RequestSeam` cross-pkg clashes            | hoist or qualify                        | P9   |
+| High | `queryOptions` bare in vue/solid/svelte/angular                       | `stitchQueryOptions`                    | P16  |
+| Med  | `CacheConfig` →                                                       | `CacheOptions`                          | P3   |
+| Med  | `OAuth2Opts`, `CookieSessionOpts`                                     | `OAuth2Options`, `CookieSessionOptions` | P3   |
+| Med  | `McpServerInfo`, `SignV4Params`                                       | `…Options`                              | P3   |
+| Med  | `StitchQueryOptions` (a result)                                       | `StitchQueryResult`                     | P3   |
+| Med  | `ReconnectOptions.maxAttempts`                                        | `attempts`                              | P4   |
+| Med  | `CacheConfig.maxEntries`                                              | `entries`                               | P4   |
+| Med  | `CircuitOptions.failureThreshold`                                     | `failures`                              | P4   |
+| Med  | `paginate.max`                                                        | `pages`                                 | P4   |
+| Med  | `*Ms` input durations (`cooldownMs`, `backoffMs`, `baseMs`, …)        | de-suffix + `number｜string`            | P17  |
+| Med  | `paginate`, `rateLimit` inline shapes                                 | `PaginateOptions`, `RateLimitOptions`   | P14  |
+| Med  | SSE helper `sendStitchSse`/`stitchSse`                                | `streamStitchSse`                       | P16  |
+| Med  | error-options `StitchErrorHandlerOptions`/`ToHttpExceptionOptions`    | `StitchErrorOptions` (+ `body`)         | P16  |
+| Low  | `RedisDriver.del`, `…quit`, sync `close`                              | `delete`, async `close`                 | P18  |
+| Low  | `SchemaFingerprint.value`                                             | `token`                                 | P5   |
+| Low  | `bodyKind` (from-curl)                                                | `bodyType`                              | P1   |
+| Low  | `StitchEvent.done.ms`, `SseEvent.retry`                               | `doneMs`, `retryMs`                     | P17  |
+
+New shorthand/toggle slots to **add** (additive, non-breaking): `stream`, `multipart`,
+`sse`, `.inspect()` scalars (P12); `idempotency`, `rateLimit` booleans (P13-toggle);
+`throttle` string (P14).
+
+---
+
+## 7. Enforcement
+
+[`scripts/check-contract.mjs`](../scripts/check-contract.mjs) is a **ratchet**, run as
+`pnpm check:contract` in `lefthook` (pre-push) and `verify.yml` — the same wiring as
+`check:exports` / `check:release`.
+
+-   It scans the published packages' public surface and reports contract violations.
+-   The current backlog is frozen in
+    [`scripts/contract-violations.baseline.json`](../scripts/contract-violations.baseline.json).
+    The lint **fails only when a NEW violation appears** (or — once the migration
+    starts — when the baseline is not shrunk to match). This mirrors the repo's existing
+    ESLint-suppression ratchet: the gate never blocks unrelated work, but the surface can
+    only get more consistent, never less.
+-   Rules implemented today (high-precision, source-text level): **R1** banned type-name
+    suffix (P3), **R2** `*Ms`-suffixed field inside an `*Options` input bag (P17),
+    **R3** function-typed `key` (P6), **R4** `scope: 'stitch'|'host'` overload (P2),
+    **R5** same identifier exported by ≥2 published packages (P9).
+-   Deferred to a type-aware phase (needs the TS checker, not regex): full
+    same-name-different-**shape** detection, duration-type conformance, default-value
+    inversion (P8). Tracked as comments in the lint.
+
+---
+
+## 8. References
+
+-   [ADR 0012 — Integration symbol naming](adr/0012-integration-symbol-naming.md) — the
+    cross-package symbol rules this contract extends to field/shape level.
+-   [ADR 0005 — Surfaces and the authoring model](adr/0005-surfaces-and-the-authoring-model.md)
+    — Decision 11, the `__config`-round-trips-as-JSON gate (P0).
+-   [ADR 0002 — Seam primitive](adr/0002-seam-primitive-and-principal-scoped-auth.md) —
+    the principal boundary and the `SeamConfig = Omit<StitchConfig>` projection (P16).
+-   [`packages/core/src/types.ts`](../packages/core/src/types.ts) — the canonical
+    `StitchConfig` envelope and result/event shapes.

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -419,6 +419,13 @@ cut; the lint skips the deprecated members so each rename ratchets the baseline 
     `CacheOptions.maxEntries`→`entries`, `paginate.max`→`pages`; runtime prefers the new
     field. (`CircuitOptions.failureThreshold`→`failures` is deferred to the P17 CircuitOptions
     overhaul, where its required-ness + `cooldownMs`/`halfOpenAfterMs` are handled together.)
+-   **P7** `RetryOptions.on` (and the folded `throttle.on`) now accept
+    `number[] | (status) => boolean` — additive widening, no alias. The engine normalizes via the
+    shared `acceptsStatus` matcher.
+-   **P14** `rateLimit` folded into `throttle` (`throttle.delegate` / `throttle.on`); the top-level
+    `rateLimit` is `@deprecated` (runtime prefers `throttle.* ?? rateLimit.*`). `PaginateOptions`
+    extracted from the inline `paginate` shape (named + exported). `throttle: { rate, delegate }` is
+    the unified envelope — delegate makes the rate inert, now legible within one object.
 
 ---
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -51,6 +51,10 @@ pre-push:
           run: pnpm check:format
         - name: lint
           run: pnpm check:lint
+        # API meta-contract ratchet (docs/CONTRACT.md). Cheap source scan, fail-fast before
+        # the expensive test/build jobs. Mirrors CI's check:contract step.
+        - name: contract
+          run: pnpm check:contract
         - name: typecheck
           run: pnpm check:types
         # Type-level tests (tsd) for the inferred public API — builds the package's d.ts and

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "check:size": "pnpm -r check:size",
         "check:size-docs": "node scripts/check-size-docs.mjs",
         "check:docs-links": "node scripts/check-docs-links.mjs",
+        "check:contract": "node scripts/check-contract.mjs",
         "check:format": "prettier --check .",
         "check:release": "node scripts/check-release.mjs",
         "check:readme": "node scripts/gen-readme-metrics.mjs --check",

--- a/packages/aws-sigv4/src/index.ts
+++ b/packages/aws-sigv4/src/index.ts
@@ -130,7 +130,7 @@ function canonicalQuery(search: URLSearchParams): string {
 // signRequestV4 — the pure signer (verifiable against AWS test vectors)
 // ---------------------------------------------------------------------------
 
-export interface SignV4Params {
+export interface SignV4Options {
     method: string;
     /** The fully-built request URL (host, path, query). */
     url: string;
@@ -161,7 +161,7 @@ export interface SignV4Result {
  * {@link awsSigV4} strategy wraps this with timestamping, payload hashing, and
  * header attachment.
  */
-export async function signRequestV4(p: SignV4Params): Promise<SignV4Result> {
+export async function signRequestV4(p: SignV4Options): Promise<SignV4Result> {
     const u = new URL(p.url);
     const amzDate = p.dateTime;
     const dateStamp = amzDate.slice(0, 8);
@@ -319,3 +319,7 @@ export function awsSigV4(opts: AwsSigV4Options): AuthStrategy {
         },
     };
 }
+
+// CONTRACT.md P3 — deprecated alias, removed at the 1.0 GA cut.
+/** @deprecated Renamed to {@link SignV4Options} (CONTRACT.md P3). Imported name kept until the 1.0 GA cut. */
+export type SignV4Params = SignV4Options;

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -235,7 +235,7 @@ export function basic(opts: { user: Secret; pass: Secret }): AuthStrategy {
     };
 }
 
-export interface OAuth2Opts {
+export interface OAuth2Options {
     /** The `client_credentials` token endpoint (POST, form-encoded). */
     tokenUrl: string;
     /** OAuth2 client id; resolved at call time (env/secretsFile), never committed. */
@@ -276,7 +276,7 @@ export interface OAuth2Opts {
      * Token tenancy (ADR 0002 §3). Default **`'app'`**: one token serves every caller — the right
      * model for `client_credentials`, which authenticates the *application*, not a user. Set
      * `'principal'` to fold the seam-bound principal into the token's cache key (and **throw if no
-     * principal is bound**, mirroring {@link CookieSessionOpts.scope}); each tenant then caches its
+     * principal is bound**, mirroring {@link CookieSessionOptions.scope}); each tenant then caches its
      * own token and one tenant's 401/refresh never disturbs another's in-flight calls. Pair it with
      * per-tenant `clientId`/`clientSecret`/`scope` for full multi-tenant separation.
      */
@@ -313,7 +313,7 @@ function singleFlight<T>(): (key: string, run: () => Promise<T>) => Promise<T> {
  * it as `Authorization: Bearer …`. A SHARED store makes one token serve many stitches/workers
  * and survive restarts; a rejected token (status in `refreshOn`) forces a fresh fetch + retry.
  */
-export function oauth2(opts: OAuth2Opts): AuthStrategy {
+export function oauth2(opts: OAuth2Options): AuthStrategy {
     const refreshOn = opts.refreshOn ?? [401];
     const skew = opts.refreshSkewMs ?? 30_000;
     const baseKey = 'oauth2:' + (opts.key ?? opts.tokenUrl);
@@ -453,9 +453,9 @@ export function oauth2(opts: OAuth2Opts): AuthStrategy {
  * Why an `apply`/`refresh` login attempt failed, categorised so the HOST can drive its OWN
  * durable state machine (wrong-creds vs rate-limited vs network) — StitchAPI keeps doing the
  * mechanical cookie capture/replay, but it can't model a host's external recovery loop, so it
- * hands the host a categorised outcome instead. Surfaced via {@link CookieSessionOpts.onAuthFailure}.
+ * hands the host a categorised outcome instead. Surfaced via {@link CookieSessionOptions.onAuthFailure}.
  */
-export interface AuthFailureInfo {
+export interface AuthFailureResult {
     /** `'apply'` = cold session had no stored cookie; `'refresh'` = a 401-style wall was hit. */
     phase: 'apply' | 'refresh';
     /** The login response status when the login responded at all (absent when it threw). */
@@ -473,7 +473,7 @@ export interface AuthFailureInfo {
     category: 'unauthenticated' | 'rate-limited' | 'network' | 'unknown';
 }
 
-/** Outcome of a single (re)login attempt, surfaced via {@link CookieSessionOpts.onRefresh}. */
+/** Outcome of a single (re)login attempt, surfaced via {@link CookieSessionOptions.onRefresh}. */
 export interface RefreshResult {
     /** A cookie (named, or any jar entry) was captured from the login response. */
     ok: boolean;
@@ -481,7 +481,7 @@ export interface RefreshResult {
     status?: number;
 }
 
-export interface CookieSessionOpts {
+export interface CookieSessionOptions {
     /** The login stitch — its raw response (the Set-Cookie headers) seeds the session. */
     login: Stitch;
     /**
@@ -516,11 +516,11 @@ export interface CookieSessionOpts {
     /**
      * Host-owned hook fired once per ACTUAL login attempt that failed to capture a cookie — NOT
      * per coalesced waiter (it runs inside the single-flight-guarded `doRefresh`). The host maps the
-     * categorised {@link AuthFailureInfo} to its own status (active/backoff/failed/unauthenticated)
+     * categorised {@link AuthFailureResult} to its own status (active/backoff/failed/unauthenticated)
      * and owns the external recovery loop that StitchAPI's per-call single-flight can't model. A
      * throwing hook never crashes the call (it is caught and announced on the `auth` trace topic).
      */
-    onAuthFailure?: (info: AuthFailureInfo) => void | Promise<void>;
+    onAuthFailure?: (info: AuthFailureResult) => void | Promise<void>;
     /**
      * Host-owned hook fired once after EVERY (re)login attempt — success or failure — with its
      * {@link RefreshResult}, so the host can persist durable session state and clear/extend its
@@ -530,7 +530,7 @@ export interface CookieSessionOpts {
     onRefresh?: (result: RefreshResult) => void | Promise<void>;
 }
 
-export function cookieSession(opts: CookieSessionOpts): AuthStrategy {
+export function cookieSession(opts: CookieSessionOptions): AuthStrategy {
     const refreshOn = opts.refreshOn ?? [401];
     const jarMode = opts.jar === true || opts.cookie === '*';
     const scope = opts.scope ?? 'principal';
@@ -585,7 +585,7 @@ export function cookieSession(opts: CookieSessionOpts): AuthStrategy {
         phase: 'apply' | 'refresh',
         status: number,
         headers: Record<string, string>,
-    ): AuthFailureInfo => {
+    ): AuthFailureResult => {
         if (status === 429) {
             // Omit `retryAfterMs` entirely when the header is absent/unparseable —
             // `exactOptionalPropertyTypes` forbids setting an optional prop to `undefined`.
@@ -608,7 +608,7 @@ export function cookieSession(opts: CookieSessionOpts): AuthStrategy {
         ctx: AuthContext,
         ok: boolean,
         status: number | undefined,
-        failure?: AuthFailureInfo,
+        failure?: AuthFailureResult,
     ): Promise<void> => {
         // Bind into locals so the optional hooks narrow to defined — no non-null assertion needed.
         const onRefresh = opts.onRefresh;
@@ -662,7 +662,7 @@ export function cookieSession(opts: CookieSessionOpts): AuthStrategy {
                 response?: AdapterResponse;
             };
             const status = typeof e.status === 'number' ? e.status : undefined;
-            const failure: AuthFailureInfo =
+            const failure: AuthFailureResult =
                 status === undefined
                     ? { phase, category: 'network', error }
                     : classify(phase, status, e.response?.headers ?? {});
@@ -775,3 +775,7 @@ function serializeJar(jar: Record<string, string> | undefined): string {
         .map(([k, v]) => `${k}=${v}`)
         .join('; ');
 }
+
+// CONTRACT.md P3 — deprecated alias, removed at the 1.0 GA cut.
+/** @deprecated Renamed to {@link AuthFailureResult} (CONTRACT.md P3). Imported name kept until the 1.0 GA cut. */
+export type AuthFailureInfo = AuthFailureResult;

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -148,7 +148,7 @@ function canonicalRequest(
 
 /** Derive the opaque 128-bit key from a resolved request, or `undefined` when the request is
  *  not hashable (an unserialisable body) — the caller then warns and passes through. With a
- *  `userKey` (the `cache.key` sugar) the request canonicalisation is replaced, but the version
+ *  `userKey` (the `cache.keyOf` sugar) the request canonicalisation is replaced, but the version
  *  and principal still fold in so scope isolation is never lost. */
 export function deriveCacheKey(
     d: RequestDescriptor,
@@ -440,7 +440,9 @@ export function createCache(opts: CacheControllerOptions): CacheController {
                 principalForScope !== undefined
                     ? { ...d, principal: principalForScope }
                     : d;
-            const userKey = config.key ? config.key(input) : undefined;
+            // eslint-disable-next-line @typescript-eslint/no-deprecated -- `key` is the @deprecated alias of `keyOf`, read as the back-compat fallback until the GA cut (CONTRACT.md P6)
+            const keyOf = config.keyOf ?? config.key;
+            const userKey = keyOf ? keyOf(input) : undefined;
             return deriveCacheKey(scoped, explicitVary, userKey);
         },
 

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -10,7 +10,7 @@
 import { resolveFingerprint } from './fingerprint';
 import type { CachePolicy } from './fingerprint';
 import { xxh128 } from './hash';
-import type { CacheConfig, StitchInput, StitchStore } from './types';
+import type { CacheOptions, StitchInput, StitchStore } from './types';
 import { parseDuration } from './util';
 
 // The 128-bit synchronous non-crypto key hash now lives in the shared `./hash` module so the cache
@@ -340,7 +340,7 @@ export interface CacheController {
 }
 
 export interface CacheControllerOptions {
-    config: CacheConfig;
+    config: CacheOptions;
     store: StitchStore;
     stitchId: string;
     principal?: string;

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -359,7 +359,8 @@ export function createCache(opts: CacheControllerOptions): CacheController {
     const methods = (config.methods ?? ['GET', 'HEAD']).map((m) =>
         m.toUpperCase(),
     );
-    const maxEntries = config.maxEntries ?? 1000;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `maxEntries` is the @deprecated alias of `entries`, read for back-compat until the GA cut (CONTRACT.md P4)
+    const maxEntries = config.entries ?? config.maxEntries ?? 1000;
     const explicitVary = config.vary?.length
         ? config.vary
               .map((n) => n.toLowerCase())

--- a/packages/core/src/config-summary.ts
+++ b/packages/core/src/config-summary.ts
@@ -39,12 +39,11 @@ export function pipelineStages(
             opts.detailed ? `retry ×${cfg.retry.attempts ?? 1}` : 'retry',
         );
     if (kind !== 'http') stages.push(`${kind} interpret`);
-    if (cfg.paginate)
-        stages.push(
-            opts.detailed
-                ? `paginate (max ${cfg.paginate.max ?? 50})`
-                : 'paginate',
-        );
+    if (cfg.paginate) {
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- `max` is the @deprecated alias of `pages`, read for back-compat until the GA cut (CONTRACT.md P4)
+        const pages = cfg.paginate.pages ?? cfg.paginate.max ?? 50;
+        stages.push(opts.detailed ? `paginate (max ${pages})` : 'paginate');
+    }
     // Post-response order matches the engine (engine.ts): transform → unwrap → validate. The body
     // is transformed, then the unwrap path is read, then the result is validated against `output`.
     if (cfg.transform) stages.push('transform');

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -858,7 +858,8 @@ async function* paginated(
     const { cfg } = rt;
     const name = nameOf(cfg);
     const pg = cfg.paginate!;
-    const max = pg.max ?? 50;
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `max` is the @deprecated alias of `pages`, read for back-compat until the GA cut (CONTRACT.md P4)
+    const max = pg.pages ?? pg.max ?? 50;
     const acc: unknown[] = [];
     let pageInput = input;
     let page = 0;
@@ -1410,7 +1411,8 @@ function resolveReconnect(cfg: ResolvedStitchConfig): {
         return { enabled: true, maxAttempts: 3, backoffMs: undefined };
     return {
         enabled: true,
-        maxAttempts: r.maxAttempts ?? 3,
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- `maxAttempts` is the @deprecated alias of `attempts`, read for back-compat until the GA cut (CONTRACT.md P4)
+        maxAttempts: r.attempts ?? r.maxAttempts ?? 3,
         backoffMs: r.backoffMs,
     };
 }

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -163,9 +163,9 @@ function applyIdempotency(
         )
     )
         return;
-    headers[header] = cfg.idempotency.key
-        ? cfg.idempotency.key(input)
-        : randomUUID();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `key` is the @deprecated alias of `keyOf`, read as the back-compat fallback until the GA cut (CONTRACT.md P6)
+    const keyOf = cfg.idempotency.keyOf ?? cfg.idempotency.key;
+    headers[header] = keyOf ? keyOf(input) : randomUUID();
 }
 
 const resolveStr = (v: string | (() => string) | undefined): string =>
@@ -255,7 +255,8 @@ const cloneReq = (r: AdapterRequest): AdapterRequest => ({
     headers: { ...r.headers },
 });
 const hostKey = (req: AdapterRequest, cfg: ResolvedStitchConfig): string => {
-    if (cfg.throttle?.scope === 'host') {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `scope` is the @deprecated alias of `pool`, read as the back-compat fallback until the GA cut (CONTRACT.md P2)
+    if ((cfg.throttle?.pool ?? cfg.throttle?.scope) === 'host') {
         try {
             return new URL(req.url).host;
         } catch {

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -598,16 +598,21 @@ async function* attemptLoop(
 ): AsyncGenerator<StitchEvent, AdapterResponse> {
     const { cfg } = rt;
     const max = cfg.retry?.attempts ?? 1;
-    const retryOn = cfg.retry?.on ?? [429, 502, 503, 504];
+    // P7: `retry.on` accepts a status list OR a predicate — normalize to one matcher.
+    const retryMatch = acceptsStatus(cfg.retry?.on ?? [429, 502, 503, 504]);
     const perAttemptMs = parseDuration(cfg.timeout?.perAttempt);
     const key = hostKey(baseReq, cfg);
     let refreshed = false;
     // Delegate-backoff mode (issue #145): the host owns the gate. We bypass the internal throttle
     // for the call (no acquire/release, so `throttle` is inert and no `throttled` event fires) and,
-    // on a response whose status is in `rlOn` (default [429]), surface a RateLimitError instead of
-    // retrying. Everything else — auth, the success path, non-rate-limit failures — is unchanged.
-    const delegate = cfg.rateLimit?.delegate === true;
-    const rlOn = cfg.rateLimit?.on ?? [429];
+    // on a response whose status matches `rlMatch` (default [429]), surface a RateLimitError instead
+    // of retrying. Everything else — auth, the success path, non-rate-limit failures — is unchanged.
+    // P14: `rateLimit` folded into `throttle` — read `throttle.delegate`/`throttle.on`, falling back
+    // to the @deprecated top-level `rateLimit` (read once here) until the GA cut.
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `rateLimit` folded into `throttle` (P14); back-compat fallback until GA
+    const legacyRl = cfg.rateLimit;
+    const delegate = (cfg.throttle?.delegate ?? legacyRl?.delegate) === true;
+    const rlMatch = acceptsStatus(cfg.throttle?.on ?? legacyRl?.on ?? [429]);
     // acceptStatus (issue #155): statuses the caller declares NORMAL — an accepted non-2xx returns
     // `res` like a 2xx (flowing through interpret → transform → unwrap → validate) instead of
     // throwing. Checked at the `>= 400` site, i.e. AFTER the retry-on-status path, so `retry.on`
@@ -721,7 +726,7 @@ async function* attemptLoop(
             // gate owns the backoff. Checked BEFORE the internal retry-on-status path so it wins even
             // when the same status is also in `retry.on` (the common `429` overlap). `Retry-After` is
             // parsed with the same helper the internal retry uses, so the host gets an identical hint.
-            if (delegate && rlOn.includes(res.status)) {
+            if (delegate && rlMatch(res.status)) {
                 throw new RateLimitError({
                     status: res.status,
                     retryAfterMs: parseRetryAfter(
@@ -732,7 +737,7 @@ async function* attemptLoop(
                 });
             }
 
-            if (retryOn.includes(res.status) && attempt < max) {
+            if (retryMatch(res.status) && attempt < max) {
                 const ra = cfg.retry?.respectRetryAfter
                     ? parseRetryAfter(res.headers['retry-after'], rt.clock)
                     : undefined;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,10 @@ export {
     secretsFile,
     secretFrom,
 } from './auth';
-export type { SecretSource, AuthFailureInfo, RefreshResult } from './auth';
+export type { SecretSource, AuthFailureResult, RefreshResult } from './auth';
+// CONTRACT.md P3 — deprecated alias re-export, removed at GA.
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- intentional back-compat re-export of the @deprecated `AuthFailureInfo` (now `AuthFailureResult`) until the GA cut
+export type { AuthFailureInfo } from './auth';
 export { fetchAdapter } from './http-adapter';
 export type { FetchAdapterOptions } from './http-adapter';
 export { axiosAdapter } from './axios-adapter';

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -113,7 +113,7 @@ function llmSurface(d: LlmDefaults): Surface<StitchInput, LlmResult> {
 }
 
 /** Config for {@link llm}: the shared {@link StitchConfig} keys plus the llm defaults. */
-export type LlmConfig = Partial<StitchConfig> & {
+export type LlmOptions = Partial<StitchConfig> & {
     provider: LlmProvider;
     model?: string;
     system?: string;
@@ -141,7 +141,7 @@ export type LlmConfig = Partial<StitchConfig> & {
  * const { text } = await chat({ body: { messages: [{ role: 'user', content: 'hi' }] } });
  * ```
  */
-export function llm(config: LlmConfig): Stitch<LlmResult> {
+export function llm(config: LlmOptions): Stitch<LlmResult> {
     const { provider, model, system, maxTokens, temperature, ...rest } = config;
     const defaults: LlmDefaults = { provider };
     if (model !== undefined) defaults.model = model;
@@ -266,3 +266,7 @@ export const openai: LlmProvider = {
         return result;
     },
 };
+
+// CONTRACT.md P3 — deprecated alias, removed at the 1.0 GA cut.
+/** @deprecated Renamed to {@link LlmOptions} (CONTRACT.md P3). Imported name kept until the 1.0 GA cut. */
+export type LlmConfig = LlmOptions;

--- a/packages/core/src/mcp.ts
+++ b/packages/core/src/mcp.ts
@@ -133,7 +133,7 @@ export interface McpServer {
     handle(message: JsonRpcMessage): Promise<JsonRpcMessage | null>;
 }
 
-export interface McpServerInfo {
+export interface McpServerOptions {
     name?: string;
     version?: string;
 }
@@ -142,7 +142,7 @@ export interface McpServerInfo {
 // its response (or null for notifications), independent of any transport.
 export function createMcpServer(
     registry: StitchRegistry,
-    info: McpServerInfo = {},
+    info: McpServerOptions = {},
 ): McpServer {
     const serverInfo = {
         name: info.name ?? SERVER_NAME,
@@ -282,7 +282,7 @@ export function createMcpServer(
 export interface StdioOptions {
     input?: Readable;
     output?: Writable;
-    info?: McpServerInfo;
+    info?: McpServerOptions;
 }
 
 // Wire an McpServer to the stdio transport: read newline-delimited JSON-RPC from
@@ -327,3 +327,7 @@ export function serveStdio(
     input.on('data', onData);
     return { server, close: () => input.off('data', onData) };
 }
+
+// CONTRACT.md P3 — deprecated alias, removed at the 1.0 GA cut.
+/** @deprecated Renamed to {@link McpServerOptions} (CONTRACT.md P3). Imported name kept until the 1.0 GA cut. */
+export type McpServerInfo = McpServerOptions;

--- a/packages/core/src/resilience.ts
+++ b/packages/core/src/resilience.ts
@@ -54,10 +54,10 @@ interface KeyState {
     nextGrantAt: number; // earliest time the next rate-limited acquire may proceed
 }
 
-// In-process registry of host-scoped limiter state. `scope:'host'` must pool the rate
+// In-process registry of host-pooled limiter state. `pool:'host'` must pool the rate
 // budget across SEPARATE stitch() instances hitting the same host even without a shared
 // store (throttle.mdx: "'host' pools the budget across every stitch hitting the same
-// host"). Closure-local maps can't do that, so host-scoped throttles share their KeyState
+// host"). Closure-local maps can't do that, so host-pooled throttles share their KeyState
 // here, keyed by the host. A configured `store` still overrides for cross-process pooling.
 const hostStates = new Map<string, KeyState>();
 
@@ -67,8 +67,8 @@ const hostStates = new Map<string, KeyState>();
  * `acquire` resolves once a slot is free (reporting how long it waited) and MUST be
  * paired with `release`. Concurrency waiters are served FIFO.
  *
- * With `scope:'host'`, per-key state lives in the module-level `hostStates` registry so the
- * budget pools in-process across independent stitch instances; `scope:'stitch'` (default)
+ * With `pool:'host'`, per-key state lives in the module-level `hostStates` registry so the
+ * budget pools in-process across independent stitch instances; `pool:'stitch'` (default)
  * keeps state closure-local to this limiter.
  */
 export function createThrottle(
@@ -81,8 +81,9 @@ export function createThrottle(
     const limit = opts?.concurrency;
     const rate = opts?.rate ? parseRate(opts.rate) : undefined;
     const spacing = rate ? rate.perMs / rate.count : 0; // ms between grants
-    const states =
-        opts?.scope === 'host' ? hostStates : new Map<string, KeyState>();
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `scope` is the @deprecated alias of `pool`, read as the back-compat fallback until the GA cut (CONTRACT.md P2)
+    const hostPooled = (opts?.pool ?? opts?.scope) === 'host';
+    const states = hostPooled ? hostStates : new Map<string, KeyState>();
 
     const stateFor = (key: string): KeyState => {
         let s = states.get(key);

--- a/packages/core/src/seam.ts
+++ b/packages/core/src/seam.ts
@@ -39,7 +39,7 @@ let seamCounter = 0;
 /**
  * The seam's shared throttle bucket. Member stitches all acquire it under ONE seam-stable key, so
  * the budget (rate + in-process concurrency) pools across every stitch — "one shared bucket"
- * (ADR 0002 §3). `scope: 'host'` keeps the engine's per-host key instead (pools per host).
+ * (ADR 0002 §3). `pool: 'host'` keeps the engine's per-host key instead (pools per host).
  */
 function seamBucket(
     opts: ThrottleOptions | undefined,
@@ -48,7 +48,8 @@ function seamBucket(
     clock: Clock,
 ): Throttle {
     const inner = createStoreThrottle(opts, store, clock);
-    if (opts?.scope === 'host') return inner; // the host key already pools across the seam
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `scope` is the @deprecated alias of `pool`, read as the back-compat fallback until the GA cut (CONTRACT.md P2)
+    if ((opts?.pool ?? opts?.scope) === 'host') return inner; // host key already pools across the seam
     const key = `seam:${seamId}`;
     return {
         // Re-key every acquire onto the one seam-stable key, forwarding the acquire options (e.g.

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -27,6 +27,7 @@ import {
     type DriftSpec,
     type HookContext,
     type Hooks,
+    type IdempotencyOptions,
     type InputSchemas,
     type InspectOptions,
     type Inspection,
@@ -136,6 +137,12 @@ function expandShorthand(cfg: Partial<StitchConfig>): void {
         cfg.timeout = { total: cfg.timeout };
     if (typeof cfg.cache === 'number' || typeof cfg.cache === 'string')
         cfg.cache = { ttl: cfg.cache };
+    // P20: `idempotency: true` enables it with defaults; `false`/absent is off. Normalize the
+    // boolean toggle to the object form the engine reads (the opaque `idempotency: {}` is a type
+    // error at the slot, so the all-defaults case arrives here as `true`).
+    if (cfg.idempotency === true)
+        (cfg as { idempotency?: IdempotencyOptions }).idempotency = {};
+    else if (cfg.idempotency === false) delete cfg.idempotency;
 }
 
 export function compose(config: Fragment): ResolvedStitchConfig {

--- a/packages/core/src/stream.ts
+++ b/packages/core/src/stream.ts
@@ -20,6 +20,7 @@ import { makeStitch } from './stitch';
 import type { Surface } from './surface';
 import {
     type AdapterResponse,
+    type ResolvedStitchConfig,
     type Seam,
     type SeamOptions,
     type Stitch,
@@ -61,7 +62,7 @@ type StreamElement<C> =
 // Decode the live body into `delta` items per `cfg.stream.decode` (default `'bytes'`).
 async function* decodeStream(
     res: AdapterResponse,
-    cfg: StitchConfig,
+    cfg: ResolvedStitchConfig,
 ): AsyncGenerator<unknown, void> {
     const body = res.body;
     if (!(body instanceof ReadableStream)) return;

--- a/packages/core/src/surface.ts
+++ b/packages/core/src/surface.ts
@@ -12,7 +12,7 @@ import type {
     Adapter,
     AdapterRequest,
     AdapterResponse,
-    StitchConfig,
+    ResolvedStitchConfig,
     StitchInput,
 } from './types';
 
@@ -35,7 +35,7 @@ export interface Surface<TInput = StitchInput, TResult = unknown> {
      * (possibly patched) one. Omitted = the http identity. (Wired for graphql in Stage 4.)
      */
     readonly buildRequest?: (
-        cfg: StitchConfig,
+        cfg: ResolvedStitchConfig,
         input: StitchInput,
         base: AdapterRequest,
     ) => AdapterRequest;
@@ -45,7 +45,7 @@ export interface Surface<TInput = StitchInput, TResult = unknown> {
      */
     readonly interpret?: (
         res: AdapterResponse,
-        cfg: StitchConfig,
+        cfg: ResolvedStitchConfig,
     ) => SurfaceOutcome<TResult>;
     /**
      * Decode a live response body into `delta` chunks. Its presence marks a surface as
@@ -53,7 +53,7 @@ export interface Surface<TInput = StitchInput, TResult = unknown> {
      */
     readonly stream?: (
         res: AdapterResponse,
-        cfg: StitchConfig,
+        cfg: ResolvedStitchConfig,
     ) => AsyncIterable<unknown>;
     /**
      * Map an emitted `delta` to the value the `output` contract validates (per-`delta`

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -262,6 +262,13 @@ export interface RetryOptions {
 export interface ThrottleOptions {
     rate?: string; // "2/s"
     concurrency?: number;
+    /**
+     * Where the limiter's counter is pooled: `'stitch'` (default) keeps a per-stitch
+     * budget; `'host'` shares one budget across every stitch hitting the same host. Renamed
+     * from `scope` (CONTRACT.md P2) so `scope` only ever means principal/app tenancy.
+     */
+    pool?: 'stitch' | 'host';
+    /** @deprecated Renamed to {@link ThrottleOptions.pool} (CONTRACT.md P2). Read until the 1.0 GA cut. */
     scope?: 'stitch' | 'host';
 }
 /**
@@ -284,7 +291,10 @@ export interface CircuitOptions {
 }
 export interface IdempotencyOptions {
     header?: string; // header name (default 'Idempotency-Key')
-    key?: (input: StitchInput) => string; // stable key per logical call (default: a random uuid)
+    /** Derive a stable key per logical call (default: a random uuid). Renamed from `key` (CONTRACT.md P6: `key` is a string, a derivation fn is `keyOf`). */
+    keyOf?: (input: StitchInput) => string;
+    /** @deprecated Renamed to {@link IdempotencyOptions.keyOf} (CONTRACT.md P6). Read until the 1.0 GA cut. */
+    key?: (input: StitchInput) => string;
 }
 
 // ---- Cache (ADR 0003) -----------------------------------------------------
@@ -357,7 +367,9 @@ export interface CacheConfig {
      * only for pure validators with no coercion/transform inside the schema).
      */
     onUnfingerprintable?: 'refuse' | 'revalidate';
-    /** Sugar: author the key seed from the input instead of deriving it from the request. */
+    /** Sugar: author the key seed from the input instead of deriving it from the request. Renamed from `key` (CONTRACT.md P6). */
+    keyOf?: (input: StitchInput) => string;
+    /** @deprecated Renamed to {@link CacheConfig.keyOf} (CONTRACT.md P6). Read until the 1.0 GA cut. */
     key?: (input: StitchInput) => string;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -265,7 +265,7 @@ export type Adapter = ((req: AdapterRequest) => Promise<AdapterResponse>) & {
 // ---- Resilience options ---------------------------------------------------
 export interface RetryOptions {
     attempts?: number; // total attempts incl. the first (default 1 = no retry)
-    on?: number[]; // status codes that trigger a retry (default [429,502,503,504])
+    on?: number[] | ((status: number) => boolean); // statuses (or a predicate) that trigger a retry (default [429,502,503,504])
     backoff?: 'expo' | 'expo-jitter' | 'fixed';
     baseMs?: number;
     maxMs?: number;
@@ -282,6 +282,15 @@ export interface ThrottleOptions {
     pool?: 'stitch' | 'host';
     /** @deprecated Renamed to {@link ThrottleOptions.pool} (CONTRACT.md P2). Read until the 1.0 GA cut. */
     scope?: 'stitch' | 'host';
+    /**
+     * Delegate rate-limit handling to the host (folded in from the top-level `rateLimit`,
+     * CONTRACT.md P14). When `true`, a rate-limit response (status matched by `on`, default `[429]`)
+     * is **not** retried or throttled internally — self-pacing (`rate`/`concurrency`) is bypassed and
+     * the outcome surfaces as a {@link RateLimitError}. Use it when an OUTER gate owns the backoff.
+     */
+    delegate?: boolean;
+    /** Statuses that count as a rate-limit signal under `delegate` — a list or a predicate. Default `[429]`. */
+    on?: number[] | ((status: number) => boolean);
 }
 /**
  * Options for one throttle `acquire`. `rateOnly` charges the rate limiter but takes NO concurrency
@@ -560,6 +569,24 @@ export interface InputSchemas {
     // slots; left undeclared, `variables` stays the loose untyped passthrough it has always been.
     variables?: SchemaLike;
 }
+/**
+ * Auto-pagination: follow pages until {@link PaginateOptions.next} returns `undefined`, aggregating
+ * `items` with auth/retry/throttle applied to every page (CONTRACT.md P14 — extracted from the
+ * inline `paginate` shape so it can be imported and composed).
+ */
+export interface PaginateOptions {
+    /**
+     * Given the previous page's raw body and how many pages were fetched, return the input (merged
+     * over the original) for the next page, or `undefined` to stop.
+     */
+    next: (prevBody: unknown, pagesFetched: number) => StitchInput | undefined;
+    /** Pull the array from each unwrapped page. Default: the value if it is an array. */
+    items?: (value: unknown) => unknown[];
+    /** Safety cap on pages. Default 50. */
+    pages?: number;
+    /** @deprecated Renamed to `pages` (CONTRACT.md P4). Read until the 1.0 GA cut. */
+    max?: number;
+}
 export interface StitchConfig {
     /** Label used in events and traces; defaults to `path` or `'stitch'`. */
     name?: string;
@@ -641,22 +668,7 @@ export interface StitchConfig {
     /** Reshape the raw body before unwrap and validation (e.g. scrape HTML to structured data). */
     transform?: (body: unknown) => unknown;
     /** Auto-loop pages, aggregating items, with auth/retry/throttle applied to every page. */
-    paginate?: {
-        /**
-         * Given the previous page's raw body and how many pages were fetched, return the
-         * input (merged over the original) for the next page, or `undefined` to stop.
-         */
-        next: (
-            prevBody: unknown,
-            pagesFetched: number,
-        ) => StitchInput | undefined;
-        /** Pull the array from each unwrapped page. Default: the value if it is an array. */
-        items?: (value: unknown) => unknown[];
-        /** Safety cap on pages. Default 50. */
-        pages?: number;
-        /** @deprecated Renamed to `pages` (CONTRACT.md P4). Read until the 1.0 GA cut. */
-        max?: number;
-    };
+    paginate?: PaginateOptions;
     /** Auth strategy — the stitch holds the credential; the caller never sees it. */
     auth?: AuthStrategy;
     /**
@@ -686,6 +698,9 @@ export interface StitchConfig {
     /** Circuit breaker that fast-fails a repeatedly failing dependency. */
     circuit?: CircuitOptions;
     /**
+     * @deprecated Folded into `throttle` (CONTRACT.md P14): use `throttle.delegate` / `throttle.on`.
+     * Read until the 1.0 GA cut.
+     *
      * Delegate backoff to the host (issue #145). When `delegate: true`, a rate-limit response
      * (status in `on`, default `[429]`) is **not** retried internally and the built-in `throttle`
      * is **bypassed** for the call — instead the outcome surfaces as a {@link RateLimitError}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,6 +10,16 @@ import type {
 import type { Surface } from './surface';
 import type { Validator } from './validator';
 
+/**
+ * A value with **at least one** property of `T` set. The empty object `{}` satisfies none of the
+ * per-key-required variants, so it is a type error — used so an all-optional options envelope's
+ * object form requires real customization while the enable-with-defaults case stays a scalar
+ * (`true`), never the opaque `{}` (CONTRACT.md P20).
+ */
+export type AtLeastOne<T, K extends keyof T = keyof T> = {
+    [P in K]: Required<Pick<T, P>> & Partial<Omit<T, P>>;
+}[K];
+
 export interface StitchInput {
     params?: Record<string, unknown>;
     query?: Record<string, unknown>;
@@ -695,8 +705,13 @@ export interface StitchConfig {
         /** Statuses treated as a rate-limit signal. Default `[429]`. */
         on?: number[];
     };
-    /** Inject a stable Idempotency-Key header on writes so safe retries don't duplicate. */
-    idempotency?: IdempotencyOptions;
+    /**
+     * Inject a stable Idempotency-Key header on writes so safe retries don't duplicate.
+     * `true` enables it with defaults (header `Idempotency-Key`, a random uuid per call); the
+     * object form customizes it and **must** set at least one field — the opaque `idempotency: {}`
+     * is rejected (CONTRACT.md P20).
+     */
+    idempotency?: boolean | AtLeastOne<IdempotencyOptions>;
     /**
      * Read-through response cache + in-process coalescing (ADR 0003). Off unless set; the engine
      * is loaded lazily from the `stitchapi/cache` subpath only when this block is present. A bare
@@ -753,11 +768,12 @@ export interface StitchConfig {
  */
 export type ResolvedStitchConfig = Omit<
     StitchConfig,
-    'retry' | 'timeout' | 'cache'
+    'retry' | 'timeout' | 'cache' | 'idempotency'
 > & {
     retry?: RetryOptions;
     timeout?: TimeoutOptions;
     cache?: CacheOptions;
+    idempotency?: IdempotencyOptions;
 };
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -142,6 +142,8 @@ export interface ReconnectOptions {
      * Total reconnect attempts after the first connection drops, before the stream gives up and
      * ends/errors exactly as today. Default 3.
      */
+    attempts?: number;
+    /** @deprecated Renamed to {@link ReconnectOptions.attempts} (CONTRACT.md P4). Read until the 1.0 GA cut. */
     maxAttempts?: number;
     /**
      * Fallback reconnect backoff (ms) when the server has NOT sent a `retry:` field on the dropped
@@ -329,6 +331,8 @@ export interface CacheOptions {
      */
     methods?: string[];
     /** In-process LRU cap on live entries (the store stays dumb). Default 1000. */
+    entries?: number;
+    /** @deprecated Renamed to {@link CacheOptions.entries} (CONTRACT.md P4). Read until the 1.0 GA cut. */
     maxEntries?: number;
     /**
      * Request coalescing mode. `'process'` (v1 default) collapses concurrent identical in-flight
@@ -639,6 +643,8 @@ export interface StitchConfig {
         /** Pull the array from each unwrapped page. Default: the value if it is an array. */
         items?: (value: unknown) => unknown[];
         /** Safety cap on pages. Default 50. */
+        pages?: number;
+        /** @deprecated Renamed to `pages` (CONTRACT.md P4). Read until the 1.0 GA cut. */
         max?: number;
     };
     /** Auth strategy — the stitch holds the credential; the caller never sees it. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -306,7 +306,7 @@ export interface IdempotencyOptions {
  *
  * Every field round-trips as JSON; `key` is **sugar** (a function override) that does not.
  */
-export interface CacheConfig {
+export interface CacheOptions {
     /** Time-to-live for a cached entry — `30_000`, `'30s'`, `'5m'`. Bounds staleness/drift. */
     ttl: number | string;
     /**
@@ -342,19 +342,19 @@ export interface CacheConfig {
      * `output`/`transform`/`unwrap` are unchanged for this tag). Leaving it unset hands off to the
      * automatic fingerprint: a registered `@stitchapi/fingerprint-*` strategy makes `output`
      * changes self-invalidate on the fast path; an un-fingerprintable schema falls to
-     * {@link CacheConfig.onUnfingerprintable} (default **refuse-to-cache**, fail-closed).
+     * {@link CacheOptions.onUnfingerprintable} (default **refuse-to-cache**, fail-closed).
      */
     version?: string | number;
     /**
      * Version tag for an opaque `transform` (ADR 0004). A `transform` is a closure that cannot be
      * soundly hashed, so by default a stitch that has one **refuses to cache** (re-validation can't
      * detect a transform change). Set this to make the transform sound and re-enable caching; bump
-     * it whenever the transform's behaviour changes. See also {@link CacheConfig.trustTransform}.
+     * it whenever the transform's behaviour changes. See also {@link CacheOptions.trustTransform}.
      */
     transformVersion?: string | number;
     /**
      * Opt in to caching despite an un-versioned `transform`, trusting that its output is stable for
-     * the `ttl`. Weaker than {@link CacheConfig.transformVersion} (a transform change is invisible,
+     * the `ttl`. Weaker than {@link CacheOptions.transformVersion} (a transform change is invisible,
      * bounded only by TTL); prefer `transformVersion` when you can name a version.
      */
     trustTransform?: boolean;
@@ -369,7 +369,7 @@ export interface CacheConfig {
     onUnfingerprintable?: 'refuse' | 'revalidate';
     /** Sugar: author the key seed from the input instead of deriving it from the request. Renamed from `key` (CONTRACT.md P6). */
     keyOf?: (input: StitchInput) => string;
-    /** @deprecated Renamed to {@link CacheConfig.keyOf} (CONTRACT.md P6). Read until the 1.0 GA cut. */
+    /** @deprecated Renamed to {@link CacheOptions.keyOf} (CONTRACT.md P6). Read until the 1.0 GA cut. */
     key?: (input: StitchInput) => string;
 }
 
@@ -698,7 +698,7 @@ export interface StitchConfig {
      * `cache: { ttl: '1m' }` (still subject to the fingerprint / `version` rules before an entry is
      * actually stored).
      */
-    cache?: number | string | CacheConfig;
+    cache?: number | string | CacheOptions;
     /**
      * Opt this stitch out of the cache **and** coalescing entirely — never stored, always a live
      * call. The honest "do not persist this response" hatch for one-time tokens or compliance-
@@ -751,7 +751,7 @@ export type ResolvedStitchConfig = Omit<
 > & {
     retry?: RetryOptions;
     timeout?: TimeoutOptions;
-    cache?: CacheConfig;
+    cache?: CacheOptions;
 };
 
 /**
@@ -1092,3 +1092,7 @@ export interface Seam {
     readonly __config: RedactedStitchConfig;
     readonly __seam: true;
 }
+
+// CONTRACT.md P3 — deprecated alias, removed at the 1.0 GA cut.
+/** @deprecated Renamed to {@link CacheOptions} (CONTRACT.md P3). Imported name kept until the 1.0 GA cut. */
+export type CacheConfig = CacheOptions;

--- a/packages/core/test/cache.spec.ts
+++ b/packages/core/test/cache.spec.ts
@@ -283,13 +283,13 @@ describe('cache — invalidation', () => {
 });
 
 describe('cache — LRU bound', () => {
-    test('maxEntries evicts the least-recently-used entry', async () => {
+    test('entries evicts the least-recently-used entry', async () => {
         const { adapter, calls } = counting();
         const s = stitch({
             url: URL,
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app', maxEntries: 2 },
+            cache: { ttl: '60s', scope: 'app', entries: 2 },
         });
         await s({ query: { id: 1 } }); // 1
         await s({ query: { id: 2 } }); // 2

--- a/packages/core/test/config-summary.spec.ts
+++ b/packages/core/test/config-summary.spec.ts
@@ -62,7 +62,7 @@ describe('pipelineStages', () => {
             method: 'POST',
             throttle: { concurrency: 2 },
             retry: { attempts: 3 },
-            paginate: { max: 7 },
+            paginate: { pages: 7 },
             transform: () => undefined,
             unwrap: 'data',
             output: () => true,
@@ -87,7 +87,7 @@ describe('pipelineStages', () => {
         const c = cfg({
             url: 'https://x/y',
             retry: { attempts: 3 },
-            paginate: { max: 7 },
+            paginate: { pages: 7 },
         });
         expect(pipelineStages(c)).toEqual([
             'call',

--- a/packages/core/test/gaps/cookie-session-hooks.spec.ts
+++ b/packages/core/test/gaps/cookie-session-hooks.spec.ts
@@ -11,7 +11,7 @@
 // These standalone stitches share ONE session across all callers, so they pass `scope: 'app'`
 // explicitly — the fail-closed default `'principal'` would throw (no seam binds a principal).
 import {
-    type AuthFailureInfo,
+    type AuthFailureResult,
     type RefreshResult,
     cookieSession,
     env,
@@ -64,7 +64,7 @@ test('onRefresh fires with { ok: true, status: 200 } after a successful cold log
     });
 
     const refreshes: RefreshResult[] = [];
-    const failures: AuthFailureInfo[] = [];
+    const failures: AuthFailureResult[] = [];
 
     const data = stitch({
         baseUrl: server.url,
@@ -139,7 +139,7 @@ test("onAuthFailure fires category 'unauthenticated' when the login returns 401 
         body: { ok: true },
     });
 
-    const failures: AuthFailureInfo[] = [];
+    const failures: AuthFailureResult[] = [];
     const refreshes: RefreshResult[] = [];
 
     const data = stitch({
@@ -181,7 +181,7 @@ test("onAuthFailure fires category 'rate-limited' + retryAfterMs when the login 
         body: { ok: true },
     });
 
-    const failures: AuthFailureInfo[] = [];
+    const failures: AuthFailureResult[] = [];
 
     const data = stitch({
         baseUrl: server.url,
@@ -219,7 +219,7 @@ test("onAuthFailure fires category 'network' + error when the login stitch throw
         body: { ok: true },
     });
 
-    const failures: AuthFailureInfo[] = [];
+    const failures: AuthFailureResult[] = [];
     const refreshes: RefreshResult[] = [];
 
     const data = stitch({

--- a/packages/core/test/gaps/delegate-backoff.spec.ts
+++ b/packages/core/test/gaps/delegate-backoff.spec.ts
@@ -38,7 +38,7 @@ async function rejectionOf(
 }
 
 // ── A. a 429 throws RateLimitError on the awaited path, with NO internal retry ──
-// `rateLimit: { delegate: true }` turns a 429 into a thrown RateLimitError carrying the parsed
+// `throttle: { delegate: true }` turns a 429 into a thrown RateLimitError carrying the parsed
 // `retryAfterMs`, and — crucially — does NOT retry: even with retry.attempts > 1 (and 429 in
 // retry.on) the adapter must be hit exactly once, because delegate mode short-circuits the loop.
 test('a 429 with Retry-After: 2 throws RateLimitError(retryAfterMs=2000) and is hit exactly once', async () => {
@@ -52,7 +52,7 @@ test('a 429 with Retry-After: 2 throws RateLimitError(retryAfterMs=2000) and is 
         path: '/rl',
         // retry would normally fire on 429 three times; delegate mode must override it.
         retry: { attempts: 3, on: [429] },
-        rateLimit: { delegate: true },
+        throttle: { delegate: true },
     });
 
     const err = await rejectionOf(call());
@@ -78,7 +78,7 @@ test('.stream() surfaces an error event with status 429 and retryAfterMs 2000', 
     const call = stitch({
         baseUrl: server.url,
         path: '/rl-stream',
-        rateLimit: { delegate: true },
+        throttle: { delegate: true },
     });
 
     const events: StitchEvent[] = [];
@@ -109,8 +109,9 @@ test('the configured throttle does not pace the call and emits no throttled even
     const call = stitch({
         baseUrl: server.url,
         path: '/rl-throttle',
-        throttle: { rate: '1/s' }, // would impose ~1000ms spacing if it were active
-        rateLimit: { delegate: true },
+        // delegate bypasses self-pacing within one envelope (P14): the '1/s' rate would impose
+        // ~1000ms spacing if active, but delegate makes it inert.
+        throttle: { rate: '1/s', delegate: true },
     });
 
     // First call arms the limiter's next-grant clock (if it were active).
@@ -142,7 +143,7 @@ test('Retry-After as an HTTP-date parses to a positive retryAfterMs', async () =
     const call = stitch({
         baseUrl: server.url,
         path: '/rl-date',
-        rateLimit: { delegate: true },
+        throttle: { delegate: true },
     });
 
     const err = await rejectionOf(call());
@@ -163,7 +164,7 @@ test('a 429 without Retry-After throws RateLimitError with retryAfterMs undefine
     const call = stitch({
         baseUrl: server.url,
         path: '/rl-bare',
-        rateLimit: { delegate: true },
+        throttle: { delegate: true },
     });
 
     const err = await rejectionOf(call());
@@ -176,7 +177,7 @@ test('a 429 without Retry-After throws RateLimitError with retryAfterMs undefine
 // ── F. a custom `on` list lets a 503 delegate while a 429 retries normally ──
 // `on: [503]` means ONLY 503 is delegated; a 429 is no longer a rate-limit signal and falls through
 // to the ordinary retry path (here retry.on includes 429), proving `on` is honoured both ways.
-test('rateLimit.on selects which statuses delegate (503 delegates, 429 retries)', async () => {
+test('throttle.on selects which statuses delegate (503 delegates, 429 retries)', async () => {
     server.route('GET', '/rl-503', {
         statuses: [503],
         retryAfter: 1,
@@ -185,7 +186,7 @@ test('rateLimit.on selects which statuses delegate (503 delegates, 429 retries)'
     const delegated = stitch({
         baseUrl: server.url,
         path: '/rl-503',
-        rateLimit: { delegate: true, on: [503] },
+        throttle: { delegate: true, on: [503] },
     });
 
     const err = await rejectionOf(delegated());
@@ -204,7 +205,7 @@ test('rateLimit.on selects which statuses delegate (503 delegates, 429 retries)'
         baseUrl: server.url,
         path: '/retry-429',
         retry: { attempts: 3, on: [429], backoff: 'fixed', baseMs: 1 },
-        rateLimit: { delegate: true, on: [503] },
+        throttle: { delegate: true, on: [503] },
     });
     await expect(retried()).resolves.toEqual({ ok: true });
     expect(server.callCount('/retry-429')).toBe(3);
@@ -222,7 +223,7 @@ test('a success response still runs transform, unwrap, and output validation', a
     const call = stitch<{ id: number; label: string }>({
         baseUrl: server.url,
         path: '/ok',
-        rateLimit: { delegate: true },
+        throttle: { delegate: true },
         unwrap: 'data',
         transform: (body) => {
             // raw body → reshape: rename `name` to `label`. Runs before unwrap.
@@ -250,7 +251,7 @@ test('.safe() surfaces the rate-limit status as a non-throwing StitchError', asy
     const call = stitch({
         baseUrl: server.url,
         path: '/rl-safe',
-        rateLimit: { delegate: true },
+        throttle: { delegate: true },
     });
 
     const out = await call.safe();
@@ -259,4 +260,52 @@ test('.safe() surfaces the rate-limit status as a non-throwing StitchError', asy
     // The real RateLimitError is preserved as the cause.
     expect(out.error?.cause).toBeInstanceOf(RateLimitError);
     expect((out.error?.cause as RateLimitError).retryAfterMs).toBe(2000);
+});
+
+// ── I. back-compat + predicate widening (CONTRACT.md P14 / P7) ──
+test('the @deprecated top-level `rateLimit` still delegates identically (P14)', async () => {
+    server.route('GET', '/rl-legacy', {
+        statuses: [429],
+        retryAfter: 2,
+        body: { error: 'slow down' },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/rl-legacy',
+        // Pre-fold spelling — must behave exactly like `throttle: { delegate: true }` until GA.
+        rateLimit: { delegate: true },
+    });
+    const err = await rejectionOf(call());
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.status).toBe(429);
+});
+
+test('throttle.on accepts a predicate (P7): a 503 matched by the predicate delegates', async () => {
+    server.route('GET', '/rl-pred', {
+        statuses: [503],
+        retryAfter: 1,
+        body: { error: 'busy' },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/rl-pred',
+        throttle: { delegate: true, on: (s) => s === 503 },
+    });
+    const err = await rejectionOf(call());
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err.status).toBe(503);
+});
+
+test('retry.on accepts a predicate (P7): retries while the predicate matches', async () => {
+    server.route('GET', '/retry-pred', {
+        statuses: [503, 200],
+        body: { ok: true },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/retry-pred',
+        retry: { attempts: 2, on: (s) => s === 503, baseMs: 1 },
+    });
+    await expect(call()).resolves.toEqual({ ok: true });
+    expect(server.calls('/retry-pred').length).toBe(2); // 503 retried, then 200
 });

--- a/packages/core/test/gaps/throttle-host-pooling.spec.ts
+++ b/packages/core/test/gaps/throttle-host-pooling.spec.ts
@@ -34,13 +34,16 @@ describe('GAP-AUDIT §1.4 — throttle scope:"host" pools across instances', () 
         });
 
         // Two INDEPENDENT stitch() instances — no `store` configured — both
-        // declaring scope:'host' against the same origin. throttle.mdx says
+        // declaring host pooling against the same origin. throttle.mdx says
         // 'host' "pools the budget across every stitch hitting the same host",
         // so the 2/s budget (500ms spacing) must apply across BOTH instances.
+        // `a` uses the canonical `pool` (CONTRACT.md P2); `b` uses the
+        // `@deprecated` `scope` alias — they MUST pool together, proving the
+        // alias is byte-equivalent to the new field.
         const a = stitch({
             baseUrl: server.url,
             path: '/pooled',
-            throttle: { rate: '2/s', scope: 'host' },
+            throttle: { rate: '2/s', pool: 'host' },
         });
         const b = stitch({
             baseUrl: server.url,

--- a/packages/core/test/gaps/timeout-total.spec.ts
+++ b/packages/core/test/gaps/timeout-total.spec.ts
@@ -134,7 +134,7 @@ test('timeout.total bounds a paginated call across pages', async () => {
             next: (body) => ({
                 query: { cursor: String((body as { cursor: number }).cursor) },
             }),
-            max: 50,
+            pages: 50,
         },
         timeout: { total: 400 },
     });

--- a/packages/core/test/idempotency.spec.ts
+++ b/packages/core/test/idempotency.spec.ts
@@ -34,7 +34,7 @@ test('injects a stable Idempotency-Key on a write, unchanged across a retry', as
         baseUrl: server.url,
         path: '/create',
         retry: { attempts: 2, on: [503], baseMs: 5 },
-        idempotency: {}, // default header + random per-call key
+        idempotency: true, // default header + random per-call key
     });
 
     await expect(create({ body: { x: 1 } })).resolves.toEqual({ ok: true });
@@ -95,7 +95,7 @@ test('separate logical calls get distinct generated keys', async () => {
         method: 'POST',
         baseUrl: server.url,
         path: '/c',
-        idempotency: {},
+        idempotency: true,
     });
 
     await create({ body: {} });
@@ -112,11 +112,25 @@ test('does not inject on GET (writes only)', async () => {
     const read = stitch({
         baseUrl: server.url,
         path: '/read',
-        idempotency: {},
+        idempotency: true,
     });
 
     await read();
     expect(
         server.calls('/read')[0]!.headers['idempotency-key'],
     ).toBeUndefined();
+});
+
+test('the opaque `idempotency: {}` is a type error — use `true` for defaults (P20)', () => {
+    const enableWithDefaults = () =>
+        stitch({
+            method: 'POST',
+            baseUrl: 'https://x',
+            path: '/y',
+            // @ts-expect-error — the empty object is rejected at the slot; `true` is the all-defaults form.
+            idempotency: {},
+        });
+    // The assertion that matters is the @ts-expect-error above (checked by `check:types`); the
+    // closure is never invoked, so this only pins the compile-time contract.
+    expect(typeof enableWithDefaults).toBe('function');
 });

--- a/packages/core/test/idempotency.spec.ts
+++ b/packages/core/test/idempotency.spec.ts
@@ -46,7 +46,7 @@ test('injects a stable Idempotency-Key on a write, unchanged across a retry', as
     expect(calls[1]!.headers['idempotency-key']).toBe(key); // identical across the retry
 });
 
-test('uses a custom key function derived from the input', async () => {
+test('uses a custom keyOf function derived from the input', async () => {
     server.route('POST', '/orders', {
         statuses: [503, 200],
         body: { ok: true },
@@ -58,7 +58,7 @@ test('uses a custom key function derived from the input', async () => {
         retry: { attempts: 2, on: [503], baseMs: 5 },
         idempotency: {
             header: 'X-Idempotency-Key',
-            key: (input) => `order-${(input.body as { id: number }).id}`,
+            keyOf: (input) => `order-${(input.body as { id: number }).id}`,
         },
     });
 
@@ -67,6 +67,26 @@ test('uses a custom key function derived from the input', async () => {
     const calls = server.calls('/orders');
     expect(calls[0]!.headers['x-idempotency-key']).toBe('order-42');
     expect(calls[1]!.headers['x-idempotency-key']).toBe('order-42'); // stable + deterministic
+});
+
+test('the @deprecated `key` alias still derives the same idempotency key (P6)', async () => {
+    server.route('POST', '/orders', { body: { ok: true } });
+    const create = stitch({
+        method: 'POST',
+        baseUrl: server.url,
+        path: '/orders',
+        idempotency: {
+            header: 'X-Idempotency-Key',
+            // The pre-rename spelling — must behave identically to `keyOf` until the GA cut.
+            key: (input) => `order-${(input.body as { id: number }).id}`,
+        },
+    });
+
+    await create({ body: { id: 7 } });
+
+    expect(server.calls('/orders')[0]!.headers['x-idempotency-key']).toBe(
+        'order-7',
+    );
 });
 
 test('separate logical calls get distinct generated keys', async () => {

--- a/packages/core/test/pagination.spec.ts
+++ b/packages/core/test/pagination.spec.ts
@@ -121,7 +121,7 @@ test('max caps the page loop (guards a runaway paginator)', async () => {
         baseUrl: server.url,
         path: '/loop',
         unwrap: 'data',
-        paginate: { next: () => ({}), max: 2 },
+        paginate: { next: () => ({}), pages: 2 },
     });
     await list();
     expect(server.callCount('/loop')).toBe(2); // stopped at the cap, not infinitely

--- a/packages/core/test/sse-reconnect.spec.ts
+++ b/packages/core/test/sse-reconnect.spec.ts
@@ -14,7 +14,7 @@ import { z } from 'zod';
 // An adapter that hands back a DIFFERENT scripted body per call and records every request it saw —
 // so a test can assert what header (e.g. Last-Event-ID) rode the Nth open. Bodies past the script
 // fall back to `tail` (default: an immediately-closing empty stream, which a resumable surface
-// treats as another reconnect signal — handy for exercising the maxAttempts cap deterministically).
+// treats as another reconnect signal — handy for exercising the attempts cap deterministically).
 function scriptedAdapter(
     bodies: (() => ReadableStream<Uint8Array>)[],
     init: { status?: number; tail?: () => ReadableStream<Uint8Array> } = {},
@@ -117,14 +117,14 @@ describe('sse reconnect is OFF by default (issue #71)', () => {
 describe('sse reconnect replays Last-Event-ID (issue #71)', () => {
     test('the SECOND open carries Last-Event-ID: 2 and its events continue to flow', async () => {
         // First body: id 1, id 2 then closes. Second body: id 3, id 4 then closes. The third open
-        // (an empty tail) closes immediately; cap at maxAttempts so it terminates deterministically.
+        // (an empty tail) closes immediately; cap at attempts so it terminates deterministically.
         const { adapter, requests } = scriptedAdapter([
             () => streamOf(['id: 1\ndata: a\n\n', 'id: 2\ndata: b\n\n']),
             () => streamOf(['id: 3\ndata: c\n\n', 'id: 4\ndata: d\n\n']),
         ]);
         const s = sse({
             url: 'https://x.test/e',
-            sse: { reconnect: { maxAttempts: 2, backoffMs: 1 } },
+            sse: { reconnect: { attempts: 2, backoffMs: 1 } },
             adapter,
         });
 
@@ -156,7 +156,7 @@ describe('sse reconnect backoff: server retry: vs fallback (issue #71)', () => {
         ]);
         const s = sse({
             url: 'https://x.test/e',
-            sse: { reconnect: { maxAttempts: 1, backoffMs: 1 } },
+            sse: { reconnect: { attempts: 1, backoffMs: 1 } },
             adapter,
         });
 
@@ -174,7 +174,7 @@ describe('sse reconnect backoff: server retry: vs fallback (issue #71)', () => {
         ]);
         const s = sse({
             url: 'https://x.test/e',
-            sse: { reconnect: { maxAttempts: 1, backoffMs: 90 } },
+            sse: { reconnect: { attempts: 1, backoffMs: 90 } },
             adapter,
         });
 
@@ -193,7 +193,7 @@ describe('sse reconnect backoff: server retry: vs fallback (issue #71)', () => {
         ]);
         const s = sse({
             url: 'https://x.test/e',
-            sse: { reconnect: { maxAttempts: 1 } },
+            sse: { reconnect: { attempts: 1 } },
             retry: { backoff: 'fixed', baseMs: 70 },
             adapter,
         });
@@ -207,16 +207,16 @@ describe('sse reconnect backoff: server retry: vs fallback (issue #71)', () => {
     });
 });
 
-describe('sse reconnect respects the maxAttempts cap (issue #71)', () => {
+describe('sse reconnect respects the attempts cap (issue #71)', () => {
     test('reconnects stop after N attempts; the stream ends with what it collected', async () => {
         // Every body is a single event then closes — a resumable surface treats each close as a
-        // reconnect signal, so this would loop forever without the cap. maxAttempts: 2 ⇒ 3 opens.
+        // reconnect signal, so this would loop forever without the cap. attempts: 2 ⇒ 3 opens.
         const { adapter, requests } = scriptedAdapter([], {
             tail: () => streamOf(['data: tick\n\n']),
         });
         const s = sse({
             url: 'https://x.test/e',
-            sse: { reconnect: { maxAttempts: 2, backoffMs: 1 } },
+            sse: { reconnect: { attempts: 2, backoffMs: 1 } },
             adapter,
         });
 
@@ -258,7 +258,7 @@ describe('sse reconnect resumes from the last id after a mid-stream ERROR (issue
         ]);
         const s = sse({
             url: 'https://x.test/e',
-            sse: { reconnect: { maxAttempts: 1, backoffMs: 1 } },
+            sse: { reconnect: { attempts: 1, backoffMs: 1 } },
             adapter,
         });
 
@@ -273,7 +273,7 @@ describe('sse reconnect resumes from the last id after a mid-stream ERROR (issue
     });
 
     test('when reconnects run out on an ERROR, the real error surfaces as error+done', async () => {
-        // Both opens throw; maxAttempts: 1 ⇒ one reconnect, then the second throw is terminal and
+        // Both opens throw; attempts: 1 ⇒ one reconnect, then the second throw is terminal and
         // its real message is surfaced (not a synthetic placeholder).
         const { adapter, requests } = scriptedAdapter([
             () => streamThenError(['id: 1\ndata: a\n\n'], new Error('drop-1')),
@@ -281,7 +281,7 @@ describe('sse reconnect resumes from the last id after a mid-stream ERROR (issue
         ]);
         const s = sse({
             url: 'https://x.test/e',
-            sse: { reconnect: { maxAttempts: 1, backoffMs: 1 } },
+            sse: { reconnect: { attempts: 1, backoffMs: 1 } },
             adapter,
         });
 
@@ -305,7 +305,7 @@ describe('sse per-delta output validation keeps firing across a reconnect (issue
         const s = sse({
             url: 'https://x.test/e',
             output: asValidator(z.object({ tok: z.string() })),
-            sse: { reconnect: { maxAttempts: 2, backoffMs: 1 } },
+            sse: { reconnect: { attempts: 2, backoffMs: 1 } },
             adapter,
         });
 
@@ -328,16 +328,16 @@ describe('sse reconnect config round-trips as JSON (contract-not-dependency gate
         expect(json.sse).toEqual({ reconnect: true });
     });
 
-    test('the object form (maxAttempts + backoffMs) survives the round-trip intact', () => {
+    test('the object form (attempts + backoffMs) survives the round-trip intact', () => {
         const cfg = {
             url: 'https://x.test/e',
-            sse: { reconnect: { maxAttempts: 5, backoffMs: 250 } },
+            sse: { reconnect: { attempts: 5, backoffMs: 250 } },
         };
         const s = sse(cfg);
         const json = JSON.parse(JSON.stringify(s.__config)) as {
-            sse?: { reconnect?: { maxAttempts?: number; backoffMs?: number } };
+            sse?: { reconnect?: { attempts?: number; backoffMs?: number } };
         };
-        expect(json.sse?.reconnect).toEqual({ maxAttempts: 5, backoffMs: 250 });
+        expect(json.sse?.reconnect).toEqual({ attempts: 5, backoffMs: 250 });
     });
 });
 

--- a/packages/core/test/surface-graphql-hooks.spec.ts
+++ b/packages/core/test/surface-graphql-hooks.spec.ts
@@ -11,13 +11,13 @@ import { graphqlSurface } from '../src/surface';
 import type {
     AdapterRequest,
     AdapterResponse,
-    StitchConfig,
+    ResolvedStitchConfig,
     StitchInput,
 } from '../src/types';
 
 const cfg = (
     o: { query?: string; method?: string; operationName?: string } = {},
-): StitchConfig => o;
+): ResolvedStitchConfig => o;
 
 const base: AdapterRequest = {
     url: 'https://api.test/graphql',
@@ -26,7 +26,7 @@ const base: AdapterRequest = {
 };
 
 // Call the hooks (wrappers invoke them, so they are never referenced unbound).
-function build(c: StitchConfig, input: StitchInput): AdapterRequest {
+function build(c: ResolvedStitchConfig, input: StitchInput): AdapterRequest {
     return graphqlSurface.buildRequest!(c, input, base);
 }
 function interpret(res: AdapterResponse) {

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -109,6 +109,26 @@ function deprecatedBefore(src, idx) {
     return open !== -1 && /@deprecated/.test(src.slice(open, j));
 }
 
+// True when every TOP-LEVEL member of an interface body is optional (`?`) — so the bag is
+// `{}`-constructible and would accept the opaque empty object at a config slot (P20). Tracks
+// brace/paren depth so a nested object-literal field type doesn't read as a required member.
+function isAllOptional(body) {
+    let depth = 0;
+    for (const line of body.split('\n')) {
+        if (depth === 0) {
+            const m = /^\s*(?:readonly\s+)?([A-Za-z_]\w*)\s*(\??)\s*[:(]/.exec(
+                line,
+            );
+            if (m && m[2] !== '?') return false; // a required member at depth 0
+        }
+        for (const ch of line) {
+            if (ch === '{' || ch === '(') depth++;
+            else if (ch === '}' || ch === ')') depth--;
+        }
+    }
+    return true;
+}
+
 // Names declared-and-exported in a file (declaration sites; not re-export resolution).
 function exportedDeclNames(src) {
     const names = [];
@@ -236,7 +256,8 @@ function collect() {
                 }
             }
 
-            for (const blk of interfaceBlocks(src)) {
+            const blocks = interfaceBlocks(src);
+            for (const blk of blocks) {
                 // R3 — function-typed `key` (P6: a derivation fn must be `keyOf`)
                 const keyM = /(^|\n)\s*key\s*\??:\s*\(/.exec(blk.body);
                 if (
@@ -266,6 +287,28 @@ function collect() {
                         `pool axis named scope → rename pool (P2)`,
                         lineOf(src, blk.bodyStart + scopeM.index),
                     );
+                }
+            }
+
+            // R6 — a StitchConfig capability slot typed as a bare all-optional `*Options` bag
+            // accepts the opaque empty object `{}` (P20). The fix is `Scalar | AtLeastOne<Options>`
+            // so the all-defaults case is a scalar and `{}` is a compile error.
+            const allOptional = new Set(
+                blocks.filter((b) => isAllOptional(b.body)).map((b) => b.name),
+            );
+            const cfgBlock = blocks.find((b) => b.name === 'StitchConfig');
+            if (cfgBlock) {
+                const fre = /(?:^|\n)\s*([A-Za-z_]\w*)\??:\s*([A-Z]\w*)\s*;/g;
+                let f6;
+                while ((f6 = fre.exec(cfgBlock.body))) {
+                    if (allOptional.has(f6[2]))
+                        add(
+                            'R6',
+                            file,
+                            `StitchConfig.${f6[1]}`,
+                            `all-optional ${f6[2]} accepts {} → Scalar|AtLeastOne<${f6[2]}> (P20)`,
+                            lineOf(src, cfgBlock.bodyStart),
+                        );
                 }
             }
         }

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -1,0 +1,333 @@
+#!/usr/bin/env node
+// API meta-contract gate — see docs/CONTRACT.md.
+//
+// A RATCHET, not a hard gate. The current surface predates the contract and violates it
+// in many places (that backlog is docs/CONTRACT.md §6). So this script freezes today's
+// violations in scripts/contract-violations.baseline.json and fails ONLY when a NEW
+// violation appears — exactly like the repo's ESLint-suppression ratchet. The gate never
+// blocks unrelated work, but the surface can only get more consistent, never less.
+//
+//   pnpm check:contract            # check working tree against the baseline (CI/hook mode)
+//   node scripts/check-contract.mjs --list     # print every current violation, grouped
+//   node scripts/check-contract.mjs --update    # rewrite the baseline to the current set
+//
+// Rules are intentionally HIGH-PRECISION source-text checks (no TS type info), so a flagged
+// line is a real violation, not a guess. Shape-diffing (full P9), duration-type conformance,
+// and default-value inversion (P8) need the TS checker and are deferred to a type-aware phase.
+import {
+    existsSync,
+    readFileSync,
+    readdirSync,
+    statSync,
+    writeFileSync,
+} from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PKGS = join(ROOT, 'packages');
+const BASELINE = join(ROOT, 'scripts', 'contract-violations.baseline.json');
+
+// ---- the published surface ------------------------------------------------
+// Every packages/* whose manifest is not `private: true`. Those are the consumer-facing
+// contracts the meta-contract governs; private tooling (eval-harness, sandbox-sim, …) is out.
+function publishedPackages() {
+    const out = [];
+    for (const dir of readdirSync(PKGS)) {
+        const manifest = join(PKGS, dir, 'package.json');
+        if (!existsSync(manifest)) continue;
+        let pkg;
+        try {
+            pkg = JSON.parse(readFileSync(manifest, 'utf8'));
+        } catch {
+            continue;
+        }
+        if (pkg.private === true) continue;
+        if (!existsSync(join(PKGS, dir, 'src'))) continue;
+        out.push({ dir, name: pkg.name });
+    }
+    return out.sort((a, b) => a.dir.localeCompare(b.dir));
+}
+
+function tsFiles(root) {
+    const out = [];
+    const walk = (d) => {
+        for (const e of readdirSync(d)) {
+            const p = join(d, e);
+            const s = statSync(p);
+            if (s.isDirectory()) walk(p);
+            else if (
+                /\.tsx?$/.test(e) &&
+                !/\.d\.ts$/.test(e) &&
+                !/\.(spec|test)\.tsx?$/.test(e) &&
+                !/\.generated\./.test(e)
+            )
+                out.push(p);
+        }
+    };
+    walk(root);
+    return out;
+}
+
+const lineOf = (src, idx) => src.slice(0, idx).split('\n').length;
+const rel = (p) => relative(ROOT, p);
+
+// Brace-match an exported `interface Name { … }`; returns { name, body, index }.
+function interfaceBlocks(src) {
+    const blocks = [];
+    const re = /\bexport\s+interface\s+([A-Za-z_]\w*)[^{]*\{/g;
+    let m;
+    while ((m = re.exec(src))) {
+        let depth = 0;
+        let j = m.index + m[0].length - 1; // sit on the opening brace
+        const open = j;
+        for (; j < src.length; j++) {
+            if (src[j] === '{') depth++;
+            else if (src[j] === '}' && --depth === 0) {
+                j++;
+                break;
+            }
+        }
+        blocks.push({
+            name: m[1],
+            body: src.slice(open + 1, j - 1),
+            index: m.index,
+        });
+    }
+    return blocks;
+}
+
+// Names declared-and-exported in a file (declaration sites; not re-export resolution).
+function exportedDeclNames(src) {
+    const names = [];
+    const re =
+        /\bexport\s+(?:abstract\s+)?(interface|type|class|function|const)\s+([A-Za-z_]\w*)/g;
+    let m;
+    while ((m = re.exec(src)))
+        names.push({ kind: m[1], name: m[2], index: m.index });
+    return names;
+}
+
+// Identifiers a package's index.ts puts on its PUBLIC surface (direct decls + `export {…}`
+// blocks, taking the post-`as` alias). `export * from` is not expanded — a known gap noted
+// in CONTRACT.md §7; the watch-list (R5) is curated so this gap doesn't hide a real clash.
+function indexExports(indexPath) {
+    if (!existsSync(indexPath)) return new Set();
+    const src = readFileSync(indexPath, 'utf8');
+    const names = new Set(exportedDeclNames(src).map((d) => d.name));
+    const block = /\bexport\s+(?:type\s+)?\{([^}]*)\}/g;
+    let m;
+    while ((m = block.exec(src))) {
+        for (let part of m[1].split(',')) {
+            part = part.trim().replace(/^type\s+/, '');
+            if (!part) continue;
+            const as = part.split(/\s+as\s+/);
+            const id = (as[1] ?? as[0]).trim();
+            if (/^[A-Za-z_]\w*$/.test(id)) names.add(id);
+        }
+    }
+    return names;
+}
+
+// ---- rules ----------------------------------------------------------------
+// P3 — banned consumer-input suffix. Carve-outs: the well-known StitchConfig authoring
+// family, and any *Like* duck-type (P18: an adapter mirror keeps its upstream spelling).
+const BANNED_SUFFIX = /(Opts|Info|Params|Config)$/;
+const SUFFIX_CARVEOUT = new Set([
+    'StitchConfig',
+    'ResolvedStitchConfig',
+    'RedactedStitchConfig',
+    'SeamConfig',
+    'OpenApiInfo', // mirrors the OpenAPI spec's InfoObject (P18: keep the upstream spelling)
+]);
+const isLike = (n) => /Like/.test(n);
+
+// P9/P16 — identifiers that MUST be unique-by-shape across packages (a curated watch list;
+// full shape-diff is the deferred type-aware phase). Flagged when ≥2 packages export one.
+const UNIQUE_WATCH = new Set([
+    'StitchStore',
+    'StitchLike',
+    'RequestSeam',
+    'StitchHost',
+    'StitchError',
+    'StitchErrorLike',
+    'queryOptions', // P16: the bare TanStack alias; canonical is stitchQueryOptions
+]);
+
+function collect() {
+    const violations = [];
+    const add = (rule, file, symbol, detail, line) =>
+        violations.push({
+            rule,
+            file: rel(file),
+            symbol,
+            detail,
+            line: line ?? null,
+            key: `${rule}|${rel(file)}|${symbol}`,
+        });
+
+    const packages = publishedPackages();
+    const exportsByName = new Map(); // identifier -> Set(dir)
+
+    for (const { dir } of packages) {
+        const srcRoot = join(PKGS, dir, 'src');
+        for (const file of tsFiles(srcRoot)) {
+            const src = readFileSync(file, 'utf8');
+
+            // R1 — banned type-name suffix (P3). Type declarations only — a `function`/`const`
+            // ending in Config (redactConfig, the ADR-0012 fromNestConfig constructor) is not
+            // a consumer-input type and is out of scope.
+            for (const { kind, name, index } of exportedDeclNames(src)) {
+                if (kind !== 'interface' && kind !== 'type' && kind !== 'class')
+                    continue;
+                if (
+                    BANNED_SUFFIX.test(name) &&
+                    !SUFFIX_CARVEOUT.has(name) &&
+                    !isLike(name)
+                ) {
+                    add(
+                        'R1',
+                        file,
+                        name,
+                        `banned suffix on consumer type → *Options (P3)`,
+                        lineOf(src, index),
+                    );
+                }
+            }
+
+            for (const blk of interfaceBlocks(src)) {
+                // R2 — *Ms-suffixed field inside an input bag (P17). Matches *Options and the
+                // legacy *Opts bags (which R1 will rename to *Options anyway).
+                if (/(Options|Opts)$/.test(blk.name)) {
+                    const fre = /(^|\n)\s*([A-Za-z_]\w*Ms)\s*\??:/g;
+                    let f;
+                    while ((f = fre.exec(blk.body))) {
+                        add(
+                            'R2',
+                            file,
+                            `${blk.name}.${f[2]}`,
+                            `input duration carries Ms suffix → de-suffix + number|string (P17)`,
+                            lineOf(src, blk.index),
+                        );
+                    }
+                }
+                // R3 — function-typed `key` (P6: a derivation fn must be `keyOf`)
+                if (/(^|\n)\s*key\s*\??:\s*\(/.test(blk.body)) {
+                    add(
+                        'R3',
+                        file,
+                        `${blk.name}.key`,
+                        `function-typed key → rename keyOf (P6)`,
+                        lineOf(src, blk.index),
+                    );
+                }
+                // R4 — `scope: 'stitch'|'host'` overloads the tenancy word (P2: rename to pool)
+                if (/(^|\n)\s*scope\s*\??:\s*'(stitch|host)'/.test(blk.body)) {
+                    add(
+                        'R4',
+                        file,
+                        `${blk.name}.scope`,
+                        `pool axis named scope → rename pool (P2)`,
+                        lineOf(src, blk.index),
+                    );
+                }
+            }
+        }
+
+        for (const id of indexExports(join(srcRoot, 'index.ts'))) {
+            if (!exportsByName.has(id)) exportsByName.set(id, new Set());
+            exportsByName.get(id).add(dir);
+        }
+    }
+
+    // R5 — watch-listed identifier exported by ≥2 published packages (P9/P16)
+    for (const [id, dirs] of exportsByName) {
+        if (UNIQUE_WATCH.has(id) && dirs.size > 1) {
+            add(
+                'R5',
+                join(PKGS, '<multiple>'),
+                id,
+                `exported by ${[...dirs].sort().join(', ')} — must be unique-by-shape (P9/P16)`,
+                null,
+            );
+        }
+    }
+
+    return violations.sort((a, b) => a.key.localeCompare(b.key));
+}
+
+// ---- ratchet --------------------------------------------------------------
+const args = new Set(process.argv.slice(2));
+const current = collect();
+const currentKeys = new Set(current.map((v) => v.key));
+
+if (args.has('--list')) {
+    const byRule = {};
+    for (const v of current) (byRule[v.rule] ??= []).push(v);
+    for (const rule of Object.keys(byRule).sort()) {
+        console.log(`\n${rule} (${byRule[rule].length}):`);
+        for (const v of byRule[rule])
+            console.log(
+                `  ${v.file}${v.line ? `:${v.line}` : ''}  ${v.symbol} — ${v.detail}`,
+            );
+    }
+    console.log(`\nTotal: ${current.length} violations.`);
+    process.exit(0);
+}
+
+if (args.has('--update')) {
+    writeFileSync(
+        BASELINE,
+        JSON.stringify(
+            {
+                generatedBy: 'scripts/check-contract.mjs --update',
+                count: current.length,
+                violations: current,
+            },
+            null,
+            4,
+        ) + '\n',
+    );
+    console.log(`✓ Baseline rewritten: ${current.length} known violations.`);
+    process.exit(0);
+}
+
+if (!existsSync(BASELINE)) {
+    console.error(
+        '✗ No baseline found. Run `node scripts/check-contract.mjs --update` to create it.',
+    );
+    process.exit(1);
+}
+
+const baseline = JSON.parse(readFileSync(BASELINE, 'utf8'));
+const baseKeys = new Set((baseline.violations ?? []).map((v) => v.key));
+
+const added = current.filter((v) => !baseKeys.has(v.key));
+const fixed = [...baseKeys].filter((k) => !currentKeys.has(k));
+
+if (fixed.length) {
+    console.log(
+        `\n✓ ${fixed.length} baseline violation(s) fixed — shrink the baseline with ` +
+            '`node scripts/check-contract.mjs --update`:',
+    );
+    for (const k of fixed.sort()) console.log(`    ${k}`);
+}
+
+if (added.length) {
+    console.error(
+        `\n✗ ${added.length} NEW API meta-contract violation(s) (docs/CONTRACT.md):`,
+    );
+    for (const v of added)
+        console.error(
+            `    [${v.rule}] ${v.file}${v.line ? `:${v.line}` : ''}  ${v.symbol} — ${v.detail}`,
+        );
+    console.error(
+        '\n  Fix it, or — if this is an intentional, contract-aligned change — refresh the ' +
+            'baseline with `node scripts/check-contract.mjs --update` and commit it.',
+    );
+    process.exit(1);
+}
+
+console.log(
+    `✓ API meta-contract: no new violations (${baseKeys.size} known, baselined).`,
+);

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -92,9 +92,21 @@ function interfaceBlocks(src) {
             name: m[1],
             body: src.slice(open + 1, j - 1),
             index: m.index,
+            bodyStart: open + 1,
         });
     }
     return blocks;
+}
+
+// True when the declaration at `idx` is immediately preceded by a JSDoc block carrying
+// `@deprecated`. A deprecated member is a known, time-boxed migration alias (P19), not an
+// active violation — so the rules skip it, and a rename-under-alias clears the finding.
+function deprecatedBefore(src, idx) {
+    let j = idx;
+    while (j > 0 && /[\s{;,(]/.test(src[j - 1])) j--; // skip whitespace + the field anchor
+    if (src.slice(j - 2, j) !== '*/') return false; // must sit right after a comment
+    const open = src.lastIndexOf('/*', j - 2);
+    return open !== -1 && /@deprecated/.test(src.slice(open, j));
 }
 
 // Names declared-and-exported in a file (declaration sites; not re-export resolution).
@@ -183,7 +195,8 @@ function collect() {
                 if (
                     BANNED_SUFFIX.test(name) &&
                     !SUFFIX_CARVEOUT.has(name) &&
-                    !isLike(name)
+                    !isLike(name) &&
+                    !deprecatedBefore(src, index)
                 ) {
                     add(
                         'R1',
@@ -206,12 +219,13 @@ function collect() {
                 const seen = new Set();
                 let f;
                 while ((f = fre.exec(src))) {
-                    if (seen.has(f[1])) continue;
-                    seen.add(f[1]);
                     // Carve-out: an epoch *timestamp* (`*UnixMs`) keeps its unit — Unix time is
                     // conventionally SECONDS, so a bare `startUnix` would be misleading, and these
                     // mirror OTLP's `*Unix*` fields (P18). The rule targets DURATIONS, not instants.
                     if (/Unix(Ms|Nano|Seconds)$/.test(f[1])) continue;
+                    if (deprecatedBefore(src, f.index)) continue; // a renamed-under-alias field
+                    if (seen.has(f[1])) continue;
+                    seen.add(f[1]);
                     add(
                         'R2',
                         file,
@@ -224,23 +238,33 @@ function collect() {
 
             for (const blk of interfaceBlocks(src)) {
                 // R3 — function-typed `key` (P6: a derivation fn must be `keyOf`)
-                if (/(^|\n)\s*key\s*\??:\s*\(/.test(blk.body)) {
+                const keyM = /(^|\n)\s*key\s*\??:\s*\(/.exec(blk.body);
+                if (
+                    keyM &&
+                    !deprecatedBefore(src, blk.bodyStart + keyM.index)
+                ) {
                     add(
                         'R3',
                         file,
                         `${blk.name}.key`,
                         `function-typed key → rename keyOf (P6)`,
-                        lineOf(src, blk.index),
+                        lineOf(src, blk.bodyStart + keyM.index),
                     );
                 }
                 // R4 — `scope: 'stitch'|'host'` overloads the tenancy word (P2: rename to pool)
-                if (/(^|\n)\s*scope\s*\??:\s*'(stitch|host)'/.test(blk.body)) {
+                const scopeM = /(^|\n)\s*scope\s*\??:\s*'(stitch|host)'/.exec(
+                    blk.body,
+                );
+                if (
+                    scopeM &&
+                    !deprecatedBefore(src, blk.bodyStart + scopeM.index)
+                ) {
                     add(
                         'R4',
                         file,
                         `${blk.name}.scope`,
                         `pool axis named scope → rename pool (P2)`,
-                        lineOf(src, blk.index),
+                        lineOf(src, blk.bodyStart + scopeM.index),
                     );
                 }
             }

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -195,22 +195,34 @@ function collect() {
                 }
             }
 
-            for (const blk of interfaceBlocks(src)) {
-                // R2 — *Ms-suffixed field inside an input bag (P17). Matches *Options and the
-                // legacy *Opts bags (which R1 will rename to *Options anyway).
-                if (/(Options|Opts)$/.test(blk.name)) {
-                    const fre = /(^|\n)\s*([A-Za-z_]\w*Ms)\s*\??:/g;
-                    let f;
-                    while ((f = fre.exec(blk.body))) {
-                        add(
-                            'R2',
-                            file,
-                            `${blk.name}.${f[2]}`,
-                            `input duration carries Ms suffix → de-suffix + number|string (P17)`,
-                            lineOf(src, blk.index),
-                        );
-                    }
+            // R2 — ANY field carrying the `Ms` suffix (P17: ms is the house unit, so the
+            // suffix is dropped EVERYWHERE — input and emitted; the unit lives in JSDoc).
+            // File-level scan so it catches type-union / class fields (StitchEvent,
+            // RateLimitError), not only interface bags. Anchored to a declaration position
+            // ([\n{;,(] then `name?:`) so prose mentions of `…Ms` in JSDoc don't match.
+            // Deduped by field name per file.
+            {
+                const fre = /(?:^|[\n{;,(])\s*([A-Za-z_]\w*Ms)\s*\??:/g;
+                const seen = new Set();
+                let f;
+                while ((f = fre.exec(src))) {
+                    if (seen.has(f[1])) continue;
+                    seen.add(f[1]);
+                    // Carve-out: an epoch *timestamp* (`*UnixMs`) keeps its unit — Unix time is
+                    // conventionally SECONDS, so a bare `startUnix` would be misleading, and these
+                    // mirror OTLP's `*Unix*` fields (P18). The rule targets DURATIONS, not instants.
+                    if (/Unix(Ms|Nano|Seconds)$/.test(f[1])) continue;
+                    add(
+                        'R2',
+                        file,
+                        f[1],
+                        `duration field carries Ms suffix → drop it (ms is the house unit; P17)`,
+                        lineOf(src, f.index),
+                    );
                 }
+            }
+
+            for (const blk of interfaceBlocks(src)) {
                 // R3 — function-typed `key` (P6: a derivation fn must be `keyOf`)
                 if (/(^|\n)\s*key\s*\??:\s*\(/.test(blk.body)) {
                     add(

--- a/scripts/contract-violations.baseline.json
+++ b/scripts/contract-violations.baseline.json
@@ -1,63 +1,7 @@
 {
     "generatedBy": "scripts/check-contract.mjs --update",
-    "count": 43,
+    "count": 36,
     "violations": [
-        {
-            "rule": "R1",
-            "file": "packages/aws-sigv4/src/index.ts",
-            "symbol": "SignV4Params",
-            "detail": "banned suffix on consumer type → *Options (P3)",
-            "line": 133,
-            "key": "R1|packages/aws-sigv4/src/index.ts|SignV4Params"
-        },
-        {
-            "rule": "R1",
-            "file": "packages/core/src/auth.ts",
-            "symbol": "AuthFailureInfo",
-            "detail": "banned suffix on consumer type → *Options (P3)",
-            "line": 458,
-            "key": "R1|packages/core/src/auth.ts|AuthFailureInfo"
-        },
-        {
-            "rule": "R1",
-            "file": "packages/core/src/auth.ts",
-            "symbol": "CookieSessionOpts",
-            "detail": "banned suffix on consumer type → *Options (P3)",
-            "line": 484,
-            "key": "R1|packages/core/src/auth.ts|CookieSessionOpts"
-        },
-        {
-            "rule": "R1",
-            "file": "packages/core/src/auth.ts",
-            "symbol": "OAuth2Opts",
-            "detail": "banned suffix on consumer type → *Options (P3)",
-            "line": 238,
-            "key": "R1|packages/core/src/auth.ts|OAuth2Opts"
-        },
-        {
-            "rule": "R1",
-            "file": "packages/core/src/llm.ts",
-            "symbol": "LlmConfig",
-            "detail": "banned suffix on consumer type → *Options (P3)",
-            "line": 116,
-            "key": "R1|packages/core/src/llm.ts|LlmConfig"
-        },
-        {
-            "rule": "R1",
-            "file": "packages/core/src/mcp.ts",
-            "symbol": "McpServerInfo",
-            "detail": "banned suffix on consumer type → *Options (P3)",
-            "line": 136,
-            "key": "R1|packages/core/src/mcp.ts|McpServerInfo"
-        },
-        {
-            "rule": "R1",
-            "file": "packages/core/src/types.ts",
-            "symbol": "CacheConfig",
-            "detail": "banned suffix on consumer type → *Options (P3)",
-            "line": 270,
-            "key": "R1|packages/core/src/types.ts|CacheConfig"
-        },
         {
             "rule": "R2",
             "file": "packages/core/src/auth.ts",
@@ -95,7 +39,7 @@
             "file": "packages/core/src/engine.ts",
             "symbol": "backoffMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 1374,
+            "line": 1376,
             "key": "R2|packages/core/src/engine.ts|backoffMs"
         },
         {
@@ -103,7 +47,7 @@
             "file": "packages/core/src/engine.ts",
             "symbol": "retryAfterMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 724,
+            "line": 726,
             "key": "R2|packages/core/src/engine.ts|retryAfterMs"
         },
         {
@@ -111,7 +55,7 @@
             "file": "packages/core/src/engine.ts",
             "symbol": "totalMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 447,
+            "line": 449,
             "key": "R2|packages/core/src/engine.ts|totalMs"
         },
         {
@@ -127,7 +71,7 @@
             "file": "packages/core/src/resilience.ts",
             "symbol": "retryAfterMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 254,
+            "line": 253,
             "key": "R2|packages/core/src/resilience.ts|retryAfterMs"
         },
         {

--- a/scripts/contract-violations.baseline.json
+++ b/scripts/contract-violations.baseline.json
@@ -1,0 +1,198 @@
+{
+    "generatedBy": "scripts/check-contract.mjs --update",
+    "count": 24,
+    "violations": [
+        {
+            "rule": "R1",
+            "file": "packages/aws-sigv4/src/index.ts",
+            "symbol": "SignV4Params",
+            "detail": "banned suffix on consumer type → *Options (P3)",
+            "line": 133,
+            "key": "R1|packages/aws-sigv4/src/index.ts|SignV4Params"
+        },
+        {
+            "rule": "R1",
+            "file": "packages/core/src/auth.ts",
+            "symbol": "AuthFailureInfo",
+            "detail": "banned suffix on consumer type → *Options (P3)",
+            "line": 458,
+            "key": "R1|packages/core/src/auth.ts|AuthFailureInfo"
+        },
+        {
+            "rule": "R1",
+            "file": "packages/core/src/auth.ts",
+            "symbol": "CookieSessionOpts",
+            "detail": "banned suffix on consumer type → *Options (P3)",
+            "line": 484,
+            "key": "R1|packages/core/src/auth.ts|CookieSessionOpts"
+        },
+        {
+            "rule": "R1",
+            "file": "packages/core/src/auth.ts",
+            "symbol": "OAuth2Opts",
+            "detail": "banned suffix on consumer type → *Options (P3)",
+            "line": 238,
+            "key": "R1|packages/core/src/auth.ts|OAuth2Opts"
+        },
+        {
+            "rule": "R1",
+            "file": "packages/core/src/llm.ts",
+            "symbol": "LlmConfig",
+            "detail": "banned suffix on consumer type → *Options (P3)",
+            "line": 116,
+            "key": "R1|packages/core/src/llm.ts|LlmConfig"
+        },
+        {
+            "rule": "R1",
+            "file": "packages/core/src/mcp.ts",
+            "symbol": "McpServerInfo",
+            "detail": "banned suffix on consumer type → *Options (P3)",
+            "line": 136,
+            "key": "R1|packages/core/src/mcp.ts|McpServerInfo"
+        },
+        {
+            "rule": "R1",
+            "file": "packages/core/src/types.ts",
+            "symbol": "CacheConfig",
+            "detail": "banned suffix on consumer type → *Options (P3)",
+            "line": 260,
+            "key": "R1|packages/core/src/types.ts|CacheConfig"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/auth.ts",
+            "symbol": "CookieSessionOpts.ttlMs",
+            "detail": "input duration carries Ms suffix → de-suffix + number|string (P17)",
+            "line": 484,
+            "key": "R2|packages/core/src/auth.ts|CookieSessionOpts.ttlMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/auth.ts",
+            "symbol": "OAuth2Opts.refreshSkewMs",
+            "detail": "input duration carries Ms suffix → de-suffix + number|string (P17)",
+            "line": 238,
+            "key": "R2|packages/core/src/auth.ts|OAuth2Opts.refreshSkewMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/types.ts",
+            "symbol": "CircuitOptions.cooldownMs",
+            "detail": "input duration carries Ms suffix → de-suffix + number|string (P17)",
+            "line": 240,
+            "key": "R2|packages/core/src/types.ts|CircuitOptions.cooldownMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/types.ts",
+            "symbol": "CircuitOptions.halfOpenAfterMs",
+            "detail": "input duration carries Ms suffix → de-suffix + number|string (P17)",
+            "line": 240,
+            "key": "R2|packages/core/src/types.ts|CircuitOptions.halfOpenAfterMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/types.ts",
+            "symbol": "ReconnectOptions.backoffMs",
+            "detail": "input duration carries Ms suffix → de-suffix + number|string (P17)",
+            "line": 140,
+            "key": "R2|packages/core/src/types.ts|ReconnectOptions.backoffMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/types.ts",
+            "symbol": "RetryOptions.baseMs",
+            "detail": "input duration carries Ms suffix → de-suffix + number|string (P17)",
+            "line": 215,
+            "key": "R2|packages/core/src/types.ts|RetryOptions.baseMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/types.ts",
+            "symbol": "RetryOptions.maxMs",
+            "detail": "input duration carries Ms suffix → de-suffix + number|string (P17)",
+            "line": 215,
+            "key": "R2|packages/core/src/types.ts|RetryOptions.maxMs"
+        },
+        {
+            "rule": "R3",
+            "file": "packages/core/src/types.ts",
+            "symbol": "CacheConfig.key",
+            "detail": "function-typed key → rename keyOf (P6)",
+            "line": 260,
+            "key": "R3|packages/core/src/types.ts|CacheConfig.key"
+        },
+        {
+            "rule": "R3",
+            "file": "packages/core/src/types.ts",
+            "symbol": "IdempotencyOptions.key",
+            "detail": "function-typed key → rename keyOf (P6)",
+            "line": 246,
+            "key": "R3|packages/core/src/types.ts|IdempotencyOptions.key"
+        },
+        {
+            "rule": "R4",
+            "file": "packages/core/src/types.ts",
+            "symbol": "ThrottleOptions.scope",
+            "detail": "pool axis named scope → rename pool (P2)",
+            "line": 223,
+            "key": "R4|packages/core/src/types.ts|ThrottleOptions.scope"
+        },
+        {
+            "rule": "R5",
+            "file": "packages/<multiple>",
+            "symbol": "queryOptions",
+            "detail": "exported by angular, react, solid, svelte, vue — must be unique-by-shape (P9/P16)",
+            "line": null,
+            "key": "R5|packages/<multiple>|queryOptions"
+        },
+        {
+            "rule": "R5",
+            "file": "packages/<multiple>",
+            "symbol": "RequestSeam",
+            "detail": "exported by elysia, express — must be unique-by-shape (P9/P16)",
+            "line": null,
+            "key": "R5|packages/<multiple>|RequestSeam"
+        },
+        {
+            "rule": "R5",
+            "file": "packages/<multiple>",
+            "symbol": "StitchError",
+            "detail": "exported by express, fastify, nest, next — must be unique-by-shape (P9/P16)",
+            "line": null,
+            "key": "R5|packages/<multiple>|StitchError"
+        },
+        {
+            "rule": "R5",
+            "file": "packages/<multiple>",
+            "symbol": "StitchErrorLike",
+            "detail": "exported by elysia, hono — must be unique-by-shape (P9/P16)",
+            "line": null,
+            "key": "R5|packages/<multiple>|StitchErrorLike"
+        },
+        {
+            "rule": "R5",
+            "file": "packages/<multiple>",
+            "symbol": "StitchHost",
+            "detail": "exported by fastify, nest — must be unique-by-shape (P9/P16)",
+            "line": null,
+            "key": "R5|packages/<multiple>|StitchHost"
+        },
+        {
+            "rule": "R5",
+            "file": "packages/<multiple>",
+            "symbol": "StitchLike",
+            "detail": "exported by angular, query-core, react, rtk-query, solid, svelte, swr, vercel-ai, vue — must be unique-by-shape (P9/P16)",
+            "line": null,
+            "key": "R5|packages/<multiple>|StitchLike"
+        },
+        {
+            "rule": "R5",
+            "file": "packages/<multiple>",
+            "symbol": "StitchStore",
+            "detail": "exported by solid, svelte — must be unique-by-shape (P9/P16)",
+            "line": null,
+            "key": "R5|packages/<multiple>|StitchStore"
+        }
+    ]
+}

--- a/scripts/contract-violations.baseline.json
+++ b/scripts/contract-violations.baseline.json
@@ -1,6 +1,6 @@
 {
     "generatedBy": "scripts/check-contract.mjs --update",
-    "count": 24,
+    "count": 46,
     "violations": [
         {
             "rule": "R1",
@@ -61,58 +61,234 @@
         {
             "rule": "R2",
             "file": "packages/core/src/auth.ts",
-            "symbol": "CookieSessionOpts.ttlMs",
-            "detail": "input duration carries Ms suffix → de-suffix + number|string (P17)",
-            "line": 484,
-            "key": "R2|packages/core/src/auth.ts|CookieSessionOpts.ttlMs"
+            "symbol": "refreshSkewMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 271,
+            "key": "R2|packages/core/src/auth.ts|refreshSkewMs"
         },
         {
             "rule": "R2",
             "file": "packages/core/src/auth.ts",
-            "symbol": "OAuth2Opts.refreshSkewMs",
-            "detail": "input duration carries Ms suffix → de-suffix + number|string (P17)",
-            "line": 238,
-            "key": "R2|packages/core/src/auth.ts|OAuth2Opts.refreshSkewMs"
+            "symbol": "retryAfterMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 463,
+            "key": "R2|packages/core/src/auth.ts|retryAfterMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/auth.ts",
+            "symbol": "ttlMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 506,
+            "key": "R2|packages/core/src/auth.ts|ttlMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/cli.ts",
+            "symbol": "avgMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 248,
+            "key": "R2|packages/core/src/cli.ts|avgMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/engine.ts",
+            "symbol": "backoffMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 1375,
+            "key": "R2|packages/core/src/engine.ts|backoffMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/engine.ts",
+            "symbol": "retryAfterMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 725,
+            "key": "R2|packages/core/src/engine.ts|retryAfterMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/engine.ts",
+            "symbol": "totalMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 448,
+            "key": "R2|packages/core/src/engine.ts|totalMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/engine.ts",
+            "symbol": "waitedMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 70,
+            "key": "R2|packages/core/src/engine.ts|waitedMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/resilience.ts",
+            "symbol": "retryAfterMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 252,
+            "key": "R2|packages/core/src/resilience.ts|retryAfterMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/resilience.ts",
+            "symbol": "waitedMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 78,
+            "key": "R2|packages/core/src/resilience.ts|waitedMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/sse.ts",
+            "symbol": "resumeRetryMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 139,
+            "key": "R2|packages/core/src/sse.ts|resumeRetryMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/store.ts",
+            "symbol": "waitedMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 106,
+            "key": "R2|packages/core/src/store.ts|waitedMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/test-clock.ts",
+            "symbol": "baseMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 38,
+            "key": "R2|packages/core/src/test-clock.ts|baseMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/test-mock.ts",
+            "symbol": "delayMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 23,
+            "key": "R2|packages/core/src/test-mock.ts|delayMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/testing.ts",
+            "symbol": "delayMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 379,
+            "key": "R2|packages/core/src/testing.ts|delayMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/testing.ts",
+            "symbol": "ttlMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 174,
+            "key": "R2|packages/core/src/testing.ts|ttlMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/testing.ts",
+            "symbol": "waitedMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 645,
+            "key": "R2|packages/core/src/testing.ts|waitedMs"
         },
         {
             "rule": "R2",
             "file": "packages/core/src/types.ts",
-            "symbol": "CircuitOptions.cooldownMs",
-            "detail": "input duration carries Ms suffix → de-suffix + number|string (P17)",
-            "line": 240,
-            "key": "R2|packages/core/src/types.ts|CircuitOptions.cooldownMs"
+            "symbol": "backoffMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 150,
+            "key": "R2|packages/core/src/types.ts|backoffMs"
         },
         {
             "rule": "R2",
             "file": "packages/core/src/types.ts",
-            "symbol": "CircuitOptions.halfOpenAfterMs",
-            "detail": "input duration carries Ms suffix → de-suffix + number|string (P17)",
-            "line": 240,
-            "key": "R2|packages/core/src/types.ts|CircuitOptions.halfOpenAfterMs"
+            "symbol": "baseMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 218,
+            "key": "R2|packages/core/src/types.ts|baseMs"
         },
         {
             "rule": "R2",
             "file": "packages/core/src/types.ts",
-            "symbol": "ReconnectOptions.backoffMs",
-            "detail": "input duration carries Ms suffix → de-suffix + number|string (P17)",
-            "line": 140,
-            "key": "R2|packages/core/src/types.ts|ReconnectOptions.backoffMs"
+            "symbol": "cooldownMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 241,
+            "key": "R2|packages/core/src/types.ts|cooldownMs"
         },
         {
             "rule": "R2",
             "file": "packages/core/src/types.ts",
-            "symbol": "RetryOptions.baseMs",
-            "detail": "input duration carries Ms suffix → de-suffix + number|string (P17)",
-            "line": 215,
-            "key": "R2|packages/core/src/types.ts|RetryOptions.baseMs"
+            "symbol": "halfOpenAfterMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 242,
+            "key": "R2|packages/core/src/types.ts|halfOpenAfterMs"
         },
         {
             "rule": "R2",
             "file": "packages/core/src/types.ts",
-            "symbol": "RetryOptions.maxMs",
-            "detail": "input duration carries Ms suffix → de-suffix + number|string (P17)",
-            "line": 215,
-            "key": "R2|packages/core/src/types.ts|RetryOptions.maxMs"
+            "symbol": "maxMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 219,
+            "key": "R2|packages/core/src/types.ts|maxMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/types.ts",
+            "symbol": "retryAfterMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 457,
+            "key": "R2|packages/core/src/types.ts|retryAfterMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/types.ts",
+            "symbol": "ttlMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 936,
+            "key": "R2|packages/core/src/types.ts|ttlMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/types.ts",
+            "symbol": "waitedMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 440,
+            "key": "R2|packages/core/src/types.ts|waitedMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/core/src/util.ts",
+            "symbol": "perMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 83,
+            "key": "R2|packages/core/src/util.ts|perMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/pino/src/index.ts",
+            "symbol": "waitedMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 179,
+            "key": "R2|packages/pino/src/index.ts|waitedMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/redis/src/index.ts",
+            "symbol": "ttlMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 46,
+            "key": "R2|packages/redis/src/index.ts|ttlMs"
+        },
+        {
+            "rule": "R2",
+            "file": "packages/sentry/src/index.ts",
+            "symbol": "waitedMs",
+            "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
+            "line": 121,
+            "key": "R2|packages/sentry/src/index.ts|waitedMs"
         },
         {
             "rule": "R3",

--- a/scripts/contract-violations.baseline.json
+++ b/scripts/contract-violations.baseline.json
@@ -1,6 +1,6 @@
 {
     "generatedBy": "scripts/check-contract.mjs --update",
-    "count": 46,
+    "count": 43,
     "violations": [
         {
             "rule": "R1",
@@ -55,7 +55,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "CacheConfig",
             "detail": "banned suffix on consumer type → *Options (P3)",
-            "line": 260,
+            "line": 270,
             "key": "R1|packages/core/src/types.ts|CacheConfig"
         },
         {
@@ -95,7 +95,7 @@
             "file": "packages/core/src/engine.ts",
             "symbol": "backoffMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 1375,
+            "line": 1374,
             "key": "R2|packages/core/src/engine.ts|backoffMs"
         },
         {
@@ -103,7 +103,7 @@
             "file": "packages/core/src/engine.ts",
             "symbol": "retryAfterMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 725,
+            "line": 724,
             "key": "R2|packages/core/src/engine.ts|retryAfterMs"
         },
         {
@@ -111,7 +111,7 @@
             "file": "packages/core/src/engine.ts",
             "symbol": "totalMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 448,
+            "line": 447,
             "key": "R2|packages/core/src/engine.ts|totalMs"
         },
         {
@@ -127,7 +127,7 @@
             "file": "packages/core/src/resilience.ts",
             "symbol": "retryAfterMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 252,
+            "line": 254,
             "key": "R2|packages/core/src/resilience.ts|retryAfterMs"
         },
         {
@@ -215,7 +215,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "cooldownMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 241,
+            "line": 248,
             "key": "R2|packages/core/src/types.ts|cooldownMs"
         },
         {
@@ -223,7 +223,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "halfOpenAfterMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 242,
+            "line": 249,
             "key": "R2|packages/core/src/types.ts|halfOpenAfterMs"
         },
         {
@@ -239,7 +239,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "retryAfterMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 457,
+            "line": 469,
             "key": "R2|packages/core/src/types.ts|retryAfterMs"
         },
         {
@@ -247,7 +247,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "ttlMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 936,
+            "line": 948,
             "key": "R2|packages/core/src/types.ts|ttlMs"
         },
         {
@@ -255,7 +255,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "waitedMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 440,
+            "line": 452,
             "key": "R2|packages/core/src/types.ts|waitedMs"
         },
         {
@@ -289,30 +289,6 @@
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
             "line": 121,
             "key": "R2|packages/sentry/src/index.ts|waitedMs"
-        },
-        {
-            "rule": "R3",
-            "file": "packages/core/src/types.ts",
-            "symbol": "CacheConfig.key",
-            "detail": "function-typed key → rename keyOf (P6)",
-            "line": 260,
-            "key": "R3|packages/core/src/types.ts|CacheConfig.key"
-        },
-        {
-            "rule": "R3",
-            "file": "packages/core/src/types.ts",
-            "symbol": "IdempotencyOptions.key",
-            "detail": "function-typed key → rename keyOf (P6)",
-            "line": 246,
-            "key": "R3|packages/core/src/types.ts|IdempotencyOptions.key"
-        },
-        {
-            "rule": "R4",
-            "file": "packages/core/src/types.ts",
-            "symbol": "ThrottleOptions.scope",
-            "detail": "pool axis named scope → rename pool (P2)",
-            "line": 223,
-            "key": "R4|packages/core/src/types.ts|ThrottleOptions.scope"
         },
         {
             "rule": "R5",

--- a/scripts/contract-violations.baseline.json
+++ b/scripts/contract-violations.baseline.json
@@ -1,6 +1,6 @@
 {
     "generatedBy": "scripts/check-contract.mjs --update",
-    "count": 36,
+    "count": 42,
     "violations": [
         {
             "rule": "R2",
@@ -39,7 +39,7 @@
             "file": "packages/core/src/engine.ts",
             "symbol": "backoffMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 1376,
+            "line": 1377,
             "key": "R2|packages/core/src/engine.ts|backoffMs"
         },
         {
@@ -143,7 +143,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "backoffMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 150,
+            "line": 162,
             "key": "R2|packages/core/src/types.ts|backoffMs"
         },
         {
@@ -151,7 +151,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "baseMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 218,
+            "line": 230,
             "key": "R2|packages/core/src/types.ts|baseMs"
         },
         {
@@ -159,7 +159,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "cooldownMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 248,
+            "line": 260,
             "key": "R2|packages/core/src/types.ts|cooldownMs"
         },
         {
@@ -167,7 +167,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "halfOpenAfterMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 249,
+            "line": 261,
             "key": "R2|packages/core/src/types.ts|halfOpenAfterMs"
         },
         {
@@ -175,7 +175,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "maxMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 219,
+            "line": 231,
             "key": "R2|packages/core/src/types.ts|maxMs"
         },
         {
@@ -183,7 +183,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "retryAfterMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 469,
+            "line": 483,
             "key": "R2|packages/core/src/types.ts|retryAfterMs"
         },
         {
@@ -191,7 +191,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "ttlMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 948,
+            "line": 970,
             "key": "R2|packages/core/src/types.ts|ttlMs"
         },
         {
@@ -199,7 +199,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "waitedMs",
             "detail": "duration field carries Ms suffix → drop it (ms is the house unit; P17)",
-            "line": 452,
+            "line": 466,
             "key": "R2|packages/core/src/types.ts|waitedMs"
         },
         {
@@ -289,6 +289,54 @@
             "detail": "exported by solid, svelte — must be unique-by-shape (P9/P16)",
             "line": null,
             "key": "R5|packages/<multiple>|StitchStore"
+        },
+        {
+            "rule": "R6",
+            "file": "packages/core/src/types.ts",
+            "symbol": "StitchConfig.hooks",
+            "detail": "all-optional Hooks accepts {} → Scalar|AtLeastOne<Hooks> (P20)",
+            "line": 524,
+            "key": "R6|packages/core/src/types.ts|StitchConfig.hooks"
+        },
+        {
+            "rule": "R6",
+            "file": "packages/core/src/types.ts",
+            "symbol": "StitchConfig.input",
+            "detail": "all-optional InputSchemas accepts {} → Scalar|AtLeastOne<InputSchemas> (P20)",
+            "line": 524,
+            "key": "R6|packages/core/src/types.ts|StitchConfig.input"
+        },
+        {
+            "rule": "R6",
+            "file": "packages/core/src/types.ts",
+            "symbol": "StitchConfig.multipart",
+            "detail": "all-optional MultipartOptions accepts {} → Scalar|AtLeastOne<MultipartOptions> (P20)",
+            "line": 524,
+            "key": "R6|packages/core/src/types.ts|StitchConfig.multipart"
+        },
+        {
+            "rule": "R6",
+            "file": "packages/core/src/types.ts",
+            "symbol": "StitchConfig.sse",
+            "detail": "all-optional SseOptions accepts {} → Scalar|AtLeastOne<SseOptions> (P20)",
+            "line": 524,
+            "key": "R6|packages/core/src/types.ts|StitchConfig.sse"
+        },
+        {
+            "rule": "R6",
+            "file": "packages/core/src/types.ts",
+            "symbol": "StitchConfig.stream",
+            "detail": "all-optional StreamOptions accepts {} → Scalar|AtLeastOne<StreamOptions> (P20)",
+            "line": 524,
+            "key": "R6|packages/core/src/types.ts|StitchConfig.stream"
+        },
+        {
+            "rule": "R6",
+            "file": "packages/core/src/types.ts",
+            "symbol": "StitchConfig.throttle",
+            "detail": "all-optional ThrottleOptions accepts {} → Scalar|AtLeastOne<ThrottleOptions> (P20)",
+            "line": 524,
+            "key": "R6|packages/core/src/types.ts|StitchConfig.throttle"
         }
     ]
 }


### PR DESCRIPTION
**Phase 1 of 3** of the API meta-contract sweep — landed as a stack of small, independently-green PRs:

1. **this PR** — the contract + ratchet + early renames (baseline 42)
2. [`contract/durations-payload`](https://github.com/rejifald/StitchAPI/tree/contract-durations-payload) — P17 durations + P5 payload renames (→ baseline 13)
3. [`contract/p9-cross-package`](https://github.com/rejifald/StitchAPI/tree/contract-p9-cross-package) — P9/P16 cross-package unique-by-shape (→ baseline 6, R5 fully clear)

## What (this phase)

Defines the **API meta-contract** and lands the **ratchet lint**, plus the lower-blast-radius early renames that don't need cross-package coordination.

- **[`docs/CONTRACT.md`](../blob/docs/api-meta-contract/docs/CONTRACT.md)** — a living normative doc (P0–P21): naming, typing, the envelope-with-scalar-shorthand model, durations, cross-surface/cross-package parity. Complements ADR 0012 at the field/shape layer. Its "Shipped" note tracks every applied rename across all three phases.
- **`scripts/check-contract.mjs`** — a ratchet (R1–R6) wired into `lefthook` (pre-push) and `verify.yml`, baseline frozen in `scripts/contract-violations.baseline.json`.

**Renames in this phase** (each under a `@deprecated` alias, P19): `throttle.scope`→`pool` (P2); `key`→`keyOf` (P6); the `*Config`/`*Opts`/`*Info`/`*Params`→`*Options`/`*Result` suffix family (P3); count caps→bare nouns `maxAttempts`/`maxEntries`/`paginate.max` (P4); `retry.on`/`throttle.on` status predicates (P7); `rateLimit` folded into `throttle` + `PaginateOptions` extracted (P14); `idempotency`/`multipart`/… empty-object slots → `boolean | AtLeastOne<Options>` (P20) + the extension-seam rule (P21).

## Verification

Whole repo (`pnpm -r`) typechecks, lints, and tests green at this tip; `check:contract` passes (baseline 42); a docs build (the AutoTypeTable/twoslash render gate) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
