### PR TITLE
feat(docs): upstream "Start here" prerequisites for blog posts & docs pages

### DIFF
--- a/apps/docs/AUTHORING.md
+++ b/apps/docs/AUTHORING.md
@@ -66,10 +66,10 @@ Pick the template by the page's `kind` in the manifest. Copy the skeleton
 verbatim, then fill it. Required sections are marked `(required)` — don't drop
 them; don't add a fifth top-level section without a reason.
 
-> **Frontmatter:** the current schema (`pageSchema`) allows `title`,
-> `description`, and `icon` only. `kind` and `code` live in the manifest, not the
-> frontmatter, until we extend the schema in `source.config.ts` (a tracked
-> tooling task). Keep frontmatter to `title` + `description`.
+> **Frontmatter:** the page schema (`pageSchema`) allows `title`, `description`,
+> and `icon`, plus an optional `prerequisites` list — see
+> [Prerequisites](#prerequisites--the-upstream-pointer). `kind` and `code` live in
+> the manifest, not the frontmatter. Keep the rest to `title` + `description`.
 
 ### Guide — the workhorse (`kind: guide`)
 
@@ -231,6 +231,45 @@ description: Authentication failed, or a soft 200 login wall was hit and could n
     <Card title="Guide: cookieSession" href="/docs/guides/auth/cookie-session" />
 </Cards>
 ````
+
+---
+
+## Prerequisites — the upstream pointer
+
+`See also` and the blog's "Related reading" footer point a reader **onward** — to
+the next page, the sibling argument. Nothing points **back**. A reader who lands
+cold on an advanced page (parallel composition, a distributed throttle, an MCP
+recipe) gets no signal for the foundational concept the prose already assumes.
+
+`prerequisites` is that signal: an **optional** frontmatter list of internal hrefs
+to the foundational pages a page leans on. The renderer resolves each to its real
+title from source — so the link text can't drift — and shows a **"New to stitches?
+Start here"** box at the _top_ of the page. It is the inverse of `See also`: a step
+_back_ before diving in, and it works the same on a docs page and a blog post.
+
+```yaml
+---
+title: Run independent API calls in parallel
+description: When calls do not depend on each other, run them concurrently.
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
+---
+```
+
+-   **Aim at the foundational set, not at siblings.** The usual targets are
+    `/docs/concepts/the-stitch`, `/docs/concepts/the-seam`,
+    `/docs/concepts/event-stream`, `/docs/concepts/capability-not-credential`, and
+    `/docs/getting-started/quickstart`. One or two is plenty — it's a heads-up, not
+    a syllabus.
+-   **Only when the opening assumes prior knowledge.** A page that self-grounds in
+    its first sentence — states its premise, defines its term — needs none, and the
+    foundational pages themselves never declare one.
+-   **Cross-surface is normal.** A blog post pointing at
+    `/docs/concepts/the-stitch` is the common case; a docs page may point at
+    another docs page.
+-   **Every href must resolve.** `test/prerequisites.spec.ts` fails the build on a
+    dangling or self-referential prerequisite — the same no-orphans guarantee the
+    blog's sibling links carry. The box silently drops a broken link at runtime, so
+    that gate is the only thing that flags it. Keep it green.
 
 ---
 
@@ -587,7 +626,10 @@ differences are below.
 
 **Frontmatter.** Posts add `author`, `date` (an ISO `YYYY-MM-DD` string, quoted),
 and an optional `tags` array, on top of the mandatory `title` + `description`.
-The schema lives in `source.config.ts` (the `blog` collection).
+Posts may also declare `prerequisites` — the upstream "Start here" pointer docs
+pages use — most often aimed at a `/docs/concepts/*` page a cold reader needs first
+(see [Prerequisites](#prerequisites--the-upstream-pointer)). The schema lives in
+`source.config.ts` (the `blog` collection).
 
 ```yaml
 ---
@@ -655,6 +697,8 @@ without `See also` strands its reader. Dangling `/blog/<slug>` links fail it too
         `events`), not a one-off domain.
 -   [ ] Reads correctly in isolation (imagine it as a lone `llms.mdx`).
 -   [ ] `See also` links neighbors, the Reference entry, and any catalog pages.
+-   [ ] If the opening assumes a foundational concept, `prerequisites` points
+        upstream to it (hrefs that resolve); foundational pages declare none.
 -   [ ] Any tempting-but-wrong use is flagged with an inline **Anti-pattern**
         `<Callout type="warn">` at the point of temptation, not a separate
         section (rule 10) — omit only when the page has no such pitfall.

--- a/apps/docs/app/(home)/blog/[slug]/page.tsx
+++ b/apps/docs/app/(home)/blog/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { getMDXComponents } from '@/components/mdx';
+import { Prerequisites } from '@/components/prerequisites';
 import {
     blogSource,
     formatPostDate,
@@ -41,6 +42,7 @@ export default async function BlogPostPage(props: PageProps<'/blog/[slug]'>) {
                         </time>
                     </p>
                 </header>
+                <Prerequisites hrefs={post.data.prerequisites} />
                 <DocsBody>
                     <MDX components={getMDXComponents()} />
                 </DocsBody>

--- a/apps/docs/app/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/docs/[[...slug]]/page.tsx
@@ -1,4 +1,5 @@
 import { getMDXComponents } from '@/components/mdx';
+import { Prerequisites } from '@/components/prerequisites';
 import { jsonLdHtml } from '@/lib/json-ld';
 import { appName, gitConfig } from '@/lib/shared';
 import { getPageImage, getPageMarkdownUrl, source } from '@/lib/source';
@@ -46,6 +47,7 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
                         githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/content/docs/${page.path}`}
                     />
                 </div>
+                <Prerequisites hrefs={page.data.prerequisites} />
                 <DocsBody>
                     <MDX
                         components={getMDXComponents({

--- a/apps/docs/components/prerequisites.tsx
+++ b/apps/docs/components/prerequisites.tsx
@@ -1,0 +1,46 @@
+import { resolvePrerequisites } from '@/lib/prerequisites';
+
+import { Compass } from 'lucide-react';
+import Link from 'next/link';
+import { Fragment } from 'react';
+
+/**
+ * "New to stitches? Start here" — the upstream counterpart to a page's `See also`
+ * footer. Given a page's `prerequisites` frontmatter (internal hrefs), it resolves
+ * each to its real title from source and renders a quiet one-line note near the
+ * TOP of the page, so a reader who lands cold can step back to the foundational
+ * concept before diving in.
+ *
+ * Deliberately low-chrome: a muted line with a thin left rule, no filled
+ * background, so it reads as a wayfinding aside the eye can skip — not a banner
+ * that competes with the title. Renders nothing when a page declares no
+ * (resolvable) prerequisites, so it is safe to drop into every page renderer.
+ */
+export function Prerequisites({ hrefs }: { hrefs?: string[] }) {
+    const items = resolvePrerequisites(hrefs);
+    if (items.length === 0) return null;
+
+    return (
+        <aside
+            aria-label="Prerequisites"
+            className="text-fd-muted-foreground border-stitch-border mb-8 border-l-2 pl-3 text-sm leading-relaxed"
+        >
+            <Compass
+                className="mr-1.5 inline size-3.5 -translate-y-px"
+                aria-hidden
+            />
+            New to stitches? Start here:{' '}
+            {items.map((item, index) => (
+                <Fragment key={item.href}>
+                    {index > 0 ? ' · ' : null}
+                    <Link
+                        href={item.href}
+                        className="text-stitch-strong underline-offset-2 hover:underline"
+                    >
+                        {item.title}
+                    </Link>
+                </Fragment>
+            ))}
+        </aside>
+    );
+}

--- a/apps/docs/content/blog/adopt-stitchapi-without-a-rewrite.mdx
+++ b/apps/docs/content/blog/adopt-stitchapi-without-a-rewrite.mdx
@@ -4,6 +4,7 @@ description: 'Wrap one endpoint as a stitch, leave the rest of your fetch and ax
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [adoption, migration, fetch, axios, architecture]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 A retry policy you added to one `fetch` call last quarter never made it to the other six that hit the same flaky endpoint, and the response shape that broke production last week was the one nobody validated. You don't want to stop shipping for a week to rewrite the data layer — you want to harden the one call that keeps paging you, today, and leave everything else exactly where it is.

--- a/apps/docs/content/blog/auth-as-a-capability-not-a-credential.mdx
+++ b/apps/docs/content/blog/auth-as-a-capability-not-a-credential.mdx
@@ -4,6 +4,8 @@ description: Handing an agent your API key leaks the secret into prompts, logs, 
 author: Oleksandr Zhuravlov
 date: '2026-06-15'
 tags: [auth, agents, security, mcp]
+prerequisites:
+    ['/docs/concepts/the-stitch', '/docs/concepts/capability-not-credential']
 ---
 
 Here is a small, common mistake. You want an agent to look up a customer, so you put the API key in its environment — or worse, in its system prompt — and let it call the endpoint directly. It works on the first try. It also just turned your credential into data the model can read, repeat, and accidentally hand to whoever asks the right question.

--- a/apps/docs/content/blog/call-any-llm-as-a-typed-function.mdx
+++ b/apps/docs/content/blog/call-any-llm-as-a-typed-function.mdx
@@ -4,6 +4,7 @@ description: 'A model call is just an HTTP request, so wrapping it in an SDK buy
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [llm, ai, anthropic, openai, typescript]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 You ship a feature on Claude, then a cost review says move the cheap path to GPT-4o, and now you are threading a second SDK through your codebase: a different client object, a different request shape, a different response shape, a different retry story. The two providers do the same thing — take messages, return text — but each one drags its own library and its own conventions, so "switch the model" turns into "rewrite the call site." A model call is an HTTP POST with an auth header. The SDK is wrapping the same request you could declare once.

--- a/apps/docs/content/blog/choosing-an-http-adapter.mdx
+++ b/apps/docs/content/blog/choosing-an-http-adapter.mdx
@@ -4,6 +4,7 @@ description: A stitch turns one endpoint into a typed resilient function; the ad
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [http, adapter, fetch, axios, typescript]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 You're streaming a server-sent-events feed in one corner of the app and uploading a multi-megabyte file with a progress bar in another, and the transport that handles one can't do the other. `fetch` streams a download but can't tell you how many bytes of an upload have left the machine; `XMLHttpRequest` reports that upload progress but can't stream a response; the axios instance you already configured with a corporate proxy and a custom CA can't stream either, but it carries the setup your platform already trusts. Under a stitch, the transport is a swappable seam — you pick the one that fits the call, and the stitch's types, validation, retries, and auth ride on top unchanged.

--- a/apps/docs/content/blog/circuit-breakers-and-layered-timeouts.mdx
+++ b/apps/docs/content/blog/circuit-breakers-and-layered-timeouts.mdx
@@ -4,6 +4,7 @@ description: When an upstream dependency is already down or crawling, naive retr
 author: Oleksandr Zhuravlov
 date: '2026-06-01'
 tags: [resilience, reliability, timeouts, circuit-breaker, retry]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 An upstream provider starts to crawl. Not down — crawling. Responses that used to land in 80ms now take eight seconds, when they land at all. Your code does the reasonable thing: it has a timeout, so it gives up after thirty seconds and retries. Three attempts, a little backoff between them. Sensible in isolation.

--- a/apps/docs/content/blog/code-mode-vs-tool-calling.mdx
+++ b/apps/docs/content/blog/code-mode-vs-tool-calling.mdx
@@ -4,6 +4,7 @@ description: Tool calling hands the model one schema per endpoint and re-sends e
 author: Oleksandr Zhuravlov
 date: '2026-06-28'
 tags: [ai, agents, mcp, code-mode, context, tokens]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Reach for **code mode** when an agent needs access to many tools and you don't want every tool's schema sitting in the model's context on every turn. It's an industry pattern, not a StitchAPI invention — the same idea shows up wherever a model is given more capabilities than fit comfortably in a per-turn tool list. This post defines code mode against the pattern it replaces, **tool calling**, then shows the concrete three-tool shape StitchAPI uses.

--- a/apps/docs/content/blog/compose-api-calls-into-a-pipeline.mdx
+++ b/apps/docs/content/blog/compose-api-calls-into-a-pipeline.mdx
@@ -4,6 +4,7 @@ description: 'A dependent chain — an order, then its shipment, then the carrie
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [composition, linked, pipeline, trace, typescript]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 You fetch an order, then the shipment booked against it, then the carrier's live tracking — and the tracking call needs the shipment's code **and** the order's region, two hops back. Three calls, in order, each needing a result from the one before. When one fails at 2am, you want a trace that shows what ran first, not three unrelated calls.

--- a/apps/docs/content/blog/cut-llm-costs-from-both-ends.mdx
+++ b/apps/docs/content/blog/cut-llm-costs-from-both-ends.mdx
@@ -4,6 +4,7 @@ description: StitchAPI attacks AI cost on two axes — the tokens you spend desc
 author: Oleksandr Zhuravlov
 date: '2026-06-25'
 tags: [ai, agents, cost, mcp]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Most advice on cutting AI costs lands in one of two buckets: compress your prompts, or switch to a cheaper model. Both help. Both also leave the structural cost untouched — the part of your bill that scales with how your agents are _wired_, not with how cleverly you phrase a system prompt.

--- a/apps/docs/content/blog/distributed-throttle-with-redis-kv.mdx
+++ b/apps/docs/content/blog/distributed-throttle-with-redis-kv.mdx
@@ -4,6 +4,7 @@ description: A throttle that's correct on one process quietly multiplies by N wh
 author: Oleksandr Zhuravlov
 date: '2026-05-07'
 tags: [throttle, sessions, distributed, edge, stores]
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
 You set a throttle on a stitch — say two requests a second to a metered upstream, a [proactive limiter that keeps you under the cap before the 429s arrive](/blog/proactive-throttling-vs-reactive-429s) — and on your laptop it behaves exactly as declared. Then you deploy three instances behind a load balancer, or your handler runs as a serverless function that scales to a dozen concurrent isolates, and the upstream starts handing you `429`s you can't explain. The math is the problem: three processes each enforcing two-per-second is six-per-second at the wall. Your real upstream rate is N times your cap, where N is however many copies of your code happen to be running right now.

--- a/apps/docs/content/blog/expose-a-stitch-as-an-ai-sdk-tool.mdx
+++ b/apps/docs/content/blog/expose-a-stitch-as-an-ai-sdk-tool.mdx
@@ -4,6 +4,7 @@ description: How to hand a model a stitch as a callable tool with @stitchapi/ver
 author: Oleksandr Zhuravlov
 date: '2026-05-11'
 tags: [ai, agents, auth, tools]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Letting a model call your API during generation is a small superpower and a real liability at the same time. The usual way to wire it up — give the model a raw `fetch` wrapper as a tool — leaks two things you'd rather keep separate. It hands the model an opaque blob of bytes to reason over, and it puts the API key on the same side of the boundary as the model that's about to improvise tool arguments.

--- a/apps/docs/content/blog/fetch-timeout-typescript.mdx
+++ b/apps/docs/content/blog/fetch-timeout-typescript.mdx
@@ -4,6 +4,7 @@ author: Oleksandr Zhuravlov
 date: '2026-06-29'
 description: fetch has no timeout option, so a hung request blocks your caller forever. This shows the AbortSignal.timeout pattern that actually cancels the socket, the Promise.race trap that doesn't, and how a stitch declares total and per-attempt deadlines that compose with retry.
 tags: [fetch, timeout, typescript, abortsignal, resilience]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Add a timeout to `fetch` when a slow or hung response shouldn't be allowed to block your caller indefinitely. `fetch` ships with no timeout option of its own, so a request to a stalled upstream waits as long as the OS lets the socket stay open — which can be minutes. You reach for a timeout the first time a single slow dependency holds up a request you promised would return in seconds.

--- a/apps/docs/content/blog/idempotency-keys-safe-retries.mdx
+++ b/apps/docs/content/blog/idempotency-keys-safe-retries.mdx
@@ -4,6 +4,7 @@ description: 'A write can time out after the server committed but before the res
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [idempotency, retry, typescript, resilience, http]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Your charge endpoint times out. The card was charged — the server committed the row — but the response packet never made it back across the wire. Your retry logic does the sensible thing and fires the request again. Now the customer has two charges and you have a support ticket.

--- a/apps/docs/content/blog/migrate-from-axios-to-stitchapi.mdx
+++ b/apps/docs/content/blog/migrate-from-axios-to-stitchapi.mdx
@@ -4,6 +4,7 @@ description: 'The axios.create() is the small part of a mature setup — the bul
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [axios, typescript, migration, interceptors, resilience]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 You open the file that configures axios for a real service, and the `axios.create()` at the top is two lines. Below it sit two hundred: a request interceptor that attaches a bearer token, a response interceptor that catches a 401 and refreshes, a retry-with-backoff bolted on by hand, a `validateStatus` override, a `transformResponse` that reshapes the body, and a cast that tells TypeScript the result is `User` without anyone checking. That interceptor stack is what you maintain. Migrating to StitchAPI is migrating _that layer_ — and you can keep axios as the transport while you do it, or drop it.

--- a/apps/docs/content/blog/migrate-from-fetch-to-stitchapi.mdx
+++ b/apps/docs/content/blog/migrate-from-fetch-to-stitchapi.mdx
@@ -4,6 +4,7 @@ description: 'Your fetch call works until the API blips: no retry, no timeout, n
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [fetch, migration, typescript, validation, resilience]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 You have a `fetch` call that reads a user from an internal API. It works on your machine, it works in CI, and then one afternoon the upstream service returns a `503` for ninety seconds, your call surfaces the error straight to the page, and the JSON you parsed turns out to have dropped a field a release ago that nobody caught because `res.json()` is typed `any`. The call did exactly what `fetch` promises — one request, one response, no opinions — and every opinion you needed (retry the blip, bound the wait, check the shape) was yours to hand-write around it. Migrating to a stitch is moving each of those opinions out of glue code and onto the call's declaration.

--- a/apps/docs/content/blog/one-definition-four-front-doors.mdx
+++ b/apps/docs/content/blog/one-definition-four-front-doors.mdx
@@ -4,6 +4,7 @@ description: The same stitch declaration is callable as an in-process function, 
 author: Oleksandr Zhuravlov
 date: '2026-05-28'
 tags: [cli, http, mcp, agents, architecture]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Look at how one integration usually gets consumed. Your app imports a function that calls the API. A CI script needs the same call, so someone writes a thin CLI wrapper around it. Another service can't import your code, so it gets an HTTP handler that does roughly the same thing. Then an agent shows up, and you write a tool definition describing the same endpoint a fourth time.

--- a/apps/docs/content/blog/one-tool-per-endpoint.mdx
+++ b/apps/docs/content/blog/one-tool-per-endpoint.mdx
@@ -4,6 +4,7 @@ description: The one-tool-per-endpoint pattern re-sends every endpoint's JSON sc
 author: Oleksandr Zhuravlov
 date: '2026-06-22'
 tags: [ai, agents, mcp, context, tokens]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 You wire forty endpoints into your agent, each as its own tool, and the demo works. Then the bill arrives, and it's bigger than the work the agent actually did. The agent ran a six-step loop; somewhere in those six steps it called three tools. You paid for forty, six times over.

--- a/apps/docs/content/blog/proactive-throttling-vs-reactive-429s.mdx
+++ b/apps/docs/content/blog/proactive-throttling-vs-reactive-429s.mdx
@@ -4,6 +4,7 @@ description: Most clients only find a rate limit by hitting it. A declared throt
 author: Oleksandr Zhuravlov
 date: '2026-06-04'
 tags: [resilience, throttle, rate-limits, http]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 The usual way to handle a rate limit is to wait for the provider to enforce it. You fire requests as fast as your code produces them, and when one comes back `429 Too Many Requests`, you retry, back off, and honor `Retry-After`. It works, and you should keep it — but notice what it costs. By the time the `429` arrives, you've already spent the request: a round trip out, a round trip back, and a rejection for your trouble. Do that in a loop and the rejections stack up, each one adding latency and, on a metered endpoint, sometimes a charge for the privilege of being told no.

--- a/apps/docs/content/blog/read-non-json-responses.mdx
+++ b/apps/docs/content/blog/read-non-json-responses.mdx
@@ -4,6 +4,7 @@ description: 'CSV reports, HTML pages, PDFs, and zips do not fit a JSON client. 
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [non-json, csv, html, responsetype, typescript]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 The report endpoint returns CSV. The scraping target returns HTML. The files service hands back a PDF or a zip. Your client was built for JSON, so each of these becomes a one-off: a manual fetch, a `res.text()` here and a `res.arrayBuffer()` there, a parser bolted on, and a return type of `any` that lies to everyone downstream. A stitch reads those bodies too — `responseType` picks how the body is decoded, `transform` reshapes it, and an `output` schema validates the shape you actually use.

--- a/apps/docs/content/blog/read-through-caching-and-coalescing.mdx
+++ b/apps/docs/content/blog/read-through-caching-and-coalescing.mdx
@@ -4,6 +4,7 @@ description: How StitchAPI's read-through cache and in-process request coalescin
 author: Oleksandr Zhuravlov
 date: '2026-06-08'
 tags: [caching, coalescing, performance, resilience]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Picture a request that fans out. A page loads, and three components each ask for the current user. An agent kicks off the same lookup across ten parallel branches. A burst of traffic hits an endpoint that returns the same answer for everyone for the next minute. In each case you make N calls upstream where one would have done — and if that upstream is metered, rate-limited, or just slow, you pay for all N.

--- a/apps/docs/content/blog/run-a-stitch-on-the-edge.mdx
+++ b/apps/docs/content/blog/run-a-stitch-on-the-edge.mdx
@@ -4,6 +4,7 @@ description: 'Most HTTP clients drag a node: import that breaks on a Worker. Sti
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [edge, cloudflare, workers, typescript, kv]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 You wrote a clean API client, it passes every test on your laptop, and then the Cloudflare deploy fails at build time with `Could not resolve "node:crypto"`. The client you picked reaches for a Node built-in somewhere deep in its transport or its cache, and a Worker has no `node:` to give it. Now you are pinning polyfills, flipping compatibility flags, and hoping the shim behaves the same as the real thing.

--- a/apps/docs/content/blog/run-api-calls-in-parallel.mdx
+++ b/apps/docs/content/blog/run-api-calls-in-parallel.mdx
@@ -4,6 +4,7 @@ description: 'When API calls do not depend on each other, running them as a ladd
 author: Oleksandr Zhuravlov
 date: '2026-06-30'
 tags: [composition, parallel, concurrency, linked, typescript]
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
 A [stitch](/docs/concepts/the-stitch) is one endpoint as a typed, validated, resilient function. When one call needs the result of the one before it, you want a sequence — that is [`linked`](/blog/compose-api-calls-into-a-pipeline). But just as often the calls are **independent**: a dashboard needs a user, their settings, and their feature flags, and none of them waits on the others. Running those in sequence is latency you are paying for nothing.

--- a/apps/docs/content/blog/scaffold-a-stitch-from-curl.mdx
+++ b/apps/docs/content/blog/scaffold-a-stitch-from-curl.mdx
@@ -4,6 +4,7 @@ description: 'You have a curl line from the API docs and a token in your shell. 
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [cli, scaffolding, auth, agents]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 You are reading an API's docs, you copy the example curl, and now you have to translate it by hand: pull the origin out of the URL, find the id buried in the path, decode which header is the credential, and rewrite the whole thing as a typed call. The mechanical part is tedious. The dangerous part is the credential — the curl you copied has a live `Bearer sk_live_…` in it, and the obvious move is to paste it straight into your code.

--- a/apps/docs/content/blog/schema-drift-is-a-production-bug.mdx
+++ b/apps/docs/content/blog/schema-drift-is-a-production-bug.mdx
@@ -4,6 +4,7 @@ description: A third-party field quietly changes shape and your code keeps compi
 author: Oleksandr Zhuravlov
 date: '2026-06-11'
 tags: [reliability, drift, validation, types, observability]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 A provider you depend on renames `total` to `total_amount`, or turns a number into a string, or starts returning `null` where it never did before. Nobody told you. Your build is green. Your tests are green. The deploy goes out. And then, hours later, a chart renders `NaN`, an order total comes out `undefined`, and a pager goes off — for a code path you didn't touch.

--- a/apps/docs/content/blog/stitch-as-react-query-queryfn.mdx
+++ b/apps/docs/content/blog/stitch-as-react-query-queryfn.mdx
@@ -4,6 +4,7 @@ description: 'You already run TanStack Query for view state. Drop a stitch in as
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [react, tanstack-query, react-query]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 You wired up TanStack Query months ago, and `useQuery` already owns your view state — caching by key, refetch on focus, invalidation after a mutation. What it doesn't own is the call inside `queryFn`: that's still a hand-written `fetch`, a `res.ok` check you keep forgetting, a `res.json()` cast to whatever type you hope came back, and a retry loop you copied between three hooks. The query layer is solid; the function it runs is the soft spot.

--- a/apps/docs/content/blog/stitch-in-react-vue-svelte-solid.mdx
+++ b/apps/docs/content/blog/stitch-in-react-vue-svelte-solid.mdx
@@ -4,6 +4,7 @@ description: The same stitch plugs into each major UI framework via a thin bindi
 author: Oleksandr Zhuravlov
 date: '2026-05-04'
 tags: [ui, react, vue, svelte, solid, angular]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 You declared a stitch — typed input, validated output, retries, drift detection — and now a component has to call it. That's where the boilerplate usually creeps back in: a `useState` for the data, another for the loading flag, another for the error, a `useEffect` to fire the call, an `AbortController` to cancel it on unmount, and — if the call streams — a reducer to fold chunks as they arrive. You wrote that once per framework, and you'll write it again the next time, slightly differently, in the next component.

--- a/apps/docs/content/blog/stop-writing-fetch-in-your-agents.mdx
+++ b/apps/docs/content/blog/stop-writing-fetch-in-your-agents.mdx
@@ -4,6 +4,7 @@ description: When an AI agent is the caller, raw fetch() is the wrong primitive 
 author: Oleksandr Zhuravlov
 date: '2026-06-18'
 tags: [agents, ai, fetch, mcp, auth]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Here's a tool definition that ships in more agent codebases than anyone wants to admit:

--- a/apps/docs/content/blog/stream-a-stitch-as-sse-in-next-app-router.mdx
+++ b/apps/docs/content/blog/stream-a-stitch-as-sse-in-next-app-router.mdx
@@ -4,6 +4,7 @@ description: Take a streaming stitch and expose it as a text/event-stream Respon
 author: Oleksandr Zhuravlov
 date: '2026-05-14'
 tags: [next, sse, streaming, react]
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/event-stream']
 ---
 
 A long-running call — a model completion, a slow report, a progressive search — produces a result over seconds, not milliseconds. If your route handler `await`s the whole thing and then returns one JSON blob, the user stares at a spinner the entire time, can't see partial output, and can't cancel a run they've already decided they don't want. Streaming fixes all three: you render tokens as they land, show progress before the final answer exists, and tear the upstream call down the moment the client navigates away.

--- a/apps/docs/content/blog/test-api-code-without-the-network.mdx
+++ b/apps/docs/content/blog/test-api-code-without-the-network.mdx
@@ -4,6 +4,7 @@ description: 'Code that calls APIs you do not own goes slow and flaky in tests. 
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [testing, mocking, typescript, adapter, mockadapter]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 You wrote a function that fetches a user, retries on `503`, validates the payload, and your test for it spins up MSW, registers a handler, and still flakes when two specs share the global `fetch`. The code under test calls an API you do not own, so the test has to fake that API somewhere — and the usual place to fake it is the network layer, which is the layer with the most moving parts.

--- a/apps/docs/content/blog/trace-api-calls-without-leaking-secrets.mdx
+++ b/apps/docs/content/blog/trace-api-calls-without-leaking-secrets.mdx
@@ -4,6 +4,7 @@ description: 'Logging your outbound calls usually means your logs now carry Auth
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [observability, tracing, security, typescript, redaction]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 A charge fails in production, you add a `console.log` around the call to your payment provider, ship it, and three days later a security scan flags your log index: it holds live `Authorization: Bearer sk_live_...` headers, an access token sitting in a query string, and a full customer record per request. You wanted to see what the call did. You spilled the secret it carried.

--- a/apps/docs/content/blog/typed-errors-without-try-catch.mdx
+++ b/apps/docs/content/blog/typed-errors-without-try-catch.mdx
@@ -4,6 +4,7 @@ description: 'A thrown error is typed `unknown`, so every catch block re-narrows
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [typescript, error-handling, validation, safe-result, stitcherror]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 You write a loader that fetches a user, and the failure path is a `try/catch` whose `catch (err)` binds `err` as `unknown`. To read the HTTP status you re-narrow — `if (err instanceof StitchError)` — every single time, in every loader, because TypeScript cannot prove what `throw` threw. The happy path and the failure path live on opposite sides of a control-flow wall, and the type system has lost track of the error before you ever touch it.

--- a/apps/docs/content/blog/typed-graphql-without-apollo.mdx
+++ b/apps/docs/content/blog/typed-graphql-without-apollo.mdx
@@ -4,6 +4,7 @@ description: 'A GraphQL endpoint can answer HTTP 200 and still have failed. A gr
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [graphql, typescript, validation, resilience]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 You point a `fetch` at a GraphQL endpoint, POST `{ query, variables }`, get back a `200`, read `json.data.user` — and three weeks later that call is silently returning `undefined` because the server moved the failure into a `200`-with-`errors` body instead of a status code. The transport said success; the operation did not. Most GraphQL clients you'd reach for to close that gap — Apollo Client, urql — also bring a normalized cache, a React layer, and a build step you didn't ask for when all you wanted was to call one query and trust the result.

--- a/apps/docs/content/blog/upload-a-file-with-a-progress-bar.mdx
+++ b/apps/docs/content/blog/upload-a-file-with-a-progress-bar.mdx
@@ -4,6 +4,7 @@ description: 'fetch cannot report how many bytes have left the machine, so a 50M
 author: Oleksandr Zhuravlov
 date: '2026-06-29'
 tags: [upload, progress, xhr, typescript, multipart]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 A user picks a 50MB video, clicks **Upload**, and your UI just sits there. No bar, no percentage, no sign the bytes are even moving — until, a minute later, the response lands and the screen jumps to "done." The user has already refreshed twice. The problem is not your code; it is the transport: `fetch` cannot tell you how many bytes of the request body have left the machine. `XMLHttpRequest` can, through `xhr.upload`. StitchAPI ships `xhrAdapter()` for exactly this case, and an upload built on it is still an ordinary stitch — typed, authenticated, time-bounded.

--- a/apps/docs/content/blog/validate-api-response-zod.mdx
+++ b/apps/docs/content/blog/validate-api-response-zod.mdx
@@ -4,6 +4,7 @@ author: Oleksandr Zhuravlov
 date: '2026-06-29'
 description: The standard way to validate an API response with Zod is to parse the JSON through a schema with safeParse at the call site. This shows that pattern and its rough edges, then how to declare the same schema on a stitch so every call validates its response — and its input — at the boundary with a typed error.
 tags: [zod, validation, typescript, api, fetch]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Validate an API response with Zod when you want a malformed or unexpected shape to fail loudly at the boundary instead of leaking through as an `undefined` three layers downstream. You reach for it the moment you stop trusting that the JSON on the wire matches the type you wrote — which is every third-party API and most internal ones.

--- a/apps/docs/content/blog/you-might-not-need-an-mcp-server-per-integration.mdx
+++ b/apps/docs/content/blog/you-might-not-need-an-mcp-server-per-integration.mdx
@@ -4,6 +4,7 @@ description: The reflex when wiring an agent to a service is to stand up a dedic
 author: Oleksandr Zhuravlov
 date: '2026-05-21'
 tags: [mcp, agents, integrations, architecture]
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 You wire your agent to its first service and it goes well: install (or stand up) an MCP server, point the agent at it, watch the tools light up. Then you add a second service. A third. Now you have three MCP servers to launch, three sets of credentials to inject, three processes whose health you have to watch — and the agent's context window is carrying every tool each of them exposes, on every turn, whether it uses them or not.

--- a/apps/docs/content/docs/agents/adopt-in-your-project.mdx
+++ b/apps/docs/content/docs/agents/adopt-in-your-project.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Adopt in your project'
 description: 'Drop a rule into your repo so any agent reaches for a typed stitch instead of a hand-rolled fetch — by hand, or with npx stitch init.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Teach the agents that work in your repo one habit: when the project calls an

--- a/apps/docs/content/docs/agents/author-from-one-example.mdx
+++ b/apps/docs/content/docs/agents/author-from-one-example.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Author from one example'
 description: 'Have an agent emit a stitch declaration from a single curl, HAR, or doc snippet.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 A complete stitch can come from one example — a `curl`, a HAR entry, a doc

--- a/apps/docs/content/docs/agents/run-stitch-tool.mdx
+++ b/apps/docs/content/docs/agents/run-stitch-tool.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'run_stitch & code-mode'
 description: 'Drive stitches from a sandbox with one context-frugal tool instead of flooding the model with per-endpoint tools.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Drive stitches from an agent sandbox with a single `run_stitch` tool — pass

--- a/apps/docs/content/docs/guides/auth/api-key.mdx
+++ b/apps/docs/content/docs/guides/auth/api-key.mdx
@@ -1,6 +1,8 @@
 ---
 title: 'apiKey'
 description: 'Send an API key as a header or query parameter, resolved at call time.'
+prerequisites:
+    ['/docs/concepts/the-stitch', '/docs/concepts/capability-not-credential']
 ---
 
 Use `apiKey` when an API authenticates with a static key and you want the stitch

--- a/apps/docs/content/docs/guides/auth/basic.mdx
+++ b/apps/docs/content/docs/guides/auth/basic.mdx
@@ -1,6 +1,8 @@
 ---
 title: 'basic'
 description: 'HTTP Basic authentication with credentials resolved from a secret resolver.'
+prerequisites:
+    ['/docs/concepts/the-stitch', '/docs/concepts/capability-not-credential']
 ---
 
 Use `basic` when an API authenticates with HTTP Basic — it base64-encodes

--- a/apps/docs/content/docs/guides/auth/bearer.mdx
+++ b/apps/docs/content/docs/guides/auth/bearer.mdx
@@ -1,6 +1,8 @@
 ---
 title: 'bearer'
 description: 'Attach a bearer token resolved at call time from an env var or a secrets file.'
+prerequisites:
+    ['/docs/concepts/the-stitch', '/docs/concepts/capability-not-credential']
 ---
 
 Use `bearer` when an API authenticates with a token sent as

--- a/apps/docs/content/docs/guides/auth/cookie-session.mdx
+++ b/apps/docs/content/docs/guides/auth/cookie-session.mdx
@@ -1,6 +1,8 @@
 ---
 title: 'cookieSession'
 description: 'Log in once, capture and replay cookies, and refresh the session on a status code or a soft 200 wall.'
+prerequisites:
+    ['/docs/concepts/the-stitch', '/docs/concepts/capability-not-credential']
 ---
 
 Use `cookieSession` when an API authenticates with a login form and a cookie

--- a/apps/docs/content/docs/guides/auth/oauth2.mdx
+++ b/apps/docs/content/docs/guides/auth/oauth2.mdx
@@ -1,6 +1,8 @@
 ---
 title: 'oauth2'
 description: 'OAuth2 client_credentials: fetch, cache, and auto-refresh a token behind the capability boundary.'
+prerequisites:
+    ['/docs/concepts/the-stitch', '/docs/concepts/capability-not-credential']
 ---
 
 Use `oauth2` when an API authenticates with the OAuth2 `client_credentials`

--- a/apps/docs/content/docs/guides/auth/secret-resolvers.mdx
+++ b/apps/docs/content/docs/guides/auth/secret-resolvers.mdx
@@ -1,6 +1,8 @@
 ---
 title: 'Secret resolvers'
 description: 'Resolve secrets lazily at call time with env() and secretsFile() instead of hard-coding them.'
+prerequisites:
+    ['/docs/concepts/the-stitch', '/docs/concepts/capability-not-credential']
 ---
 
 Every auth strategy takes a secret as a reference, not a value, and resolves it

--- a/apps/docs/content/docs/guides/authoring/extends.mdx
+++ b/apps/docs/content/docs/guides/authoring/extends.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'extends'
 description: 'Layer fragments — strings, objects, or other stitches — with deep-merge to compose configuration.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `extends` to build a stitch from layered fragments — a shared base, an

--- a/apps/docs/content/docs/guides/authoring/hooks.mdx
+++ b/apps/docs/content/docs/guides/authoring/hooks.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Hooks'
 description: 'Observe a call as it runs — onRequest, onResponse, onError, onRetry — and where each fires relative to auth, retry, throttle, and timeout.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Hooks are observation points on a stitch's lifecycle: small callbacks that run as a

--- a/apps/docs/content/docs/guides/authoring/seam.mdx
+++ b/apps/docs/content/docs/guides/authoring/seam.mdx
@@ -1,6 +1,7 @@
 ---
 title: seam
 description: Group stitches under one shared runtime — store, vault, throttle bucket, and trace sink — behind a shared base config, and bind per-principal sessions with seam.as().
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
 Use `seam` when several stitches hit the same API and should share one runtime — one throttle budget, one store, one trace sink, one auth vault — instead of each carrying its own copy of the config. Build it once, then create members with `.stitch()` and `.graphql()`.

--- a/apps/docs/content/docs/guides/authoring/with.mdx
+++ b/apps/docs/content/docs/guides/authoring/with.mdx
@@ -1,6 +1,7 @@
 ---
 title: '.with() partial application'
 description: 'Pre-bind part of a call and reuse the same runtime so cookies, throttle, and sessions persist.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `.with()` when you want to pre-bind part of a stitch's input — a query

--- a/apps/docs/content/docs/guides/data/body-encoding.mdx
+++ b/apps/docs/content/docs/guides/data/body-encoding.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Body encoding'
 description: 'Send request bodies as json, form, or multipart.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Set `bodyType` when an API expects a request body in a particular wire format —

--- a/apps/docs/content/docs/guides/data/graphql.mdx
+++ b/apps/docs/content/docs/guides/data/graphql.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'GraphQL'
 description: 'Call a GraphQL endpoint with variables, unwrap data, and treat a 200 carrying errors as a failure.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `graphql()` when an API speaks GraphQL-over-HTTP and you want a stitch that

--- a/apps/docs/content/docs/guides/data/pagination.mdx
+++ b/apps/docs/content/docs/guides/data/pagination.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Pagination'
 description: 'Auto-loop pages and aggregate items, with auth, retry, and throttle applied to every page.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/getting-started/quickstart']
 ---
 
 Add `paginate` when one logical call spans many pages and you want the stitch to

--- a/apps/docs/content/docs/guides/data/transform.mdx
+++ b/apps/docs/content/docs/guides/data/transform.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'transform'
 description: 'Reshape a response before unwrap and validation — for example, scrape HTML into structured data.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `transform` when the raw response isn't yet the shape the rest of the

--- a/apps/docs/content/docs/guides/data/unwrap.mdx
+++ b/apps/docs/content/docs/guides/data/unwrap.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'unwrap'
 description: 'Pull just the part of the response you want by dot-path.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `unwrap` when an API wraps the value you want in an envelope and you want

--- a/apps/docs/content/docs/guides/data/url-shaping.mdx
+++ b/apps/docs/content/docs/guides/data/url-shaping.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'URL shaping'
 description: 'RFC 6570 path templates and qs-style nested query serialization — how params and query become the URL.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 A stitch builds its URL from an

--- a/apps/docs/content/docs/guides/observability/otlp.mdx
+++ b/apps/docs/content/docs/guides/observability/otlp.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'OTLP export'
 description: 'Export traces as OpenTelemetry spans for your existing observability stack.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/event-stream']
 ---
 
 Reach for OTLP export when you want a stitch's events as OpenTelemetry spans in

--- a/apps/docs/content/docs/guides/observability/trace-sinks.mdx
+++ b/apps/docs/content/docs/guides/observability/trace-sinks.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Trace sinks'
 description: 'Tracing is off by default — opt in with trace: console, a fileSink, env vars, or your own TraceSink.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/event-stream']
 ---
 
 A trace sink is any consumer of a stitch's [event stream](/docs/concepts/event-stream) —

--- a/apps/docs/content/docs/guides/resilience/accept-status.mdx
+++ b/apps/docs/content/docs/guides/resilience/accept-status.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Accept status'
 description: 'Declare statuses that are a normal result, not an error — an accepted non-2xx flows through transform/unwrap/validate instead of throwing.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 By default every `status >= 400` is a failure: the stitch throws a

--- a/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
+++ b/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Circuit breaker'
 description: 'Stop hammering a failing dependency by opening a circuit after repeated failures.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Add `circuit` when a dependency is failing and you want the stitch to stop

--- a/apps/docs/content/docs/guides/resilience/delegate-backoff.mdx
+++ b/apps/docs/content/docs/guides/resilience/delegate-backoff.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Delegate backoff'
 description: 'Surface rate-limit outcomes as a RateLimitError so an outer gate owns the backoff, instead of retrying and throttling them internally.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 By default a stitch handles a rate limit _itself_: a `429` listed in

--- a/apps/docs/content/docs/guides/resilience/idempotency.mdx
+++ b/apps/docs/content/docs/guides/resilience/idempotency.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Idempotency keys'
 description: "Attach idempotency keys to writes so safe retries don't duplicate side effects."
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Add `idempotency` to a write stitch so each logical call carries a stable

--- a/apps/docs/content/docs/guides/resilience/retry.mdx
+++ b/apps/docs/content/docs/guides/resilience/retry.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Retry & backoff'
 description: 'Retry on configurable status codes with expo/jitter/fixed backoff and respect for Retry-After.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Add `retry` when an API returns transient failures — rate limits and gateway

--- a/apps/docs/content/docs/guides/resilience/throttle.mdx
+++ b/apps/docs/content/docs/guides/resilience/throttle.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Throttle'
 description: 'Space requests by rate and cap concurrency, scoped per stitch or per host.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Add `throttle` to a stitch when you need to stay under an API's rate limit and

--- a/apps/docs/content/docs/guides/resilience/timeout.mdx
+++ b/apps/docs/content/docs/guides/resilience/timeout.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Timeouts'
 description: 'Enforce total and per-attempt timeouts with a real AbortSignal.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Add `timeout` when a slow or hung response shouldn't be allowed to block the

--- a/apps/docs/content/docs/guides/state/distributed-throttle.mdx
+++ b/apps/docs/content/docs/guides/state/distributed-throttle.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Distributed throttle'
 description: 'Share one rate budget across workers by pointing the throttle at a shared store.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
 By default a stitch keeps its throttle counters in the in-memory store, so the

--- a/apps/docs/content/docs/guides/state/pluggable-store.mdx
+++ b/apps/docs/content/docs/guides/state/pluggable-store.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'The pluggable store'
 description: 'Swap the in-memory store for a shared one to back throttle and sessions with get/set/incr + TTL.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
 Swap the in-memory store for a shared one when you want throttle counters and

--- a/apps/docs/content/docs/guides/state/shared-sessions.mdx
+++ b/apps/docs/content/docs/guides/state/shared-sessions.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Shared sessions'
 description: 'Persist and share a login across stitches and workers via a session key and a shared store.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
 Give two stitches the same auth `key` plus a shared `store` and they share one

--- a/apps/docs/content/docs/guides/testing/mocking.mdx
+++ b/apps/docs/content/docs/guides/testing/mocking.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Testing'
 description: 'Mock the transport to test a stitch definition, or swap in a fake stitch to test code that calls one — from stitchapi/testing.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 There are two things to test, and a tool for each. To test a **stitch

--- a/apps/docs/content/docs/guides/validation/drift.mdx
+++ b/apps/docs/content/docs/guides/validation/drift.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Drift detection'
 description: 'Detect silent contract changes as non-fatal findings by diffing the raw response against the validated value.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Wrap a stitch's `output` with `drift` when you want to catch an API quietly

--- a/apps/docs/content/docs/guides/validation/standard-schema.mdx
+++ b/apps/docs/content/docs/guides/validation/standard-schema.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Standard Schema'
 description: 'Bring any Standard Schema validator — Zod, Valibot, ArkType — for validation and inferred types.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Reach for this when you already have a schema and want a stitch to validate

--- a/apps/docs/content/docs/guides/validation/validation.mdx
+++ b/apps/docs/content/docs/guides/validation/validation.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Validation'
 description: 'Validate params, query, body, headers, and the response, failing fast before the request when input is wrong.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use validation when you want a stitch to reject bad input before it leaves the

--- a/apps/docs/content/docs/integrations/angular.mdx
+++ b/apps/docs/content/docs/integrations/angular.mdx
@@ -1,6 +1,7 @@
 ---
 title: Angular
 description: injectStitch and injectStitchStream expose a stitch's lifecycle as both Angular signals and an RxJS observable over the framework-agnostic @stitchapi/query-core store — plus an optional TanStack Query adapter.
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `@stitchapi/angular` when you call stitches from Angular components and want the

--- a/apps/docs/content/docs/integrations/aws-sigv4.mdx
+++ b/apps/docs/content/docs/integrations/aws-sigv4.mdx
@@ -1,6 +1,8 @@
 ---
 title: AWS SigV4
 description: awsSigV4 signs each request with AWS Signature Version 4 — the request-signing AuthStrategy that core's built-in bearer/apiKey/basic/oauth2 don't cover. Edge-safe Web Crypto, no dependencies.
+prerequisites:
+    ['/docs/concepts/the-stitch', '/docs/concepts/capability-not-credential']
 ---
 
 Core's built-in [auth strategies](/docs/reference/auth-strategies) cover bearer,

--- a/apps/docs/content/docs/integrations/elysia.mdx
+++ b/apps/docs/content/docs/integrations/elysia.mdx
@@ -1,6 +1,7 @@
 ---
 title: Elysia
 description: An Elysia plugin for StitchAPI — a principal-bound seam on the request context, an SSE bridge with streamStitchSse returning a Response, and stitch errors mapped to HTTP via the plugin's onError.
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
 Use `@stitchapi/elysia` when you serve an API with [Elysia](https://elysiajs.com).

--- a/apps/docs/content/docs/integrations/expo.mdx
+++ b/apps/docs/content/docs/integrations/expo.mdx
@@ -1,6 +1,7 @@
 ---
 title: Expo
 description: expoFetchAdapter streams over expo/fetch with no polyfills, and expoSecureStore keeps auth tokens encrypted — over the same hooks, AsyncStorage store, and lifecycle helpers as @stitchapi/react-native.
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `@stitchapi/expo` when you call stitches from an Expo app. Expo ships

--- a/apps/docs/content/docs/integrations/express.mdx
+++ b/apps/docs/content/docs/integrations/express.mdx
@@ -1,6 +1,7 @@
 ---
 title: Express
 description: Express 4/5 middleware for StitchAPI — a principal-bound seam on req.stitch, an SSE bridge with streamStitchSse, and stitch errors mapped to JSON by a 4-arg error handler.
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
 Use `@stitchapi/express` when you serve an API with [Express](https://expressjs.com)

--- a/apps/docs/content/docs/integrations/fastify.mdx
+++ b/apps/docs/content/docs/integrations/fastify.mdx
@@ -1,6 +1,7 @@
 ---
 title: Fastify
 description: Register stitchPlugin and your Fastify app gets a shared seam, a request-scoped principal, and bridges into Fastify's Pino logger, SSE streaming, and error handling.
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
 Use `@stitchapi/fastify` when you serve an API with [Fastify](https://fastify.dev)

--- a/apps/docs/content/docs/integrations/hono.mdx
+++ b/apps/docs/content/docs/integrations/hono.mdx
@@ -1,6 +1,7 @@
 ---
 title: Hono
 description: Edge-ready Hono middleware for StitchAPI — a principal-bound seam on c.var.stitch, an SSE bridge with streamStitchSse, and stitch errors mapped to HTTPException.
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
 Use `@stitchapi/hono` when you serve an API with [Hono](https://hono.dev) on the

--- a/apps/docs/content/docs/integrations/nestjs.mdx
+++ b/apps/docs/content/docs/integrations/nestjs.mdx
@@ -1,6 +1,7 @@
 ---
 title: NestJS
 description: Wire stitches into a NestJS app with StitchModule — injectable stitches, a Logger trace bridge, ConfigService-backed secrets, and request-scoped multi-tenancy.
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
 Use `@stitchapi/nest` when you want your stitches available through NestJS

--- a/apps/docs/content/docs/integrations/next.mdx
+++ b/apps/docs/content/docs/integrations/next.mdx
@@ -1,6 +1,7 @@
 ---
 title: Next.js
 description: Web-standard helpers for Next App Router route handlers — sseResponse streams a stitch as text/event-stream, and stitchErrorResponse maps a StitchError to a Response.
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
 Next App Router route handlers are **Web-standard**: they take a `Request` and return

--- a/apps/docs/content/docs/integrations/pino.mdx
+++ b/apps/docs/content/docs/integrations/pino.mdx
@@ -1,6 +1,7 @@
 ---
 title: Pino
 description: Forward a stitch's event stream to a Pino logger with pinoSink — structured, leveled logs at every call site, metadata-only and safe on a secret-bearing seam.
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/event-stream']
 ---
 
 Use `@stitchapi/pino` when your app already logs with [Pino](https://getpino.io)

--- a/apps/docs/content/docs/integrations/react-native.mdx
+++ b/apps/docs/content/docs/integrations/react-native.mdx
@@ -1,6 +1,7 @@
 ---
 title: React Native
 description: A streaming XHR adapter (the streaming fetch bare RN lacks), an AsyncStorage-backed StitchStore for persistent sessions, and AppState/NetInfo refetch helpers — plus the re-exported useStitch / useStitchStream hooks.
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `@stitchapi/react-native` when you call stitches from a bare React Native app.

--- a/apps/docs/content/docs/integrations/react.mdx
+++ b/apps/docs/content/docs/integrations/react.mdx
@@ -1,6 +1,7 @@
 ---
 title: React
 description: Tearing-free useStitch and useStitchStream hooks built on useSyncExternalStore, over the framework-agnostic @stitchapi/query-core store — plus an optional TanStack Query adapter.
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `@stitchapi/react` when you call stitches from React components and want the

--- a/apps/docs/content/docs/integrations/rtk-query.mdx
+++ b/apps/docs/content/docs/integrations/rtk-query.mdx
@@ -1,6 +1,7 @@
 ---
 title: RTK Query
 description: stitchQueryFn turns a stitch into an RTK Query endpoint, and stitchStreamUpdater folds a streaming stitch into the cache — RTK Query keeps the cache, tags, and generated hooks.
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `@stitchapi/rtk-query` when your app is already on

--- a/apps/docs/content/docs/integrations/sentry.mdx
+++ b/apps/docs/content/docs/integrations/sentry.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sentry
 description: A Sentry TraceSink that maps the stitch event stream to breadcrumbs and captures error events with the call's context — metadata-only, safe on a secret-bearing seam.
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/event-stream']
 ---
 
 The logger sinks ([`@stitchapi/pino`](/docs/integrations/pino), core's `loggerSink`)

--- a/apps/docs/content/docs/integrations/solid.mdx
+++ b/apps/docs/content/docs/integrations/solid.mdx
@@ -1,6 +1,7 @@
 ---
 title: Solid
 description: createStitch and createStitchStream primitives that reconcile a Solid store from a stitch call, over the framework-agnostic @stitchapi/query-core store — plus an optional TanStack Query adapter.
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `@stitchapi/solid` when you call stitches from Solid components and want the

--- a/apps/docs/content/docs/integrations/stores.mdx
+++ b/apps/docs/content/docs/integrations/stores.mdx
@@ -1,6 +1,7 @@
 ---
 title: Distributed stores
 description: Attach a Redis, Cloudflare Workers KV, or Deno KV StitchStore so a stitch's throttle, sessions, and cache become fleet-wide — same call site, no backend in core. Includes the atomic-incr trade-off that decides which store fits.
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
 A [`StitchStore`](/docs/guides/state/pluggable-store) is the one seam that turns

--- a/apps/docs/content/docs/integrations/svelte.mdx
+++ b/apps/docs/content/docs/integrations/svelte.mdx
@@ -1,6 +1,7 @@
 ---
 title: Svelte
 description: stitchStore and stitchStreamStore — real Svelte stores wrapping a stitch call, over the framework-agnostic @stitchapi/query-core store. Works on Svelte 4 and 5, plus an optional TanStack Query adapter.
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `@stitchapi/svelte` when you call stitches from Svelte components and want the

--- a/apps/docs/content/docs/integrations/swr.mdx
+++ b/apps/docs/content/docs/integrations/swr.mdx
@@ -1,6 +1,7 @@
 ---
 title: SWR
 description: useStitchSWR runs a stitch as an SWR fetcher, so SWR owns caching and revalidation while the stitch stays typed, validated, and traced.
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `@stitchapi/swr` when your app is already on [SWR](https://swr.vercel.app) and

--- a/apps/docs/content/docs/integrations/vercel-ai.mdx
+++ b/apps/docs/content/docs/integrations/vercel-ai.mdx
@@ -1,6 +1,8 @@
 ---
 title: Vercel AI SDK
 description: stitchTool exposes a stitch as a Vercel AI SDK tool() the model can call — the stitch runs as the tool's execute, so the model gets typed, validated data and never the credential.
+prerequisites:
+    ['/docs/concepts/the-stitch', '/docs/concepts/capability-not-credential']
 ---
 
 StitchAPI is agent-native through the [MCP surface](/docs/surfaces/mcp) — the

--- a/apps/docs/content/docs/integrations/vue.mdx
+++ b/apps/docs/content/docs/integrations/vue.mdx
@@ -1,6 +1,7 @@
 ---
 title: Vue
 description: Reactive useStitch and useStitchStream composables backed by Vue 3 reactivity, over the framework-agnostic @stitchapi/query-core store — plus an optional TanStack Query adapter.
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `@stitchapi/vue` when you call stitches from Vue 3 components and want the

--- a/apps/docs/content/docs/recipes/auth-as-a-capability.mdx
+++ b/apps/docs/content/docs/recipes/auth-as-a-capability.mdx
@@ -1,6 +1,8 @@
 ---
 title: 'Authenticate without the token touching your code'
 description: 'Declare auth on the stitch so callers get a capability, not a credential — the secret is read per call and never returned.'
+prerequisites:
+    ['/docs/concepts/the-stitch', '/docs/concepts/capability-not-credential']
 ---
 
 ## Task

--- a/apps/docs/content/docs/recipes/catch-a-breaking-api-change.mdx
+++ b/apps/docs/content/docs/recipes/catch-a-breaking-api-change.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Catch a breaking API change before your users do'
 description: 'Wrap output with drift to validate every response against the declared schema and catch a dropped required field, a type coercion, or an undeclared new key.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/getting-started/quickstart']
 ---
 
 ## Task

--- a/apps/docs/content/docs/recipes/catch-a-selector-rename.mdx
+++ b/apps/docs/content/docs/recipes/catch-a-selector-rename.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Catch a silent selector rename in scraped HTML'
 description: 'Scrape an HTML page into a structured object with transform, then drift the structured shape against its schema so a markup or selector rename becomes a hard contract error instead of a silently missing field.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/getting-started/quickstart']
 ---
 
 ## Task

--- a/apps/docs/content/docs/recipes/define-an-entity-once.mdx
+++ b/apps/docs/content/docs/recipes/define-an-entity-once.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Define an entity once, derive every request shape'
 description: 'Declare a resource schema once and derive the create body, update body, and query filter with your validator’s own .omit()/.partial()/.pick() — no StitchAPI-specific schema layer.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/getting-started/quickstart']
 ---
 
 ## Task

--- a/apps/docs/content/docs/recipes/expose-a-stitch-to-an-agent.mdx
+++ b/apps/docs/content/docs/recipes/expose-a-stitch-to-an-agent.mdx
@@ -1,6 +1,8 @@
 ---
 title: 'Let an agent call your API without handing it the key'
 description: 'Expose your stitches over MCP through one run_stitch tool — the agent invokes a capability and never sees the credential.'
+prerequisites:
+    ['/docs/concepts/the-stitch', '/docs/concepts/capability-not-credential']
 ---
 
 ## Task

--- a/apps/docs/content/docs/recipes/idempotent-writes.mdx
+++ b/apps/docs/content/docs/recipes/idempotent-writes.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Retry a write without double-charging'
 description: 'Attach an idempotency key so a retried POST settles once, not twice.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/getting-started/quickstart']
 ---
 
 ## Task

--- a/apps/docs/content/docs/recipes/inspect-what-the-server-sent.mdx
+++ b/apps/docs/content/docs/recipes/inspect-what-the-server-sent.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Inspect what the server actually sent'
 description: 'Probe a fresh call with .inspect() to read the unredacted raw body next to the validated value and the drift findings diffed between them — without throwing — when you need to see what changed after the fact.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/event-stream']
 ---
 
 ## Task

--- a/apps/docs/content/docs/recipes/make-a-flaky-call-succeed.mdx
+++ b/apps/docs/content/docs/recipes/make-a-flaky-call-succeed.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Make a flaky call succeed on its own'
 description: 'Add retry with backoff so transient 429s and 5xxs recover without your code noticing.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/getting-started/quickstart']
 ---
 
 ## Task

--- a/apps/docs/content/docs/recipes/mirror-a-paginated-api.mdx
+++ b/apps/docs/content/docs/recipes/mirror-a-paginated-api.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Mirror a paginated API to NDJSON'
 description: 'Pull every page of a cursor-paginated, OAuth2-protected endpoint — with retry and throttle on each page — and write the rows as newline-delimited JSON.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/getting-started/quickstart']
 ---
 
 ## Task

--- a/apps/docs/content/docs/recipes/one-rate-limit-across-workers.mdx
+++ b/apps/docs/content/docs/recipes/one-rate-limit-across-workers.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Share one rate limit across every worker'
 description: 'Point the throttle at a shared store so a whole fleet draws from a single rate budget instead of N× the limit.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
 ## Task

--- a/apps/docs/content/docs/recipes/one-stitch-every-surface.mdx
+++ b/apps/docs/content/docs/recipes/one-stitch-every-surface.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Call one stitch as a function, a CLI command, and an agent tool'
 description: 'One definition, four front doors — in-process, shell, HTTP, and MCP — with nothing about the stitch changing.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/getting-started/quickstart']
 ---
 
 ## Task

--- a/apps/docs/content/docs/recipes/paginate-into-one-array.mdx
+++ b/apps/docs/content/docs/recipes/paginate-into-one-array.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Loop a cursor API into one array'
 description: 'Follow nextCursor across every page and aggregate the items — no manual while-loop, cursor bookkeeping, or concat.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/getting-started/quickstart']
 ---
 
 ## Task

