### PR TITLE
docs(blog): typed-errors, edge/Cloudflare, and LLM-as-function posts

### DIFF
--- a/apps/docs/content/blog/call-any-llm-as-a-typed-function.mdx
+++ b/apps/docs/content/blog/call-any-llm-as-a-typed-function.mdx
@@ -1,0 +1,148 @@
+---
+title: 'Call Any LLM as a Typed Function'
+description: 'A model call is just an HTTP request, so wrapping it in an SDK buys you a dependency, a bespoke client, and a rewrite every time you switch providers. Declare the call as a stitch and switching models is a one-line change.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [llm, ai, anthropic, openai, typescript]
+---
+
+You ship a feature on Claude, then a cost review says move the cheap path to GPT-4o, and now you are threading a second SDK through your codebase: a different client object, a different request shape, a different response shape, a different retry story. The two providers do the same thing — take messages, return text — but each one drags its own library and its own conventions, so "switch the model" turns into "rewrite the call site." A model call is an HTTP POST with an auth header. The SDK is wrapping the same request you could declare once.
+
+## What an SDK call actually is
+
+Strip a chat completion down and it is a request to one endpoint with a JSON body of messages and an `Authorization` header:
+
+```ts
+const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+        'x-api-key': process.env.ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+        model: 'claude-opus-4-8',
+        max_tokens: 1024,
+        messages: [{ role: 'user', content: 'Summarize this.' }],
+    }),
+});
+const data = await res.json();
+const text = data.content[0].text; // any — you hope content[0] exists
+```
+
+The vendor SDK hides the URL and the header names, but it does not buy you anything `fetch` cannot: it is the same POST. What it costs you is a dependency you now upgrade, a client object you construct and pass around, and a response shape (`data.content[0].text`) that differs from the next provider's (`data.choices[0].message.content`). Swap providers and every one of those lines changes. And the call is still raw: a `529` overload throws, the token sits in scope where any log line can catch it, and `text` is `any`.
+
+## Declare the call as a stitch
+
+A stitch turns one endpoint into a typed function you call with `await`. The `llm` surface declares a chat call the same way, binding the provider and its defaults to the surface; the messages travel in the call:
+
+```ts
+import { apiKey, env } from 'stitchapi';
+import { anthropic, llm } from 'stitchapi/llm';
+
+const chat = llm({
+    provider: anthropic,
+    model: 'claude-opus-4-8',
+    auth: apiKey({ header: 'x-api-key', value: env('ANTHROPIC_API_KEY') }),
+});
+
+const { text } = await chat({
+    body: { messages: [{ role: 'user', content: 'Summarize this.' }] },
+});
+```
+
+Each field replaces something the SDK did opaquely or `fetch` did by hand:
+
+| Axis               | Raw fetch / SDK                                                                  | A stitch                                                                                |
+| ------------------ | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Endpoint + headers | Hard-coded in the call, or hidden in the client                                  | `provider: anthropic` carries the `/v1/messages` URL and the `anthropic-version` header |
+| Model              | Re-typed at the call site                                                        | `model` bound to the surface once, overridable per call                                 |
+| Credential         | A token in scope you hope nobody logs                                            | `auth: apiKey(...)` resolves at call time; the caller never holds it                    |
+| Response shape     | `data.content[0].text` (Anthropic) vs `data.choices[0].message.content` (OpenAI) | `result.text` — one normalised shape across providers                                   |
+| Resilience         | Hand-rolled, or absent                                                           | `retry` / `throttle` / `timeout` as fields, because the call is HTTP                    |
+
+`anthropic` is plain config, not an SDK: it declares the endpoint, the non-secret `anthropic-version` header, the default model, and the maps between the normalised request and Anthropic's wire body. The credential is never the provider's — it is the stitch's `auth`, so the same provider object is safe to share. Awaiting `chat(...)` returns an `LlmResult` whose `.text` is the completion and whose `.raw` keeps the provider's full response body when you need a field the normalised shape does not carry.
+
+## Providers are config, so switching is one line
+
+The reason the rewrite goes away is that the provider is a value, not a library. The first-party providers ship as plain `LlmProvider` config — no SDK dependency, the contract-not-dependency gate — so moving from Claude to GPT-4o is a `provider:` change and an `auth:` change, nothing at the call site:
+
+```ts
+import { bearer, env } from 'stitchapi';
+import { llm, openai } from 'stitchapi/llm';
+
+const chat = llm({
+    provider: openai,
+    model: 'gpt-4o',
+    auth: bearer(env('OPENAI_API_KEY')),
+});
+
+// the call is byte-for-byte the same
+const { text } = await chat({
+    body: { messages: [{ role: 'user', content: 'Summarize this.' }] },
+});
+```
+
+`openai` authenticates with `bearer(env('OPENAI_API_KEY'))`; `anthropic` authenticates with `apiKey({ header: 'x-api-key', value: env('ANTHROPIC_API_KEY') })`. The provider absorbs the wire difference — different URL, different header, different body and response shapes — and `result.text` is the same on both sides. The code that sends messages and reads the completion does not move.
+
+When you need a provider that does not ship first-party, you implement the same contract the built-ins do. An `LlmProvider` declares its `id`, its full completions `endpoint`, optional non-secret `headers`, an optional `defaultModel`, a `buildBody` that maps a normalised `LlmRequest` to that vendor's wire body, and a `parse` that lifts the response back into an `LlmResult`:
+
+```ts
+import { bearer, env } from 'stitchapi';
+import { type LlmProvider, llm } from 'stitchapi/llm';
+
+const mistral: LlmProvider = {
+    id: 'mistral',
+    endpoint: 'https://api.mistral.ai/v1/chat/completions',
+    defaultModel: 'mistral-large-latest',
+    buildBody: (req) => ({
+        model: req.model,
+        messages: req.messages,
+    }),
+    // lift the provider's response back into an LlmResult
+    parse: (body) => ({
+        text: (body as any).choices[0].message.content,
+        raw: body,
+    }),
+};
+
+const chat = llm({ provider: mistral, auth: bearer(env('MISTRAL_API_KEY')) });
+```
+
+The credential stays the stitch's `auth`, never the provider — so a provider you write is config you can commit, with no secret baked in.
+
+## An LLM call is HTTP, so resilience comes free
+
+Because the surface sends an HTTP request, every resilience field a stitch has applies to a model call. Provider overloads (`429`, `529`) are exactly what retry is for, and a metered key is exactly what throttle is for:
+
+```ts
+const chat = llm({
+    provider: anthropic,
+    model: 'claude-opus-4-8',
+    auth: apiKey({ header: 'x-api-key', value: env('ANTHROPIC_API_KEY') }),
+    retry: {
+        attempts: 3,
+        on: [429, 529],
+        backoff: 'expo-jitter',
+        respectRetryAfter: true,
+    },
+    throttle: { rate: '5/s', concurrency: 2, scope: 'host' },
+    timeout: { total: '60s' },
+});
+```
+
+`retry` backs off with jitter and honors the provider's `Retry-After`; `throttle` keeps you under the rate limit instead of discovering it at `429`; `timeout` bounds a call that hangs. None of that is LLM-specific code — it is the same engine that runs any stitch, applied to a request that happens to carry messages. `trace` works the same way, with the API key kept out of the event stream.
+
+One thing the `llm` surface does not do yet: stream tokens. It is buffered today — you `await` the full completion, you do not iterate it chunk by chunk. Token streaming is a follow-up; if you need to push tokens to a browser now, that is the SSE surface's job, covered in [streaming a stitch as SSE](/blog/stream-a-stitch-as-sse-in-next-app-router).
+
+## From one call to every model
+
+This `chat` is one declaration that bounds the call you have today: one provider, one model, one typed result. It scales down to a single line — drop the resilience fields and you still have a typed model call that hides the URL and the token, which is less than the SDK's client-construction ceremony it replaces. It scales up without a rewrite — add `retry` for overloads, `throttle` to respect a metered key, `cache` so identical prompts skip the round trip, all as fields on the same object, the call site untouched. And the day a cost review says move to a cheaper model, you change `provider:` and `auth:` and ship — the messages and the `result.text` that reads them do not move.
+
+## Try it
+
+```package-install
+stitchapi
+```
+
+Declare a model call as a stitch, then switch providers without touching the call site. Start with [the stitch concept](/docs/concepts/the-stitch) and [auth as a capability](/docs/concepts/capability-not-credential), then see [cutting LLM costs from both ends](/blog/cut-llm-costs-from-both-ends) for where caching and a cheaper model fit.

