### PR TITLE
feat(core): all/any/race accept a variadic argument list, not just an array

### DIFF
--- a/apps/docs/content/blog/run-api-calls-in-parallel.mdx
+++ b/apps/docs/content/blog/run-api-calls-in-parallel.mdx
@@ -50,7 +50,7 @@ const { user, settings, flags } = await dashboard({ params: { id: 1 } });
 // user, settings, flags — each typed from its own stitch, no casts
 ```
 
-Prefer positional? Pass an **array** and get a tuple back — the exact `Promise.all` shape, with the resilience and cancellation added:
+Prefer positional? Pass an **array** — or just list the stitches as bare arguments — and get a tuple back. The brackets are optional: `all([a, b])` and `all(a, b)` build the identical group, the exact `Promise.all` shape with the resilience and cancellation added:
 
 ```ts twoslash
 import { stitch } from 'stitchapi';
@@ -66,12 +66,21 @@ const fetchSettings = stitch({
     output: z.object({ theme: z.string() }),
 });
 // ---cut---
+// an array — the exact `Promise.all` shape:
 const [user, settings] = await all([fetchUser, fetchSettings])({
+    params: { id: 1 },
+});
+
+// the same members as bare arguments — identical group, identical tuple:
+const [user2, settings2] = await all(
+    fetchUser,
+    fetchSettings,
+)({
     params: { id: 1 },
 });
 ```
 
-Both forms are the same combinator — pick whichever reads better. Either way it's `Promise.all` with the rough edges removed: it's **fail-fast** — the first member to fail rejects the whole `all` with that call's `StitchError` (`.status`, `.url`, …) **and aborts the others** (their in-flight requests are cancelled, not left running) — and each member keeps its own retry, timeout, and validation.
+Named object, array, or bare arguments — the same combinator; pick whichever reads better. Either way it's `Promise.all` with the rough edges removed: it's **fail-fast** — the first member to fail rejects the whole `all` with that call's `StitchError` (`.status`, `.url`, …) **and aborts the others** (their in-flight requests are cancelled, not left running) — and each member keeps its own retry, timeout, and validation.
 
 ## `any` — the first one that works
 
@@ -97,6 +106,8 @@ const fetchUser = any([fetchFromPrimary, fetchFromMirror]);
 
 const user = await fetchUser({ params: { id: 1 } });
 ```
+
+Like `all`, `any` and `race` take their members either way — an array (`any([a, b])`) or bare arguments (`any(a, b)`).
 
 This is distinct from a stitch's built-in `retry`, which re-hits the **same** endpoint. `any` is for redundancy across **different** endpoints — a primary and a mirror, two regions, two providers of the same shape.
 

--- a/packages/core/src/pipe.ts
+++ b/packages/core/src/pipe.ts
@@ -7,9 +7,13 @@
 // inside one another — and `run` accepts a combinator as a node, so a parallel fan joins the scope.
 //
 //   - `linked(body)` — SEQUENTIAL: plain `await`s through `run`; ancestors are variables (no `ctx`).
-//   - `all({ k: node })` / `all([...])` — resolve when ALL succeed (fail-fast); a named object or tuple.
-//   - `any([...])` — resolve on the FIRST success (else `AggregateError`); failover across mirrors.
-//   - `race([...])` — resolve on the FIRST to settle (win or lose); hedging a slow call against a mirror.
+//   - `all({ k: node })` / `all([...])` / `all(a, b)` — resolve when ALL succeed (fail-fast); object or tuple.
+//   - `any([...])` / `any(a, b)` — resolve on the FIRST success (else `AggregateError`); failover across mirrors.
+//   - `race([...])` / `race(a, b)` — resolve on the FIRST to settle (win or lose); hedging a slow call.
+//
+// The array members and the bare-argument members are the SAME thing — `all([a, b])` and `all(a, b)`
+// build the identical group. The bracketed form is the `Promise.all`/`Promise.any`/`Promise.race`
+// shape; the argument-list form drops the ceremony when you are just listing stitches inline.
 //
 // Every parallel combinator AUTO-CANCELS the members that can no longer affect the result — `all` on
 // the first failure, `any` on the first success, `race` on the first settle — via a per-group
