### PR TITLE
docs(blog): establish inline interlinking pattern + no-orphans gate

### DIFF
--- a/apps/docs/AUTHORING.md
+++ b/apps/docs/AUTHORING.md
@@ -53,6 +53,11 @@ subfolders (`authoring`, `auth`, `resilience`, `data`, `validation`,
 one focused `llms.mdx` per feature, so an agent pulls just the `cookieSession`
 page into context, not the whole auth manual.
 
+The **blog** (`content/blog`, served at `/blog`) is a **separate collection** with
+its own rules — flat files, dated frontmatter, prose-first, and its own
+interlinking convention. See [Blog posts](#blog-posts). Everything above this
+line is about the `content/docs` tree.
+
 ---
 
 ## The four templates
@@ -538,6 +543,70 @@ Errors & pitfalls is keyed to a registry of stable codes (`STITCH_VALIDATION`,
     new page and redirect the old one.
 -   The registry of codes will live in `packages/core` and be the shared source of
     truth for both the runtime (which throws the code + url) and these pages.
+
+---
+
+## Blog posts
+
+The blog (`content/blog`, served at `/blog`) is a separate fumadocs collection
+from the docs tree — flat `.mdx` files, no `content.manifest.ts`, no `meta.json`,
+no IA drift guard. A post is a dated essay aimed at a search query or a
+positioning argument, not a reference page. Most docs rules above (Twoslash,
+neutral naming, the canonical roster, anti-patterns inline) still apply; the
+differences are below.
+
+**Frontmatter.** Posts add `author`, `date` (an ISO `YYYY-MM-DD` string, quoted),
+and an optional `tags` array, on top of the mandatory `title` + `description`.
+The schema lives in `source.config.ts` (the `blog` collection).
+
+```yaml
+---
+title: 'How to Retry a Failed Fetch in TypeScript (the Right Way)'
+description: A real, search-shaped sentence — the meta description and the agent's relevance signal.
+author: Oleksandr Zhuravlov
+date: '2026-06-28'
+tags: [retry, fetch, typescript, resilience, http]
+---
+```
+
+`tags` are not decorative: the "Related reading" footer under every post is
+generated from tag overlap (`getRelatedPosts` in `lib/blog.ts`). Tag honestly —
+share a tag with the posts a reader of this one should see next.
+
+**Interlink in prose — this is the rule the product sells, applied to the blog.**
+Every post must link to **sibling posts inline**, in the sentence where the
+related idea comes up, with a descriptive anchor — never a bare "click here" and
+never a detached "further reading" dump as the only connection. The automated
+footer is a safety net, not a substitute: it catches the post a reader lands on,
+but inline links are what carry a reader _mid-argument_ to the post that goes
+deeper.
+
+-   **Link down to docs** for the canonical mechanism — the primitive, the guide,
+    the reference, the error. `[the stitch](/docs/concepts/the-stitch)`.
+-   **Link across to sibling posts** for the adjacent argument or the next step —
+    `([schema drift is a production bug](/blog/schema-drift-is-a-production-bug))`.
+-   **Anchor on the idea, not the URL.** The link text reads as part of the
+    sentence: _"…shares one limiter across every stitch hitting that host
+    ([proactive throttling beats reacting to 429s](/blog/proactive-throttling-vs-reactive-429s))."_
+
+A good post threads two-to-four such links through its body and closes by pointing
+at the obvious next read. A post that links to **no** sibling post fails
+`test/blog-interlinking.spec.ts` (the no-orphans gate) — the same way a docs page
+without `See also` strands its reader. Dangling `/blog/<slug>` links fail it too.
+
+**Writing a new post — the interlinking checklist:**
+
+1. Before drafting, skim `content/blog` for the two or three posts nearest your
+   topic. Those are your inbound and outbound links.
+2. As you write, link each sibling post **at the point its idea appears**, not in
+   a trailer.
+3. Add an inline link **back from** at least one of those existing posts to the
+   new one, so the new post isn't a dead end others can't reach. (The footer
+   surfaces it automatically once tags overlap, but an inbound prose link is
+   stronger.)
+4. Give the post `tags` that overlap its true neighbors so the "Related reading"
+   footer resolves to the right posts.
+5. Run `pnpm test` in `apps/docs` — the no-orphans gate must stay green.
 
 ---
 

--- a/apps/docs/app/(home)/blog/[slug]/page.tsx
+++ b/apps/docs/app/(home)/blog/[slug]/page.tsx
@@ -1,5 +1,10 @@
 import { getMDXComponents } from '@/components/mdx';
-import { blogSource, formatPostDate } from '@/lib/blog';
+import {
+    blogSource,
+    formatPostDate,
+    getRelatedPosts,
+    postSlug,
+} from '@/lib/blog';
 import { appName, siteUrl } from '@/lib/shared';
 
 import { DocsBody } from 'fumadocs-ui/layouts/docs/page';
@@ -13,6 +18,7 @@ export default async function BlogPostPage(props: PageProps<'/blog/[slug]'>) {
     if (!post) notFound();
 
     const MDX = post.data.body;
+    const related = getRelatedPosts(post);
 
     return (
         <main className="container mx-auto max-w-3xl px-4 py-16">
@@ -39,6 +45,36 @@ export default async function BlogPostPage(props: PageProps<'/blog/[slug]'>) {
                     <MDX components={getMDXComponents()} />
                 </DocsBody>
             </article>
+
+            {related.length > 0 ? (
+                <aside
+                    aria-label="Related posts"
+                    className="border-fd-border mt-16 border-t pt-10"
+                >
+                    <h2 className="mb-6 text-sm font-semibold tracking-wide uppercase">
+                        Related reading
+                    </h2>
+                    <ul className="flex flex-col gap-6">
+                        {related.map((other) => (
+                            <li key={other.url}>
+                                <Link
+                                    href={`/blog/${postSlug(other)}`}
+                                    className="group block"
+                                >
+                                    <h3 className="group-hover:text-fd-primary text-lg font-medium tracking-tight transition-colors">
+                                        {other.data.title}
+                                    </h3>
+                                    {other.data.description ? (
+                                        <p className="text-fd-muted-foreground mt-1 text-sm">
+                                            {other.data.description}
+                                        </p>
+                                    ) : null}
+                                </Link>
+                            </li>
+                        ))}
+                    </ul>
+                </aside>
+            ) : null}
         </main>
     );
 }

--- a/apps/docs/content/blog/adopt-stitchapi-without-a-rewrite.mdx
+++ b/apps/docs/content/blog/adopt-stitchapi-without-a-rewrite.mdx
@@ -72,9 +72,9 @@ const user = await getUserViaFetch(id);
 const user = await getUser({ params: { id } });
 ```
 
-The rest of the file keeps using raw `fetch`. The other twenty endpoints keep using whatever they use today. There is no provider to mount, no client to thread through props, no global to initialize before the first call works. One endpoint becomes typed and resilient; everything around it is untouched.
+The rest of the file keeps using raw `fetch`. The other twenty endpoints keep using whatever they use today. There is no provider to mount, no client to thread through props, no global to initialize before the first call works. One endpoint becomes typed and resilient; everything around it is untouched. When you _do_ want to convert a whole module wholesale, the mechanical swap goes end to end in [migrating from fetch](/blog/migrate-from-fetch-to-stitchapi) and [from axios](/blog/migrate-from-axios-to-stitchapi).
 
-It drops into the libraries you already run, too. A stitch is the `queryFn` TanStack Query wants — awaiting it returns the validated value and throws on failure, which is exactly the contract — so it goes straight in:
+It drops into the libraries you already run, too. A stitch is the `queryFn` TanStack Query wants — awaiting it returns the validated value and throws on failure, which is exactly the contract ([a stitch as your React Query `queryFn`](/blog/stitch-as-react-query-queryfn) walks through the whole pattern) — so it goes straight in:
 
 ```ts
 useQuery({

--- a/apps/docs/content/blog/auth-as-a-capability-not-a-credential.mdx
+++ b/apps/docs/content/blog/auth-as-a-capability-not-a-credential.mdx
@@ -93,9 +93,9 @@ The username and password live in the environment, get read at call time, and pa
 
 ## The same secret behind all four front doors
 
-A stitch is reachable four ways — an in-process **function**, the **CLI** (`stitch run`), an **HTTP** endpoint (`stitch serve`), and an **MCP** tool (`stitch mcp`). Auth lives on the definition, so the boundary holds identically across all four. The human running `stitch run get-user --id 7` from a terminal and the agent calling the `get_user` MCP tool are both invoking the same capability, and neither one is handed the credential.
+A stitch is reachable four ways — an in-process **function**, the **CLI** (`stitch run`), an **HTTP** endpoint (`stitch serve`), and an **MCP** tool (`stitch mcp`) — [one definition behind four front doors](/blog/one-definition-four-front-doors). Auth lives on the definition, so the boundary holds identically across all four. The human running `stitch run get-user --id 7` from a terminal and the agent calling the `get_user` MCP tool are both invoking the same capability, and neither one is handed the credential.
 
-That property is what makes the MCP door safe to open. Exposing an endpoint to an agent _normally_ means exposing whatever authorizes it. Here, the MCP tool is the capability; the secret stays in the host process behind the seam. StitchAPI's code-mode goes further — an agent drives a single `run_stitch` tool by writing a small snippet that calls stitches by name, so it composes capabilities without ever seeing, or needing, the keys behind them.
+That property is what makes the MCP door safe to open. Exposing an endpoint to an agent _normally_ means exposing whatever authorizes it. Here, the MCP tool is the capability; the secret stays in the host process behind the seam. StitchAPI's code-mode goes further — an agent drives a single `run_stitch` tool by writing a small snippet that calls stitches by name, so it composes capabilities without ever seeing, or needing, the keys behind them ([code-mode vs. one tool per call](/blog/code-mode-vs-tool-calling) weighs the two approaches).
 
 ## Honest caveats
 

--- a/apps/docs/content/blog/distributed-throttle-with-redis-kv.mdx
+++ b/apps/docs/content/blog/distributed-throttle-with-redis-kv.mdx
@@ -6,7 +6,7 @@ date: '2026-05-07'
 tags: [throttle, sessions, distributed, edge, stores]
 ---
 
-You set a throttle on a stitch — say two requests a second to a metered upstream — and on your laptop it behaves exactly as declared. Then you deploy three instances behind a load balancer, or your handler runs as a serverless function that scales to a dozen concurrent isolates, and the upstream starts handing you `429`s you can't explain. The math is the problem: three processes each enforcing two-per-second is six-per-second at the wall. Your real upstream rate is N times your cap, where N is however many copies of your code happen to be running right now.
+You set a throttle on a stitch — say two requests a second to a metered upstream, a [proactive limiter that keeps you under the cap before the 429s arrive](/blog/proactive-throttling-vs-reactive-429s) — and on your laptop it behaves exactly as declared. Then you deploy three instances behind a load balancer, or your handler runs as a serverless function that scales to a dozen concurrent isolates, and the upstream starts handing you `429`s you can't explain. The math is the problem: three processes each enforcing two-per-second is six-per-second at the wall. Your real upstream rate is N times your cap, where N is however many copies of your code happen to be running right now.
 
 The throttle isn't broken. It's doing precisely what it was told — for one process. The default state lives in memory, and memory isn't shared across instances.
 

--- a/apps/docs/content/blog/schema-drift-is-a-production-bug.mdx
+++ b/apps/docs/content/blog/schema-drift-is-a-production-bug.mdx
@@ -8,7 +8,7 @@ tags: [reliability, drift, validation, types, observability]
 
 A provider you depend on renames `total` to `total_amount`, or turns a number into a string, or starts returning `null` where it never did before. Nobody told you. Your build is green. Your tests are green. The deploy goes out. And then, hours later, a chart renders `NaN`, an order total comes out `undefined`, and a pager goes off — for a code path you didn't touch.
 
-This is schema drift, and it's a peculiarly nasty class of bug because every guardrail you'd expect to catch it was looking the wrong way. The change happened on a machine you don't own, to a contract you only assumed. The first runtime that sees the new shape is production.
+This is schema drift ([what schema drift is, exactly](/blog/what-is-schema-drift), if the term is new), and it's a peculiarly nasty class of bug because every guardrail you'd expect to catch it was looking the wrong way. The change happened on a machine you don't own, to a contract you only assumed. The first runtime that sees the new shape is production.
 
 ## Why types don't save you here
 
@@ -22,7 +22,7 @@ So the breakage slips through the net by construction. Types check source agains
 
 ## Make the silent change loud
 
-The fix isn't more types or more mocks. It's to check the response you actually receive against a contract, on the calls you actually make, and route any difference as a signal. And you already have the contract — it's the schema you declared. There is nothing extra to maintain.
+The fix isn't more types or more mocks. It's to [validate the response you actually receive](/blog/validate-api-response-zod) against a contract, on the calls you actually make, and route any difference as a signal. And you already have the contract — it's the schema you declared. There is nothing extra to maintain.
 
 StitchAPI does this with **schema-anchored drift detection**. You wrap a stitch's `output` schema in `drift()`, and every live response is checked against that schema in two tiers:
 

--- a/apps/docs/content/blog/typescript-pagination.mdx
+++ b/apps/docs/content/blog/typescript-pagination.mdx
@@ -38,7 +38,7 @@ async function fetchAllUsers(): Promise<unknown[]> {
 
 An offset or page-number API is the same loop with a counter instead of a cursor — bump `page` until a short page (or an empty one) tells you to stop. For one well-behaved endpoint, this is fine; the logic is small and you can read it.
 
-The fragility shows up under real conditions. The loop fires requests back to back with nothing pacing them, so a rate-limited API answers page seven with a `429` and the whole run throws. Add retry and you're wrapping the `fetch` in backoff code, then a throttle to stay under the limit, then a guard so a misbehaving `nextCursor` can't loop forever — and all of it is now tangled into the pagination loop, re-written for the next paginated endpoint you hit.
+The fragility shows up under real conditions. The loop fires requests back to back with nothing pacing them, so a rate-limited API answers page seven with a `429` and the whole run throws. Add retry and you're wrapping the `fetch` in backoff code, then a throttle to stay under the limit, then a guard so a misbehaving `nextCursor` can't loop forever — and all of it is now tangled into the pagination loop, re-written for the next paginated endpoint you hit. These are the same fixes one endpoint up: [retrying a failed fetch the right way](/blog/retry-fetch-in-typescript) and [rate-limiting your calls in TypeScript](/blog/rate-limit-api-calls-typescript).
 
 ## The stitch way: declare next and items, await once
 

--- a/apps/docs/lib/blog.ts
+++ b/apps/docs/lib/blog.ts
@@ -39,3 +39,34 @@ export function formatPostDate(date: string): string {
         timeZone: 'UTC',
     });
 }
+
+/**
+ * The automated half of the blog's interlinking (see AUTHORING.md → "Blog
+ * posts"). Inline contextual links are the author's job; this is the safety net
+ * that keeps every post connected even when the prose forgets — ranked by shared
+ * `tags`, newest breaking ties, so a post is never an island.
+ *
+ * Returns up to `limit` other posts sharing at least one tag with `post`. Posts
+ * with more tags in common rank higher; among equal overlap the newer post wins.
+ */
+export function getRelatedPosts(post: BlogPost, limit = 3): BlogPost[] {
+    const tags = new Set(post.data.tags ?? []);
+    if (tags.size === 0) return [];
+
+    return (
+        getSortedPosts()
+            .filter((candidate) => postSlug(candidate) !== postSlug(post))
+            .map((candidate) => ({
+                candidate,
+                overlap: (candidate.data.tags ?? []).filter((tag) =>
+                    tags.has(tag),
+                ).length,
+            }))
+            .filter(({ overlap }) => overlap > 0)
+            // `getSortedPosts` is already newest-first, so a stable sort on overlap
+            // alone keeps date as the tie-breaker.
+            .sort((a, b) => b.overlap - a.overlap)
+            .slice(0, limit)
+            .map(({ candidate }) => candidate)
+    );
+}

--- a/apps/docs/test/blog-interlinking.spec.ts
+++ b/apps/docs/test/blog-interlinking.spec.ts
@@ -1,0 +1,70 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { basename, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// The enforcement half of the blog's interlinking convention (AUTHORING.md →
+// "Blog posts"). The house style is that every post links to sibling posts in
+// prose; the automated `getRelatedPosts` footer is only a safety net. These
+// tests fail the moment a post is authored as an island so the network can't
+// silently rot — the same role `content-manifest.spec.ts` plays for the docs IA.
+
+const DOCS_ROOT = resolve(fileURLToPath(import.meta.url), '..', '..');
+const BLOG = resolve(DOCS_ROOT, 'content', 'blog');
+
+/** Map of slug → raw post body, for every `.mdx` post under `content/blog`. */
+function readPosts(): Map<string, string> {
+    const posts = new Map<string, string>();
+    for (const entry of readdirSync(BLOG, { withFileTypes: true })) {
+        if (!entry.isFile() || !entry.name.endsWith('.mdx')) continue;
+        const slug = basename(entry.name, '.mdx');
+        posts.set(slug, readFileSync(join(BLOG, entry.name), 'utf8'));
+    }
+    return posts;
+}
+
+/** Every `/blog/<slug>` reference in `body`, excluding self-links. */
+function blogLinksIn(body: string, selfSlug: string): string[] {
+    const slugs = new Set<string>();
+    for (const match of body.matchAll(/\/blog\/([a-z0-9-]+)/g)) {
+        const slug = match[1];
+        if (slug && slug !== selfSlug) slugs.add(slug);
+    }
+    return [...slugs];
+}
+
+const posts = readPosts();
+const slugs = new Set(posts.keys());
+
+describe('blog interlinking', () => {
+    it('has posts to check', () => {
+        expect(posts.size).toBeGreaterThan(0);
+    });
+
+    it('every post links to at least one sibling post (no orphans)', () => {
+        const orphans = [...posts]
+            .filter(([slug, body]) => blogLinksIn(body, slug).length === 0)
+            .map(([slug]) => slug);
+
+        expect(
+            orphans,
+            `These posts link to no sibling post. Add an inline contextual ` +
+                `link to a related /blog/<slug> post (see AUTHORING.md → ` +
+                `"Blog posts"):\n  ${orphans.join('\n  ')}`,
+        ).toEqual([]);
+    });
+
+    it('every cross-link points at a real post (no dangling links)', () => {
+        const dangling: string[] = [];
+        for (const [slug, body] of posts) {
+            for (const target of blogLinksIn(body, slug)) {
+                if (!slugs.has(target)) dangling.push(`${slug} → ${target}`);
+            }
+        }
+
+        expect(
+            dangling,
+            `These cross-links point at a /blog/ slug that does not exist:\n  ${dangling.join('\n  ')}`,
+        ).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Why

The blog posts were *mostly* cross-linked inline already (26/31 posts, 43 links) but the convention was **undocumented and unenforced** — 5 posts were orphans and nothing stopped the next one from being one. This turns the existing good behavior into a real pattern, in three layers.

## What

**1. The nudge for agents — a written rule.** A new `## Blog posts` section in `apps/docs/AUTHORING.md` (which agents read before authoring) names the in-prose linking style as a rule — *anchor on the idea, link siblings at the point their idea appears, not a trailer* — with worked examples and a 5-step "writing a new post" interlinking checklist. A pointer in the IA section makes the blog visible in that doc for the first time.

**2. The safety net — automated "Related reading" footer.** `getRelatedPosts()` in `apps/docs/lib/blog.ts` ranks other posts by `tags` overlap (newest breaks ties); the post page renders them in an `<aside>`. Every post is now connected automatically, so inline links are a quality bonus rather than the only thing preventing isolation.

**3. The gate — a CI test.** `apps/docs/test/blog-interlinking.spec.ts` fails on any post with **zero** sibling links (no orphans) or any **dangling** `/blog/` link — the same role `content-manifest.spec.ts` plays for the docs IA.

**4. Backfill.** Added natural mid-prose sibling links to the 5 orphan posts (adopt-without-a-rewrite, auth-as-a-capability, distributed-throttle, schema-drift, typescript-pagination) so the gate is green.

## Verification

- `apps/docs` vitest suite 18/18 green (3 new interlinking assertions).
- Full pre-push gate passed: format, lint, typecheck, types-d, test, exports, build-docs.
- Footer confirmed live in the dev server — the drift post's footer leads with *"What Is Schema Drift?"*, the correct tag-ranked neighbor; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)