### PR TITLE
chore(core): raise bundle-size budget after composition + meta-contract growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 <!-- METRICS:BADGES:END -->
 
 <p align="center">
-  <strong>Zero runtime dependencies · ~23&nbsp;kB min+gzip</strong> — a typical <code>import { stitch }</code> tree-shakes to ~18&nbsp;kB, and with no transitive tree there is nothing else to install or audit. The size is an <a href="packages/core/scripts/bundle-size.mjs">enforced budget in CI</a>, not an aspiration.
+  <strong>Zero runtime dependencies · ~23&nbsp;kB min+gzip</strong> — a typical <code>import { stitch }</code> tree-shakes to ~19&nbsp;kB, and with no transitive tree there is nothing else to install or audit. The size is an <a href="packages/core/scripts/bundle-size.mjs">enforced budget in CI</a>, not an aspiration.
 </p>
 
 > [!NOTE]
@@ -149,7 +149,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 -   **Pluggable state store** — throttle counters and sessions behind a 3-method store; swap in Redis/Postgres to go distributed.
 -   **Zero-infra observability** — tracing is **off by default**; opt in per stitch or via `STITCH_TRACE_*` env vars. No collector, no dashboard.
 -   **Four front doors, one definition** — in-process function, CLI (`stitch run`), HTTP (`stitch serve`), and MCP (`stitch mcp`).
--   **Zero runtime dependencies** — `"dependencies": {}`, built on global `fetch`, tree-shakeable; **~23 kB min+gzip** for the whole entry, **~18 kB** for a typical `import { stitch }`.
+-   **Zero runtime dependencies** — `"dependencies": {}`, built on global `fetch`, tree-shakeable; **~23 kB min+gzip** for the whole entry, **~19 kB** for a typical `import { stitch }`.
 
 ## Install
 

--- a/apps/docs/app/(home)/components/metrics.tsx
+++ b/apps/docs/app/(home)/components/metrics.tsx
@@ -10,7 +10,7 @@ const metrics = [
         body: 'The whole stitchapi entry, tree-shaken — and it is an enforced budget in CI, not an aspiration.',
     },
     {
-        value: '~18 kB',
+        value: '~19 kB',
         unit: 'import { stitch }',
         body: 'Pay only for what you import: every surface beyond http lives behind its own subpath, so the core trims down.',
     },

--- a/apps/docs/content/docs/concepts/principles.mdx
+++ b/apps/docs/content/docs/concepts/principles.mdx
@@ -107,7 +107,7 @@ package practices with your bundle.
 
 Concretely, the whole `stitch` entry is **~23 kB minified + gzipped**
 (≈61 kB raw), and because every surface beyond `http` is a separate subpath
-import, a typical `import { stitch }` tree-shakes to **~18 kB**. With zero
+import, a typical `import { stitch }` tree-shakes to **~19 kB**. With zero
 runtime dependencies, that figure is the entire cost — not the tip of a
 transitive tree.
 

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -7,7 +7,7 @@ Install the package, import `stitch`, and turn your first endpoint into a typed,
 callable function. `stitchapi` has zero dependencies and runs anywhere `fetch`
 does — Node, the browser, and edge runtimes. The whole entry is **~23 kB
 minified + gzipped** — and with no dependencies, there is no transitive tree
-behind it (a typical `import { stitch }` tree-shakes to ~18 kB).
+behind it (a typical `import { stitch }` tree-shakes to ~19 kB).
 
 <Callout type="info">
     **Validators are bring-your-own.** Because `stitchapi` ships with zero

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -120,7 +120,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 -   **CLI, HTTP & MCP surfaces** - the definition your code imports is also runnable from the shell (`stitch run <name>` streams JSONL events), served over HTTP (`stitch serve`), or exposed to agents over MCP (`stitch mcp`) — the same stitch behind every front door.
 -   **Typed URLs** - full [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) URI templates (`{id}`, `{+path}`, `{?q,sort}`, explode `*`, prefix `:n`), and a `qs`-style query builder that serializes nested objects (`a[b]=c`) and arrays — both dependency-free.
 -   **Pluggable transport** - `fetch` by default; drop in the shipped `axiosAdapter`, or any `Adapter` function, to route requests through axios or another HTTP client.
--   **Zero runtime dependencies** - `"dependencies": {}`; built on the platform's global `fetch`; tree-shakeable. The whole entry is **~23 kB min+gzip**; a typical `import { stitch }` trims to **~18 kB** — and with no transitive tree, that is the entire cost.
+-   **Zero runtime dependencies** - `"dependencies": {}`; built on the platform's global `fetch`; tree-shakeable. The whole entry is **~23 kB min+gzip**; a typical `import { stitch }` trims to **~19 kB** — and with no transitive tree, that is the entire cost.
 
 ## Documentation
 
