### PR TITLE
feat(core): nudge on idempotency misuse; split correlation from dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ npm release are grouped under the in-development version that introduced them.
 
 ## [Unreleased]
 
+### Changed
+
+-   **BREAKING — run-identity fields renamed to the OpenTelemetry names.** The
+    `RunContext` struct and the `start` event now carry **`spanId`** and
+    **`parentSpanId`** instead of `runId` and `parentId` (`traceId` is unchanged).
+    The names now match what the OTLP exporter already emits, so the mapping is an
+    identity and there is no translation seam. Custom trace sinks reading
+    `ctx.runId` / `ctx.parentId` (or `event.runId` / `event.parentId`) must read
+    `ctx.spanId` / `ctx.parentSpanId`. The `@stitchapi/sentry` integration now
+    reports the failing run's id under a `spanId` tag. See
+    [ADR 0017 Decision 7](docs/adr/0017-outbound-trace-context-propagation.md) and
+    the new `concepts/run-identity` page.
+
+### Added
+
+-   **Idempotency misuse nudges.** A stitch now logs a one-time construction
+    warning when `idempotency` is set on a read (the key is sent on writes only —
+    almost always a missing `method: 'POST'`) or with the random default key and no
+    `retry` (it only dedupes the call's own retries). Both are respectful hints with
+    an out — set `idempotency: { warn: false }` to silence them — and fire only on
+    the default HTTP surface. New `IdempotencyOptions.warn` field.
+
 ## [1.0.0-rc.4] — 2026-06-29
 
 ### Added

--- a/apps/docs/EDITORIAL.md
+++ b/apps/docs/EDITORIAL.md
@@ -22,11 +22,11 @@ a page reads well both rendered in a browser and pulled out of context as
 
 ---
 
-## The eight dimensions
+## The nine dimensions
 
 Each dimension has a **rule** (what good looks like), a **tell** (the failure
 smell — most are greppable), and an **example** drawn from a real page. An audit
-scores a page against all eight.
+scores a page against all nine.
 
 ### 1. The lede earns its place in one sentence
 
@@ -134,6 +134,33 @@ deleting it turns an honest comparison into an advertisement nobody trusts. Keep
 concession; reframe only the dead-end phrasing (_"stitching isn't worth it"_ →
 _"when you'd graduate to a stitch"_).
 
+### 9. Respect the reader — diagnose, don't blame
+
+The reader arrived with a problem. Prose names the constraint and points to the fix;
+it never implies the limitation is the reader's fault, their data's fault, or beneath
+the feature to bother with. State a limit as _where the work lives_ — "you handle that
+one layer down" — not as a verdict on the person hitting it. This is the honesty of
+dimension 8 turned toward the reader: a true constraint is fine to state, a true
+constraint stated _at the reader_ is not. Condescension fails here for the same reason —
+"simply", "obviously", "any competent dev" tell a stuck reader the fault is theirs.
+
+-   ✅ _"If two submissions share nothing stable to derive a key from, no key can join
+    them at this layer — you dedupe them one level down, on a unique constraint in the
+    database."_ (`idempotency-keys-safe-retries`) — names the constraint, then the next move.
+-   🚩 **Tell — blame-shifting / dismissive:** a limit pinned on the reader instead of
+    located — _that is a fact about your data not a gap in the feature, not our problem,
+    works as intended, you're doing it wrong, you're holding it wrong, that's on you,
+    nothing we can do, if you'd only._ Grep: `not a (bug|gap|problem|flaw|limitation) in`,
+    `your (data|problem|fault)`, `works as intended`, `(doing|holding) it wrong`, `that'?s on you`.
+-   🚩 **Tell — condescension:** difficulty waved away as if trivial for the reader —
+    _obviously, clearly, of course, any competent, as everyone knows, it should be obvious._
+    Grep: `\bobviously\b`, `\bclearly\b`, `any competent`, `everyone knows`.
+
+The fix is always the same shape: keep the fact, drop the judgment, add the next step.
+"That's a gap in your data, not the feature" → "nothing stable to key on means you dedupe
+a layer down — here's where." The constraint survives; the reader is pointed somewhere,
+not pushed away.
+
 ---
 
 ## A note on terminology (shared with `AUTHORING.md`)
@@ -156,9 +183,10 @@ standard. This file is English-prose only.
    found. Does the lede tell you what and when (dim. 1)? Did anything make you
    re-read (dim. 6)?
 2. **Grep the tells.** The delete-on-sight list (dim. 2), agentless passive
-   (dim. 5), back-references (dim. 6), and door-closing closers (dim. 8 —
-   `## When .* is enough`, `stop here`, `leaner`, `overkill`) are mechanical —
-   find them first.
+   (dim. 5), back-references (dim. 6), door-closing closers (dim. 8 —
+   `## When .* is enough`, `stop here`, `leaner`, `overkill`), and blame /
+   condescension (dim. 9 — `your (data|problem|fault)`, `not a .* in the feature`,
+   `obviously`, `clearly`) are mechanical — find them first.
 3. **Score each dimension** and record findings as
    `file:line · dimension · severity · the rewrite`. A finding is not a flag; it
    is the replacement sentence.
@@ -172,6 +200,9 @@ standard. This file is English-prose only.
     obscure the point.
 -   **`minor`** — violates dimensions 5–7. Polish: a passive that wants an actor, a
     stray "we", an avoidable back-reference.
+-   **Tone (dims. 8–9) is at least `major`.** A door-closing closer or a blaming /
+    condescending line drives the reader off — score it `major`, or `blocker` if the
+    blame also restates something false about what the feature can do.
 
 A page is **done** when it has no `blocker` or `major` findings and reads, start to
 finish, like the exemplar pages this standard was drawn from.
@@ -189,4 +220,6 @@ finish, like the exemplar pages this standard was drawn from.
 -   [ ] Second person for the reader; no authorial "we" (dim. 7).
 -   [ ] No door-closing closer; the bare tool is framed as the on-ramp's first
         step, concessions read as graduation triggers, not dismissals (dim. 8).
+-   [ ] No blame or condescension; constraints are located, not pinned on the
+        reader, and difficulty is never waved away as obvious (dim. 9).
 -   [ ] Product vocabulary matches `AUTHORING.md` rule 4 exactly.

--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -283,6 +283,20 @@ export const pages: Page[] = [
         kind: 'concept',
     },
     {
+        path: 'concepts/run-identity',
+        title: 'Run identity & the trace tree',
+        description:
+            'How a stitch identifies one call and its place in a tree — a shared traceId, the span id (spanId), and a parentSpanId — so composed runs form one OpenTelemetry span tree, and how that maps onto the traceparent header on the wire.',
+        kind: 'concept',
+    },
+    {
+        path: 'concepts/correlation-vs-idempotency',
+        title: 'Correlation vs idempotency',
+        description:
+            'Two keys that look alike but answer different questions — an idempotency key decides what makes two attempts the same write, a correlation/trace id identifies one request for logs and spans — and why they stay separate fields.',
+        kind: 'concept',
+    },
+    {
         path: 'concepts/capability-not-credential',
         title: 'Capability, not credential',
         description:

--- a/apps/docs/content/blog/circuit-breakers-and-layered-timeouts.mdx
+++ b/apps/docs/content/blog/circuit-breakers-and-layered-timeouts.mdx
@@ -116,7 +116,7 @@ async function getQuote(symbol: string) {
 }
 ```
 
-Read top to bottom, that's a coherent reliability story. Retry absorbs the transient blips — a stray 503, a rate-limited 429 whose `Retry-After` you honor. The layered timeout bounds how long any single attempt and the whole call can take, with real aborts so nothing leaks. And the breaker is the backstop for when the failures stop being transient: once five in a row have failed, retrying is clearly futile, so it stops trying and fast-fails until a probe says otherwise.
+Read top to bottom, that's a coherent reliability story. Retry absorbs the transient blips — a stray 503, a rate-limited 429 whose `Retry-After` you honor. The layered timeout bounds how long any single attempt and the whole call can take, with real aborts so nothing leaks. And the breaker is the backstop for when the failures stop being transient: once five in a row have failed, more retries only add load to a service that is already down, so it stops trying and fast-fails until a probe says otherwise.
 
 Each piece covers a gap the others can't. Retry without a breaker turns a sustained outage into a retry storm. A breaker without timeouts still lets individual slow calls block you right up until the threshold trips. Timeouts without a breaker bound each call but never stop you from re-discovering the same outage, caller after caller. Declared together on the stitch, they cover transient, slow, and sustained failure as one policy — and because it lives on the definition, every front door inherits it: the in-process function, the CLI, the HTTP endpoint, and the agent calling over MCP all get the same behavior, not three slightly different hand-rolled versions.
 

--- a/apps/docs/content/blog/idempotency-keys-safe-retries.mdx
+++ b/apps/docs/content/blog/idempotency-keys-safe-retries.mdx
@@ -65,7 +65,7 @@ const result = await charge({ body: { amount: 4200, ref: 'inv_88' } });
 
 `idempotency: true` does the work the loop did, correctly. It generates a random uuid **once per logical call** and reuses it across that call's retries, sending it as the `Idempotency-Key` header. One `await charge(...)` settles one charge, even when the engine retries it twice under the hood. The server sees one token, dedupes the replay, and returns the committed result.
 
-`retry` and `idempotency` are deliberately separate fields because they answer separate questions. `retry` decides _when to try again_ — which statuses, how many attempts, how to back off. `idempotency` decides _what makes two attempts the same write_. Pair them on every write: a retry without a key double-applies, a key without a retry never gets exercised.
+`retry` and `idempotency` are deliberately separate fields because they answer separate questions. `retry` decides _when to try again_ — which statuses, how many attempts, how to back off. `idempotency` decides _what makes two attempts the same write_. Pair them on every write: a retry without a key double-applies, and a key earns its keep most clearly alongside a retry — the retry is the duplicate it absorbs. Declare the random key without a retry and a stitch nudges you at construction, since it usually has nothing to collapse. The key isn't wasted in every such case, though: it also rides any replay the stitch never issued — a proxy or the transport resending the same request — and a server that honors it dedupes that too. If that's the case you're after, `idempotency: { warn: false }` silences the nudge.
 
 ## The default key dedupes retries, not submissions
 
@@ -99,11 +99,11 @@ The rule splits cleanly:
 | Collapse a retry of one call                                | `idempotency: true` (random, per-call)                             |
 | Collapse two separate submissions of the same logical write | `idempotency: { keyOf: (input) => ... }` derived from shared input |
 
-If the duplicates have nothing in common to hash, no key can join them — that is a fact about your data, not a gap in the feature.
+If two submissions share nothing stable to derive a key from, no key can join them at this layer — you dedupe them one level down instead, on a unique constraint in the database that rejects the second write.
 
 ## A different header
 
-Some APIs expect the token on a header other than `Idempotency-Key`. Name it:
+Some APIs expect the token on a header other than `Idempotency-Key` — `Idempotency-Token`, say, or a vendor-prefixed `X-Idempotency-Key`. Name it:
 
 ```ts twoslash
 import { stitch } from 'stitchapi';
@@ -115,13 +115,15 @@ const createOrder = stitch({
     path: '/orders',
     retry: { attempts: 3 },
     idempotency: {
-        header: 'X-Request-Id',
+        header: 'Idempotency-Token',
         keyOf: (input) => `order-${(input.body as { ref: string }).ref}`,
     },
 });
 ```
 
 The default is `Idempotency-Key`; `header` overrides it. Everything else is unchanged.
+
+`header` renames the idempotency key — the value a server _dedupes_ on. It is **not** the place to set a correlation header like `traceparent` or `X-Request-Id`: those answer a different question — _which request is this?_, for logs and spans — carry your trace id, and belong to tracing, not dedupe. Routing one through `idempotency` would send a fresh per-call value that never lines up with your traces.
 
 ## What it does not do
 
@@ -139,7 +141,7 @@ From there the same config object carries `timeout: { total: '30s', perAttempt: 
 stitchapi
 ```
 
-Add `idempotency` and `retry` to your write stitches, then derive a stable `key` wherever two submissions can be the same logical write.
+Add `idempotency` and `retry` to your write stitches, then derive a stable `keyOf` wherever two submissions can be the same logical write.
 
 -   [Idempotency guide](/docs/guides/resilience/idempotency) — the full field reference and server-contract notes.
 -   [Retry guide](/docs/guides/resilience/retry) and [Timeout guide](/docs/guides/resilience/timeout) — the policies you pair idempotency with on writes.

--- a/apps/docs/content/blog/one-tool-per-endpoint.mdx
+++ b/apps/docs/content/blog/one-tool-per-endpoint.mdx
@@ -86,7 +86,7 @@ There's an even cheaper way for an agent to orient, one that doesn't spend a too
 
 Code-mode is not free, and it isn't always the right call. Reach for the flat per-endpoint menu instead when:
 
--   **It needs a sandbox.** `run_stitch` executes a named stitch on the server side of the capability boundary; a setup where the model writes and runs code needs an eval/execution path you trust. One tool per endpoint needs none of that — the model just fills in a schema. If you can't or won't run a sandbox, the per-endpoint pattern is the simpler thing.
+-   **It needs a sandbox.** `run_stitch` executes a named stitch on the server side of the capability boundary; a setup where the model writes and runs code needs an eval/execution path you trust. One tool per endpoint needs none of that — the model just fills in a schema. When running a sandbox isn't an option, the per-endpoint pattern is the simpler thing.
 -   **It leans on the model.** Driving stitches by name — listing, describing, composing a call — asks more of the model than picking from a flat menu of typed tools. A model that's weak at this kind of structured tool use may do better with explicit per-endpoint schemas, paid-per-turn and all.
 -   **Small catalogs see no savings.** The whole win is `catalog × turns` collapsing on the catalog axis. With two endpoints and a single-shot call, there was never a fat menu to re-send — two schemas once is cheaper than standing up code-mode. The savings only show up when the catalog is large, the loops are long, or both.
 

--- a/apps/docs/content/blog/read-non-json-responses.mdx
+++ b/apps/docs/content/blog/read-non-json-responses.mdx
@@ -31,7 +31,7 @@ async function getRevenueReport(month: string) {
 }
 ```
 
-Nothing here is wrong, but nothing here is reusable. You chose `res.text()` by hand because `res.json()` would have thrown on a comma. The return shape is whatever `parseCsv` happens to give you. A flaky gateway is your problem to handle, and the bearer token is captured in the closure. Every non-JSON endpoint in the codebase grows its own copy of this.
+Nothing here is wrong, but nothing here is reusable. You chose `res.text()` by hand because `res.json()` would have thrown on a comma. The return shape is whatever `parseCsv` happens to give you. A flaky gateway is yours to handle by hand, and the bearer token is captured in the closure. Every non-JSON endpoint in the codebase grows its own copy of this.
 
 ## The stitch version
 

--- a/apps/docs/content/docs/concepts/correlation-vs-idempotency.mdx
+++ b/apps/docs/content/docs/concepts/correlation-vs-idempotency.mdx
@@ -1,0 +1,63 @@
+---
+title: 'Correlation vs idempotency'
+description: 'Two keys that look alike but answer different questions — an idempotency key decides what makes two attempts the same write, a correlation/trace id identifies one request for logs and spans — and why they stay separate fields.'
+---
+
+A write can carry two different ids, and they are easy to confuse: an **idempotency
+key** so a server collapses a duplicate, and a **correlation / trace id** so logs and
+spans can find the request. Reach for this distinction whenever you're deciding which
+header carries which — because routing one through the other quietly fails.
+
+## Why it's shaped this way
+
+The two keys answer different questions:
+
+|                                      | **Idempotency key**                | **Correlation / trace id**          |
+| ------------------------------------ | ---------------------------------- | ----------------------------------- |
+| Question                             | "are these the same _write_?"      | "which _operation_ is this?"        |
+| Server does                          | dedupe / collapse the replay       | log it, link spans                  |
+| Stable across retries                | yes (must be)                      | yes (typically)                     |
+| Stable across _separate submissions_ | only if **derived**                | **no** — each call is its own trace |
+| Right value                          | random _or_ derived from the input | the engine's `traceId` / `spanId`   |
+| Standard header                      | `Idempotency-Key`                  | `traceparent`, `X-Request-Id`       |
+
+They share exactly one property — "stable across a call's retries" — which is why a
+random idempotency key _feels_ like a request id. But their semantics diverge the moment
+you look past that:
+
+-   An idempotency key is sometimes **derived** from the input, so two _separate_
+    submissions (a double-clicked button) collapse into one write. A correlation id is the
+    opposite: you want each submission to stay **distinct** in the logs.
+-   A correlation id wants to **be** the trace id, so the line a server logs joins the
+    spans you already export. An idempotency key has no such tie — a random uuid is fine,
+    because all it needs to be is _the same_ across one write's attempts.
+
+So one field can't serve both. The idempotency `header` option renames the key a server
+**dedupes** on — nothing more. A correlation id belongs to tracing, where its value is
+your [run's trace id](/docs/concepts/run-identity).
+
+## How it relates
+
+**The tempting shortcut that breaks.** Setting `idempotency.header` to `X-Request-Id` to
+"also get a request id" pushes a correlation header through the dedupe machinery. It
+looks like tracing without being it: the random idempotency key is unrelated to your
+real `traceId`, so the `X-Request-Id` a server logs can never be joined to the spans you
+export. Keep the idempotency header for dedupe; let tracing own correlation.
+
+**Where each lives.** The idempotency key is a write-safety tool — see
+[Idempotency keys](/docs/guides/resilience/idempotency), which pairs it with retries and
+shows when to derive a stable key. The correlation/trace id is a property of
+[run identity](/docs/concepts/run-identity); carrying it to a downstream service on a
+`traceparent` header is planned trace-context propagation, distinct from anything
+idempotency does.
+
+## See also
+
+<Cards>
+    <Card title="Idempotency keys" href="/docs/guides/resilience/idempotency" />
+    <Card
+        title="Run identity & the trace tree"
+        href="/docs/concepts/run-identity"
+    />
+    <Card title="OTLP export" href="/docs/guides/observability/otlp" />
+</Cards>

--- a/apps/docs/content/docs/concepts/meta.json
+++ b/apps/docs/content/docs/concepts/meta.json
@@ -5,6 +5,8 @@
         "the-stitch",
         "the-seam",
         "event-stream",
+        "run-identity",
+        "correlation-vs-idempotency",
         "capability-not-credential",
         "principles"
     ]

--- a/apps/docs/content/docs/concepts/run-identity.mdx
+++ b/apps/docs/content/docs/concepts/run-identity.mdx
@@ -1,0 +1,76 @@
+---
+title: 'Run identity & the trace tree'
+description: 'How a stitch identifies one call and its place in a tree — a shared traceId, the span id (spanId), and a parentSpanId — so composed runs form one OpenTelemetry span tree, and how that maps onto the traceparent header on the wire.'
+---
+
+Every stitch call carries a **run identity**: a shared `traceId`, a span id (`spanId`)
+for the call itself, and a `parentSpanId` when one call spawned another. Reach for this
+model when you want a stitch, the login it runs, and the steps it composes to read
+back as **one tree**, not a flat list of unrelated calls.
+
+## Why it's shaped this way
+
+Three ids, in the OpenTelemetry shape — because a run has to answer two questions at
+once, and one id can't:
+
+-   **`traceId`** — a 32-hex id **shared** by every run in one logical operation. It is
+    not parented; it is the same value everywhere in the tree. Filter by it and you get
+    the whole operation.
+-   **`spanId`** — a 16-hex id for **this** call (the OpenTelemetry span id).
+-   **`parentSpanId`** — the **caller's** `spanId`, set only when one run spawned
+    another. Absent on a root run.
+
+The tree comes from **composition**, not configuration. When a stitch spawns another
+run, the child **inherits** the `traceId` and points its `parentSpanId` at the parent's
+`spanId`. Two paths do this today: a `cookieSession` login runs as a child of the call
+that triggered it, and each step of a `pipe()` is a child of the step before it.
+
+```
+traceId = abc…   (shared by every node below)
+
+[spanId A]                         ← root: a getUser call. parentSpanId = none
+   └─ [spanId B]  parentSpanId = A     ← the cookieSession login it triggered
+[spanId C]                         ← a pipe(): step 1. parentSpanId = none
+   └─ [spanId D]  parentSpanId = C     ← step 2, a child of step 1
+```
+
+A single flat per-call id could say "these are different calls" but never "this login
+happened **inside** that request." The `parentSpanId` is what carries that causality, so
+it has to be its own field alongside `spanId`, not folded into it.
+
+The ids are **engine-minted, never caller-supplied** — a caller-named id would let one
+caller spoof another's identity, the same reason a stitch never takes its principal
+from call input.
+
+## How it relates
+
+**To OpenTelemetry.** The field names _are_ the OTel span names — `traceId`, `spanId`,
+`parentSpanId` — so the OTLP exporter writes them straight through, no translation. It
+reads them as fields and builds the tree; it never guesses structure from timing.
+
+**To the wire.** The W3C `traceparent` header is `version-trace-id-parent-id-flags` —
+one `traceId` + **one** span id + flags. A run needs **two** span ids (its own `spanId`
+_and_ its `parentSpanId`), so `traceparent` is a **projection** of the run identity onto a
+single header, not a replacement for it. The spec's middle field (`parent-id`) is
+directional: it carries the sender's `spanId` going out and becomes the receiver's
+`parentSpanId` coming in, so a downstream server's spans become children under the same
+`traceId`. **Today the tree is in-process** — it covers a stitch and the runs it composes;
+carrying it across the wire so a downstream service joins your trace is planned
+trace-context propagation, not a shipped feature.
+
+**To the two keys.** A run identity is for **observability** — "which call is this, and
+what spawned it?" It is not the idempotency key (which answers "is this the same
+write?"). See [Correlation vs idempotency](/docs/concepts/correlation-vs-idempotency)
+for why those stay separate.
+
+## See also
+
+<Cards>
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+    <Card
+        title="Correlation vs idempotency"
+        href="/docs/concepts/correlation-vs-idempotency"
+    />
+    <Card title="OTLP export" href="/docs/guides/observability/otlp" />
+    <Card title="Trace sinks" href="/docs/guides/observability/trace-sinks" />
+</Cards>

--- a/apps/docs/content/docs/guides/resilience/idempotency.mdx
+++ b/apps/docs/content/docs/guides/resilience/idempotency.mdx
@@ -29,7 +29,7 @@ const createOrder = stitch({
     baseUrl: 'https://api.example.com',
     path: '/orders',
     idempotency: {
-        key: (input) => `order-${(input.body as { ref: string }).ref}`,
+        keyOf: (input) => `order-${(input.body as { ref: string }).ref}`,
     },
 });
 ```
@@ -41,29 +41,41 @@ that call, so a network blip that triggers a retry settles a single charge.
     **Anti-pattern:** don't lean on the default random key to dedupe two
     separate submissions — a double-clicked "Pay" fires two distinct `charge()`
     calls, each with a fresh key, so the server sees two writes and charges
-    twice; derive a stable `key` from something the duplicate submissions share
-    (an order reference, a request id) so both map to one key. See [Reference →
-    Config types](/docs/reference/config-types).
+    twice; derive a stable `keyOf` from something the duplicate submissions
+    share (an order reference, or an id your client mints once per intent) so
+    both map to one key. See [Reference → Config
+    types](/docs/reference/config-types).
 </Callout>
 
 ## Options
 
 `header` is the header name the key rides on, default `'Idempotency-Key'`. Set
-it when the API expects a different header.
+it when the API expects a different name (`'Idempotency-Token'`, a vendor-prefixed
+`'X-Idempotency-Key'`). It renames the idempotency key — the value the server
+_dedupes_ on — not a correlation or trace header like `traceparent`/`X-Request-Id`,
+which identify a request for logs and spans and belong to tracing, not dedupe.
 
-`key` builds the key from the call's [`StitchInput`](/docs/reference/config-types)
+`keyOf` builds the key from the call's [`StitchInput`](/docs/reference/config-types)
 (`params`, `query`, `body`, `headers`, `variables`). The default is a random
-uuid generated once per logical call; a custom `key` lets you derive a stable
+uuid generated once per logical call; a custom `keyOf` lets you derive a stable
 key from the request — for example an order reference — so the same logical
 write maps to the same key. `body` is typed `unknown`, so narrow or cast it
 before reading a property, as the `createOrder` example does.
 
-Why it matters: idempotency only pays off alongside [retries](/docs/guides/resilience/retry).
-A retried write replays the same key, so the server can recognize the duplicate
-and skip the side effect — safe retries don't double-charge.
+Why it matters: idempotency pairs most naturally with [retries](/docs/guides/resilience/retry) —
+a retried write replays the same key, so the server recognizes the duplicate and
+skips the side effect, and safe retries don't double-charge. It isn't only for
+retries, though: the same key also covers a duplicate the stitch never issued (a
+proxy or the transport resending the request), and a derived `keyOf` dedupes two
+separate submissions with no retry at all.
+
+Because the random default key mostly earns its keep alongside a retry, declaring
+it on a write with **no** `retry` logs a one-time construction nudge pointing you
+at `retry` (or a derived `keyOf`). It's a hint, not an error — set `warn: false`
+to silence it when the keyless-retry case (a proxy dedupe, say) is deliberate.
 
 <Callout type="warn">
-    A custom `key` derived from `body` must be stable for a given logical call
+    A custom `keyOf` derived from `body` must be stable for a given logical call
     and unique across distinct ones — colliding keys make the server dedupe two
     different writes into one.
 </Callout>

--- a/apps/docs/content/docs/recipes/idempotent-writes.mdx
+++ b/apps/docs/content/docs/recipes/idempotent-writes.mdx
@@ -24,7 +24,7 @@ const createOrder = stitch({
     retry: { attempts: 3, on: [429, 503] },
     idempotency: {
         // body is unknown, so narrow it before reading a property.
-        key: (input) => `order-${(input.body as { ref: string }).ref}`,
+        keyOf: (input) => `order-${(input.body as { ref: string }).ref}`,
     },
 });
 
@@ -36,13 +36,13 @@ const order = await createOrder({ body: { ref: 'inv-1001' } });
 Each logical call carries a stable `Idempotency-Key` header. When
 [`retry`](/docs/guides/resilience/retry) replays the write, the server sees the
 same key and dedupes the side effect instead of running it twice. The default
-key is a random uuid generated once per call — already retry-safe; a custom
-`key` derives a stable value from the
+key is a random uuid generated once per call — already retry-safe; `keyOf` derives a stable value from the
 [input](/docs/reference/config-types) (here the order ref) so the same logical
-write always maps to the same key. Idempotency only pays off alongside retries.
+write always maps to the same key — which collapses two separate submissions
+(a double-click) even with no retry in play.
 
 <Callout type="warn">
-    A derived `key` must be stable for a given logical call and unique across
+    A derived `keyOf` must be stable for a given logical call and unique across
     distinct ones — colliding keys make the server dedupe two different writes
     into one.
 </Callout>

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -368,6 +368,32 @@ state is a pluggable `StitchStore`; observability is any `TraceSink`; auth is an
 `AuthStrategy`; validation is any Standard-Schema `Validator`; and every stitch composes
 via `extends` fragments. A new capability that exposes none of these is the violation.
 
+### P22 · A standards-interop contract uses the standard's field names
+
+When one of StitchAPI's **own** contracts exists to interoperate with an external standard
+— it round-trips to that standard's wire format or object model — its fields **MUST** use
+that standard's names, not a house alias, even though [P18](#p18--adapter-mirrors-keep-upstream-spelling-house-contracts-use-house-vocabulary)
+would otherwise let a normalized house contract pick its own vocabulary. P18's "house
+vocabulary" exists for one consistent _internal_ language; it does **not** license renaming
+a field whose entire job is to carry that standard's value. Match the standard's token
+(house casing per our convention) so the export is an **identity mapping** with no
+translation seam. As with P18, follow the standard that governs **each** layer and convert
+at the edge — never blend two standards' vocabularies in one place.
+
+_Why:_ a private alias on an interop field is paid for twice — a translation step at the
+boundary where it meets the standard, and a lookup for every reader who knows the standard
+but not our word for it. P18 keeps duck-type mirrors **structurally** matching; P22 keeps
+value-level interop contracts **nominally** matching, for the same reason.
+
+_Canonical case:_ `RunContext` is StitchAPI's run identity, exported verbatim as
+OpenTelemetry spans (ADR 0007). Its fields were `runId`/`parentId` (house aliases) →
+renamed to **`spanId`/`parentSpanId`** (`traceId` already matched), so the `otlp.ts`
+mapping is an identity and `parentId`'s collision with W3C's directional `parent-id` header
+field is gone. The **wire** side still follows its own standard — W3C Trace Context
+(`trace-id`/`parent-id`/`trace-flags`) — translated at the boundary, never blended. See
+[ADR 0017 Decision 7](adr/0017-outbound-trace-context-propagation.md) and the
+`concepts/run-identity` page.
+
 ---
 
 ## 6. Migration backlog (proposed renames — confirm during sweep)

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -228,7 +228,7 @@ v1.0 release candidate, zero runtime deps). Full gate green — eslint, prettier
     backoff).
 -   **Non-HTTP surfaces** — `llm` and `shell` as symmetric kinds, plus `pipe()` to compose
     heterogeneous stitches with one causal trace across the chain (ADR 0008).
--   **Composition causality** — a run-identity OTLP span tree (`runId` / `traceId` / `parentId`):
+-   **Composition causality** — a run-identity OTLP span tree (`spanId` / `traceId` / `parentSpanId`):
     retries and pages are child spans with their own latency/outcome (ADR 0007).
 -   **Observability** — console / JSONL / OTLP, secret redaction, **off by default**.
 -   **Four surfaces, one definition** — in-process function · CLI (`stitch run`/`trace`/`export`/`diagram`) ·

--- a/docs/adr/0007-composition-causality-and-run-identity.md
+++ b/docs/adr/0007-composition-causality-and-run-identity.md
@@ -8,6 +8,10 @@
 >
 > The four open questions are now **resolved** (review of PR #163, recorded below). The guiding principle the review set: **trace richly, for OTLP operators analysing real traffic** — every retry, page, login, and composed step is visible, with per-iteration performance, not just a flat per-call stream. This is FOUNDATIONAL for #7's `pipe()` ([ADR 0008](./0008-non-http-surfaces-and-pipe.md)), so it lands first.
 
+> [!IMPORTANT]
+>
+> **Amendment — `RunContext` field names aligned to OpenTelemetry.** This ADR was written with `runId` / `parentId`; the fields were since renamed to the OTel-canonical **`spanId`** / **`parentSpanId`** (`traceId` was already canonical), so the internal struct, the `start`-event fields, and the OTLP export all use the same names and the exporter's mapping is an identity. Read `runId` as `spanId` and `parentId` as `parentSpanId` throughout the text below. Rationale and the "wire form is a projection, not a replacement" rule live in [ADR 0017 Decision 7](./0017-outbound-trace-context-propagation.md); the reader-facing explainer is [concepts/run-identity](../../apps/docs/content/docs/concepts/run-identity.mdx).
+
 ## Context
 
 A stitch's events are a **flat per-call stream**: `start → progress* → (info|drift|delta)* → result|error → done` (`StitchEvent`, [`types.ts`](../../packages/core/src/types.ts)), drained/teed to the trace sink in `tee()` ([`stitch.ts`](../../packages/core/src/stitch.ts)). Each `execute()` ([`engine.ts`](../../packages/core/src/engine.ts)) is **one logical run**, and the stream carries no notion of one run having spawned another, nor of structure _within_ a run.

--- a/docs/adr/0017-outbound-trace-context-propagation.md
+++ b/docs/adr/0017-outbound-trace-context-propagation.md
@@ -1,0 +1,165 @@
+# ADR 0017 — Outbound trace-context propagation: correlation is not idempotency
+
+-   **Status:** Proposed
+-   **Date:** 2026-06-29
+-   **Tags:** observability, tracing, traceparent, w3c-trace-context, propagation, correlation, idempotency, browser-first
+
+> [!NOTE]
+>
+> The load-bearing decision is a **separation**, not a feature: an _idempotency
+> key_ and a _correlation/trace id_ answer different questions and only
+> coincidentally share "stable across a call's retries". Give correlation its own
+> **outbound** door that reuses the engine's existing `traceId` — instead of
+> overloading [`idempotency.header`](../../packages/core/src/types.ts), which sends a
+> value that can never line up with the spans the OTLP sink already exports.
+
+## Context
+
+[ADR 0007](./0007-composition-causality-and-run-identity.md) mints an OTel-shaped
+run identity — `traceId` (shared across a tree), `spanId` (this run), `parentSpanId` —
+**engine-minted, never caller-supplied**, and exports it to OTLP. But that identity
+**never reaches the wire**: the request a stitch makes carries no `traceparent`, so
+a downstream server cannot continue the client's trace tree. ADR 0007 explicitly
+reserved the _inbound_ `traceparent` continuation as "a separate opt-in future
+feature"; the symmetric **outbound emit is simply unbuilt**.
+
+Because of that gap, the only way to put a per-request id on the wire today is to
+**repurpose `idempotency.header`** — set it to `X-Request-Id` and let the random
+idempotency key double as a request id. That conflates two distinct concerns:
+
+|                                      | **Idempotency key**           | **Correlation / trace id**          |
+| ------------------------------------ | ----------------------------- | ----------------------------------- |
+| Question                             | "are these the same _write_?" | "which _operation_ is this?"        |
+| Server does                          | dedupe / collapse the replay  | log it, link spans                  |
+| Stable across retries                | yes (must be)                 | yes (typically)                     |
+| Stable across _separate submissions_ | only if **derived**           | **no** — each call is its own trace |
+| Right value                          | random _or_ derived           | the engine's `traceId` / `spanId`   |
+| Standard header                      | `Idempotency-Key`             | `traceparent`, `X-Request-Id`       |
+
+The codebase already draws this line in one place and blurs it in another: the
+cache's volatile-header denylist ([`cache.ts`](../../packages/core/src/cache.ts))
+classifies `traceparent` / `x-request-id` / `x-correlation-id` as correlation
+headers excluded from the derived key — while the idempotency docs teach
+`header: 'X-Request-Id'` as a rename. The workaround is also _wrong on its own
+terms_: the random idempotency key is unrelated to the real `traceId`, so the
+`X-Request-Id` a server logs can never be joined to the spans StitchAPI exports.
+
+**Current state (audited).** The in-process tree is **live, with no dead code**:
+`newRunContext(parent)` ([`util.ts`](../../packages/core/src/util.ts)) inherits the
+`traceId` and sets `parentSpanId` for the two paths that spawn children — a `pipe()`
+step (each a child of the prior) and a `cookieSession` login (a child of the
+caller) — and [`otlp.ts`](../../packages/core/src/otlp.ts) reads
+`traceId`/`spanId`/`parentSpanId` as `traceId`/`spanId`/`parentSpanId`. Every field is
+consumed. What is absent is purely the **wire projection, in both directions**:
+nothing formats a `traceparent` onto the outbound request (this ADR), and nothing
+parses an inbound one (ADR 0007's reserved continuation). So the tree is real but
+**stops at the process boundary** today — it does not yet link to a downstream
+server's spans.
+
+## Decision (proposed)
+
+**Add opt-in outbound trace-context propagation that emits the run's
+engine-minted identity on the outbound request, as a field distinct from
+`idempotency`. `idempotency` reverts to meaning only "the key a server dedupes
+on".**
+
+1.  **W3C `traceparent` is the default carrier.** Build it from the run's
+    `traceId` + `spanId` + sampled flag, so a downstream server continues
+    **the same trace tree** the OTLP sink ([`otlp.ts`](../../packages/core/src/otlp.ts))
+    already emits — the outbound header and the exported span agree by construction.
+    `tracestate` is carried through when present.
+
+2.  **A configurable correlation header, for systems that don't speak W3C.**
+    Some infrastructure keys on `X-Request-Id` / `X-Correlation-Id` rather than
+    `traceparent`; allow naming one, carrying the same `traceId` (or `spanId`). This
+    is the legitimate version of the workaround — same intent, but the value is the
+    real trace id and it travels through the propagation door, not the dedupe door.
+
+3.  **Off by default, and host-scoped when on — a policy, not a blanket switch.**
+    Nothing is emitted unless propagation is configured, and configuring it names
+    _which hosts_ receive the headers (an allowlist, or a predicate on the resolved
+    URL), never a global "emit to everything". A correlation id is **low-sensitivity**
+    — an opaque random token, not a secret like a bearer token — so this is _not_ the
+    fail-closed auth posture; the scoping exists for two milder reasons: (a) sending
+    the same `traceId` to several third parties lets them correlate your traffic, and
+    (b) spraying W3C trace headers at APIs that don't speak them is noise.
+    Default-when-enabled = only the hosts you name (typically your own services); a
+    third-party API (Stripe, OpenAI) gets nothing unless you opt it in. This mirrors
+    ADR 0007's reserved inbound continuation and the "a stitch's only effect is its
+    call" posture.
+
+4.  **Ids stay engine-minted and unforgeable.** No caller-supplied trace/correlation
+    id (a caller-named id spoofs correlation — the same reasoning that keeps
+    `principal` off `StitchInput` in [ADR 0002](./0002-seam-primitive-and-principal-scoped-auth.md)
+    and run ids engine-minted in ADR 0007). Browser-safe — reuses `otlp.ts#hex`,
+    no `node:*`, no `AsyncLocalStorage`.
+
+5.  **Built on the request path, beside `applyIdempotency`, but a separate seam.**
+    The two never share a field again. `idempotency.header` keeps its narrowed
+    meaning; propagation owns `traceparent` / the correlation header.
+
+6.  **One child span per retry on the wire — the deliberate asymmetry with the key.**
+    Across a write's retries the idempotency key stays **fixed** ("same write"), but
+    the `traceparent` does **not**: each attempt mints a child span (ADR 0007 already
+    models retries as iterations), so the downstream trace shows every attempt. The
+    two answer different questions — the key, "is this the same write?"; the span,
+    "which attempt is this?" — so they _should_ diverge across a retry, not match.
+
+7.  **The wire form is a projection of the run identity, never a replacement for it.**
+    `traceparent` packs `traceId` + **one** span id + flags; a `RunContext` needs
+    `traceId` + **two** span ids — its own `spanId` _and_ its `parentSpanId` — to both
+    place itself in the OTLP tree and parent its children. The middle field of
+    `traceparent` is directional: it is the sender's `spanId` going out and becomes the
+    receiver's `parentSpanId` coming in, so one header can hold _either_ `(traceId, spanId)`
+    _or_ `(traceId, parentSpanId)`, never all three. The engine therefore keeps the
+    three-field `RunContext` struct as the source of truth and **derives** a
+    `traceparent` from it on the way out (`traceId` + `spanId` + flags); the reserved
+    inbound continuation **parses** one into a seed (`traceId` + `parentSpanId`, then a
+    fresh `spanId`). Do not collapse the struct into a single stored `traceparent` — it
+    drops one of the two span ids and silently breaks child-span parenting, and
+    `otlp.ts` reads all three as fields, not substrings.
+
+## Consequences
+
+-   `idempotency.header` documents cleanly as "rename the idempotency key" — the
+    docs de-conflation (blog `idempotency-keys-safe-retries`, guide
+    `resilience/idempotency`, recipe `idempotent-writes`) lands ahead of this ADR
+    and stops teaching the mix.
+-   Correlation gets a first-class, **trace-aligned** door: the id on the wire is
+    the id in the user's traces, so client and server spans actually join.
+-   With correlation moved here, `idempotency` is unambiguously about dedupe — so
+    the idempotency feature's construction nudge (a random key with no `retry`
+    usually has nothing to collapse) no longer has "but it's my request id" as a
+    counter-argument: that need is served by this door instead, and the nudge stays
+    silenceable (`idempotency.warn = false`) for the narrow proxy-dedupe case.
+-   New surface + bytes on an opt-in path. Measure against the core bundle budget
+    ([`bundle-size.mjs`](../../packages/core/scripts/bundle-size.mjs)); if it doesn't
+    fit the hot path, ship it behind a `stitchapi/trace` subpath like cache / sse —
+    propagation is a tracing concern and consumers who don't opt in shouldn't pay
+    for it.
+
+## Open questions
+
+-   **Header set:** `traceparent` only, or also a configurable correlation header
+    in the first cut?
+-   **Policy shape:** a host allowlist (simplest), a predicate on the resolved URL
+    (most flexible), or both? And does it live on `trace` config, a dedicated
+    `propagation` block, or the `seam`?
+-   **Home:** core hot path vs a `stitchapi/trace` subpath, given the bundle budget.
+-   **Pair with inbound?** ADR 0007's reserved inbound `traceparent` continuation
+    is the mirror of this; decide whether they land together.
+-   **Fan-out into separate traces.** `traceparent` only links a child to its direct
+    caller in the _same_ trace. When one initiator spawns work that runs as its own
+    trace (a queue job, a batch, an async webhook with a fresh `traceId`), parent-child
+    can't join them — that's OTel **span links** (explicit references to other
+    spanContexts), which neither this ADR nor ADR 0007 models. Out of scope here;
+    recorded so propagation isn't mistaken for covering it.
+
+## Alternatives considered
+
+-   **Keep overloading `idempotency.header`.** Rejected: conflates dedupe with
+    correlation, and the random key can never equal the `traceId`, so it never
+    correlates with the spans StitchAPI exports — it _looks_ like tracing without
+    being it.
+-   **Caller-supplied correlation id on `StitchInput`.** Rejected: ids must be
+    engine-minted and unforgeable (ADR 0002 principal, ADR 0007 run identity).

--- a/docs/sandbox/runtime/trace-collector.test.ts
+++ b/docs/sandbox/runtime/trace-collector.test.ts
@@ -36,7 +36,7 @@ function fakeCore(opts: {
     events: () => any[];
     value?: unknown;
     onConfig?: (config: any) => void;
-    runId?: string;
+    spanId?: string;
 }): (config: unknown) => unknown {
     return (config: any) => {
         opts.onConfig?.(config);
@@ -46,10 +46,10 @@ function fakeCore(opts: {
         const name = config.name ?? config.path ?? 'stitch';
         return (_input?: unknown) => {
             // Mimic the real engine `tee` (ADR 0007): one run identity per call, on the ctx of
-            // EVERY event. The collector keys entries by `ctx.runId`.
+            // EVERY event. The collector keys entries by `ctx.spanId`.
             const ctx = {
                 name,
-                runId: opts.runId ?? 'run-1',
+                spanId: opts.spanId ?? 'run-1',
                 traceId: 'trace-1',
             };
             for (const ev of opts.events()) sink.handle(ev, ctx);
@@ -375,12 +375,12 @@ async function runTests(): Promise<void> {
         );
     }
 
-    /* 9 — a CHILD run (parentId) becomes a dependsOn edge, even interleaved --- */
+    /* 9 — a CHILD run (parentSpanId) becomes a dependsOn edge, even interleaved --- */
     {
         // The cookieSession login case: a child run's events arrive on the SAME sink, NESTED
         // inside the parent's (start parent → start/result/done child → result/done parent). The
         // run-id keying must attribute each event to the right entry (a FIFO would not) and turn
-        // the child's parentId into a `dependsOn` edge (ADR 0007).
+        // the child's parentSpanId into a `dependsOn` edge (ADR 0007).
         const events: RunEvent[] = [];
         let dag!: { handle: (e: any, ctx: any) => void };
         const collector = createTraceCollector(
@@ -388,12 +388,12 @@ async function runTests(): Promise<void> {
         );
         collector.bindProgress((e) => events.push(e));
         collector.stitch({ name: 'parent' }); // realize the dag sink via onConfig
-        const parent = { name: 'parent', runId: 'p1', traceId: 't1' };
+        const parent = { name: 'parent', spanId: 'p1', traceId: 't1' };
         const child = {
             name: 'login',
-            runId: 'c1',
+            spanId: 'c1',
             traceId: 't1',
-            parentId: 'p1',
+            parentSpanId: 'p1',
         };
         dag.handle(startEv({ name: 'parent' }), parent);
         dag.handle(startEv({ name: 'login' }), child); // child opens mid-parent

--- a/docs/sandbox/runtime/trace-collector.ts
+++ b/docs/sandbox/runtime/trace-collector.ts
@@ -20,7 +20,7 @@
  * guesswork — and the handler never throws.
  *
  * Scope: nodes render from real runs, and runtime-causality EDGES (`dependsOn`) now populate from
- * the `parentId` core stamps on a child run's ctx (ADR 0007) — a cookieSession login (or, later, a
+ * the `parentSpanId` core stamps on a child run's ctx (ADR 0007) — a cookieSession login (or, later, a
  * `pipe()` step) draws a parent → child edge. The STATIC `extends` composition graph is a separate
  * axis core deliberately does not emit (ADR 0007 Q4, out of scope).
  */
@@ -132,16 +132,16 @@ export function createTraceCollector(
     const makeDagSink = (): TraceSink => {
         const open = new Map<string, OpenEntry>();
         const find = (ctx: TraceContext): OpenEntry | undefined =>
-            ctx.runId ? open.get(ctx.runId) : undefined;
+            ctx.spanId ? open.get(ctx.spanId) : undefined;
         return {
             handle(event: StitchEvent, ctx: TraceContext): void {
                 switch (event.type) {
                     case 'start': {
-                        const id = ctx.runId ?? `stitch-${(counter += 1)}`;
+                        const id = ctx.spanId ?? `stitch-${(counter += 1)}`;
                         open.set(id, {
                             id,
-                            ...(ctx.parentId !== undefined
-                                ? { parentId: ctx.parentId }
+                            ...(ctx.parentSpanId !== undefined
+                                ? { parentId: ctx.parentSpanId }
                                 : {}),
                             label: ctx.name,
                             method: event.method,
@@ -186,8 +186,8 @@ export function createTraceCollector(
                     }
                     case 'done': {
                         const e = find(ctx);
-                        if (e && ctx.runId) {
-                            open.delete(ctx.runId);
+                        if (e && ctx.spanId) {
+                            open.delete(ctx.spanId);
                             activeSink?.({
                                 type: 'trace',
                                 entry: finalize(e, event.ok, event.ms),

--- a/packages/core/scripts/bundle-size.mjs
+++ b/packages/core/scripts/bundle-size.mjs
@@ -76,16 +76,26 @@ const KB = 1024;
 // since #362). Neither wave can move to a subpath — composition and the renamed
 // result/throttle/circuit surfaces are the core API. The step restores the same
 // tight ~0.2 KB headroom the gate is meant to hold.
+//
+// Budgets raised for the idempotency-misuse nudges + the OTLP-name alignment (23.35→23.55 /
+// 18.80→19.0 KB; measured 23.32 / 18.80). Stacking on the wave above, two more things land on the core
+// path and can't move to a subpath: (1) two construction-time `idempotency` nudges in
+// `makeStitch` — on a read (the key is write-only, so it's silently dropped — almost always a
+// missing `method: 'POST'`) and on a random key with no `retry` (it only dedupes the call's own
+// retries), both silenced by `idempotency.warn = false`; and (2) the run-identity rename to the
+// OTel span names (`runId`→`spanId`, `parentId`→`parentSpanId`, CONTRACT.md P22), whose longer
+// public property names are emitted verbatim on every `start` event / trace ctx and can't be
+// minified. The step restores the same tight ~0.2 KB headroom the gate is meant to hold.
 const SCENARIOS = [
     {
         name: 'stitchapi — whole entry',
         code: `export * from './index.mjs';`,
-        budget: 23.35 * KB,
+        budget: 23.55 * KB,
     },
     {
         name: 'import { stitch }',
         code: `export { stitch } from './index.mjs';`,
-        budget: 18.8 * KB,
+        budget: 19.0 * KB,
     },
 ];
 

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -121,7 +121,7 @@ function emitInto(
     return {
         ...authCtx,
         // The current run (ADR 0007) so a strategy that spawns a sub-call — `cookieSession`'s
-        // login — can run it as a CHILD of this run (parentId = run.runId).
+        // login — can run it as a CHILD of this run (parentSpanId = run.spanId).
         run,
         emit: (topic, detail) =>
             sink.push(
@@ -1028,9 +1028,9 @@ const startEvt = (
         url: baseReq.url,
         input,
         at: now(),
-        runId: run.runId,
+        spanId: run.spanId,
         traceId: run.traceId,
-        parentId: run.parentId,
+        parentSpanId: run.parentSpanId,
     });
 
 const cacheEvt = (detail: string): StitchEvent => ({
@@ -1605,7 +1605,7 @@ export async function* execute(
     input: StitchInput = {},
     // Run identity (ADR 0007). Defaults to a fresh root run; the caller supplies one to make
     // this a CHILD run — `newRunContext(parent)` inherits the parent's `traceId` and sets
-    // `parentId` (a `cookieSession` login, a `linked` step). Stamped on the `start` event and
+    // `parentSpanId` (a `cookieSession` login, a `linked` step). Stamped on the `start` event and
     // carried onto the trace-sink ctx by `tee` (stitch.ts).
     run: RunContext = newRunContext(),
     // Per-call run flags (ADR 0016), set by `.inspect()`: `retainRaw` surfaces the pre-validation
@@ -1728,7 +1728,7 @@ export async function executeRaw(
 /**
  * Like {@link executeRaw}, but TEES the run's events to `sink` as a CHILD run (ADR 0007) and
  * returns the raw response. `cookieSession` uses it to run its login as a traced child of the call
- * that triggered it (`run.parentId` = the caller's runId), so the login is no longer an invisible
+ * that triggered it (`run.parentSpanId` = the caller's spanId), so the login is no longer an invisible
  * side-call. The login's `result` carries only its **status** — never the (sensitive) login body —
  * and any `throttled`/`retry`/`info` events from the login's own attempts are teed through.
  */
@@ -1744,9 +1744,9 @@ export async function executeRawTraced(
     const state = { attempts: 0 };
     const ctx = compact({
         name,
-        runId: run.runId,
+        spanId: run.spanId,
         traceId: run.traceId,
-        parentId: run.parentId,
+        parentSpanId: run.parentSpanId,
     });
     const baseReq = buildRequest(cfg, input);
     sink.handle(startEvt(name, baseReq, input, run), ctx);

--- a/packages/core/src/otlp.ts
+++ b/packages/core/src/otlp.ts
@@ -169,7 +169,7 @@ export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
             const name = ctx.name;
             // Correlate by run id (ADR 0007) — each run is unique, so no name-stack is needed;
             // fall back to the name when a sink is fed events by hand without ids.
-            const key = ctx.runId ?? name;
+            const key = ctx.spanId ?? name;
             switch (event.type) {
                 case 'start': {
                     // url.full is OTLP's only secret-bearing attribute (it never exports
@@ -188,8 +188,8 @@ export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
                             // Read the engine-minted ids off the ctx (real trace tree); fall back to
                             // freshly-minted ids for a hand-fed sink with no run identity.
                             traceId: ctx.traceId ?? hex(16),
-                            spanId: ctx.runId ?? hex(8),
-                            parentSpanId: ctx.parentId,
+                            spanId: ctx.spanId ?? hex(8),
+                            parentSpanId: ctx.parentSpanId,
                             startUnixMs: event.at,
                             endUnixMs: event.at,
                             attributes,

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -189,6 +189,38 @@ export function compose(config: Fragment): ResolvedStitchConfig {
     return merged as ResolvedStitchConfig;
 }
 
+// Construction-time nudges for `idempotency` misuse — hints with an out, never errors. Two cases,
+// both silenced by `idempotency.warn = false` and both scoped to the **default HTTP surface**: a
+// surface (graphql → POST) can force the method after construction, so its writes aren't knowable
+// here, and we don't guess.
+//   1. On a read (GET/HEAD) the engine drops the key (writes only) — almost always a missing
+//      `method`, so the write protection the author expects silently isn't there.
+//   2. The *random* default key only dedupes a replay of the same request, and `retry` is what
+//      replays it; with no `retry` it usually has nothing to collapse. (Not useless in every case —
+//      a proxy/transport resending the request below the stitch carries the same key for a server
+//      to dedupe — hence a hint, not an error. A *derived* `keyOf` dedupes resubmissions on its own.)
+function warnIdempotency(cfg: ResolvedStitchConfig): void {
+    const idem = cfg.idempotency;
+    if (!idem || idem.warn === false || cfg.kind) return;
+    const name = cfg.name ?? cfg.path ?? 'stitch';
+    const method = (cfg.method ?? 'GET').toUpperCase();
+    if (method === 'GET' || method === 'HEAD') {
+        console.warn(
+            `stitchapi: \`${name}\` sets \`idempotency\` on a ${method}, but the key is sent on ` +
+                `writes only — set \`method: 'POST'\`, or drop \`idempotency\`.`,
+        );
+        return;
+    }
+    // A derived key (either spelling — `keyOf`, or the @deprecated `key` alias) dedupes
+    // resubmissions on its own, so only the random default with no retry is the inert case.
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `key` is the back-compat alias of `keyOf` (CONTRACT.md P6)
+    if (idem.keyOf || idem.key || cfg.retry) return;
+    console.warn(
+        `stitchapi: \`${name}\` has \`idempotency\` with a random key and no \`retry\`, so it ` +
+            `only dedupes its own retries — add \`retry\`, or set \`idempotency.keyOf\`.`,
+    );
+}
+
 // ---- the trace sink — off by default (a stitch's only effect is its call) ------
 // Nothing is printed or written unless you opt in: STITCH_TRACE_CONSOLE=1 streams a
 // colored line per event to stderr, STITCH_TRACE_FILE=<path> appends JSONL, and
@@ -425,9 +457,9 @@ function tee<T>(
     // the span tree; a sink that reads only `ctx.name` is unaffected.
     const ctx = compact({
         name,
-        runId: run.runId,
+        spanId: run.spanId,
         traceId: run.traceId,
-        parentId: run.parentId,
+        parentSpanId: run.parentSpanId,
     });
     async function* wrapped() {
         for await (const ev of gen) {
@@ -541,6 +573,7 @@ export function makeStitch<T = unknown>(
     shared?: SharedRuntime,
 ): Stitch<T> {
     const cfg = compose(config);
+    warnIdempotency(cfg);
     // A seam injects shared instances; a standalone stitch builds its own (unchanged behaviour:
     // a store-backed throttle only when a `store` is configured, else the in-process limiter).
     const store = shared?.store ?? cfg.store ?? memoryStore();
@@ -561,7 +594,7 @@ export function makeStitch<T = unknown>(
 
     // One traced run for `input` under a given run identity (ADR 0007). `streamFn` mints a fresh
     // ROOT run per consumption; composition (`linked`/`all`, stitchapi/pipe) supplies a CHILD run via
-    // `__runWith`, so a step joins the scope's chain (its events tee with parentId set).
+    // `__runWith`, so a step joins the scope's chain (its events tee with parentSpanId set).
     const streamWith = (
         input: StitchInput,
         run: RunContext,
@@ -667,7 +700,7 @@ export function makeStitch<T = unknown>(
     };
     stitchFn.__raw = (input?: StitchInput) => executeRaw(rt, input ?? {});
     // Traced login child-run (ADR 0007): cookieSession reaches this to run its login under the
-    // caller's run. `newRunContext(parent)` inherits the parent's traceId + sets parentId.
+    // caller's run. `newRunContext(parent)` inherits the parent's traceId + sets parentSpanId.
     stitchFn.__rawTraced = (input, parent) =>
         executeRawTraced(rt, input ?? {}, rt.trace, newRunContext(parent));
     // Run this stitch under a supplied run identity (ADR 0007) and resolve to its value — `linked`

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -338,12 +338,36 @@ export interface CircuitOptions {
     /** Store namespace to share a breaker across stitches (default: stitch/host key). */
     key?: string;
 }
+/**
+ * Inject an idempotency token on writes so a server can collapse a duplicate. The default key is a
+ * random uuid minted **once per logical call** and reused across that call's retries — it makes a
+ * {@link RetryOptions | retry} safe to attempt. Because the random key only dedupes a replay of the
+ * *same* request, it pairs with `retry` (the retry is the duplicate it absorbs); declaring it on a
+ * write with **no** `retry` logs a one-time construction nudge, since it usually has nothing to
+ * collapse. It isn't strictly useless without one — a proxy or the transport resending the request
+ * below the stitch carries the same key for a server to dedupe — so the nudge has an out: set
+ * `warn: false` to silence it.
+ *
+ * To collapse two *separate* submissions of the same write — a double-clicked button — give `keyOf`
+ * and derive the token from something the duplicates share. A derived key dedupes submissions
+ * server-side without any retry, so it stands on its own (and is never nudged).
+ *
+ * `header` renames the idempotency key — the value the server *dedupes* on. It is not a place to
+ * set a correlation/trace header like `traceparent` or `X-Request-Id`; those identify a request
+ * for logs and spans and belong to tracing, not dedupe.
+ *
+ * The key is sent on **writes only**; setting `idempotency` on a read (GET/HEAD) drops it and logs
+ * a construction nudge — almost always a missing `method: 'POST'`. Both nudges fire only on the
+ * default HTTP surface and are silenced by `warn: false`.
+ */
 export interface IdempotencyOptions {
     header?: string; // header name (default 'Idempotency-Key')
     /** Derive a stable key per logical call (default: a random uuid). Renamed from `key` (CONTRACT.md P6: `key` is a string, a derivation fn is `keyOf`). */
     keyOf?: (input: StitchInput) => string;
     /** @deprecated Renamed to {@link IdempotencyOptions.keyOf} (CONTRACT.md P6). Read until the 1.0 GA cut. */
     key?: (input: StitchInput) => string;
+    /** false silences the "idempotency without retry" / "idempotency on a read" construction nudge. */
+    warn?: boolean;
 }
 
 // ---- Cache (ADR 0003) -----------------------------------------------------
@@ -531,9 +555,9 @@ export type StitchEvent<T = unknown> =
           // Run identity (ADR 0007) — also delivered on the {@link TraceContext} ctx. Stamped
           // here too so a non-sink `.stream()` consumer can read a run's identity off its first
           // event. Optional: a `start` event built by hand (tests) may omit them.
-          runId?: string;
+          spanId?: string;
           traceId?: string;
-          parentId?: string;
+          parentSpanId?: string;
       }
     | {
           type: 'progress';
@@ -1040,17 +1064,18 @@ export function isSeam(x: unknown): x is Seam {
 // ---- Run identity (ADR 0007) ----------------------------------------------
 /**
  * OTLP-aligned identity for one logical call ({@link Stitch} run) and its place in a run
- * tree. `runId` is the OTel **spanId**; `traceId` is shared across a whole tree; `parentId`
- * (the OTel **parentSpanId**) is set when one run spawns another — a `cookieSession` login,
- * a `linked` step. Minted by the engine (`newRunContext`), never supplied by a caller.
+ * tree. The field names are the OpenTelemetry span names verbatim: `traceId` is shared across a
+ * whole tree, `spanId` identifies this run, and `parentSpanId` is set when one run spawns another —
+ * a `cookieSession` login, a `linked` step. Minted by the engine (`newRunContext`), never supplied
+ * by a caller.
  */
 export interface RunContext {
-    /** 32-hex trace id, shared across every run in a tree. */
+    /** 32-hex trace id, shared across every run in a tree (OTel `traceId`). */
     traceId: string;
-    /** 16-hex id for this run (the OTel spanId). */
-    runId: string;
-    /** The spawning run's `runId` (OTel parentSpanId); absent for a root run. */
-    parentId?: string;
+    /** 16-hex id for this run (OTel `spanId`). */
+    spanId: string;
+    /** The spawning run's `spanId` (OTel `parentSpanId`); absent for a root run. */
+    parentSpanId?: string;
 }
 
 /**
@@ -1061,9 +1086,9 @@ export interface RunContext {
  */
 export interface TraceContext {
     name: string;
-    runId?: string;
+    spanId?: string;
     traceId?: string;
-    parentId?: string;
+    parentSpanId?: string;
 }
 
 // A trace sink consumes every event a stitch emits.

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -6,7 +6,7 @@ export const now = (): number => Date.now();
 // ---- run identity (ADR 0007) ----------------------------------------------
 // Browser-safe random hex ids for the OTLP-aligned span tree: crypto.getRandomValues
 // where available, else Math.random (ids need to be unique-ish, not secret). 16 bytes
-// → a 32-hex traceId, 8 bytes → a 16-hex spanId/runId. The lone minter, shared by the
+// → a 32-hex traceId, 8 bytes → a 16-hex spanId. The lone minter, shared by the
 // engine (run identity) and the OTLP sink (its fallback when fed events by hand).
 export function hex(bytes: number): string {
     const buf = new Uint8Array(bytes);
@@ -20,19 +20,19 @@ export function hex(bytes: number): string {
 
 /**
  * Mint a {@link RunContext} for one logical call (ADR 0007). A root run gets a fresh
- * 32-hex `traceId` and a 16-hex `runId`; a child run (a `cookieSession` login, a `linked`
- * step) passes its caller's context to **inherit** the `traceId` and set `parentId` to the
- * caller's `runId`, so runs form one OTLP span tree. Ids are engine-minted, never supplied
+ * 32-hex `traceId` and a 16-hex `spanId`; a child run (a `cookieSession` login, a `linked`
+ * step) passes its caller's context to **inherit** the `traceId` and set `parentSpanId` to the
+ * caller's `spanId`, so runs form one OTLP span tree. Ids are engine-minted, never supplied
  * by a caller (a caller-named id would spoof correlation — ADR 0002 §2 reasoning).
  */
 export function newRunContext(parent?: {
     traceId: string;
-    runId: string;
+    spanId: string;
 }): RunContext {
     return {
         traceId: parent?.traceId ?? hex(16),
-        runId: hex(8),
-        ...(parent ? { parentId: parent.runId } : {}),
+        spanId: hex(8),
+        ...(parent ? { parentSpanId: parent.spanId } : {}),
     };
 }
 

--- a/packages/core/test/combinators.spec.ts
+++ b/packages/core/test/combinators.spec.ts
@@ -194,7 +194,7 @@ test('all: members run as sibling child runs of one parent (trace fan)', async (
         seen.find((s) => s.ctx.name === name && s.ev.type === 'start')!;
     const a = start('a');
     const b = start('b');
-    expect(a.ctx.parentId).toBeDefined();
-    expect(a.ctx.parentId).toBe(b.ctx.parentId); // same parent — the group run
+    expect(a.ctx.parentSpanId).toBeDefined();
+    expect(a.ctx.parentSpanId).toBe(b.ctx.parentSpanId); // same parent — the group run
     expect(a.ctx.traceId).toBe(b.ctx.traceId); // one trace tree
 });

--- a/packages/core/test/gaps/resource-leaks.spec.ts
+++ b/packages/core/test/gaps/resource-leaks.spec.ts
@@ -153,16 +153,16 @@ test('otlp sink: the internal open-span map is empty after a completed run', () 
     });
     const open = probeMap(sink, OPEN_SPANS);
 
-    const ev = (e: StitchEvent, runId: string): void => {
+    const ev = (e: StitchEvent, spanId: string): void => {
         sink.handle(e, {
             name: 'ping',
-            runId,
+            spanId,
             traceId: 'a'.repeat(32),
         });
     };
 
     for (let i = 0; i < 5; i++) {
-        const runId = `run-${i}`;
+        const spanId = `run-${i}`;
         ev(
             {
                 type: 'start',
@@ -172,13 +172,13 @@ test('otlp sink: the internal open-span map is empty after a completed run', () 
                 input: {},
                 at: 0,
             },
-            runId,
+            spanId,
         );
         ev(
             { type: 'result', data: {}, status: 200, attempts: 1, at: 1 },
-            runId,
+            spanId,
         );
-        ev({ type: 'done', ok: true, elapsed: 1, attempts: 1, at: 1 }, runId);
+        ev({ type: 'done', ok: true, elapsed: 1, attempts: 1, at: 1 }, spanId);
     }
 
     expect(open.size).toBe(0);

--- a/packages/core/test/idempotency.spec.ts
+++ b/packages/core/test/idempotency.spec.ts
@@ -1,7 +1,7 @@
 // Idempotency keys: on a write, the stitch injects an Idempotency-Key header that is STABLE
 // for one logical call — the same value rides every retry of that call — so a server can
 // dedupe a retried write. A custom key function derives a deterministic key from the input.
-import { stitch } from '../src';
+import { graphql, stitch } from '../src';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
 
@@ -95,7 +95,7 @@ test('separate logical calls get distinct generated keys', async () => {
         method: 'POST',
         baseUrl: server.url,
         path: '/c',
-        idempotency: true,
+        idempotency: { warn: false }, // random key, no retry by design — silence the nudge
     });
 
     await create({ body: {} });
@@ -107,12 +107,91 @@ test('separate logical calls get distinct generated keys', async () => {
     );
 });
 
+test('nudges when a write pairs the random default key with no retry', () => {
+    // A random key only dedupes a replay of the same request, and `retry` is what replays it. On a
+    // write with no retry it usually has nothing to collapse, so the engine nudges at construction.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+        stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/no-retry',
+            idempotency: true,
+        });
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0]![0]).toContain('idempotency');
+        expect(warn.mock.calls[0]![0]).toContain('retry');
+    } finally {
+        warn.mockRestore();
+    }
+});
+
+test('nudges when idempotency is set on a read — the key is dropped, almost always a missing method', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+        // no method → GET; the engine drops the key on reads, so the author's write protection
+        // silently isn't there. Point at the missing `method`.
+        stitch({ baseUrl: server.url, path: '/read-idem', idempotency: true });
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0]![0]).toContain('writes only');
+        expect(warn.mock.calls[0]![0]).toContain('method');
+    } finally {
+        warn.mockRestore();
+    }
+});
+
+test('the nudge is a hint with an out — silenced, and never fired for the cases that earn the key', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+        // `warn: false` opts out of both nudges (e.g. relying on a proxy/transport to dedupe, or
+        // an idempotency block shared on a seam that also feeds reads).
+        stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/silenced',
+            idempotency: { warn: false },
+        });
+        stitch({
+            baseUrl: server.url,
+            path: '/read-silenced',
+            idempotency: { warn: false },
+        });
+        // a retry exercises the key — no nudge.
+        stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/with-retry',
+            retry: { attempts: 2 },
+            idempotency: true,
+        });
+        // a derived key dedupes submissions without a retry — useful on its own, no nudge.
+        stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/derived',
+            idempotency: {
+                keyOf: (input) => `k-${(input.body as { id: number }).id}`,
+            },
+        });
+        // a surface (graphql → POST) owns its method; we don't guess at construction, so no nudge
+        // even though `method` is unset here.
+        graphql({
+            baseUrl: server.url,
+            query: '{ me { id } }',
+            idempotency: true,
+        });
+        expect(warn).not.toHaveBeenCalled();
+    } finally {
+        warn.mockRestore();
+    }
+});
+
 test('does not inject on GET (writes only)', async () => {
     server.route('GET', '/read', { body: { ok: true } });
     const read = stitch({
         baseUrl: server.url,
         path: '/read',
-        idempotency: true,
+        idempotency: { warn: false }, // idempotency-on-read nudge is asserted elsewhere; silence here
     });
 
     await read();

--- a/packages/core/test/linked.spec.ts
+++ b/packages/core/test/linked.spec.ts
@@ -72,9 +72,9 @@ test('linked: resolves to the body return and chains the runs into one trace', a
     expect(o.ctx.traceId).toBeDefined();
     expect(s.ctx.traceId).toBe(o.ctx.traceId);
     expect(t.ctx.traceId).toBe(o.ctx.traceId); // one trace tree
-    expect(o.ctx.parentId).toBeUndefined(); // order is the scope root
-    expect(s.ctx.parentId).toBe(o.ctx.runId); // shipment a child of order
-    expect(t.ctx.parentId).toBe(s.ctx.runId); // tracking a child of shipment
+    expect(o.ctx.parentSpanId).toBeUndefined(); // order is the scope root
+    expect(s.ctx.parentSpanId).toBe(o.ctx.spanId); // shipment a child of order
+    expect(t.ctx.parentSpanId).toBe(s.ctx.spanId); // tracking a child of shipment
 });
 
 test('linked: fails fast — a rejected call rejects the scope and stops the body', async () => {
@@ -124,7 +124,7 @@ test('linked: a combinator run through `run` nests its fan inside the scope trac
     expect(sb.ctx.traceId).toBe(o.ctx.traceId);
     // `a` and `b` are siblings under the `all` group (a child of the scope), not direct children of
     // the order — and the chain continues under that same group run for `tracking`.
-    expect(sa.ctx.parentId).toBe(sb.ctx.parentId);
-    expect(sa.ctx.parentId).not.toBe(o.ctx.runId);
-    expect(t.ctx.parentId).toBe(sa.ctx.parentId);
+    expect(sa.ctx.parentSpanId).toBe(sb.ctx.parentSpanId);
+    expect(sa.ctx.parentSpanId).not.toBe(o.ctx.spanId);
+    expect(t.ctx.parentSpanId).toBe(sa.ctx.parentSpanId);
 });

--- a/packages/core/test/run-identity.spec.ts
+++ b/packages/core/test/run-identity.spec.ts
@@ -1,8 +1,8 @@
-// Run identity (ADR 0007): each execute() mints an OTLP-aligned runId (=spanId) + traceId,
+// Run identity (ADR 0007): each execute() mints an OTLP-aligned spanId + traceId,
 // stamped on the `start` event and carried on the TraceSink ctx for EVERY event of the run.
 // The OTLP sink reads them to build a real span tree (shared traceId, parentSpanId) instead of
 // minting per-start and guessing by name; a child run inherits the parent's traceId and points
-// parentId at the parent's runId. Ids are engine-minted, never caller-supplied (ADR 0002 §2).
+// parentSpanId at the parent's spanId. Ids are engine-minted, never caller-supplied (ADR 0002 §2).
 import {
     cookieSession,
     multiplex,
@@ -73,18 +73,18 @@ test('a call stamps OTLP-aligned run identity on `start` and shares it across th
     for await (const _ev of thing.stream()) void _ev; // drain
 
     const start = seen.find((s) => s.ev.type === 'start')!.ev as StartEvent;
-    expect(start.runId).toMatch(/^[0-9a-f]{16}$/); // = OTel spanId
+    expect(start.spanId).toMatch(/^[0-9a-f]{16}$/); // = OTel spanId
     expect(start.traceId).toMatch(/^[0-9a-f]{32}$/);
-    expect(start.parentId).toBeUndefined(); // a root run
+    expect(start.parentSpanId).toBeUndefined(); // a root run
 
     // EVERY event of the run carries the SAME identity on the ctx (it is per-run-constant).
-    expect(new Set(seen.map((s) => s.ctx.runId))).toEqual(
-        new Set([start.runId]),
+    expect(new Set(seen.map((s) => s.ctx.spanId))).toEqual(
+        new Set([start.spanId]),
     );
     expect(new Set(seen.map((s) => s.ctx.traceId))).toEqual(
         new Set([start.traceId]),
     );
-    expect(seen.every((s) => s.ctx.parentId === undefined)).toBe(true);
+    expect(seen.every((s) => s.ctx.parentSpanId === undefined)).toBe(true);
 });
 
 test('each call of one stitch is its own run with a distinct id', async () => {
@@ -102,30 +102,30 @@ test('each call of one stitch is its own run with a distinct id', async () => {
 
     const runIds = [
         ...new Set(
-            seen.filter((s) => s.ev.type === 'start').map((s) => s.ctx.runId),
+            seen.filter((s) => s.ev.type === 'start').map((s) => s.ctx.spanId),
         ),
     ];
     expect(runIds).toHaveLength(2);
     expect(runIds[0]).not.toBe(runIds[1]);
 });
 
-test('newRunContext: a root mints fresh ids; a child inherits traceId and sets parentId', () => {
+test('newRunContext: a root mints fresh ids; a child inherits traceId and sets parentSpanId', () => {
     const root = newRunContext();
     expect(root.traceId).toMatch(/^[0-9a-f]{32}$/);
-    expect(root.runId).toMatch(/^[0-9a-f]{16}$/);
-    expect(root.parentId).toBeUndefined();
+    expect(root.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(root.parentSpanId).toBeUndefined();
 
     const child = newRunContext(root);
     expect(child.traceId).toBe(root.traceId); // same tree
-    expect(child.runId).not.toBe(root.runId); // its own span
-    expect(child.parentId).toBe(root.runId); // linked to the parent
+    expect(child.spanId).not.toBe(root.spanId); // its own span
+    expect(child.parentSpanId).toBe(root.spanId); // linked to the parent
 });
 
 test('the OTLP sink builds a span tree from the ctx ids (traceId / spanId / parentSpanId)', () => {
     const { exporter, spans } = stubExporter();
     const sink = otlpTrace({ exporter });
     const parent = newRunContext();
-    const child = newRunContext(parent); // shares traceId, parentId = parent.runId
+    const child = newRunContext(parent); // shares traceId, parentSpanId = parent.spanId
 
     const emit = (name: string, run: typeof parent) => {
         const ctx: TraceContext = { name, ...run };
@@ -156,11 +156,11 @@ test('the OTLP sink builds a span tree from the ctx ids (traceId / spanId / pare
     const ps = spans.find((s) => s.name.includes('parentCall'))!;
     const cs = spans.find((s) => s.name.includes('childCall'))!;
     expect(ps.traceId).toBe(parent.traceId);
-    expect(ps.spanId).toBe(parent.runId);
+    expect(ps.spanId).toBe(parent.spanId);
     expect(ps.parentSpanId).toBeUndefined();
     expect(cs.traceId).toBe(parent.traceId); // one tree
-    expect(cs.spanId).toBe(child.runId);
-    expect(cs.parentSpanId).toBe(parent.runId); // linked to its parent
+    expect(cs.spanId).toBe(child.spanId);
+    expect(cs.parentSpanId).toBe(parent.spanId); // linked to its parent
 
     // …and parentSpanId is serialised onto the child span only.
     const out = toOtlpJson(spans) as {
@@ -171,11 +171,11 @@ test('the OTLP sink builds a span tree from the ctx ids (traceId / spanId / pare
         }[];
     };
     const outSpans = out.resourceSpans[0]!.scopeSpans[0]!.spans;
-    expect(outSpans.find((s) => s.spanId === child.runId)!.parentSpanId).toBe(
-        parent.runId,
+    expect(outSpans.find((s) => s.spanId === child.spanId)!.parentSpanId).toBe(
+        parent.spanId,
     );
     expect(
-        outSpans.find((s) => s.spanId === parent.runId)!.parentSpanId,
+        outSpans.find((s) => s.spanId === parent.spanId)!.parentSpanId,
     ).toBeUndefined();
 });
 
@@ -195,7 +195,7 @@ test('end-to-end: a real call feeds the OTLP sink the same ids it stamped on `st
     const start = seen.find((s) => s.ev.type === 'start')!.ev as StartEvent;
     expect(spans).toHaveLength(1);
     expect(spans[0]!.traceId).toBe(start.traceId);
-    expect(spans[0]!.spanId).toBe(start.runId); // the span IS the run
+    expect(spans[0]!.spanId).toBe(start.spanId); // the span IS the run
 });
 
 test('a hand-fed OTLP sink (no ctx ids) still mints a valid span — back-compat', () => {
@@ -211,7 +211,7 @@ test('a hand-fed OTLP sink (no ctx ids) still mints a valid span — back-compat
             input: {},
             at: 1,
         },
-        { name }, // no runId/traceId — the fallback path
+        { name }, // no spanId/traceId — the fallback path
     );
     sink.handle(
         { type: 'done', ok: true, elapsed: 1, attempts: 1, at: 2 },
@@ -260,9 +260,9 @@ test('cookieSession runs its login as a traced CHILD of the call that triggered 
     );
     // The login is no longer an invisible side-call: it is a child run under the `me` call.
     expect(loginStart).toBeDefined();
-    expect(loginStart!.ctx.parentId).toBe(meStart.ctx.runId); // parent = the triggering run
+    expect(loginStart!.ctx.parentSpanId).toBe(meStart.ctx.spanId); // parent = the triggering run
     expect(loginStart!.ctx.traceId).toBe(meStart.ctx.traceId); // one trace tree
-    expect(loginStart!.ctx.runId).not.toBe(meStart.ctx.runId); // its own span
+    expect(loginStart!.ctx.spanId).not.toBe(meStart.ctx.spanId); // its own span
     // …and the child run opens AND closes (start → done), so its span is complete.
     expect(
         seen.some((s) => s.ctx.name === 'login' && s.ev.type === 'done'),

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -217,7 +217,7 @@ export function sentrySink(
                         }),
                         extra: {
                             attempts: event.attempts,
-                            ...(ctx.runId ? { runId: ctx.runId } : {}),
+                            ...(ctx.spanId ? { spanId: ctx.spanId } : {}),
                         },
                     },
                 );

--- a/packages/sentry/test/sentry.spec.ts
+++ b/packages/sentry/test/sentry.spec.ts
@@ -27,7 +27,7 @@ function mockSentry() {
     return { sentry, breadcrumbs, captures };
 }
 
-const ctx: TraceContext = { name: 'getUser', runId: 'run-1' };
+const ctx: TraceContext = { name: 'getUser', spanId: 'run-1' };
 
 const ev = {
     start: {
@@ -80,7 +80,7 @@ describe('sentrySink', () => {
         expect(captures[0]!.context).toMatchObject({
             level: 'error',
             tags: { stitch: 'getUser', status: 500 },
-            extra: { attempts: 2, runId: 'run-1' },
+            extra: { attempts: 2, spanId: 'run-1' },
         });
         // The error is also breadcrumbed so it shows in the trail of any later issue.
         expect(breadcrumbs).toHaveLength(1);


### PR DESCRIPTION
Two related threads, kept separate, in one PR.

## 1. Idempotency misuse nudges (shipping)

Construction-time hints — **respectful, not verdicts** (they're the first users of the new EDITORIAL dimension 9), scoped to the default HTTP surface, and silenced by `idempotency: { warn: false }`:

- **`idempotency` on a read (GET/HEAD)** — the engine drops the key on reads, so the write protection the author expects silently isn't there. Almost always a missing `method: 'POST'`.
- **A random default key with no `retry`** — it only dedupes the call's own retries, so without a retry it usually has nothing to collapse. *Not* useless in every case (a proxy/transport resending the request below the stitch carries the same key for a server to dedupe), hence a hint with an out.

A surface (graphql → POST) forces the method *after* construction, so nudges fire only on the default surface — we don't guess. New `IdempotencyOptions.warn` field; expanded TSDoc.

## 2. De-conflate idempotency vs correlation (docs)

The docs taught `idempotency.header: 'X-Request-Id'` — pushing a *correlation* header through the *dedupe* machinery. Fixed in the blog + guide, with the distinction spelled out. Also corrected the over-absolute "idempotency only pays off alongside retries" claim in the blog, guide, and recipe.

## 3. EDITORIAL dimension 9 — "diagnose, don't blame"

New prose dimension forbidding blaming/condescending tone (the trigger was a line that read *"that is a fact about your data, not a gap in the feature"*). Greppable tells + rewrite pattern, wired into the audit/severity/done. Four existing posts backfilled.

## 4. ADR 0017 — outbound trace-context propagation (proposed)

The proper home for correlation: emit the run's `traceId` as W3C `traceparent` (+ optional correlation header) so the wire id equals the exported span. **Opt-in and host-scoped by policy** — correlation ids are low-sensitivity (opaque tokens, not secrets), so the scoping is about cross-vendor correlation + noise, not secret-leak. One child span per retry (the deliberate asymmetry with the stable idempotency key).

## Verification

- Core suite **1091 passed**; typecheck clean (src + test).
- Bundle within budget after a **documented +0.25 / +0.20 KB** raise for the two diagnostic strings (they live in `makeStitch`'s constructor and can't move to a subpath; rationale in `bundle-size.mjs`).
- Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
