### PR TITLE
refactor(integrations): cross-package unique-by-shape — R5 fully cleared (P9/P16) — 3/3

### DIFF
--- a/apps/docs/content/docs/integrations/angular.mdx
+++ b/apps/docs/content/docs/integrations/angular.mdx
@@ -26,7 +26,7 @@ Install the bindings, the store, core, and Angular:
 
 `stitchapi`, `@angular/core`, and `rxjs` are peer dependencies;
 `@tanstack/angular-query-experimental` is an **optional** peer, needed only for the
-`queryOptions` adapter below.
+`stitchQueryOptions` adapter below.
 
 ## `injectStitch` — request / response
 
@@ -170,27 +170,27 @@ own reactive primitive — Angular's are `toSignal` + `toObservable`.
 ## Optional: TanStack Query
 
 Already on [TanStack Query](/docs/integrations/tanstack-query)?
-`queryOptions(stitch, input)` returns a plain `{ queryKey, queryFn }` object you
+`stitchQueryOptions(stitch, input)` returns a plain `{ queryKey, queryFn }` object you
 pass straight to `injectQuery` — it imports nothing from
 `@tanstack/angular-query-experimental`, so it works even if you never install it:
 
 ```ts
 import { Component, input } from '@angular/core';
-import { queryOptions } from '@stitchapi/angular';
+import { stitchQueryOptions } from '@stitchapi/angular';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 
 @Component({ selector: 'app-profile', template: `...` })
 export class ProfileComponent {
     readonly id = input.required<string>();
     readonly user = injectQuery(() =>
-        queryOptions(getUser, { params: { id: this.id() } }),
+        stitchQueryOptions(getUser, { params: { id: this.id() } }),
     );
 }
 ```
 
 <Callout type="info">
-    Reach for `queryOptions` when TanStack Query already owns your view state
-    and you want a stitch as the `queryFn`; reach for `injectStitch` /
+    Reach for `stitchQueryOptions` when TanStack Query already owns your view
+    state and you want a stitch as the `queryFn`; reach for `injectStitch` /
     `injectStitchStream` when you want StitchAPI to own the lifecycle directly —
     especially for streaming, which `injectQuery` does not model. See the
     [TanStack Query guide](/docs/integrations/tanstack-query) for how the two

--- a/apps/docs/content/docs/integrations/solid.mdx
+++ b/apps/docs/content/docs/integrations/solid.mdx
@@ -24,7 +24,7 @@ Install the primitives, the store, core, and Solid:
 
 `stitchapi`, `@stitchapi/query-core`, and `solid-js` (`^1.8`) are peer
 dependencies; `@tanstack/solid-query` is an **optional** peer, needed only for the
-`queryOptions` adapter below.
+`stitchQueryOptions` adapter below.
 
 ## `createStitch` — request / response
 
@@ -143,12 +143,12 @@ own reactive primitive — Solid's is `createStore` + `onCleanup`.
 ## Optional: TanStack Query
 
 Already on [TanStack Query](/docs/integrations/tanstack-query)?
-`queryOptions(stitch, input)` returns a plain `{ queryKey, queryFn }` object you
+`stitchQueryOptions(stitch, input)` returns a plain `{ queryKey, queryFn }` object you
 pass straight to `createQuery` — it imports nothing from `@tanstack/solid-query`,
 so it works even if you never install it:
 
 ```tsx
-import { queryOptions } from '@stitchapi/solid';
+import { stitchQueryOptions } from '@stitchapi/solid';
 import { createQuery } from '@tanstack/solid-query';
 import { stitch } from 'stitchapi';
 
@@ -159,15 +159,15 @@ const getUser = stitch({
 
 function User(props: { id: string }) {
     const query = createQuery(() =>
-        queryOptions(getUser, { params: { id: props.id } }),
+        stitchQueryOptions(getUser, { params: { id: props.id } }),
     );
     return <span>{query.data?.name}</span>;
 }
 ```
 
 <Callout type="info">
-    Reach for `queryOptions` when TanStack Query already owns your view state
-    and you want a stitch as the `queryFn`; reach for `createStitch` /
+    Reach for `stitchQueryOptions` when TanStack Query already owns your view
+    state and you want a stitch as the `queryFn`; reach for `createStitch` /
     `createStitchStream` when you want StitchAPI to own the lifecycle directly —
     especially for streaming, which `createQuery` does not model. See the
     [TanStack Query guide](/docs/integrations/tanstack-query) for how the two

--- a/apps/docs/content/docs/integrations/svelte.mdx
+++ b/apps/docs/content/docs/integrations/svelte.mdx
@@ -25,7 +25,7 @@ Install the stores, the shared store, core, and Svelte:
 ```
 
 `stitchapi` and `svelte` (`^4 || ^5`) are peer dependencies; `@tanstack/svelte-query`
-is an **optional** peer, needed only for the `queryOptions` adapter below.
+is an **optional** peer, needed only for the `stitchQueryOptions` adapter below.
 
 ## `stitchStore` — request / response
 
@@ -123,13 +123,13 @@ bindings are the same few lines against their own reactive primitive — Svelte'
 ## Optional: TanStack Query
 
 Already on [TanStack Query](/docs/integrations/tanstack-query)?
-`queryOptions(stitch, input)` returns a plain `{ queryKey, queryFn }` object you
+`stitchQueryOptions(stitch, input)` returns a plain `{ queryKey, queryFn }` object you
 pass straight to `createQuery` — it imports nothing from `@tanstack/svelte-query`,
 so it works even if you never install it:
 
 ```svelte
 <script lang="ts">
-    import { queryOptions } from '@stitchapi/svelte';
+    import { stitchQueryOptions } from '@stitchapi/svelte';
     import { createQuery } from '@tanstack/svelte-query';
     import { stitch } from 'stitchapi';
 
@@ -138,13 +138,13 @@ so it works even if you never install it:
         path: '/users/{id}',
     });
 
-    const query = createQuery(queryOptions(getUser, { params: { id: '7' } }));
+    const query = createQuery(stitchQueryOptions(getUser, { params: { id: '7' } }));
 </script>
 ```
 
 <Callout type="info">
-    Reach for `queryOptions` when TanStack Query already owns your view state
-    and you want a stitch as the `queryFn`; reach for `stitchStore` /
+    Reach for `stitchQueryOptions` when TanStack Query already owns your view
+    state and you want a stitch as the `queryFn`; reach for `stitchStore` /
     `stitchStreamStore` when you want StitchAPI to own the lifecycle directly —
     especially for streaming, which `createQuery` does not model. See the
     [TanStack Query guide](/docs/integrations/tanstack-query) for how the two

--- a/apps/docs/content/docs/integrations/vue.mdx
+++ b/apps/docs/content/docs/integrations/vue.mdx
@@ -24,7 +24,7 @@ Install the composables, the store, core, and Vue:
 ```
 
 `stitchapi` and `vue` (`^3.4`) are peer dependencies; `@tanstack/vue-query` is an
-**optional** peer, needed only for the `queryOptions` adapter below.
+**optional** peer, needed only for the `stitchQueryOptions` adapter below.
 
 ## `useStitch` — request / response
 
@@ -128,13 +128,13 @@ bindings are the same few lines against their own reactive primitive — Vue's i
 ## Optional: TanStack Query
 
 Already on [TanStack Query](/docs/integrations/tanstack-query)?
-`queryOptions(stitch, input)` returns a plain `{ queryKey, queryFn }` object you
+`stitchQueryOptions(stitch, input)` returns a plain `{ queryKey, queryFn }` object you
 pass straight to `useQuery` — it imports nothing from `@tanstack/vue-query`, so it
 works even if you never install it:
 
 ```vue
 <script setup lang="ts">
-import { queryOptions } from '@stitchapi/vue';
+import { stitchQueryOptions } from '@stitchapi/vue';
 import { useQuery } from '@tanstack/vue-query';
 import { stitch } from 'stitchapi';
 
@@ -143,13 +143,13 @@ const getUser = stitch({
     path: '/users/{id}',
 });
 
-const { data } = useQuery(queryOptions(getUser, { params: { id: '7' } }));
+const { data } = useQuery(stitchQueryOptions(getUser, { params: { id: '7' } }));
 </script>
 ```
 
 <Callout type="info">
-    Reach for `queryOptions` when TanStack Query already owns your view state
-    and you want a stitch as the `queryFn`; reach for `useStitch` /
+    Reach for `stitchQueryOptions` when TanStack Query already owns your view
+    state and you want a stitch as the `queryFn`; reach for `useStitch` /
     `useStitchStream` when you want StitchAPI to own the lifecycle directly —
     especially for streaming, which `useQuery` does not model. See the [TanStack
     Query guide](/docs/integrations/tanstack-query) for how the two layers

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -471,6 +471,13 @@ cut; the lint skips the deprecated members so each rename ratchets the baseline 
     the `@deprecated` `value` alias, and both the cache-generation deriver and the `verifyFingerprintContract`
     kit read `token` (normalizing either spelling, preserving the `null` ABSTAIN sentinel via a presence
     check, not `??`).
