### PR TITLE
feat(core): composition family — ancestor ctx, pipe.step builder, all/any/race

### DIFF
--- a/apps/docs/content/blog/compose-api-calls-into-a-pipeline.mdx
+++ b/apps/docs/content/blog/compose-api-calls-into-a-pipeline.mdx
@@ -6,47 +6,47 @@ date: '2026-06-29'
 tags: [pipeline, composition, pipe, typescript, orchestration]
 ---
 
-You need a user, then that user's posts, then each post enriched with its author's name. Three calls, in order, where each one needs the result of the one before it. In most TypeScript codebases this becomes a stack of `await`s glued together with `try/catch`, and when one of them fails at 2am you get a stack trace pointing at a single line with no record of what ran first.
+A customer asks where their order is. You have the order number — nothing else. To answer, you need the order, then the shipment booked against it, then the carrier's live tracking for that shipment. Three calls, in order, where each one needs an id from the one before it. In most TypeScript codebases this becomes a stack of `await`s glued together with `try/catch`, and when one of them fails at 2am you get a stack trace pointing at a single line with no record of what ran first.
 
-`pipe()` declares that chain as one value. Each step feeds the next, a failure anywhere rejects the whole thing, and a trace shows `fetchUser → fetchPosts` as connected steps instead of three unrelated calls.
+`pipe()` declares that chain as one value. Each step feeds the next, a failure anywhere rejects the whole thing, and a trace shows `fetchOrder → fetchShipment` as connected steps instead of three unrelated calls.
 
 ## The honest before
 
 Here is the real multi-step flow, written by hand. It works. It is also where every project quietly accumulates scar tissue.
 
 ```ts
-async function getUserPosts(id: number) {
-    let user;
+async function getOrderShipment(orderId: number) {
+    let order;
     try {
-        const res = await fetch(`https://api.example.com/users/${id}`);
-        if (!res.ok) throw new Error(`user ${id}: ${res.status}`);
-        user = await res.json();
+        const res = await fetch(`https://api.example.com/orders/${orderId}`);
+        if (!res.ok) throw new Error(`order ${orderId}: ${res.status}`);
+        order = await res.json();
     } catch (err) {
         // retry? log? rethrow? every call site decides again
         throw err;
     }
 
-    let posts;
+    let shipment;
     try {
         const res = await fetch(
-            `https://api.example.com/posts?userId=${user.id}`,
+            `https://api.example.com/shipments/${order.shipmentId}`,
         );
-        if (!res.ok) throw new Error(`posts: ${res.status}`);
-        posts = await res.json();
+        if (!res.ok) throw new Error(`shipment: ${res.status}`);
+        shipment = await res.json();
     } catch (err) {
         throw err;
     }
 
-    return posts;
+    return shipment;
 }
 ```
 
 The sharp edges, named:
 
 -   **Each step re-implements error handling.** Two `try/catch` blocks, two status checks, two ways to phrase the same failure. The third step would add a third.
--   **Nothing ties the steps together.** When `fetchPosts` fails, the log shows a posts request. It does not show that a user fetch ran first, succeeded, and produced the `userId` that the failed call used. You reconstruct the sequence by hand.
--   **No types.** `user` is `any`, `user.id` is `any`, `posts` is `any`. A typo in `user.id` surfaces as `undefined` in a query string, not a compile error.
--   **Resilience is missing or copy-pasted.** Want a retry on the user call? Wrap it in a loop. Want a timeout? Race it against a `setTimeout`. Now do it again for posts.
+-   **Nothing ties the steps together.** When `fetchShipment` fails, the log shows a shipment request. It does not show that an order fetch ran first, succeeded, and produced the `shipmentId` that the failed call used. You reconstruct the sequence by hand.
+-   **No types.** `order` is `any`, `order.shipmentId` is `any`, `shipment` is `any`. A typo in `order.shipmentId` surfaces as `undefined` in a URL, not a compile error.
+-   **Resilience is missing or copy-pasted.** Want a retry on the order call? Wrap it in a loop. Want a timeout? Race it against a `setTimeout`. Now do it again for the shipment.
 
 ## The pipeline version
 
@@ -57,41 +57,50 @@ import { stitch } from 'stitchapi';
 import { pipe } from 'stitchapi/pipe';
 import { z } from 'zod';
 
-const User = z.object({ id: z.number(), name: z.string() });
-type User = z.infer<typeof User>;
-const Posts = z.array(z.object({ id: z.number(), title: z.string() }));
-type Posts = z.infer<typeof Posts>;
+const Order = z.object({
+    id: z.number(),
+    shipmentId: z.string(),
+    total: z.number(),
+});
+type Order = z.infer<typeof Order>;
+const Shipment = z.object({
+    id: z.string(),
+    carrier: z.string(),
+    trackingCode: z.string(),
+    status: z.string(),
+});
+type Shipment = z.infer<typeof Shipment>;
 
-const fetchUser = stitch({
-    url: 'https://api.example.com/users/{id}',
-    output: User,
+const fetchOrder = stitch({
+    url: 'https://api.example.com/orders/{id}',
+    output: Order,
     retry: 3,
     timeout: '5s',
 });
 
-const fetchPosts = stitch({
-    url: 'https://api.example.com/posts',
-    output: Posts,
+const fetchShipment = stitch({
+    url: 'https://api.example.com/shipments/{id}',
+    output: Shipment,
     retry: 3,
 });
 
-const userPosts = pipe(
-    fetchUser, // receives the pipe's input
+const orderShipment = pipe(
+    fetchOrder, // receives the pipe's input
     {
-        stitch: fetchPosts,
-        input: (u) => ({ query: { userId: (u as User).id } }),
+        stitch: fetchShipment,
+        input: (o) => ({ params: { id: (o as Order).shipmentId } }),
     },
 );
 
-const posts = await userPosts({ params: { id: 1 } });
+const shipment = await orderShipment({ params: { id: 1043 } });
 ```
 
 What each piece does:
 
 -   `pipe(...steps)` returns a callable, `(input?) => Promise<Out>`. You `await` it like any function. It resolves to the **last** step's result.
 -   A **step** is either a bare stitch or a `{ stitch, input }` object. The `input` function maps the previous result into the next call's input.
--   The **first step** receives the pipe's own input — `{ params: { id: 1 } }` lands on `fetchUser`.
--   The **second step** runs `input(u)` over the user that `fetchUser` returned, building `{ query: { userId: (u as User).id } }` for `fetchPosts`. The mapper receives the previous result as `unknown`, so you cast it to the shape you already declared — `u as User` — and because `fetchUser` validated that response against the `User` schema at runtime, the value behind the cast really is a `User`, not the unchecked `any` a raw `res.json()` hands back.
+-   The **first step** receives the pipe's own input — `{ params: { id: 1043 } }` lands on `fetchOrder`.
+-   The **second step** runs `input(o)` over the order that `fetchOrder` returned, building `{ params: { id: (o as Order).shipmentId } }` for `fetchShipment`. The mapper receives the previous result as `unknown`, so you cast it to the shape you already declared — `o as Order` — and because `fetchOrder` validated that response against the `Order` schema at runtime, the value behind the cast really is an `Order`, not the unchecked `any` a raw `res.json()` hands back.
 -   Omit `input` and the previous result is passed as the next call's `body`. Useful when one step's output is literally the next step's request payload.
 
 The two `try/catch` blocks are gone, and so is the status checking, the manual rethrow, and the untyped intermediate values. Each stitch carries its own `retry`, `timeout`, `output` validation, and `auth` — written once, at the declaration, not re-derived at every call site.
@@ -104,7 +113,7 @@ It also **fails fast, not best-effort.** A stitch throws `StitchError` once it e
 
 ```ts
 try {
-    const posts = await userPosts({ params: { id: 1 } });
+    const shipment = await orderShipment({ params: { id: 1043 } });
 } catch (err) {
     // err is the StitchError from whichever step failed —
     // with .status, .attempts, .body, .url already attached
@@ -122,27 +131,32 @@ The detail that pays off in production: each step runs as a **child run of the p
 | Order               | implicit in code flow    | declared as ordered steps                                         |
 | Error handling      | one `try/catch` per call | one rejection at the boundary                                     |
 | Intermediate values | unchecked `any`          | runtime-validated against each step's `output`, cast to that type |
-| Trace identity      | three unrelated calls    | `fetchUser → fetchPosts`, one chain                               |
+| Trace identity      | three unrelated calls    | `fetchOrder → fetchShipment`, one chain                           |
 | Resilience          | copy-pasted or absent    | each step keeps its own retry/timeout/auth                        |
 
-So when posts come back wrong, the trace (and the playground's call-graph DAG) shows the user fetch that ran first, the value it produced, and the mapped input the posts call received. You read the sequence instead of reassembling it.
+So when the shipment comes back pointing at the wrong address, the trace (and the playground's call-graph DAG) shows the order fetch that ran first, the value it produced, and the mapped input the shipment call received. You read the sequence instead of reassembling it.
 
 The step-to-step `input` mapper is a closure — sugar, the same category as `transform` or `paginate.next`. The structure that round-trips is the **ordered list of member stitches.** The pipe composes stitches you already declared; it does not absorb them or change how any one of them behaves on its own.
 
 ## Where the pipeline takes you
 
-`pipe()` bounds a flow exactly as tightly as you bound a single stitch. One call you `await`; a sequence of dependent calls is the same `await` over a value that happens to contain three. Adding a third enrichment step is one more entry in the list, not another `try/catch` block and another untyped variable:
+`pipe()` bounds a flow exactly as tightly as you bound a single stitch. One call you `await`; a sequence of dependent calls is the same `await` over a value that happens to contain three. Adding a third step — the carrier's live tracking for that shipment — is one more entry in the list, not another `try/catch` block and another untyped variable:
 
 ```ts