--- a/apps/docs/content/docs/recipes/survive-a-flaky-dependency.mdx
+++ b/apps/docs/content/docs/recipes/survive-a-flaky-dependency.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Keep a failing dependency from taking you down'
 description: 'Compose timeout, retry, and a circuit breaker so a degraded upstream fails fast instead of hanging every caller.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/getting-started/quickstart']
 ---
 
 ## Task

--- a/apps/docs/content/docs/recipes/typed-json-round-trip.mdx
+++ b/apps/docs/content/docs/recipes/typed-json-round-trip.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Send JSON and get a typed result back'
 description: 'POST a validated body and read a typed, runtime-validated result — input checked before the request, output checked after.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/getting-started/quickstart']
 ---
 
 ## Task

--- a/apps/docs/content/docs/recipes/watch-a-call-as-it-happens.mdx
+++ b/apps/docs/content/docs/recipes/watch-a-call-as-it-happens.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Watch retries and throttling as they happen'
 description: "Iterate a stitch's event stream instead of awaiting it, and observe every retry, pause, and drift in real time."
+prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/event-stream']
 ---
 
 ## Task

--- a/apps/docs/content/docs/surfaces/cli.mdx
+++ b/apps/docs/content/docs/surfaces/cli.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'CLI'
 description: 'Run, trace, diagram, and export stitches from the shell — no app boot.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Reach for the `stitch` CLI when you want to run a stitch and read its trace from