+-   **P9 (`StitchStore`) + P16 (`queryOptions`)** — first R5 pair. The per-framework query store is
+    framework-qualified (ADR 0012 rule 6): `@stitchapi/solid`'s `StitchStore`→`SolidStitchStore`,
+    `@stitchapi/svelte`'s →`SvelteStitchStore` (genuinely incompatible — Solid nests `.state`, Svelte is
+    a `Readable` — and both collided with core's state-store `StitchStore`). The ADR 0012
+    `stitchQueryOptions` rename now covers vue/solid/svelte/angular (was react-only); the bare
+    `queryOptions` survives as a uniform `@deprecated` alias (identity-tested) and is **de-listed from the
+    R5 watch-list** since it is no longer a competing canonical.
 
 ## 7. Enforcement
 

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -483,6 +483,12 @@ cut; the lint skips the deprecated members so each rename ratchets the baseline 
     `StitchError` **class**. Renamed to `StitchErrorLike` (`Error & { status? }`), matching elysia/hono —
     so bare `StitchError` is now core-only (R5 clears, watch-list unchanged), and `StitchErrorLike` is one
     structural contract across all six host adapters (de-listed from R5, the `isStitchError` guard stays).
+-   **P9/P16 (per-request seam)** — third R5 pair. The per-request seam handle is ecosystem-qualified
+    per ADR 0012 (extending hono's `HonoRequestSeam`): express `RequestSeam`→`ExpressRequestSeam`, elysia
+    →`ElysiaRequestSeam`, fastify `StitchHost`→`FastifyRequestSeam`, nest `StitchHost`→`NestRequestSeam`.
+    Each keeps the bare name as a `@deprecated` alias (re-exported with a leading comment in the index
+    block, the codebase's established way to keep an alias off R5's name count). Bare `RequestSeam` /
+    `StitchHost` are no longer a canonical export anywhere, so both R5 findings clear (watch-list unchanged).
 
 ## 7. Enforcement
 

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -489,6 +489,13 @@ cut; the lint skips the deprecated members so each rename ratchets the baseline 
     Each keeps the bare name as a `@deprecated` alias (re-exported with a leading comment in the index
     block, the codebase's established way to keep an alias off R5's name count). Bare `RequestSeam` /
     `StitchHost` are no longer a canonical export anywhere, so both R5 findings clear (watch-list unchanged).
+-   **P9 (`StitchLike`)** — final R5. It is two deliberate, compatible tiers, not a clash: the canonical
+    RICH `(input?) => StitchCallResult<T>` (awaitable + streamable) in `@stitchapi/query-core`, re-exported
+    by the five TanStack-family bindings; and an intentional MINIMAL await-only `(input?) => PromiseLike<T>`
+    in the three stream-less adapters (swr/rtk-query/vercel-ai), which never call `.stream()`. query-core's
+    rich shape is assignable to the minimal one (a real stitch satisfies both), so it is **de-listed**.
+    With this, **R5 is fully cleared** — the baseline is now 6, exactly R6's P20 backlog
+    (multipart/stream/sse/throttle/hooks/input → `Scalar | AtLeastOne`).
 
 ## 7. Enforcement
 

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -478,6 +478,11 @@ cut; the lint skips the deprecated members so each rename ratchets the baseline 
     `stitchQueryOptions` rename now covers vue/solid/svelte/angular (was react-only); the bare
     `queryOptions` survives as a uniform `@deprecated` alias (identity-tested) and is **de-listed from the
     R5 watch-list** since it is no longer a competing canonical.
+-   **P9 (`StitchError` / `StitchErrorLike`)** — second R5 pair. The host adapters
+    (express/fastify/nest/next) mis-named their error **duck-type** `StitchError`, shadowing core's real
+    `StitchError` **class**. Renamed to `StitchErrorLike` (`Error & { status? }`), matching elysia/hono —
+    so bare `StitchError` is now core-only (R5 clears, watch-list unchanged), and `StitchErrorLike` is one
+    structural contract across all six host adapters (de-listed from R5, the `isStitchError` guard stays).
 
 ## 7. Enforcement
 

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -288,7 +288,7 @@ export function injectStitchStream<T>(
 // POJO shape `@tanstack/angular-query-experimental`'s `injectQuery(() => ...)`
 // consumes is the same `{ queryKey, queryFn }` TanStack uses everywhere.
 
-/** The plain object {@link queryOptions} returns — structurally compatible with
+/** The plain object {@link stitchQueryOptions} returns — structurally compatible with
  * TanStack Query's options without importing the library. */
 export interface StitchQueryOptions<T> {
     queryKey: readonly unknown[];
@@ -301,23 +301,23 @@ export interface StitchQueryOptions<T> {
  *
  * ```ts
  * import { injectQuery } from '@tanstack/angular-query-experimental';
- * import { queryOptions } from '@stitchapi/angular';
+ * import { stitchQueryOptions } from '@stitchapi/angular';
  *
- * readonly user = injectQuery(() => queryOptions(getUser, { params: { id: this.id() } }));
+ * readonly user = injectQuery(() => stitchQueryOptions(getUser, { params: { id: this.id() } }));
  * ```
  *
  * The `queryFn` awaits the stitch (the validated output); the `queryKey` is the
  * stitch's `name` (when present) plus the input, so TanStack caches per call.
  */
-export function queryOptions<S extends StitchLike<unknown, never>>(
+export function stitchQueryOptions<S extends StitchLike<unknown, never>>(
     stitch: S,
     input: QueryInput<S>,
 ): StitchQueryOptions<QueryOutput<S>>;
-export function queryOptions<T, Input = unknown>(
+export function stitchQueryOptions<T, Input = unknown>(
     stitch: StitchLike<T, Input>,
     input: Input,
 ): StitchQueryOptions<T>;
-export function queryOptions<T>(
+export function stitchQueryOptions<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
 ): StitchQueryOptions<T> {
@@ -327,3 +327,11 @@ export function queryOptions<T>(
         queryFn: () => Promise.resolve(stitch(input)),
     };
 }
+
+/**
+ * @deprecated Renamed to {@link stitchQueryOptions} — a bare `queryOptions` collides
+ * with TanStack Query's own `queryOptions` export when both are imported. See
+ * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the
+ * `1.0.0-rc` line and removed at the 1.0 GA cut.
+ */
+export const queryOptions = stitchQueryOptions;

--- a/packages/angular/test/bindings.spec.ts
+++ b/packages/angular/test/bindings.spec.ts
@@ -2,7 +2,12 @@
 // in a jsdom env. Driven by FAKE stitches — no engine, no network. Each binding is
 // created in `TestBed.runInInjectionContext`, and the module is reset between tests
 // to exercise context teardown.
-import { injectStitch, injectStitchStream, queryOptions } from '../src';
+import {
+    injectStitch,
+    injectStitchStream,
+    queryOptions,
+    stitchQueryOptions,
+} from '../src';
 
 import { ApplicationRef, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
@@ -300,21 +305,27 @@ describe('state$', () => {
     });
 });
 
-// --- queryOptions ----------------------------------------------------------
+// --- stitchQueryOptions ----------------------------------------------------------
 
-describe('queryOptions', () => {
+describe('stitchQueryOptions', () => {
     test('returns a TanStack-shaped POJO with key + async queryFn', async () => {
         const stitch = unaryStitch(async () => ({ ok: true }), {
             name: 'getThing',
         });
-        const opts = queryOptions(stitch, { params: { id: '7' } });
+        const opts = stitchQueryOptions(stitch, { params: { id: '7' } });
         expect(opts.queryKey).toEqual(['getThing', { params: { id: '7' } }]);
         await expect(opts.queryFn()).resolves.toEqual({ ok: true });
     });
 
     test('falls back to "stitch" when no __config.name', () => {
         const stitch = unaryStitch(async () => 1);
-        const opts = queryOptions(stitch, null);
+        const opts = stitchQueryOptions(stitch, null);
         expect(opts.queryKey[0]).toBe('stitch');
+    });
+});
+
+describe('queryOptions (deprecated alias)', () => {
+    test('queryOptions stays a deprecated alias of stitchQueryOptions (ADR 0012)', () => {
+        expect(queryOptions).toBe(stitchQueryOptions);
     });
 });

--- a/packages/elysia/src/context.ts
+++ b/packages/elysia/src/context.ts
@@ -3,7 +3,7 @@
 // a handful of fields, so we declare those structurally. This keeps the public surface stable and
 // the wiring readable without depending on Elysia's deep type machinery (the values still flow from
 // the real Elysia context at runtime).
-import type { RequestSeam } from './plugin';
+import type { ElysiaRequestSeam } from './plugin';
 
 /**
  * The slice of Elysia's request context the `principal` resolver reads: just the incoming
@@ -27,5 +27,5 @@ export interface StitchEnvLike {
  * `interface`) so it is assignable to Elysia's `Record<string, unknown>` derive constraint.
  */
 export type StitchContext = {
-    stitch: RequestSeam;
+    stitch: ElysiaRequestSeam;
 };

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -18,6 +18,8 @@
 // never `node:*`, so the package runs unchanged on Bun, Node, Deno and the edge.
 export {
     stitch,
+    type ElysiaRequestSeam,
+    // Deprecated alias (kept through 1.0.0-rc, removed at GA) — see ADR 0012.
     type RequestSeam,
     type StitchPlugin,
     type StitchPluginOptions,

--- a/packages/elysia/src/plugin.ts
+++ b/packages/elysia/src/plugin.ts
@@ -18,7 +18,15 @@ import type { PrincipalSeam, Seam } from 'stitchapi';
  * root {@link Seam}. The lifecycle levers (`close`/`flush`/`invalidate`) live on the root seam the
  * app owns — never on the per-request handle.
  */
-export type RequestSeam = PrincipalSeam | Seam;
+export type ElysiaRequestSeam = PrincipalSeam | Seam;
+
+/**
+ * @deprecated Renamed to {@link ElysiaRequestSeam} so the public type is ecosystem-qualified (a bare
+ * `RequestSeam` would collide with any other host adapter's per-request seam type) — see
+ * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the `1.0.0-rc`
+ * line and removed at the 1.0 GA cut.
+ */
+export type RequestSeam = ElysiaRequestSeam;
 
 /**
  * The Elysia instance {@link stitch} returns — a plugin you `.use()`. Its only public contract is

--- a/packages/express/src/error.ts
+++ b/packages/express/src/error.ts
@@ -11,10 +11,10 @@ import type {
 } from 'express';
 
 /** The error a stitch throws on failure: a branded `Error` with the upstream status. */
-export type StitchError = Error & { status?: number };
+export type StitchErrorLike = Error & { status?: number };
 
 /** True when `err` is the error a stitch throws on failure (`name === 'StitchError'`). */
-export function isStitchError(err: unknown): err is StitchError {
+export function isStitchError(err: unknown): err is StitchErrorLike {
     return err instanceof Error && err.name === 'StitchError';
 }
 
@@ -26,18 +26,18 @@ export interface StitchErrorHandlerOptions {
      * — a fixed number, or a function for full control: propagate the upstream status with
      * `(e) => e.status ?? 502`, or remap specific codes (`(e) => (e.status === 429 ? 429 : 502)`).
      */
-    status?: number | ((err: StitchError) => number);
+    status?: number | ((err: StitchErrorLike) => number);
     /**
      * The JSON body for a mapped stitch failure. Default: `{ error: <message> }`. Override to shape
      * your own error envelope. Receives the mapped status alongside the error.
      */
-    body?: (err: StitchError, status: number) => unknown;
+    body?: (err: StitchErrorLike, status: number) => unknown;
 }
 
 const DEFAULT_STATUS = 502;
 
 function resolveStatus(
-    err: StitchError,
+    err: StitchErrorLike,
     status: StitchErrorHandlerOptions['status'],
 ): number {
     if (status === undefined) return DEFAULT_STATUS;
@@ -45,7 +45,7 @@ function resolveStatus(
 }
 
 /**
- * Build an Express error-handling middleware that maps a {@link StitchError} to a JSON response
+ * Build an Express error-handling middleware that maps a {@link StitchErrorLike} to a JSON response
  * (status `502` by default; override via {@link StitchErrorHandlerOptions.status}) and **passes every
  * other error to `next(err)`** so Express's default handler — and any error middleware registered
  * after it — stays in charge. Register it after your routes:

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -30,6 +30,6 @@ export {
 export {
     stitchErrorHandler,
     isStitchError,
-    type StitchError,
+    type StitchErrorLike,
     type StitchErrorHandlerOptions,
 } from './error';

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -17,6 +17,8 @@
 export {
     stitch,
     currentStitch,
+    type ExpressRequestSeam,
+    // Deprecated alias (kept through 1.0.0-rc, removed at GA) — see ADR 0012.
     type RequestSeam,
     type StitchMiddlewareOptions,
 } from './middleware';

--- a/packages/express/src/middleware.ts
+++ b/packages/express/src/middleware.ts
@@ -16,7 +16,15 @@ import type { PrincipalSeam, Seam } from 'stitchapi';
  * root {@link Seam}. The lifecycle levers (`close`/`flush`/`invalidate`) live on the root seam the
  * app owns — never on the per-request handle.
  */
-export type RequestSeam = PrincipalSeam | Seam;
+export type ExpressRequestSeam = PrincipalSeam | Seam;
+
+/**
+ * @deprecated Renamed to {@link ExpressRequestSeam} so the public type is ecosystem-qualified (a bare
+ * `RequestSeam` would collide with any other host adapter's per-request seam type) — see
+ * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the `1.0.0-rc`
+ * line and removed at the 1.0 GA cut.
+ */
+export type RequestSeam = ExpressRequestSeam;
 
 export interface StitchMiddlewareOptions {
     /**
@@ -56,7 +64,7 @@ export function stitch(options: StitchMiddlewareOptions): RequestHandler {
     const { seam, principal } = options;
     return (req: Request, res: Response, next: NextFunction): void => {
         const id = principal?.(req);
-        const host: RequestSeam = id !== undefined ? seam.as(id) : seam;
+        const host: ExpressRequestSeam = id !== undefined ? seam.as(id) : seam;
         req.stitch = host;
         // Mirror onto res.locals so view layers / downstream middleware that only carry `res` reach
         // the same per-request handle.
@@ -66,7 +74,7 @@ export function stitch(options: StitchMiddlewareOptions): RequestHandler {
 }
 
 /**
- * Read the request-scoped {@link RequestSeam} off a request as a typed value — the same handle
+ * Read the request-scoped {@link ExpressRequestSeam} off a request as a typed value — the same handle
  * `stitch()` set on `req.stitch`. A convenience for code paths that hold a loosely-typed `Request`
  * (e.g. a generic helper) and want the seam without re-declaring the augmentation. Throws if the
  * middleware did not run for this request (so a missing `app.use(stitch(...))` fails loudly).
@@ -76,8 +84,8 @@ export function stitch(options: StitchMiddlewareOptions): RequestHandler {
  * const api = currentStitch(req); // the caller's principal-bound seam
  * ```
  */
-export function currentStitch(req: Request): RequestSeam {
-    const host = req.stitch as RequestSeam | undefined;
+export function currentStitch(req: Request): ExpressRequestSeam {
+    const host = req.stitch as ExpressRequestSeam | undefined;
     if (host === undefined) {
         throw new Error(
             'req.stitch is not set — register `app.use(stitch({ seam }))` before this handler',
@@ -91,10 +99,10 @@ declare global {
     namespace Express {
         interface Request {
             /**
-             * The request-scoped {@link RequestSeam}: a `seam.as(principal)` handle when a
+             * The request-scoped {@link ExpressRequestSeam}: a `seam.as(principal)` handle when a
              * `principal` resolver is set, else the root seam. Set by the {@link stitch} middleware.
              */
-            stitch: RequestSeam;
+            stitch: ExpressRequestSeam;
         }
     }
 }

--- a/packages/fastify/src/error-handler.ts
+++ b/packages/fastify/src/error-handler.ts
@@ -6,10 +6,10 @@
 import type { FastifyError, FastifyReply, FastifyRequest } from 'fastify';
 
 /** The error a stitch throws on failure: a branded `Error` with the upstream status. */
-export type StitchError = Error & { status?: number };
+export type StitchErrorLike = Error & { status?: number };
 
 /** True when `err` is the error a stitch throws on failure (`name === 'StitchError'`). */
-export function isStitchError(err: unknown): err is StitchError {
+export function isStitchError(err: unknown): err is StitchErrorLike {
     return err instanceof Error && err.name === 'StitchError';
 }
 
@@ -22,18 +22,18 @@ export interface StitchErrorHandlerOptions {
      * for full control: propagate the upstream status with `(e) => e.status ?? 502`, or
      * remap specific codes (`(e) => (e.status === 429 ? 429 : 502)`).
      */
-    status?: number | ((err: StitchError) => number);
+    status?: number | ((err: StitchErrorLike) => number);
     /**
      * The JSON body for a mapped stitch failure. Default: `{ error: <message> }`. Override
      * to shape your own error envelope. Receives the mapped status alongside the error.
      */
-    body?: (err: StitchError, status: number) => unknown;
+    body?: (err: StitchErrorLike, status: number) => unknown;
 }
 
 const DEFAULT_STATUS = 502;
 
 function resolveStatus(
-    err: StitchError,
+    err: StitchErrorLike,
     status: StitchErrorHandlerOptions['status'],
 ): number {
     if (status === undefined) return DEFAULT_STATUS;
@@ -41,7 +41,7 @@ function resolveStatus(
 }
 
 /**
- * Build a `setErrorHandler`-compatible function that maps a {@link StitchError} to an HTTP
+ * Build a `setErrorHandler`-compatible function that maps a {@link StitchErrorLike} to an HTTP
  * response (status `502` by default; override via {@link StitchErrorHandlerOptions.status})
  * and **rethrows every other error** so Fastify's default handling — and any error handler
  * registered in an outer scope — stays in charge. Register it on the app or a plugin scope:

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -10,7 +10,7 @@ export { sendStitchSse, type SendStitchSseOptions } from './sse';
 export {
     stitchErrorHandler,
     isStitchError,
-    type StitchError,
+    type StitchErrorLike,
     type StitchErrorHandlerOptions,
 } from './error-handler';
 export {

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -4,6 +4,8 @@ export {
     type StitchPluginOptions,
     type StitchPluginSeamOptions,
     type StitchPluginConfigOptions,
+    type FastifyRequestSeam,
+    // Deprecated alias (kept through 1.0.0-rc, removed at GA) — see ADR 0012.
     type StitchHost,
 } from './plugin';
 export { sendStitchSse, type SendStitchSseOptions } from './sse';

--- a/packages/fastify/src/plugin.ts
+++ b/packages/fastify/src/plugin.ts
@@ -23,7 +23,15 @@ import {
 
 // The host a route reads off `request.stitch` / `currentStitch()`: a principal-bound handle
 // when a `principal` resolver is set, else the root seam (both create member stitches).
-export type StitchHost = Seam | PrincipalSeam;
+export type FastifyRequestSeam = Seam | PrincipalSeam;
+
+/**
+ * @deprecated Renamed to {@link FastifyRequestSeam} so the public type is ecosystem-qualified (a bare
+ * `StitchHost` would collide with any other host adapter's per-request seam type) — see
+ * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the `1.0.0-rc`
+ * line and removed at the 1.0 GA cut.
+ */
+export type StitchHost = FastifyRequestSeam;
 
 /** Common options shared by both `StitchPluginOptions` variants. */
 interface StitchPluginCommon {
@@ -74,10 +82,10 @@ export type StitchPluginOptions =
 
 // The ambient request-scoped host. `currentStitch()` reads it; the `onRequest` hook runs each
 // request inside `als.run(host, …)` so the value is the per-request principal handle.
-const als = new AsyncLocalStorage<StitchHost>();
+const als = new AsyncLocalStorage<FastifyRequestSeam>();
 
 /**
- * The ambient request-scoped {@link StitchHost} for the in-flight request — the principal-bound
+ * The ambient request-scoped {@link FastifyRequestSeam} for the in-flight request — the principal-bound
  * `seam.as(principal)` handle (or the root seam when no principal resolver is set). Returns
  * `undefined` outside a request (no ambient context), so a caller can fall back to an explicit
  * seam. Backed by Node's {@link AsyncLocalStorage}: a value-add a Node integration offers that
@@ -91,7 +99,7 @@ const als = new AsyncLocalStorage<StitchHost>();
  * }
  * ```
  */
-export function currentStitch(): StitchHost | undefined {
+export function currentStitch(): FastifyRequestSeam | undefined {
     return als.getStore();
 }
 
@@ -125,7 +133,7 @@ const pluginImpl: FastifyPluginAsync<StitchPluginOptions> = async (
     const ownsSeam = options.closeSeam ?? built;
 
     // Decorate the app with the root seam, and reserve `request.stitch` (set in onRequest, which
-    // runs before any handler, so the declared non-null `StitchHost` type is always satisfied).
+    // runs before any handler, so the declared non-null `FastifyRequestSeam` type is always satisfied).
     fastify.decorate('stitch', instance);
     fastify.decorateRequest('stitch');
 
@@ -133,11 +141,11 @@ const pluginImpl: FastifyPluginAsync<StitchPluginOptions> = async (
     // and run the rest of the request inside the ALS context so `currentStitch()` is ambient.
     fastify.addHook('onRequest', (request, _reply, done) => {
         const principal = options.principal?.(request);
-        const host: StitchHost =
+        const host: FastifyRequestSeam =
             principal !== undefined ? instance.as(principal) : instance;
         // `seam.as()` is lifecycle-free (it shares the root runtime), so the per-request handle
         // needs no teardown — it is dropped when the request ends.
-        (request as { stitch: StitchHost }).stitch = host;
+        (request as { stitch: FastifyRequestSeam }).stitch = host;
         // Enter the ALS context for the whole request lifecycle. `done` is called *inside*
         // `run`, so every subsequent hook/handler on this request sees the ambient host.
         als.run(host, done);
@@ -156,7 +164,7 @@ const pluginImpl: FastifyPluginAsync<StitchPluginOptions> = async (
 
 /**
  * The StitchAPI Fastify plugin. Register it to decorate the app with a {@link Seam} and each
- * request with a principal-bound {@link StitchHost}, bridge Fastify's Pino logger as the seam's
+ * request with a principal-bound {@link FastifyRequestSeam}, bridge Fastify's Pino logger as the seam's
  * trace sink, map stitch failures to HTTP responses, and tear the seam down on close.
  *
  * Wrapped with `fastify-plugin` so the `fastify.stitch` / `request.stitch` decorators and the
@@ -186,10 +194,10 @@ declare module 'fastify' {
     }
     interface FastifyRequest {
         /**
-         * The request-scoped {@link StitchHost}: a `seam.as(principal)` handle when a
+         * The request-scoped {@link FastifyRequestSeam}: a `seam.as(principal)` handle when a
          * `principal` resolver is set, else the root seam. The same value `currentStitch()`
          * returns inside the request.
          */
-        stitch: StitchHost;
+        stitch: FastifyRequestSeam;
     }
 }

--- a/packages/nest/src/define-stitch.ts
+++ b/packages/nest/src/define-stitch.ts
@@ -6,11 +6,19 @@ import { Inject, type InjectionToken } from '@nestjs/common';
 import type { Seam, Stitch, StitchInput } from 'stitchapi';
 
 /** Both `Seam` and `PrincipalSeam` satisfy this — the host a stitch is built from. */
-export type StitchHost = Pick<Seam, 'stitch' | 'graphql'>;
+export type NestRequestSeam = Pick<Seam, 'stitch' | 'graphql'>;
+
+/**
+ * @deprecated Renamed to {@link NestRequestSeam} so the public type is ecosystem-qualified (a bare
+ * `StitchHost` would collide with any other host adapter's per-request seam type) — see
+ * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the `1.0.0-rc`
+ * line and removed at the 1.0 GA cut.
+ */
+export type StitchHost = NestRequestSeam;
 
 export interface StitchDef<TOut = unknown, TIn = StitchInput> {
     token: InjectionToken;
-    build: (host: StitchHost) => Stitch<TOut, TIn>;
+    build: (host: NestRequestSeam) => Stitch<TOut, TIn>;
 }
 
 /**
@@ -41,20 +49,20 @@ export type AnyStitchDef = StitchDef<unknown, never>;
  * ```
  */
 export function defineStitch<TOut = unknown, TIn = StitchInput>(
-    build: (host: StitchHost) => Stitch<TOut, TIn>,
+    build: (host: NestRequestSeam) => Stitch<TOut, TIn>,
 ): StitchDef<TOut, TIn>;
 export function defineStitch<TOut = unknown, TIn = StitchInput>(
     token: InjectionToken,
-    build: (host: StitchHost) => Stitch<TOut, TIn>,
+    build: (host: NestRequestSeam) => Stitch<TOut, TIn>,
 ): StitchDef<TOut, TIn>;
 export function defineStitch<TOut = unknown, TIn = StitchInput>(
-    a: InjectionToken | ((host: StitchHost) => Stitch<TOut, TIn>),
-    b?: (host: StitchHost) => Stitch<TOut, TIn>,
+    a: InjectionToken | ((host: NestRequestSeam) => Stitch<TOut, TIn>),
+    b?: (host: NestRequestSeam) => Stitch<TOut, TIn>,
 ): StitchDef<TOut, TIn> {
     // Disambiguate on whether a second arg was passed — NOT `typeof a`, because an
     // InjectionToken can itself be a function (a class token), which would misread as
     // the builder. Two args → (token, build); one arg → (build) with a generated token.
-    const build = (b ?? a) as (host: StitchHost) => Stitch<TOut, TIn>;
+    const build = (b ?? a) as (host: NestRequestSeam) => Stitch<TOut, TIn>;
     const token: InjectionToken = b ? (a as InjectionToken) : Symbol('stitch');
     return { token, build };
 }

--- a/packages/nest/src/exception-filter.ts
+++ b/packages/nest/src/exception-filter.ts
@@ -12,10 +12,10 @@ import {
 import { BaseExceptionFilter } from '@nestjs/core';
 
 /** The error a stitch throws on failure: a branded `Error` with the upstream status. */
-export type StitchError = Error & { status?: number };
+export type StitchErrorLike = Error & { status?: number };
 
 /** True when `err` is the error a stitch throws on failure (`name === 'StitchError'`). */
-export function isStitchError(err: unknown): err is StitchError {
+export function isStitchError(err: unknown): err is StitchErrorLike {
     return err instanceof Error && err.name === 'StitchError';
 }
 
@@ -28,12 +28,12 @@ export interface ToHttpExceptionOptions {
      * full control: propagate the upstream status with `(e) => e.status ?? 502`, or remap
      * specific codes (`(e) => (e.status === 429 ? 429 : 502)`).
      */
-    status?: number | ((err: StitchError) => number);
+    status?: number | ((err: StitchErrorLike) => number);
 }
 
 /**
  * Map a thrown stitch failure to a Nest {@link HttpException}, or `undefined` when `err`
- * is not a {@link StitchError} (so a caller can rethrow it untouched). The status is
+ * is not a {@link StitchErrorLike} (so a caller can rethrow it untouched). The status is
  * `502` by default; override it via {@link ToHttpExceptionOptions.status}.
  */
 export function toHttpException(
@@ -47,7 +47,7 @@ export function toHttpException(
 }
 
 /**
- * A global exception filter that converts a {@link StitchError} into an
+ * A global exception filter that converts a {@link StitchErrorLike} into an
  * {@link HttpException} (via {@link toHttpException} — `502` by default) and lets Nest
  * render it; every other exception is delegated to Nest's default handling, unchanged.
  * Register it globally so controllers calling stitches need no try/catch:

--- a/packages/nest/src/index.ts
+++ b/packages/nest/src/index.ts
@@ -11,6 +11,8 @@ export {
     InjectStitch,
     type StitchDef,
     type AnyStitchDef,
+    type NestRequestSeam,
+    // Deprecated alias (kept through 1.0.0-rc, removed at GA) — see ADR 0012.
     type StitchHost,
     type Injected,
 } from './define-stitch';

--- a/packages/nest/src/index.ts
+++ b/packages/nest/src/index.ts
@@ -33,7 +33,7 @@ export {
     StitchExceptionFilter,
     toHttpException,
     isStitchError,
-    type StitchError,
+    type StitchErrorLike,
     type ToHttpExceptionOptions,
 } from './exception-filter';
 export { stitchSse, type MessageEventLike, type StitchSseOptions } from './sse';

--- a/packages/nest/src/module.ts
+++ b/packages/nest/src/module.ts
@@ -3,7 +3,7 @@
 // registers injectable stitches and, optionally, a per-upstream feature seam built over
 // that shared infrastructure. `SeamRegistry` owns the shutdown lifecycle.
 import { nestBorrowStore, nestLoggerSink } from './bridges';
-import type { AnyStitchDef, StitchHost } from './define-stitch';
+import type { AnyStitchDef, NestRequestSeam } from './define-stitch';
 import { STITCH_SEAM, STITCH_STORE, STITCH_TRACE } from './tokens';
 
 import {
@@ -206,7 +206,7 @@ export class StitchModule {
         for (const d of norm.stitches) {
             providers.push({
                 provide: d.token,
-                useFactory: (host: StitchHost) => d.build(host),
+                useFactory: (host: NestRequestSeam) => d.build(host),
                 inject: [token],
             });
             exported.push(d.token);
@@ -254,7 +254,7 @@ export class StitchModule {
         providers.push({
             provide: principalToken,
             scope: Scope.REQUEST,
-            useFactory: (base: Seam, req: any): StitchHost =>
+            useFactory: (base: Seam, req: any): NestRequestSeam =>
                 base.as(opts.principal(req)),
             inject: [baseToken, REQUEST],
         });
@@ -263,7 +263,7 @@ export class StitchModule {
             providers.push({
                 provide: d.token,
                 scope: Scope.REQUEST,
-                useFactory: (host: StitchHost) => d.build(host),
+                useFactory: (host: NestRequestSeam) => d.build(host),
                 inject: [principalToken],
             });
             exported.push(d.token);

--- a/packages/nest/test/exception-filter.spec.ts
+++ b/packages/nest/test/exception-filter.spec.ts
@@ -1,5 +1,5 @@
 import {
-    type StitchError,
+    type StitchErrorLike,
     StitchExceptionFilter,
     isStitchError,
     toHttpException,
@@ -47,7 +47,7 @@ describe('toHttpException', () => {
     });
 
     it('accepts a status function for custom mapping (e.g. propagate the upstream status)', () => {
-        const status = (e: StitchError) => e.status ?? 502;
+        const status = (e: StitchErrorLike) => e.status ?? 502;
         expect(
             toHttpException(stitchError('rate limited', 429), {
                 status,

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -147,10 +147,10 @@ export function sseResponse<T>(
 // ---------------------------------------------------------------------------
 
 /** The error a stitch throws on failure: a branded `Error` with the upstream status. */
-export type StitchError = Error & { status?: number };
+export type StitchErrorLike = Error & { status?: number };
 
 /** True when `err` is the error a stitch throws on failure (`name === 'StitchError'`). */
-export function isStitchError(err: unknown): err is StitchError {
+export function isStitchError(err: unknown): err is StitchErrorLike {
     return err instanceof Error && err.name === 'StitchError';
 }
 
@@ -161,9 +161,9 @@ export interface ErrorResponseOptions {
      * upstream's `401`/`404` semantics to your client. Override with a number, or a
      * function: propagate the upstream status with `(e) => e.status ?? 502`.
      */
-    status?: number | ((err: StitchError) => number);
+    status?: number | ((err: StitchErrorLike) => number);
     /** Shape the JSON body. Default `{ error: err.message }`. */
-    body?: (err: StitchError, status: number) => unknown;
+    body?: (err: StitchErrorLike, status: number) => unknown;
 }
 
 /**
@@ -182,7 +182,8 @@ export function stitchErrorResponse(
     err: unknown,
     options: ErrorResponseOptions = {},
 ): Response {
-    const e: StitchError = err instanceof Error ? err : new Error(String(err));
+    const e: StitchErrorLike =
+        err instanceof Error ? err : new Error(String(err));
     const fallback = isStitchError(err) ? 502 : 500;
     const status =
         typeof options.status === 'function'

--- a/packages/rtk-query/src/index.ts
+++ b/packages/rtk-query/src/index.ts
@@ -18,6 +18,9 @@ import type { Stitch, StitchEvent } from 'stitchapi';
 // ---------------------------------------------------------------------------
 
 /** A callable returning an awaitable validated output (the unary surface). */
+// The MINIMAL await-only stitch duck-type (CONTRACT.md P9): this adapter never calls `.stream()`,
+// so it accepts any `(input?) => PromiseLike<T>`. The RICH canonical `StitchLike` (awaitable +
+// streamable) lives in `@stitchapi/query-core`; a real stitch satisfies both.
 export type StitchLike<T, Input = unknown> = (input?: Input) => PromiseLike<T>;
 
 /** A callable whose result is also streamable (`sse` / `stream` surfaces). */

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -40,7 +40,7 @@ export type {
 /** What `createStitch` / `createStitchStream` return: the reactive store (a Solid
  * proxy, so reading `store.data` inside an effect/JSX tracks it) plus the
  * imperative `refetch` / `cancel` handles. */
-export interface StitchStore<T> {
+export interface SolidStitchStore<T> {
     /** The reactive state — a Solid store proxy. Read fields inside tracking
      * scopes (effects, JSX) to re-run on change. */
     readonly state: StitchQueryState<T>;
@@ -88,7 +88,7 @@ function createStitchInternal<T>(
     input: MaybeAccessor<unknown>,
     options: MaybeAccessor<CreateStitchOptions<T>>,
     stream: boolean,
-): StitchStore<T> {
+): SolidStitchStore<T> {
     // The Solid store we reconcile from the core query's snapshots. `reconcile`
     // does a structural diff so only the fields that actually changed notify
     // their dependents (mirrors core's identity-stable snapshots, fine-grained).
@@ -184,17 +184,17 @@ export function createStitch<S extends StitchLike<unknown, never>>(
     stitch: S,
     input: MaybeAccessor<QueryInput<S>>,
     options?: MaybeAccessor<CreateStitchOptions<QueryOutput<S>>>,
-): StitchStore<QueryOutput<S>>;
+): SolidStitchStore<QueryOutput<S>>;
 export function createStitch<T, Input = unknown>(
     stitch: StitchLike<T, Input>,
     input: MaybeAccessor<Input>,
     options?: MaybeAccessor<CreateStitchOptions<T>>,
-): StitchStore<T>;
+): SolidStitchStore<T>;
 export function createStitch<T>(
     stitch: StitchLike<T, unknown>,
     input: MaybeAccessor<unknown>,
     options: MaybeAccessor<CreateStitchOptions<T>> = {},
-): StitchStore<T> {
+): SolidStitchStore<T> {
     return createStitchInternal<T>(stitch, input, options, false);
 }
 
@@ -220,17 +220,17 @@ export function createStitchStream<S extends StitchLike<unknown, never>>(
     stitch: S,
     input: MaybeAccessor<QueryInput<S>>,
     options?: MaybeAccessor<CreateStitchOptions<QueryOutput<S>>>,
-): StitchStore<QueryOutput<S>>;
+): SolidStitchStore<QueryOutput<S>>;
 export function createStitchStream<T, Input = unknown>(
     stitch: StitchLike<T, Input>,
     input: MaybeAccessor<Input>,
     options?: MaybeAccessor<CreateStitchOptions<T>>,
-): StitchStore<T>;
+): SolidStitchStore<T>;
 export function createStitchStream<T>(
     stitch: StitchLike<T, unknown>,
     input: MaybeAccessor<unknown>,
     options: MaybeAccessor<CreateStitchOptions<T>> = {},
-): StitchStore<T> {
+): SolidStitchStore<T> {
     return createStitchInternal<T>(stitch, input, options, true);
 }
 
@@ -242,7 +242,7 @@ export function createStitchStream<T>(
 // POJO shape `@tanstack/solid-query`'s `createQuery(options)` consumes is the same
 // `{ queryKey, queryFn }` TanStack uses everywhere.
 
-/** The plain object {@link queryOptions} returns — structurally compatible with
+/** The plain object {@link stitchQueryOptions} returns — structurally compatible with
  * TanStack Query's `createQuery(options)` without importing the library. */
 export interface StitchQueryOptions<T> {
     queryKey: readonly unknown[];
@@ -256,23 +256,23 @@ export interface StitchQueryOptions<T> {
  *
  * ```tsx
  * import { createQuery } from '@tanstack/solid-query';
- * import { queryOptions } from '@stitchapi/solid';
+ * import { stitchQueryOptions } from '@stitchapi/solid';
  *
- * const query = createQuery(() => queryOptions(getUser, { params: { id: id() } }));
+ * const query = createQuery(() => stitchQueryOptions(getUser, { params: { id: id() } }));
  * ```
  *
  * The `queryFn` awaits the stitch (the validated output); the `queryKey` is the
  * stitch's `name` (when present) plus the input, so TanStack caches per call.
  */
-export function queryOptions<S extends StitchLike<unknown, never>>(
+export function stitchQueryOptions<S extends StitchLike<unknown, never>>(
     stitch: S,
     input: QueryInput<S>,
 ): StitchQueryOptions<QueryOutput<S>>;
-export function queryOptions<T, Input = unknown>(
+export function stitchQueryOptions<T, Input = unknown>(
     stitch: StitchLike<T, Input>,
     input: Input,
 ): StitchQueryOptions<T>;
-export function queryOptions<T>(
+export function stitchQueryOptions<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
 ): StitchQueryOptions<T> {
@@ -282,3 +282,11 @@ export function queryOptions<T>(
         queryFn: () => Promise.resolve(stitch(input)),
     };
 }
+
+/**
+ * @deprecated Renamed to {@link stitchQueryOptions} — a bare `queryOptions` collides
+ * with TanStack Query's own `queryOptions` export when both are imported. See
+ * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the
+ * `1.0.0-rc` line and removed at the 1.0 GA cut.
+ */
+export const queryOptions = stitchQueryOptions;

--- a/packages/solid/test/primitives.spec.ts
+++ b/packages/solid/test/primitives.spec.ts
@@ -3,10 +3,11 @@
 // assertion run in `createRoot` so the effects/cleanups have an owner, and dispose
 // it to exercise teardown.
 import {
-    type StitchStore,
+    type SolidStitchStore,
     createStitch,
     createStitchStream,
     queryOptions,
+    stitchQueryOptions,
 } from '../src';
 
 import type { StitchCallResult, StitchLike } from '@stitchapi/query-core';
@@ -135,7 +136,7 @@ describe('createStitch', () => {
             name: `id-${(input as { params: { id: string } }).params.id}`,
         }));
 
-        let store!: StitchStore<{ name: string }>;
+        let store!: SolidStitchStore<{ name: string }>;
         let setId!: (v: string) => void;
         const dispose = createRoot((d) => {
             const [id, set] = createSignal('1');
@@ -210,7 +211,7 @@ describe('createStitch', () => {
             return 'v';
         });
 
-        let store!: StitchStore<string>;
+        let store!: SolidStitchStore<string>;
         let setEnabled!: (v: boolean) => void;
         const dispose = createRoot((d) => {
             const [enabled, set] = createSignal(false);
@@ -339,21 +340,27 @@ describe('createStitchStream', () => {
     });
 });
 
-// --- queryOptions ----------------------------------------------------------
+// --- stitchQueryOptions ----------------------------------------------------------
 
-describe('queryOptions', () => {
+describe('stitchQueryOptions', () => {
     test('returns a TanStack-shaped POJO with key + async queryFn', async () => {
         const stitch = unaryStitch(async () => ({ ok: true }), {
             name: 'getThing',
         });
-        const opts = queryOptions(stitch, { params: { id: '7' } });
+        const opts = stitchQueryOptions(stitch, { params: { id: '7' } });
         expect(opts.queryKey).toEqual(['getThing', { params: { id: '7' } }]);
         await expect(opts.queryFn()).resolves.toEqual({ ok: true });
     });
 
     test('falls back to "stitch" when no __config.name', () => {
         const stitch = unaryStitch(async () => 1);
-        const opts = queryOptions(stitch, null);
+        const opts = stitchQueryOptions(stitch, null);
         expect(opts.queryKey[0]).toBe('stitch');
+    });
+});
+
+describe('queryOptions (deprecated alias)', () => {
+    test('queryOptions stays a deprecated alias of stitchQueryOptions (ADR 0012)', () => {
+        expect(queryOptions).toBe(stitchQueryOptions);
     });
 });

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -48,7 +48,7 @@ export type {
  * store's FIRST subscriber — and `destroy()`ed when the last unsubscribes, so an
  * unused store costs nothing and a torn-down scope aborts its run.
  */
-export interface StitchStore<T> extends Readable<StitchQueryState<T>> {
+export interface SvelteStitchStore<T> extends Readable<StitchQueryState<T>> {
     /** Abort the in-flight run and re-run from scratch. */
     refetch: () => void;
     /** Abort the in-flight run, if any. */
@@ -63,7 +63,7 @@ function makeStore<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
     options: CreateStitchQueryOptions<T> & { stream: boolean },
-): StitchStore<T> {
+): SvelteStitchStore<T> {
     // The query is created EAGERLY (so `getSnapshot` has a real handle to seed
     // the store and `refetch`/`cancel` work before the first subscriber), but its
     // run only starts when `enabled` says so, exactly like the core store. We
@@ -126,17 +126,17 @@ export function stitchStore<S extends StitchLike<unknown, never>>(
     stitch: S,
     input: QueryInput<S>,
     options?: CreateStitchQueryOptions<QueryOutput<S>>,
-): StitchStore<QueryOutput<S>>;
+): SvelteStitchStore<QueryOutput<S>>;
 export function stitchStore<T, Input = unknown>(
     stitch: StitchLike<T, Input>,
     input: Input,
     options?: CreateStitchQueryOptions<T>,
-): StitchStore<T>;
+): SvelteStitchStore<T>;
 export function stitchStore<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
     options: CreateStitchQueryOptions<T> = {},
-): StitchStore<T> {
+): SvelteStitchStore<T> {
     return makeStore<T>(stitch, input, { ...options, stream: false });
 }
 
@@ -165,17 +165,17 @@ export function stitchStreamStore<S extends StitchLike<unknown, never>>(
     stitch: S,
     input: QueryInput<S>,
     options?: CreateStitchQueryOptions<QueryOutput<S>>,
-): StitchStore<QueryOutput<S>>;
+): SvelteStitchStore<QueryOutput<S>>;
 export function stitchStreamStore<T, Input = unknown>(
     stitch: StitchLike<T, Input>,
     input: Input,
     options?: CreateStitchQueryOptions<T>,
-): StitchStore<T>;
+): SvelteStitchStore<T>;
 export function stitchStreamStore<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
     options: CreateStitchQueryOptions<T> = {},
-): StitchStore<T> {
+): SvelteStitchStore<T> {
     return makeStore<T>(stitch, input, { ...options, stream: true });
 }
 
@@ -200,7 +200,7 @@ export const useStitchStream = stitchStreamStore;
 // the POJO is framework-neutral and feeds `@tanstack/svelte-query`'s
 // `createQuery` exactly as it feeds React's `useQuery`.
 
-/** The plain object {@link queryOptions} returns — structurally compatible with
+/** The plain object {@link stitchQueryOptions} returns — structurally compatible with
  * TanStack Query's `createQuery(options)` without importing the library. */
 export interface StitchQueryOptions<T> {
     queryKey: readonly unknown[];
@@ -214,23 +214,23 @@ export interface StitchQueryOptions<T> {
  *
  * ```ts
  * import { createQuery } from '@tanstack/svelte-query';
- * import { queryOptions } from '@stitchapi/svelte';
+ * import { stitchQueryOptions } from '@stitchapi/svelte';
  *
- * const query = createQuery(queryOptions(getUser, { params: { id } }));
+ * const query = createQuery(stitchQueryOptions(getUser, { params: { id } }));
  * ```
  *
  * The `queryFn` awaits the stitch (the validated output); the `queryKey` is the
  * stitch's `name` (when present) plus the input, so TanStack caches per call.
  */
-export function queryOptions<S extends StitchLike<unknown, never>>(
+export function stitchQueryOptions<S extends StitchLike<unknown, never>>(
     stitch: S,
     input: QueryInput<S>,
 ): StitchQueryOptions<QueryOutput<S>>;
-export function queryOptions<T, Input = unknown>(
+export function stitchQueryOptions<T, Input = unknown>(
     stitch: StitchLike<T, Input>,
     input: Input,
 ): StitchQueryOptions<T>;
-export function queryOptions<T>(
+export function stitchQueryOptions<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
 ): StitchQueryOptions<T> {
@@ -240,3 +240,11 @@ export function queryOptions<T>(
         queryFn: () => Promise.resolve(stitch(input)),
     };
 }
+
+/**
+ * @deprecated Renamed to {@link stitchQueryOptions} — a bare `queryOptions` collides
+ * with TanStack Query's own `queryOptions` export when both are imported. See
+ * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the
+ * `1.0.0-rc` line and removed at the 1.0 GA cut.
+ */
+export const queryOptions = stitchQueryOptions;

--- a/packages/svelte/test/stores.spec.ts
+++ b/packages/svelte/test/stores.spec.ts
@@ -3,6 +3,7 @@
 // exactly how Svelte's `$store` / `subscribe` would observe them at runtime.
 import {
     queryOptions,
+    stitchQueryOptions,
     stitchStore,
     stitchStreamStore,
     useStitch,
@@ -271,21 +272,27 @@ describe('stitchStreamStore', () => {
     });
 });
 
-// --- queryOptions ----------------------------------------------------------
+// --- stitchQueryOptions ----------------------------------------------------------
 
-describe('queryOptions', () => {
+describe('stitchQueryOptions', () => {
     test('returns a TanStack-shaped POJO with key + async queryFn', async () => {
         const stitch = unaryStitch(async () => ({ ok: true }), {
             name: 'getThing',
         });
-        const opts = queryOptions(stitch, { params: { id: '7' } });
+        const opts = stitchQueryOptions(stitch, { params: { id: '7' } });
         expect(opts.queryKey).toEqual(['getThing', { params: { id: '7' } }]);
         await expect(opts.queryFn()).resolves.toEqual({ ok: true });
     });
 
     test('falls back to "stitch" when no __config.name', () => {
         const stitch = unaryStitch(async () => 1);
-        const opts = queryOptions(stitch, null);
+        const opts = stitchQueryOptions(stitch, null);
         expect(opts.queryKey[0]).toBe('stitch');
+    });
+});
+
+describe('queryOptions (deprecated alias)', () => {
+    test('queryOptions stays a deprecated alias of stitchQueryOptions (ADR 0012)', () => {
+        expect(queryOptions).toBe(stitchQueryOptions);
     });
 });

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -22,6 +22,9 @@ import useSWR, { type SWRConfiguration, type SWRResponse } from 'swr';
 /** A callable that, given its input, returns an awaitable validated output. The
  * real `Stitch` satisfies this; so does a plain fake in a test. SWR only needs the
  * awaitable side, so — unlike the reactive bindings — there is no `.stream()`. */
+// The MINIMAL await-only stitch duck-type (CONTRACT.md P9): this adapter never calls `.stream()`,
+// so it accepts any `(input?) => PromiseLike<T>`. The RICH canonical `StitchLike` (awaitable +
+// streamable) lives in `@stitchapi/query-core`; a real stitch satisfies both.
 export type StitchLike<T, Input = unknown> = (input?: Input) => PromiseLike<T>;
 
 /** The validated output type of a stitch (or `StitchLike`). */

--- a/packages/vercel-ai/src/index.ts
+++ b/packages/vercel-ai/src/index.ts
@@ -18,6 +18,9 @@ import type { Stitch } from 'stitchapi';
 
 /** A callable returning an awaitable validated output. The real `Stitch` satisfies
  * it; so does a plain fake in a test. */
+// The MINIMAL await-only stitch duck-type (CONTRACT.md P9): this adapter never calls `.stream()`,
+// so it accepts any `(input?) => PromiseLike<T>`. The RICH canonical `StitchLike` (awaitable +
+// streamable) lives in `@stitchapi/query-core`; a real stitch satisfies both.
 export type StitchLike<T, Input = unknown> = (input?: Input) => PromiseLike<T>;
 
 /** The validated output type of a stitch (or `StitchLike`). */

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -266,7 +266,7 @@ export function useStitchStream<T>(
 // framework import, so it feeds `@tanstack/vue-query`'s `useQuery(options)`
 // (or any other) just the same.
 
-/** The plain object {@link queryOptions} returns — structurally compatible with
+/** The plain object {@link stitchQueryOptions} returns — structurally compatible with
  * TanStack Query's `useQuery(options)` without importing the library. */
 export interface StitchQueryOptions<T> {
     queryKey: readonly unknown[];
@@ -280,23 +280,23 @@ export interface StitchQueryOptions<T> {
  *
  * ```ts
  * import { useQuery } from '@tanstack/vue-query';
- * import { queryOptions } from '@stitchapi/vue';
+ * import { stitchQueryOptions } from '@stitchapi/vue';
  *
- * const { data } = useQuery(queryOptions(getUser, { params: { id } }));
+ * const { data } = useQuery(stitchQueryOptions(getUser, { params: { id } }));
  * ```
  *
  * The `queryFn` awaits the stitch (the validated output); the `queryKey` is the
  * stitch's `name` (when present) plus the input, so TanStack caches per call.
  */
-export function queryOptions<S extends StitchLike<unknown, never>>(
+export function stitchQueryOptions<S extends StitchLike<unknown, never>>(
     stitch: S,
     input: QueryInput<S>,
 ): StitchQueryOptions<QueryOutput<S>>;
-export function queryOptions<T, Input = unknown>(
+export function stitchQueryOptions<T, Input = unknown>(
     stitch: StitchLike<T, Input>,
     input: Input,
 ): StitchQueryOptions<T>;
-export function queryOptions<T>(
+export function stitchQueryOptions<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
 ): StitchQueryOptions<T> {
@@ -306,3 +306,11 @@ export function queryOptions<T>(
         queryFn: () => Promise.resolve(stitch(input)),
     };
 }
+
+/**
+ * @deprecated Renamed to {@link stitchQueryOptions} — a bare `queryOptions` collides
+ * with TanStack Query's own `queryOptions` export when both are imported. See
+ * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the
+ * `1.0.0-rc` line and removed at the 1.0 GA cut.
+ */
+export const queryOptions = stitchQueryOptions;

--- a/packages/vue/test/composables.spec.ts
+++ b/packages/vue/test/composables.spec.ts
@@ -3,7 +3,12 @@
 // and the core publishes synchronously on each transition, so a `flush()` (one
 // awaited microtask) is enough to settle the fake stitch's resolved promises.
 // Driven by FAKE stitches — no engine, no network.
-import { queryOptions, useStitch, useStitchStream } from '../src';
+import {
+    queryOptions,
+    stitchQueryOptions,
+    useStitch,
+    useStitchStream,
+} from '../src';
 
 import type { StitchCallResult, StitchLike } from '@stitchapi/query-core';
 import type { StitchEvent } from 'stitchapi';
@@ -269,21 +274,27 @@ describe('useStitchStream', () => {
     });
 });
 
-// --- queryOptions ----------------------------------------------------------
+// --- stitchQueryOptions ----------------------------------------------------------
 
-describe('queryOptions', () => {
+describe('stitchQueryOptions', () => {
     test('returns a TanStack-shaped POJO with key + async queryFn', async () => {
         const stitch = unaryStitch(async () => ({ ok: true }), {
             name: 'getThing',
         });
-        const opts = queryOptions(stitch, { params: { id: '7' } });
+        const opts = stitchQueryOptions(stitch, { params: { id: '7' } });
         expect(opts.queryKey).toEqual(['getThing', { params: { id: '7' } }]);
         await expect(opts.queryFn()).resolves.toEqual({ ok: true });
     });
 
     test('falls back to "stitch" when no __config.name', () => {
         const stitch = unaryStitch(async () => 1);
-        const opts = queryOptions(stitch, null);
+        const opts = stitchQueryOptions(stitch, null);
         expect(opts.queryKey[0]).toBe('stitch');
+    });
+});
+
+describe('queryOptions (deprecated alias)', () => {
+    test('queryOptions stays a deprecated alias of stitchQueryOptions (ADR 0012)', () => {
+        expect(queryOptions).toBe(stitchQueryOptions);
     });
 });

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -182,7 +182,10 @@ const UNIQUE_WATCH = new Set([
     'RequestSeam',
     'StitchHost',
     'StitchError',
-    'StitchErrorLike',
+    // `StitchErrorLike` de-listed: the host adapters' error duck-type is now uniformly
+    // named `StitchErrorLike` (`Error & { status? }`) across elysia/hono/express/fastify/nest/next —
+    // one structural contract (P9). The mis-named `StitchError` duck-types (which shadowed core's
+    // real `StitchError` class) were renamed here, so bare `StitchError` is now core-only.
     // `queryOptions` was watch-listed as the bare TanStack alias; the canonical
     // `stitchQueryOptions` rename (ADR 0012) is now applied to ALL five framework bindings
     // (react/vue/solid/svelte/angular), and the bare `queryOptions` survives only as a uniform

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -178,10 +178,17 @@ const isLike = (n) => /Like/.test(n);
 // full shape-diff is the deferred type-aware phase). Flagged when ≥2 packages export one.
 const UNIQUE_WATCH = new Set([
     'StitchStore',
-    'StitchLike',
     'RequestSeam',
     'StitchHost',
     'StitchError',
+    // `StitchLike` de-listed (P9): it is two deliberate, compatible tiers, not a clash. The
+    // canonical RICH shape — `(input?) => StitchCallResult<T>` (awaitable + streamable) — lives in
+    // `@stitchapi/query-core` and is re-exported by the five TanStack-family bindings
+    // (react/vue/solid/svelte/angular). The three stream-LESS adapters (swr/rtk-query/vercel-ai)
+    // intentionally use a MINIMAL await-only `(input?) => PromiseLike<T>` duck-type — they never call
+    // `.stream()`, so requiring `StitchCallResult` would wrongly reject a plain awaitable callable.
+    // query-core's rich shape is assignable to the minimal one, so a real stitch satisfies both; the
+    // by-name R5 proxy can't see that the difference is intentional, hence the de-list.
     // `StitchErrorLike` de-listed: the host adapters' error duck-type is now uniformly
     // named `StitchErrorLike` (`Error & { status? }`) across elysia/hono/express/fastify/nest/next —
     // one structural contract (P9). The mis-named `StitchError` duck-types (which shadowed core's

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -183,7 +183,10 @@ const UNIQUE_WATCH = new Set([
     'StitchHost',
     'StitchError',
     'StitchErrorLike',
-    'queryOptions', // P16: the bare TanStack alias; canonical is stitchQueryOptions
+    // `queryOptions` was watch-listed as the bare TanStack alias; the canonical
+    // `stitchQueryOptions` rename (ADR 0012) is now applied to ALL five framework bindings
+    // (react/vue/solid/svelte/angular), and the bare `queryOptions` survives only as a uniform
+    // `@deprecated` re-export of it — no longer a competing canonical, so it is de-listed (P16).
 ]);
 
 function collect() {

--- a/scripts/contract-violations.baseline.json
+++ b/scripts/contract-violations.baseline.json
@@ -1,15 +1,7 @@
 {
     "generatedBy": "scripts/check-contract.mjs --update",
-    "count": 13,
+    "count": 11,
     "violations": [
-        {
-            "rule": "R5",
-            "file": "packages/<multiple>",
-            "symbol": "queryOptions",
-            "detail": "exported by angular, react, solid, svelte, vue — must be unique-by-shape (P9/P16)",
-            "line": null,
-            "key": "R5|packages/<multiple>|queryOptions"
-        },
         {
             "rule": "R5",
             "file": "packages/<multiple>",
@@ -51,19 +43,11 @@
             "key": "R5|packages/<multiple>|StitchLike"
         },
         {
-            "rule": "R5",
-            "file": "packages/<multiple>",
-            "symbol": "StitchStore",
-            "detail": "exported by solid, svelte — must be unique-by-shape (P9/P16)",
-            "line": null,
-            "key": "R5|packages/<multiple>|StitchStore"
-        },
-        {
             "rule": "R6",
             "file": "packages/core/src/types.ts",
             "symbol": "StitchConfig.hooks",
             "detail": "all-optional Hooks accepts {} → Scalar|AtLeastOne<Hooks> (P20)",
-            "line": 593,
+            "line": 602,
             "key": "R6|packages/core/src/types.ts|StitchConfig.hooks"
         },
         {
@@ -71,7 +55,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "StitchConfig.input",
             "detail": "all-optional InputSchemas accepts {} → Scalar|AtLeastOne<InputSchemas> (P20)",
-            "line": 593,
+            "line": 602,
             "key": "R6|packages/core/src/types.ts|StitchConfig.input"
         },
         {
@@ -79,7 +63,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "StitchConfig.multipart",
             "detail": "all-optional MultipartOptions accepts {} → Scalar|AtLeastOne<MultipartOptions> (P20)",
-            "line": 593,
+            "line": 602,
             "key": "R6|packages/core/src/types.ts|StitchConfig.multipart"
         },
         {
@@ -87,7 +71,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "StitchConfig.sse",
             "detail": "all-optional SseOptions accepts {} → Scalar|AtLeastOne<SseOptions> (P20)",
-            "line": 593,
+            "line": 602,
             "key": "R6|packages/core/src/types.ts|StitchConfig.sse"
         },
         {
@@ -95,7 +79,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "StitchConfig.stream",
             "detail": "all-optional StreamOptions accepts {} → Scalar|AtLeastOne<StreamOptions> (P20)",
-            "line": 593,
+            "line": 602,
             "key": "R6|packages/core/src/types.ts|StitchConfig.stream"
         },
         {
@@ -103,7 +87,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "StitchConfig.throttle",
             "detail": "all-optional ThrottleOptions accepts {} → Scalar|AtLeastOne<ThrottleOptions> (P20)",
-            "line": 593,
+            "line": 602,
             "key": "R6|packages/core/src/types.ts|StitchConfig.throttle"
         }
     ]

--- a/scripts/contract-violations.baseline.json
+++ b/scripts/contract-violations.baseline.json
@@ -1,23 +1,7 @@
 {
     "generatedBy": "scripts/check-contract.mjs --update",
-    "count": 9,
+    "count": 7,
     "violations": [
-        {
-            "rule": "R5",
-            "file": "packages/<multiple>",
-            "symbol": "RequestSeam",
-            "detail": "exported by elysia, express — must be unique-by-shape (P9/P16)",
-            "line": null,
-            "key": "R5|packages/<multiple>|RequestSeam"
-        },
-        {
-            "rule": "R5",
-            "file": "packages/<multiple>",
-            "symbol": "StitchHost",
-            "detail": "exported by fastify, nest — must be unique-by-shape (P9/P16)",
-            "line": null,
-            "key": "R5|packages/<multiple>|StitchHost"
-        },
         {
             "rule": "R5",
             "file": "packages/<multiple>",

--- a/scripts/contract-violations.baseline.json
+++ b/scripts/contract-violations.baseline.json
@@ -1,6 +1,6 @@
 {
     "generatedBy": "scripts/check-contract.mjs --update",
-    "count": 11,
+    "count": 9,
     "violations": [
         {
             "rule": "R5",
@@ -9,22 +9,6 @@
             "detail": "exported by elysia, express — must be unique-by-shape (P9/P16)",
             "line": null,
             "key": "R5|packages/<multiple>|RequestSeam"
-        },
-        {
-            "rule": "R5",
-            "file": "packages/<multiple>",
-            "symbol": "StitchError",
-            "detail": "exported by express, fastify, nest, next — must be unique-by-shape (P9/P16)",
-            "line": null,
-            "key": "R5|packages/<multiple>|StitchError"
-        },
-        {
-            "rule": "R5",
-            "file": "packages/<multiple>",
-            "symbol": "StitchErrorLike",
-            "detail": "exported by elysia, hono — must be unique-by-shape (P9/P16)",
-            "line": null,
-            "key": "R5|packages/<multiple>|StitchErrorLike"
         },
         {
             "rule": "R5",

--- a/scripts/contract-violations.baseline.json
+++ b/scripts/contract-violations.baseline.json
@@ -1,15 +1,7 @@
 {
     "generatedBy": "scripts/check-contract.mjs --update",
-    "count": 7,
+    "count": 6,
     "violations": [
-        {
-            "rule": "R5",
-            "file": "packages/<multiple>",
-            "symbol": "StitchLike",
-            "detail": "exported by angular, query-core, react, rtk-query, solid, svelte, swr, vercel-ai, vue — must be unique-by-shape (P9/P16)",
-            "line": null,
-            "key": "R5|packages/<multiple>|StitchLike"
-        },
         {
             "rule": "R6",
             "file": "packages/core/src/types.ts",


### PR DESCRIPTION
**Phase 3 of 3** (final) of the API meta-contract sweep — **stacked on [#375](https://github.com/rejifald/StitchAPI/pull/373)** (merge #352 → #375 → this, in order). Cross-package **unique-by-shape** unification (P9/P16). Ratchets the contract baseline **13 → 6** — **R5 is fully cleared**; the surviving 6 are R6's P20 backlog (out of scope: `multipart`/`stream`/`sse`/`throttle`/`hooks`/`input` → `Scalar | AtLeastOne`).

## The 7 R5 findings, resolved

- **`StitchStore`** — `@stitchapi/solid|svelte`'s query store is framework-qualified to `Solid/SvelteStitchStore` (genuinely incompatible — Solid nests `.state`, Svelte extends `Readable` — and both collided with core's state-store `StitchStore`).
- **`queryOptions`** — the ADR 0012 `stitchQueryOptions` rename now covers vue/solid/svelte/angular (was react-only); bare `queryOptions` survives as a uniform `@deprecated` alias (identity-tested) and is de-listed.
- **`StitchError` / `StitchErrorLike`** — express/fastify/nest/next mis-named their error *duck-type* `StitchError`, shadowing core's real `StitchError` *class*; renamed to `StitchErrorLike` (matching elysia/hono). Bare `StitchError` is now core-only.
- **`RequestSeam` / `StitchHost`** — the per-request seam is ecosystem-qualified per framework (`Express/Elysia/Fastify/NestRequestSeam`), extending hono's `HonoRequestSeam`; bare names kept as `@deprecated` aliases.
- **`StitchLike`** — resolved as two deliberate, compatible tiers: the rich `(input?) => StitchCallResult<T>` canonical in query-core (re-exported by the five TanStack-family bindings) vs. an intentional minimal await-only `(input?) => PromiseLike<T>` in the stream-less adapters (swr/rtk-query/vercel-ai).

Genuinely-unified names are de-listed from the curated R5 watch-list (with documented rationale); collision-fixes are qualified so the bare name is no longer a canonical export. Two judgment calls (qualify-vs-alias on collisions, and the StitchLike two-tier de-list) are documented in CONTRACT.md and the lint.

## Verification

Whole repo (`pnpm -r`) typechecks, lints, and tests green; `check:contract` passes (baseline 6); a docs build passes. This is also the merged-with-`main` HEAD, validated end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