--- a/apps/docs/content/blog/run-a-stitch-on-the-edge.mdx
+++ b/apps/docs/content/blog/run-a-stitch-on-the-edge.mdx
@@ -1,0 +1,126 @@
+---
+title: 'Run a Stitch on the Edge: Cloudflare Workers and Zero node:'
+description: 'Most HTTP clients drag a node: import that breaks on a Worker. StitchAPI core is Web-API only, so the same stitch runs unchanged on Cloudflare Workers and Deno — and a KV-backed store shares its cache and auth across isolates.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [edge, cloudflare, workers, typescript, kv]
+---
+
+You wrote a clean API client, it passes every test on your laptop, and then the Cloudflare deploy fails at build time with `Could not resolve "node:crypto"`. The client you picked reaches for a Node built-in somewhere deep in its transport or its cache, and a Worker has no `node:` to give it. Now you are pinning polyfills, flipping compatibility flags, and hoping the shim behaves the same as the real thing.
+
+The edge runtime is not a smaller Node. It is a different runtime: no `node:` built-ins, no filesystem, isolates that cold-start per request and share no memory between them. A library that imports `node:crypto`, `node:fs`, or `node:http` does not run here — and the cache or session store it kept in a module-level variable evaporates the moment the isolate is recycled.
+
+## What runs on the edge
+
+StitchAPI core is Web-API only on the hot path — `fetch`, `Request`, `URL`, `crypto.subtle`, nothing from `node:`. It ships a `browser` export condition that the Workers and Deno bundlers pick automatically, and it has zero runtime dependencies, so there is no transitive package waiting to pull a Node built-in in behind your back. A stitch you wrote for a server runs unchanged in a Worker, in Pages Functions, on Deno Deploy — no polyfills, no `node:` shims, no compatibility flag.
+
+Here is the whole client. A stitch declares one endpoint as a typed function; the Worker's `fetch` handler calls it.
+
+```ts
+import { stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const getUser = stitch({
+    url: 'https://api.example.com/users/{id}',
+    output: z.object({ id: z.string(), name: z.string(), email: z.string() }),
+    retry: { attempts: 3, on: [429, 502, 503, 504], backoff: 'expo-jitter' },
+    timeout: { total: '10s', perAttempt: '4s' },
+});
+
+export default {
+    async fetch(req: Request): Promise<Response> {
+        const id = new URL(req.url).searchParams.get('id') ?? '1';
+        const user = await getUser({ params: { id } });
+        return Response.json(user);
+    },
+};
+```
+
+`await getUser(...)` returns the validated `User` and throws a `StitchError` (with `.status`, `.attempts`, `.body`, `.url`) once the stitch exhausts its own retries — so the resilience and the validation that you would otherwise hand-write live in the declaration, and they run on the isolate exactly as they run on your laptop.
+
+That covers a stateless call. The problem the edge adds is everything that wants to _remember_.
+
+## The state the edge throws away
+
+Two of a stitch's jobs are read-heavy and want shared state across calls:
+
+-   The **response cache** dedupes repeat reads and coalesces concurrent ones.
+-   The **auth jar** holds a `cookieSession` cookie jar or an `oauth2` token cache so you reuse a session instead of re-authenticating on every request.
+
+On a single Node process both live in memory and that is fine. On the edge it is not: each isolate has its own memory and gets recycled between requests, so an in-memory cache is cold on nearly every hit, and a token refreshed on one isolate is invisible to the next. You would be re-authenticating constantly and caching nothing.
+
+The fix is the `store` seam. A stitch keeps its mutable state behind a pluggable `StitchStore`; swap the backend and the cache and auth jar move with it. `@stitchapi/cloudflare-kv` exports `cloudflareKvStore`, a Workers-KV-backed store you attach as `store`:
+
+```ts
+import {
+    type KVNamespaceLike,
+    cloudflareKvStore,
+} from '@stitchapi/cloudflare-kv';
+import { cookieSession, seam } from 'stitchapi';
+import { z } from 'zod';
+
+export default {
+    async fetch(
+        req: Request,
+        env: { MY_KV: KVNamespaceLike },
+    ): Promise<Response> {
+        const api = seam({
+            baseUrl: 'https://api.example.com',
+            store: cloudflareKvStore(env.MY_KV),
+        });
+
+        // the login stitch — its Set-Cookie seeds the session
+        const login = api.stitch({ method: 'POST', path: '/auth/login' });
+
+        const getUser = api.stitch({
+            path: '/users/{id}',
+            auth: cookieSession({ login, cookie: 'session' }),
+            output: z.object({ id: z.string(), name: z.string() }),
+            cache: '5m',
+        });
+
+        const id = new URL(req.url).searchParams.get('id') ?? '1';
+        return Response.json(await getUser({ params: { id } }));
+    },
+};
+```
+
+Pass `cloudflareKvStore(env.MY_KV)` the KV binding — that is the whole API. With it attached, the cache lives in KV: shared across every isolate, surviving cold starts, so a value one request wrote another request reads. The auth cookie jar and token cache live in KV too: a session or token refreshed by one isolate is visible to all of them. The call site does not change. `await getUser({ params: { id } })` is identical with or without the store; only where the state lives moved.
+
+## It imports no Cloudflare types
+
+`@stitchapi/cloudflare-kv` is itself Web-API only — no `node:*`, zero runtime dependencies — and it imports **no** Cloudflare runtime types. It runs against a small structural surface, `KVNamespaceLike`, that a real `KVNamespace` binding satisfies as-is. You do not need `@cloudflare/workers-types` for the store to typecheck or run; the binding you already have fits the shape.
+
+The same seam reaches past Cloudflare. `@stitchapi/deno-kv` is the Deno-KV equivalent — same `store` field, different backend — for a stitch deployed to Deno Deploy.
+
+## One seam, the backend you have
+
+The `store` field is the same on the edge as it is on a Node fleet. The distributed-throttle post wires a stitch to a Redis-backed store so a rate limiter, cache, and session jar are shared across a fleet of Node processes. This is that exact seam — the call site is unchanged, the state moves to a shared backend — with the backend chosen for where you deploy:
+
+| Axis              | In-memory (default) | Redis store         | Workers KV store                 |
+| ----------------- | ------------------- | ------------------- | -------------------------------- |
+| Where it runs     | one process         | a Node fleet        | edge isolates                    |
+| Cache scope       | this process only   | fleet-wide          | fleet-wide, survives cold starts |
+| Auth jar / tokens | this process only   | shared across nodes | shared across isolates           |
+| `node:` needed    | no                  | the Redis client's  | none                             |
+| Call-site change  | —                   | none                | none                             |
+
+You pick the row that matches your deployment. The stitch — its types, retries, timeout, validation, auth — is the same code in every column. Redis for a Node fleet behind a load balancer; Workers KV for the edge.
+
+## From one Worker to a fleet
+
+The bare `fetch` handler at the top of this post is already a working edge client: a typed, validated, retrying call with no `node:` import to break the build. Reach for the KV store the day a second isolate needs to see the first one's cache or session — and reaching for it is one field, `store: cloudflareKvStore(env.MY_KV)`, on a `seam`. Nothing about the call you write changes between the single-Worker version and the fleet-wide one; you add a backend, not a rewrite. The same stitch scales down to one stateless handler and up to a shared edge fleet on the strength of a single line.
+
+## Try it
+
+```package-install
+stitchapi @stitchapi/cloudflare-kv
+```
+
+Attach `cloudflareKvStore(env.MY_KV)` as your seam's `store` and the cache and auth jar go fleet-wide across isolates — no call-site change. For the backend story end to end, see:
+
+-   [The pluggable store](/docs/guides/state/pluggable-store)
+-   [Distributed throttle, cache, and sessions](/docs/guides/state/distributed-throttle)
+-   [What a stitch is](/docs/concepts/the-stitch)
+-   [Distributed throttle with Redis as the KV](/blog/distributed-throttle-with-redis-kv) — the same seam, a Node backend
+-   [Choosing an HTTP adapter](/blog/choosing-an-http-adapter) and [adopting StitchAPI without a rewrite](/blog/adopt-stitchapi-without-a-rewrite)

