### PR TITLE
docs(blog): reuse the installation snippet for "Try it" sections

### DIFF
--- a/apps/docs/content/blog/auth-as-a-capability-not-a-credential.mdx
+++ b/apps/docs/content/blog/auth-as-a-capability-not-a-credential.mdx
@@ -109,8 +109,8 @@ In short: this closes the channel where most agent key leaks actually happen —
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare the credential once on a seam, hand a stitch to an agent, and watch the call site go quiet — no secret in sight. The per-mode guides walk through each strategy: [bearer](/docs/guides/auth/bearer), [apiKey](/docs/guides/auth/api-key), [basic](/docs/guides/auth/basic), [cookieSession](/docs/guides/auth/cookie-session), and [oauth2](/docs/guides/auth/oauth2). For the agent angle, see [Auth as a capability](/docs/recipes/auth-as-a-capability) and [Use StitchAPI from an agent](/docs/agents).

--- a/apps/docs/content/blog/axios-alternatives.mdx
+++ b/apps/docs/content/blog/axios-alternatives.mdx
@@ -78,8 +78,8 @@ A stitch earns its keep on the opposite shape of problem: APIs that rate-limit, 
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare one endpoint with a `retry` and an `output` schema, and watch the retry, the rate-limit handling, and the shape check that used to be three interceptors collapse into the declaration. The primitive itself is [The stitch](/docs/concepts/the-stitch), the policies live in [Retry](/docs/guides/resilience/retry), [Throttle](/docs/guides/resilience/throttle), and [Validation & drift](/docs/guides/validation/drift), and if you're coming from a generated client instead, there's [stitching vs. codegen](/blog/stitch-vs-codegen-api-clients).

--- a/apps/docs/content/blog/circuit-breakers-and-layered-timeouts.mdx
+++ b/apps/docs/content/blog/circuit-breakers-and-layered-timeouts.mdx
@@ -103,8 +103,8 @@ The throughline: these tools bound a bad situation, they don't fix it. A depende
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare a stitch, give it a `timeout`, a `retry` policy, and a `circuit`, and you've described how it should behave when the upstream misbehaves — once, for every caller. The per-feature guides go deeper:

--- a/apps/docs/content/blog/code-mode-vs-tool-calling.mdx
+++ b/apps/docs/content/blog/code-mode-vs-tool-calling.mdx
@@ -57,8 +57,8 @@ For the deeper opinion on the catalog-tax math and why the per-endpoint reflex c
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare your endpoints once, point an agent at the three-tool surface, and watch the per-turn tool list stop growing. See [Use StitchAPI from an agent](/docs/agents) for the entry point and the capability boundary, [run_stitch & code-mode](/docs/agents/run-stitch-tool) for the three tools in full, and [capability, not credential](/docs/concepts/capability-not-credential) for why the agent calls without seeing the secret.

--- a/apps/docs/content/blog/cut-llm-costs-from-both-ends.mdx
+++ b/apps/docs/content/blog/cut-llm-costs-from-both-ends.mdx
@@ -120,8 +120,8 @@ If you want the mechanics:
 
 Or just start:
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare one endpoint, point an agent at it, and watch the two taxes shrink at the same time.

--- a/apps/docs/content/blog/distributed-throttle-with-redis-kv.mdx
+++ b/apps/docs/content/blog/distributed-throttle-with-redis-kv.mdx
@@ -103,8 +103,8 @@ It's a config change, not a rewrite. The call sites don't move.
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Then attach a driver and your throttle and sessions go fleet-wide without touching a call site:

--- a/apps/docs/content/blog/expose-a-stitch-as-an-ai-sdk-tool.mdx
+++ b/apps/docs/content/blog/expose-a-stitch-as-an-ai-sdk-tool.mdx
@@ -121,8 +121,8 @@ For most apps already on the AI SDK, the MCP surface is still the canonical way 
 
 ## Try it
 
