### PR TITLE
docs(blog): tracing, scaffold-from-curl, and upload-progress posts

### DIFF
--- a/apps/docs/content/blog/scaffold-a-stitch-from-curl.mdx
+++ b/apps/docs/content/blog/scaffold-a-stitch-from-curl.mdx
@@ -1,0 +1,121 @@
+---
+title: 'Scaffold a Stitch From a curl Command'
+description: 'You have a curl line from the API docs and a token in your shell. Paste it into stitch from-curl and get back a typed stitch declaration with the credential turned into an env() placeholder — never the literal secret.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [cli, scaffolding, auth, agents]
+---
+
+You are reading an API's docs, you copy the example curl, and now you have to translate it by hand: pull the origin out of the URL, find the id buried in the path, decode which header is the credential, and rewrite the whole thing as a typed call. The mechanical part is tedious. The dangerous part is the credential — the curl you copied has a live `Bearer sk_live_…` in it, and the obvious move is to paste it straight into your code.
+
+`stitch from-curl` does the mechanical translation and refuses to do the dangerous one. Hand it a curl line and it prints a ready-to-paste `stitch({…})` declaration — origin lifted to `baseUrl`, id-like path segments templated into `{param}` slots, and any recognised credential replaced with an `env('NAME')` placeholder. The token stays in your shell history. It never lands in committed source.
+
+## The curl you copied
+
+Here is a typical line from an API's "try it" panel or your browser's **Copy as cURL**:
+
+```sh
+curl https://api.acme.dev/v1/orders/4821
+```
+
+Translating that by hand means deciding where the origin ends and the path begins, noticing that `4821` is an id and not a fixed route, and writing the declaration. The CLI does it deterministically:
+
+```sh
+stitch from-curl 'curl https://api.acme.dev/v1/orders/4821'
+```
+
+```ts
+import { stitch } from 'stitchapi';
+
+export const getOrders = stitch({
+    baseUrl: 'https://api.acme.dev',
+    path: '/v1/orders/{orderId}',
+});
+
+// add an output schema to validate + type the response (rerun with --zod)
+await getOrders({
+    params: {
+        orderId: 4821,
+    },
+});
+```
+
+The origin becomes `baseUrl`; the rest becomes `path`. The all-digit segment `4821` looks like an id, so it is lifted into a `{orderId}` slot — named from the preceding `orders` segment — and surfaces as `params: { orderId }` in the example call. Each lift is reported as a warning so you can revert a false positive. The method line is omitted because `GET` is the default; a `POST` or `DELETE` would print a `method:` line.
+
+## The credential never makes the jump
+
+Add an auth header — the realistic case — and the security behavior is the point:
+
+```sh
+stitch from-curl 'curl https://api.acme.dev/v1/orders/4821 \
+  -H "Authorization: Bearer sk_live_a1b2c3d4e5f6"'
+```
+
+```ts
+import { bearer, env, stitch } from 'stitchapi';
+
+export const getOrders = stitch({
+    baseUrl: 'https://api.acme.dev',
+    path: '/v1/orders/{orderId}',
+    auth: bearer(env('API_TOKEN')),
+});
+
+// add an output schema to validate + type the response (rerun with --zod)
+await getOrders({
+    params: {
+        orderId: 4821,
+    },
+});
+```
+
+The literal `sk_live_a1b2c3d4e5f6` is gone. The recognised `Authorization: Bearer` header became `auth: bearer(env('API_TOKEN'))` — a capability that resolves the secret from the environment at call time, not a string baked into the file. Only headers the curl actually carried are emitted, so there is no fabricated `Accept` or `User-Agent` cluttering the output. This is the difference between a generated declaration you can commit and a curl you have to scrub by hand before anyone sees it.
+
+The CLI recognises three credential shapes, each from the header (or query param) it actually appears in — `from-curl` reads the request it was given, not flags it was not:
+
+-   **`Authorization: Bearer <token>`** → `auth: bearer(env('API_TOKEN'))`
+-   **`Authorization: Basic <base64>`** → `auth: basic({ user: env('API_USER'), pass: env('API_PASSWORD') })`
+-   **An `X-API-Key` header or an API-key query param** → `auth: apiKey({ value: env('API_KEY') })` for a header, or `auth: apiKey({ in: 'query', name: 'api_key', value: env('API_KEY') })` for a query param
+
+In every case the value is an `env(...)` placeholder, not the captured secret — `basic` and `apiKey` each take a single options object, so the generated call is the real API you would have written. (curl's `-u user:password` flag is a different story: `from-curl` does not parse it and warns it as an unknown flag. Basic auth is recognised from an `Authorization: Basic …` header, the form a browser's **Copy as cURL** actually emits.)
+
+## Type the response when you want it
+
+The declaration above leaves a comment where an `output` schema would go. To generate one from a real response body, pass a sample **and** `--zod`:
+
+```sh
+stitch from-curl 'curl https://api.acme.dev/v1/orders/4821' \
+  --response ./sample.json --zod
+```
+
+`--zod` emits an `output:` Zod schema; `--response <file|->` supplies the sample body its shape is inferred from. The two go together — `--response` is read only when `--zod` is set, and without `--zod` no `output` schema is emitted at all, just the reminder comment. The generated schema is plain text the CLI renders, never an imported validator, so the core stays zero-dependency and validator-agnostic. From there an `output` schema validates and types every response, and `drift` can flag the day the upstream renames a field. See [validating an API response](/docs/guides/validation/validation).
+
+## It is just a starting point
+
+What you get back is an ordinary stitch declaration, not a frozen artifact. The same fields you would reach for on any stitch are one edit away:
+
+```ts
+export const getOrder = stitch({
+    baseUrl: 'https://api.acme.dev',
+    path: '/v1/orders/{orderId}',
+    auth: bearer(env('API_TOKEN')),
+    retry: 3,
+    timeout: '5s',
+});
+```
+
+`from-curl` bounds the work of getting from a copied curl to a typed call: it lifts the origin, templates the ids, and quarantines the credential. The declaration it prints scales down to that one endpoint and up to a full client as you add `retry`, `timeout`, `output`, and the rest — the same way you would author a stitch from scratch, minus the by-hand translation and the temptation to commit the token.
+
+It is deterministic and offline — no network, no clock, just text in and text out — which makes it as good a fit for an agent scaffolding a tool from API docs as for a human pasting from devtools. The credential it never emits is one less secret for either of them to leak.
+
+## Try it
+
+```package-install
+stitchapi
+```
+
+`stitch from-curl '<curl>'` is part of the core CLI. Paste a curl line and commit the result — the token stays in your shell.
+
+-   [The CLI surface](/docs/surfaces/cli)
+-   [Auth as a capability, not a credential](/docs/concepts/capability-not-credential)
+-   [Stop writing fetch() in your agents](/blog/stop-writing-fetch-in-your-agents)
+-   [Choosing an HTTP adapter](/blog/choosing-an-http-adapter)

