### PR TITLE
docs(blog): GraphQL, testing, and idempotency posts

### DIFF
--- a/apps/docs/content/blog/idempotency-keys-safe-retries.mdx
+++ b/apps/docs/content/blog/idempotency-keys-safe-retries.mdx
@@ -1,0 +1,139 @@
+---
+title: 'Idempotency Keys: Make Retries Safe for Writes'
+description: 'A write can time out after the server committed but before the response reaches you, so the retry charges the card twice. An idempotency key lets the server collapse the duplicate.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [idempotency, retry, typescript, resilience, http]
+---
+
+Your charge endpoint times out. The card was charged — the server committed the row — but the response packet never made it back across the wire. Your retry logic does the sensible thing and fires the request again. Now the customer has two charges and you have a support ticket.
+
+This is the failure every retry guide warns about and few of them fix. Retrying a `GET` is free: read it twice, you read the same bytes. Retrying a blind `POST` is a second write. The danger lives in the gap between "server committed" and "client received" — a window a timeout lands in precisely when the network is slow, which is precisely when you retry.
+
+An idempotency key closes that gap. The client sends a unique token with the write; the server records "I already processed this token" and, on the replay, returns the original result instead of doing the work twice. The catch is that the same token has to ride every attempt. Generate a fresh one per try and you are back to two charges.
+
+## The before
+
+Here is the honest version with `fetch`. You want a retry, and you want it to be safe, so you mint a key once and thread it through the loop by hand.
+
+```ts
+async function charge(body: { amount: number; ref: string }) {
+    const key = crypto.randomUUID();
+
+    for (let attempt = 1; attempt <= 3; attempt++) {
+        try {
+            const res = await fetch('https://api.example.com/charges', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Idempotency-Key': key, // same key on every attempt — easy to get wrong
+                },
+                body: JSON.stringify(body),
+            });
+            if (res.ok) return res.json();
+            if (![429, 502, 503, 504].includes(res.status))
+                throw new Error(`HTTP ${res.status}`);
+        } catch (err) {
+            if (attempt === 3) throw err;
+        }
+        await new Promise((r) => setTimeout(r, 200 * attempt));
+    }
+}
+```
+
+The bug is one indentation level away. Move `const key = crypto.randomUUID()` inside the loop — a refactor that looks harmless — and every retry carries a new token. The server sees three distinct writes and the safety you wrote evaporates. The correctness of this code depends on a variable's scope, and nothing in the type system or the test suite guards it.
+
+## The stitch
+
+A stitch is one API endpoint declared as a typed function. The retry policy and the idempotency key are config fields, not control flow, so the key cannot drift out of the loop — there is no loop to drift out of.
+
+```ts
+import { stitch } from 'stitchapi';
+
+const charge = stitch({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/charges',
+    retry: { attempts: 3, on: [429, 502, 503, 504], backoff: 'expo-jitter' },
+    idempotency: {},
+});
+
+const result = await charge({ body: { amount: 4200, ref: 'inv_88' } });
+```
+
+`idempotency: {}` does the work the loop did, correctly. It generates a random uuid **once per logical call** and reuses it across that call's retries, sending it as the `Idempotency-Key` header. One `await charge(...)` settles one charge, even when the engine retries it twice under the hood. The server sees one token, dedupes the replay, and returns the committed result.
+
+`retry` and `idempotency` are deliberately separate fields because they answer separate questions. `retry` decides _when to try again_ — which statuses, how many attempts, how to back off. `idempotency` decides _what makes two attempts the same write_. Pair them on every write: a retry without a key double-applies, a key without a retry never gets exercised.
+
+## The default key dedupes retries, not submissions
+
+The random default is scoped to one call. That is exactly right for the timeout-then-retry case and exactly wrong for the case people reach for it next.
+
+A customer double-clicks "Pay." Your handler fires `charge(...)` twice. Each call mints its **own** random key. The server sees two distinct tokens, processes both, and charges the card twice — the default did its job (it deduped each call's retries) but it was never asked to dedupe the second call, because nothing told it the two calls were the same write.
+
+The fix is a stable key derived from something the duplicates share — an order reference, a request id, anything that is identical across the two submissions:
+
+```ts
+const createOrder = stitch({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/orders',
+    retry: { attempts: 3 },
+    idempotency: {
+        key: (input) => `order-${(input.body as { ref: string }).ref}`,
+    },
+});
+```
+
+`key` receives the call input and returns the token. `input.body` is typed `unknown` — the engine cannot know your payload shape — so narrow it before reading a property — `(input.body as { ref: string }).ref` casts it inline. Now both clicks produce `order-inv_88`, the server sees one token, and the second submission collapses into the first.
+
+The rule splits cleanly:
+
+| Goal                                                        | Key strategy                                                     |
+| ----------------------------------------------------------- | ---------------------------------------------------------------- |
+| Collapse a retry of one call                                | `idempotency: {}` (random, per-call)                             |
+| Collapse two separate submissions of the same logical write | `idempotency: { key: (input) => ... }` derived from shared input |
+
+If the duplicates have nothing in common to hash, no key can join them — that is a fact about your data, not a gap in the feature.
+
+## A different header
+
+Some APIs expect the token on a header other than `Idempotency-Key`. Name it:
+
+```ts
+const createOrder = stitch({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/orders',
+    retry: { attempts: 3 },
+    idempotency: {
+        header: 'X-Request-Id',
+        key: (input) => `order-${(input.body as { ref: string }).ref}`,
+    },
+});
+```
+
+The default is `Idempotency-Key`; `header` overrides it. Everything else is unchanged.
+
+## What it does not do
+
+An idempotency key is a contract, not a guarantee. It works only when the **server** honors the header — records the token, recognizes the replay, and returns the original result. Send a key to an endpoint that ignores it and you get two writes with two headers. The feature makes a retry _safe to attempt_; it does not make a write safe _by itself_. You still need server support, and for the double-submission case you still need a stable key. A stitch attaches the key reliably and reuses it across retries — the half of the job that lives on your side.
+
+## Where this scales
+
+The `charge` stitch with `idempotency: {}` is the smallest safe write you can declare: a method, a URL, a retry policy, a key. When the duplicate you care about stops being a retry and becomes a double-clicked button, you add one field — `key` — and the same declaration now collapses submissions too. Same call site, same `await`, no rewrite of the surrounding handler.
+
+From there the same config object carries `timeout: { total: '30s', perAttempt: '10s' }`, an `output` schema to validate the response, and `auth: bearer(env('API_TOKEN'))` so the token resolves at call time and the caller never holds it. Each is one more field on the write you already have, bounding one more failure mode of the same call.
+
+## Try it
+
+```package-install
+stitchapi
+```
+
+Add `idempotency` and `retry` to your write stitches, then derive a stable `key` wherever two submissions can be the same logical write.
+
+-   [Idempotency guide](/docs/guides/resilience/idempotency) — the full field reference and server-contract notes.
+-   [Retry guide](/docs/guides/resilience/retry) and [Timeout guide](/docs/guides/resilience/timeout) — the policies you pair idempotency with on writes.
+-   [Retrying fetch in TypeScript](/blog/retry-fetch-in-typescript) — why the retry is what creates the duplicate in the first place.
+-   [Circuit breakers and layered timeouts](/blog/circuit-breakers-and-layered-timeouts) and [Migrate from fetch to StitchAPI](/blog/migrate-from-fetch-to-stitchapi) — the rest of the resilience surface and how to adopt it.

--- a/apps/docs/content/blog/test-api-code-without-the-network.mdx
+++ b/apps/docs/content/blog/test-api-code-without-the-network.mdx
@@ -1,0 +1,210 @@
+---
+title: 'Test API Code Without Hitting the Network'
+description: 'Code that calls APIs you do not own goes slow and flaky in tests. A stitch gives you two clean seams: inject a mock adapter and run the real engine, or stub the stitch when only the caller is under test.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [testing, mocking, typescript, adapter, mockadapter]
+---
+
+You wrote a function that fetches a user, retries on `503`, validates the payload, and your test for it spins up MSW, registers a handler, and still flakes when two specs share the global `fetch`. The code under test calls an API you do not own, so the test has to fake that API somewhere — and the usual place to fake it is the network layer, which is the layer with the most moving parts.
+
+A stitch moves the seam. Because a stitch is a function with a transport plugged in underneath, you can swap the transport for canned responses and run the real engine — validation, retry, pagination — against them. Or, when you only care about the code that _calls_ the stitch, you can replace the whole stitch with a stub and skip transport entirely.
+
+## The test most suites end up with
+
+Here is the function and the test you reach for first. The function calls `GET /users/{id}` and the test fakes `fetch`:
+
+```ts
+async function getUser(id: string): Promise<User> {
+    const res = await fetch(`https://api.example.com/users/${id}`);
+    if (!res.ok) throw new Error(`getUser failed: ${res.status}`);
+    return (await res.json()) as User;
+}
+
+// the test
+beforeEach(() => {
+    globalThis.fetch = vi.fn(
+        async () => new Response(JSON.stringify({ id: '1', name: 'Ada' })),
+    );
+});
+
+test('reads a user', async () => {
+    const user = await getUser('1');
+    expect(user.name).toBe('Ada');
+});
+```
+
+The sharp edges are real. The mock is global: every spec sharing this process shares the patched `fetch`, so one suite leaking a mock breaks the next. The fake `Response` is hand-rolled and lies — it answers `.json()` but not `.headers`, so the day your code reads a header the mock diverges from a real one. And if you wanted to test the retry-on-`503` behavior, you'd have to write the retry loop yourself and script the fake `fetch` to fail twice then succeed. `nock` and MSW move this mock to a more faithful HTTP layer, which is better, but it is still a layer below your code and still shared process-wide.
+
+## Layer 1: inject a mock adapter, run the real engine
+
+Declare the call as a stitch. The transport is a config field — `adapter` — that defaults to `fetchAdapter()`. In a test you pass `mockAdapter` instead and the real engine runs against your fixtures:
+
+```ts
+import { stitch } from 'stitchapi';
+import { mockAdapter } from 'stitchapi/testing';
+import { z } from 'zod';
+
+const User = z.object({ id: z.string(), name: z.string() });
+
+const adapter = mockAdapter({
+    match: '/users/',
+    respond: { body: { id: '1', name: 'Ada' } },
+});
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    output: User,
+    adapter,
+});
+
+test('validates the user', async () => {
+    const user = await getUser({ params: { id: '1' } });
+    expect(user.name).toBe('Ada');
+    expect(adapter.callCount()).toBe(1);
+});
+```
+
+The fixture is scoped to this stitch, not to a global. `mockAdapter` returns a real adapter — the same contract `fetchAdapter` satisfies — so the engine cannot tell it apart from a socket. That means `output: User` actually validates the canned body, `unwrap` actually unwraps it, and `paginate` actually walks your fixture pages. You are testing the stitch's behavior, not a fake of it.
+
+A `MockRoute` is `{ method?, match?, respond }`. `match` is a URL substring, a `RegExp` against the full URL, or a predicate — first match wins. `respond` is a fixed `MockResponse` (status defaults to `200`), a function of the call, or — the useful one for resilience — an array consumed one per call, last entry repeating. That last form scripts a flaky endpoint, which is how you exercise the real retry path:
+
+```ts
+const adapter = mockAdapter({
+    match: '/users/',
+    respond: [
+        { status: 503 },
+        { status: 503 },
+        { body: { id: '1', name: 'Ada' } },
+    ],
+});
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    output: User,
+    retry: { attempts: 3, on: [503], backoff: 'fixed', baseMs: 0 },
+    adapter,
+});
+
+test('retries past two 503s', async () => {
+    const user = await getUser({ params: { id: '1' } });
+    expect(user.name).toBe('Ada');
+    expect(adapter.callCount()).toBe(3); // two failures, then success
+});
+```
+
+No retry loop in the test, and none in your code — the stitch's retry did the work, and the array fixture fed it the sequence to retry through. Inspect what hit the wire with `.calls(filter?)` for the recorded requests and `.lastRequest()` for the most recent one; `.reset()` clears the log between assertions.
+
+One default worth knowing: an unmatched request **throws** by default. `opts.onUnmatched` is `'throw'` unless you set it, so a request your test did not plan for fails the test loudly instead of returning `undefined` and slipping through. Pass a number to reply with that status instead.
+
+## Layer 2: stub the stitch when the caller is under test
+
+Sometimes the stitch is not what you are testing — it is a dependency of the function you are testing, and you want to control its output without a transport at all. `stubStitch` and `failStitch`, both from `stitchapi/testing`, stand in for the stitch itself:
+
+```ts
+import { failStitch, stubStitch } from 'stitchapi/testing';
+
+test('loader renders the user', async () => {
+    const getUser = stubStitch({ id: '1', name: 'Ada' });
+    const view = await loadProfile(getUser);
+    expect(view.heading).toBe('Ada');
+    expect(getUser.callCount).toBe(1);
+});
+
+test('loader renders the error state', async () => {
+    const getUser = failStitch({ status: 500, message: 'upstream down' });
+    const view = await loadProfile(getUser);
+    expect(view.error).toBe('upstream down');
+});
+```
+
+`stubStitch(impl)` gives a `Stitch & StubSpy`: `impl` is a value or a function of the input, awaiting returns it, and `.safe()` / `.unwrap()` / `.stream()` all behave like a real stitch while the spy records every call. `callCount` is a property on the stub — a number, not a method — so you read it as `getUser.callCount`. `failStitch(error)` always fails — `await` and `.unwrap()` reject with a `StitchError`, `.safe()` resolves to `{ ok: false }`, and `.stream()` yields `start` to `error` to `done`. Use `failStitch` to drive the error branch of code that calls a stitch without staging a real failure.
+
+The two layers split cleanly:
+
+| Axis                | Mock adapter                                            | Stub the stitch                       |
+| ------------------- | ------------------------------------------------------- | ------------------------------------- |
+| Subject under test  | the stitch's own behavior                               | the code that calls the stitch        |
+| What runs           | the real engine — validation, retry, pagination         | nothing below your code               |
+| Question it answers | does retry fire, does validation reject the wrong shape | does my loader render the error state |
+| Transport           | a fixture adapter                                       | none at all                           |
+
+Inject a mock adapter when the stitch's own behavior is the subject. Stub the stitch when the caller is the subject — the first runs the engine, the second runs nothing below your code.
+
+## Assert the process, not only the return value
+
+A stitch emits an event stream as it works: `start`, `progress`, `info`, `drift`, `delta`, `result`, `error`, `done`. A retry is not a peer event — it rides a `progress` event whose `phase` is `'retry'`. `collectStitchEvents(source)` drains the stream into its parts so you can assert the process, not only the return value — that it retried twice, or that the response drifted from its schema:
+
+```ts
+import { collectStitchEvents } from 'stitchapi/testing';
+
+test('retries before succeeding', async () => {
+    const events = await collectStitchEvents(getUser({ params: { id: '1' } }));
+
+    const retries = events.events.filter(
+        (e) => e.type === 'progress' && e.phase === 'retry',
+    );
+    expect(retries).toHaveLength(2); // two 503s, two retry phases
+
+    expect(events.result?.name).toBe('Ada');
+});
+```
+
+`collectStitchEvents` returns a `CollectedEvents` object — `{ types, deltas, drifts, result, error, done, events }` — not a bare array. The full ordered list lives at `.events`; the convenience fields surface the common asks, so `events.drifts` collects every `drift` finding when a response no longer matches its validated shape. That is the contract test that fails the moment an upstream API renames a field:
+
+```ts
+test('flags drift when a field is renamed', async () => {
+    const events = await collectStitchEvents(getUser({ params: { id: '1' } }));
+    expect(events.drifts).not.toHaveLength(0);
+});
+```
+
+## Make the clock instant
+
+Retry backoff, throttle pacing, and per-attempt timeouts all wait on a clock. A test that waits on the real clock is slow and timing-dependent — the flake you were trying to delete. Inject `manualClock()` as the stitch's `clock` and advance it yourself:
+
+```ts
+import { manualClock } from 'stitchapi/testing';
+
+const clock = manualClock();
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    output: User,
+    retry: { attempts: 3, on: [503], baseMs: 1000 },
+    adapter,
+    clock,
+});
+
+test('backoff costs zero real time', async () => {
+    const call = getUser({ params: { id: '1' } });
+    await clock.advance(1000); // a one-second backoff, instantly
+    const user = await call;
+    expect(user.name).toBe('Ada');
+});
+```
+
+The default is the real `systemClock`. Swap in `manualClock` and a one-second backoff costs zero milliseconds — `advance(1000)` moves the clock, the retry fires, the test stays deterministic. The same handle drives throttle windows, timeout deadlines, and circuit cooldowns.
+
+## One declaration, two honest seams
+
+This is the honest contrast, not a dismissal. Network-layer mocks are the right tool when many code paths share one HTTP boundary and you want to fake it once. The trade is that they sit below your code and live in shared process state. A mock adapter is narrower — one stitch, one fixture — and it runs the real engine, so what passes the test is the behavior that ships. A stub is narrower still and runs nothing below your code, which is exactly what you want when the stitch is someone else's dependency.
+
+The same stitch you ship is the one you test. In production it carries `adapter: fetchAdapter()` (the default, so you write nothing) and runs against a real socket. In a test you pass `mockAdapter` for the transport and `manualClock` for the clock — two config fields, same declaration, no second code path. The seam you mock is a seam the engine already has, so the test exercises the production object, not a parallel fake of it. When the next call you add needs the same treatment, it is the same two fields again — no test harness to grow.
+
+## Try it
+
+Install the core package; the testing utilities ride along at the `stitchapi/testing` subpath, which is browser-safe.
+
+```package-install
+stitchapi
+```
+
+Then reach for `mockAdapter`, `stubStitch`, `failStitch`, `collectStitchEvents`, and `manualClock` from `stitchapi/testing`.
+
+-   [Mocking and testing a stitch](/docs/guides/testing/mocking)
+-   [The event stream](/docs/concepts/event-stream)
+-   [Validation](/docs/guides/validation/validation) and [drift](/docs/guides/validation/drift)
+-   [Choosing an HTTP adapter](/blog/choosing-an-http-adapter)

--- a/apps/docs/content/blog/typed-graphql-without-apollo.mdx
+++ b/apps/docs/content/blog/typed-graphql-without-apollo.mdx
@@ -1,0 +1,157 @@
+---
+title: 'Typed GraphQL Without Apollo'
+description: 'A GraphQL endpoint can answer HTTP 200 and still have failed. A graphql() stitch posts the operation, treats a 200-with-errors as a failure, and hands back the validated data — no client, no codegen.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [graphql, typescript, validation, resilience]
+---
+
+You point a `fetch` at a GraphQL endpoint, POST `{ query, variables }`, get back a `200`, read `json.data.user` — and three weeks later that call is silently returning `undefined` because the server moved the failure into a `200`-with-`errors` body instead of a status code. The transport said success; the operation did not. Most GraphQL clients you'd reach for to close that gap — Apollo Client, urql — also bring a normalized cache, a React layer, and a build step you didn't ask for when all you wanted was to call one query and trust the result.
+
+A `graphql()` stitch is that one query as a typed function. It POSTs the operation, treats a `200` carrying an `errors` array as the failure it is, validates the response, and hands you the unwrapped `data` — without a client object, a cache, or codegen.
+
+## The honest "before"
+
+Here is the call most TypeScript codebases write against a GraphQL API they don't own:
+
+```ts
+type User = { id: string; name: string };
+
+async function getUser(id: string): Promise<User> {
+    const res = await fetch('https://api.example.com/graphql', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+            query: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
+            variables: { id },
+        }),
+    });
+
+    const json = await res.json();
+    // res.ok is true even when the operation failed.
+    return json.data.user as User;
+}
+```
+
+The sharp edges are real. `res.ok` is `true` for a `200` that carries `{ "errors": [...] }`, so the failure path never runs and `json.data` is `undefined` — you read `.user` off `undefined` and crash somewhere far from the cause. The `as User` is a lie the compiler believes: nothing checked that the body matches the shape. And every variant of this query is a fresh copy of the POST boilerplate, each free to drift.
+
+## The same job as a stitch
+
+Declare the operation once. `graphql()` is a thin wrapper over `stitch()` that fixes `kind: 'graphql'`, `method: 'POST'`, and `unwrap: 'data'`:
+
+```ts
+import { graphql } from 'stitchapi';
+
+const getUser = graphql<{ user: { id: string; name: string } }>({
+    baseUrl: 'https://api.example.com',
+    path: '/graphql',
+    query: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
+});
+
+const data = await getUser({ variables: { id: '1' } });
+// data is already unwrapped from `data`: { user: { id, name } }
+```
+
+Each field maps to glue you no longer write. `graphql()` sends the POST and the JSON body shape for you, so the `method`, the `content-type` header, and the `{ query, variables }` envelope vanish from your code. The arguments travel in the call input's `variables` field at call time, so one declared stitch serves every set of arguments — you do not interpolate values into the query string and mint a stitch per call. Because `unwrap` defaults to `'data'`, the resolved value is the contents of the response's `data` field; override `unwrap` to read a different field or the raw envelope.
+
+The footgun closes here. A GraphQL endpoint can return HTTP `200` while carrying a top-level `errors` array; the stitch treats that as a failure and surfaces it, rather than unwrapping a `data` that isn't there. A failed query rejects the awaitable with a `StitchError` whose message carries the GraphQL error text, prefixed `GraphQL:` (joined with `; ` when there is more than one):
+
+```ts
+import { StitchError, graphql } from 'stitchapi';
+
+const getUser = graphql<{ user: { name: string } }>({
+    baseUrl: 'https://api.example.com',
+    path: '/graphql',
+    query: `query GetUser($id: ID!) { user(id: $id) { name } }`,
+});
+
+try {
+    await getUser({ variables: { id: '42' } });
+} catch (err) {
+    if (err instanceof StitchError) {
+        // err is a StitchError. The GraphQL messages are folded into err.message,
+        // prefixed `GraphQL:` — e.g. 'GraphQL: Not authorized to view user 42.'
+        // err.status is the HTTP status (200 for an errors-in-body failure).
+        console.error(err.message);
+    }
+}
+```
+
+(`STITCH_GRAPHQL` is the provisional registry label for this failure in the [error reference](/docs/errors/stitch-graphql); the runtime throws a plain `StitchError` today — it carries no `.code`.)
+
+## It is still a stitch
+
+`graphql()` returns the same object `stitch()` does, so every resilience and validation field applies. Add an `output` schema and the unwrapped `data` is validated before you touch it — the `as User` cast is gone, replaced by a runtime check the compiler can trust:
+
+```ts
+import { bearer, env, graphql } from 'stitchapi';
+import { z } from 'zod';
+
+const getUser = graphql({
+    baseUrl: 'https://api.example.com',
+    path: '/graphql',
+    query: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
+    output: z.object({
+        user: z.object({ id: z.string(), name: z.string() }),
+    }),
+    auth: bearer(env('API_TOKEN')),
+    retry: 3,
+    timeout: '10s',
+});
+
+const { user } = await getUser({ variables: { id: '1' } });
+// user is typed AND validated; auth, retry, and timeout all applied.
+```
+
+The secret resolves at call time from the environment, so the caller never holds the token. `retry` retries the request on transient transport failures; `timeout` bounds the call. `operationName` rides along with the request when you set it.
+
+## What moved where
+
+| Axis                     | Hand-rolled `fetch`                                                                   | A `graphql()` stitch                                               |
+| ------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| The POST + JSON envelope | You write `method`, `content-type`, `JSON.stringify({ query, variables })` every call | `graphql()` fixes them; you supply `path` + `query`                |
+| Variables                | Re-stringified per call site                                                          | Travel in `variables` at call time; one stitch, every argument set |
+| `200` with `errors`      | `res.ok` is `true` — failure slips through as `undefined`                             | A `StitchError` whose message is prefixed `GraphQL:`               |
+| Response shape           | `as User` — unchecked                                                                 | `output` schema validates the unwrapped `data` at runtime          |
+| Unwrapping `data`        | `json.data.user`, by hand                                                             | `unwrap: 'data'` by default; resolved value is `data`              |
+| Auth, retry, timeout     | More hand-written loops and headers                                                   | Config fields on the same declaration                              |
+
+The layer split is clean: the GraphQL document describes **what** you're asking for, and the stitch config describes **how** the call behaves — validation, auth, resilience — without a client object owning either. You keep writing GraphQL; you stop writing the POST around it.
+
+## From one query to a typed surface
+
+The bare `graphql()` form is one query, one function — and it scales the way the rest of StitchAPI does. When a second query against the same endpoint shows up, bind the shared `baseUrl` and `auth` once with a seam and let each operation inherit them:
+
+```ts
+import { bearer, env, seam } from 'stitchapi';
+
+const api = seam({
+    baseUrl: 'https://api.example.com',
+    auth: bearer(env('API_TOKEN')),
+});
+
+const getUser = api.graphql({
+    path: '/graphql',
+    query: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
+});
+
+const listOrders = api.graphql({
+    path: '/graphql',
+    query: `query Orders($userId: ID!) { orders(userId: $userId) { id total } }`,
+});
+```
+
+The first query is one line you can ship today; the tenth is the same declaration ten times, each one a typed, validated, resilient function. No client to instantiate, no schema to generate, no second code path between the query you tried in a playground and the one running in production.
+
+## Try it
+
+```package-install
+stitchapi zod
+```
+
+`graphql()` wraps `stitch()`, so install the core package, bring your own validator, and point a query at an endpoint.
+
+-   [Guide: GraphQL](/docs/guides/data/graphql) — how `graphql()` posts the operation and unwraps `data`
+-   [Error: STITCH_GRAPHQL](/docs/errors/stitch-graphql) — what a `200`-with-`errors` failure looks like
+-   [Validate an API response with Zod](/blog/validate-api-response-zod) — wiring an `output` schema
+-   [A type-safe API client without codegen](/blog/type-safe-api-client-without-codegen) — the same idea across REST and GraphQL


### PR DESCRIPTION
## What

Batch 2 of the comprehensive blog-coverage push — three posts on angles backed by shipped features that had no blog coverage:

| Post | Owns |
|---|---|
| [typed-graphql-without-apollo](apps/docs/content/blog/typed-graphql-without-apollo.mdx) | `graphql()` as a typed function — POSTs the operation, treats a 200-with-`errors` body as the failure it is (a `StitchError`), unwraps + validates `data`. No Apollo, no codegen. |
| [test-api-code-without-the-network](apps/docs/content/blog/test-api-code-without-the-network.mdx) | Two testing seams from `stitchapi/testing`: inject `mockAdapter` to run the real engine against canned/sequenced responses, or `stubStitch`/`failStitch` to stand in for the stitch when testing the caller; `collectStitchEvents` + `manualClock`. |
| [idempotency-keys-safe-retries](apps/docs/content/blog/idempotency-keys-safe-retries.mdx) | Attach a stable `Idempotency-Key` so a retried write dedupes server-side; default per-call uuid vs a key derived from input, and the double-submission anti-pattern. |

Follows Batch 1 ([#355](https://github.com/rejifald/StitchAPI/pull/355), merged).

## Verification

- Drafted → adversarially fact-checked against `core` source → revised.
- Editorial pass (3 finders): **API accuracy — no errors** (incl. the `GraphQL:` message format, `mockAdapter.callCount()` method vs `StubSpy.callCount` getter, `applyIdempotency` semantics); **EDITORIAL.md** — one minor back-reference fixed; **links/frontmatter/structure** — clean.
- `prettier` clean; pre-commit gate (`format` + full `typecheck` incl. `fumadocs-mdx` + `next typegen`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)