### PR TITLE
feat(core): parallel composition — all / any / race with auto-cancellation

### DIFF
--- a/apps/docs/content/blog/run-api-calls-in-parallel.mdx
+++ b/apps/docs/content/blog/run-api-calls-in-parallel.mdx
@@ -1,0 +1,174 @@
+---
+title: 'Run Independent API Calls in Parallel: all, any, race'
+description: 'When API calls do not depend on each other, running them as a ladder of awaits is wasted latency — and Promise.all drops the trace, the cancellation, and the per-call resilience. all, any, and race run independent stitches concurrently as one traced, fail-fast group, and because each returns the same callable shape a stitch does, they nest.'
+author: Oleksandr Zhuravlov
+date: '2026-06-30'
+tags: [composition, parallel, concurrency, pipe, typescript]
+---
+
+A [stitch](/docs/concepts/the-stitch) is one endpoint as a typed, validated, resilient function. When one call needs the result of the one before it, you want a sequence — that is [`pipe`](/blog/compose-api-calls-into-a-pipeline). But just as often the calls are **independent**: a dashboard needs a user, their settings, and their feature flags, and none of them waits on the others. Running those in sequence is latency you are paying for nothing.
+
+`Promise.all` is the reflex, and it gets you the concurrency. What it doesn't get you is everything a stitch already carries: the three calls become three unrelated runs with no shared trace, a failure leaves the other requests running, and you reassemble the error yourself. StitchAPI's parallel family — `all`, `any`, `race` — runs independent stitches concurrently as **one group**: a shared trace, fail-fast with auto-cancellation, and each member keeping its own retry, timeout, and validation.
+
+The whole family answers two questions any set of calls can have: _do I need all of them, or just one?_ and _does "done" mean a success, or any result at all?_
+
+| Combinator | Resolves when                         | Result               | For                            |
+| ---------- | ------------------------------------- | -------------------- | ------------------------------ |
+| `all`      | **all** succeed (fail-fast)           | named object / tuple | independent **fan-out**        |
+| `any`      | the **first success** (else all fail) | one output           | **failover** across redundancy |
+| `race`     | the **first to settle** (win or lose) | one output           | **hedging** / fastest-wins     |
+
+## `all` — independent, all of them
+
+`all` runs a **named bag** of stitches concurrently and resolves to a typed object keyed by the names you gave:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+import { all } from 'stitchapi/pipe';
+import { z } from 'zod';
+
+const fetchUser = stitch({
+    url: 'https://api.example.com/users/{id}',
+    output: z.object({ id: z.number(), name: z.string() }),
+});
+const fetchSettings = stitch({
+    url: 'https://api.example.com/users/{id}/settings',
+    output: z.object({ theme: z.string() }),
+});
+const fetchFlags = stitch({
+    url: 'https://api.example.com/users/{id}/flags',
+    output: z.object({ beta: z.boolean() }),
+});
+// ---cut---
+const dashboard = all({
+    user: fetchUser,
+    settings: fetchSettings,
+    flags: fetchFlags,
+});
+
+const { user, settings, flags } = await dashboard({ params: { id: 1 } });
+// user, settings, flags — each typed from its own stitch, no casts
+```
+
+Prefer positional? Pass an **array** and get a tuple back — the exact `Promise.all` shape, with the resilience and cancellation added:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+import { all } from 'stitchapi/pipe';
+import { z } from 'zod';
+
+const fetchUser = stitch({
+    url: 'https://api.example.com/users/{id}',
+    output: z.object({ id: z.number(), name: z.string() }),
+});
+const fetchSettings = stitch({
+    url: 'https://api.example.com/users/{id}/settings',
+    output: z.object({ theme: z.string() }),
+});
+// ---cut---
+const [user, settings] = await all([fetchUser, fetchSettings])({
+    params: { id: 1 },
+});
+```
+
+Both forms are the same combinator — pick whichever reads better. Either way it's `Promise.all` with the rough edges removed: it's **fail-fast** — the first member to fail rejects the whole `all` with that call's `StitchError` (`.status`, `.url`, …) **and aborts the others** (their in-flight requests are cancelled, not left running) — and each member keeps its own retry, timeout, and validation.
+
+## `any` — the first one that works
+
+`any` runs its members concurrently and resolves with the **first to succeed**, ignoring failures until none are left — then it rejects with an `AggregateError` of every failure. The moment one wins, the **losers are aborted**. That's failover across interchangeable sources:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+import { any } from 'stitchapi/pipe';
+import { z } from 'zod';
+
+const User = z.object({ id: z.number(), name: z.string() });
+const fetchFromPrimary = stitch({
+    url: 'https://api.example.com/users/{id}',
+    output: User,
+});
+const fetchFromMirror = stitch({
+    url: 'https://mirror.example.com/users/{id}',
+    output: User,
+});
+// ---cut---
+// hit both, take whichever returns first; only fail if BOTH do
+const fetchUser = any([fetchFromPrimary, fetchFromMirror]);
+
+const user = await fetchUser({ params: { id: 1 } });
+```
+
+This is distinct from a stitch's built-in `retry`, which re-hits the **same** endpoint. `any` is for redundancy across **different** endpoints — a primary and a mirror, two regions, two providers of the same shape.
+
+## `race` — the first one to finish, win or lose
+
+`race` resolves or rejects with the first member to **settle** — success _or_ failure — and **cancels the rest**. Use it to hedge a latency-sensitive call against a second source and take whichever returns first:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+import { race } from 'stitchapi/pipe';
+import { z } from 'zod';
+
+const User = z.object({ id: z.number(), name: z.string() });
+const fetchFromUsEast = stitch({
+    url: 'https://us-east.example.com/users/{id}',
+    output: User,
+});
+const fetchFromEuWest = stitch({
+    url: 'https://eu-west.example.com/users/{id}',
+    output: User,
+});
+// ---cut---
+const fastest = race([fetchFromUsEast, fetchFromEuWest]);
+
+const user = await fastest({ params: { id: 1 } });
+```
+
+The difference from `any` is what counts as "done": `any` waits past failures for a success; `race` takes the first result of any kind. Reach for `race` when latency is the enemy and a fast failure is still information; reach for `any` when you want the answer and don't care who provides it.
+
+## They nest
+
+Every combinator returns the same callable shape `(input?) => Promise<Out>` that a stitch does, so a combinator is a valid member of any other — and the types flow straight through. A failover _inside_ a fan-out is just an `any` as a member of an `all`:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+import { all, any } from 'stitchapi/pipe';
+import { z } from 'zod';
+
+const User = z.object({ id: z.number(), name: z.string() });
+const fetchUserPrimary = stitch({
+    url: 'https://api.example.com/users/{id}',
+    output: User,
+});
+const fetchUserMirror = stitch({
+    url: 'https://mirror.example.com/users/{id}',
+    output: User,
+});
+const fetchSettings = stitch({
+    url: 'https://api.example.com/users/{id}/settings',
+    output: z.object({ theme: z.string() }),
+});
+// ---cut---
+const dashboard = all({
+    user: any([fetchUserPrimary, fetchUserMirror]), // failover, inside the fan
+    settings: fetchSettings,
+});
+
+const { user, settings } = await dashboard({ params: { id: 1 } });
+```
+
+An `all` can hold an `any`; an `any` can hold a `race`; and any of them composes with a sequential [`pipe`](/blog/compose-api-calls-into-a-pipeline). The tree goes as deep as the problem, and every node is typed from the stitches at its leaves.
+
+## Still composition, not orchestration
+
+A group of concurrent calls is fenced the same way `pipe` is. The shape is **fixed when you write it** — `all`/`any`/`race` take a list of stitches you already declared; nothing branches, loops, or spawns at runtime. Each member runs as a **child run** of the group, so the trace draws a fan ([the run-identity model](/docs/concepts/event-stream)) instead of three unrelated calls. Composition adds ordering and concurrency around stitches; it never changes how any one of them behaves alone. That's why this stays [runtime stitching, not a workflow platform](/blog/runtime-stitching-vs-workflow-platforms).
+
+## Try it
+
+```package-install
+stitchapi
+```
+
+The parallel family lives at the `stitchapi/pipe` subpath, so it only enters your bundle when a flow needs it. Each member is a [stitch](/docs/concepts/the-stitch) with its own [validation](/blog/validate-api-response-zod) and resilience, and the whole group is visible in the [event stream](/docs/concepts/event-stream).
+
+Related reading: [compose API calls into one pipeline](/blog/compose-api-calls-into-a-pipeline), [typed errors without try/catch](/blog/typed-errors-without-try-catch), and [runtime stitching vs. workflow platforms](/blog/runtime-stitching-vs-workflow-platforms).

--- a/packages/core/src/pipe.ts
+++ b/packages/core/src/pipe.ts
@@ -1,11 +1,282 @@
-// The `stitchapi/pipe` subpath (ADR 0008): linear composition. Run stitches in sequence, feeding
-// each result to the next, with each step a CHILD run of the prior (ADR 0007 run identity) — so a
-// trace shows the chain `stepA → stepB → stepC` and the playground DAG draws the same edges. The
-// step-to-step MAPPING is a closure (acknowledged sugar, the same category as `transform` /
-// `paginate.next`), while the STRUCTURE — the ordered member stitches — round-trips. Fail-fast: a
-// step's error rejects the pipeline. Bundle-frugal: reached only through the `pipe` subpath.
+// The `stitchapi/pipe` subpath (ADR 0008): composition. Combine stitches — and each other — into
+// flows you `await` like any function. SEQUENTIAL composition is `pipe(...)`: run stitches in order,
+// feeding each result to the next, each step a CHILD run of the prior (ADR 0007 run identity), so a
+// trace shows the chain `stepA → stepB → stepC`. PARALLEL composition is `all` / `any` / `race`: run
+// independent stitches CONCURRENTLY as sibling child runs (the trace draws a fan), and because every
+// combinator returns the same callable shape a stitch does, they NEST inside one another.
+//
+//   - `all({ k: node })` / `all([...])` — resolve when ALL succeed (fail-fast); a named object or tuple.
+//   - `any([...])` — resolve on the FIRST success (else `AggregateError`); failover across mirrors.
+//   - `race([...])` — resolve on the FIRST to settle (win or lose); hedging a slow call against a mirror.
+//
+// Every parallel combinator AUTO-CANCELS the members that can no longer affect the result — `all` on
+// the first failure, `any` on the first success, `race` on the first settle — via a per-group
+// `AbortSignal` linked to the caller's. There is deliberately NO `allSettled` (best-effort) variant;
+// for that, compose `.safe()` members by hand. Bundle-frugal: reached only through this subpath.
 import type { RunContext, Stitch, StitchInput } from './types';
 import { newRunContext } from './util';
+
+// The internal child-run invocation a node exposes (stitch.ts `__runWith`, and the combinators
+// below): run under a supplied run identity and resolve to the value. Reached through a cast — it is
+// not on the public Stitch.
+interface Runnable {
+    __runWith: (
+        input: StitchInput | undefined,
+        run: RunContext,
+    ) => Promise<unknown>;
+}
+
+/**
+ * A composed flow — what every combinator returns. It is callable (`await composable(input)` runs it
+ * as a root) and nests inside any other combinator (it carries the same child-run protocol a stitch
+ * does). `__composable` brands it so it is distinguishable from a bare callable.
+ */
+export interface Composable<Out> {
+    (input?: StitchInput): Promise<Out>;
+    readonly __composable: true;
+}
+
+/** A composition member: a single-endpoint {@link Stitch} or a nested {@link Composable}. */
+export type Node<O = unknown> = Stitch<O> | Composable<O>;
+
+// ---- abort plumbing (auto-cancel losers) ----------------------------------
+
+/**
+ * A controller whose `signal` is handed to every member of a parallel combinator. It is LINKED to the
+ * caller's signal (an outer abort cancels the whole group), and the combinator aborts it the moment
+ * the result is decided — cancelling the members that can no longer matter.
+ */
+function linkedController(parent?: AbortSignal): AbortController {
+    const ctrl = new AbortController();
+    if (parent) {
+        if (parent.aborted) ctrl.abort(parent.reason);
+        else
+            parent.addEventListener(
+                'abort',
+                () => {
+                    ctrl.abort(parent.reason);
+                },
+                { once: true },
+            );
+    }
+    return ctrl;
+}
+
+// Run one member under the group's abort signal, as a child run of the group node. The group's signal
+// REPLACES any inbound signal on the shared input (the inbound one is already linked into it).
+function runMember(
+    node: Node,
+    input: StitchInput | undefined,
+    signal: AbortSignal,
+    groupRun: RunContext,
+): Promise<unknown> {
+    const memberInput: StitchInput = { ...input, signal };
+    return (node as unknown as Runnable).__runWith(
+        memberInput,
+        newRunContext(groupRun),
+    );
+}
+
+// Pre-handle each member so a cancelled member's late rejection is never an unhandled rejection (the
+// combinator's own `await` is the single place a failure is observed).
+function swallowLateRejections(settling: readonly Promise<unknown>[]): void {
+    for (const p of settling) void p.catch(() => undefined);
+}
+
+// `all`: every member concurrently; resolve to a named object when ALL succeed; the FIRST failure
+// aborts the rest and rejects. Members run as siblings under `groupRun`.
+async function runAll(
+    members: Record<string, Node>,
+    input: StitchInput | undefined,
+    groupRun: RunContext,
+): Promise<Record<string, unknown>> {
+    const ctrl = linkedController(input?.signal);
+    const entries = Object.entries(members);
+    const settling = entries.map(([, node]) =>
+        runMember(node, input, ctrl.signal, groupRun),
+    );
+    swallowLateRejections(settling);
+    try {
+        const values = await Promise.all(settling);
+        const out: Record<string, unknown> = {};
+        entries.forEach(([k], i) => {
+            out[k] = values[i];
+        });
+        return out;
+    } catch (err) {
+        ctrl.abort();
+        throw err;
+    }
+}
+
+// `all` over a positional array; resolve to a tuple when ALL succeed; the FIRST failure aborts the
+// rest and rejects (the `Promise.all` shape, with auto-cancel + child runs).
+async function runAllArray(
+    members: readonly Node[],
+    input: StitchInput | undefined,
+    groupRun: RunContext,
+): Promise<unknown[]> {
+    const ctrl = linkedController(input?.signal);
+    const settling = members.map((m) =>
+        runMember(m, input, ctrl.signal, groupRun),
+    );
+    swallowLateRejections(settling);
+    try {
+        return await Promise.all(settling);
+    } catch (err) {
+        ctrl.abort();
+        throw err;
+    }
+}
+
+// `any`: every member concurrently; resolve on the FIRST success; if all fail, reject with the
+// `AggregateError` of their errors. Abort the losers once a winner (or total failure) is known.
+async function runAny(
+    members: readonly Node[],
+    input: StitchInput | undefined,
+    groupRun: RunContext,
+): Promise<unknown> {
+    const ctrl = linkedController(input?.signal);
+    const settling = members.map((m) =>
+        runMember(m, input, ctrl.signal, groupRun),
+    );
+    swallowLateRejections(settling);
+    try {
+        return await Promise.any(settling);
+    } finally {
+        ctrl.abort();
+    }
+}
+
+// `race`: every member concurrently; resolve/reject with the FIRST to SETTLE; abort the rest.
+async function runRace(
+    members: readonly Node[],
+    input: StitchInput | undefined,
+    groupRun: RunContext,
+): Promise<unknown> {
+    const ctrl = linkedController(input?.signal);
+    const settling = members.map((m) =>
+        runMember(m, input, ctrl.signal, groupRun),
+    );
+    swallowLateRejections(settling);
+    try {
+        return await Promise.race(settling);
+    } finally {
+        ctrl.abort();
+    }
+}
+
+// ---- types -----------------------------------------------------------------
+
+/**
+ * The public member constraint: gate on the stitch / composable BRAND, not the call signature. A
+ * stitch's input is CONTRAVARIANT, so constraining on the call signature would (exactly like `pipe`
+ * before #365) reject a stitch built from a templated URL — its narrow `TIn` is not assignable to the
+ * bare `Stitch` default. Gating on `__stitch` / `__composable` accepts every real stitch or composable,
+ * narrow input or not, while still rejecting a plain function. The internal {@link Node} keeps the call
+ * signature — the runtime reaches members through a cast, not through this constraint.
+ */
+type Member = { readonly __stitch: true } | { readonly __composable: true };
+
+/**
+ * A member's resolved output — `Awaited` of its call-signature return (a `StitchResult<O>` or a
+ * `Promise<O>`). Inferred from the CALL SIGNATURE alone (not full-`Stitch` assignability), so a
+ * narrow-input stitch resolves to its real output instead of collapsing to `never`.
+ */
+type OutputOf<S> = S extends (...args: never[]) => infer R ? Awaited<R> : never;
+/** Flatten an accumulated intersection into one object literal (readable hovers). */
+type Prettify<T> = { [K in keyof T]: T[K] } & {};
+/** The named-object output of a parallel bag `{ k: node }` — each key mapped to that node's output. */
+type BagOut<M extends Record<string, Member>> = Prettify<{
+    [K in keyof M]: OutputOf<M[K]>;
+}>;
+/** The tuple output of a positional `all([...])` — each member mapped to its output, in order. */
+type TupleOut<T extends readonly Member[]> = { [K in keyof T]: OutputOf<T[K]> };
+
+// ---- parallel combinators --------------------------------------------------
+
+// Build a Composable from a `(input, groupRun) => Promise<Out>` core: callable mints a root run; the
+// internal `__runWith` runs under the supplied child run (so it nests inside a pipe / another group).
+function makeComposable<Out>(
+    core: (
+        input: StitchInput | undefined,
+        groupRun: RunContext,
+    ) => Promise<Out>,
+): Composable<Out> {
+    const fn = ((input?: StitchInput) =>
+        core(input, newRunContext())) as Composable<Out> & Runnable;
+    fn.__runWith = (input, run) => core(input, run);
+    return Object.assign(fn, { __composable: true as const });
+}
+
+/**
+ * Run nodes CONCURRENTLY and resolve when ALL succeed; fail-fast — the first to reject aborts the rest
+ * and rejects the whole `all`. Two interchangeable forms (pick whichever reads better):
+ *
+ * - a NAMED object → a typed object keyed by the same names:
+ *   `all({ user: fetchUser, prefs: fetchPrefs })` ⇒ `Promise<{ user; prefs }>`.
+ * - a positional ARRAY (the `Promise.all` shape) → a typed tuple:
+ *   `all([fetchUser, fetchPrefs])` ⇒ `Promise<readonly [User, Prefs]>`.
+ *
+ * Each member keeps its own retry/timeout/validation, runs as a sibling child run (the trace draws a
+ * fan), and is auto-cancelled if a sibling fails first.
+ */
+export function all<const T extends readonly Member[]>(
+    members: T,
+): Composable<TupleOut<T>>;
+export function all<M extends Record<string, Member>>(
+    members: M,
+): Composable<BagOut<M>>;
+export function all(
+    members: readonly Member[] | Record<string, Member>,
+): Composable<unknown> {
+    return Array.isArray(members)
+        ? makeComposable((input, run) =>
+              runAllArray(members as unknown as readonly Node[], input, run),
+          )
+        : makeComposable((input, run) =>
+              runAll(members as unknown as Record<string, Node>, input, run),
+          );
+}
+
+/**
+ * Run nodes CONCURRENTLY and resolve with the FIRST to SUCCEED — failover across interchangeable
+ * sources. If every member fails, rejects with an `AggregateError`. The losers are auto-cancelled.
+ * Distinct from a stitch's built-in `retry` (which re-hits the SAME endpoint): `any` is redundancy
+ * across DIFFERENT ones — a primary and a mirror, two regions, two providers of the same shape.
+ */
+export function any<M extends readonly Member[]>(
+    members: M,
+): Composable<OutputOf<M[number]>> {
+    return makeComposable(
+        (input, run) =>
+            runAny(
+                members as unknown as readonly Node[],
+                input,
+                run,
+            ) as Promise<OutputOf<M[number]>>,
+    );
+}
+
+/**
+ * Run nodes CONCURRENTLY and resolve/reject with the FIRST to SETTLE (success OR failure) — hedging a
+ * latency-sensitive call against a faster mirror. The slower members are auto-cancelled. Where `any`
+ * waits past failures for a success, `race` takes the first result of any kind.
+ */
+export function race<M extends readonly Member[]>(
+    members: M,
+): Composable<OutputOf<M[number]>> {
+    return makeComposable(
+        (input, run) =>
+            runRace(
+                members as unknown as readonly Node[],
+                input,
+                run,
+            ) as Promise<OutputOf<M[number]>>,
+    );
+}
+
+// ---- sequential: the variadic `pipe(...)` ---------------------------------
 
 /**
  * A stitch accepted as a pipe member regardless of its inferred input/output types. `Stitch<TOut,