--- a/apps/docs/content/blog/trace-api-calls-without-leaking-secrets.mdx
+++ b/apps/docs/content/blog/trace-api-calls-without-leaking-secrets.mdx
@@ -1,0 +1,153 @@
+---
+title: 'Trace Every API Call Without Leaking Secrets'
+description: 'Logging your outbound calls usually means your logs now carry Authorization headers, tokens in URLs, and full PII bodies. StitchAPI tracing is off by default and redacts secrets before anything is written.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [observability, tracing, security, typescript, redaction]
+---
+
+A charge fails in production, you add a `console.log` around the call to your payment provider, ship it, and three days later a security scan flags your log index: it holds live `Authorization: Bearer sk_live_...` headers, an access token sitting in a query string, and a full customer record per request. You wanted to see what the call did. You spilled the secret it carried.
+
+That trade — visibility for exposure — is the default of every hand-rolled logger. StitchAPI inverts it. Tracing is off until you ask for it, and when you ask for it, redaction is already on.
+
+## The honest "before"
+
+Here is the logging you actually write when a call misbehaves:
+
+```ts
+async function chargeCard(token, amount) {
+    const headers = {
+        authorization: `Bearer ${process.env.PAYMENTS_TOKEN}`,
+        'idempotency-key': token,
+    };
+    const url = `https://api.payments.com/charges?access_token=${accessToken}`;
+
+    console.log('-> POST', url, headers, { amount, card }); // here it is
+
+    const res = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ amount, card }),
+    });
+    console.log('<- ', res.status, await res.clone().json());
+    return res.json();
+}
+```
+
+Every sharp edge is real:
+
+-   The `headers` object you printed contains the bearer token verbatim. So does any logger you hand it to.
+-   The `access_token` query parameter is a secret, now in plaintext in the URL you logged.
+-   `{ amount, card }` is the request body — the card object is PII, logged in full.
+-   This line shows the **first** attempt only. If `fetch` is wrapped in a retry loop, the 429, the wait, and the second attempt never appear.
+-   Redaction is a step you have to remember, every time, on every new field. The day you forget is the day it lands in the index.
+
+You can write a `redact()` helper. You then have to remember to call it, keep its denylist current, and trust that no teammate logs the raw object next to it.
+
+## The stitch version
+
+A stitch is the call as a declaration. Tracing is one field, and the redaction is structural — it runs inside the engine before a byte reaches the sink.
+
+```ts
+import { bearer, env, stitch } from 'stitchapi';
+
+const chargeCard = stitch({
+    method: 'POST',
+    url: 'https://api.payments.com/charges',
+    auth: bearer(env('PAYMENTS_TOKEN')),
+    retry: { attempts: 3, on: [429, 503], respectRetryAfter: true },
+    trace: 'console',
+});
+```
+
+`trace: 'console'` is the quickest on-switch. Make the call exactly as before:
+
+```ts
+await chargeCard({
+    query: { access_token: accessToken },
+    body: { amount, card },
+});
+```
+
+The trace that lands shows the request, every retry, and the result — with the secrets already gone:
+
+-   The `authorization` header reads `[REDACTED]`. So does `cookie`. Both are on the built-in denylist; you opted out of nothing.
+-   The secret value of the `access_token` query parameter is scrubbed out of the logged URL string, and the same value is scrubbed from the structured `input.query` it also appears in. Scrub the URL, miss the copy: not here.
+-   The request body and the response are truncated to 2048 bytes, so a megabyte of PII never becomes a megabyte of log.
+
+You did not write a `redact()`. You wrote `trace: 'console'`. The redaction is the default, not the step you can forget.
+
+## Off by default is the security posture
+
+Omit `trace` and there is no tracing — no sink, no serialization, no hot-path cost. A stitch with no `trace` field does the call and nothing else. This is the safe state, and it is the state you are in until you opt out of it deliberately.
+
+When you do turn it on, `'console'` is the shorthand. For anything past a terminal, reach for a sink:
+
+```ts
+import {
+    consoleSink,
+    createTrace,
+    fileSink,
+    multiplex,
+    stitch,
+} from 'stitchapi';
+
+// Pretty console output (same as the 'console' shorthand, but explicit):
+const a = stitch({ url, trace: consoleSink() });
+
+// One JSON object per line, appended to disk:
+const b = stitch({ url, trace: fileSink('./traces.jsonl') });
+
+// Configure redaction and capture:
+const trace = createTrace({
+    console: true,
+    file: './traces.jsonl',
+    redactHeaders: ['x-internal-token', 'x-customer-id'],
+    maxBodyBytes: 4096,
+});
+const c = stitch({ url, trace });
+
+// Fan one trace to several sinks at once:
+const d = stitch({
+    url,
+    trace: multiplex(consoleSink(), fileSink('./traces.jsonl')),
+});
+```
+
+`createTrace` is where you tune the two things you might want to widen. `redactHeaders` **adds** your own header names to the built-in denylist — it does not replace `authorization` and `cookie`, it joins them. `maxBodyBytes` defaults to `2048`; pass `maxBodyBytes: false` to capture full bodies when you are debugging in a place you trust and have decided the size is fine.
+
+## What gets redacted, before anything is written
+
+The redaction is not a post-processing pass you hope ran. It happens between the event and the sink, on every sink, every time:
+
+| Axis                | A hand-rolled logger                    | A stitch trace                                                                |
+| ------------------- | --------------------------------------- | ----------------------------------------------------------------------------- |
+| Secret headers      | You print `headers`; the token is in it | `authorization`, `cookie`, and your `redactHeaders` names become `[REDACTED]` |
+| URL credentials     | `https://user:pass@host` logged whole   | `scrubUrl` strips inline credentials from the URL string                      |
+| Secret query values | The token in `?token=...` is plaintext  | Scrubbed from the URL string **and** the structured `input.query`             |
+| Large bodies        | Full PII body, however big              | Truncated to `maxBodyBytes` (2048 by default)                                 |
+| New secret field    | You must remember to redact it          | On the denylist, or one `redactHeaders` entry away                            |
+
+The contrast is the whole point: with a logger, safety is a habit you maintain. With a stitch, safety is the default and capturing more is the explicit choice.
+
+## The trace rides the event stream
+
+A stitch emits a stream of events as it runs — `start`, `progress`, `drift`, `result`, `done` — and the trace is driven off that stream. That is why a trace shows what a single log line cannot: every retry attempt, every wait before a retry, a `drift` event when a validated response shape changed, and the terminal result. You see the 429, the backoff, the second attempt, and the eventual 200 as separate entries — not one line written after everything already happened.
+
+This is the same event stream that powers everything else observable about a call, so the trace and your other instrumentation see the identical sequence of facts.
+
+## OpenTelemetry, when you have a collector
+
+If your logs go to an OpenTelemetry pipeline, there is an OTLP exporter that turns the same event stream into spans for your collector — [the OTLP guide](/docs/guides/observability/otlp) covers wiring it up. The redaction story is the same: secrets are scrubbed before the span is built, so an OTLP backend never receives what a `console.log` would have handed it.
+
+## Start narrow, widen on purpose
+
+The smallest safe trace is one field: `trace: 'console'`, and the secrets are already handled. That is the call you have right now, made visible without making it dangerous. When you need durable traces, swap `'console'` for `fileSink(...)`; when you need to fan out, wrap them in `multiplex(...)`; when you need a span pipeline, point the OTLP exporter at your collector. Each step is one edit, and at every step redaction stays on by default — widening capture (`maxBodyBytes: false`, extra `redactHeaders`) is a thing you choose, never a thing you forget. The field that costs nothing when absent is the field that protects you the moment it is present.
+
+## Try it
+
+```package-install
+stitchapi
+```
+
+Add `trace: 'console'` to one stitch and watch a redacted call come through. Then read [trace sinks](/docs/guides/observability/trace-sinks) for `fileSink`/`createTrace`/`multiplex`, the [helpers reference](/docs/reference/helpers) for every option, and [the event stream](/docs/concepts/event-stream) for what each trace entry maps to. For the secrets a trace must never print in the first place, see [auth as a capability, not a credential](/blog/auth-as-a-capability-not-a-credential); for catching shape changes a trace will surface as `drift`, see [schema drift is a production bug](/blog/schema-drift-is-a-production-bug); to decide which transport carries these calls, see [choosing an HTTP adapter](/blog/choosing-an-http-adapter).

