### PR TITLE
feat(docs): add Vercel Analytics to the docs site

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -4,6 +4,7 @@ import { jsonLdHtml } from '@/lib/json-ld';
 import { releaseVersion } from '@/lib/release';
 import { appName, gitConfig, siteUrl } from '@/lib/shared';
 
+import { Analytics } from '@vercel/analytics/next';
 import 'fumadocs-twoslash/twoslash.css';
 import { Banner } from 'fumadocs-ui/components/banner';
 import { RootProvider } from 'fumadocs-ui/provider/next';
@@ -164,6 +165,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
                     </Banner>
                     {children}
                 </RootProvider>
+                <Analytics />
             </body>
         </html>
     );

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -25,6 +25,7 @@
         "@lezer/highlight": "^1.2.3",
         "@stitchapi/sandbox": "workspace:*",
         "@uiw/react-codemirror": "^4.23.0",
+        "@vercel/analytics": "^2.0.1",
         "fumadocs-core": "^16.10.0",
         "fumadocs-mdx": "^15.0.12",
         "fumadocs-twoslash": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       '@uiw/react-codemirror':
         specifier: ^4.23.0
         version: 4.25.10(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.0)(@codemirror/state@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.1)(codemirror@6.0.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vue@3.5.38(typescript@6.0.3))
       fumadocs-core:
         specifier: ^16.10.0
         version: 16.10.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
@@ -3768,6 +3771,35 @@ packages:
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
@@ -11366,6 +11398,13 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vercel/analytics@2.0.1(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vue@3.5.38(typescript@6.0.3))':
+    optionalDependencies:
+      next: 16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
+      vue: 3.5.38(typescript@6.0.3)
+
   '@vercel/oidc@3.2.0': {}
 
   '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
@@ -11494,6 +11533,13 @@ snapshots:
       '@vue/compiler-ssr': 3.5.38
       '@vue/shared': 3.5.38
       vue: 3.5.38(typescript@5.9.3)
+
+  '@vue/server-renderer@3.5.38(vue@3.5.38(typescript@6.0.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.38
+      '@vue/shared': 3.5.38
+      vue: 3.5.38(typescript@6.0.3)
+    optional: true
 
   '@vue/shared@3.5.38': {}
 
@@ -16869,6 +16915,17 @@ snapshots:
       '@vue/shared': 3.5.38
     optionalDependencies:
       typescript: 5.9.3
+
+  vue@3.5.38(typescript@6.0.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.38
+      '@vue/compiler-sfc': 3.5.38
+      '@vue/runtime-dom': 3.5.38
+      '@vue/server-renderer': 3.5.38(vue@3.5.38(typescript@6.0.3))
+      '@vue/shared': 3.5.38
+    optionalDependencies:
+      typescript: 6.0.3
+    optional: true
 
   w3c-keyname@2.2.8: {}
 


### PR DESCRIPTION
## What

Mount `<Analytics />` from `@vercel/analytics/next` in the docs root layout so page views are tracked once deployed on Vercel.

## Changes

- Add `@vercel/analytics@^2.0.1` to `apps/docs`
- Import `Analytics` from `@vercel/analytics/next` and render it inside `<body>` in `apps/docs/app/layout.tsx`

## Verification

- `pnpm install --frozen-lockfile` clean — no lockfile drift
- Dev server boots, home page renders, zero console errors
- Component injects the Vercel insights script (debug build in dev; `/_vercel/insights/script.js` once on Vercel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)