--- a/apps/docs/content/blog/typed-errors-without-try-catch.mdx
+++ b/apps/docs/content/blog/typed-errors-without-try-catch.mdx
@@ -1,0 +1,123 @@
+---
+title: 'Typed Errors Without try/catch'
+description: 'A thrown error is typed `unknown`, so every catch block re-narrows before it can read a status. Call a stitch with .safe() and branch on a discriminated union where the failure arm is already a StitchError.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [typescript, error-handling, validation, safe-result, stitcherror]
+---
+
+You write a loader that fetches a user, and the failure path is a `try/catch` whose `catch (err)` binds `err` as `unknown`. To read the HTTP status you re-narrow — `if (err instanceof StitchError)` — every single time, in every loader, because TypeScript cannot prove what `throw` threw. The happy path and the failure path live on opposite sides of a control-flow wall, and the type system has lost track of the error before you ever touch it.
+
+A stitch gives you the other shape. Awaiting a stitch throws on failure — the contract a `queryFn` wants — but calling it with `.safe()` resolves to a discriminated union instead, where the failure arm is already a `StitchError` and the success arm is already your validated type. You branch on a boolean; the compiler narrows both arms for you.
+
+## The `unknown` you keep re-narrowing
+
+Here is the honest "before" — fetch, a hand-written status check, and a `catch` that has to reconstruct what it caught:
+
+```ts
+async function loadUser(id: string) {
+    try {
+        const res = await fetch(`https://api.example.com/users/${id}`);
+        if (!res.ok) {
+            throw new StitchError('getUser failed', { status: res.status });
+        }
+        const user = (await res.json()) as User; // unchecked cast
+        return { heading: user.name };
+    } catch (err) {
+        // err: unknown — narrow before you can read .status
+        if (err instanceof StitchError && err.status === 404) {
+            return { error: 'No such user' };
+        }
+        return { error: 'Something went wrong' };
+    }
+}
+```
+
+Three sharp edges, all real. The `catch` parameter is `unknown` (TypeScript has typed it that way since 4.4), so the first thing every handler does is re-prove the error's shape before it can branch on a status. The success value is an unchecked `as User` cast — the JSON could be anything and the compiler believes you. And the two outcomes straddle a `try`/`catch` boundary, so the control flow that produced the value and the control flow that handles its failure never meet in one expression.
+
+## `.safe()` returns a union, not a throw
+
+Declare the call as a stitch with an `output` schema, then call it with `.safe()`. The result is a `SafeResult<T>` you branch on — no `try`, no `catch`, no re-narrowing:
+
+```ts
+import { stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const User = z.object({ id: z.string(), name: z.string() });
+
+const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    output: User,
+});
+
+async function loadUser(id: string) {
+    const result = await getUser.safe({ params: { id } });
+
+    if (!result.ok) {
+        // result.error: StitchError — already narrowed, .status is here
+        if (result.error.status === 404) return { error: 'No such user' };
+        return { error: 'Something went wrong' };
+    }
+
+    // result.data: User — validated, not cast
+    return { heading: result.data.name };
+}
+```
+
+`.safe()` never throws. It resolves to a value whose `ok` flag the compiler uses to narrow both arms: in the `!result.ok` branch `result.error` is a `StitchError` with `.status` in reach and no `instanceof` guard; in the other branch `result.data` is a `User` that the `output` schema actually validated, not an `as` cast you hoped was right. The status check that needed a re-narrow before now reads straight off the failure arm.
+
+## The shape of the union
+
+`SafeResult<T>` is a discriminated union, and every member carries all four fields so the discriminant is exhaustive on both arms:
+
+```ts
+type SafeResult<T> =
+    | { ok: true; data: T; error: null }
+    | { ok: false; data: null; error: StitchError };
+```
+
+Branch on `ok` (or check `error === null`) and the union collapses to one arm. The `StitchError` on the failure side is the same error `await` would have thrown, populated on the `.safe()` path: `.status` (the HTTP status, or `undefined` for a transport or internal error), `.attempts` (tries made before giving up — `1` means no retry fired), `.body` (the parsed error payload, an API's `{ error: "..." }`), and `.url` (the final request URL). That error is built after the stitch exhausts its own `retry` policy, so a `404` on the failure arm is a settled `404`, not a transient blip the stitch would have retried.
+
+## The two extra doors
+
+`.safe()` is one of four ways to consume the same single run. The stitch executes once; `then`, `catch`, `finally`, and `safe` all share that run rather than firing it again:
+
+```ts
+const user = await getUser({ params: { id } }); // throws StitchError on failure
+const safe = await getUser.safe({ params: { id } }); // { ok, data, error }, never throws
+const user2 = await getUser.unwrap({ params: { id } }); // the throwing twin of .safe()
+const user3 = await getUser({ params: { id } }).catch((err) => fallbackUser); // err: unknown
+```
+
+`.unwrap()` is the explicit spelling of the bare `await` — it throws, same as awaiting the stitch directly. `.catch()` mirrors `Promise.catch`: its handler parameter is typed `unknown`, exactly like a `try/catch` binding, so reading `.status` inside it still costs you an `instanceof StitchError` narrow. That is the contrast worth naming: `.catch()` keeps the `unknown` and the re-narrow; `.safe()` is the door that hands you the union with the error already typed. Reach for the throwing call where a throw _is_ the contract — a TanStack Query `queryFn`, which wants a rejected promise — and for `.safe()` where you would rather branch than catch.
+
+The split between the two:
+
+| Axis              | `await` / `.unwrap()`                 | `.safe()`                        |
+| ----------------- | ------------------------------------- | -------------------------------- |
+| On failure        | throws a `StitchError`                | resolves `{ ok: false, error }`  |
+| Error type at use | `unknown` until you narrow            | `StitchError` on the failure arm |
+| Success value     | the validated `T`                     | `data: T` on the success arm     |
+| Where it fits     | a `queryFn`, a throw-is-contract path | a loader, a server action        |
+
+## Branch where the call is, not in a catch
+
+A `try/catch` puts the failure handler in a different block from the call, and TypeScript forgets the error's type on the way across. `.safe()` keeps both outcomes in one expression: the call returns a value, you branch on `.ok`, and each arm is already narrowed — the failure arm to `StitchError`, the success arm to the schema-validated `T`. There is no separate code path to keep in sync and no `unknown` to re-prove.
+
+The same stitch serves both shapes from one declaration. Where a throw is the contract you `await` it; where a branch reads cleaner you call `.safe()`; the run underneath is the same, and so are the `output` validation, the `auth`, and the `retry` that settled the status before it reached you. Add the next endpoint and it is the same `output` schema and the same two doors — no per-call error plumbing to grow.
+
+## Try it
+
+Install the core package. `stitch`, `StitchError`, and the `SafeResult` shape all live in the main `stitchapi` entry.
+
+```package-install
+stitchapi
+```
+
+Then call `.safe()` for the union, or `await` (or `.unwrap()`) where a throw is the contract.
+
+-   [The stitch](/docs/concepts/the-stitch)
+-   [Validation](/docs/guides/validation/validation)
+-   [Retry](/docs/guides/resilience/retry)
+-   [A stitch is a React Query `queryFn`](/blog/stitch-as-react-query-queryfn)


### PR DESCRIPTION
## What

Batch 4 of the comprehensive blog-coverage push:

| Post | Owns |
|---|---|
| [typed-errors-without-try-catch](apps/docs/content/blog/typed-errors-without-try-catch.mdx) | `.safe()` returns a discriminated `SafeResult` union (failure arm is already a `StitchError`) vs a `try/catch` that binds `unknown`; `await`/`.unwrap()` throw where a throw is the contract. |
| [run-a-stitch-on-the-edge](apps/docs/content/blog/run-a-stitch-on-the-edge.mdx) | Core is Web-API only / zero `node:`, so a stitch runs unchanged on Cloudflare Workers and Deno; `cloudflareKvStore()` makes the cache + auth jar fleet-wide across isolates — no call-site change, no `@cloudflare/workers-types` (structural `KVNamespaceLike`). |
| [call-any-llm-as-a-typed-function](apps/docs/content/blog/call-any-llm-as-a-typed-function.mdx) | `llm()` makes a chat completion a typed function; `anthropic`/`openai` are plain config (no SDK), the provider swaps in a line, auth/retry/throttle apply. Buffered today (states plainly: no token streaming yet). |

Follows Batches 1–3 ([#355](https://github.com/rejifald/StitchAPI/pull/355), [#356](https://github.com/rejifald/StitchAPI/pull/356), [#357](https://github.com/rejifald/StitchAPI/pull/357)), all merged.

## Verification

- Drafted → adversarially fact-checked → revised. The fact-checker confirmed the LLM post does **not** claim token streaming, and caught two real errors, both fixed: an invalid `cookieSession({ login: '/path', credentials })` shape (→ a real `login` stitch + `cookie: 'session'`), and a `bearer`/`x-api-key` lede mismatch. Also aligned the edge snippet to `KVNamespaceLike`.
- Editorial pass (3 finders): EDITORIAL.md + links/frontmatter/structure clean.
- `prettier` clean; pre-commit gate (`format` + full `typecheck` incl. `fumadocs-mdx` + `next typegen`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)