-```bash
-npm i stitchapi @stitchapi/vercel-ai
+```package-install
+stitchapi @stitchapi/vercel-ai
 ```
 
 Declare one endpoint as a stitch, wrap it with `stitchTool`, and drop it into your `tools` map. The model gets typed, validated data; the credential never leaves the seam. The full surface — `stitchTool`, `stitchExecute`, and the v4/v5 bridging — is in the [Vercel AI SDK integration docs](/docs/integrations/vercel-ai), and the broader agent story lives under [/docs/agents](/docs/agents).

--- a/apps/docs/content/blog/fetch-timeout-typescript.mdx
+++ b/apps/docs/content/blog/fetch-timeout-typescript.mdx
@@ -126,8 +126,8 @@ Same call site, same callers, more guarantees. That's the trade: a bare `AbortSi
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Give a stitch a `timeout: { total, perAttempt }` and a slow upstream is bounded at two scopes with a real abort and a typed error — once, for every caller. The mechanics are in [Timeouts](/docs/guides/resilience/timeout), the error in [STITCH_TIMEOUT](/docs/errors/stitch-timeout), and how it composes with backoff in [Retry](/docs/guides/resilience/retry).

--- a/apps/docs/content/blog/one-definition-four-front-doors.mdx
+++ b/apps/docs/content/blog/one-definition-four-front-doors.mdx
@@ -123,8 +123,8 @@ The point isn't turning everything on. It's that when a stitch belongs behind se
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare one stitch, then reach it four ways — the [in-process function](/docs/surfaces/function), the [CLI](/docs/surfaces/cli), [HTTP serve](/docs/surfaces/http-serve), and [MCP](/docs/surfaces/mcp).

