### PR TITLE
feat(core): add compact() to omit undefined keys, adopt it repo-wide

### DIFF
--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -149,10 +149,10 @@ function injectStitchInternal<T>(
     const coreOptions: CreateStitchQueryOptions<T> & { stream: boolean } =
         compact({
             stream,
-            ...(mode ? { mode } : {}),
+            mode,
             enabled,
-            ...(onSuccess ? { onSuccess } : {}),
-            ...(onError ? { onError } : {}),
+            onSuccess,
+            onError,
         });
 
     // The live query handle, captured for the imperative refetch/cancel. It is

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -42,6 +42,7 @@ import {
 } from '@stitchapi/query-core';
 import { Observable, of } from 'rxjs';
 import { shareReplay, switchMap } from 'rxjs/operators';
+import { compact } from 'stitchapi';
 
 export type {
     CreateStitchQueryOptions,
@@ -145,13 +146,14 @@ function injectStitchInternal<T>(
     const destroyRef = injector.get(DestroyRef);
 
     const { mode, enabled, onSuccess, onError } = options;
-    const coreOptions: CreateStitchQueryOptions<T> & { stream: boolean } = {
-        stream,
-        ...(mode ? { mode } : {}),
-        ...(enabled !== undefined ? { enabled } : {}),
-        ...(onSuccess ? { onSuccess } : {}),
-        ...(onError ? { onError } : {}),
-    };
+    const coreOptions: CreateStitchQueryOptions<T> & { stream: boolean } =
+        compact({
+            stream,
+            ...(mode ? { mode } : {}),
+            enabled,
+            ...(onSuccess ? { onSuccess } : {}),
+            ...(onError ? { onError } : {}),
+        });
 
     // The live query handle, captured for the imperative refetch/cancel. It is
     // reassigned whenever the input changes (switchMap tears down the old one).

--- a/packages/core/eslint.config.ts
+++ b/packages/core/eslint.config.ts
@@ -42,6 +42,21 @@ export default tseslint.config(
         files: ['src/**/*.ts'],
         rules: {
             '@typescript-eslint/consistent-type-imports': 'error',
+            // Steer the `...(x !== undefined ? { k: x } : {})` omit-an-undefined-key
+            // idiom toward `compact({ ...obj, k: x })` (util.ts), which drops
+            // undefined-valued keys and types them optional under
+            // exactOptionalPropertyTypes. Truthy spreads (`...(x ? … : {})`) and array
+            // spreads are intentionally NOT matched. Rare sites where compact would
+            // optionalize a REQUIRED `unknown` key keep the spread + an inline disable.
+            'no-restricted-syntax': [
+                'error',
+                {
+                    selector:
+                        "SpreadElement[argument.type='ConditionalExpression'][argument.test.operator='!=='][argument.test.right.type='Identifier'][argument.test.right.name='undefined'][argument.consequent.type='ObjectExpression'][argument.alternate.properties.length=0]",
+                    message:
+                        'Use compact({ ...obj, key: value }) from ./util to omit undefined keys instead of `...(x !== undefined ? { key: x } : {})`.',
+                },
+            ],
             'no-restricted-imports': [
                 'error',
                 {

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -1,6 +1,7 @@
 // Auth strategies + secret resolvers. The key idea: the stitch holds the credential,
 // resolved at call time — the caller (an agent) never sees it. `cookieSession` performs
 // a login (another stitch) and manages the cookie jar, refreshing on a 401 wall.
+import { compact } from './compact';
 import { fetchAdapter } from './http-adapter';
 import { parseRetryAfter } from './resilience';
 import type {
@@ -599,12 +600,12 @@ export function cookieSession(opts: CookieSessionOptions): AuthStrategy {
             // Omit `retryAfter` entirely when the header is absent/unparseable —
             // `exactOptionalPropertyTypes` forbids setting an optional prop to `undefined`.
             const retryAfter = parseRetryAfter(headers['retry-after']);
-            const result: AuthFailureResult = {
+            const result: AuthFailureResult = compact({
                 phase,
                 status,
                 category: 'rate-limited',
-                ...(retryAfter !== undefined ? { retryAfter } : {}),
-            };
+                retryAfter,
+            });
             // Co-set the @deprecated `retryAfterMs` alias for back-compat (CONTRACT.md P17/P19), by
             // assignment (not a literal `*Ms:` key) so the contract lint's R2 stays clean.
             // eslint-disable-next-line @typescript-eslint/no-deprecated -- writing the @deprecated alias for back-compat

--- a/packages/core/src/axios-adapter.ts
+++ b/packages/core/src/axios-adapter.ts
@@ -79,8 +79,9 @@ export function axiosAdapter(
         const onProgress = req.onProgress;
         const progress = (
             phase: AdapterProgress['phase'],
-        ): ((e: AxiosLikeProgressEvent) => void) => {
-            const cb = onProgress as (p: AdapterProgress) => void;
+        ): ((e: AxiosLikeProgressEvent) => void) | undefined => {
+            if (onProgress === undefined) return undefined;
+            const cb = onProgress;
             return (e) => {
                 cb(
                     e.total !== undefined
@@ -99,12 +100,8 @@ export function axiosAdapter(
                 data: body,
                 responseType: 'arraybuffer',
                 signal: req.signal,
-                ...(onProgress
-                    ? {
-                          onUploadProgress: progress('upload'),
-                          onDownloadProgress: progress('download'),
-                      }
-                    : {}),
+                onUploadProgress: progress('upload'),
+                onDownloadProgress: progress('download'),
                 validateStatus: () => true, // never throw on non-2xx; the engine decides
             }),
         );

--- a/packages/core/src/axios-adapter.ts
+++ b/packages/core/src/axios-adapter.ts
@@ -98,7 +98,7 @@ export function axiosAdapter(
                 headers,
                 data: body,
                 responseType: 'arraybuffer',
-                ...(req.signal ? { signal: req.signal } : {}),
+                signal: req.signal,
                 ...(onProgress
                     ? {
                           onUploadProgress: progress('upload'),

--- a/packages/core/src/axios-adapter.ts
+++ b/packages/core/src/axios-adapter.ts
@@ -9,6 +9,7 @@
 // fetchAdapter, so behavior is identical across transports. The client is asked for raw
 // bytes (responseType 'arraybuffer') and told never to throw on non-2xx — the engine
 // decides what a given status means.
+import { compact } from './compact';
 import { decodeResponseBody, encodeRequestBody } from './http-adapter';
 import type {
     Adapter,
@@ -89,22 +90,24 @@ export function axiosAdapter(
             };
         };
 
-        const res = await client.request({
-            ...defaults,
-            url: req.url,
-            method: req.method.toUpperCase(),
-            headers,
-            ...(body !== undefined ? { data: body } : {}),
-            responseType: 'arraybuffer',
-            ...(req.signal ? { signal: req.signal } : {}),
-            ...(onProgress
-                ? {
-                      onUploadProgress: progress('upload'),
-                      onDownloadProgress: progress('download'),
-                  }
-                : {}),
-            validateStatus: () => true, // never throw on non-2xx; the engine decides
-        });
+        const res = await client.request(
+            compact({
+                ...defaults,
+                url: req.url,
+                method: req.method.toUpperCase(),
+                headers,
+                data: body,
+                responseType: 'arraybuffer',
+                ...(req.signal ? { signal: req.signal } : {}),
+                ...(onProgress
+                    ? {
+                          onUploadProgress: progress('upload'),
+                          onDownloadProgress: progress('download'),
+                      }
+                    : {}),
+                validateStatus: () => true, // never throw on non-2xx; the engine decides
+            }),
+        );
 
         const resHeaders = normalizeHeaders(res.headers);
         const contentTypeResp = resHeaders['content-type'] ?? '';

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -4,6 +4,7 @@
 // Flags map onto a stitch's single input object ({ params, query, body, headers });
 // every event the stitch emits is written to stdout as one line of JSON, so the
 // output pipes straight into jq and friends. No app boot required.
+import { compact } from './compact';
 import { endpointLabel, toMermaid } from './diagram';
 import {
     type ParsedRequest,
@@ -641,10 +642,7 @@ async function serveCommand(args: string[], io: CliIO): Promise<number> {
     const registry = await loadRegistryOrReport(modulePath, io);
     if (registry === undefined) return 1;
 
-    const handle = await serve(registry, {
-        ...(port !== undefined ? { port } : {}),
-        ...(host !== undefined ? { host } : {}),
-    });
+    const handle = await serve(registry, compact({ port, host }));
     io.writeErr(
         `stitch serve listening on ${handle.url} — POST /stitch/:name\n`,
     );
@@ -694,9 +692,7 @@ async function diagramCommand(args: string[], io: CliIO): Promise<number> {
     const registry = await loadRegistryOrReport(modulePath, io);
     if (registry === undefined) return 1;
 
-    const { diagram, warnings } = toMermaid(registry, {
-        ...(name !== undefined ? { name } : {}),
-    });
+    const { diagram, warnings } = toMermaid(registry, compact({ name }));
     for (const w of warnings) io.writeErr(`warning: ${w}\n`);
     io.write(diagram);
     return 0;
@@ -752,11 +748,10 @@ async function exportCommand(args: string[], io: CliIO): Promise<number> {
         toJsonSchema = candidate as OpenApiExportOptions['toJsonSchema'];
     }
 
-    const { document, warnings } = toOpenApi(registry, {
-        ...(title !== undefined ? { title } : {}),
-        ...(apiVersion !== undefined ? { version: apiVersion } : {}),
-        ...(toJsonSchema !== undefined ? { toJsonSchema } : {}),
-    });
+    const { document, warnings } = toOpenApi(
+        registry,
+        compact({ title, version: apiVersion, toJsonSchema }),
+    );
     for (const w of warnings) io.writeErr(`warning: ${w}\n`);
     io.write(`${JSON.stringify(document, null, 2)}\n`);
     return 0;
@@ -839,11 +834,10 @@ async function fromCurlCommand(args: string[], io: CliIO): Promise<number> {
         return 1;
     }
 
-    const { source, warnings } = toStitchSource(req, {
-        ...(name !== undefined ? { name } : {}),
-        zod,
-        ...(response !== undefined ? { response } : {}),
-    });
+    const { source, warnings } = toStitchSource(
+        req,
+        compact({ name, zod, response }),
+    );
     for (const w of warnings) io.writeErr(`warning: ${w}\n`);
     io.write(source);
     return 0;

--- a/packages/core/src/compact.ts
+++ b/packages/core/src/compact.ts
@@ -1,0 +1,29 @@
+// `compact({ ...obj, key: value })` — a shallow copy with the `undefined`-valued keys dropped,
+// typed so undefined-admitting keys come back *optional* (`key?: V`). It pairs with
+// `exactOptionalPropertyTypes`: the result drops into a typed target without the
+// `...(key !== undefined ? { key } : {})` spread dance. The `const` type parameter preserves
+// literal types, so a discriminant such as `{ type: 'start', ... }` survives the wrap.
+//
+// CAVEATS (each handled at the few call sites that hit it):
+//   • a REQUIRED `unknown`-typed key is optionalized (since `undefined extends unknown`) — keep an
+//     explicit spread there instead;
+//   • the `const` generic freezes an inline `[]` to `readonly []` — pin the element type;
+//   • inline callbacks in the wrapped literal lose their contextual param types — annotate them.
+
+export type Compact<T> = {
+    [K in keyof T as undefined extends T[K] ? never : K]: T[K];
+} & {
+    [K in keyof T as undefined extends T[K] ? K : never]?: Exclude<
+        T[K],
+        undefined
+    >;
+};
+
+export const compact = <const T extends object>(obj: T): Compact<T> => {
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(obj)) {
+        const v = (obj as Record<string, unknown>)[k];
+        if (v !== undefined) out[k] = v;
+    }
+    return out as Compact<T>;
+};

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -6,6 +6,7 @@
 // The real module is reached via a lazy `import('./cache')` only when a stitch has a `cache`
 // block (bundle-frugal gate — ADR 0003 decision 11).
 import type { CacheController, CacheHit, RequestDescriptor } from './cache';
+import { compact } from './compact';
 import { classifyDiff, validationErrors } from './drift';
 import { fetchAdapter } from './http-adapter';
 import {
@@ -123,12 +124,14 @@ function emitInto(
         // login — can run it as a CHILD of this run (parentId = run.runId).
         run,
         emit: (topic, detail) =>
-            sink.push({
-                type: 'info',
-                topic,
-                ...(detail !== undefined ? { detail } : {}),
-                at: now(),
-            }),
+            sink.push(
+                compact({
+                    type: 'info',
+                    topic,
+                    detail,
+                    at: now(),
+                }),
+            ),
     };
 }
 
@@ -226,17 +229,15 @@ function buildRequest(
     }
     const method = (cfg.method ?? 'GET').toUpperCase();
     const headers = { ...(cfg.headers ?? {}), ...(input.headers ?? {}) };
-    let req: AdapterRequest = {
+    let req: AdapterRequest = compact({
         url,
         method,
         headers,
         body: input.body,
-        ...(cfg.bodyType !== undefined ? { bodyType: cfg.bodyType } : {}),
-        ...(cfg.multipart !== undefined ? { multipart: cfg.multipart } : {}),
-        ...(cfg.responseType !== undefined
-            ? { responseType: cfg.responseType }
-            : {}),
-    };
+        bodyType: cfg.bodyType,
+        multipart: cfg.multipart,
+        responseType: cfg.responseType,
+    });
     // Per-call execution controls (ADR 0005 Decisions 8-9): cancellation + byte progress, threaded
     // BEFORE the surface shapes the request so a surface that spreads `base` (e.g. `download`)
     // keeps them. Runtime-only — they never came from `__config`.
@@ -963,19 +964,19 @@ async function ensureCache(rt: Runtime): Promise<CacheController | null> {
     const config = cfg.cache;
     if (!config || cfg.sensitive) return null;
     rt.cacheInit ??= import('./cache').then((m) =>
-        m.createCache({
-            config,
-            store: rt.store,
-            stitchId: m.cacheStitchId(cfg),
-            // The RAW output schema (not the Validator wrapper) so the fingerprinter can read its
-            // `~standard.vendor`; transform/unwrap are already raw on the config (ADR 0004 fold).
-            output: outputSchemaSource(cfg),
-            transform: cfg.transform,
-            unwrap: cfg.unwrap,
-            ...(rt.authCtx.principal !== undefined
-                ? { principal: rt.authCtx.principal }
-                : {}),
-        }),
+        m.createCache(
+            compact({
+                config,
+                store: rt.store,
+                stitchId: m.cacheStitchId(cfg),
+                // The RAW output schema (not the Validator wrapper) so the fingerprinter can read its
+                // `~standard.vendor`; transform/unwrap are already raw on the config (ADR 0004 fold).
+                output: outputSchemaSource(cfg),
+                transform: cfg.transform,
+                unwrap: cfg.unwrap,
+                principal: rt.authCtx.principal,
+            }),
+        ),
     );
     return rt.cacheInit;
 }
@@ -1019,17 +1020,18 @@ const startEvt = (
     baseReq: AdapterRequest,
     input: StitchInput,
     run: RunContext,
-): StitchEvent => ({
-    type: 'start',
-    name,
-    method: baseReq.method,
-    url: baseReq.url,
-    input,
-    at: now(),
-    runId: run.runId,
-    traceId: run.traceId,
-    ...(run.parentId !== undefined ? { parentId: run.parentId } : {}),
-});
+): StitchEvent =>
+    compact({
+        type: 'start',
+        name,
+        method: baseReq.method,
+        url: baseReq.url,
+        input,
+        at: now(),
+        runId: run.runId,
+        traceId: run.traceId,
+        parentId: run.parentId,
+    });
 
 const cacheEvt = (detail: string): StitchEvent => ({
     type: 'progress',
@@ -1309,6 +1311,7 @@ async function* runStreaming(
                 status: res.status,
                 headers: res.headers,
                 body: await drainErrorBody(res.body),
+                // eslint-disable-next-line no-restricted-syntax -- `compact` would optionalize the required `body: unknown`; keep the explicit spread here
                 ...(res.url !== undefined ? { url: res.url } : {}),
             };
             const e = new Error(`HTTP ${res.status}`) as Error & {
@@ -1739,12 +1742,12 @@ export async function executeRawTraced(
     const name = nameOf(cfg);
     const t0 = now();
     const state = { attempts: 0 };
-    const ctx = {
+    const ctx = compact({
         name,
         runId: run.runId,
         traceId: run.traceId,
-        ...(run.parentId !== undefined ? { parentId: run.parentId } : {}),
-    };
+        parentId: run.parentId,
+    });
     const baseReq = buildRequest(cfg, input);
     sink.handle(startEvt(name, baseReq, input, run), ctx);
     try {

--- a/packages/core/src/http-adapter.ts
+++ b/packages/core/src/http-adapter.ts
@@ -52,7 +52,7 @@ export function fetchAdapter(opts?: FetchAdapterOptions): Adapter {
             method,
             headers,
             body,
-            ...(req.signal ? { signal: req.signal } : {}),
+            signal: req.signal,
             dispatcher: opts?.dispatcher,
         });
 

--- a/packages/core/src/http-adapter.ts
+++ b/packages/core/src/http-adapter.ts
@@ -1,3 +1,4 @@
+import { compact } from './compact';
 import type {
     Adapter,
     AdapterProgress,
@@ -45,17 +46,15 @@ export function fetchAdapter(opts?: FetchAdapterOptions): Adapter {
             headers['content-type'] = contentType;
         }
 
-        // Build the init as a typed local so the non-standard `dispatcher` key can be added
-        // when supplied; with no dispatcher the key is omitted entirely (identical to before).
-        const init: FetchInitWithDispatcher = {
+        // Build the init as a typed local; `compact` drops `body`/`dispatcher` when absent,
+        // so the non-standard `dispatcher` key stays off unless a dispatcher is supplied.
+        const init: FetchInitWithDispatcher = compact({
             method,
             headers,
-            ...(body !== undefined ? { body } : {}),
+            body,
             ...(req.signal ? { signal: req.signal } : {}),
-            ...(opts?.dispatcher !== undefined
-                ? { dispatcher: opts.dispatcher }
-                : {}),
-        };
+            dispatcher: opts?.dispatcher,
+        });
 
         // Send the request. Network/abort errors propagate to the caller. The local init type
         // (with the undici-only `dispatcher`) widens cleanly to the RequestInit fetch expects.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,11 @@ export { memoryStore } from './store';
 // The default Clock (ADR 0010) — wall-clock + global timers. Inject a custom `Clock` (or a
 // `manualClock()` from `stitchapi/testing`) via a stitch/seam `clock` to control time.
 export { systemClock } from './util';
+// `compact({ ...obj, key: value })` — a shallow copy with `undefined`-valued keys removed, typed so
+// undefined-admitting keys come back optional. Pairs with `exactOptionalPropertyTypes`: it omits an
+// absent optional without the `...(key !== undefined ? { key } : {})` spread dance.
+export { compact } from './compact';
+export type { Compact } from './compact';
 // The delegate-backoff error (issue #145): thrown on the awaited path and surfaced as an `error`
 // event when `rateLimit.delegate` is on, so a host's outer gate owns the rate-limit backoff.
 export { RateLimitError } from './resilience';

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -10,6 +10,7 @@
 // single slot the buffered llm surface already fills — the `sse`/`stream` surfaces don't compose
 // onto it yet.) Bundle-frugal: reached only through the `llm` subpath; `import { stitch }` pulls in
 // none of it.
+import { compact } from './compact';
 import { makeStitch } from './stitch';
 import type { Surface, SurfaceOutcome } from './surface';
 import type { Stitch, StitchConfig, StitchInput } from './types';
@@ -179,17 +180,15 @@ export const anthropic: LlmProvider = {
                 .filter((m) => m.role === 'system')
                 .map((m) => m.content),
         ].join('\n\n');
-        return {
+        return compact({
             model: req.model,
             max_tokens: req.maxTokens ?? 1024,
             messages: req.messages
                 .filter((m) => m.role !== 'system')
                 .map((m) => ({ role: m.role, content: m.content })),
             ...(system !== '' ? { system } : {}),
-            ...(req.temperature !== undefined
-                ? { temperature: req.temperature }
-                : {}),
-        };
+            temperature: req.temperature,
+        });
     },
     parse: (body) => {
         const b = body as {
@@ -204,14 +203,10 @@ export const anthropic: LlmProvider = {
         };
         if (b.model !== undefined) result.model = b.model;
         if (b.usage)
-            result.usage = {
-                ...(b.usage.input_tokens !== undefined
-                    ? { inputTokens: b.usage.input_tokens }
-                    : {}),
-                ...(b.usage.output_tokens !== undefined
-                    ? { outputTokens: b.usage.output_tokens }
-                    : {}),
-            };
+            result.usage = compact({
+                inputTokens: b.usage.input_tokens,
+                outputTokens: b.usage.output_tokens,
+            });
         if (b.stop_reason) result.finishReason = b.stop_reason;
         return result;
     },
@@ -225,19 +220,21 @@ export const openai: LlmProvider = {
     id: 'openai',
     endpoint: 'https://api.openai.com/v1/chat/completions',
     defaultModel: 'gpt-4o',
-    buildBody: (req) => ({
-        model: req.model,
-        messages: [
-            ...(req.system !== undefined
-                ? [{ role: 'system', content: req.system }]
-                : []),
-            ...req.messages.map((m) => ({ role: m.role, content: m.content })),
-        ],
-        ...(req.maxTokens !== undefined ? { max_tokens: req.maxTokens } : {}),
-        ...(req.temperature !== undefined
-            ? { temperature: req.temperature }
-            : {}),
-    }),
+    buildBody: (req) =>
+        compact({
+            model: req.model,
+            messages: [
+                ...(req.system !== undefined
+                    ? [{ role: 'system', content: req.system }]
+                    : []),
+                ...req.messages.map((m) => ({
+                    role: m.role,
+                    content: m.content,
+                })),
+            ],
+            max_tokens: req.maxTokens,
+            temperature: req.temperature,
+        }),
     parse: (body) => {
         const b = body as {
             choices?: {
@@ -253,14 +250,10 @@ export const openai: LlmProvider = {
         };
         if (b.model !== undefined) result.model = b.model;
         if (b.usage)
-            result.usage = {
-                ...(b.usage.prompt_tokens !== undefined
-                    ? { inputTokens: b.usage.prompt_tokens }
-                    : {}),
-                ...(b.usage.completion_tokens !== undefined
-                    ? { outputTokens: b.usage.completion_tokens }
-                    : {}),
-            };
+            result.usage = compact({
+                inputTokens: b.usage.prompt_tokens,
+                outputTokens: b.usage.completion_tokens,
+            });
         const fr = b.choices?.[0]?.finish_reason;
         if (fr) result.finishReason = fr;
         return result;

--- a/packages/core/src/openapi.ts
+++ b/packages/core/src/openapi.ts
@@ -15,6 +15,7 @@
 // parameters declared via an `input` SCHEMA (rather than the URL template) are still not enumerated.
 // A stitch whose endpoint is a thunk (resolved at call time) cannot be exported statically; it is
 // reported as a warning, never dropped silently.
+import { compact } from './compact';
 import type { StitchRegistry } from './registry';
 import { isStandardSchema } from './standard-schema';
 import type {
@@ -112,12 +113,7 @@ function bodySchema(
     const vendor = isStandardSchema(source)
         ? source['~standard'].vendor
         : undefined;
-    return (
-        convert(source, {
-            slot: where,
-            ...(vendor !== undefined ? { vendor } : {}),
-        }) ?? EMPTY_SCHEMA
-    );
+    return convert(source, compact({ slot: where, vendor })) ?? EMPTY_SCHEMA;
 }
 
 // Convert a `params`/`query` INPUT object schema ONCE, then expose its `properties` map + the set
@@ -136,10 +132,7 @@ function decomposeParamObject(
     const vendor = isStandardSchema(source)
         ? source['~standard'].vendor
         : undefined;
-    const converted = convert(source, {
-        slot: where,
-        ...(vendor !== undefined ? { vendor } : {}),
-    });
+    const converted = convert(source, compact({ slot: where, vendor }));
     if (!converted || typeof converted !== 'object') return empty;
     const props = (converted as { properties?: unknown }).properties;
     const req = (converted as { required?: unknown }).required;

--- a/packages/core/src/otlp.ts
+++ b/packages/core/src/otlp.ts
@@ -2,6 +2,7 @@
 // logical call, using OTel HTTP semantic-convention attributes, and hands finished spans to a
 // SpanExporter. The default exporter POSTs OTLP/JSON to a collector; tests inject a stub
 // exporter (no running collector). It is a normal TraceSink, so it tees alongside console/JSONL.
+import { compact } from './compact';
 import type { StitchEvent, TraceContext, TraceSink } from './types';
 import { hex, readEnv, scrubUrl, stripTrailingSlashes } from './util';
 
@@ -104,12 +105,11 @@ function buildChildSpans(run: OtelSpan): OtelSpan[] {
             );
             const detail = retry?.attributes?.['stitch.detail'];
             const status: OtelSpan['status'] = next
-                ? {
+                ? compact({
                       code: 'ERROR',
-                      ...(detail !== undefined
-                          ? { message: String(detail) }
-                          : {}),
-                  }
+                      message:
+                          detail !== undefined ? String(detail) : undefined,
+                  })
                 : run.status;
             return child(
                 `attempt ${attempt}`,
@@ -135,10 +135,12 @@ function buildChildSpans(run: OtelSpan): OtelSpan[] {
 export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
     const exporter =
         opts.exporter ??
-        otlpHttpExporter({
-            ...(opts.endpoint !== undefined ? { endpoint: opts.endpoint } : {}),
-            ...(opts.headers !== undefined ? { headers: opts.headers } : {}),
-        });
+        otlpHttpExporter(
+            compact({
+                endpoint: opts.endpoint,
+                headers: opts.headers,
+            }),
+        );
     const open = new Map<string, OtelSpan[]>();
     const push = (name: string, span: OtelSpan): void => {
         const stack = open.get(name) ?? [];
@@ -178,22 +180,25 @@ export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
                     };
                     const host = serverAddress(event.url);
                     if (host) attributes['server.address'] = host;
-                    push(key, {
-                        name: `${event.method} ${name}`,
-                        kind: 'CLIENT',
-                        // Read the engine-minted ids off the ctx (real trace tree); fall back to
-                        // freshly-minted ids for a hand-fed sink with no run identity.
-                        traceId: ctx.traceId ?? hex(16),
-                        spanId: ctx.runId ?? hex(8),
-                        ...(ctx.parentId !== undefined
-                            ? { parentSpanId: ctx.parentId }
-                            : {}),
-                        startUnixMs: event.at,
-                        endUnixMs: event.at,
-                        attributes,
-                        status: { code: 'UNSET' },
-                        events: [],
-                    });
+                    push(
+                        key,
+                        compact({
+                            name: `${event.method} ${name}`,
+                            kind: 'CLIENT',
+                            // Read the engine-minted ids off the ctx (real trace tree); fall back to
+                            // freshly-minted ids for a hand-fed sink with no run identity.
+                            traceId: ctx.traceId ?? hex(16),
+                            spanId: ctx.runId ?? hex(8),
+                            parentSpanId: ctx.parentId,
+                            startUnixMs: event.at,
+                            endUnixMs: event.at,
+                            attributes,
+                            status: { code: 'UNSET' },
+                            // `compact`'s `const` generic would freeze `[]` to `readonly []`;
+                            // OtelSpan.events is mutable, so pin the element type.
+                            events: [] as OtelSpanEvent[],
+                        }),
+                    );
                     break;
                 }
                 case 'progress': {

--- a/packages/core/src/postmessage.ts
+++ b/packages/core/src/postmessage.ts
@@ -27,6 +27,7 @@
 // Browser-first + bundle-frugal + zero-dep: only `postMessage`/`MessageEvent`/`MessagePort`/
 // `ReadableStream`/`globalThis.crypto` — no `node:*`, no `Buffer`. Reached only through this subpath;
 // `import { stitch }` pulls in none of it.
+import { compact } from './compact';
 import type { InputOf, OutputOf, SchemaLike } from './infer';
 import { makeStitch } from './stitch';
 import type { Surface } from './surface';
@@ -465,11 +466,13 @@ function makeChannel(
         }
         if (!(await passes(responder.output, result))) return; // off-contract → never post
         if (closed) return;
-        transport.post({
-            type: responder.reply,
-            ...(env.id !== undefined ? { id: env.id } : {}),
-            payload: result,
-        });
+        transport.post(
+            compact({
+                type: responder.reply,
+                id: env.id,
+                payload: result,
+            }),
+        );
     }
 
     // ---- request: a buffered execute surface --------------------------------
@@ -544,22 +547,21 @@ function makeChannel(
                     transport.post({ type, id, payload: req.body });
                 }),
         };
-        // The assembled config is handed to `makeStitch` as the loose `Partial<StitchConfig>`
-        // Fragment: a generic `const C` keeps each slot's literal optionality (`C['name']` is
-        // `string | undefined`), which `exactOptionalPropertyTypes` rejects against `Fragment`'s
-        // `name?: string` — so widen the spread with `as Partial<StitchConfig>` (the generic
-        // optionality is sound at runtime), then retype the loose result back to the declared
-        // `InputOf<C>` (the sse/stream/graphql `as unknown as` idiom).
-        return makeStitch<OutputOf<C>>({
-            ...rest,
-            ...(input !== undefined ? { input } : {}),
-            ...(output !== undefined ? { output } : {}),
-            kind: surface,
-            url,
-        } as Partial<StitchConfig>) as unknown as Stitch<
-            OutputOf<C>,
-            InputOf<C>
-        >;
+        // `compact` drops the `undefined`-valued slots and yields an optional-keyed shape
+        // (`name?: string`), so the generic `const C`'s `string | undefined` optionality —
+        // which `exactOptionalPropertyTypes` would otherwise reject against `Fragment`'s
+        // `name?: string` — no longer needs a widening `as Partial<StitchConfig>` cast. The
+        // loose result is still retyped to the declared `InputOf<C>` (the sse/stream/graphql
+        // `as unknown as` idiom).
+        return makeStitch<OutputOf<C>>(
+            compact({
+                ...rest,
+                input,
+                output,
+                kind: surface,
+                url,
+            }),
+        ) as unknown as Stitch<OutputOf<C>, InputOf<C>>;
     }
 
     // ---- emit: a buffered execute surface, no reply -------------------------
@@ -591,12 +593,14 @@ function makeChannel(
         };
         // `makeStitch`'s generic can't be `void` (lint: void only valid as a return type) — build it
         // loose and cast the result to the `void`-typed Stitch (emit's call resolves to nothing).
-        return makeStitch({
-            ...rest,
-            ...(input !== undefined ? { input } : {}),
-            kind: surface,
-            url,
-        } as Partial<StitchConfig>) as unknown as Stitch<void, InputOf<C>>;
+        return makeStitch(
+            compact({
+                ...rest,
+                input,
+                kind: surface,
+                url,
+            }) as Partial<StitchConfig>,
+        ) as unknown as Stitch<void, InputOf<C>>;
     }
 
     // ---- events: a streaming surface ----------------------------------------
@@ -683,15 +687,14 @@ function makeChannel(
                 }
             },
         };
-        return makeStitch<OutputOf<C>[]>({
-            ...rest,
-            ...(output !== undefined ? { output } : {}),
-            kind: surface,
-            url,
-        } as Partial<StitchConfig>) as unknown as Stitch<
-            OutputOf<C>[],
-            InputOf<C>
-        >;
+        return makeStitch<OutputOf<C>[]>(
+            compact({
+                ...rest,
+                output,
+                kind: surface,
+                url,
+            }),
+        ) as unknown as Stitch<OutputOf<C>[], InputOf<C>>;
     }
 
     // ---- respond: register an inbound handler (NOT a stitch) -----------------

--- a/packages/core/src/seam.ts
+++ b/packages/core/src/seam.ts
@@ -4,6 +4,7 @@
 // job is the trusted principal boundary: `seam.as(req.user.id)` binds identity in the closure, so
 // a caller can never name another principal (the principal is never in `StitchInput`). Auth is
 // principal-scoped (separate sessions, no bleed); throttle stays shared (one bucket).
+import { compact } from './compact';
 import {
     type SharedRuntime,
     compose,
@@ -208,15 +209,17 @@ export function seam(options: SeamOptions = {}): Seam {
     const vault = vaultView(secretStore ?? store);
     const trace = resolveTrace(fragment.trace);
     const seamId = `s${(seamCounter += 1)}`;
-    const shared: SharedSeam = {
+    const shared: SharedSeam = compact({
         fragment,
         store,
         clock,
         vault,
         trace,
         throttle: seamBucket(fragment.throttle, store, seamId, clock),
-        stitches: [],
-        ...(secretStore ? { secretStore } : {}),
-    };
+        // `compact`'s `const` generic would freeze `[]` to `readonly []`; SharedSeam.stitches
+        // is mutable, so pin the element type.
+        stitches: [] as Stitch[],
+        secretStore,
+    });
     return rootHandle(shared);
 }

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -1,6 +1,7 @@
 // The authoring surface: stitch() + the extends composition facade +
 // `.with()` partial application, all resolving to one canonical config. For a shared surface —
 // shared runtime + a trusted principal boundary — reach for `seam` (see seam.ts).
+import { compact } from './compact';
 import {
     ERROR_SOURCE,
     RAW_BODY,
@@ -219,11 +220,13 @@ function maxBodyFromEnv(value: string | undefined): number | false | undefined {
 function getTrace(): TraceSink {
     const file = fileFromEnv(readEnv('STITCH_TRACE_FILE'));
     const maxBodyBytes = maxBodyFromEnv(readEnv('STITCH_TRACE_MAX_BODY'));
-    const base = createTrace({
-        console: readEnv('STITCH_TRACE_CONSOLE') === '1',
-        file,
-        ...(maxBodyBytes !== undefined ? { maxBodyBytes } : {}),
-    });
+    const base = createTrace(
+        compact({
+            console: readEnv('STITCH_TRACE_CONSOLE') === '1',
+            file,
+            maxBodyBytes,
+        }),
+    );
     if (!exportsFromEnv(readEnv('STITCH_EXPORT')).includes('otlp')) return base;
     return multiplex(base, otlpTrace());
 }
@@ -420,12 +423,12 @@ function tee<T>(
     // Run identity (ADR 0007) is per-run-constant, so build the ctx once and hand it to the
     // sink with every event — the OTLP sink and the playground DAG collector read it to build
     // the span tree; a sink that reads only `ctx.name` is unaffected.
-    const ctx = {
+    const ctx = compact({
         name,
         runId: run.runId,
         traceId: run.traceId,
-        ...(run.parentId !== undefined ? { parentId: run.parentId } : {}),
-    };
+        parentId: run.parentId,
+    });
     async function* wrapped() {
         for await (const ev of gen) {
             trace.handle(ev, ctx);

--- a/packages/core/src/test-stub.ts
+++ b/packages/core/src/test-stub.ts
@@ -3,6 +3,7 @@
 // conformant {@link Stitch} — callable, with `.safe`/`.unwrap`/`.stream`/`.with`/`.cache`/
 // `__config`/`__stitch` — so `isStitch()`, a registry, or a Nest `overrideProvider(useValue:…)`
 // accept it. A call spy records every invocation. Browser-safe: no `node:*`.
+import { compact } from './compact';
 import {
     type RedactedStitchConfig,
     type SafeResult,
@@ -76,14 +77,14 @@ function defaultEvents<TOut>(
         at,
     };
     if (error) {
-        const err: StitchEvent<TOut> = {
+        const err: StitchEvent<TOut> = compact({
             type: 'error',
             name: error.name,
             message: error.message,
             attempts: 1,
             at,
-            ...(error.status !== undefined ? { status: error.status } : {}),
-        };
+            status: error.status,
+        });
         return [
             start,
             err,
@@ -242,10 +243,9 @@ export function failStitch<TOut = unknown, TIn = StitchInput>(
             ? error
             : typeof error === 'string'
               ? new StitchError(error)
-              : new StitchError(error.message ?? 'stub failure', {
-                    ...(error.status !== undefined
-                        ? { status: error.status }
-                        : {}),
-                });
+              : new StitchError(
+                    error.message ?? 'stub failure',
+                    compact({ status: error.status }),
+                );
     return assemble<TOut, TIn>(() => Promise.reject(err), opts);
 }

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -1,5 +1,6 @@
 // Zero-infra observability sink: append every StitchEvent as a JSONL record and,
 // optionally, print a compact colored one-line-per-event summary to stderr. No deps.
+import { compact } from './compact';
 import type { DriftLevel, StitchEvent, TraceContext, TraceSink } from './types';
 import { dirnameOf, isSecretQueryKey, nodeFs, readEnv, scrubUrl } from './util';
 
@@ -465,11 +466,13 @@ export function fileSink(
     path?: string,
     opts?: Omit<TraceOptions, 'console' | 'file'>,
 ): TraceSink {
-    return createTrace({
-        console: false,
-        ...(path !== undefined ? { file: path } : {}),
-        ...opts,
-    });
+    return createTrace(
+        compact({
+            console: false,
+            file: path,
+            ...opts,
+        }),
+    );
 }
 
 /** Fan every event out to several sinks (e.g. console/JSONL + OTLP) — one event stream, many consumers. */

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -59,11 +59,15 @@ export function redactEventForTransport(event: StitchEvent): StitchEvent {
     return {
         ...event,
         url: scrubUrl(event.url),
-        input: {
+        // `compact` drops `headers`/`query` when their redacted values are undefined —
+        // which is exactly when `event.input` lacked them (safeHeaders/safeQuery are derived
+        // from event.input.headers/.query), so it only ever omits the conditional override,
+        // never a key the `...event.input` spread provided.
+        input: compact({
             ...event.input,
-            ...(safeHeaders ? { headers: safeHeaders } : {}),
-            ...(safeQuery ? { query: safeQuery } : {}),
-        },
+            headers: safeHeaders,
+            query: safeQuery,
+        }),
     };
 }
 

--- a/packages/eval-harness/index.ts
+++ b/packages/eval-harness/index.ts
@@ -32,6 +32,7 @@ import { runProduced } from './score/run';
 import { type EvalTask, TASKS, getTask, taskIds } from './tasks/index';
 
 import { promises as fs } from 'node:fs';
+import { compact } from 'stitchapi';
 
 interface Args {
     command: string;
@@ -99,7 +100,7 @@ async function evalCell(
         error = scored.error;
     }
 
-    return {
+    return compact({
         taskId: task.id,
         family: task.family,
         condition,
@@ -110,8 +111,8 @@ async function evalCell(
         transcriptTurns: run.transcriptTurns,
         tokensIn: run.tokensIn,
         tokensOut: run.tokensOut,
-        ...(error !== undefined ? { error } : {}),
-    };
+        error,
+    });
 }
 
 /** Run the full task × condition matrix. */

--- a/packages/eval-harness/tsconfig.json
+++ b/packages/eval-harness/tsconfig.json
@@ -9,7 +9,15 @@
         "skipLibCheck": true,
         "noEmit": true,
         "strict": true,
-        "types": ["node"]
+        "types": ["node"],
+
+        // Resolve the workspace `stitchapi` import to its SOURCE so typecheck
+        // doesn't depend on core being built first (the published `exports` map
+        // still points at `lib/`). Mirrors the sibling integration packages.
+        "baseUrl": ".",
+        "paths": {
+            "stitchapi": ["../core/src/index.ts"]
+        }
     },
     "include": ["**/*.ts"],
     "comment": "Mirrors packages/sandbox-sim/tsconfig.json (strict, ES2022, Bundler resolution). This package is Node-only (shells out, reads fs, runs under tsx) so it bundles @types/node and type-checks its test files in the same pass — unlike sandbox-sim, whose shipped source must type-check dependency-free."

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -15,6 +15,7 @@
 // `next` import — so the same helpers work in Next route handlers, Remix, SvelteKit
 // endpoints, Bun, Deno, and Workers. `stitchapi` is the only peer dependency.
 import type { StitchEvent } from 'stitchapi';
+import { compact } from 'stitchapi';
 
 // ---------------------------------------------------------------------------
 // SSE Response
@@ -101,13 +102,13 @@ export function sseResponse<T>(
                     } else if (event.type === 'error') {
                         controller.enqueue(
                             encoder.encode(
-                                `event: error\ndata: ${JSON.stringify({
-                                    name: event.name,
-                                    message: event.message,
-                                    ...(event.status !== undefined
-                                        ? { status: event.status }
-                                        : {}),
-                                })}\n\n`,
+                                `event: error\ndata: ${JSON.stringify(
+                                    compact({
+                                        name: event.name,
+                                        message: event.message,
+                                        status: event.status,
+                                    }),
+                                )}\n\n`,
                             ),
                         );
                         break;

--- a/packages/pino/src/index.ts
+++ b/packages/pino/src/index.ts
@@ -172,14 +172,12 @@ function recordFor(
             };
         case 'progress':
             return {
-                obj: {
+                obj: compact({
                     stitch: name,
                     phase: event.phase,
                     attempt: event.attempt,
-                    ...(event.waited !== undefined
-                        ? { waited: event.waited }
-                        : {}),
-                },
+                    waited: event.waited,
+                }),
                 msg: `· ${name} ${event.phase}#${event.attempt}${
                     event.waited !== undefined
                         ? ` waited ${event.waited}ms`

--- a/packages/pino/src/index.ts
+++ b/packages/pino/src/index.ts
@@ -8,6 +8,7 @@
 // plain test double all satisfy it (mirroring core's "contract, not dependency"
 // stance). `pino` is the single peer dependency.
 import type { StitchEvent, TraceContext, TraceSink } from 'stitchapi';
+import { compact } from 'stitchapi';
 
 // ---------------------------------------------------------------------------
 // logger contract
@@ -188,13 +189,13 @@ function recordFor(
         case 'drift': {
             const f = event.finding;
             return {
-                obj: {
+                obj: compact({
                     stitch: name,
                     path: f.path,
                     level: f.level,
                     change: f.change,
-                    ...(f.detail !== undefined ? { detail: f.detail } : {}),
-                },
+                    detail: f.detail,
+                }),
                 msg: `drift ${name} ${f.path} ${f.change}${f.detail ? ` (${f.detail})` : ''}`,
             };
         }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -86,10 +86,7 @@ function useStitchInternal<T>(
         onSuccess?: (d: T) => void;
         onError?: (e: unknown) => void;
     }>({});
-    cbRef.current = {
-        ...(onSuccess ? { onSuccess } : {}),
-        ...(onError ? { onError } : {}),
-    };
+    cbRef.current = compact({ onSuccess, onError });
 
     // Hold the latest `stitch` in a ref. A caller who passes an INLINE stitch
     // (`useStitch(() => stitch(...), ...)`) hands us a fresh function identity on
@@ -118,7 +115,7 @@ function useStitchInternal<T>(
                 input,
                 compact({
                     stream,
-                    ...(mode ? { mode } : {}),
+                    mode,
                     enabled,
                     onSuccess: (d: T) => cbRef.current.onSuccess?.(d),
                     onError: (e: unknown) => cbRef.current.onError?.(e),

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -24,6 +24,7 @@ import {
 } from '@stitchapi/query-core';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSyncExternalStore } from 'react';
+import { compact } from 'stitchapi';
 
 export type {
     CreateStitchQueryOptions,
@@ -112,13 +113,17 @@ function useStitchInternal<T>(
 
     const query: StitchQuery<T> = useMemo(
         () =>
-            createStitchQuery<T, unknown>(stableStitch, input, {
-                stream,
-                ...(mode ? { mode } : {}),
-                ...(enabled !== undefined ? { enabled } : {}),
-                onSuccess: (d) => cbRef.current.onSuccess?.(d),
-                onError: (e) => cbRef.current.onError?.(e),
-            }),
+            createStitchQuery<T, unknown>(
+                stableStitch,
+                input,
+                compact({
+                    stream,
+                    ...(mode ? { mode } : {}),
+                    enabled,
+                    onSuccess: (d: T) => cbRef.current.onSuccess?.(d),
+                    onError: (e: unknown) => cbRef.current.onError?.(e),
+                }),
+            ),
         // eslint-disable-next-line react-hooks/exhaustive-deps
         depKey,
     );

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -18,6 +18,7 @@
 // `event.input` (its headers carry the live `authorization`/`cookie`), `event.data`,
 // or a `delta` chunk. The URL query string is dropped (it can carry `?api_key=…`).
 import type { StitchEvent, TraceContext, TraceSink } from 'stitchapi';
+import { compact } from 'stitchapi';
 
 // ---------------------------------------------------------------------------
 // Sentry contract (structural — any @sentry/* SDK satisfies it)
@@ -128,12 +129,12 @@ function breadcrumbFor(
                 category: 'stitch.drift',
                 level: DRIFT_TO_SENTRY[f.level] ?? 'debug',
                 message: `drift ${name} ${f.path} ${f.change}`,
-                data: {
+                data: compact({
                     path: f.path,
                     level: f.level,
                     change: f.change,
-                    ...(f.detail !== undefined ? { detail: f.detail } : {}),
-                },
+                    detail: f.detail,
+                }),
             };
         }
         case 'result':

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -115,13 +115,11 @@ function breadcrumbFor(
                         ? 'warning'
                         : 'debug',
                 message: `· ${name} ${event.phase}#${event.attempt}`,
-                data: {
+                data: compact({
                     phase: event.phase,
                     attempt: event.attempt,
-                    ...(event.waited !== undefined
-                        ? { waited: event.waited }
-                        : {}),
-                },
+                    waited: event.waited,
+                }),
             };
         case 'drift': {
             const f = event.finding;
@@ -152,12 +150,10 @@ function breadcrumbFor(
                 category: 'stitch',
                 level: 'error',
                 message: `✗ ${name} ${event.name}: ${event.message}`,
-                data: {
-                    ...(event.status !== undefined
-                        ? { status: event.status }
-                        : {}),
+                data: compact({
+                    status: event.status,
                     attempts: event.attempts,
-                },
+                }),
             };
         case 'done':
             return lifecycle
@@ -215,12 +211,10 @@ export function sentrySink(
                     `${ctx.name}: ${event.name} — ${event.message}`,
                     {
                         level: 'error',
-                        tags: {
+                        tags: compact({
                             stitch: ctx.name,
-                            ...(event.status !== undefined
-                                ? { status: event.status }
-                                : {}),
-                        },
+                            status: event.status,
+                        }),
                         extra: {
                             attempts: event.attempts,
                             ...(ctx.runId ? { runId: ctx.runId } : {}),
@@ -237,12 +231,10 @@ export function sentrySink(
                     {
                         level: 'warning',
                         tags: { stitch: ctx.name, drift: event.finding.change },
-                        extra: {
+                        extra: compact({
                             path: event.finding.path,
-                            ...(event.finding.detail !== undefined
-                                ? { detail: event.finding.detail }
-                                : {}),
-                        },
+                            detail: event.finding.detail,
+                        }),
                     },
                 );
             }

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -15,7 +15,7 @@
 //     into a child — pass exactly what's needed (incl. `PATH` for a bare command name, or use an
 //     absolute command path).
 import { execFile } from 'node:child_process';
-import { stitch } from 'stitchapi';
+import { compact, stitch } from 'stitchapi';
 import type {
     AdapterRequest,
     AdapterResponse,
@@ -55,13 +55,13 @@ function runCommand(
         execFile(
             d.command,
             argv,
-            {
-                ...(d.cwd !== undefined ? { cwd: d.cwd } : {}),
+            compact({
+                cwd: d.cwd,
                 env: d.env ?? {}, // FAIL-CLOSED: no inherited process.env
-                ...(req.signal !== undefined ? { signal: req.signal } : {}),
+                signal: req.signal,
                 maxBuffer: d.maxBuffer,
                 encoding: 'utf8',
-            },
+            }),
             (err, stdout, stderr) => {
                 if (err) {
                     // A non-zero EXIT carries a numeric `.code` (the exit status) → a "response".

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -23,6 +23,7 @@ import {
 } from '@stitchapi/query-core';
 import { createEffect, on, onCleanup } from 'solid-js';
 import { createStore, reconcile } from 'solid-js/store';
+import { compact } from 'stitchapi';
 
 export type {
     CreateStitchQueryOptions,
@@ -121,13 +122,13 @@ function createStitchInternal<T>(
                 const handle = createStitchQuery<T, unknown>(
                     stableStitch,
                     currentInput,
-                    {
+                    compact({
                         stream,
                         ...(mode ? { mode } : {}),
-                        ...(enabled !== undefined ? { enabled } : {}),
+                        enabled,
                         ...(onSuccess ? { onSuccess } : {}),
                         ...(onError ? { onError } : {}),
-                    },
+                    }),
                 );
                 query = handle;
 

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -124,10 +124,10 @@ function createStitchInternal<T>(
                     currentInput,
                     compact({
                         stream,
-                        ...(mode ? { mode } : {}),
+                        mode,
                         enabled,
-                        ...(onSuccess ? { onSuccess } : {}),
-                        ...(onError ? { onError } : {}),
+                        onSuccess,
+                        onError,
                     }),
                 );
                 query = handle;

--- a/packages/vercel-ai/src/index.ts
+++ b/packages/vercel-ai/src/index.ts
@@ -148,6 +148,8 @@ export function stitchTool<T>(
     stitch: StitchLike<T, unknown>,
     options: StitchToolOptions<unknown, unknown>,
 ): StitchTool<unknown, T> {
+    // `compact` is the wrong tool here: `parameters`/`inputSchema` are required `unknown`
+    // keys it would optionalize. Keep the explicit spread to omit only `description`.
     return {
         ...(options.description !== undefined
             ? { description: options.description }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -22,6 +22,7 @@ import {
     type StitchQueryState,
     createStitchQuery,
 } from '@stitchapi/query-core';
+import { compact } from 'stitchapi';
 import {
     type ComputedRef,
     type MaybeRefOrGetter,
@@ -116,13 +117,17 @@ function useStitchInternal<T>(
 
         const opts = toValue(options);
         const resolvedInput = toValue(input);
-        query = createStitchQuery<T, unknown>(stitch, resolvedInput, {
-            stream,
-            ...(opts.mode ? { mode: opts.mode } : {}),
-            ...(opts.enabled !== undefined ? { enabled: opts.enabled } : {}),
-            ...(opts.onSuccess ? { onSuccess: opts.onSuccess } : {}),
-            ...(opts.onError ? { onError: opts.onError } : {}),
-        });
+        query = createStitchQuery<T, unknown>(
+            stitch,
+            resolvedInput,
+            compact({
+                stream,
+                ...(opts.mode ? { mode: opts.mode } : {}),
+                enabled: opts.enabled,
+                ...(opts.onSuccess ? { onSuccess: opts.onSuccess } : {}),
+                ...(opts.onError ? { onError: opts.onError } : {}),
+            }),
+        );
 
         // Seed synchronously (the store may already be `pending`), then track.
         snapshot.value = query.getSnapshot();

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -122,10 +122,10 @@ function useStitchInternal<T>(
             resolvedInput,
             compact({
                 stream,
-                ...(opts.mode ? { mode: opts.mode } : {}),
+                mode: opts.mode,
                 enabled: opts.enabled,
-                ...(opts.onSuccess ? { onSuccess: opts.onSuccess } : {}),
-                ...(opts.onError ? { onError: opts.onError } : {}),
+                onSuccess: opts.onSuccess,
+                onError: opts.onError,
             }),
         );
 


### PR DESCRIPTION
## What & why

We had ~49 copies of the `...(x !== undefined ? { key: x } : {})` conditional-spread idiom — the dance `exactOptionalPropertyTypes` forces when you want to omit an optional key rather than set it to `undefined`. This replaces them with a single helper.

`compact({ ...obj, key })` returns a shallow copy with the `undefined`-valued keys dropped, **typed** so undefined-admitting keys come back optional (`key?: V`) — so the result drops straight into a typed target. A `const` type parameter preserves literal types, so discriminants like `{ type: 'start' }` survive the wrap.

```ts
// before
const ev: StitchEvent = {
    type: 'start', name, runId, traceId,
    ...(run.parentId !== undefined ? { parentId: run.parentId } : {}),
};

// after
const ev: StitchEvent = compact({
    type: 'start', name, runId, traceId, parentId: run.parentId,
});
```

## Scope

- **New module** `packages/core/src/compact.ts` (`compact` + `Compact<T>`), **exported publicly** from `stitchapi` (sits alongside the existing `systemClock` / `isSecretQueryKey` util exports).
- **49 call sites** converted: 40 in core + 9 across 8 integration packages (`shell`, `pino`, `sentry`, `react`, `vue`, `solid`, `angular`, `eval-harness`).
- **Lint rule** (`no-restricted-syntax`, `core/src`) steers the idiom to `compact()`. It's AST-precise: it deliberately ignores truthy spreads (`...(x ? … : {})`), array spreads, and `!== ''` / `!== null` (an `Identifier` guard was needed — esquery otherwise coerces an absent `.name` to match `'undefined'`).

## Notable

- **Drops two `as Partial<StitchConfig>` casts** in `postmessage.ts` — `compact`'s optional-keyed output is exactly what those casts were laundering, so they (and their comment) are gone. The migration *removed* type-casting rather than adding it.
- **The lint rule found 9 sites a regex pass had missed** — all multi-line spreads where `? {` wraps to the next line.

## Caveats (documented in `compact.ts`; each handled at its site)

`compact` is not a blanket replacement — three cases need care, all addressed:
1. A **required `unknown`** key gets optionalized (since `undefined extends unknown`). One site — the errored `AdapterResponse` whose `body` is required `unknown` ([engine.ts](packages/core/src/engine.ts)) — keeps the explicit spread with an inline `eslint-disable`.
2. The `const` generic freezes an inline `[]` to `readonly []` — pinned the element type in `otlp.ts` (`events: [] as OtelSpanEvent[]`).
3. Inline callbacks lose contextual param types — annotated them in `react` (`onSuccess: (d: T) => …`).

## Impact

Net bundle is **smaller on every metric** (it's a frugality win, not a cost):

| scenario | gzip (main → this PR) | min Δ |
|---|---|---|
| whole entry | 23.13 → 23.06 KB | −0.30 KB |
| `import { stitch }` | 18.61 → 18.58 KB | −0.25 KB |

## Validation

- `check:types` (src + test), `check:lint`, `check:types-d` (tsd) — all clean.
- **1121 core tests** pass; all 8 integration package suites pass.

## Reviewer notes

- **Public API:** `compact` / `Compact` are now exported from `stitchapi` — a new (additive) surface item as we approach 1.0. May want a changelog/docs line.
- **Pre-existing, not from this PR:** the core bundle-size budget is already failing on `main` (23.13 > 22.95 KB gzip). This PR *reduces* the overage but doesn't clear it — worth a separate budget review or trim.