--- a/apps/docs/content/docs/surfaces/function.mdx
+++ b/apps/docs/content/docs/surfaces/function.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'In-process function'
 description: 'Call a stitch directly as a typed async function, awaited or streamed.'
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 A stitch is a typed async function — no server, no transport. `await` it for the

--- a/apps/docs/content/docs/surfaces/http-serve.mdx
+++ b/apps/docs/content/docs/surfaces/http-serve.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'HTTP serve'
 description: "Expose a stitch over HTTP for callers that aren't in-process."
+prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Reach for `stitch serve` when a caller can't import your stitches in-process —

--- a/apps/docs/content/docs/surfaces/mcp.mdx
+++ b/apps/docs/content/docs/surfaces/mcp.mdx
@@ -1,6 +1,8 @@
 ---
 title: 'MCP'
 description: 'Expose a single code-mode run_stitch tool to agents instead of one tool per endpoint.'
+prerequisites:
+    ['/docs/concepts/the-stitch', '/docs/concepts/capability-not-credential']
 ---
 
 Reach for the MCP surface when an agent should call your stitches: it exposes a

--- a/apps/docs/lib/prerequisites.ts
+++ b/apps/docs/lib/prerequisites.ts
@@ -1,0 +1,72 @@
+import { blogSource } from './blog';
+import { blogRoute, docsRoute } from './shared';
+import { source } from './source';
+
+export interface ResolvedPrerequisite {
+    href: string;
+    title: string;
+    description?: string;
+}
+
+/**
+ * Resolve a page's `prerequisites` frontmatter — internal hrefs to the
+ * foundational pages it assumes the reader already knows — into the linked
+ * pages' real titles and descriptions, pulled from the same fumadocs sources
+ * that render those pages. Resolving from source (rather than letting the author
+ * retype a title) means the link text can never drift from its target — the
+ * anti-drift rule the product sells, applied to the docs' own navigation.
+ *
+ * Works across both surfaces:
+ *   `/docs/concepts/the-stitch`   → docs source
+ *   `/blog/what-is-schema-drift`  → blog source
+ *
+ * An unresolvable href is dropped here so the renderer never shows a broken
+ * link; the build gate (`test/prerequisites.spec.ts`) is what fails CI when a
+ * prerequisite dangles, the same way the no-orphans gate guards blog links.
+ */
+export function resolvePrerequisites(
+    hrefs: string[] | undefined,
+): ResolvedPrerequisite[] {
+    if (!hrefs?.length) return [];
+
+    const resolved: ResolvedPrerequisite[] = [];
+    for (const href of hrefs) {
+        const page = pageForHref(href);
+        if (page) {
+            resolved.push({
+                href,
+                title: page.data.title,
+                description: page.data.description,
+            });
+        }
+    }
+    return resolved;
+}
+
+/** The page a `/docs/...` or `/blog/<slug>` href points at, or undefined. */
+function pageForHref(href: string) {
+    // Defensive: drop any query/hash and a trailing slash before matching.
+    const path = (href.split(/[?#]/)[0] ?? href).replace(/\/+$/, '');
+
+    const docsSlugs = segmentsUnder(path, docsRoute);
+    if (docsSlugs) return source.getPage(docsSlugs);
+
+    const blogSlugs = segmentsUnder(path, blogRoute);
+    if (blogSlugs) return blogSource.getPage(blogSlugs);
+
+    return undefined;
+}
+
+/**
+ * If `path` is `base` or sits under `base/`, return the remaining URL segments
+ * (`/docs/concepts/the-stitch` under `/docs` → `['concepts','the-stitch']`;
+ * `/docs` → `[]`). Returns undefined when `path` is not under `base`.
+ */
+function segmentsUnder(path: string, base: string): string[] | undefined {
+    if (path === base) return [];
+    if (!path.startsWith(`${base}/`)) return undefined;
+    return path
+        .slice(base.length + 1)
+        .split('/')
+        .filter(Boolean);
+}

--- a/apps/docs/source.config.ts
+++ b/apps/docs/source.config.ts
@@ -7,12 +7,20 @@ import { defineConfig, defineDocs } from 'fumadocs-mdx/config';
 import { transformerTwoslash } from 'fumadocs-twoslash';
 import { z } from 'zod';
 
+// Optional upstream "Start here" pointers: internal hrefs (`/docs/...` or
+// `/blog/<slug>`) to the foundational pages a page assumes the reader already
+// knows. Rendered as a top-of-page box (the inverse of `See also`) and resolved
+// to real titles from the source; `test/prerequisites.spec.ts` fails the build
+// on a dangling href. Shared by both collections so docs pages and blog posts
+// declare it the same way.
+const prerequisites = z.array(z.string()).optional();
+
 // You can customize Zod schemas for frontmatter and `meta.json` here
 // see https://fumadocs.dev/docs/mdx/collections
 export const docs = defineDocs({
     dir: 'content/docs',
     docs: {
-        schema: pageSchema,
+        schema: pageSchema.extend({ prerequisites }),
         postprocess: {
             includeProcessedMarkdown: true,
         },
@@ -58,6 +66,7 @@ export const blog = defineDocs({
                     ),
             ),
             tags: z.array(z.string()).optional(),
+            prerequisites,
         }),
     },
     meta: {

--- a/apps/docs/test/prerequisites.spec.ts
+++ b/apps/docs/test/prerequisites.spec.ts
@@ -1,0 +1,104 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// The enforcement half of the `prerequisites` frontmatter field (AUTHORING.md →
+// "Prerequisites — the upstream pointer"). A page may point upstream at the
+// foundational pages it assumes via `prerequisites:` hrefs; the <Prerequisites>
+// box resolves each from source and silently drops anything unresolvable, so the
+// reader never sees a broken link. This gate is what fails the build when a
+// prerequisite dangles — the same role blog-interlinking.spec.ts plays for
+// sibling links and content-manifest.spec.ts for the docs IA. Raw-FS, like those
+// specs, so it needs no generated `.source`.
+
+const DOCS_ROOT = resolve(fileURLToPath(import.meta.url), '..', '..');
+const DOCS = resolve(DOCS_ROOT, 'content', 'docs');
+const BLOG = resolve(DOCS_ROOT, 'content', 'blog');
+
+/** Absolute paths of every `.mdx` under `dir`, recursively. */
+function walk(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...walk(full));
+        else if (entry.name.endsWith('.mdx')) out.push(full);
+    }
+    return out;
+}
+
+/**
+ * The site URL an `.mdx` file is served at:
+ *   content/blog/x.mdx                    → /blog/x
+ *   content/docs/concepts/the-stitch.mdx  → /docs/concepts/the-stitch
+ *   content/docs/getting-started/index.mdx → /docs/getting-started (index → root)
+ *   content/docs/index.mdx                → /docs
+ */
+function urlFor(absMdx: string): string {
+    if (absMdx.startsWith(BLOG)) {
+        return `/blog/${relative(BLOG, absMdx).replace(/\.mdx$/, '')}`;
+    }
+    const path = relative(DOCS, absMdx)
+        .split(sep)
+        .join('/')
+        .replace(/\.mdx$/, '')
+        .replace(/(^|\/)index$/, '');
+    return path ? `/docs/${path}` : '/docs';
+}
+
+/** The frontmatter block (between the first two `---`) of an `.mdx` file, or ''. */
+function frontmatterOf(body: string): string {
+    return body.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? '';
+}
+
+/**
+ * The internal hrefs declared under `prerequisites:` in a frontmatter block.
+ * Captures the `prerequisites:` value — the rest of its line plus any following
+ * more-indented lines — so it tolerates both inline (`[...]`) and block (`- ...`)
+ * YAML, then pulls `/docs/...` and `/blog/...` hrefs from it. Trailing slashes
+ * are normalized away to match how the resolver and `urlFor` spell a URL.
+ */
+function prerequisiteHrefsIn(frontmatter: string): string[] {
+    const block = frontmatter.match(/^prerequisites:.*(?:\n[ \t]+.*)*/m)?.[0];
+    if (!block) return [];
+    return [...block.matchAll(/\/(?:docs|blog)\/[a-z0-9/-]+/g)].map((m) =>
+        m[0].replace(/\/+$/, ''),
+    );
+}
+
+const files = [...walk(DOCS), ...walk(BLOG)];
+const validUrls = new Set(files.map(urlFor));
+const declared = files.map((file) => ({
+    url: urlFor(file),
+    hrefs: prerequisiteHrefsIn(frontmatterOf(readFileSync(file, 'utf8'))),
+}));
+
+describe('prerequisites resolve', () => {
+    it('has content to check', () => {
+        expect(files.length).toBeGreaterThan(0);
+    });
+
+    it('every prerequisite href points at a real page (no dangling)', () => {
+        const dangling: string[] = [];
+        for (const { url, hrefs } of declared) {
+            for (const href of hrefs) {
+                if (!validUrls.has(href)) dangling.push(`${url} → ${href}`);
+            }
+        }
+        expect(
+            dangling,
+            `These \`prerequisites\` hrefs point at a page that does not ` +
+                `exist (see AUTHORING.md → "Prerequisites"):\n  ${dangling.join('\n  ')}`,
+        ).toEqual([]);
+    });
+
+    it('no page lists itself as a prerequisite', () => {
+        const selfRefs = declared
+            .filter(({ url, hrefs }) => hrefs.includes(url))
+            .map(({ url }) => url);
+        expect(
+            selfRefs,
+            `A page lists its own URL under \`prerequisites\`:\n  ${selfRefs.join('\n  ')}`,
+        ).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Why

When a reader lands cold on an advanced blog post or docs page (parallel composition, the pagination guide, an MCP recipe), the prose assumes they already know what a stitch / seam / the event stream is. The site already cross-links **onward** — docs pages have a required `See also`, blog posts get a tag-overlap "Related reading" footer plus inline prose links — but nothing points **upstream**. Every existing link says "read this *next*"; none says "read this *first*."

This adds the missing upstream signal: an optional, declarative **"New to stitches? Start here"** pointer at the *top* of a page. It's the inverse of `See also` — a step *back* before diving in.

## The pointer

A quiet, low-chrome one-line note (no filled card — deliberately easy for a returning reader to skip), with a thin left rule and the foundational pages inline as links:

> **▸ New to stitches? Start here:** The stitch primitive · The seam

It renders on both surfaces and is absent on pages that declare nothing.

## Mechanism

- **`prerequisites` frontmatter** (an array of internal hrefs) on both the docs and blog collections — `apps/docs/source.config.ts`.
- **Resolver** (`apps/docs/lib/prerequisites.ts`) maps each href to its **real title from source**, so the link text can never drift from the target page.
- **`<Prerequisites>` component** (`apps/docs/components/prerequisites.tsx`) — renders nothing when a page declares none, so it's safe to drop into every renderer.
- Wired into the top of both page renderers (blog `[slug]` and docs `[[...slug]]`).
- **Build gate** (`apps/docs/test/prerequisites.spec.ts`) fails on a dangling or self-referential prerequisite — the same no-orphans guarantee the blog's sibling links carry.
- Documented in `AUTHORING.md` (new section + a Definition-of-done checkbox).

## Backfill (108 pages)

Every page that assumes a foundational concept now declares its prerequisites: **blog posts, guides, recipes, surfaces, integrations, and agent pages**. Most point at `the-stitch`; pages that lean on shared runtime also point at `the-seam`, streaming pages at `event-stream`, auth/agent pages at `capability-not-credential`, and how-to recipes at `quickstart`.

**Intentionally excluded** (left to self-ground): the foundational concept pages themselves, `getting-started/*`, `reference/*`, error deep-links, section-landing pages, and the comparison/definition essays that already explain their own premise in sentence one.

## Verification

- `pnpm test` (docs) — 23/23, including the new resolve gate; verified it reds on a bogus href, then reverted.
- `check:format`, `check:lint`, `check:types` (`tsc` exit 0) all green.
- `next build` — all 373 pages prerender; spot-checked that 108 pages render the box with correctly-resolved titles and that excluded pages (e.g. `reference/stitch`) render none.
- Full pre-push gate (format / lint / typecheck / typecheck-d / test / exports / build-docs) passed.

The box weight and the per-page targets are easy to tune — the field is one frontmatter line per page, and the styling lives in a single component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