-const enriched = pipe(
-    fetchUser,
+const tracked = pipe(
+    fetchOrder,
     {
-        stitch: fetchPosts,
-        input: (u) => ({ query: { userId: (u as User).id } }),
+        stitch: fetchShipment,
+        input: (o) => ({ params: { id: (o as Order).shipmentId } }),
     },
     {
-        stitch: fetchComments,
-        input: (p) => ({ query: { postId: (p as Posts)[0].id } }),
+        stitch: fetchTracking,
+        input: (s) => ({
+            params: {
+                carrier: (s as Shipment).carrier,
+                code: (s as Shipment).trackingCode,
+            },
+        }),
     },
 );
 ```
@@ -157,4 +171,4 @@ stitchapi
 
 `pipe` lives at the `stitchapi/pipe` subpath, so you only pull it into the bundle when a flow needs it. Each step is a [stitch](/docs/concepts/the-stitch) with its own [validation](/docs/guides/validation/validation), and the chain is visible in the [event stream](/docs/concepts/event-stream).
 
-Related reading: [Type-safe pagination](/blog/typescript-pagination), [one definition, four front doors](/blog/one-definition-four-front-doors), and [runtime stitching vs. workflow platforms](/blog/runtime-stitching-vs-workflow-platforms).
+Related reading: [when a step needs an earlier result](/blog/read-earlier-results-in-a-pipeline), [type-safe pagination](/blog/typescript-pagination), [one definition, four front doors](/blog/one-definition-four-front-doors), and [runtime stitching vs. workflow platforms](/blog/runtime-stitching-vs-workflow-platforms).

--- a/apps/docs/content/blog/compose-pipe-all-any-race.mdx
+++ b/apps/docs/content/blog/compose-pipe-all-any-race.mdx
@@ -1,0 +1,140 @@
+---
+title: 'Sequential and Parallel: pipe, all, any, race'
+description: 'A stitch is one typed call; composition combines them. pipe runs steps in order and feeds each into the next; all/any/race run independent calls concurrently. They all return the same callable shape, so they nest — a parallel all inside a sequential pipe, a failover any as a single step — and stay fully typed throughout.'
+author: Oleksandr Zhuravlov
+date: '2026-06-30'
+tags: [composition, pipe, parallel, concurrency, typescript]
+---
+
+A [stitch](/docs/concepts/the-stitch) is one endpoint as a typed, validated, resilient function. Real work rarely stops at one call — you chain them, or fan them out. StitchAPI's composition family covers both axes with one idea: **every combinator returns the same thing a stitch does — a callable you `await` — so they all nest inside each other.**
+
+There are two questions any two calls can have between them: _does one depend on the other?_ and _do I need all of them?_ That's the whole family.
+
+| Combinator | Runs members              | Resolves when                         | Result            | For                            |
+| ---------- | ------------------------- | ------------------------------------- | ----------------- | ------------------------------ |
+| `pipe`     | in order, each feeds next | the last step resolves                | the last output   | a **dependent** chain          |
+| `all`      | concurrently              | **all** succeed (fail-fast)           | named obj / tuple | independent **fan-out**        |
+| `any`      | concurrently              | the **first success** (else all fail) | one output        | **failover** across redundancy |
+| `race`     | concurrently              | the **first to settle** (win or lose) | one output        | **hedging** / fastest-wins     |
+
+## `pipe` — dependent, in order
+
+When each call needs the previous one's result, you want a sequence. [`pipe`](/blog/compose-api-calls-into-a-pipeline) runs steps in order, feeds each result to the next, and fails fast. Its builder lets a step [read an earlier ancestor](/blog/read-earlier-results-in-a-pipeline), fully typed:
+
+```ts
+import { pipe } from 'stitchapi/pipe';
+
+const tracked = pipe
+    .step(fetchOrder, 'order')
+    .step(fetchShipment, (order) => ({ params: { id: order.shipmentId } }))
+    .step(fetchTracking, (shipment, ctx) => ({
+        params: { code: shipment.trackingCode, region: ctx.order.region },
+    }));
+
+const events = await tracked({ params: { id: 1043 } });
+```
+
+## `all` — independent, all of them
+
+When calls _don't_ depend on each other, running them in sequence is just wasted latency. `all` runs a **named bag** of stitches concurrently and resolves to a typed object keyed by the names you gave:
+
+```ts
+import { all } from 'stitchapi/pipe';
+
+const dashboard = all({
+    user: fetchUser,
+    settings: fetchSettings,
+    flags: fetchFlags,
+});
+
+const { user, settings, flags } = await dashboard({ params: { id: 1 } });
+// user: User, settings: Settings, flags: Flags — each typed from its stitch
+```
+
+Prefer positional? Pass an **array** and get a tuple back — the exact `Promise.all` shape, with the resilience and cancellation added:
+
+```ts
+const [user, settings, flags] = await all([
+    fetchUser,
+    fetchSettings,
+    fetchFlags,
+])({ params: { id: 1 } });
+```
+
+Both forms are the same combinator — pick whichever reads better. (The named form is the one that merges into a pipe's `ctx` via an inline `.step({...})`; an array nests through `.step(all([...]), 'name')`.)
+
+Either way it's `Promise.all` with the rough edges removed: it's **fail-fast** — the first member to fail rejects the whole `all` with that call's `StitchError` (`.status`, `.url`, …) **and aborts the others** (their in-flight requests are cancelled, not left running) — and each member keeps its own retry, timeout, and validation.
+
+## `any` — the first one that works
+
+`any` runs its members concurrently and resolves with the **first to succeed**, ignoring failures until none are left — then it rejects with an `AggregateError` of every failure. The moment one wins, the **losers are aborted**. That's failover across interchangeable sources:
+
+```ts
+import { any } from 'stitchapi/pipe';
+
+// hit both, take whichever returns first; only fail if BOTH do
+const fetchUser = any([fetchFromPrimary, fetchFromMirror]);
+
+const user = await fetchUser({ params: { id: 1 } });
+```
+
+This is distinct from a stitch's built-in `retry`, which re-hits the **same** endpoint. `any` is for redundancy across **different** endpoints — a primary and a mirror, two regions, two providers of the same shape.
+
+## `race` — the first one to finish, win or lose
+
+`race` resolves with the first member to **settle** — success _or_ failure — and **cancels the rest**. Use it to hedge a latency-sensitive call against a second source and take whichever returns first:
+
+```ts
+import { race } from 'stitchapi/pipe';
+
+const fastest = race([fetchFromUsEast, fetchFromEuWest]);
+```
+
+The difference from `any` is what counts as "done": `any` waits past failures for a success; `race` takes the first result of any kind. Reach for `race` when latency is the enemy and a fast failure is still information; reach for `any` when you want the answer and don't care who provides it.
+
+## They nest — that's the point
+
+Every combinator returns the same callable shape `(input?) => Promise<Out>`, so a combinator is a valid member of any other — and the types flow straight through. Inside the `pipe` builder, an **object-literal step is a parallel fan-out**: each `{ key: node }` runs concurrently and its keys merge straight into `ctx`. Fetch the order, then in parallel its shipment and invoice, then sequentially the tracking:
+
+```ts
+import { pipe } from 'stitchapi/pipe';
+
+const enriched = pipe
+    .step(fetchOrder, 'order')
+    .step({ shipment: fetchShipment, invoice: fetchInvoice }) // parallel; merges into ctx
+    .step(fetchTracking, (details, ctx) => ({
+        params: {
+            code: details.shipment.trackingCode, // `details` = the parallel result, typed
+            total: ctx.invoice.total, // a merged key, readable by name
+            region: ctx.order.region, // an earlier ancestor, still typed
+        },
+    }));
+
+const events = await enriched({ params: { id: 1043 } });
+```
+
+The `{ shipment, invoice }` step fans out in parallel and lands its keys in `ctx` directly (`ctx.shipment`, `ctx.invoice`) — no wrapper name to invent. And a standalone `all` / `any` / `race` nests just as well as a single step, so a failover reads naturally:
+
+```ts
+import { any, pipe } from 'stitchapi/pipe';
+
+const flow = pipe
+    .step(any([fetchOrderPrimary, fetchOrderMirror]), 'order') // failover on the first call
+    .step(fetchShipment, (order) => ({ params: { id: order.shipmentId } }));
+```
+
+An `all` can hold a `pipe`; a `pipe` step can be an `any`; a `race` can hold `all`s. The tree goes as deep as the problem, and every node is typed from the stitches at its leaves.
+
+## Still composition, not orchestration
+
+Nesting combinators is powerful enough to feel like a workflow engine — so it's fenced the same way `pipe` is. The shape is **fixed when you write it**: a step's mapper returns a request input, never a step, so nothing branches, loops, or spawns at runtime. The trace mirrors the structure — `pipe` draws a line, `all` a fan — because each member runs as a child run of its parent ([the run-identity model](/docs/concepts/event-stream)). It composes the stitches you already declared; it never changes how any one of them behaves alone. That's why this stays [runtime stitching, not a workflow platform](/blog/runtime-stitching-vs-workflow-platforms).
+
+## Try it
+
+```package-install
+stitchapi
+```
+
+The composition family lives at the `stitchapi/pipe` subpath, so it only enters your bundle when a flow needs it. Each member is a [stitch](/docs/concepts/the-stitch) with its own [validation](/blog/validate-api-response-zod) and resilience, and the whole tree is visible in the [event stream](/docs/concepts/event-stream).
+
+Related reading: [compose API calls into one pipeline](/blog/compose-api-calls-into-a-pipeline), [when a step needs an earlier result](/blog/read-earlier-results-in-a-pipeline), and [runtime stitching vs. workflow platforms](/blog/runtime-stitching-vs-workflow-platforms).

--- a/apps/docs/content/blog/read-earlier-results-in-a-pipeline.mdx
+++ b/apps/docs/content/blog/read-earlier-results-in-a-pipeline.mdx
@@ -1,0 +1,124 @@
+---
+title: 'When a Pipeline Step Needs an Earlier Result'
+description: 'A pipeline feeds each step the previous result — but real chains often need a result from two or three steps back. This shows the hand-threaded workaround, then pipe.step(): a builder that types prev and every named ancestor with no casts, and makes a duplicate name a compile error.'
+author: Oleksandr Zhuravlov
+date: '2026-06-30'
+tags: [pipeline, composition, pipe, context, typescript]
+---
+
+[`pipe()`](/blog/compose-api-calls-into-a-pipeline) feeds each step the result of the one before it: `order → shipment → tracking`, where the tracking call uses the shipment the previous step produced. That covers most chains. It does not cover the one that bites you in production: a step that needs a result from **two or three steps back**, not the one right before it.
+
+You have the order. You fetch its shipment. Now you call the carrier's tracking API — and it needs the shipment's `trackingCode` (from the previous step, fine) **and** the order's `region` (to return events in the right locale). The order is two hops back. A previous-result-only chain can't hand it to you.
+
+## The workaround you write without it
+
+You break the chain open and keep the early result alive in a variable until the call that needs it:
+
+```ts
+const order = await fetchOrder({ params: { id: 1043 } });
+const shipment = await fetchShipment({ params: { id: order.shipmentId } });
+const tracking = await fetchTracking({
+    params: {
+        carrier: shipment.carrier,
+        code: shipment.trackingCode,
+        region: order.region, // ← the order, still in scope two calls later, only for this
+    },
+});
+```
+
+Every call works. But you've given back everything `pipe()` bought you — the chain as one value, one linked trace, fail-fast, each call's own retry and timeout — and `order` now lingers in scope for the sole purpose of feeding the third call. `pipe()` itself can't rescue this: its mapper only sees the **previous** result.
+
+## `pipe.step()`: name what you reach back to
+
+`pipe.step(...)` builds the pipeline fluently — and because each step is added in its own call, it **types everything as it goes**. A later step reads an earlier one through `ctx`, by a name you give it:
+
+```ts
+import { stitch } from 'stitchapi';
+import { pipe } from 'stitchapi/pipe';
+import { z } from 'zod';
+
+const Order = z.object({
+    id: z.number(),
+    shipmentId: z.string(),
+    region: z.string(),
+});
+const Shipment = z.object({ carrier: z.string(), trackingCode: z.string() });
+const Tracking = z.object({ events: z.array(z.string()) });
+
+const fetchOrder = stitch({
+    url: 'https://api.example.com/orders/{id}',
+    output: Order,
+});
+const fetchShipment = stitch({
+    url: 'https://api.example.com/shipments/{id}',
+    output: Shipment,
+});
+const fetchTracking = stitch({
+    url: 'https://api.example.com/tracking/{carrier}/{code}',
+    output: Tracking,
+});
+
+const tracked = pipe
+    .step(fetchOrder, 'order') // name it — a later step reaches back to it
+    .step(fetchShipment, (order) => ({ params: { id: order.shipmentId } }))
+    .step(fetchTracking, (shipment, ctx) => ({
+        params: {
+            carrier: shipment.carrier,
+            code: shipment.trackingCode,
+            region: ctx.order.region, // the order — an ancestor, two hops back
+        },
+    }));
+
+const tracking = await tracked({ params: { id: 1043 } });
+```
+
+What's happening:
+
+-   **Every argument is typed — no `as`.** `order` is `Order`, `shipment` is `Shipment`, `ctx.order` is `Order`. The builder already knows each earlier step's output, so it hands you real types instead of the `unknown` you'd have to cast. That's the whole [resilient-typed-function](/blog/type-safe-api-client-without-codegen) promise holding through a multi-step flow.
+-   **Naming is just an argument to `step`.** Pass a name (`.step(fetchOrder, 'order')`) to file that step's result under `ctx.order` for later steps — no separate method, no wrapper object. You name a step only when something downstream reads it: `fetchShipment` here is anonymous, because nothing reaches back to it.
+-   **The builder _is_ the pipeline.** No `.build()` to call — `tracked` is the runnable function itself, so you `await tracked(input)` directly. It's the same engine as `pipe()` underneath: steps run in order, each a [child run](/docs/concepts/event-stream) of the last, [fail-fast](/blog/typed-errors-without-try-catch) on the first error.
+
+### The initial input, reachable anywhere: `ctx.$input`
+
+`ctx.$input` is the pipe's own initial argument, readable from any depth — for the root value that every call needs but no intermediate step returns:
+
+```ts
+// GitHub: repo → branch → commit, where every call needs owner/repo from the start
+.step(fetchCommit, (branch, ctx) => ({
+    params: { ...ctx.$input?.params, ref: branch.commit.sha },
+}))
+```
+
+No threading `owner` and `repo` through three mappers — they were in `$input` all along.
+
+### Names you don't have to keep unique
+
+Reach back by name, and the obvious worry is keeping names straight. You don't — the compiler does:
+
+```ts
+pipe.step(fetchOrder, 'order').step(fetchShipment, 'order'); // ✗ compile error: 'order' is already taken
+```
+
+Reusing a name — or a reserved `$`-name like `$input` — is a **type error**, caught as you type. And a typo on the reading side (`ctx.oder`, or a name you never declared) is a compile error too, not an `undefined` that silently lands in a URL at runtime.
+
+## Why a builder, and not flat `pipe(a, b, c)` args?
+
+Because the flat form **can't** be typed, and pretending otherwise would be the dishonest version. A later step's input would have to be typed from an earlier argument of the _same_ `pipe(a, b, c)` call that TypeScript is still inferring — and the compiler can't look back into a call it hasn't finished resolving. So on the flat form, `prev` is `unknown` and you cast.
+
+`pipe.step()` sidesteps it by making each `.step()` its own call — its own inference site. By the time you write the third step, the first two are already resolved and typed, so `prev` and every `ctx` ancestor come through fully typed.
+
+The flat [`pipe(...)`](/blog/compose-api-calls-into-a-pipeline) is still there for a simple linear chain where one `prev` cast is no bother. Reach for the builder the moment a step needs an ancestor — or you'd just rather not cast.
+
+## Still not a workflow engine
+
+Letting a step reach back to any ancestor is exactly the feature that _could_ turn a composition tool into an orchestrator — so it's fenced. `ctx` is read-only: you read ancestors, you never write run state through it. And a mapper returns a request input, never a step — it can _shape_ the next call (even with a `ctx.order.region === 'EU' ? … : …` inside) but it can't skip a step, add one, or reorder the chain. The shape of the pipeline is fixed when you write it; `ctx` only changes the data flowing through it. That line is what keeps this [runtime stitching, not a workflow platform](/blog/runtime-stitching-vs-workflow-platforms).
+
+## Try it
+
+```package-install
+stitchapi
+```
+
+`pipe` and `pipe.step()` both live at the `stitchapi/pipe` subpath, so they only enter your bundle when a flow needs them. Each step is a [stitch](/docs/concepts/the-stitch) with its own [validation](/blog/validate-api-response-zod), the chain shows up in the [event stream](/docs/concepts/event-stream), and a failure anywhere rejects with a [typed error](/blog/typed-errors-without-try-catch) carrying the failing call's `.status`, `.attempts`, and `.url`.
+
+Related reading: [sequential and parallel — pipe, all, any, race](/blog/compose-pipe-all-any-race), [compose API calls into one pipeline](/blog/compose-api-calls-into-a-pipeline), and [runtime stitching vs. workflow platforms](/blog/runtime-stitching-vs-workflow-platforms).

--- a/apps/docs/content/docs/concepts/composition.mdx
+++ b/apps/docs/content/docs/concepts/composition.mdx
@@ -1,0 +1,88 @@
+---
+title: 'Composition'
+description: 'Combine stitches — and combinators — into typed flows: pipe runs steps in sequence, all/any/race run them in parallel, and because every combinator returns the same callable shape they nest arbitrarily.'
+---
+
+A [stitch](/docs/concepts/the-stitch) is one API call as a typed, resilient function. **Composition** is how those calls combine into a flow — sequential or parallel — without giving up the types, the resilience, or the trace. It lives at the `stitchapi/pipe` subpath, so it only enters your bundle when a flow needs it.
+
+The whole family rests on one idea: **every combinator returns the same thing a stitch does — a callable you `await` — so combinators nest inside each other.** A `pipe` step can be an `all`; an `all` member can be a `pipe`; the tree goes as deep as the problem, and every node is typed from the stitches at its leaves.
+
+## Two questions, four combinators
+
+Any two calls have only two relationships: _does one depend on the other?_ and _do I need all of them?_
+
+| Combinator | Runs members              | Resolves when                         | Result               |
+| ---------- | ------------------------- | ------------------------------------- | -------------------- |
+| `pipe`     | in order, each feeds next | the last step resolves                | the last output      |
+| `all`      | concurrently              | **all** succeed (fail-fast)           | named object / tuple |
+| `any`      | concurrently              | the **first success** (else all fail) | one output           |
+| `race`     | concurrently              | the **first to settle** (win or lose) | one output           |
+
+Each member runs as a **child run** of its parent ([run identity](/docs/concepts/event-stream)), so a trace draws the shape: `pipe` a line, `all`/`any`/`race` a fan. Every parallel combinator **auto-cancels** the members that can no longer affect the result — `all` aborts its siblings on the first failure, `any` on the first success, `race` on the first settle.
+
+## Sequential — `pipe`
+
+`pipe` runs steps in order, feeding each result to the next, and fails fast. The fluent builder (`pipe.step`) types `prev` and gives each step a `ctx` of earlier **named** ancestors, with no casts:
+
+```ts
+import { pipe } from 'stitchapi/pipe';
+
+const tracked = pipe
+    .step(fetchOrder, 'order') // name it so a later step can read it back
+    .step(fetchShipment, (order) => ({ params: { id: order.shipmentId } }))
+    .step(fetchTracking, (shipment, ctx) => ({
+        params: { code: shipment.trackingCode, region: ctx.order.region },
+    }));
+
+const events = await tracked({ params: { id: 1043 } });
+```
+
+`ctx.$input` is the pipe's initial argument, reachable at any depth. Names are unique by construction — a duplicate or `$`-prefixed name is a compile error. (Deep dives: [compose API calls into one pipeline](/blog/compose-api-calls-into-a-pipeline) and [when a step needs an earlier result](/blog/read-earlier-results-in-a-pipeline).)
+
+## Parallel — `all`, `any`, `race`
+
+`all` runs independent calls concurrently. Pass a **named object** for a keyed result, or a positional **array** for a tuple (the `Promise.all` shape):
+
+```ts
+import { all } from 'stitchapi/pipe';
+
+const { user, prefs } = await all({ user: fetchUser, prefs: fetchPrefs })();
+const [a, b] = await all([fetchA, fetchB])(); // readonly [A, B]
+```
+
+`any` resolves with the first member to **succeed** (and rejects with an `AggregateError` only if all fail) — failover across interchangeable sources. `race` resolves with the first to **settle**, win or lose — hedging against a slower mirror:
+
+```ts
+import { any, race } from 'stitchapi/pipe';
+
+const user = await any([fetchFromPrimary, fetchFromMirror])();
+const fastest = await race([fetchFromUsEast, fetchFromEuWest])();
+```
+
+`any` is distinct from a stitch's `retry`, which re-hits the **same** endpoint; `any` is redundancy across **different** ones.
+
+## They nest
+
+Because every combinator is a callable, it is a valid member of any other. Inside the `pipe` builder, an **object-literal step is a parallel fan-out** — each `{ key: node }` runs concurrently and merges its keys into `ctx`:
+
+```ts
+const enriched = pipe
+    .step(fetchOrder, 'order')
+    .step({ shipment: fetchShipment, invoice: fetchInvoice }) // parallel; merges into ctx
+    .step(fetchTracking, (details, ctx) => ({
+        params: {
+            code: details.shipment.trackingCode,
+            region: ctx.order.region,
+        },
+    }));
+```
+
+A standalone `all` / `any` / `race` nests just as well as a single step — `.step(any([primary, mirror]), 'order')` is a failover on one call.
+
+## Not a workflow engine
+
+Composition is deliberately fenced to stay a static primitive, not an orchestrator. The shape is **fixed when you write it**: a step's mapper returns a request input, never a step, so nothing branches, loops, or spawns at runtime; `ctx` is read-only. It composes the stitches you already declared and never changes how any one behaves alone — [runtime stitching, not a workflow platform](/blog/runtime-stitching-vs-workflow-platforms).
+
+## How it relates
+
+A composed flow is itself callable, so it consumes and emits the same [event stream](/docs/concepts/event-stream) a single stitch does — the trace links the whole tree under one root. Each member keeps its own [auth](/docs/concepts/capability-not-credential), retry, timeout, and validation; composition adds ordering and concurrency around stitches without absorbing them.

--- a/apps/docs/content/docs/concepts/meta.json
+++ b/apps/docs/content/docs/concepts/meta.json
@@ -3,6 +3,7 @@
     "icon": "Lightbulb",
     "pages": [
         "the-stitch",
+        "composition",
         "the-seam",
         "event-stream",
         "capability-not-credential",

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -257,3 +257,224 @@ shared helper would make each new framework cheap.
 **Open questions** — Is Express worth a first-party package given how thin the bridge is, or better as
 a docs recipe? Extract the shared backend helper now, or after a 4th framework proves the pattern?
 Elysia priority vs. waiting for a clearer Bun-server adoption signal?
+
+---
+
+## Parallel composition — `all` · `any` · `race`
+
+-   **Status:** IMPLEMENTED + green (2026-06, in branch — not yet released). `all`/`any`/`race` in
+    `packages/core/src/pipe.ts` (subpath `stitchapi/pipe`), returning the shared `Composable` so they
+    NEST. `all` takes EITHER a named object (→ named result, merges into a pipe `ctx`) OR a positional
+    array (→ a `readonly` tuple, the `Promise.all` shape) — additive overloads, `const` type param for
+    tuple inference. Decisions baked in: **no `allSettled`** (no separate combinator, no flag on `all` — for
+    best-effort, compose `.safe()` members by hand); **auto-cancel** losers via a per-group
+    `AbortSignal` (`all` aborts siblings on first failure, `any` on first success, `race` on first
+    settle); the pipe builder gains an **inline parallel bag** `.step({ k: node })` that merges keys
+    into `ctx`. Tests: `test/combinators.spec.ts` + `test-d/combinators.test-d.ts`
+    (tsc/eslint/tsd/1110 unit/bundle-size all pass). Article: blog `compose-pipe-all-any-race`.
+-   **Date:** 2026-06
+-   **Tags:** composition, pipe, parallel, subpath
+-   **Gates:** browser-first ✅ (just `Promise.all`/`race`/`any` over child runs) · bundle-frugal ✅
+    (reached only through a composition subpath, like `stitchapi/pipe`) · contract-not-dependency ✅
+    (members are an ordered/named list of stitches that round-trips — arguably _cleaner_ than `pipe`,
+    which leans on per-step `input` closures).
+
+**Problem / why** — `pipe` (ADR 0008) composes **dependent** calls: step N+1's input is derived from
+step N's result, so it must run sequentially. The complement — **independent** calls you want to run
+**concurrently** — has no primitive today. "Fetch the user, their settings, and their feature flags at
+once" forces users back to a hand-rolled `Promise.all`, which drops the run-identity/trace story and
+the typed-result shape that `pipe` gives a dependent chain.
+
+**Sketch** — a parallel family living alongside `pipe`:
+
+-   **`all`** — run independent stitches concurrently, resolve when all succeed, fail fast on the first
+    rejection (`Promise.all` semantics). Members are **sibling child runs of one parent** (ADR 0007
+    `parentId` already models fan-out), so the trace/DAG draws a fan instead of a line. Proposed shape
+    favours a **named object** over a tuple for ergonomics + JSON-friendliness:
+    `all({ user: fetchUser, settings: fetchSettings })` → `(input) => Promise<{ user, settings }>`.
+    This is the high-value one and composes inside `pipe` (a pipe step could be an `all`).
+-   **`any`** — first to **succeed** wins; collect failures into an `AggregateError` if all fail
+    (`Promise.any`). Use case: cross-_provider_ **failover** (primary → mirror). Distinct from a
+    stitch's built-in retry (which re-hits the _same_ endpoint), so it earns its place — but lower
+    demand than `all`.
+-   **`race`** — first to **settle** (resolve _or_ reject) wins (`Promise.race`). Use case: hedged /
+    fastest-mirror requests. Least justified: a power-user trick that doubles load and overlaps the
+    resilience each stitch already owns.
+
+**Recommendation** — build **`all` first**; design `any`/`race` as a follow-on "first-wins" family
+only if real demand appears, with `any` the more defensible of the two.
+
+**Backed by / builds on** — the `pipe` subpath (`packages/core/src/pipe.ts`) for the combinator +
+child-run pattern (`__runWith` / `newRunContext`), and ADR 0007 run identity for the sibling-fan trace.
+
+**Open questions** — Named-object vs. tuple results (lean named). How does each member receive input —
+the shared pipe input verbatim, or a per-member mapper from it? One subpath (`stitchapi/parallel`) for
+the whole family or one per combinator? Does `any`'s failover overlap enough with per-stitch retry to
+defer it indefinitely?
+
+---
+
+## Nestable composition — combinators that compose, not a `compose` keyword
+
+-   **Status:** IMPLEMENTED + green (2026-06, in branch) — the `Composable` contract + child-run
+    nesting shipped with the parallel family above (combinators and pipe steps both run via `__runWith`
+    under a supplied run); a `pipe` step accepts any `Node` (stitch or combinator), and an inline
+    `{ k: node }` step is the pipe-native parallel fan. No top-level `compose` keyword (as designed).
+-   **Date:** 2026-06
+-   **Tags:** composition, pipe, parallel, algebra, contract-not-dependency
+-   **Gates:** browser-first ✅ · bundle-frugal ✅ (one shared composable contract, reached through the
+    composition subpaths) · contract-not-dependency ⚠️ — **this is where the idea lives or dies** (see
+    open questions): the _tree of nodes_ round-trips as JSON; the per-edge input mappers stay the same
+    acknowledged sugar as `pipe` today.
+
+**Problem / why** — Real flows mix sequential and parallel: fetch the order, then **in parallel** its
+shipment + invoice, then sequentially the tracking for the shipment. Today `pipe` steps must be
+**stitches** — it casts each step to `__runWith` (`pipe.ts`) — and a nested `pipe(...)` / `all(...)`
+returns a plain `(input) => Promise`, which is _not_ a stitch. So the combinators **don't nest**, and
+you can't express a mixed flow as one traced value. That's the actual gap behind "a `compose` that
+mixes `all`/`race`/`any`/`pipe` in one pipeline."
+
+**Sketch** — the answer is **not** a new top-level `compose` keyword (that drifts toward a workflow
+DSL, which StitchAPI explicitly is not — see the [runtime-stitching-vs-workflow-platforms] post).
+Instead, give every combinator a **shared `Composable` contract** so composition is just **nesting**:
+
+-   A `Composable` is a callable `(input?) => Promise<Out>` that _also_ carries the child-run protocol
+    (`__runWith` / `newRunContext`) **and** a serialisable structure descriptor (`{ kind, members }`).
+    A `stitch` is the leaf; `pipe` / `all` / `any` / `race` are nodes; **any node can hold any node.**
+-   Then this Just Works, no new primitive — composition = nesting an algebra of stitches:
+
+    ```ts
+    const flow = pipe(
+        fetchOrder,
+        all({
+            shipment: { stitch: fetchShipment, input: (o) => ... },
+            invoice: { stitch: fetchInvoice, input: (o) => ... },
+        }),
+        { stitch: fetchTracking, input: ({ shipment }) => ... },
+    );
+    ```
+
+-   The trace/DAG falls out for free: the tree of nodes maps onto ADR 0007 run identity (sequential =
+    parent→child line, parallel = sibling fan), so the playground draws the real graph.
+
+**Recommendation** — ship `all` first (its own entry), then make the combinators return a `Composable`
+so they nest. **Do not** add a `compose` keyword. Hold the workflow-engine line hard: **static tree
+only** — no conditionals, loops, dynamic step generation, persistence, or cross-node retry. The shape
+is fixed at definition time; data flows through mappers; fail-fast. Keep that discipline and it's still
+stitching, not Temporal/Inngest.
+
+**Backed by / builds on** — `pipe.ts` (`__runWith`, `newRunContext`, `PipeStep`), the parallel family
+above, and ADR 0007 run identity. Mostly a **refactor of the step contract** (accept any `Composable`,
+not just `Stitch`) plus the structure descriptor, rather than net-new machinery.
+
+**Open questions** — **The threading model is the crux** (now designed — see
+[Ancestor-readable pipe input](#ancestor-readable-pipe-input--frozen-lexical-context)). `pipe` threads
+only the _previous_ result; real DAGs often want an earlier ancestor too (the tracking step wants the
+order _and_ the shipment). The resolved answer is a **fenced** version of path (b): an opt-in,
+**frozen, read-only, lexically-scoped** accumulating context handed as a _second_ mapper argument —
+powerful enough for two-hops-back + initial-input, but append-only/single-pass so it does not become a
+mutable run-state bag. Still open at the composition level: does the structure descriptor stay fully
+serialisable once nodes nest arbitrarily? Where exactly is the line past which this stops being a
+composition primitive and becomes an orchestrator we said we wouldn't build?
+
+---
+
+## Ancestor-readable pipe input — frozen lexical context
+
+-   **Status:** Phase 1 IMPLEMENTED + green (2026-06, in branch — not yet merged). **Ancestors are
+    BUILDER-ONLY** after an API-review pass (the variadic `pipe(...)` reverted to the simple shipped
+    one-arg `(prev) => StitchInput`, no `name`/`ctx`): the typed `pipe.step()` builder in
+    `packages/core/src/pipe.ts` owns ancestor access + full typing + **compile-time unique names**,
+    with `test/pipe-context.spec.ts` + `test-d/pipe-context.test-d.ts` (tsc/eslint/tsd/1103 unit/
+    bundle-size all pass). Phases 0/2/3 still open. Implements the threading model for
+    [Nestable composition](#nestable-composition--combinators-that-compose-not-a-compose-keyword)
+-   **Date:** 2026-06
+-   **Tags:** composition, pipe, context, ancestor, contract-not-dependency
+-   **Gates:** browser-first ✅ · bundle-frugal ✅ · contract-not-dependency ✅ (the new `name` is a
+    serialisable string that joins the structure; the mapper stays acknowledged sugar) · NOT a workflow
+    engine ✅ (frozen / append-only / topology fixed at definition time).
+
+**Problem / why** — `pipe`'s `input` mapper receives only the _immediately-previous_ result
+(`(prev) => StitchInput`). Real chains need an **earlier ancestor**: `order → shipment → tracking`
+where `tracking` needs `order.region` **and** `shipment.carrier`/`trackingCode`; or GitHub
+`repo → branch → commit` where every call needs `owner`/`repo` from the **first** result, not the
+previous one. Today you can't reach back without awkwardly bundling state forward through `all`.
+
+**Decision (as built, after API review)** — ancestor access lives on a **typed fluent builder**, not on
+the variadic form. An API-review pass killed the "second `ctx` arg on `pipe(...)`" idea: it forced
+casts everywhere (`shipment as Shipment`), made the user supply + police `name` strings, and read as
+_more_ complex than the builder — defeating the typed-function promise. So:
+
+-   **Two surfaces, one engine.** `pipe(...)` stays the **simple, shipped** form — one-arg
+    `input?: (prev: unknown) => StitchInput`, previous-only, no `name`/`ctx` (so this is **non-breaking**
+    and the variadic story stays flat). `pipe.step(...)` is the typed builder entry (no `.with()` —
+    the empty call was pure ceremony): a single overloaded `.step(stitch, mapper?)` (unnamed) /
+    `.step(stitch, name, mapper?)` (named — positional string), and the builder is the callable.
+    **No dedicated `.named()`** (naming is an attribute of a step, not a kind of step), **no `{ name }`
+    wrapper** (the object ceremony bought nothing once naming left the mapper return — a plain string
+    arg is terser and gives a cleaner misuse error), and **no `.build()`** — the builder IS the
+    runnable, so you `await tracked(input)` directly (`makeBuilder` returns `Object.assign(run, { step })`).
+-   **Builder types everything — no casts.** Each `.step` is its own inference site, so `prev` AND
+    `ctx.<name>` are fully typed (`OutputOfStitch<S> = Awaited<ReturnType<S>>`), and `ctx.$input` is
+    `StitchInput | undefined`. This is the only surface where typed ancestors are possible (the variadic
+    fold is a TS mirage — see below).
+-   **Names are the compiler's job, not the user's.** The named overload `step<N>(stitch, name:
+    N extends `$${string}` | keyof Ctx ? never : N, mapper?)` makes a **duplicate name OR a reserved
+    `$`-name a COMPILE error** (`name`narrows to`never`) — the user never tracks uniqueness.
+You only name a step a later step reads; anonymous `.step`s run but aren't addressable. `assertNames`stays as a runtime backstop for dynamically-built names. A frozen`{ $input, ...namedSoFar }`snapshot
+is rebuilt before each step; run identity unchanged (step N a child of N-1). Parallel`all`siblings
+(Phase 2): each gets the snapshot from **before**`all`, so a sibling can't read another (structural
+    isolation).
+
+**Rejected** — (1) a **breaking single-`ctx`-arg** API: its dual-arg migration shim is incoherent (a
+migrated `(ctx) => …` mapper would bind the old `prev` slot and crash), so there's no safe gradual
+path — not worth it for a capability we can add additively. (2) a **typed variadic-tuple `ctx` fold**
+(making `ctx.order` infer as `Order`) on the `pipe(a, b, c)` surface: a later step's `ctx` would need
+contextual typing from a _prior element of the same rest-tuple TS is still inferring_, which it cannot
+do — `ctx.order` collapses to `unknown` (sound, cast required) or, if forced, `any` (unsound, defeats
+`--strict`). **Empirically confirmed** (tsc 5.9.3, `--strict`): the variadic form yields
+`TS18046 'ctx.order' is of type 'unknown'`.
+
+**Typed `ctx` IS achievable — on a chained-builder surface** (each `.step`/`.named` is its own
+inference site, so the prior step's output is resolved and folded into an accumulated `Ctx` type
+param). **Empirically verified** (same tsc run): `pipe().named('order', s).step(s, (prev, ctx) => …)`
+types `ctx.order.region` and `prev.shipmentId` with **zero** errors and a `bogus`/undeclared-name
+access **errors** (`TS2339`) — real typing, not `any`. So the two surfaces are a genuine choice over
+**one runtime engine**: `pipe(...)` (loose `ctx`, cast — what's shipped/taught) vs a `pipe.step()`
+builder (typed `ctx`, no casts, typo-proof). Recommendation upgraded from "Phase 3 optional" to **the
+supported path to typed ancestor access**; offer BOTH, not one instead of the other.
+
+**Boundary guarantee** — stays a static composition primitive: (1) topology fixed at definition time —
+a mapper returns `StitchInput`, never a `Composable`, so it can't synthesise/skip/reorder/repeat a
+step; (2) the `ctx` CONTAINER is `Object.freeze`d (no key writes → not a mutable run-state bag) — the
+freeze is **shallow by design**: ancestor _values_ are the user's own result objects passed by
+reference (deep-freezing would also freeze the caller's `$input` and the pipeline's return value, a
+surprising regression), so they are read-only by contract, like `prev`, not by enforcement; (3) no
+persistence, no cross-node retry;
+(4) the only fan-in is `all`/`any`/`race` collapsing at their own node. **The line we hold in review:**
+a mapper may _shape_ the next call's input (even with a ternary on `ctx`), but we **refuse** any
+follow-on that lets it return a skip/`when` sentinel, a fan-out array, or a new node.
+
+**Honest caveat** — `name` makes the dependency **nodes** legible in the trace/DAG, but **which step
+reads which ancestor lives inside the opaque closure and does NOT round-trip**: the `parentId` chain
+stays linear (`order→shipment→tracking`) while the real data graph is a fan-in (`order→tracking`), so
+the DAG _under-represents_ data edges. Mitigation: an optional, serialisable `reads?: readonly
+string[]` hint per step so `stitch diagram`/the playground can draw the real edge. Also note: pipe does
+**not** emit a serialisable structure descriptor today (it returns a bare closure) — introducing
+`{ kind, members }` is real work, costed below.
+
+**Rollout** — **Phase 0** (shared with the parallel family): `Composable` contract +
+`__runWith(input, run, ctx)`, widen `pipe` to return `Composable<Out>`, thread the Frame. **Phase 1**
+(this feature): sequential `ctx` + `name` + `$input`, construction-time name validation, loose
+`PipeContext` typing, `pipe-ctx.spec.ts`, and a `tsd` pin (**1-arg mapper still checks; `ctx.order` is
+`unknown`, not `any`**). **Phase 2** (with `all`): sibling isolation + nested lexical chain + namespaced
+`all` result. **Phase 3** (optional, additive): `reads?` DAG hint and/or the typed chained-builder.
+
+**Top risks** — (1) **DAG dishonesty** — ship the `reads?` hint before marketing the observability
+story. (2) **Memory** — naming pins a result for the whole invocation (bounded by named-step count;
+omit `name` to avoid). (3) **`unknown`-cast footgun** — a `ctx.oder` typo yields `undefined` in a URL
+(the exact failure pipe markets against); mitigate with a dev/test-only `Proxy` that throws on a
+never-declared / not-yet-resolved name, stripped in prod.
+
+**Backed by / builds on** — `packages/core/src/pipe.ts` (the shipped runner this extends), `infer.ts`
+(loose, fail-open typing stance), ADR 0007 run identity, and the parallel/Composable entries above.

--- a/packages/core/src/pipe.ts
+++ b/packages/core/src/pipe.ts
@@ -1,26 +1,24 @@
-// The `stitchapi/pipe` subpath (ADR 0008): linear composition. Run stitches in sequence, feeding
-// each result to the next, with each step a CHILD run of the prior (ADR 0007 run identity) — so a
-// trace shows the chain `stepA → stepB → stepC` and the playground DAG draws the same edges. The
-// step-to-step MAPPING is a closure (acknowledged sugar, the same category as `transform` /
-// `paginate.next`), while the STRUCTURE — the ordered member stitches — round-trips. Fail-fast: a
-// step's error rejects the pipeline. Bundle-frugal: reached only through the `pipe` subpath.
+// The `stitchapi/pipe` subpath (ADR 0008): the composition family. Compose stitches — and each other —
+// into typed flows, sequential or parallel, that you `await` like any function. Every combinator
+// returns the same callable shape, so they NEST. Each member runs as a CHILD run (ADR 0007 run
+// identity), so a trace/DAG shows the tree. Bundle-frugal: reached only through this subpath.
+//
+//   - `pipe(...)` / `pipe.step(...)` — SEQUENTIAL: steps in order, each feeds the next, fail-fast. The
+//     builder (`pipe.step`) types `prev` AND a `ctx` of named ancestors with no casts, and an inline
+//     `{ k: node }` object fans out in parallel and merges its keys into `ctx`.
+//   - `all({ k: node })` — PARALLEL, resolve when ALL succeed (fail-fast); a typed named object.
+//   - `any([...])` — PARALLEL, resolve on the FIRST success (else `AggregateError`); failover.
+//   - `race([...])` — PARALLEL, resolve on the FIRST to settle (win or lose); hedging.
+//
+// All parallel combinators AUTO-CANCEL the members that can no longer affect the result: `all` aborts
+// its siblings on the first failure, `any` on the first success, `race` on the first settle — each via
+// a per-run `AbortSignal` threaded onto every member call. There is deliberately NO `allSettled`
+// (best-effort) variant; for that, compose `.safe()` members by hand.
 import type { RunContext, Stitch, StitchInput } from './types';
 import { newRunContext } from './util';
 
-/** A pipe step: the stitch to run, and how to turn the previous result into its call input. */
-export interface PipeStep {
-    /** The stitch to run for this step. */
-    readonly stitch: Stitch;
-    /**
-     * Map the previous step's result to this step's call input (sugar; not serialised). Omitted ⇒
-     * the previous result is passed as the call `body`. The FIRST step receives the pipe's initial
-     * input directly and ignores this.
-     */
-    readonly input?: (prev: unknown) => StitchInput;
-}
-
-// The internal child-run invocation a stitch exposes (stitch.ts `__runWith`): run under a supplied
-// run identity and resolve to the value. Reached through a cast — it is not on the public Stitch.
+// The internal child-run invocation a node exposes (stitch.ts `__runWith`, and the combinators
+// below): run under a supplied run identity and resolve to the value. Reached through a cast.
 interface Runnable {
     __runWith: (
         input: StitchInput | undefined,
@@ -28,52 +26,459 @@ interface Runnable {
     ) => Promise<unknown>;
 }
 
-const asStep = (s: PipeStep | Stitch): PipeStep =>
-    typeof s === 'function' ? { stitch: s } : s;
+/**
+ * A composed flow — what every combinator returns. It is callable (`await composable(input)` runs it
+ * as a root) and nests inside any other combinator (it carries the same child-run protocol a stitch
+ * does). `__composable` brands it so a `{ k: node }` step is distinguishable from a single node.
+ */
+export interface Composable<Out> {
+    (input?: StitchInput): Promise<Out>;
+    readonly __composable: true;
+}
+
+/** A composition member: a single-endpoint {@link Stitch} or a nested {@link Composable}. */
+export type Node<O = unknown> = Stitch<O> | Composable<O>;
+
+// ---- abort plumbing (auto-cancel losers) ----------------------------------
+
+/**
+ * A controller whose `signal` is handed to every member of a parallel combinator. It is LINKED to the
+ * caller's signal (an outer abort cancels the whole group), and the combinator aborts it the moment
+ * the result is decided — cancelling the members that can no longer matter.
+ */
+function linkedController(parent?: AbortSignal): AbortController {
+    const ctrl = new AbortController();
+    if (parent) {
+        if (parent.aborted) ctrl.abort(parent.reason);
+        else
+            parent.addEventListener(
+                'abort',
+                () => {
+                    ctrl.abort(parent.reason);
+                },
+                { once: true },
+            );
+    }
+    return ctrl;
+}
+
+// Run one member under the group's abort signal, as a child run of the group node. The group's signal
+// REPLACES any inbound signal on the shared input (the inbound one is already linked into it).
+function runMember(
+    node: Node,
+    input: StitchInput | undefined,
+    signal: AbortSignal,
+    groupRun: RunContext,
+): Promise<unknown> {
+    const memberInput: StitchInput = { ...input, signal };
+    return (node as unknown as Runnable).__runWith(
+        memberInput,
+        newRunContext(groupRun),
+    );
+}
+
+// Pre-handle each member so a cancelled member's late rejection is never an unhandled rejection (the
+// combinator's own `await` is the single place a failure is observed).
+function swallowLateRejections(settling: readonly Promise<unknown>[]): void {
+    for (const p of settling) void p.catch(() => undefined);
+}
+
+// `all`: every member concurrently; resolve to a named object when ALL succeed; the FIRST failure
+// aborts the rest and rejects. Members run as siblings under `groupRun`.
+async function runAll(
+    members: Record<string, Node>,
+    input: StitchInput | undefined,
+    groupRun: RunContext,
+): Promise<Record<string, unknown>> {
+    const ctrl = linkedController(input?.signal);
+    const entries = Object.entries(members);
+    const settling = entries.map(([, node]) =>
+        runMember(node, input, ctrl.signal, groupRun),
+    );
+    swallowLateRejections(settling);
+    try {
+        const values = await Promise.all(settling);
+        const out: Record<string, unknown> = {};
+        entries.forEach(([k], i) => {
+            out[k] = values[i];
+        });
+        return out;
+    } catch (err) {
+        ctrl.abort();
+        throw err;
+    }
+}
+
+// `all` over a positional array; resolve to a tuple when ALL succeed; the FIRST failure aborts the
+// rest and rejects (the `Promise.all` shape, with auto-cancel + child runs).
+async function runAllArray(
+    members: readonly Node[],
+    input: StitchInput | undefined,
+    groupRun: RunContext,
+): Promise<unknown[]> {
+    const ctrl = linkedController(input?.signal);
+    const settling = members.map((m) =>
+        runMember(m, input, ctrl.signal, groupRun),
+    );
+    swallowLateRejections(settling);
+    try {
+        return await Promise.all(settling);
+    } catch (err) {
+        ctrl.abort();
+        throw err;
+    }
+}
+
+// `any`: every member concurrently; resolve on the FIRST success; if all fail, reject with the
+// `AggregateError` of their errors. Abort the losers once a winner (or total failure) is known.
+async function runAny(
+    members: readonly Node[],
+    input: StitchInput | undefined,
+    groupRun: RunContext,
+): Promise<unknown> {
+    const ctrl = linkedController(input?.signal);
+    const settling = members.map((m) =>
+        runMember(m, input, ctrl.signal, groupRun),
+    );
+    swallowLateRejections(settling);
+    try {
+        return await Promise.any(settling);
+    } finally {
+        ctrl.abort();
+    }
+}
+
+// `race`: every member concurrently; resolve/reject with the FIRST to SETTLE; abort the rest.
+async function runRace(
+    members: readonly Node[],
+    input: StitchInput | undefined,
+    groupRun: RunContext,
+): Promise<unknown> {
+    const ctrl = linkedController(input?.signal);
+    const settling = members.map((m) =>
+        runMember(m, input, ctrl.signal, groupRun),
+    );
+    swallowLateRejections(settling);
+    try {
+        return await Promise.race(settling);
+    } finally {
+        ctrl.abort();
+    }
+}
+
+// ---- types -----------------------------------------------------------------
+
+/** A node's resolved output — what `await node(...)` yields. Works for a stitch or a composable. */
+type OutputOf<S extends Node> = Awaited<ReturnType<S>>;
+/** Flatten an accumulated intersection into one object literal (readable hovers). */
+type Prettify<T> = { [K in keyof T]: T[K] } & {};
+/** The named-object output of a parallel bag `{ k: node }` — each key mapped to that node's output. */
+type BagOut<M extends Record<string, Node>> = Prettify<{
+    [K in keyof M]: OutputOf<M[K]>;
+}>;
+/** The tuple output of a positional `all([...])` — each member mapped to its output, in order. */
+type TupleOut<T extends readonly Node[]> = { [K in keyof T]: OutputOf<T[K]> };
+
+// ---- parallel combinators --------------------------------------------------
+
+// Build a Composable from a `(input, groupRun) => Promise<Out>` core: callable mints a root run; the
+// internal `__runWith` runs under the supplied child run (so it nests inside a pipe / another group).
+function makeComposable<Out>(
+    core: (
+        input: StitchInput | undefined,
+        groupRun: RunContext,
+    ) => Promise<Out>,
+): Composable<Out> {
+    const fn = ((input?: StitchInput) =>
+        core(input, newRunContext())) as Composable<Out> & Runnable;
+    fn.__runWith = (input, run) => core(input, run);
+    return Object.assign(fn, { __composable: true as const });
+}
+
+/**
+ * Run nodes CONCURRENTLY and resolve when ALL succeed; fail-fast — the first to reject aborts the rest
+ * and rejects the whole `all`. Two interchangeable forms (pick whichever reads better):
+ *
+ * - a NAMED object → a typed object keyed by the same names:
+ *   `all({ user: fetchUser, prefs: fetchPrefs })` ⇒ `Promise<{ user; prefs }>`.
+ * - a positional ARRAY (the `Promise.all` shape) → a typed tuple:
+ *   `all([fetchUser, fetchPrefs])` ⇒ `Promise<readonly [User, Prefs]>`.
+ *
+ * Only the named form merges into a pipe's `ctx` via an inline `.step({...})`; an array nests through
+ * `.step(all([...]), 'name')`. Each member keeps its own retry/timeout/validation.
+ */
+export function all<const T extends readonly Node[]>(
+    members: T,
+): Composable<TupleOut<T>>;
+export function all<M extends Record<string, Node>>(
+    members: M,
+): Composable<BagOut<M>>;
+export function all(
+    members: readonly Node[] | Record<string, Node>,
+): Composable<unknown> {
+    return Array.isArray(members)
+        ? makeComposable((input, run) =>
+              runAllArray(members as readonly Node[], input, run),
+          )
+        : makeComposable((input, run) =>
+              runAll(members as Record<string, Node>, input, run),
+          );
+}
+
+/**
+ * Run nodes CONCURRENTLY and resolve with the FIRST to SUCCEED — failover across interchangeable
+ * sources. If every member fails, rejects with an `AggregateError`. The losers are auto-cancelled.
+ */
+export function any<M extends readonly Node[]>(
+    members: M,
+): Composable<OutputOf<M[number]>> {
+    return makeComposable(
+        (input, run) =>
+            runAny(members, input, run) as Promise<OutputOf<M[number]>>,
+    );
+}
+
+/**
+ * Run nodes CONCURRENTLY and resolve/reject with the FIRST to SETTLE (success OR failure) — hedging a
+ * latency-sensitive call against a faster mirror. The slower members are auto-cancelled.
+ */
+export function race<M extends readonly Node[]>(
+    members: M,
+): Composable<OutputOf<M[number]>> {
+    return makeComposable(
+        (input, run) =>
+            runRace(members, input, run) as Promise<OutputOf<M[number]>>,
+    );
+}
+
+// ---- the sequential engine (shared by both pipe surfaces) -----------------
+
+/** The frozen ancestor view the engine hands a mapper: `$input` plus every earlier NAMED result. */
+interface RunCtx {
+    readonly $input: StitchInput | undefined;
+    readonly [name: string]: unknown;
+}
+/** The engine's mapper shape: previous result + the ancestor view → the next call's input. */
+type RunMapper = (prev: unknown, ctx: RunCtx) => StitchInput;
+/** The internal step shape the engine runs: a single node (optionally named) OR an inline parallel bag. */
+type RunStep =
+    | {
+          readonly node: Node;
+          readonly name?: string;
+          readonly input?: RunMapper;
+      }
+    | { readonly bag: Record<string, Node>; readonly input?: RunMapper };
+
+// Reject reserved / duplicate names up front (construction, not mid-run) — across single-step names
+// AND inline-bag keys. The builder enforces this at COMPILE time for literals; this is the runtime
+// backstop for dynamically-built names.
+function assertNames(steps: readonly RunStep[]): void {
+    const seen = new Set<string>();
+    const check = (name: string) => {
+        if (name.startsWith('$'))
+            throw new Error(
+                `pipe: step name ${JSON.stringify(name)} is reserved — a name cannot start with '$'`,
+            );
+        if (seen.has(name))
+            throw new Error(
+                `pipe: duplicate step name ${JSON.stringify(name)}`,
+            );
+        seen.add(name);
+    };
+    for (const step of steps) {
+        if ('bag' in step) Object.keys(step.bag).forEach(check);
+        else if (step.name !== undefined) check(step.name);
+    }
+}
+
+function compile(
+    steps: readonly RunStep[],
+): (input?: StitchInput) => Promise<unknown> {
+    assertNames(steps);
+    return async (input?: StitchInput): Promise<unknown> => {
+        let value: unknown;
+        let prevRun: RunContext | undefined;
+        let first = true;
+        // Already-resolved NAMED results, accumulated for ancestor access. A fresh frozen snapshot
+        // (`{ $input, ...named }`) is handed to each mapper, so a later read sees a point-in-time view
+        // and the container can't be written to. (Shallow freeze — ancestor VALUES are the user's own
+        // result objects, read-only by contract like `prev`, not deep-frozen.)
+        const named: Record<string, unknown> = {};
+        for (const step of steps) {
+            const stepInput: StitchInput = first
+                ? (input ?? {})
+                : step.input
+                  ? step.input(
+                        value,
+                        Object.freeze({ $input: input, ...named }),
+                    )
+                  : { body: value };
+            // Chain the run identity: this step is a child of the previous (ADR 0007). A bag step is
+            // one node whose members fan out as its children.
+            const run = newRunContext(prevRun);
+            if ('bag' in step) {
+                const bagOut = await runAll(step.bag, stepInput, run);
+                for (const k of Object.keys(step.bag)) named[k] = bagOut[k];
+                value = bagOut;
+            } else {
+                value = await (step.node as unknown as Runnable).__runWith(
+                    stepInput,
+                    run,
+                );
+                if (step.name !== undefined) named[step.name] = value;
+            }
+            prevRun = run;
+            first = false;
+        }
+        return value;
+    };
+}
+
+// ---- surface 1: the simple variadic `pipe(...)` ---------------------------
+
+/** A pipe step: the stitch to run, and how to map the PREVIOUS result into its call input. */
+export interface PipeStep {
+    /** The stitch to run for this step. */
+    readonly stitch: Stitch;
+    /**
+     * Map the previous step's result into this step's call input (sugar; not serialised). `prev` is
+     * `unknown` — narrow it with a cast. Omitted ⇒ the previous result is passed as the call `body`.
+     * The FIRST step receives the pipe's initial input directly and ignores this. For typed `prev` /
+     * ancestors / parallel steps, use the {@link pipe.step} builder instead.
+     */
+    readonly input?: (prev: unknown) => StitchInput;
+}
+
+const asStep = (s: PipeStep | Stitch): RunStep =>
+    typeof s === 'function'
+        ? { node: s }
+        : { node: s.stitch, ...(s.input ? { input: s.input } : {}) };
 
 /**
  * Compose stitches into a linear pipeline. The returned callable takes the FIRST step's input; each
- * later step receives the previous result through its `input` mapper (or the raw result as the call
- * `body` when no mapper is given), and the pipeline resolves to the LAST step's result.
+ * later step receives the PREVIOUS result through its `input` mapper (or the raw result as the call
+ * `body` when no mapper is given), and the pipeline resolves to the LAST step's result. Runs in order,
+ * each step a CHILD run of the previous (ADR 0007), fail-fast.
  *
- * Each step runs as a CHILD run of the previous (ADR 0007), so a trace/DAG shows the chain. Steps
- * run sequentially and the pipeline FAILS FAST — a step's `StitchError` rejects the whole pipe.
+ * `prev` is `unknown` here (TS can't infer it across a variadic call). When a step needs an EARLIER
+ * result, typed `prev`, or a parallel sub-step, reach for the {@link pipe.step} builder.
  *
  * @example
  * ```ts
  * import { pipe } from 'stitchapi/pipe';
  *
  * const flow = pipe(
- *     fetchUser, // receives the pipe's input
- *     { stitch: fetchPosts, input: (u) => ({ params: { userId: (u as User).id } }) },
+ *     fetchOrder, // receives the pipe's input
+ *     { stitch: fetchShipment, input: (o) => ({ params: { id: (o as Order).shipmentId } }) },
  * );
- * const posts = await flow({ params: { id: 1 } });
+ * const shipment = await flow({ params: { id: 1043 } });
  * ```
  */
 export function pipe<Out = unknown>(
     ...steps: (PipeStep | Stitch)[]
 ): (input?: StitchInput) => Promise<Out> {
-    const resolved = steps.map(asStep);
-    return async (input?: StitchInput): Promise<Out> => {
-        let value: unknown;
-        let prevRun: RunContext | undefined;
-        let first = true;
-        for (const step of resolved) {
-            const stepInput: StitchInput = first
-                ? (input ?? {})
-                : step.input
-                  ? step.input(value)
-                  : { body: value };
-            // Chain the run identity: step N is a child of step N-1 — the linear causality the
-            // trace/DAG draws. The first step (prevRun undefined) is a root run.
-            const run = newRunContext(prevRun);
-            value = await (step.stitch as unknown as Runnable).__runWith(
-                stepInput,
-                run,
-            );
-            prevRun = run;
-            first = false;
-        }
-        return value as Out;
-    };
+    return compile(steps.map(asStep)) as (input?: StitchInput) => Promise<Out>;
 }
+
+// ---- surface 2: the typed builder (`pipe.step(...)`) ----------------------
+
+/** The base context every builder starts with — just the pipe's initial input. */
+interface BaseCtx {
+    readonly $input: StitchInput | undefined;
+}
+
+/**
+ * The `.step` operation, typed as a callable PROPERTY (three call signatures) rather than a method, so
+ * it can be detached — `pipe.step = makeBuilder([]).step` — without tripping `unbound-method`. Pass a
+ * single node (optionally a positional `name`), or an inline `{ k: node }` bag to fan out in parallel.
+ */
+export interface PipeStepFn<Ctx extends BaseCtx, Prev> {
+    /**
+     * Append an inline PARALLEL bag: each `{ key: node }` runs concurrently (fail-fast, auto-cancel),
+     * its keys MERGE into `ctx`, and `prev` becomes the named result object. A duplicate or
+     * `$`-prefixed key narrows to `never` — a compile error.
+     */
+    <M extends Record<string, Node>>(
+        bag: keyof M extends `$${string}` | keyof Ctx ? never : M,
+        input?: (prev: Prev, ctx: Ctx) => StitchInput,
+    ): PipeBuilder<Prettify<Ctx & BagOut<M>>, BagOut<M>>;
+    /**
+     * Append a NAMED step: `name` files its result under `ctx[name]` (typed) for every later step. A
+     * duplicate or `$`-prefixed name narrows to `never` — a compile error you never police by hand.
+     */
+    <N extends string, S extends Node>(
+        node: S,
+        name: N extends `$${string}` | keyof Ctx ? never : N,
+        input?: (prev: Prev, ctx: Ctx) => StitchInput,
+    ): PipeBuilder<Prettify<Ctx & Record<N, OutputOf<S>>>, OutputOf<S>>;
+    /**
+     * Append a step, optionally with a mapper of the previous result. Unnamed ⇒ not addressable by a
+     * later step; pass a `name` (the overload above) to make its result readable through `ctx`.
+     */
+    <S extends Node>(
+        node: S,
+        input?: (prev: Prev, ctx: Ctx) => StitchInput,
+    ): PipeBuilder<Ctx, OutputOf<S>>;
+}
+
+export interface PipeBuilder<Ctx extends BaseCtx, Prev> {
+    /** Run the pipeline: resolves to the LAST step's output. The builder itself is the callable. */
+    (input?: StitchInput): Promise<Prev>;
+    /** Append a step / parallel bag (and optionally name a single step) — see {@link PipeStepFn}. */
+    readonly step: PipeStepFn<Ctx, Prev>;
+}
+
+function makeBuilder(steps: readonly RunStep[]): PipeBuilder<BaseCtx, unknown> {
+    // The builder IS the runnable: calling it compiles (once) and runs the accumulated steps.
+    let compiled: ((input?: StitchInput) => Promise<unknown>) | undefined;
+    const run = (input?: StitchInput): Promise<unknown> =>
+        (compiled ??= compile(steps))(input);
+    // A function first arg is a single node — `(node, name?|mapper?, mapper?)`; an object first arg is
+    // an inline bag — `(bag, mapper?)`. Typed via the public PipeStepFn signature; loose here.
+    const step = (
+        first: Node | Record<string, Node>,
+        second?: string | RunMapper,
+        third?: RunMapper,
+    ): PipeBuilder<BaseCtx, unknown> => {
+        let next: RunStep;
+        if (typeof first === 'function') {
+            const name = typeof second === 'string' ? second : undefined;
+            const input = typeof second === 'function' ? second : third;
+            next = {
+                node: first,
+                ...(name !== undefined ? { name } : {}),
+                ...(input ? { input } : {}),
+            };
+        } else {
+            const input = typeof second === 'function' ? second : undefined;
+            next = { bag: first, ...(input ? { input } : {}) };
+        }
+        return makeBuilder([...steps, next]);
+    };
+    // The impl `step` returns a generic-erased builder; the public PipeStepFn overloads (esp. the bag
+    // overload's mapped-type result) make it structurally non-assignable, so cast at this seam.
+    return Object.assign(run, { step }) as unknown as PipeBuilder<
+        BaseCtx,
+        unknown
+    >;
+}
+
+/**
+ * Begin a TYPED pipeline on `pipe` itself — `pipe.step(...)` starts the fluent builder (the same
+ * `.step` you chain). Each step is its own inference site, so the builder types `prev` AND a `ctx` of
+ * named ancestors with no casts, and enforces unique names at compile time, over the SAME runtime
+ * engine as `pipe(...)`. The builder is itself the runnable pipeline — call it directly. (The first
+ * step's `input` mapper is ignored — it receives the pipe's input.)
+ *
+ * @example
+ * ```ts
+ * const tracked = pipe
+ *     .step(fetchOrder, 'order') // named only because a later step reads it back
+ *     .step({ shipment: fetchShipment, invoice: fetchInvoice }) // parallel; merges into ctx
+ *     .step(fetchTracking, (details, ctx) => ({
+ *         params: { code: details.shipment.trackingCode, region: ctx.order.region },
+ *     }));
+ * const tracking = await tracked({ params: { id: 1043 } }); // the builder is the callable
+ * ```
+ */
+pipe.step = makeBuilder([]).step;

--- a/packages/core/test-d/combinators.test-d.ts
+++ b/packages/core/test-d/combinators.test-d.ts
@@ -1,0 +1,64 @@
+// Type-level contract for the parallel combinators and how they compose with the pipe builder:
+// `all` → a typed named object, `any`/`race` → the members' output, an inline `{ k: node }` bag
+// merges into `ctx`, and a standalone combinator nests as a single (named) node. See src/pipe.ts.
+import { stitch } from '..';
+import { all, any, pipe, race } from '../src/pipe';
+
+import { expectError, expectType } from 'tsd';
+
+interface Order {
+    id: number;
+    shipmentId: string;
+    region: string;
+}
+interface Shipment {
+    carrier: string;
+}
+interface Invoice {
+    total: number;
+}
+
+const fetchOrder = stitch<Order>({ baseUrl: 'x', path: '/o' });
+const fetchShipment = stitch<Shipment>({ baseUrl: 'x', path: '/s' });
+const fetchInvoice = stitch<Invoice>({ baseUrl: 'x', path: '/i' });
+const fetchOrderMirror = stitch<Order>({ baseUrl: 'x', path: '/om' });
+
+// all (object form) → a typed named object
+expectType<Promise<{ shipment: Shipment; invoice: Invoice }>>(
+    all({ shipment: fetchShipment, invoice: fetchInvoice })(),
+);
+
+// all (array form) → a typed positional tuple (readonly)
+expectType<Promise<readonly [Shipment, Invoice]>>(
+    all([fetchShipment, fetchInvoice])(),
+);
+
+// any / race → the members' (common) output
+expectType<Promise<Order>>(any([fetchOrder, fetchOrderMirror])());
+expectType<Promise<Order>>(race([fetchOrder, fetchOrderMirror])());
+
+// inline bag in a pipe: merges keys into ctx, prev = the bag
+const flow = pipe
+    .step(fetchOrder, 'order')
+    .step({ shipment: fetchShipment, invoice: fetchInvoice })
+    .step(fetchOrder, (prev, ctx) => {
+        expectType<Shipment>(prev.shipment); // prev = the bag
+        expectType<Invoice>(prev.invoice);
+        expectType<Shipment>(ctx.shipment); // bag key merged into ctx
+        expectType<string>(ctx.order.region); // earlier ancestor, still typed
+        return {};
+    });
+expectType<Promise<Order>>(flow({}));
+
+// a standalone combinator nests as a single named node (failover on the first call)
+const failover = pipe
+    .step(any([fetchOrder, fetchOrderMirror]), 'order')
+    .step(fetchShipment, (order) => ({ params: { id: order.shipmentId } }));
+expectType<Promise<Shipment>>(failover({}));
+
+// duplicate name across a single step and a later bag key → compile error
+expectError(
+    pipe.step(fetchShipment, 'shipment').step({ shipment: fetchInvoice }),
+);
+// a `$`-prefixed bag key → compile error
+expectError(pipe.step({ $bad: fetchShipment }));

--- a/packages/core/test-d/pipe-context.test-d.ts
+++ b/packages/core/test-d/pipe-context.test-d.ts
@@ -1,0 +1,82 @@
+// Type-level contract for the typed `pipe.with()` builder: typed `prev` AND a typed `ctx` of named
+// ancestors (no casts), with unique names enforced at COMPILE time. The simple variadic `pipe(...)`
+// stays one-arg, previous-only. See packages/core/src/pipe.ts.
+import { stitch } from '..';
+import type { StitchInput } from '..';
+import { pipe } from '../src/pipe';
+
+import { expectError, expectType } from 'tsd';
+
+interface Order {
+    id: number;
+    shipmentId: string;
+    region: string;
+}
+interface Shipment {
+    carrier: string;
+    trackingCode: string;
+}
+interface Tracking {
+    events: string[];
+}
+
+const fetchOrder = stitch<Order>({ baseUrl: 'x', path: '/o' });
+const fetchShipment = stitch<Shipment>({ baseUrl: 'x', path: '/s' });
+const fetchTracking = stitch<Tracking>({ baseUrl: 'x', path: '/t' });
+
+// ---- builder: typed prev + typed ctx ancestors, no casts; the builder is itself the callable ----
+const tracked = pipe
+    .step(fetchOrder, 'order') // name via the optional positional arg on `step`
+    .step(fetchShipment, (order, ctx) => {
+        expectType<Order>(order); // prev typed as the order output
+        expectType<StitchInput | undefined>(ctx.$input); // initial input reachable
+        return { params: { id: order.shipmentId } };
+    })
+    .step(fetchTracking, (shipment, ctx) => {
+        expectType<Shipment>(shipment); // prev now the shipment output
+        expectType<string>(ctx.order.region); // ancestor typed, two hops back
+        return {};
+    });
+
+// no .build() — call the builder directly; it resolves to the LAST step's output type
+expectType<Promise<Tracking>>(tracked({ params: { id: 1 } }));
+
+// ---- ctx is REAL typing, not `any` ----
+expectError(
+    pipe.step(fetchOrder, 'order').step(fetchShipment, (_o, ctx) => ({
+        params: { x: String(ctx.order.bogus) }, // unknown property on a typed ancestor
+    })),
+);
+expectError(
+    pipe.step(fetchOrder, 'order').step(fetchShipment, (_o, ctx) => ({
+        params: { x: String(ctx.invoice) }, // undeclared name
+    })),
+);
+
+// ---- unique names are a COMPILE-time guarantee ----
+expectError(
+    // duplicate name
+    pipe.step(fetchOrder, 'order').step(fetchShipment, 'order'),
+);
+expectError(
+    // reserved `$input`
+    pipe.step(fetchOrder, '$input'),
+);
+expectError(
+    // reserved `$`-prefix
+    pipe.step(fetchOrder, '$weird'),
+);
+
+// ---- variadic pipe(): simple, one-arg, no name / no ctx ----
+expectType<Promise<unknown>>(
+    pipe(fetchOrder, {
+        stitch: fetchShipment,
+        input: (prev) => ({
+            params: { id: String((prev as Order).shipmentId) },
+        }),
+    })(),
+);
+// Note: the variadic surface is deliberately LOOSE — TS relaxes excess-property and function-arity
+// checks when the parameter is a union (`PipeStep | Stitch`), so a stray `name` or a 2-arg mapper
+// isn't a type error there. The typed/strict contract lives entirely on the `pipe.with()` builder
+// (asserted above). The variadic mapper's documented shape is one-arg, `prev: unknown`.

--- a/packages/core/test/combinators.spec.ts
+++ b/packages/core/test/combinators.spec.ts
@@ -1,0 +1,222 @@
+// stitchapi/pipe — the parallel combinators all / any / race, plus the inline-bag pipe step. Covers
+// the result shapes, fail-fast / first-success / first-settle semantics, AUTO-CANCELLATION of members
+// that can no longer affect the result (a blocker member observes its `req.signal`), and the
+// sibling-child-run fan that a trace draws. The decider in each cancel test is delayed a beat so the
+// blocker has attached its abort listener before the result is known (deterministic, not a race).
+import { stitch } from '../src';
+import type { StitchEvent, TraceContext, TraceSink } from '../src';
+import { all, any, pipe, race } from '../src/pipe';
+
+interface Res {
+    status: number;
+    headers: Record<string, string>;
+    body: unknown;
+}
+
+// Resolve immediately to `body` (HTTP 200).
+const ok = (body: unknown) =>
+    stitch({
+        name: 'ok',
+        baseUrl: 'http://x',
+        path: '/ok',
+        adapter: async (): Promise<Res> => ({ status: 200, headers: {}, body }),
+    });
+
+// Resolve `body` after `ms` (HTTP 200).
+const okAfter = (ms: number, body: unknown) =>
+    stitch({
+        name: 'ok',
+        baseUrl: 'http://x',
+        path: '/ok',
+        adapter: (): Promise<Res> =>
+            new Promise((res) => {
+                setTimeout(() => {
+                    res({ status: 200, headers: {}, body });
+                }, ms);
+            }),
+    });
+
+// Fail immediately with a non-retryable 400 → a `StitchError` with `.status` 400.
+const boom = () =>
+    stitch({
+        name: 'boom',
+        baseUrl: 'http://x',
+        path: '/boom',
+        adapter: async (): Promise<Res> => ({
+            status: 400,
+            headers: {},
+            body: { e: 'x' },
+        }),
+    });
+
+// Fail with a 400 after `ms`.
+const boomAfter = (ms: number) =>
+    stitch({
+        name: 'boom',
+        baseUrl: 'http://x',
+        path: '/boom',
+        adapter: (): Promise<Res> =>
+            new Promise((res) => {
+                setTimeout(() => {
+                    res({ status: 400, headers: {}, body: { e: 'x' } });
+                }, ms);
+            }),
+    });
+
+// Never settles on its own — only when its request is aborted. Records the abort.
+function blocker() {
+    let aborted = false;
+    const s = stitch({
+        name: 'blocker',
+        baseUrl: 'http://x',
+        path: '/b',
+        adapter: (req): Promise<Res> =>
+            new Promise<Res>((_resolve, reject) => {
+                const onAbort = () => {
+                    aborted = true;
+                    reject(new Error('aborted'));
+                };
+                if (req.signal?.aborted) onAbort();
+                else req.signal?.addEventListener('abort', onAbort);
+            }),
+    });
+    return { s, aborted: () => aborted };
+}
+
+function capturingSink(): {
+    sink: TraceSink;
+    seen: { ev: StitchEvent; ctx: TraceContext }[];
+} {
+    const seen: { ev: StitchEvent; ctx: TraceContext }[] = [];
+    return {
+        seen,
+        sink: { handle: (ev, ctx) => void seen.push({ ev, ctx: { ...ctx } }) },
+    };
+}
+
+test('all: resolves to a typed named object when every member succeeds', async () => {
+    await expect(all({ a: ok({ n: 1 }), b: ok({ n: 2 }) })()).resolves.toEqual({
+        a: { n: 1 },
+        b: { n: 2 },
+    });
+});
+
+test('all (array form): resolves to a positional tuple, in order', async () => {
+    await expect(all([ok({ n: 1 }), ok({ n: 2 })])()).resolves.toEqual([
+        { n: 1 },
+        { n: 2 },
+    ]);
+});
+
+test('all (array form): fail-fast — the first failure rejects and aborts the rest', async () => {
+    const slow = blocker();
+    await expect(all([boomAfter(10), slow.s])()).rejects.toMatchObject({
+        status: 400,
+    });
+    expect(slow.aborted()).toBe(true);
+});
+
+test('all: fail-fast — the first failure rejects and aborts the rest', async () => {
+    const slow = blocker();
+    await expect(
+        all({ bad: boomAfter(10), slow: slow.s })(),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(slow.aborted()).toBe(true); // sibling auto-cancelled
+});
+
+test('any: resolves with the first success and cancels the losers', async () => {
+    const slow = blocker();
+    await expect(any([slow.s, okAfter(10, { ok: true })])()).resolves.toEqual({
+        ok: true,
+    });
+    expect(slow.aborted()).toBe(true);
+});
+
+test('any: rejects with an AggregateError when every member fails', async () => {
+    await expect(any([boom(), boom()])()).rejects.toBeInstanceOf(
+        AggregateError,
+    );
+});
+
+test('race: the first to settle wins — even a fast failure — and cancels the rest', async () => {
+    const slow = blocker();
+    await expect(race([boomAfter(10), slow.s])()).rejects.toMatchObject({
+        status: 400,
+    });
+    expect(slow.aborted()).toBe(true);
+});
+
+test('pipe inline bag: members run in parallel and merge into ctx', async () => {
+    const order = stitch<{ id: number; region: string }>({
+        name: 'order',
+        baseUrl: 'http://x',
+        path: '/o',
+        adapter: async (): Promise<Res> => ({
+            status: 200,
+            headers: {},
+            body: { id: 1, region: 'EU' },
+        }),
+    });
+    const shipment = stitch<{ carrier: string }>({
+        name: 'shipment',
+        baseUrl: 'http://x',
+        path: '/s',
+        adapter: async (): Promise<Res> => ({
+            status: 200,
+            headers: {},
+            body: { carrier: 'dhl' },
+        }),
+    });
+    const invoice = stitch<{ total: number }>({
+        name: 'invoice',
+        baseUrl: 'http://x',
+        path: '/i',
+        adapter: async (): Promise<Res> => ({
+            status: 200,
+            headers: {},
+            body: { total: 42 },
+        }),
+    });
+
+    let seen: { region: string; carrier: string; total: number } | undefined;
+    const flow = pipe
+        .step(order, 'order')
+        .step({ shipment, invoice }) // inline parallel bag → merges into ctx
+        .step(ok({ done: true }), (details, ctx) => {
+            seen = {
+                region: ctx.order.region, // earlier ancestor
+                carrier: details.shipment.carrier, // prev = the bag
+                total: ctx.invoice.total, // merged bag key
+            };
+            return {};
+        });
+
+    await expect(flow({})).resolves.toEqual({ done: true });
+    expect(seen).toEqual({ region: 'EU', carrier: 'dhl', total: 42 });
+});
+
+test('all: members run as sibling child runs of one parent (trace fan)', async () => {
+    const { sink, seen } = capturingSink();
+    const mk = (name: string) =>
+        stitch({
+            name,
+            baseUrl: 'http://x',
+            path: `/${name}`,
+            trace: sink,
+            adapter: async (): Promise<Res> => ({
+                status: 200,
+                headers: {},
+                body: {},
+            }),
+        });
+
+    await all({ a: mk('a'), b: mk('b') })();
+
+    const start = (name: string) =>
+        seen.find((s) => s.ctx.name === name && s.ev.type === 'start')!;
+    const a = start('a');
+    const b = start('b');
+    expect(a.ctx.parentId).toBeDefined();
+    expect(a.ctx.parentId).toBe(b.ctx.parentId); // same parent — the group run
+    expect(a.ctx.traceId).toBe(b.ctx.traceId); // one trace tree
+});

--- a/packages/core/test/pipe-context.spec.ts
+++ b/packages/core/test/pipe-context.spec.ts
@@ -1,0 +1,102 @@
+// stitchapi/pipe — ancestor access via the typed `pipe.with()` builder. A builder step's mapper takes
+// a second `ctx` argument: a frozen view of `$input` (the pipe's initial input) plus every earlier
+// NAMED step, so a step can read an ANCESTOR — typed, no cast — not just the previous result. The
+// simple variadic `pipe(...)` stays previous-only; ancestors live on the builder.
+import { stitch } from '../src';
+import { pipe } from '../src/pipe';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+test('pipe.with(): a later step reads a typed ANCESTOR, not just the previous result', async () => {
+    server.route('GET', '/order', {
+        body: { id: 1043, shipmentId: 'shp_9', region: 'EU' },
+    });
+    server.route('GET', '/shipment', {
+        body: { carrier: 'dhl', trackingCode: 'Z1' },
+    });
+    server.route('GET', '/tracking', { body: { events: ['picked-up'] } });
+    const order = stitch<{ id: number; shipmentId: string; region: string }>({
+        name: 'order',
+        baseUrl: server.url,
+        path: '/order',
+    });
+    const shipment = stitch<{ carrier: string; trackingCode: string }>({
+        name: 'shipment',
+        baseUrl: server.url,
+        path: '/shipment',
+    });
+    const tracking = stitch<{ events: string[] }>({
+        name: 'tracking',
+        baseUrl: server.url,
+        path: '/tracking',
+    });
+
+    const tracked = pipe
+        .step(order, 'order')
+        .step(shipment, (o) => ({ query: { id: o.shipmentId } })) // o typed → no cast
+        .step(tracking, (s, ctx) => ({
+            query: {
+                carrier: s.carrier, // previous step
+                code: s.trackingCode,
+                region: ctx.order.region, // ancestor, two hops back (typed)
+            },
+        }));
+
+    // the builder is itself the callable — no .build()
+    await expect(tracked({ params: {} })).resolves.toEqual({
+        events: ['picked-up'],
+    });
+    const t = server.calls('/tracking')[0]!;
+    expect(t.query['carrier']).toBe('dhl'); // from the previous (shipment) result
+    expect(t.query['region']).toBe('EU'); // from the order, an ancestor two steps back
+});
+
+test('pipe.with(): ctx exposes $input + named ancestors only, is frozen, and unnamed steps are not addressable', async () => {
+    server.route('GET', '/a', { body: { tag: 'A' } });
+    server.route('GET', '/b', { body: { tag: 'B' } });
+    server.route('GET', '/c', { body: { tag: 'C' } });
+    const a = stitch({ name: 'a', baseUrl: server.url, path: '/a' });
+    const b = stitch({ name: 'b', baseUrl: server.url, path: '/b' });
+    const c = stitch({ name: 'c', baseUrl: server.url, path: '/c' });
+
+    let captured: Record<string, unknown> | undefined;
+    const flow = pipe
+        .step(a, 'first')
+        .step(b) // anonymous — contributes no ctx key
+        .step(c, (_prev, ctx) => {
+            captured = ctx;
+            return {};
+        });
+
+    await flow({ params: { id: 1 } });
+
+    expect(captured!['$input']).toEqual({ params: { id: 1 } });
+    expect(captured!['first']).toEqual({ tag: 'A' }); // named ancestor, reachable past the anonymous step
+    expect(Object.keys(captured!).sort()).toEqual(['$input', 'first']); // b (anonymous) absent
+    expect(Object.isFrozen(captured)).toBe(true);
+});
+
+test('engine rejects reserved $-names and duplicate names (runtime backstop)', () => {
+    const s = stitch({ name: 's', baseUrl: server.url, path: '/s' });
+    // The builder blocks these at COMPILE time for literal names; DYNAMIC (non-literal) names slip
+    // past the type guard, so the engine's `assertNames` (run when the built pipeline is invoked) is
+    // the runtime backstop. A `$`-prefixed name:
+    const reserved = '$bad' as string;
+    expect(() => pipe.step(s, reserved)()).toThrow(/reserved/);
+    // ...and a duplicate (a literal name, then a bag with the same dynamic key):
+    const dupKey = 'dup' as string;
+    expect(() => pipe.step(s, 'dup').step({ [dupKey]: s })()).toThrow(
+        /duplicate/,
+    );
+});


### PR DESCRIPTION
Grows the `stitchapi/pipe` subpath from a single linear `pipe` into a small **composition family**, all returning the same `Composable` callable so they nest arbitrarily. Builds on the shipped `pipe` (ADR 0008); the variadic `pipe(...)` is unchanged (non-breaking).

## What's new

**Typed `pipe.step(...)` builder** — each step is its own inference site, so `prev` and a `ctx` of earlier **named** ancestors are fully typed, no casts:
```ts
const tracked = pipe
  .step(fetchOrder, 'order')                                          // positional name
  .step(fetchShipment, (order) => ({ params: { id: order.shipmentId } }))
  .step(fetchTracking, (shipment, ctx) => ({                          // ctx.order, typed
    params: { code: shipment.trackingCode, region: ctx.order.region },
  }));
await tracked({ params: { id: 1043 } });                              // builder IS the runnable
```
- `ctx.$input` reaches the pipe's initial input from any depth.
- Unique names by construction — a duplicate or `$`-prefixed name is a **compile error** (runtime backstop for dynamically-built names).
- No `.with()`, no `.named()`, no `.build()` — naming is positional, the builder is the callable.

**Parallel combinators `all` / `any` / `race`:**
- `all` takes a **named object** (→ named result, inline-mergeable into a pipe `ctx` via `.step({...})`) **or** a positional **array** (→ `readonly` tuple — the `Promise.all` shape). Fail-fast.
- `any` → first success (`AggregateError` only if all fail). `race` → first to settle.
- All **auto-cancel** the members that can no longer affect the result, via a per-group `AbortSignal` linked to the caller's.
- **No `allSettled`** (deliberate): compose `.safe()` members for best-effort.

**Nesting** — every combinator is a `Composable`, so a `pipe` step can be an `all`, an `all` member a `pipe`, etc. An inline `.step({ k: node })` is the pipe-native parallel fan (merges keys into `ctx`). Members run as **child runs**, so a trace draws the tree.

## Docs
- New concept page `docs/concepts/composition` (added to the Concepts nav).
- Blog: rewrote `compose-api-calls-into-a-pipeline` (order→shipment→tracking instead of the JSONPlaceholder toy), added `read-earlier-results-in-a-pipeline` (ancestor `ctx`) and `compose-pipe-all-any-race` (the family).

## Verification
Full local CI gate green on the pushed commit: `check:format`, `check:lint`, `check:types`, `check:types-d` (tsd), `check:exports`, `test` (1112 unit + tsd type-tests), and `build-docs` (the docs `next build` renders the new pages). Bundle-size within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)