@@ -28,15 +299,6 @@ export interface PipeStep {
      * input directly and ignores this.
      */
     readonly input?: (prev: unknown) => StitchInput;
-}
-
-// The internal child-run invocation a stitch exposes (stitch.ts `__runWith`): run under a supplied
-// run identity and resolve to the value. Reached through a cast — it is not on the public Stitch.
-interface Runnable {
-    __runWith: (
-        input: StitchInput | undefined,
-        run: RunContext,
-    ) => Promise<unknown>;
 }
 
 const asStep = (s: PipeStep | AnyStitch): PipeStep =>

--- a/packages/core/test-d/combinators.test-d.ts
+++ b/packages/core/test-d/combinators.test-d.ts
@@ -1,0 +1,54 @@
+// Type-level contract for the parallel combinators all / any / race: `all` → a typed named object
+// (object form) or a positional tuple (array form), `any`/`race` → the members' common output. Also
+// pins the #365 input-variance widening: a member built from a TEMPLATED url (a narrow `TIn`) is still
+// accepted, with its OUTPUT inferred precisely. A type error in any of these fails check:types-d.
+import { stitch } from '..';
+import { all, any, race } from '../src/pipe';
+
+import { expectType } from 'tsd';
+import { z } from 'zod';
+
+interface Order {
+    id: number;
+    shipmentId: string;
+    region: string;
+}
+interface Shipment {
+    carrier: string;
+}
+interface Invoice {
+    total: number;
+}
+
+const fetchOrder = stitch<Order>({ baseUrl: 'x', path: '/o' });
+const fetchShipment = stitch<Shipment>({ baseUrl: 'x', path: '/s' });
+const fetchInvoice = stitch<Invoice>({ baseUrl: 'x', path: '/i' });
+const fetchOrderMirror = stitch<Order>({ baseUrl: 'x', path: '/om' });
+
+// all (object form) → a typed named object
+expectType<Promise<{ shipment: Shipment; invoice: Invoice }>>(
+    all({ shipment: fetchShipment, invoice: fetchInvoice })(),
+);
+
+// all (array form) → a typed positional tuple (readonly)
+expectType<Promise<readonly [Shipment, Invoice]>>(
+    all([fetchShipment, fetchInvoice])(),
+);
+
+// any / race → the members' (common) output
+expectType<Promise<Order>>(any([fetchOrder, fetchOrderMirror])());
+expectType<Promise<Order>>(race([fetchOrder, fetchOrderMirror])());
+
+// #365-style input variance: a member from a TEMPLATED url has a narrow `TIn` (a required `params: { id }`)
+// that is NOT assignable to the bare `Stitch` default. The combinators gate members on the stitch BRAND
+// (not the call signature), so a narrow-input stitch is accepted as readily as a plain one — its OUTPUT
+// still inferred precisely. Without that gating these would be TS2345.
+const User = z.object({ id: z.number(), name: z.string() });
+type User = z.infer<typeof User>;
+const fetchUserById = stitch({
+    url: 'https://api.example.com/users/{id}',
+    output: User,
+});
+expectType<Promise<{ user: User }>>(all({ user: fetchUserById })());
+expectType<Promise<readonly [User]>>(all([fetchUserById])());
+expectType<Promise<User>>(any([fetchUserById, fetchUserById])());

