### PR TITLE
docs(blog): migration, adapter, and React Query onboarding posts

### DIFF
--- a/apps/docs/content/blog/adopt-stitchapi-without-a-rewrite.mdx
+++ b/apps/docs/content/blog/adopt-stitchapi-without-a-rewrite.mdx
@@ -1,0 +1,132 @@
+---
+title: Adopt StitchAPI Without a Rewrite
+description: 'Wrap one endpoint as a stitch, leave the rest of your fetch and axios code untouched, and grow the typed-resilient surface one call at a time.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [adoption, migration, fetch, axios, architecture]
+---
+
+A retry policy you added to one `fetch` call last quarter never made it to the other six that hit the same flaky endpoint, and the response shape that broke production last week was the one nobody validated. You don't want to stop shipping for a week to rewrite the data layer — you want to harden the one call that keeps paging you, today, and leave everything else exactly where it is.
+
+That is the whole adoption story: a stitch wraps **one endpoint**, returns a function, and sits next to the `fetch` and axios code you already have. Nothing else has to move. The next call you harden is another stitch; the call after that is another. You convert by the call, not by the codebase.
+
+## The call that keeps paging you
+
+Here is the kind of `fetch` that ends up everywhere — a read that the team has quietly copied, tweaked, and re-tweaked across the app.
+
+```ts
+async function getUser(id: string) {
+    const res = await fetch(`https://api.example.com/users/${id}`, {
+        headers: { Authorization: `Bearer ${process.env.API_TOKEN}` },
+    });
+    if (!res.ok) throw new Error(`getUser ${res.status}`);
+    return res.json() as Promise<{ id: number; name: string }>;
+}
+```
+
+The sharp edges are real, and they are the ones you keep patching by hand:
+
+-   **No retry.** A 503 from the upstream propagates straight to the caller. The fix is a loop with backoff, written once here and forgotten in the next copy.
+-   **No timeout.** A hung connection hangs the request behind it. You reach for `AbortController` and a `setTimeout` you have to clear.
+-   **The cast lies.** `as Promise<{ id: number; name: string }>` is a promise to the compiler, not a check against the bytes. The day the API renames `name`, this code reads `undefined` and keeps going.
+-   **The token is in the function.** `process.env.API_TOKEN` is interpolated inline, so every copy holds the secret and every log line risks leaking it.
+
+## The same call, as a stitch
+
+Wrap that one endpoint. Each field is a sharp edge moved from glue into a declaration.
+
+```ts
+import { bearer, env, stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const getUser = stitch({
+    url: 'https://api.example.com/users/{id}',
+    auth: bearer(env('API_TOKEN')),
+    output: z.object({ id: z.number(), name: z.string() }),
+    retry: { attempts: 3, on: [429, 502, 503, 504], backoff: 'expo-jitter' },
+    timeout: { total: '10s', perAttempt: '4s' },
+});
+
+const user = await getUser({ params: { id: '42' } }); // typed · validated
+```
+
+Field by field, against the list above:
+
+-   `retry` replaces the hand-rolled loop — status-aware, capped attempts, jittered backoff, and it honors `Retry-After` on its own.
+-   `timeout` replaces the `AbortController` dance with a layered budget: `total` bounds the whole call, `perAttempt` bounds each try.
+-   `output` replaces the cast with a real check. `await` returns the **validated** value; a renamed `name` throws a `StitchError` at the boundary instead of leaking `undefined` downstream.
+-   `auth: bearer(env('API_TOKEN'))` keeps the secret out of the function — it resolves at call time, and the caller never holds it.
+
+`await getUser(...)` throws `StitchError` (with `.status`, `.attempts`, `.body`, `.url`) after the stitch exhausts its own retries. In a loader or server action, call `getUser.safe({ params: { id } })` instead — it resolves to `{ ok, data, error }` and never throws.
+
+## Coexistence: a stitch is a function
+
+The reason this is a no-rewrite move: a stitch IS an async function. It takes input, it returns a promise, it throws on failure. Anything that already accepts a `fetch`-shaped call accepts a stitch with no adapter in between.
+
+So you swap the call site and stop:
+
+```ts
+// before
+const user = await getUserViaFetch(id);
+// after — same signature, same await, same caller
+const user = await getUser({ params: { id } });
+```
+
+The rest of the file keeps using raw `fetch`. The other twenty endpoints keep using whatever they use today. There is no provider to mount, no client to thread through props, no global to initialize before the first call works. One endpoint becomes typed and resilient; everything around it is untouched.
+
+It drops into the libraries you already run, too. A stitch is the `queryFn` TanStack Query wants — awaiting it returns the validated value and throws on failure, which is exactly the contract — so it goes straight in:
+
+```ts
+useQuery({
+    queryKey: ['user', id],
+    queryFn: () => getUser({ params: { id } }),
+});
+```
+
+Let the stitch own retries and set `retry: false` on the query so attempts don't multiply across the two layers. The same shape works with SWR and RTK Query: the query owns view state — cache, invalidation, refetch on focus — and the stitch owns the call — types, auth, resilience. They compose, not compete.
+
+## Grow the surface, one call at a time
+
+Once two endpoints share a base URL and an auth scheme, lift those into a `seam` and stop repeating them. The seam declares the shared config once; each stitch inherits it, and an explicit per-stitch field wins.
+
+```ts
+import { bearer, env, seam } from 'stitchapi';
+
+const api = seam({
+    baseUrl: 'https://api.example.com',
+    auth: bearer(env('API_TOKEN')),
+    retry: { attempts: 3, on: [429, 503] },
+});
+
+const getUser = api.stitch({ path: '/users/{id}', output: User });
+const listOrders = api.stitch({ path: '/orders', output: Orders });
+```
+
+This is the same incremental move at the next size up: you hardened one call, then a second, and the shared parts converge into one declaration on their own schedule. Nothing forced the seam early; you reached for it when the repetition appeared.
+
+| Axis           | Before (per-call glue)             | A stitch                                          |
+| -------------- | ---------------------------------- | ------------------------------------------------- |
+| Retry          | A loop you copy into the next call | `retry` — status-aware, jittered, `Retry-After`   |
+| Timeout        | `AbortController` + `setTimeout`   | `timeout: { total, perAttempt }`                  |
+| Response shape | A cast the compiler trusts blindly | `output` schema — validated, throws on a mismatch |
+| Secret         | Interpolated inline, held per copy | `auth` — resolved at call time, never held        |
+| Adoption unit  | Rewrite the data layer             | One endpoint, swap the call site                  |
+
+## You can start with no schema at all
+
+The smallest possible stitch is one line, and it already buys you something:
+
+```ts
+const ping = stitch({ url: 'https://api.example.com/health' });
+const data = await ping();
+```
+
+No `output`, no `retry`, no `auth` — `await` still returns the parsed body, and you've moved the URL into a declaration you can grow. You can start with no schema at all: add `output` the day you want the response checked, add `retry` the day the endpoint flakes, add `auth` the day it needs a token. The bare stitch bounds the call you have today; the configured stitch bounds it just as directly and is one edit from the call it becomes. It scales down to a single line and up to a seam-shared resilience policy without ever asking you to rewrite the calls in between.
+
+## Try it
+
+```package-install
+stitchapi
+```
+
+Wrap the one endpoint that keeps paging you, swap its call site, and leave the rest of your code alone. Start with [the stitch concept](/docs/concepts/the-stitch) and the [quickstart](/docs/getting-started/quickstart), then lift shared config into a [seam](/docs/guides/authoring/seam) and pin down responses with [output validation](/docs/guides/validation/validation).

--- a/apps/docs/content/blog/choosing-an-http-adapter.mdx
+++ b/apps/docs/content/blog/choosing-an-http-adapter.mdx
@@ -1,0 +1,149 @@
+---
+title: 'Choosing an HTTP Adapter: fetch, axios, or xhr Under a Stitch'
+description: A stitch turns one endpoint into a typed resilient function; the adapter underneath decides how the bytes move. Here's how to pick fetch, axios, or xhr — and when to write your own.
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [http, adapter, fetch, axios, typescript]
+---
+
+You're streaming a server-sent-events feed in one corner of the app and uploading a multi-megabyte file with a progress bar in another, and the transport that handles one can't do the other. `fetch` streams a download but can't tell you how many bytes of an upload have left the machine; `XMLHttpRequest` reports that upload progress but can't stream a response; the axios instance you already configured with a corporate proxy and a custom CA does neither. Under a stitch, the transport is a swappable seam — you pick the one that fits the call, and the stitch's types, validation, retries, and auth ride on top unchanged.
+
+A stitch turns one endpoint into a typed, validated, resilient function. The **adapter** is the layer it delegates to for the actual round trip: take a request, return a response. Swapping it changes how the bytes move; it never changes what the stitch promises the caller.
+
+## The contract
+
+An adapter is one function:
+
+```ts
+type Adapter = (req: AdapterRequest) => Promise<AdapterResponse>;
+```
+
+The request carries everything the transport needs and nothing about policy: `{ url, method, headers, body?, bodyType?, multipart?, responseType?, stream?, onProgress?, signal? }`. The response is `{ status, headers, body, url? }`, where `body` is the parsed value — JSON when the content type allows, otherwise text — or a `ReadableStream<Uint8Array>` when `stream` was set.
+
+One rule separates an adapter from the engine above it: **an adapter never throws on a non-2xx status.** A 500 is a returned `{ status: 500, ... }`, not a rejected promise. Only a genuine network failure or an abort propagates. The stitch decides what a status _means_ — whether 503 triggers a retry, whether 404 is an error or an empty result — so the adapter stays a dumb pipe and the policy stays in one place.
+
+All three built-in adapters share the same body-encoding and response-decoding helpers. JSON, form, and multipart bodies encode identically across them; the same content-type detection decodes the response. **Swapping the transport never changes behavior** — only what the transport itself can and can't do.
+
+## fetch, axios, xhr
+
+The default is `fetchAdapter()`. You rarely name it — the engine wires `cfg.adapter ?? fetchAdapter()` — so a stitch with no `adapter` field is already on `fetch`.
+
+```ts
+import { stitch } from 'stitchapi';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+}); // adapter defaults to fetchAdapter()
+```
+
+You reach for `fetchAdapter(opts?)` explicitly when you need to thread infrastructure through it. It backs onto the global `fetch`, and its `dispatcher` option takes an undici `Agent` — a proxy, a custom CA, a bound network interface — without StitchAPI ever importing undici, so the zero-dependency core stays zero-dependency. It is also the **only** built-in that streams: `stream` and `sse` surfaces and download progress run through `fetch` and nothing else.
+
+```ts
+import { fetchAdapter, stitch } from 'stitchapi';
+import { Agent } from 'undici';
+
+const behindProxy = stitch({
+    baseUrl: 'https://internal.example.com',
+    path: '/reports/{id}',
+    adapter: fetchAdapter({
+        dispatcher: new Agent({
+            /* proxy, CA */
+        }),
+    }),
+});
+```
+
+`axiosAdapter(client, defaults?)` routes the call through an axios instance you supply. axios is never a dependency — you bring the client, the adapter borrows it. Use it when an instance is already configured the way your platform demands: an `httpsAgent`, a proxy, interceptors a team relies on. The `defaults` merge under every request and per-call values override them.
+
+```ts
+import axios from 'axios';
+import { axiosAdapter, stitch } from 'stitchapi';
+
+const legacy = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/orders',
+    adapter: axiosAdapter(axios, { proxy: false, timeout: 0 }),
+});
+```
+
+The honest tradeoff: `axiosAdapter` is **buffered-only**. Point it at a `stream` or `sse` surface and it throws — by design, so the failure is loud at wiring time, not a silent hang. Reach for `fetchAdapter` to stream. axios also reports no upload progress.
+
+`xhrAdapter(XHR?)` is browser-only and backed by `XMLHttpRequest`. Its one reason to exist over `fetchAdapter` is **upload progress**: `fetch` cannot report bytes sent, `xhr.upload` can. If you're drawing a progress bar for a file going up, this is the adapter.
+
+```ts
+import { stitch, xhrAdapter } from 'stitchapi';
+
+const upload = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/files',
+    adapter: xhrAdapter(),
+    // onProgress on the call reports bytes sent
+});
+```
+
+It is buffered-only too — it rejects `stream`. Pass it a constructor (`xhrAdapter(FakeXHR)`) to inject a stand-in in tests.
+
+## Which one
+
+| Need                                                                                   | Before (raw transport)                  | A stitch's adapter                                       |
+| -------------------------------------------------------------------------------------- | --------------------------------------- | -------------------------------------------------------- |
+| **Default request/response**                                                           | `fetch` + your own `response.ok` check  | `fetchAdapter()` (implicit)                              |
+| **Stream a response (`stream`/`sse`)**                                                 | hand-rolled `ReadableStream` plumbing   | `fetchAdapter` (the only one)                            |
+| **Upload progress bar**                                                                | `XMLHttpRequest` by hand                | `xhrAdapter()`                                           |
+| **Reuse a proxy / CA / agent**                                                         | configure undici or axios per call site | `fetchAdapter({ dispatcher })` or `axiosAdapter(client)` |
+| **An axios instance you already trust**                                                | keep the interceptor stack as-is        | `axiosAdapter(axios)`                                    |
+| **Canned responses in a test**                                                         | mock `global.fetch`                     | `mockAdapter([...])`                                     |
+| **Anything bespoke (logging, timing, retry-shim, a transport StitchAPI doesn't ship)** | a wrapper around your client            | a function matching the `Adapter` contract               |
+
+## Writing your own
+
+The contract _is_ the extension point. Take `req`, return `{ status, headers, body }`, never throw on a non-2xx, honor `req.signal`, and reject `req.stream` if you can't stream. That's the whole interface, so a custom adapter is usually a thin wrapper — one that logs and times around another adapter, or one that returns canned responses for a test.
+
+The canned-response case is common enough that it already ships: `mockAdapter(routes, opts?)` from `stitchapi/testing` builds an adapter from one route or a list of them. Each route is `{ method?, match?, respond }` — `method` and `match` decide which requests it answers (a string or `RegExp` against the URL pathname, or a predicate), and `respond` is the reply. The reply can be a fixed `MockResponse`, an array consumed one per call (to script a flaky endpoint), or a function of the call. You pass one route or an **array** of them, and the first whose `method` and `match` accept a request wins:
+
+```ts
+import { stitch } from 'stitchapi';
+import { mockAdapter } from 'stitchapi/testing';
+
+const api = mockAdapter([
+    {
+        method: 'GET',
+        match: '/users/1',
+        respond: { body: { id: 1, name: 'Ada' } },
+    },
+    {
+        method: 'GET',
+        match: '/users/999',
+        respond: { status: 404, body: { error: 'not found' } },
+    },
+    // a sequence: fail twice, then succeed — for retry tests
+    {
+        match: '/flaky',
+        respond: [{ status: 503 }, { status: 503 }, { body: { ok: true } }],
+    },
+]);
+
+const getUser = stitch({
+    baseUrl: 'https://api.test',
+    path: '/users/{id}',
+    adapter: api,
+});
+
+const ada = await getUser({ params: { id: 1 } });
+expect(api.callCount('/users/1')).toBe(1);
+```
+
+Because the adapter is the only thing you swapped, the stitch under test runs its real retry, validation, and auth against your fixtures — the `[{ status: 503 }, { status: 503 }, { body: { ok: true } }]` sequence exercises the same retry path production hits, with no network and no mocked globals. An unmatched request throws by default; pass `{ onUnmatched: 404 }` to return a status instead.
+
+## Start on the default, move when the call asks
+
+Leave the `adapter` field off and the stitch is already on `fetch` — typed, validated, retried, no transport decision to make. The day a call needs more, you change one field: `fetchAdapter({ dispatcher })` to thread a proxy, `xhrAdapter()` to draw an upload bar, `axiosAdapter(axios)` to ride an instance you already trust, or a function of your own when none of those fit. The stitch's promise to the caller doesn't move when the transport does — the same validated, resilient function answers, however the bytes travel.
+
+## Try it
+
+```package-install
+stitchapi
+```
+
+Declare one endpoint, leave `adapter` off, and it runs on `fetchAdapter()`; then set the field when a call needs to stream, show upload progress, or reuse an agent. The transport seam is documented in the [helpers reference](/docs/reference/helpers), the canned-response path in the [testing & mocking guide](/docs/guides/testing/mocking), and the primitive everything rides on is [The stitch](/docs/concepts/the-stitch). Coming off axios specifically? See [axios alternatives](/blog/axios-alternatives).

--- a/apps/docs/content/blog/migrate-from-axios-to-stitchapi.mdx
+++ b/apps/docs/content/blog/migrate-from-axios-to-stitchapi.mdx
@@ -1,0 +1,187 @@
+---
+title: 'Migrate From axios to StitchAPI'
+description: 'The axios.create() is the small part of a mature setup — the bulk is interceptors: retry-with-backoff, a 401 refresh, baseURL, validateStatus, manual typing. Migrate that layer onto a stitch, keeping or dropping axios.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [axios, typescript, migration, interceptors, resilience]
+---
+
+You open the file that configures axios for a real service, and the `axios.create()` at the top is two lines. Below it sit two hundred: a request interceptor that attaches a bearer token, a response interceptor that catches a 401 and refreshes, a retry-with-backoff bolted on by hand, a `validateStatus` override, a `transformResponse` that reshapes the body, and a cast that tells TypeScript the result is `User` without anyone checking. That interceptor stack is what you maintain. Migrating to StitchAPI is migrating _that layer_ — and you can keep axios as the transport while you do it, or drop it.
+
+This is the how-to after you've already decided to leave axios. If you're still weighing the move against ky, ofetch, or staying put, start with [axios alternatives](/blog/axios-alternatives) and come back.
+
+## The "before" — a mature axios instance
+
+Here's the shape of the thing, condensed. None of it is wrong; it's just yours to carry.
+
+```ts
+import axios from 'axios';
+
+const http = axios.create({
+    baseURL: 'https://api.example.com',
+    timeout: 10_000,
+    validateStatus: (s) => s < 500, // don't throw on 4xx; handle them downstream
+});
+
+// request interceptor: attach the token
+http.interceptors.request.use((config) => {
+    const token = store.getAccessToken();
+    if (token) config.headers.Authorization = `Bearer ${token}`;
+    return config;
+});
+
+// response interceptor: refresh once on 401, then replay
+http.interceptors.response.use(undefined, async (error) => {
+    if (error.response?.status === 401 && !error.config._retried) {
+        error.config._retried = true;
+        await store.refresh();
+        return http(error.config);
+    }
+    throw error;
+});
+
+// retry interceptor: back off on 429/502/503/504
+http.interceptors.response.use(undefined, async (error) => {
+    const cfg = error.config;
+    cfg._attempt = (cfg._attempt ?? 0) + 1;
+    const retriable = [429, 502, 503, 504].includes(error.response?.status);
+    if (retriable && cfg._attempt < 4) {
+        await sleep(2 ** cfg._attempt * 200);
+        return http(cfg);
+    }
+    throw error;
+});
+
+// transformResponse: the API wraps everything in { data }
+http.defaults.transformResponse = [(body) => JSON.parse(body).data];
+
+async function getUser(id: string) {
+    const res = await http.get(`/users/${id}`);
+    return res.data as User; // the cast nobody verifies
+}
+```
+
+The sharp edges are familiar. The two response interceptors fire in an order you have to reason about, and each tracks its own retry flag on the request config. The refresh path replays the request by hand. `validateStatus` quietly changes what a non-2xx means for _every_ call on this instance. And `as User` is a promise to the compiler that the runtime never keeps — the day the API renames a field, you find out three layers downstream when something is `undefined`.
+
+## The "after" — the interceptors become fields
+
+A stitch is one endpoint as a typed, validated, resilient function. The interceptor stack above isn't ported line by line; it's _declared_ as data on the stitch.
+
+```ts
+import { bearer, drift, env, oauth2, seam, stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const User = z.object({ id: z.string(), name: z.string(), email: z.string() });
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    auth: bearer(env('API_TOKEN')),
+    retry: {
+        attempts: 4,
+        on: [429, 502, 503, 504],
+        backoff: 'expo-jitter',
+        respectRetryAfter: true,
+    },
+    timeout: { total: '30s', perAttempt: '10s' },
+    unwrap: 'data', // the API wraps payloads in { data }
+    output: drift(User),
+});
+
+const user = await getUser({ params: { id } }); // typed · validated · retried
+```
+
+`await getUser({ params: { id } })` returns the validated `User` and throws a `StitchError` on failure, after the stitch has exhausted its own retries — `.status`, `.attempts`, `.body`, and `.url` ride along on the error. In a loader or server action where you don't want a throw, call `getUser.safe({ params: { id } })` for an `{ ok, data, error }` envelope instead.
+
+### Interceptor → field
+
+| axios interceptor / option                  | What it did                   | On a stitch                                                                                                                       |
+| ------------------------------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| request interceptor adding `Authorization`  | attaches a token per request  | `auth: bearer(env('API_TOKEN'))` — secret resolves at call time, caller never holds it ([bearer](/docs/guides/auth/bearer))       |
+| 401 response interceptor → refresh + replay | re-login on expiry            | `auth: oauth2(...)` or `cookieSession(...)` — auto re-login on expiry, no hand-rolled replay ([oauth2](/docs/guides/auth/oauth2)) |
+| retry interceptor with backoff              | re-issues on 429/502/503/504  | `retry: { attempts, on, backoff: 'expo-jitter', respectRetryAfter: true }` ([retry](/docs/guides/resilience/retry))               |
+| `baseURL`                                   | one host for many calls       | `baseUrl` on the stitch, or once on a `seam()` ([seam](/docs/guides/authoring/seam))                                              |
+| `validateStatus`                            | decide what status throws     | the engine never throws on a non-2xx by itself — you declare which statuses `retry`, and a `StitchError` carries the rest         |
+| `transformResponse` + `as User`             | reshape, then assert the type | `unwrap` plus an `output` schema (wrap in `drift()` to flag shape changes) ([drift](/docs/guides/validation/drift))               |
+
+The last row is the one axios never had. `output` validates the _live_ response on every call, so a mismatch is a typed error at the boundary, not an `undefined` downstream. Wrap it in `drift()` and each response is diffed against its validated form, every change leveled by severity — a renamed required field throws, a coercion the schema absorbed surfaces as a `warn` on the event stream.
+
+## Path A — keep axios as the transport
+
+You don't have to rip axios out to get the layer. Your configured instance — proxy, custom CA, `httpsAgent`, timeouts negotiated with a finicky upstream — stays exactly as it is, and the stitch routes its requests through it via `axiosAdapter`. axios is the transport; the interceptors-turned-fields are the layer above it.
+
+```ts
+import axios from 'axios';
+import { axiosAdapter, bearer, env, stitch } from 'stitchapi';
+
+const client = axios.create({ proxy: false, httpsAgent: myAgent });
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    adapter: axiosAdapter(client, { timeout: 10_000 }), // defaults merge under every request
+    auth: bearer(env('API_TOKEN')),
+    retry: { attempts: 4, on: [429, 502, 503, 504], respectRetryAfter: true },
+    output: User,
+});
+```
+
+The second argument to `axiosAdapter` is a defaults object — `{ httpsAgent, proxy, timeout }` — merged under every request and overridden by per-call values. One honest limit: `axiosAdapter` is **buffered-only**. It throws on a `stream`/`sse` surface and reports no progress, because axios buffers the whole body. If you need streaming on a given endpoint, that one rides `fetchAdapter` instead — which is Path B. The two adapters share the same body-encoding and response-decoding helpers, so swapping the transport never changes how a request is sent or a response is read. Picking between them is its own short decision: [choosing an HTTP adapter](/blog/choosing-an-http-adapter).
+
+## Path B — drop axios entirely
+
+If nothing in your instance needed axios specifically, leave the adapter off. A stitch defaults to `fetchAdapter()`, backed by global `fetch`, and StitchAPI's core is zero runtime dependencies — there's no transitive tree to vet.
+
+```ts
+import { bearer, env, stitch } from 'stitchapi';
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    auth: bearer(env('API_TOKEN')),
+    retry: { attempts: 4, on: [429, 502, 503, 504], respectRetryAfter: true },
+    output: User,
+}); // no adapter → fetchAdapter() · zero runtime deps
+```
+
+The declaration is identical to Path A minus the `adapter` line. `fetchAdapter` is also the only adapter that streams: it backs `stream`/`sse` surfaces and download progress, and it threads an undici `Agent` through `fetchAdapter({ dispatcher })` for a proxy or custom CA without StitchAPI importing undici. So the proxy story Path A kept axios for is reachable here too, with one less package installed.
+
+## Declare it once with a seam
+
+A mature codebase has many endpoints behind one host, sharing a base URL, an auth scheme, and a retry policy. Declare that surface once with `seam()` and let each stitch inherit it; explicit per-stitch fields still win.
+
+```ts
+import { env, oauth2, seam } from 'stitchapi';
+
+const api = seam({
+    baseUrl: 'https://api.example.com',
+    auth: oauth2({
+        tokenUrl: 'https://api.example.com/oauth/token',
+        clientId: env('CLIENT_ID'),
+        clientSecret: env('CLIENT_SECRET'),
+    }),
+    retry: { attempts: 4, on: [429, 502, 503, 504], respectRetryAfter: true },
+});
+
+const getUser = api.stitch({ path: '/users/{id}', output: User });
+const listOrders = api.stitch({
+    path: '/orders',
+    output: z.object({ orders: z.array(Order) }),
+});
+```
+
+This is where the 401-refresh interceptor finally disappears. `oauth2` on the seam handles the token lifecycle for every stitch under it — acquire, attach, re-login on expiry — so the replay logic you wrote by hand isn't ported, it's deleted. The seam is the migration target for `axios.create()` itself: the shared instance becomes shared config.
+
+## The migration is one layer, then a line
+
+The interceptor stack was the thing you maintained, and it migrates as a block of fields — not a rewrite of every call site. Adopt it where it earns its keep: a stitch bounds the call you already have, and it bounds it just as simply whether axios stays underneath or leaves, whether one endpoint moves or twenty share a seam. Honest edges stay honest — `axiosAdapter` can't stream, so the streaming endpoints ride `fetchAdapter`; retrying a write is unsafe, so set `retry` only where replays are safe. Each is guidance you apply inline, not a reason to stop.
+
+If the callers are React components, the same stitch slots straight into TanStack Query as a `queryFn` with no glue — [a stitch as a React Query queryFn](/blog/stitch-as-react-query-queryfn). And if axios isn't your starting point, the [fetch migration](/blog/migrate-from-fetch-to-stitchapi) covers the same move from raw `fetch`.
+
+## Try it
+
+```package-install
+stitchapi
+```
+
+Pick one endpoint with the heaviest interceptor stack, declare it as a stitch — keep axios via `axiosAdapter(client)` or drop it for the default `fetchAdapter()` — and watch the request-auth, the 401 refresh, the backoff, and the unchecked cast collapse into fields. The adapter reference is in [Helpers](/docs/reference/helpers), shared config lives in [Seam](/docs/guides/authoring/seam), and the auth and resilience policies are documented in [bearer](/docs/guides/auth/bearer), [oauth2](/docs/guides/auth/oauth2), [retry](/docs/guides/resilience/retry), and [drift](/docs/guides/validation/drift).

--- a/apps/docs/content/blog/migrate-from-fetch-to-stitchapi.mdx
+++ b/apps/docs/content/blog/migrate-from-fetch-to-stitchapi.mdx
@@ -1,0 +1,125 @@
+---
+title: 'Migrate From Fetch to StitchAPI'
+description: 'Your fetch call works until the API blips: no retry, no timeout, no validation, and the JSON is typed `any`. Here is the same call as a stitch, field by field, and how each line of glue becomes a declaration.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [fetch, migration, typescript, validation, resilience]
+---
+
+You have a `fetch` call that reads a user from an internal API. It works on your machine, it works in CI, and then one afternoon the upstream service returns a `503` for ninety seconds, your call surfaces the error straight to the page, and the JSON you parsed turns out to have dropped a field a release ago that nobody caught because `res.json()` is typed `any`. The call did exactly what `fetch` promises — one request, one response, no opinions — and every opinion you needed (retry the blip, bound the wait, check the shape) was yours to hand-write around it. Migrating to a stitch is moving each of those opinions out of glue code and onto the call's declaration.
+
+## The call you have now
+
+Here is the honest version — the `fetch` call with the edges it actually has in production, not the three-line happy path:
+
+```ts
+async function getUser(id: string): Promise<User> {
+    const res = await fetch(`https://api.example.com/users/${id}`, {
+        headers: { authorization: `Bearer ${process.env.API_TOKEN}` },
+    });
+    if (!res.ok) {
+        throw new Error(`getUser failed: ${res.status}`);
+    }
+    return (await res.json()) as User; // typed, not validated
+}
+```
+
+It runs. It also carries four sharp edges that only show up off the happy path:
+
+-   **No retry.** A single `503` or a dropped connection surfaces to the caller, even when the data was there a second earlier and one retry would have caught it.
+-   **No timeout.** A hung connection blocks the `await` until the platform's default kills it — often minutes, sometimes never — and the call holds its slot the whole time.
+-   **No validation.** `res.json() as User` is a cast, not a check. The runtime never compares the bytes to `User`, so a renamed or missing field flows downstream as the wrong type and crashes somewhere far from here.
+-   **The token lives at the call site.** `process.env.API_TOKEN` is read inline, interpolated into a header, and now sits in this function's scope where every code path can see it.
+
+Each fix is a known recipe — a retry loop, an `AbortController`, a schema parse, a secret helper — and each one is more code wrapped around the same call, in a function that grows until the request is the smallest part of it.
+
+## The same call as a stitch
+
+A stitch is the same request expressed as a declaration: the URL, the auth, the resilience policy, and the response shape are fields, and the engine applies them on every call.
+
+```ts
+import { bearer, env, stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const User = z.object({
+    id: z.string(),
+    name: z.string(),
+    email: z.string().email(),
+});
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    auth: bearer(env('API_TOKEN')),
+    output: User,
+    retry: { attempts: 3, on: [429, 503], backoff: 'expo-jitter' },
+    timeout: { total: '10s', perAttempt: '4s' },
+});
+
+const user = await getUser({ params: { id: '42' } }); // validated User, or throws StitchError
+```
+
+Awaiting the stitch returns a validated `User`. On failure — after the stitch exhausts its own retries — it throws a `StitchError` carrying `.status`, `.attempts`, `.body`, and `.url`, so the `catch` block sees structured detail instead of a hand-rolled `Error` string.
+
+## The migration is field-by-field
+
+Each sharp edge in the `fetch` version corresponds to exactly one field on the stitch, and nothing in the request itself disappears — the URL, the bearer token, and the path parameter all carry over. What changes is that the glue around them becomes data:
+
+| Axis        | The `fetch` version                        | A stitch                                           |
+| ----------- | ------------------------------------------ | -------------------------------------------------- |
+| URL + param | template string, `${id}` interpolated      | `baseUrl` + `path: '/users/{id}'`, `{ params }`    |
+| Auth        | `process.env` read and interpolated inline | `auth: bearer(env('API_TOKEN'))`, resolved later   |
+| Failure     | `if (!res.ok) throw new Error(...)`        | throws `StitchError` with `.status`/`.body`/`.url` |
+| Retry       | hand-written loop, or absent               | `retry: { attempts, on, backoff }`                 |
+| Timeout     | `AbortController` plumbing, or absent      | `timeout: { total, perAttempt }`                   |
+| Validation  | `as User` cast, never checked at runtime   | `output: User`, parsed on every response           |
+
+Two of those rows are worth reading closely, because they change behavior rather than just relocating it.
+
+`auth: bearer(env('API_TOKEN'))` does not read the variable when the module loads. The secret resolves at call time, so the token never sits in your function's scope — the call site holds a capability to make the request, not the credential itself. That is the [capability, not credential](/docs/concepts/capability-not-credential) split.
+
+`output: User` runs the schema against every response. A renamed or missing field is caught here, at the boundary, instead of flowing downstream as the wrong type. If you want the boundary to report drift rather than only reject it, wrap the schema in [`drift`](/docs/guides/validation/drift) and each response is diffed against its validated form — a renamed required field throws, an absorbed coercion logs a `warn`.
+
+## What composes once the call is a declaration
+
+The `fetch` version tangles policy into the call: the retry loop, the abort plumbing, and the parse all live inside the function body, so a second endpoint means copying the function and letting the copies drift. A stitch keeps the policy as fields, so it composes instead.
+
+**Declare the shared parts once, not per call.** When a second and third endpoint hit the same host with the same auth and retry, a [`seam`](/docs/guides/authoring/seam) holds that base and every stitch inherits it:
+
+```ts
+import { bearer, env, seam } from 'stitchapi';
+
+const api = seam({
+    baseUrl: 'https://api.example.com',
+    auth: bearer(env('API_TOKEN')),
+    retry: { attempts: 3, on: [429, 503], backoff: 'expo-jitter' },
+});
+
+const getUser = api.stitch({ path: '/users/{id}', output: User });
+const listOrders = api.stitch({ path: '/orders', output: Orders });
+```
+
+**The query owns the view; the stitch owns the call.** A stitch is a function that returns a validated value and throws `StitchError` on failure — exactly the contract TanStack Query's `queryFn` wants, so it drops straight in:
+
+```ts
+useQuery({
+    queryKey: ['user', id],
+    queryFn: () => getUser({ params: { id } }),
+});
+```
+
+The query layer keeps the cache, the refetch-on-focus, and the invalidation; the stitch keeps the types, the auth, and the resilience. Pick one retry owner — the stitch's retry is status-aware and honors `Retry-After`, so let it own retries and set `retry: false` on the query. The same shape works with SWR and RTK Query; the [React Query guide](/docs/integrations/tanstack-query) walks through it.
+
+**Side effects need a deliberate line.** Retrying a write is not safe by default, and a stitch does not pretend otherwise — adding `retry` to a `POST` is a line you write on purpose, paired with an idempotency key so the server collapses the duplicate. The tradeoff stays visible on the declaration instead of hiding in a shared loop.
+
+## One call, or a hundred — same declaration
+
+The plain `fetch` call bounds exactly the one request in front of you: this URL, this header, this parse. A stitch bounds that same single call just as tightly — `getUser({ params: { id } })` is one line at the call site — and it is one edit away from the call it grows into. Add `retry` when the upstream starts flaking; add `timeout` when an attempt hangs; add a `seam` when the second endpoint shows up; pass it to `useQuery` when a component needs it. None of those is a rewrite of the call. They are fields on a declaration that already holds your one request, so the call scales down to a single line today and up to the whole API surface without your touching the call site again.
+
+## Try it
+
+```package-install
+stitchapi zod
+```
+
+Move one `fetch` call onto a stitch: set `baseUrl` and `path`, add `output` for the response shape, and the retry loop, the abort plumbing, and the `as User` cast collapse into fields you can read at a glance. Start with the [quickstart](/docs/getting-started/quickstart), then add resilience from the [retry](/docs/guides/resilience/retry) and [timeout](/docs/guides/resilience/timeout) guides. Coming from interceptors instead of raw `fetch`? The same trade is mapped in [migrate from axios to StitchAPI](/blog/migrate-from-axios-to-stitchapi).

--- a/apps/docs/content/blog/stitch-as-react-query-queryfn.mdx
+++ b/apps/docs/content/blog/stitch-as-react-query-queryfn.mdx
@@ -1,0 +1,148 @@
+---
+title: 'A Stitch Is Your React Query queryFn'
+description: 'You already run TanStack Query for view state. Drop a stitch in as the queryFn and the call gains types, validation, retries, and auth — no glue code.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [react, tanstack-query, react-query]
+---
+
+You wired up TanStack Query months ago, and `useQuery` already owns your view state — caching by key, refetch on focus, invalidation after a mutation. What it doesn't own is the call inside `queryFn`: that's still a hand-written `fetch`, a `res.ok` check you keep forgetting, a `res.json()` cast to whatever type you hope came back, and a retry loop you copied between three hooks. The query layer is solid; the function it runs is the soft spot.
+
+A stitch is exactly the function `queryFn` wants. It returns the validated value and throws on failure — the precise contract `useQuery` expects — so it drops in with no adapter, no wrapper, no glue.
+
+## The `queryFn` you have
+
+Here's the typical fetch sitting inside a query: the status check, the cast, and a retry the hook owns by hand.
+
+```tsx
+import { useQuery } from '@tanstack/react-query';
+
+function useUser(id: string) {
+    return useQuery({
+        queryKey: ['user', id],
+        queryFn: async () => {
+            const res = await fetch(`https://api.example.com/users/${id}`, {
+                headers: { Authorization: `Bearer ${process.env.API_TOKEN}` },
+            });
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            return (await res.json()) as User; // a hope, not a guarantee
+        },
+        retry: 3,
+    });
+}
+```
+
+The sharp edges are all in `queryFn`. The `as User` is a lie the compiler can't catch — if the API drops a field, the cast still passes and the bug surfaces three components downstream. `retry: 3` retries everything, including the 400 that will never succeed and the `POST` you should never replay. The token is read where the component can see it. And the next hook that calls this endpoint copies the whole block again.
+
+## The `queryFn` you want
+
+Declare the call once as a stitch, then hand the stitch to `queryFn`:
+
+```tsx
+import { bearer, env, stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const getUser = stitch({
+    url: 'https://api.example.com/users/{id}',
+    output: z.object({ id: z.string(), name: z.string() }),
+    auth: bearer(env('API_TOKEN')),
+    retry: { attempts: 3, on: [429, 502, 503, 504], backoff: 'expo-jitter' },
+});
+```
+
+```tsx
+import { useQuery } from '@tanstack/react-query';
+
+function useUser(id: string) {
+    return useQuery({
+        queryKey: ['user', id],
+        queryFn: () => getUser({ params: { id } }),
+        retry: false, // the stitch owns retries
+    });
+}
+```
+
+Each field replaces a piece of the glue. `output` validates the response against the schema, so `data` is the _checked_ shape — no cast, and a dropped field throws at the boundary instead of leaking downstream. `auth: bearer(env('API_TOKEN'))` resolves the secret at call time; the component never holds it. The `retry` object only replays the status codes worth replaying, honors `Retry-After`, and backs off with jitter. And `getUser` is one value you import wherever the endpoint is called — declared once, not pasted per hook.
+
+Awaiting a stitch returns the validated value and throws `StitchError` on failure. That's the exact contract `queryFn` is built around: resolve with `data`, reject with `error`. So there is no adapter between them — the stitch _is_ the `queryFn`.
+
+## Use the throwing call inside a query — not `.safe()`
+
+A stitch gives you two call shapes. Inside a query, use the bare awaitable (or `.unwrap()`), which throws on failure:
+
+```tsx
+queryFn: () => getUser({ params: { id } });
+```
+
+Do **not** reach for `.safe()` here. `.safe()` resolves to `{ ok, data, error }` and never throws — perfect for a loader or a server action, wrong for a `queryFn`. If you hand `.safe()` to a query, every call looks successful and `data` arrives shaped like an error envelope, so `useQuery`'s `isError` never fires. Throw inside the query; save `.safe()` for the places that want a result object instead of a `try`/`catch`.
+
+## Pick one retry owner
+
+Both layers can retry, and if you let them, the attempts multiply: TanStack's `retry: 3` wrapping the stitch's `attempts: 3` is up to nine round-trips for one failure. Pick one owner.
+
+Let the stitch own it. The query's retry is count-based — it replays any rejection N times. The stitch's retry is status-aware (`on: [429, 502, 503, 504]`), honors `Retry-After`, and backs off with jitter, so it waits out a rate limit instead of hammering through it. Keep that one and set `retry: false` on the query (or on the `QueryClient` default).
+
+| Axis          | TanStack `retry`       | Stitch `retry`                   |
+| ------------- | ---------------------- | -------------------------------- |
+| Trigger       | any rejection          | specific statuses (`on: [...]`)  |
+| `Retry-After` | ignored                | honored                          |
+| Backoff       | fixed-ish, count-based | `expo-jitter` / `expo` / `fixed` |
+| Scope         | this query             | every caller of the stitch       |
+
+The last row is why the stitch is the better owner: resilience lives with the call, so the `loader`, the server action, and the three other components calling `getUser` all inherit the same retry policy — not just the one hook you remembered to configure.
+
+## Writes, options helpers, and streaming
+
+A writing stitch is a `mutationFn` the same way — hand it straight to `useMutation`, then invalidate with `queryClient.invalidateQueries`. One honest caveat: retrying a non-idempotent write can double-submit, so keep `retry: false` on a plain `POST` unless the endpoint is idempotent (or you've set an idempotency key).
+
+If you'd rather not spell out the `queryKey` each time, `@stitchapi/react` ships `stitchQueryOptions` — a typed `{ queryKey, queryFn }` object you spread into `useQuery`:
+
+```tsx
+import { stitchQueryOptions } from '@stitchapi/react';
+import { useQuery } from '@tanstack/react-query';
+
+const { data } = useQuery(stitchQueryOptions(getUser, { params: { id } }));
+```
+
+It returns a plain object, so it needs no import of `@tanstack/react-query` — `@tanstack/react-query` is an optional peer of `@stitchapi/react`, pulled in only when you spread the result into a real `useQuery`.
+
+Streaming surfaces (`sse` / `stream` / `llm`) stay out of `useQuery` — that hook is request/response only. Consume `.stream()` directly, or use the `useStitchStream` hook, which re-renders as each `delta` chunk arrives. Its result carries a `chunks` list and an `isStreaming` flag that stays true until the terminal `result`:
+
+```tsx
+import { useStitchStream } from '@stitchapi/react';
+
+function Answer({ prompt }: { prompt: string }) {
+    const { chunks, isStreaming } = useStitchStream(askLLM, {
+        body: { prompt },
+    });
+    return (
+        <p>
+            {chunks.map((c, i) => (
+                <span key={i}>{String(c)}</span>
+            ))}
+            {isStreaming ? '…' : ''}
+        </p>
+    );
+}
+```
+
+## The layer split — compose, not compete
+
+The query and the stitch own different things, and that's why they fit:
+
+-   **The query owns view state** — caching by key, invalidation, refetch on focus, subscriptions across components.
+-   **The stitch owns the call** — types, validation, auth, retries, timeouts, drift detection.
+
+This isn't a React-Query-only arrangement. The same shape works with **SWR** (`useSWR(key, () => getUser({ params: { id } }))`) and **RTK Query** (a stitch as the endpoint's `queryFn`). Whichever query layer you run, the split holds: it owns the view, the stitch owns the call.
+
+## Start with the call you have
+
+`await getUser({ params: { id } })` is the floor — a typed, validated, resilient call you can run anywhere, no query library in sight. When a component needs to render against loading, error, and refetch state over time, you hand that same stitch to `useQuery` as the `queryFn` and the query layer takes the view. Nothing about the call changes; you've only added a reactive layer on top of it. The stitch you wrote for a one-line `await` is the exact stitch a query runs — it scales up to the cache without a rewrite, and back down to a bare call without one.
+
+## Try it
+
+```package-install
+@stitchapi/react @stitchapi/query-core stitchapi @tanstack/react-query
+```
+
+Hand a stitch to `useQuery` and the call gains types, validation, and resilience with no glue. See the [TanStack Query integration](/docs/integrations/tanstack-query) and the [React bindings](/docs/integrations/react) for the full surface, [retry](/docs/guides/resilience/retry) for the status-aware policy, and [adopt StitchAPI without a rewrite](/blog/adopt-stitchapi-without-a-rewrite) to migrate one `queryFn` at a time.


### PR DESCRIPTION
## What

Five new ramp-up blog posts that meet readers at their current stack and show the on-ramp to a stitch — addressing the most common adoption questions (how do I move my fetch/axios code? which transport? how does this fit React Query? do I have to rewrite?).

| Post | Owns |
|---|---|
| [migrate-from-fetch-to-stitchapi](apps/docs/content/blog/migrate-from-fetch-to-stitchapi.mdx) | The `fetch` glue (`res.ok`, `as` casts, hand-rolled retry/abort) collapsing to declarative fields, field by field. fetch stays the engine (default `fetchAdapter()`). |
| [migrate-from-axios-to-stitchapi](apps/docs/content/blog/migrate-from-axios-to-stitchapi.mdx) | Interceptors → fields, with an interceptor-to-field table. Two honest paths: keep axios via `axiosAdapter(client)` or drop it. |
| [choosing-an-http-adapter](apps/docs/content/blog/choosing-an-http-adapter.mdx) | The transport seam — fetch / axios / xhr / a one-function custom adapter — with a decision table and `mockAdapter` for tests. |
| [stitch-as-react-query-queryfn](apps/docs/content/blog/stitch-as-react-query-queryfn.mdx) | A stitch *is* the `queryFn`; the layer split, let-it-throw (not `.safe()`), one retry owner, `stitchQueryOptions`, SWR/RTK. |
| [adopt-stitchapi-without-a-rewrite](apps/docs/content/blog/adopt-stitchapi-without-a-rewrite.mdx) | Incremental adoption — wrap the one endpoint that hurts, coexist with existing fetch/axios/React Query, grow by the call. |

## Why

The blog skews toward shareable thought-leadership; per the SEO editorial roadmap the gap is searchable, action-stage content that captures readers mid-problem ("migrate from axios", "react query api client", "custom http adapter"). These five are keyword-framed front doors that link down into the docs.

## How it was built / verified

- Each post was drafted, **adversarially fact-checked against the real `core`/`react` source**, and revised.
- Editorial pass run afterward (3 independent reviewers): API accuracy, EDITORIAL.md 8-dimension compliance, and link/consistency.
  - **No factual/API errors** — every imported symbol, config field, signature, and behavioral claim verifies against source (`stitch`/`seam`/`bearer`/`oauth2`/`drift`/`unwrap`, the `Adapter` contract, `axiosAdapter` buffered-only, `xhrAdapter` upload-progress, `mockAdapter`, `stitchQueryOptions`, `StitchError` fields).
  - **All internal links resolve**; frontmatter valid; plain `ts` fences (no twoslash); every post ends with `## Try it`.
  - EDITORIAL pass found **no blockers/majors**; two minor code-comment nits fixed.
- `prettier` clean; pre-commit gate (`format` + full `typecheck`, incl. `fumadocs-mdx` + `next typegen`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)