### PR TITLE
docs(blog): OpenAPI-export, non-JSON, and pipeline posts

### DIFF
--- a/apps/docs/content/blog/compose-api-calls-into-a-pipeline.mdx
+++ b/apps/docs/content/blog/compose-api-calls-into-a-pipeline.mdx
@@ -1,0 +1,160 @@
+---
+title: 'Compose API Calls Into One Typed Pipeline'
+description: 'Chaining API calls in TypeScript usually means a ladder of awaits with hand-rolled error handling and nothing tying the steps together. pipe() declares the chain: each step feeds the next, it fails fast, and a trace shows the whole sequence.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [pipeline, composition, pipe, typescript, orchestration]
+---
+
+You need a user, then that user's posts, then each post enriched with its author's name. Three calls, in order, where each one needs the result of the one before it. In most TypeScript codebases this becomes a stack of `await`s glued together with `try/catch`, and when one of them fails at 2am you get a stack trace pointing at a single line with no record of what ran first.
+
+`pipe()` declares that chain as one value. Each step feeds the next, a failure anywhere rejects the whole thing, and a trace shows `fetchUser → fetchPosts` as connected steps instead of three unrelated calls.
+
+## The honest before
+
+Here is the real multi-step flow, written by hand. It works. It is also where every project quietly accumulates scar tissue.
+
+```ts
+async function getUserPosts(id: number) {
+    let user;
+    try {
+        const res = await fetch(`https://api.example.com/users/${id}`);
+        if (!res.ok) throw new Error(`user ${id}: ${res.status}`);
+        user = await res.json();
+    } catch (err) {
+        // retry? log? rethrow? every call site decides again
+        throw err;
+    }
+
+    let posts;
+    try {
+        const res = await fetch(
+            `https://api.example.com/posts?userId=${user.id}`,
+        );
+        if (!res.ok) throw new Error(`posts: ${res.status}`);
+        posts = await res.json();
+    } catch (err) {
+        throw err;
+    }
+
+    return posts;
+}
+```
+
+The sharp edges, named:
+
+-   **Each step re-implements error handling.** Two `try/catch` blocks, two status checks, two ways to phrase the same failure. The third step would add a third.
+-   **Nothing ties the steps together.** When `fetchPosts` fails, the log shows a posts request. It does not show that a user fetch ran first, succeeded, and produced the `userId` that the failed call used. You reconstruct the sequence by hand.
+-   **No types.** `user` is `any`, `user.id` is `any`, `posts` is `any`. A typo in `user.id` surfaces as `undefined` in a query string, not a compile error.
+-   **Resilience is missing or copy-pasted.** Want a retry on the user call? Wrap it in a loop. Want a timeout? Race it against a `setTimeout`. Now do it again for posts.
+
+## The pipeline version
+
+Declare each call once as a stitch — a typed, validated, resilient function over one endpoint — then state the order.
+
+```ts
+import { stitch } from 'stitchapi';
+import { pipe } from 'stitchapi/pipe';
+import { z } from 'zod';
+
+const User = z.object({ id: z.number(), name: z.string() });
+type User = z.infer<typeof User>;
+const Posts = z.array(z.object({ id: z.number(), title: z.string() }));
+type Posts = z.infer<typeof Posts>;
+
+const fetchUser = stitch({
+    url: 'https://api.example.com/users/{id}',
+    output: User,
+    retry: 3,
+    timeout: '5s',
+});
+
+const fetchPosts = stitch({
+    url: 'https://api.example.com/posts',
+    output: Posts,
+    retry: 3,
+});
+
+const userPosts = pipe(
+    fetchUser, // receives the pipe's input
+    {
+        stitch: fetchPosts,
+        input: (u) => ({ query: { userId: (u as User).id } }),
+    },
+);
+
+const posts = await userPosts({ params: { id: 1 } });
+```
+
+What each piece does:
+
+-   `pipe(...steps)` returns a callable, `(input?) => Promise<Out>`. You `await` it like any function. It resolves to the **last** step's result.
+-   A **step** is either a bare stitch or a `{ stitch, input }` object. The `input` function maps the previous result into the next call's input.
+-   The **first step** receives the pipe's own input — `{ params: { id: 1 } }` lands on `fetchUser`.
+-   The **second step** runs `input(u)` over the user that `fetchUser` returned, building `{ query: { userId: (u as User).id } }` for `fetchPosts`. The mapper receives the previous result as `unknown`, so you cast it to the shape you already declared — `u as User` — and because `fetchUser` validated that response against the `User` schema at runtime, the value behind the cast really is a `User`, not the unchecked `any` a raw `res.json()` hands back.
+-   Omit `input` and the previous result is passed as the next call's `body`. Useful when one step's output is literally the next step's request payload.
+
+The two `try/catch` blocks are gone, and so is the status checking, the manual rethrow, and the untyped intermediate values. Each stitch carries its own `retry`, `timeout`, `output` validation, and `auth` — written once, at the declaration, not re-derived at every call site.
+
+## Sequential and fail-fast — by contract, not by convention
+
+`pipe()` runs its steps **in sequence, not in parallel.** Step N+1 cannot start until step N resolves, because step N+1's input is computed _from_ step N's result. That is the whole point of a dependent chain.
+
+It also **fails fast, not best-effort.** A stitch throws `StitchError` once it exhausts its own retries; inside a pipe, that error rejects the entire pipeline. No later step runs, and the rejection carries the failing call's `.status`, `.attempts`, `.body`, and `.url`. You handle one failure at the boundary instead of one per step:
+
+```ts
+try {
+    const posts = await userPosts({ params: { id: 1 } });
+} catch (err) {
+    // err is the StitchError from whichever step failed —
+    // with .status, .attempts, .body, .url already attached
+}
+```
+
+The retry that fires here is the stitch's own status-aware retry — it backs off, honors `Retry-After`, and only re-sends safe calls. The pipe does not add a second retry layer on top; each step owns its resilience and the pipe owns the ordering.
+
+## The chain shows up in the trace
+
+The detail that pays off in production: each step runs as a **child run of the previous one** (the run-identity model behind StitchAPI's [event stream](/docs/concepts/event-stream)). A hand-written ladder of `await`s produces three unrelated calls in your logs. A pipe produces one connected sequence.
+
+| Axis                | Ladder of awaits         | A pipeline                                                        |
+| ------------------- | ------------------------ | ----------------------------------------------------------------- |
+| Order               | implicit in code flow    | declared as ordered steps                                         |
+| Error handling      | one `try/catch` per call | one rejection at the boundary                                     |
+| Intermediate values | unchecked `any`          | runtime-validated against each step's `output`, cast to that type |
+| Trace identity      | three unrelated calls    | `fetchUser → fetchPosts`, one chain                               |
+| Resilience          | copy-pasted or absent    | each step keeps its own retry/timeout/auth                        |
+
+So when posts come back wrong, the trace (and the playground's call-graph DAG) shows the user fetch that ran first, the value it produced, and the mapped input the posts call received. You read the sequence instead of reassembling it.
+
+The step-to-step `input` mapper is a closure — sugar, the same category as `transform` or `paginate.next`. The structure that round-trips is the **ordered list of member stitches.** The pipe composes stitches you already declared; it does not absorb them or change how any one of them behaves on its own.
+
+## Where the pipeline takes you
+
+`pipe()` bounds a flow exactly as tightly as you bound a single stitch. One call you `await`; a sequence of dependent calls is the same `await` over a value that happens to contain three. Adding a third enrichment step is one more entry in the list, not another `try/catch` block and another untyped variable:
+
+```ts
+const enriched = pipe(
+    fetchUser,
+    {
+        stitch: fetchPosts,
+        input: (u) => ({ query: { userId: (u as User).id } }),
+    },
+    {
+        stitch: fetchComments,
+        input: (p) => ({ query: { postId: (p as Posts)[0].id } }),
+    },
+);
+```
+
+Each stitch in the chain stays a standalone function you can call, test, or [expose through any front door](/blog/one-definition-four-front-doors) on its own. The pipe is the explicit, traced statement of how they run together — and it scales from two steps to ten without rewriting the ones you already have.
+
+## Try it
+
+```package-install
+stitchapi
+```
+
+`pipe` lives at the `stitchapi/pipe` subpath, so you only pull it into the bundle when a flow needs it. Each step is a [stitch](/docs/concepts/the-stitch) with its own [validation](/docs/guides/validation/validation), and the chain is visible in the [event stream](/docs/concepts/event-stream).
+
+Related reading: [Type-safe pagination](/blog/typescript-pagination), [one definition, four front doors](/blog/one-definition-four-front-doors), and [runtime stitching vs. workflow platforms](/blog/runtime-stitching-vs-workflow-platforms).

--- a/apps/docs/content/blog/export-stitches-to-openapi.mdx
+++ b/apps/docs/content/blog/export-stitches-to-openapi.mdx
@@ -1,0 +1,112 @@
+---
+title: Export Your Stitches to an OpenAPI Spec
+description: 'Codegen consumes an OpenAPI document to build a client. Run it the other way: emit an OpenAPI 3.1 spec from the stitches you already declared, so the teams and tools that still need a spec get one without the stitch stopping being the source of truth.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [openapi, codegen, cli, typescript, tooling]
+---
+
+Your stitches already describe the endpoints you call: the path, the method, the parameters, the auth. Then a downstream team — the API gateway, a partner's import wizard, the docs portal — asks for an OpenAPI document, and you are staring at hand-writing one that restates facts already living in your code. Keep them in sync by hand and they drift the day someone forgets.
+
+The `stitch` CLI runs codegen in reverse. Instead of consuming a spec to generate a client, it reads the stitches you wrote and emits an OpenAPI 3.1 document. The stitch stays the source of truth; the spec is a view of it.
+
+## The reverse of codegen
+
+A code generator points at an OpenAPI document and produces a typed client. That bets the spec is accurate and treats it as the origin of every type. A stitch makes the opposite bet — the response on the wire is the only thing you fully trust — so you declare the few endpoints you call and validate them at runtime.
+
+But the spec format does not disappear just because you stopped consuming it. Gateways ingest one, partners import one, a docs site renders one. So you emit it from the declarations instead of authoring it alongside them:
+
+```sh
+stitch export --openapi --module ./stitches.ts > openapi.json
+```
+
+That prints an OpenAPI 3.1 JSON document to stdout. `--module` points at the file that exports your stitches; it probes `stitches.ts` and friends by default. `--title` and `--api-version` set the `info` block.
+
+## What it derives from a declaration
+
+Take two stitches you would write anyway. `listOrders` declares its `status` query parameter where the export can see it — as an RFC 6570 `{?status}` template in the path, with an `input.query` schema describing the value:
+
+```ts
+import { stitch } from 'stitchapi';
+import { bearer, env } from 'stitchapi';
+import { z } from 'zod';
+
+export const getUser = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+    auth: bearer(env('API_TOKEN')),
+    output: z.object({ id: z.number(), name: z.string() }),
+});
+
+export const listOrders = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/orders{?status}',
+    input: { query: z.object({ status: z.string().optional() }) },
+    output: z.array(z.object({ id: z.number(), total: z.number() })),
+});
+```
+
+Run the export against that file and the structural pass fills in the parts of the spec it can read straight off the config, no extra wiring:
+
+-   **Paths and methods** — each export becomes a `paths` entry with its HTTP method and an `operationId`.
+-   **Path parameters** — every `{id}` slot in the path template becomes a required path parameter.
+-   **Query parameters** — every query-position expression in the path template becomes a query parameter: `/orders{?status}` emits `status`. An `input.query` schema refines those parameters, marking a name required when the schema requires it. (A path with no `{?...}` template and no `input.query` emits no query parameters — there is no top-level `query` config slot, because on a stitch `query` is the GraphQL query string.)
+-   **Security schemes** — each stitch's `auth` (`bearer`/`basic`/`apiKey`/`oauth2`) becomes a security scheme on the operation. The credential itself is never emitted.
+
+The pass is structural by design, so request and response **body** schemas are `{}` (any) by default. That keeps core zero-dependency: turning a `z.object({...})` into JSON Schema needs a converter, and a converter is a dependency.
+
+## Real body schemas, bring your own converter
+
+When you want the bodies and the per-parameter shapes filled in with real JSON Schema, pass a converter — the same bring-your-own seam `axiosAdapter` uses for the transport. You hand the export a `toJsonSchema(source, info)` function and it converts `input.body`, `output`, and the decomposed `params`/`query` schemas; without it those stay `{}`.
+
+```sh
+stitch export --openapi --module ./stitches.ts \
+  --schema-module ./to-json-schema.ts > openapi.json
+```
+
+The `--schema-module` file exports a `toJsonSchema(source, info)` converter — for Zod, a thin wrapper around `zod-to-json-schema`. Core never imports it; you bring the one that matches the validator you already chose.
+
+Prefer to do it in code? `toOpenApi` is the same machinery the CLI runs on:
+
+```ts
+import { getUser, listOrders } from './stitches';
+import { toJsonSchema } from './to-json-schema';
+
+import { toOpenApi } from 'stitchapi/registry';
+
+const { document, warnings } = toOpenApi(
+    { getUser, listOrders },
+    { title: 'Orders API', version: '1.0.0', toJsonSchema },
+);
+```
+
+The registry is a plain object mapping export names to stitches. `toOpenApi` is pure — it returns `{ document, warnings }` and reaches for nothing on disk — so you can write the document wherever you like or assert on it in a test.
+
+## A view, not a second source of truth
+
+| Axis                   | Hand-written spec                 | Exported from stitches                       |
+| ---------------------- | --------------------------------- | -------------------------------------------- |
+| Where the truth lives  | The spec, restated in code        | The stitch; the spec is generated            |
+| Drift between them     | Manual sync, silent when it slips | One command regenerates the view             |
+| Paths, methods, params | Typed by hand                     | Read off `path`/method/`input.query`         |
+| Auth                   | Documented separately             | Derived from each stitch's `auth`            |
+| Body schemas           | Authored twice                    | One `toJsonSchema` converter, your validator |
+
+This is not StitchAPI going spec-first. The stitch is still where the call is defined, validated, and made resilient; the OpenAPI document is a projection you regenerate whenever the declarations change. The teams that need a spec get one; you keep writing functions.
+
+## Where the spec takes you
+
+Wire the export into a commit hook or a CI step and the document tracks the stitches automatically — change a path or add an endpoint, regenerate, and the gateway or portal gets the new shape without anyone editing JSON by hand. Each stitch stays a standalone typed function you call, test, and run on its own; the spec is one more front door onto the same declarations, added with a single command and dropped when no downstream tool asks for it.
+
+## Try it
+
+The export ships in the core package and its CLI — no extra install beyond what a stitch already needs.
+
+```package-install
+stitchapi
+```
+
+-   [The CLI surface](/docs/surfaces/cli) — `run`, `serve`, `mcp`, `diagram`, and `export`.
+-   [What a stitch is](/docs/concepts/the-stitch) — the declaration the spec is generated from.
+-   [Stitching vs. codegen API clients](/blog/stitch-vs-codegen-api-clients) — the consume-a-spec direction, argued axis by axis.
+-   [Orval vs. runtime stitching](/blog/orval-vs-runtime-stitching) — where generating from a spec earns its keep.

--- a/apps/docs/content/blog/read-non-json-responses.mdx
+++ b/apps/docs/content/blog/read-non-json-responses.mdx
@@ -1,0 +1,174 @@
+---
+title: 'Read Non-JSON Responses With a Typed Stitch'
+description: 'CSV reports, HTML pages, PDFs, and zips do not fit a JSON client. A stitch reads them too: responseType picks the decode, transform reshapes the body, and an output schema validates the value you actually use.'
+author: Oleksandr Zhuravlov
+date: '2026-06-29'
+tags: [non-json, csv, html, responsetype, typescript]
+---
+
+The report endpoint returns CSV. The scraping target returns HTML. The files service hands back a PDF or a zip. Your client was built for JSON, so each of these becomes a one-off: a manual fetch, a `res.text()` here and a `res.arrayBuffer()` there, a parser bolted on, and a return type of `any` that lies to everyone downstream. A stitch reads those bodies too — `responseType` picks how the body is decoded, `transform` reshapes it, and an `output` schema validates the shape you actually use.
+
+## The honest before
+
+Here is a CSV report read by hand. The job is small, but the sharp edges are real:
+
+```ts
+async function getRevenueReport(month: string) {
+    for (let attempt = 0; attempt < 3; attempt++) {
+        const res = await fetch(
+            `https://api.example.com/reports/${month}.csv`,
+            {
+                headers: { authorization: `Bearer ${process.env.API_TOKEN}` },
+            },
+        );
+        if (res.status === 503) continue; // hope it works next time
+        const text = await res.text(); // res.json() would throw on a comma
+        return parseCsv(text); // returns... whatever parseCsv returns
+    }
+    throw new Error('report failed');
+}
+```
+
+Nothing here is wrong, but nothing here is reusable. You chose `res.text()` by hand because `res.json()` would have thrown on a comma. The return shape is whatever `parseCsv` happens to give you. A flaky gateway is your problem to handle, and the bearer token is captured in the closure. Every non-JSON endpoint in the codebase grows its own copy of this.
+
+## The stitch version
+
+The same job as a declaration. Each field replaces a piece of that glue:
+
+```ts
+import { bearer, env, stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const getRevenueReport = stitch({
+    url: 'https://api.example.com/reports/{month}.csv',
+    responseType: 'text', // decode the body as a string, not guessed JSON
+    transform: (raw) => parseCsv(raw as string), // your CSV parser
+    output: z.array(z.object({ sku: z.string(), revenue: z.number() })),
+    auth: bearer(env('API_TOKEN')),
+    retry: 3,
+});
+
+const rows = await getRevenueReport({ params: { month: '2026-06' } });
+// rows: { sku: string; revenue: number }[]
+```
+
+`responseType: 'text'` forces the body to be decoded as a string instead of guessed by content-type. `transform` runs your CSV parser over that raw string. `output` validates the parsed rows, so `rows` is fully typed and coerced — `revenue` is a number, not the string the CSV held. `auth` resolves the token at call time, so the caller never holds it. `retry: 3` makes a transient 503 the stitch's problem, not yours. The next CSV endpoint is another five-line declaration, not another copy of the hand-rolled fetch-and-parse block.
+
+## responseType: pick the decode, or let it pick
+
+`responseType` is one of four values, and the default is auto:
+
+-   **default (omitted)** — JSON when the content-type says so, else text. This is the right choice for ordinary JSON APIs; you never set it.
+-   **`'text'`** — force a string. Use it for HTML, CSV, or plain text, where content-type sniffing might guess wrong or the parser you want runs on the raw string.
+-   **`'arrayBuffer'`** — force bytes as an `ArrayBuffer`. Use it for binary: an image, a PDF, a zip.
+-   **`'blob'`** — force a `Blob`, the better shape when you hand bytes to a browser API.
+
+For binary you set `responseType` and skip `transform` if the bytes are the deliverable:
+
+```ts
+const invoicePdf = stitch({
+    url: 'https://api.example.com/invoices/{id}.pdf',
+    responseType: 'arrayBuffer',
+    auth: bearer(env('API_TOKEN')),
+});
+
+const bytes = await invoicePdf({ params: { id: 'inv_2026_06' } });
+// static type: unknown (no output schema); an ArrayBuffer at runtime
+```
+
+Output inference reads the `output` schema, never `responseType`, so a stitch with no `output` is `Stitch<unknown>` — the value is an `ArrayBuffer` at runtime, but the type system does not know that. Add an `output` validator or an explicit generic when you want the static type to say `ArrayBuffer`.
+
+Setting `responseType` is the difference between a body the engine guessed at and a body decoded the way the endpoint actually answers.
+
+## transform: reshape the raw body before validation
+
+`transform` runs on the raw decoded body, before the `output` schema sees it:
+
+```ts
+const fetchArticle = stitch({
+    url: 'https://example.com/articles/{slug}',
+    responseType: 'text', // an HTML string
+    transform: (html) => scrapeArticle(html as string), // your scraper -> object
+    output: z.object({
+        title: z.string(),
+        author: z.string(),
+        body: z.string(),
+    }),
+});
+
+const article = await fetchArticle({ params: { slug: 'stitching-apis' } });
+// article: { title: string; author: string; body: string }
+```
+
+It is the seam where you turn a non-JSON payload into the structured value your code wants — parse a CSV string into rows, scrape an HTML string into fields, decode bytes into a record. Pair it with `output` and the transformed shape is what gets validated and typed, not the raw string.
+
+The endpoint returns HTML. `responseType: 'text'` hands `transform` a string, your scraper turns it into an object, and `output` proves that object has the three fields you claimed. Downstream code sees a typed article, never a tag soup.
+
+## Parsing is bring-your-own — on purpose
+
+StitchAPI does not ship an HTML-to-Markdown converter or a CSV parser. That is a design choice, not a gap. The core is zero runtime dependencies, and bundling a parser would break two of the gates every feature passes: contract-not-dependency (you bring the converter, the core defines the seam) and bundle-frugal (a CSV library does not belong in everyone's bundle).
+
+So you call your own converter inside `transform`:
+
+```ts
+import { stitch } from 'stitchapi';
+import Turndown from 'turndown';
+
+// your dependency, your version
+
+const td = new Turndown();
+
+const fetchAsMarkdown = stitch({
+    url: 'https://example.com/docs/{slug}',
+    responseType: 'text',
+    transform: (html) => td.turndown(html as string),
+    output: z.string(),
+});
+```
+
+The parser lives in your `package.json`, where you can pin it, swap it, or drop it. The stitch only knows the contract: a function from raw body to a value, validated on the way out.
+
+## What changes, axis by axis
+
+The left column is glue you rewrite per endpoint. The right column is configuration you declare per endpoint and read the same way every time.
+
+| Axis          | By hand                                           | A stitch                                |
+| ------------- | ------------------------------------------------- | --------------------------------------- |
+| Decode        | `res.text()` / `res.arrayBuffer()` picked by hand | `responseType` names the decode         |
+| Reshape       | parser called inline, ad hoc                      | `transform` is the declared seam        |
+| Return type   | whatever the parser returns (`any`)               | `output` validates and types the result |
+| Resilience    | hand-rolled retry loop                            | `retry` / `timeout` are fields          |
+| Credential    | token captured in the closure                     | `auth` resolves at call time            |
+| Next endpoint | copy the block                                    | another short declaration               |
+
+## It is still a stitch
+
+Reading HTML or bytes does not put you on a side path. The same configuration that surrounds a JSON call surrounds this one — auth, retry, timeout, and trace apply regardless of the body format, because the body format is one field:
+
+```ts
+const fetchPage = stitch({
+    url: 'https://example.com/pages/{slug}',
+    responseType: 'text',
+    transform: (html) => scrapePage(html as string),
+    output: PageSchema,
+    auth: bearer(env('API_TOKEN')),
+    retry: { attempts: 3, on: [429, 503], backoff: 'expo-jitter' },
+    timeout: { total: '30s', perAttempt: '10s' },
+    trace: 'console',
+});
+```
+
+A scalar JSON call is one line — `stitch({ url })`, and the auto `responseType` returns parsed JSON. A non-JSON call is the same declaration with the decode named and a converter wired in, and it gains resilience and validation by adding fields, never by rewriting the call. The endpoint that answers CSV today and JSON tomorrow stays one declaration; you change `responseType` and the `transform`, and every caller reads it the same way.
+
+## Try it
+
+Declare a stitch with `responseType: 'text'`, run your own parser in `transform`, and validate the result with an `output` schema — a typed function over any non-JSON endpoint.
+
+```package-install
+stitchapi
+```
+
+-   [transform](/docs/guides/data/transform) — the reshape seam, in full.
+-   [Validation](/docs/guides/validation/validation) — how `output` types and checks the result.
+-   [Helpers reference](/docs/reference/helpers) — adapters and the rest of the surface.
+-   [Read non-JSON, then compose it](/blog/compose-api-calls-into-a-pipeline) — chain these stitches into one pipeline.


### PR DESCRIPTION
## What

Batch 5 — the final batch of the comprehensive blog-coverage push:

| Post | Owns |
|---|---|
| [export-stitches-to-openapi](apps/docs/content/blog/export-stitches-to-openapi.mdx) | Codegen in reverse — `stitch export --openapi` (and `toOpenApi` from `stitchapi/registry`) emits an OpenAPI 3.1 spec from your stitches; paths/methods/params/security derived structurally, real body schemas via a BYO `toJsonSchema` converter. The stitch stays the source of truth. |
| [read-non-json-responses](apps/docs/content/blog/read-non-json-responses.mdx) | `responseType` (`text`/`arrayBuffer`/`blob`) picks the decode, `transform` reshapes the body (CSV/HTML/binary, BYO converter), `output` validates the value you use. |
| [compose-api-calls-into-a-pipeline](apps/docs/content/blog/compose-api-calls-into-a-pipeline.mdx) | `pipe()` from `stitchapi/pipe` chains stitches sequentially and fail-fast; each step is a child run so a trace shows the chain; the mapper receives the previous result as `unknown` (cast to the validated schema type). |

Follows Batches 1–4 ([#355](https://github.com/rejifald/StitchAPI/pull/355), [#356](https://github.com/rejifald/StitchAPI/pull/356), [#357](https://github.com/rejifald/StitchAPI/pull/357), [#358](https://github.com/rejifald/StitchAPI/pull/358)), all merged.

## Verification

- Drafted → adversarially fact-checked → revised. The fact-checker (which reads + runs the real source) confirmed the OpenAPI post's subtle claims (no top-level `query` config slot — `query` is the GraphQL string; bodies are `{}` without a BYO converter) and **caught an overstated static-typing claim** in the pipeline post: `PipeStep.input` receives `unknown`, so intermediate access needs a cast to the validated schema type — corrected to match `pipe.ts` (and its own JSDoc).
- Editorial pass (3 finders): EDITORIAL.md + links/frontmatter/structure clean (minor polish applied).
- `prettier` clean; pre-commit gate (`format` + full `typecheck` incl. `fumadocs-mdx` + `next typegen`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)