--- a/packages/core/test/combinators.spec.ts
+++ b/packages/core/test/combinators.spec.ts
@@ -1,0 +1,173 @@
+// stitchapi/pipe — the parallel combinators all / any / race. Covers the result shapes, fail-fast /
+// first-success / first-settle semantics, AUTO-CANCELLATION of members that can no longer affect the
+// result (a blocker member observes its `req.signal`), and the sibling-child-run fan that a trace
+// draws. The decider in each cancel test is delayed a beat so the blocker has attached its abort
+// listener before the result is known (deterministic, not a race).
+import { stitch } from '../src';
+import type { StitchEvent, TraceContext, TraceSink } from '../src';
+import { all, any, race } from '../src/pipe';
+
+interface Res {
+    status: number;
+    headers: Record<string, string>;
+    body: unknown;
+}
+
+// Resolve immediately to `body` (HTTP 200).
+const ok = (body: unknown) =>
+    stitch({
+        name: 'ok',
+        baseUrl: 'http://x',
+        path: '/ok',
+        adapter: async (): Promise<Res> => ({ status: 200, headers: {}, body }),
+    });
+
+// Resolve `body` after `ms` (HTTP 200).
+const okAfter = (ms: number, body: unknown) =>
+    stitch({
+        name: 'ok',
+        baseUrl: 'http://x',
+        path: '/ok',
+        adapter: (): Promise<Res> =>
+            new Promise((res) => {
+                setTimeout(() => {
+                    res({ status: 200, headers: {}, body });
+                }, ms);
+            }),
+    });
+
+// Fail immediately with a non-retryable 400 → a `StitchError` with `.status` 400.
+const boom = () =>
+    stitch({
+        name: 'boom',
+        baseUrl: 'http://x',
+        path: '/boom',
+        adapter: async (): Promise<Res> => ({
+            status: 400,
+            headers: {},
+            body: { e: 'x' },
+        }),
+    });
+
+// Fail with a 400 after `ms`.
+const boomAfter = (ms: number) =>
+    stitch({
+        name: 'boom',
+        baseUrl: 'http://x',
+        path: '/boom',
+        adapter: (): Promise<Res> =>
+            new Promise((res) => {
+                setTimeout(() => {
+                    res({ status: 400, headers: {}, body: { e: 'x' } });
+                }, ms);
+            }),
+    });
+
+// Never settles on its own — only when its request is aborted. Records the abort.
+function blocker() {
+    let aborted = false;
+    const s = stitch({
+        name: 'blocker',
+        baseUrl: 'http://x',
+        path: '/b',
+        adapter: (req): Promise<Res> =>
+            new Promise<Res>((_resolve, reject) => {
+                const onAbort = () => {
+                    aborted = true;
+                    reject(new Error('aborted'));
+                };
+                if (req.signal?.aborted) onAbort();
+                else req.signal?.addEventListener('abort', onAbort);
+            }),
+    });
+    return { s, aborted: () => aborted };
+}
+
+function capturingSink(): {
+    sink: TraceSink;
+    seen: { ev: StitchEvent; ctx: TraceContext }[];
+} {
+    const seen: { ev: StitchEvent; ctx: TraceContext }[] = [];
+    return {
+        seen,
+        sink: { handle: (ev, ctx) => void seen.push({ ev, ctx: { ...ctx } }) },
+    };
+}
+
+test('all: resolves to a typed named object when every member succeeds', async () => {
+    await expect(all({ a: ok({ n: 1 }), b: ok({ n: 2 }) })()).resolves.toEqual({
+        a: { n: 1 },
+        b: { n: 2 },
+    });
+});
+
+test('all (array form): resolves to a positional tuple, in order', async () => {
+    await expect(all([ok({ n: 1 }), ok({ n: 2 })])()).resolves.toEqual([
+        { n: 1 },
+        { n: 2 },
+    ]);
+});
+
+test('all (array form): fail-fast — the first failure rejects and aborts the rest', async () => {
+    const slow = blocker();
+    await expect(all([boomAfter(10), slow.s])()).rejects.toMatchObject({
+        status: 400,
+    });
+    expect(slow.aborted()).toBe(true);
+});
+
+test('all: fail-fast — the first failure rejects and aborts the rest', async () => {
+    const slow = blocker();
+    await expect(
+        all({ bad: boomAfter(10), slow: slow.s })(),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(slow.aborted()).toBe(true); // sibling auto-cancelled
+});
+
+test('any: resolves with the first success and cancels the losers', async () => {
+    const slow = blocker();
+    await expect(any([slow.s, okAfter(10, { ok: true })])()).resolves.toEqual({
+        ok: true,
+    });
+    expect(slow.aborted()).toBe(true);
+});
+
+test('any: rejects with an AggregateError when every member fails', async () => {
+    await expect(any([boom(), boom()])()).rejects.toBeInstanceOf(
+        AggregateError,
+    );
+});
+
+test('race: the first to settle wins — even a fast failure — and cancels the rest', async () => {
+    const slow = blocker();
+    await expect(race([boomAfter(10), slow.s])()).rejects.toMatchObject({
+        status: 400,
+    });
+    expect(slow.aborted()).toBe(true);
+});
+
+test('all: members run as sibling child runs of one parent (trace fan)', async () => {
+    const { sink, seen } = capturingSink();
+    const mk = (name: string) =>
+        stitch({
+            name,
+            baseUrl: 'http://x',
+            path: `/${name}`,
+            trace: sink,
+            adapter: async (): Promise<Res> => ({
+                status: 200,
+                headers: {},
+                body: {},
+            }),
+        });
+
+    await all({ a: mk('a'), b: mk('b') })();
+
+    const start = (name: string) =>
+        seen.find((s) => s.ctx.name === name && s.ev.type === 'start')!;
+    const a = start('a');
+    const b = start('b');
+    expect(a.ctx.parentId).toBeDefined();
+    expect(a.ctx.parentId).toBe(b.ctx.parentId); // same parent — the group run
+    expect(a.ctx.traceId).toBe(b.ctx.traceId); // one trace tree
+});


### PR DESCRIPTION
Carves the **parallel composition family** out of #367 so it can land on its own, ahead of the larger sequential-composition decision (`pipe.step` builder vs. a `linked` scope), which stays open and is **not** in this PR.

Adds `all` / `any` / `race` to the `stitchapi/pipe` subpath: run independent stitches concurrently as one traced, fail-fast group with auto-cancellation. The shipped variadic `pipe(...)` is **unchanged** (byte-for-byte, including the #365 `AnyStitch` widening).

## What's new

- **`all`** — run members concurrently, resolve when **all** succeed (fail-fast). A **named object** (`all({ user, prefs })` → `{ user; prefs }`) or a positional **array** (`all([a, b])` → `readonly [A, B]`, the `Promise.all` shape).
- **`any`** — resolve on the **first success** (else `AggregateError`); failover across interchangeable sources. Distinct from a stitch's `retry`, which re-hits the *same* endpoint.
- **`race`** — resolve/reject on the **first to settle**; hedging a latency-sensitive call against a mirror.
- **Auto-cancellation** — every combinator aborts the members that can no longer affect the result (`all` on first failure, `any` on first success, `race` on first settle) via a per-group `AbortSignal` linked to the caller's. No `allSettled` (compose `.safe()` members for best-effort).
- **Nesting** — each combinator returns a `Composable` (the same callable shape a stitch has), so they nest within one another and run as **child runs** (ADR 0007), so a trace draws the fan.

### Member typing — brand-gated (fixes the #365 gap for the parallel family)

Members are constrained on the `__stitch` / `__composable` **brand**, not the call signature. A stitch built from a templated URL has a contravariant narrow `TIn` that isn't assignable to the bare `Stitch` default — the exact problem #365 fixed for `pipe`. Gating on the brand (and inferring output from the call signature alone) accepts every real stitch — narrow input or not — while still rejecting a plain function, and keeps per-member output types precise. Locked by a templated-URL case in `combinators.test-d.ts`.

> #367 used `Node = Stitch<O> | Composable<O>`, which silently rejects templated-URL stitches (it never tested that case). This PR closes that gap.

## Deferred to the composition PR (not here)

The sequential builder and everything entangled with the pipe-vs-`linked` decision: `pipe.step()`, ancestor `ctx` / `$input`, compile-time unique names, inline parallel bag-steps, the `composition` concept page, and the `read-earlier-results` / `compose-pipe-all-any-race` posts.

## Verification

Full local core gate green on this branch: `check:format`, `check:lint`, `check:types`, `check:types-d` (tsd), `check:exports` (attw), `test` (**1108** unit + tsd type-tests), `check:size` (within budget — the family is in the `pipe` subpath, off the main entry), and the docs `next build` (twoslash type-checks the new blog snippets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
