### PR TITLE
chore(docs): add Vercel Speed Insights to the app layout

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -5,6 +5,7 @@ import { releaseVersion } from '@/lib/release';
 import { appName, gitConfig, siteUrl } from '@/lib/shared';
 
 import { Analytics } from '@vercel/analytics/next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import 'fumadocs-twoslash/twoslash.css';
 import { Banner } from 'fumadocs-ui/components/banner';
 import { RootProvider } from 'fumadocs-ui/provider/next';
@@ -166,6 +167,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
                     {children}
                 </RootProvider>
                 <Analytics />
+                <SpeedInsights />
             </body>
         </html>
     );

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -26,6 +26,7 @@
         "@stitchapi/sandbox": "workspace:*",
         "@uiw/react-codemirror": "^4.23.0",
         "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "fumadocs-core": "^16.10.0",
         "fumadocs-mdx": "^15.0.12",
         "fumadocs-twoslash": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vue@3.5.38(typescript@6.0.3))
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vue@3.5.38(typescript@6.0.3))
       fumadocs-core:
         specifier: ^16.10.0
         version: 16.10.0(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@1.17.0(react@19.2.7))(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
@@ -3804,6 +3807,32 @@ packages:
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitest/coverage-v8@4.1.8':
     resolution: {integrity: sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==}
@@ -11406,6 +11435,13 @@ snapshots:
       vue: 3.5.38(typescript@6.0.3)
 
   '@vercel/oidc@3.2.0': {}
+
+  '@vercel/speed-insights@2.0.0(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vue@3.5.38(typescript@6.0.3))':
+    optionalDependencies:
+      next: 16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      svelte: 5.56.3(@typescript-eslint/types@8.61.0)
+      vue: 3.5.38(typescript@6.0.3)
 
   '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
     dependencies:


### PR DESCRIPTION
## What

Adds [`@vercel/speed-insights`](https://www.npmjs.com/package/@vercel/speed-insights) to the docs app and renders `<SpeedInsights />` in the root layout, right beside the existing `<Analytics />`.

## Why

The docs site already ships `@vercel/analytics`; Speed Insights is its companion, reporting real-user Core Web Vitals (LCP, CLS, INP, …) from the Vercel production deployment. It has zero visible UI — it injects a reporting beacon that only sends data in production.

## Changes

- `apps/docs/package.json` — add `@vercel/speed-insights@^2.0.0`
- `apps/docs/app/layout.tsx` — import and render `<SpeedInsights />` next to `<Analytics />`
- `pnpm-lock.yaml` — resolved dependency

## Verification

- `pnpm --filter @stitchapi/docs check:types` → ✅ `tsc --noEmit` clean
- `eslint app/layout.tsx` → ✅ import order clean
- `prettier --check` → ✅
- `pnpm install --frozen-lockfile` → ✅ lockfile consistent with manifest
- lefthook pre-commit (format + typecheck across all packages) → ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