@@ -162,7 +162,7 @@ const { stitch } = require("stitchapi");
 
 The runtime ships with zero dependencies. Schema validation is bring-your-own — pass a [Zod](https://zod.dev) schema or any [Standard Schema](https://standardschema.dev) validator ([Valibot](https://valibot.dev), [ArkType](https://arktype.io), …); none of them is bundled. The examples below use Zod for familiarity.
 
-**Bundle size.** The whole `stitchapi` entry is **~23 kB minified + gzipped** (~64 kB raw, ~20 kB brotli); because the package is side-effect-free and every surface beyond `http` lives behind its own subpath import, a typical `import { stitch }` tree-shakes to **~18 kB min+gzip**. With zero dependencies, that is the _whole_ cost — there is no transitive tree to install or audit.
+**Bundle size.** The whole `stitchapi` entry is **~23 kB minified + gzipped** (~64 kB raw, ~20 kB brotli); because the package is side-effect-free and every surface beyond `http` lives behind its own subpath import, a typical `import { stitch }` tree-shakes to **~19 kB min+gzip**. With zero dependencies, that is the _whole_ cost — there is no transitive tree to install or audit.
 
 ## Quick start
 

--- a/packages/core/scripts/bundle-size.mjs
+++ b/packages/core/scripts/bundle-size.mjs
@@ -62,16 +62,30 @@ const KB = 1024;
 // check is in `execute` and the default `fetch` adapter carries the descriptor — so neither
 // can move to a subpath. They add ~0.10 / ~0.04 KB gzip (entry ~22.74 / stitch ~18.34). The
 // step restores the same tight ~0.2 KB headroom the gate is meant to hold.
+//
+// Budgets raised for core composition primitives + the API meta-contract sweep
+// (22.95→23.35 / 18.55→18.80 KB): two waves of intentional, already-merged work
+// landed on the core path since #362. (1) Composition gained parallel all/any/race
+// with auto-cancellation (#368), linked() replacing pipe() as a run scope
+// (#369/#370), and variadic argument lists (#371) — core-entry surface, so it lifts
+// the whole entry more than `import { stitch }`, which tree-shakes it away. (2) The
+// meta-contract sweep (#352, P3–P20) renamed/de-suffixed public fields and co-emits
+// the old names as @deprecated runtime aliases (throttle.scope→pool, key→keyOf;
+// value→data on result envelopes; *Ms duration de-suffixing) — shared code on
+// stitch's own path. Together they reach ~23.13 / ~18.61 KB gzip (+~0.39 / +~0.27
+// since #362). Neither wave can move to a subpath — composition and the renamed
+// result/throttle/circuit surfaces are the core API. The step restores the same
+// tight ~0.2 KB headroom the gate is meant to hold.
 const SCENARIOS = [
     {
         name: 'stitchapi — whole entry',
         code: `export * from './index.mjs';`,
-        budget: 22.95 * KB,
+        budget: 23.35 * KB,
     },
     {
         name: 'import { stitch }',
         code: `export { stitch } from './index.mjs';`,
-        budget: 18.55 * KB,
+        budget: 18.8 * KB,
     },
 ];
 


### PR DESCRIPTION
## What

Raises the core bundle-size budget (`packages/core/scripts/bundle-size.mjs`) and re-syncs the advertised size figures — fixing the **red `size` CI job on `main`**.

## Why

The `size` job runs two gates back-to-back and was failing on the first (masking that the second would fail too):

- **`check:size`** — the tree-shaken core entry drifted over budget:
  - whole entry **23.13 KB** gzip vs 22.95 budget (over by 0.18)
  - `import { stitch }` **18.61 KB** vs 18.55 (over by 0.06)
- **`check:size-docs`** — the gzip `import { stitch }` figure now rounds **18.61 → 19**, but every advertising file still said `~18 kB`.

The growth is two intentional, already-merged waves on the core path, neither movable to a subpath:

1. **Composition primitives** — parallel `all`/`any`/`race` (#368), `linked()` replacing `pipe()` as a run scope (#369/#370), variadic args (#371). These lift the whole entry more than `import { stitch }` (which tree-shakes them away) — which is why the entry grew 0.18 but stitch only 0.06.
2. **API meta-contract sweep** (#352, P3–P20) — public-field renames/de-suffixing that co-emit the old names as `@deprecated` runtime aliases (e.g. `throttle.scope→pool`, `key→keyOf`, `value→data` on result envelopes) on shared core code.

This matches the documented escape hatch in `bundle-size.mjs`: when genuinely-necessary core-path growth can't move to a subpath, raise the budget deliberately and record why.

## Changes

- `packages/core/scripts/bundle-size.mjs` — budget **22.95 → 23.35** / **18.55 → 18.80** KB (restores the ~0.2 KB headroom the gate keeps), with a rationale comment in the established per-bump style.
- Advertised `import { stitch }` figure **~18 → ~19 kB** across all five gated files (`README.md` ×2 spots, `packages/core/README.md`, `installation.mdx`, `principles.mdx`, homepage `metrics.tsx`). The `~23 kB` whole-entry figure is unchanged.

Deliberately not touched: `docs/adr/0010` (a historical record of the earlier ~17→~18 step), and the allowlisted raw/brotli figures (the gate tracks gzip only).

## Verification

- `pnpm --filter stitchapi check:size` → ✅ 0.22 / 0.19 KB headroom
- `pnpm check:size-docs` → ✅ in sync (measured ~19 kB / ~23 kB)
- pre-commit lefthook: `size-docs` ✅, `readme-metrics` ✅, `format` ✅, `typecheck` ✅ (full tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
