### PR TITLE
fix(core): widen pipe() to accept any stitch regardless of inferred input

### DIFF
--- a/packages/core/src/pipe.ts
+++ b/packages/core/src/pipe.ts
@@ -7,10 +7,21 @@
 import type { RunContext, Stitch, StitchInput } from './types';
 import { newRunContext } from './util';
 
+/**
+ * A stitch accepted as a pipe member regardless of its inferred input/output types. `Stitch<TOut,
+ * TIn>` is CONTRAVARIANT in `TIn` (it sits in the call signature and in `with()`'s parameter), so a
+ * stitch with a NARROWER input — e.g. one built from a templated URL `'/users/{id}'`, whose `TIn`
+ * carries a required `params: { id }` — is *not* assignable to the bare `Stitch` default
+ * (`Stitch<unknown, StitchInput>`). `never` in the input slot erases that contravariance (`never`
+ * is assignable to every `TIn`), so every stitch is accepted while `TOut` stays `unknown`. This is
+ * the idiom pipe's own example uses; without it that example fails to type-check (TS2345).
+ */
+type AnyStitch = Stitch<unknown, never>;
+
 /** A pipe step: the stitch to run, and how to turn the previous result into its call input. */
 export interface PipeStep {
     /** The stitch to run for this step. */
-    readonly stitch: Stitch;
+    readonly stitch: AnyStitch;
     /**
      * Map the previous step's result to this step's call input (sugar; not serialised). Omitted ⇒
      * the previous result is passed as the call `body`. The FIRST step receives the pipe's initial
@@ -28,7 +39,7 @@ interface Runnable {
     ) => Promise<unknown>;
 }
 
-const asStep = (s: PipeStep | Stitch): PipeStep =>
+const asStep = (s: PipeStep | AnyStitch): PipeStep =>
     typeof s === 'function' ? { stitch: s } : s;
 
 /**
@@ -51,7 +62,7 @@ const asStep = (s: PipeStep | Stitch): PipeStep =>
  * ```
  */
 export function pipe<Out = unknown>(
-    ...steps: (PipeStep | Stitch)[]
+    ...steps: (PipeStep | AnyStitch)[]
 ): (input?: StitchInput) => Promise<Out> {
     const resolved = steps.map(asStep);
     return async (input?: StitchInput): Promise<Out> => {

--- a/packages/core/test-d/pipe.test-d.ts
+++ b/packages/core/test-d/pipe.test-d.ts
@@ -1,0 +1,70 @@
+// Type-level regression for `pipe` (stitchapi/pipe, ADR 0008): a pipe must accept ANY stitch as a
+// member regardless of its inferred input/output. `Stitch<TOut, TIn>` is contravariant in `TIn`
+// (call signature + `with()`), so a stitch built from a templated URL — whose `TIn` carries a
+// required `params: { id }` — is NOT assignable to the bare `Stitch<unknown, StitchInput>` default.
+// Before the fix, the idiom in pipe's own JSDoc and in the compose-a-pipeline blog post failed with
+// TS2345; the parameter/`PipeStep.stitch` types are now variance-erased (`Stitch<unknown, never>`).
+//
+// The assertion here is simply that these constructions COMPILE — a type error in any of them fails
+// the `check:types-d` gate. (Runtime behaviour is covered in test/pipe.spec.ts.)
+import { stitch } from '../src';
+import type { StitchInput } from '../src';
+import { pipe } from '../src/pipe';
+
+import { expectError, expectType } from 'tsd';
+import { z } from 'zod';
+
+const User = z.object({ id: z.number(), name: z.string() });
+type User = z.infer<typeof User>;
+const Post = z.object({ id: z.number(), title: z.string() });
+type Post = z.infer<typeof Post>;
+
+// A stitch from a TEMPLATED url + output schema: its inferred `TIn` requires `params: { id }`, and
+// its `TOut` is `User` — the exact narrowing that broke assignability to the bare `Stitch` default.
+const fetchUser = stitch({
+    url: 'https://api.example.com/users/{id}',
+    output: User,
+});
+const fetchPosts = stitch({
+    url: 'https://api.example.com/posts',
+    output: z.array(Post),
+});
+
+// 1) The headline repro: a typed stitch as the FIRST step, plus a `PipeStep` whose `.stitch` is also
+//    a typed stitch. Pre-fix this was `TS2345: ... not assignable to 'Stitch<unknown, StitchInput>'`.
+const userPosts = pipe(fetchUser, {
+    stitch: fetchPosts,
+    input: (u) => ({ query: { userId: (u as User).id } }),
+});
+// The returned callable takes the FIRST step's input and resolves to `Out` (defaults to `unknown`).
+expectType<(input?: StitchInput) => Promise<unknown>>(userPosts);
+
+// 2) The `Out` generic flows through to the returned promise.
+const typedFlow = pipe<Post[]>(fetchUser, {
+    stitch: fetchPosts,
+    input: (u) => ({ query: { userId: (u as User).id } }),
+});
+expectType<(input?: StitchInput) => Promise<Post[]>>(typedFlow);
+
+// 3) A bare typed stitch (no wrapping `PipeStep`) is accepted on its own.
+expectType<(input?: StitchInput) => Promise<unknown>>(pipe(fetchUser));
+
+// 4) A plain, non-templated stitch (loose `StitchInput`) still composes — the widening accepts every
+//    stitch, not only the narrow ones.
+const ping = stitch({ url: 'https://api.example.com/ping' });
+expectType<(input?: StitchInput) => Promise<unknown>>(pipe(ping, fetchUser));
+
+// 5) A stitch with a REQUIRED `body` schema (another narrowing of `TIn`) is accepted too.
+const createUser = stitch({
+    url: 'https://api.example.com/users',
+    input: { body: z.object({ name: z.string() }) },
+    output: User,
+});
+expectType<(input?: StitchInput) => Promise<unknown>>(
+    pipe(createUser, fetchUser),
+);
+
+// 6) A non-stitch, non-`PipeStep` value is still rejected — the widening erases variance, not the
+//    member shape.
+expectError(pipe(fetchUser, 42));
+expectError(pipe({ notAStitch: true }));


### PR DESCRIPTION
## Problem

`pipe()` (the `stitchapi/pipe` subpath, ADR 0008) typed its variadic steps and `PipeStep.stitch` against the bare `Stitch` default, which resolves to `Stitch<unknown, StitchInput>`. Because `Stitch<TOut, TIn>` is **contravariant in `TIn`** (it appears in the call signature and in `with()`'s parameter), a stitch with a *narrower* input — e.g. one built from a templated URL `'https://api.example.com/users/{id}'`, whose inferred `TIn` requires `params: { id }` — is **not** assignable to that bare default.

So the exact idiom shown in `pipe`'s own JSDoc example and in the `compose-api-calls-into-a-pipeline` blog post failed to type-check with **TS2345**:

```ts
const userPosts = pipe(
    fetchUser, // Stitch<User, { params: { id } }>
    { stitch: fetchPosts, input: (u) => ({ query: { userId: (u as User).id } }) },
);
// Argument of type 'Stitch<{…}, {… params: { id } …}>' is not assignable to
// parameter of type 'Stitch<unknown, StitchInput> | PipeStep'.
```

## Fix

Widen the parameter and `PipeStep.stitch` types to a variance-erased alias `Stitch<unknown, never>`. `never` in the input slot erases the contravariance (`never` is assignable to every `TIn`), so **every** stitch is accepted while `TOut` stays `unknown`.

Chosen over `Stitch<any, any>` (also valid) to keep `src/` free of `any`: `strictTypeChecked` bans `no-explicit-any` and `src/` has zero suppressions today, so the `never` form is lint-clean.

## Test

New type-level regression `packages/core/test-d/pipe.test-d.ts` under the existing `check:types-d` gate: it builds a `pipe()` from a templated-URL + output-schema stitch and asserts it type-checks, with extra coverage for the `Out` generic, plain/required-`body` stitches, and `expectError` on non-stitch members. Verified it's a genuine guard — reverting the fix reproduces the exact TS2345; with the fix it passes.

## Docs

No change needed: the `compose-api-calls-into-a-pipeline.mdx` snippets use plain ` ```ts ` fences (not twoslash), so they're never type-checked and already show the clean cast-free idiom.

## Verification

`check:types-d` ✓ · `check:types` ✓ · `check:lint` ✓ · runtime `test/pipe.spec.ts` (3 tests) ✓ · prettier ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)