--- a/apps/docs/content/blog/upload-a-file-with-a-progress-bar.mdx
+++ b/apps/docs/content/blog/upload-a-file-with-a-progress-bar.mdx
@@ -1,0 +1,152 @@
+---
+title: 'Upload a File With a Progress Bar'
+description: 'fetch cannot report how many bytes have left the machine, so a 50MB upload looks frozen. Declare a multipart upload on xhrAdapter, pass onProgress per call, and drive a real bar from the bytes sent.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [upload, progress, xhr, typescript, multipart]
+---
+
+A user picks a 50MB video, clicks **Upload**, and your UI just sits there. No bar, no percentage, no sign the bytes are even moving — until, a minute later, the response lands and the screen jumps to "done." The user has already refreshed twice. The problem is not your code; it is the transport: `fetch` cannot tell you how many bytes of the request body have left the machine. `XMLHttpRequest` can, through `xhr.upload`. StitchAPI ships `xhrAdapter()` for exactly this case, and an upload built on it is still an ordinary stitch — typed, authenticated, time-bounded.
+
+## Why fetch leaves you blind
+
+`fetch` reports nothing about the request body's progress. There is no `upload` event, no `onUploadProgress` option, no way to read bytes sent. The Streams API can give you a request `ReadableStream`, but browsers do not surface per-chunk upload counts from it, and support is uneven. So the honest "before" with `fetch` is a spinner and a guess:
+
+```ts
+async function uploadVideo(file: File) {
+    const body = new FormData();
+    body.append('file', file);
+
+    // No upload-progress signal exists here. The bar can only be fake.
+    const res = await fetch('https://api.example.com/videos', {
+        method: 'POST',
+        body,
+        headers: { Authorization: `Bearer ${process.env.API_TOKEN}` },
+    });
+    if (!res.ok) throw new Error(`Upload failed: ${res.status}`);
+    return res.json();
+}
+```
+
+You can animate a CSS bar to 90% and freeze it there, but that is theater. The bytes are not being measured, so the bar is not tracking anything.
+
+`XMLHttpRequest` predates `fetch` and kept a feature `fetch` dropped: an `upload` object that fires `progress` events as the body is sent. Hand-rolling it means wiring `xhr.upload.onprogress`, `xhr.onload`, `xhr.onerror`, `xhr.onabort`, `setRequestHeader` for auth, JSON-parsing the response, and translating non-2xx into an error — every callback by hand, every time. That is the glue `xhrAdapter()` already wrote.
+
+## Declare the upload as a stitch
+
+A stitch turns one endpoint into a typed function you call with `await`. Swap the default transport for `xhrAdapter()` and set `bodyType: 'multipart'`, and you get upload-progress reporting with the rest of the stitch contract intact:
+
+```ts
+import { bearer, env, stitch, xhrAdapter } from 'stitchapi';
+import { z } from 'zod';
+
+const uploadVideo = stitch({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/videos',
+    bodyType: 'multipart',
+    adapter: xhrAdapter(),
+    auth: bearer(env('API_TOKEN')),
+    timeout: '2m',
+    output: z.object({ id: z.string(), url: z.string().url() }),
+});
+```
+
+Each field replaces glue you would otherwise write:
+
+-   `adapter: xhrAdapter()` routes the request through `XMLHttpRequest` instead of the default `fetchAdapter()`, so `xhr.upload` is available to report bytes sent. It is **browser-only** (it needs `XMLHttpRequest`) and **buffered**, not streaming — it reads the whole response into memory, and rejects a `stream` request. Upload progress is its reason to exist.
+-   `bodyType: 'multipart'` encodes the body as `multipart/form-data` and sets the boundary header for you.
+-   `auth: bearer(env('API_TOKEN'))` resolves the token at call time and sets the `Authorization` header; the caller never holds the secret.
+-   `output` validates the JSON the server returns, so a successful `await` hands back a typed `{ id, url }` — not `unknown`.
+
+A multipart **file part** in the body can be a `Blob` (a `File` is a `Blob`), a `Uint8Array`, or a `{ value, filename?, type? }` wrapper when you want to name the part or set its content type explicitly. Scalar values — strings, numbers — become string parts. So the body for this stitch is a plain object whose `file` key holds the upload.
+
+## Drive the bar from bytes sent
+
+`onProgress` is a **per-call control**, not config. You pass it in the call input alongside the body, and the callback receives an `AdapterProgress`:
+
+```ts
+type AdapterProgress = {
+    phase: 'upload' | 'download';
+    loaded: number;
+    total?: number;
+};
+```
+
+`loaded` is the number of bytes transferred so far; `total` is the full size when the transport knows it. Tag by `phase` so you only move the upload bar while the request body is going out:
+
+```ts
+async function send(file: File, onPct: (pct: number) => void) {
+    const result = await uploadVideo({
+        body: { file },
+        onProgress: (p) => {
+            if (p.phase === 'upload') {
+                onPct(Math.round((p.loaded / (p.total ?? 1)) * 100));
+            }
+        },
+    });
+    return result; // typed { id, url }
+}
+```
+
+Wiring that into a `<progress>` element is the whole feature:
+
+```tsx
+function Uploader() {
+    const [pct, setPct] = useState(0);
+
+    async function handle(file: File) {
+        setPct(0);
+        const { url } = await send(file, setPct);
+        console.log('uploaded to', url);
+    }
+
+    return (
+        <>
+            <input type="file" onChange={(e) => handle(e.target.files![0])} />
+            <progress value={pct} max={100} />
+        </>
+    );
+}
+```
+
+The bar now moves because it is reading real bytes off the wire, not a timer pretending to.
+
+Two controls travel with the call this way, and in both cases **the call argument wins over a bound or configured value**:
+
+-   `onProgress`, above — supply a different callback per upload without redeclaring the stitch.
+-   `signal`, an `AbortSignal` — pass `{ body, onProgress, signal }` and a cancel button aborts the in-flight upload.
+
+```ts
+const controller = new AbortController();
+uploadVideo({ body: { file }, onProgress, signal: controller.signal });
+// later: controller.abort();
+```
+
+## Upload progress, not just any progress
+
+The `phase` tag exists because progress runs **both directions**:
+
+| Axis        | `phase: 'upload'`              | `phase: 'download'`             |
+| ----------- | ------------------------------ | ------------------------------- |
+| Measures    | bytes of the request body sent | bytes of the response body read |
+| Transport   | needs `xhrAdapter()`           | works on `fetchAdapter()` too   |
+| Typical use | a file/video upload bar        | a large-download bar            |
+
+Download progress is the easier half — `fetchAdapter()`, the default transport, reports it by reading the response stream — so if you only need a download bar you do not have to switch adapters at all. The reason this article reaches for `xhrAdapter()` is the upload direction, which `fetch` cannot measure at all. Filter on `p.phase === 'upload'` and the same callback ignores the download tail.
+
+This stays inside the stitch contract, not beside it. `auth` still resolves the token at call time; `timeout` still bounds the call (a generous `'2m'` here, because a large upload is slow, not stuck); `output` still validates the response, so a corrupt or unexpected body throws a `StitchError` carrying the offending `.body` instead of slipping through as `any`. You traded the transport, not the guarantees.
+
+One honest edge: `xhrAdapter()` is **browser-only and buffered**. It cannot run under Node, and it cannot stream a response — ask it to `stream` and it rejects. If you need response streaming (SSE, an LLM token feed, a chunked download you consume as it arrives), that is `fetchAdapter()`'s job. Pick `xhrAdapter()` when the thing you must show the user is the upload climbing.
+
+## From one upload to every upload
+
+This `uploadVideo` is one declaration that bounds the call you have today: one endpoint, one progress callback, one typed result. It scales **down** to a single line — drop `output` and `timeout` and you still have a multipart POST with a real progress bar, which is fewer moving parts than the hand-rolled `XMLHttpRequest` callbacks it replaces. It scales **up** without a rewrite — add `retry` for transient network blips, `throttle` to cap concurrent uploads, `hooks` to log each attempt, all as fields on the same object, the call site untouched. (Be deliberate about `retry` on an upload: re-sending a 50MB body is rarely free, so scope it tightly or skip it.) And every other endpoint in your app declares the same way, so the upload is not a special case bolted onto your client — it is one more stitch.
+
+## Try it
+
+```package-install
+stitchapi
+```
+
+`xhrAdapter()` and the other built-in transports live in core — no extra package. From there: read [choosing an HTTP adapter](/blog/choosing-an-http-adapter) for when to reach for `xhrAdapter` over `fetchAdapter`, [migrate from fetch to StitchAPI](/blog/migrate-from-fetch-to-stitchapi) to convert an existing client, the [helpers reference](/docs/reference/helpers) for the adapter signatures, the [body-encoding guide](/docs/guides/data/body-encoding) for how multipart parts are serialized, and [the stitch](/docs/concepts/the-stitch) for the full call contract.