--- a/apps/docs/content/blog/one-tool-per-endpoint.mdx
+++ b/apps/docs/content/blog/one-tool-per-endpoint.mdx
@@ -100,8 +100,8 @@ This is the sharp version of one half of [cutting your LLM bill from both ends](
 
 Or just start:
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare your endpoints once, point an agent at `run_stitch`, and watch the per-turn catalog stop growing.

--- a/apps/docs/content/blog/orval-vs-runtime-stitching.mdx
+++ b/apps/docs/content/blog/orval-vs-runtime-stitching.mdx
@@ -99,8 +99,8 @@ Runtime stitching earns its keep on the opposite shape: spec-less, partial-spec,
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare the few endpoints you actually call, give each an `output` schema, and drive them from `useStitch` or TanStack Query — no spec, no generated client, and the next upstream rename arrives as a typed signal instead of a stale generated type. The primitive is in [The stitch](/docs/concepts/the-stitch), validation in [Validation](/docs/guides/validation/validation), and the React hooks in [the React integration](/docs/integrations/react).

--- a/apps/docs/content/blog/proactive-throttling-vs-reactive-429s.mdx
+++ b/apps/docs/content/blog/proactive-throttling-vs-reactive-429s.mdx
@@ -89,8 +89,8 @@ The reactive path is the floor you start from. `throttle` is the field you add w
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare a `throttle` on a stitch, pair it with `retry` as a backstop, and the next time you brush a provider's rate limit you'll pace under it instead of bouncing off it. The full field list and `scope` semantics are in the [Throttle guide](/docs/guides/resilience/throttle); the reactive side is in [Retry & backoff](/docs/guides/resilience/retry).

--- a/apps/docs/content/blog/rate-limit-api-calls-typescript.mdx
+++ b/apps/docs/content/blog/rate-limit-api-calls-typescript.mdx
@@ -98,8 +98,8 @@ If you're weighing this against the interceptor stack you'd otherwise hand-write
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare a `throttle` on a stitch, set `scope: 'host'` to share the budget the way the provider counts, and pace under the limit instead of bouncing off it. The full field list and `scope` semantics are in the [Throttle guide](/docs/guides/resilience/throttle).

--- a/apps/docs/content/blog/read-through-caching-and-coalescing.mdx
+++ b/apps/docs/content/blog/read-through-caching-and-coalescing.mdx
@@ -115,8 +115,8 @@ Keep this distinct from [throttling](/blog/proactive-throttling-vs-reactive-429s
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Add `cache: '5m'` to one read-heavy stitch, fan a few identical calls at it, and watch them collapse to a single upstream request. The full configuration surface — `ttl`, `scope`, `vary`, `maxEntries`, the stitch-level `sensitive` flag, and the fingerprinting rules — lives in the [docs](/docs).

--- a/apps/docs/content/blog/retry-fetch-in-typescript.mdx
+++ b/apps/docs/content/blog/retry-fetch-in-typescript.mdx
@@ -136,8 +136,8 @@ That's the line, and crossing it is a field, not a rewrite: the same call gains 
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare one endpoint with a `retry` field and the loop, the backoff math, the status-code allowlist, and the `Retry-After` parsing collapse into five lines of policy you can read at a glance. The full option list — every `backoff` curve, `baseMs`, `maxMs`, and the idempotency caveat — lives in [Retry & backoff](/docs/guides/resilience/retry).

--- a/apps/docs/content/blog/runtime-stitching-vs-workflow-platforms.mdx
+++ b/apps/docs/content/blog/runtime-stitching-vs-workflow-platforms.mdx
@@ -101,8 +101,8 @@ The useful frame: a platform answers "in what order, and when, do these steps ru
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare one endpoint as a stitch, then decide whether it lives in your own code or inside a workflow's code step — the definition is the same either way. The [concepts overview](/docs/concepts/the-stitch) explains the primitive, and [the docs](/docs) cover composition, auth, and resilience in depth.

--- a/apps/docs/content/blog/schema-drift-is-a-production-bug.mdx
+++ b/apps/docs/content/blog/schema-drift-is-a-production-bug.mdx
@@ -93,8 +93,8 @@ None of that changes the core trade. Without drift, a quietly renamed field is a
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Wrap an `output` in `drift()` and make the fields you depend on required. The full mechanics — the change kinds, `severity`, `ignore`, and the `STITCH_DRIFT` error — are in the [Drift detection](/docs/guides/validation/drift) guide, with the broader picture in [Validation](/docs/guides/validation/validation) and the [event stream](/docs/concepts/event-stream).

--- a/apps/docs/content/blog/stitch-vs-codegen-api-clients.mdx
+++ b/apps/docs/content/blog/stitch-vs-codegen-api-clients.mdx
@@ -106,8 +106,8 @@ And the honesty runs the other way too: for a single internal endpoint that neve
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare one endpoint, wrap its output in `drift()`, and watch the next upstream rename arrive as a typed signal instead of a downstream `undefined`. The mechanics live in [Validation & drift](/docs/guides/validation/drift), the agent surface in [Use from an agent](/docs/agents), and the primitive itself in [The stitch](/docs/concepts/the-stitch).

--- a/apps/docs/content/blog/stop-writing-fetch-in-your-agents.mdx
+++ b/apps/docs/content/blog/stop-writing-fetch-in-your-agents.mdx
@@ -101,8 +101,8 @@ So the rule isn't "never write `fetch`." It's: the moment the caller is an agent
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare one endpoint as a stitch, point an agent at it over MCP, and the agent invokes a capability instead of constructing a request. Start with [the stitch concept](/docs/concepts/the-stitch), then [use it from an agent](/docs/agents) to see the credential-free call path end to end.

--- a/apps/docs/content/blog/stream-a-stitch-as-sse-in-next-app-router.mdx
+++ b/apps/docs/content/blog/stream-a-stitch-as-sse-in-next-app-router.mdx
@@ -35,8 +35,8 @@ App Router route handlers are **Web-standard** — they receive a `Request` and 
 
 Install it alongside the core library:
 
-```bash
-npm install @stitchapi/next stitchapi
+```package-install
+@stitchapi/next stitchapi
 ```
 
 Then `sseResponse` takes the stitch's event stream and returns a `text/event-stream` `Response`. Each `delta` becomes one SSE frame; you tell it how to pull the renderable payload out of a chunk with `data`:
@@ -109,8 +109,8 @@ Streaming over HTTP has sharp edges that have nothing to do with StitchAPI, and 
 
 ## Try it
 
-```bash
-npm i stitchapi @stitchapi/next
+```package-install
+stitchapi @stitchapi/next
 ```
 
 Declare a streaming stitch, return `sseResponse(stitch.stream())` from a route handler, and consume the deltas with `useStitchStream`. The full guides: [`@stitchapi/next`](/docs/integrations/next), [`@stitchapi/react`](/docs/integrations/react), and the [event stream](/docs/reference/events) that makes all of it one moving part.

--- a/apps/docs/content/blog/type-safe-api-client-without-codegen.mdx
+++ b/apps/docs/content/blog/type-safe-api-client-without-codegen.mdx
@@ -100,8 +100,8 @@ A stitch earns its place on the opposite shape of problem: spec-less, partial-sp
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare one endpoint, give its `output` a `toValidator()` schema, pair it with the `stitch<T>` generic, and you have a typed, runtime-validated call with no generated file in your tree. The mechanics live in [Validation](/docs/guides/validation/validation), the validator adapter in [Standard Schema](/docs/guides/validation/standard-schema), and the primitive itself in [The stitch](/docs/concepts/the-stitch).

--- a/apps/docs/content/blog/typescript-pagination.mdx
+++ b/apps/docs/content/blog/typescript-pagination.mdx
@@ -137,8 +137,8 @@ One caveat in the other direction: `paginate` aggregates every page into a singl
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Give a stitch a `paginate` with a `next` and an `items`, and one `await` follows every page into a single array — with `retry` and `throttle` applied per page when you add them. The mechanics are in [Pagination](/docs/guides/data/pagination), the envelope handling in [Unwrap](/docs/guides/data/unwrap), and typed rows in [Validation](/docs/guides/validation/validation).

--- a/apps/docs/content/blog/validate-api-response-zod.mdx
+++ b/apps/docs/content/blog/validate-api-response-zod.mdx
@@ -90,8 +90,8 @@ The schema is the same Zod object either way. The only question is whether it ru
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Move your `safeParse` schema onto a stitch's `output` with `toValidator()`, pair it with the `stitch<T>` generic, and every call validates its response with a typed error and no per-call-site boilerplate. The mechanics are in [Validation](/docs/guides/validation/validation), the validator adapter in [Standard Schema](/docs/guides/validation/standard-schema), and getting types without a codegen step in [a type-safe API client without codegen](/blog/type-safe-api-client-without-codegen).

--- a/apps/docs/content/blog/what-is-schema-drift.mdx
+++ b/apps/docs/content/blog/what-is-schema-drift.mdx
@@ -91,8 +91,8 @@ The trade is the same either way. Without a contract checked on every call, a qu
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Wrap an `output` in `drift()`, make the fields you depend on required, and the next upstream rename arrives as a typed signal instead of a downstream `undefined`. The mechanics live in [Drift detection](/docs/guides/validation/drift), the hard-failure error in [STITCH_DRIFT](/docs/errors/stitch-drift), and the broader case in [schema drift is the bug you ship to production](/blog/schema-drift-is-a-production-bug).

--- a/apps/docs/content/blog/you-might-not-need-an-mcp-server-per-integration.mdx
+++ b/apps/docs/content/blog/you-might-not-need-an-mcp-server-per-integration.mdx
@@ -95,8 +95,8 @@ The decision isn't "MCP servers, yes or no." It's "how many processes, auth boun
 
 ## Try it
 
-```bash
-npm i stitchapi
+```package-install
+stitchapi
 ```
 
 Declare a couple of endpoints, run `stitch mcp`, and point your agent at the three-tool surface. See [Use from an agent](/docs/agents), the [run_stitch & code-mode](/docs/agents/run-stitch-tool) tool, and the [MCP surface](/docs/surfaces/mcp) for starting the server and the transport details.


### PR DESCRIPTION
## What

Blog \"Try it\" sections now reuse the **same install snippet as the installation guide** — multi-package-manager tabs (npm/pnpm/yarn/bun) with the canonical release channel (`@rc` today) stamped on automatically.

## Why

Every blog post hardcoded its install as a single-manager block:

```` bash
npm i stitchapi
````

That has two drift bugs the docs install snippet already solved:

1. **npm-only** — readers on pnpm/yarn/bun had to mentally translate.
2. **Stale channel** — no `@rc` suffix, so the command pointed at the `latest` dist-tag, which during a prerelease is *not* the documented release.

The installation guide avoids both by using a ```` ```package-install ```` fence, which the global remark pipeline (`remarkInstallChannel` + fumadocs' `remarkNpm`, configured once in `apps/docs/source.config.ts` for **both** the `docs` and `blog` collections) expands into per-manager tabs and stamps with the build-time dist-tag derived from the canonical core `package.json`. Once `1.0.0` ships stable the suffix becomes `''` and it's a no-op — no per-page edits at release time.

## Change

Pure fence swaps — ```` ```bash / npm i … ```` → ```` ```package-install / … ````, package order preserved:

- All 23 blog **\"Try it\"** sections.
- Plus the body install block in `stream-a-stitch-as-sse-in-next-app-router.mdx` (line ~38), which had the identical hardcoded-npm drift — converted for consistency within the file.

26 blocks across 25 posts. No prose changes.

## Verification

- `prettier --check` clean on all changed files.
- `fumadocs-mdx` compiles the blog collection with no errors.
- Full `apps/docs check:types` (pre-commit) and `build-docs` Next.js build (pre-push) both pass — the whole docs site, blog included, builds green.
- Confirmed the blog renderer shares `getMDXComponents()` with docs (`apps/docs/app/(home)/blog/[slug]/page.tsx`), so the `CodeBlockTabs` components `remarkNpm` emits resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)