@@ -212,14 +216,32 @@ function makeComposable<Out>(
     return Object.assign(fn, { __composable: true as const });
 }
 
+// Normalize a combinator's arguments to its member list. A single ARRAY argument IS the list (the
+// bracketed `all([a, b])` form); otherwise the arguments themselves are the members (the bare
+// `all(a, b)` argument-list form). A member is always a function — never an array — so a lone array
+// argument is unambiguous.
+function membersFrom(args: readonly unknown[]): readonly Node[] {
+    const lone = args.length === 1 ? args[0] : undefined;
+    return (Array.isArray(lone) ? lone : args) as readonly Node[];
+}
+
+// True for the NAMED-bag argument of `all`: a single plain object of named members. A stitch or
+// composable is a FUNCTION (so `typeof === 'object'` excludes it) and the array form is an array, so a
+// lone non-array object can only be the named-bag form.
+function isBag(x: unknown): x is Record<string, Node> {
+    return typeof x === 'object' && x !== null && !Array.isArray(x);
+}
+
 /**
  * Run nodes CONCURRENTLY and resolve when ALL succeed; fail-fast — the first to reject aborts the rest
- * and rejects the whole `all`. Two interchangeable forms (pick whichever reads better):
+ * and rejects the whole `all`. Three interchangeable forms (pick whichever reads better):
  *
  * - a NAMED object → a typed object keyed by the same names:
  *   `all({ user: fetchUser, prefs: fetchPrefs })` ⇒ `Promise<{ user; prefs }>`.
  * - a positional ARRAY (the `Promise.all` shape) → a typed tuple:
  *   `all([fetchUser, fetchPrefs])` ⇒ `Promise<readonly [User, Prefs]>`.
+ * - the same members as bare ARGUMENTS → the identical tuple, without the brackets:
+ *   `all(fetchUser, fetchPrefs)` ⇒ `Promise<readonly [User, Prefs]>`.
  *
  * Each member keeps its own retry/timeout/validation, runs as a sibling child run (the trace draws a
  * fan), and is auto-cancelled if a sibling fails first.
@@ -230,52 +252,56 @@ export function all<const T extends readonly Member[]>(
 export function all<M extends Record<string, Member>>(
     members: M,
 ): Composable<BagOut<M>>;
-export function all(
-    members: readonly Member[] | Record<string, Member>,
-): Composable<unknown> {
-    return Array.isArray(members)
-        ? makeComposable((input, run) =>
-              runAllArray(members as unknown as readonly Node[], input, run),
-          )
-        : makeComposable((input, run) =>
-              runAll(members as unknown as Record<string, Node>, input, run),
-          );
+export function all<const T extends readonly Member[]>(
+    ...members: T
+): Composable<TupleOut<T>>;
+export function all(...args: readonly unknown[]): Composable<unknown> {
+    // A lone plain-object argument is the NAMED-bag form; a lone array or bare member arguments are the
+    // positional tuple form.
+    const first = args[0];
+    if (args.length === 1 && isBag(first)) {
+        const bag = first;
+        return makeComposable((input, run) => runAll(bag, input, run));
+    }
+    return makeComposable((input, run) =>
+        runAllArray(membersFrom(args), input, run),
+    );
 }
 
 /**
  * Run nodes CONCURRENTLY and resolve with the FIRST to SUCCEED — failover across interchangeable
  * sources. If every member fails, rejects with an `AggregateError`. The losers are auto-cancelled.
  * Distinct from a stitch's built-in `retry` (which re-hits the SAME endpoint): `any` is redundancy
- * across DIFFERENT ones — a primary and a mirror, two regions, two providers of the same shape.
+ * across DIFFERENT ones — a primary and a mirror, two regions, two providers of the same shape. Pass
+ * the members as an ARRAY (`any([a, b])`) or as bare ARGUMENTS (`any(a, b)`) — same combinator.
  */
 export function any<M extends readonly Member[]>(
     members: M,
-): Composable<OutputOf<M[number]>> {
-    return makeComposable(
-        (input, run) =>
-            runAny(
-                members as unknown as readonly Node[],
-                input,
-                run,
-            ) as Promise<OutputOf<M[number]>>,
+): Composable<OutputOf<M[number]>>;
+export function any<M extends readonly Member[]>(
+    ...members: M
+): Composable<OutputOf<M[number]>>;
+export function any(...args: readonly unknown[]): Composable<unknown> {
+    return makeComposable((input, run) =>
+        runAny(membersFrom(args), input, run),
     );
 }
 
 /**
  * Run nodes CONCURRENTLY and resolve/reject with the FIRST to SETTLE (success OR failure) — hedging a
  * latency-sensitive call against a faster mirror. The slower members are auto-cancelled. Where `any`
- * waits past failures for a success, `race` takes the first result of any kind.
+ * waits past failures for a success, `race` takes the first result of any kind. Pass the members as an
+ * ARRAY (`race([a, b])`) or as bare ARGUMENTS (`race(a, b)`) — same combinator.
  */
 export function race<M extends readonly Member[]>(
     members: M,
-): Composable<OutputOf<M[number]>> {
-    return makeComposable(
-        (input, run) =>
-            runRace(
-                members as unknown as readonly Node[],
-                input,
-                run,
-            ) as Promise<OutputOf<M[number]>>,
+): Composable<OutputOf<M[number]>>;
+export function race<M extends readonly Member[]>(
+    ...members: M
+): Composable<OutputOf<M[number]>>;
+export function race(...args: readonly unknown[]): Composable<unknown> {
+    return makeComposable((input, run) =>
+        runRace(membersFrom(args), input, run),
     );
 }
 

--- a/packages/core/test-d/combinators.test-d.ts
+++ b/packages/core/test-d/combinators.test-d.ts
@@ -52,3 +52,21 @@ const fetchUserById = stitch({
 expectType<Promise<{ user: User }>>(all({ user: fetchUserById })());
 expectType<Promise<readonly [User]>>(all([fetchUserById])());
 expectType<Promise<User>>(any([fetchUserById, fetchUserById])());
+
+// Argument-list form: the SAME members passed as bare arguments (no brackets) infer the identical
+// shapes as the array form — a positional tuple for `all`, the common output for `any`/`race`. This
+// is the variadic overload; it must not collide with the array form (a single array argument) or, for
+// `all`, the named-object form (a single plain-object argument), both pinned above.
+expectType<Promise<readonly [Shipment, Invoice]>>(
+    all(fetchShipment, fetchInvoice)(),
+);
+expectType<Promise<Order>>(any(fetchOrder, fetchOrderMirror)());
+expectType<Promise<Order>>(race(fetchOrder, fetchOrderMirror)());
+
+// A single bare member still reads as the variadic tuple form (one-element tuple), distinct from the
+// named-object form — `all(fetchShipment)` is `[Shipment]`, not an object.
+expectType<Promise<readonly [Shipment]>>(all(fetchShipment)());
+
+// Narrow-input (#365) members are accepted in the argument-list form too, output inferred precisely.
+expectType<Promise<readonly [User, User]>>(all(fetchUserById, fetchUserById)());
+expectType<Promise<User>>(any(fetchUserById, fetchUserById)());

--- a/packages/core/test/combinators.spec.ts
+++ b/packages/core/test/combinators.spec.ts
@@ -108,6 +108,17 @@ test('all (array form): resolves to a positional tuple, in order', async () => {
     ]);
 });
 
+test('all (argument-list form): bare members resolve to a positional tuple, in order', async () => {
+    await expect(all(ok({ n: 1 }), ok({ n: 2 }))()).resolves.toEqual([
+        { n: 1 },
+        { n: 2 },
+    ]);
+});
+
+test('all (argument-list form): a single bare member is a one-element tuple, not a bag', async () => {
+    await expect(all(ok({ n: 1 }))()).resolves.toEqual([{ n: 1 }]);
+});
+
 test('all (array form): fail-fast — the first failure rejects and aborts the rest', async () => {
     const slow = blocker();
     await expect(all([boomAfter(10), slow.s])()).rejects.toMatchObject({
@@ -136,6 +147,22 @@ test('any: rejects with an AggregateError when every member fails', async () => 
     await expect(any([boom(), boom()])()).rejects.toBeInstanceOf(
         AggregateError,
     );
+});
+
+test('any (argument-list form): bare members behave like the array form', async () => {
+    const slow = blocker();
+    await expect(any(slow.s, okAfter(10, { ok: true }))()).resolves.toEqual({
+        ok: true,
+    });
+    expect(slow.aborted()).toBe(true);
+});
+
+test('race (argument-list form): bare members behave like the array form', async () => {
+    const slow = blocker();
+    await expect(race(boomAfter(10), slow.s)()).rejects.toMatchObject({
+        status: 400,
+    });
+    expect(slow.aborted()).toBe(true);
 });
 
 test('race: the first to settle wins — even a fast failure — and cancels the rest', async () => {


### PR DESCRIPTION
## What

`all`, `any`, and `race` required their members wrapped in an array. They now accept a **bare argument list** too — the brackets are optional ceremony:

```ts
all(fetchUser, fetchSettings); // ≡ all([fetchUser, fetchSettings])
any(primary, mirror); //          ≡ any([primary, mirror])
race(usEast, euWest); //          ≡ race([usEast, euWest])
```

Motivation: requiring `[...]` when you're just listing a couple of stitches inline is friction with no payoff. Both spellings build the identical group, with the same trace fan, fail-fast/first-success/first-settle semantics, and auto-cancellation.

## How

A variadic overload per combinator, plus shape-based dispatch at the call boundary:

- **`membersFrom(args)`** — a lone **array** argument is the bracketed form; otherwise the arguments themselves are the members. A member is always a function (never an array), so a lone array is unambiguous.
- **`isBag(x)`** — only `all` needs it: a lone **plain object** is the named-bag form. A stitch/composable is a *function*, so `typeof === 'object'` cleanly separates the bag from a single bare member.

So `all` now has three interchangeable forms that never collide:

| Call | Result |
| --- | --- |
| `all({ user, prefs })` | `{ user; prefs }` (named bag — unchanged) |
| `all([user, prefs])` | `readonly [User, Prefs]` (array — unchanged) |
| `all(user, prefs)` | `readonly [User, Prefs]` (**new** — variadic) |
| `all(user)` | `readonly [User]` (one-element tuple, **not** a bag) |

Overload order (single-array → object → variadic) is what makes resolution unambiguous; the tsd tests pin it.

**Additive and fully backward-compatible** — every existing `all([...])` / `all({...})` / `any([...])` / `race([...])` call resolves to the same overload as before.

## Tests

- **`combinators.test-d.ts`** (tsd): `all(a,b)→[A,B]`, single bare member `all(a)→[A]`, `any`/`race` variadic, and narrow-input (#365) members in the new form.
- **`combinators.spec.ts`**: argument-list form behaves identically at runtime — tuple order, single-member, first-success + loser-cancel, first-settle + cancel.

## Docs

`run-api-calls-in-parallel.mdx` now teaches the bracket-optional spelling (twoslash-checked).

## Verification

All green locally: `check:types` · `check:types-d` (tsd) · full core suite **1108/1108** · `check:lint` · bundle-size gate within budget (helpers live in the `pipe` subpath — main entry untouched) · docs twoslash gate · Prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