### PR DESCRIPTION
## What

Batch 3 of the comprehensive blog-coverage push — three posts on shipped features with no blog coverage:

| Post | Owns |
|---|---|
| [trace-api-calls-without-leaking-secrets](apps/docs/content/blog/trace-api-calls-without-leaking-secrets.mdx) | Tracing is off by default and redacts by construction — secret-header denylist, URL + query scrubbing, body truncation (`maxBodyBytes`), `consoleSink`/`fileSink`/`createTrace`/`multiplex`, OTLP exporter. |
| [scaffold-a-stitch-from-curl](apps/docs/content/blog/scaffold-a-stitch-from-curl.mdx) | `stitch from-curl '<curl>'` turns a curl line or HAR entry into a ready-to-paste stitch; captured credentials become `env()` placeholders, never emitted. |
| [upload-a-file-with-a-progress-bar](apps/docs/content/blog/upload-a-file-with-a-progress-bar.mdx) | `xhrAdapter()` reports upload bytes that `fetch` cannot; a multipart POST + per-call `onProgress` drives a real progress bar. |

Follows Batch 1 ([#355](https://github.com/rejifald/StitchAPI/pull/355)) and Batch 2 ([#356](https://github.com/rejifald/StitchAPI/pull/356)), both merged.

## Verification

- Drafted → adversarially fact-checked → revised. The fact-checker **ran the real `from-curl` and trace-scrubber code** and caught three drafting errors, all fixed: the trace example's `account` query param isn't on the scrubber denylist (→ `access_token`, which is); the generated export name is `getOrders` not `getOrdersOrderId`; an all-digit path param renders unquoted (`orderId: 4821`).
- Editorial pass (3 finders): EDITORIAL.md + links/frontmatter/structure clean (two minor nits fixed).
- `prettier` clean; pre-commit gate (`format` + full `typecheck` incl. `fumadocs-mdx` + `next typegen`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)