### PR TITLE
refactor(core): fold the two deferred truthy spreads into compact()

### DIFF
--- a/packages/core/src/seam.ts
+++ b/packages/core/src/seam.ts
@@ -4,6 +4,7 @@
 // job is the trusted principal boundary: `seam.as(req.user.id)` binds identity in the closure, so
 // a caller can never name another principal (the principal is never in `StitchInput`). Auth is
 // principal-scoped (separate sessions, no bleed); throttle stays shared (one bucket).
+import { compact } from './compact';
 import {
     type SharedRuntime,
     compose,
@@ -208,15 +209,17 @@ export function seam(options: SeamOptions = {}): Seam {
     const vault = vaultView(secretStore ?? store);
     const trace = resolveTrace(fragment.trace);
     const seamId = `s${(seamCounter += 1)}`;
-    const shared: SharedSeam = {
+    const shared: SharedSeam = compact({
         fragment,
         store,
         clock,
         vault,
         trace,
         throttle: seamBucket(fragment.throttle, store, seamId, clock),
-        stitches: [],
-        ...(secretStore ? { secretStore } : {}),
-    };
+        // `compact`'s `const` generic would freeze `[]` to `readonly []`; SharedSeam.stitches
+        // is mutable, so pin the element type.
+        stitches: [] as Stitch[],
+        secretStore,
+    });
     return rootHandle(shared);
 }

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -59,11 +59,15 @@ export function redactEventForTransport(event: StitchEvent): StitchEvent {
     return {
         ...event,
         url: scrubUrl(event.url),
-        input: {
+        // `compact` drops `headers`/`query` when their redacted values are undefined —
+        // which is exactly when `event.input` lacked them (safeHeaders/safeQuery are derived
+        // from event.input.headers/.query), so it only ever omits the conditional override,
+        // never a key the `...event.input` spread provided.
+        input: compact({
             ...event.input,
-            ...(safeHeaders ? { headers: safeHeaders } : {}),
-            ...(safeQuery ? { query: safeQuery } : {}),
-        },
+            headers: safeHeaders,
+            query: safeQuery,
+        }),
     };
 }
 


### PR DESCRIPTION
## What

Follow-up to #379. That PR adopted `compact()` repo-wide but **deliberately left two
object-valued truthy spreads** for backlog. This PR folds those two in. Both guarded values
are objects (never falsy-when-defined), so the `truthy → compact` swap is behavior-preserving.

> **Stacked on #379.** Base branch is `claude/charming-wright-0c0b92` (#379's head), not `main`,
> because `compact()` doesn't exist on `main` yet. Retarget to `main` once #379 merges.

## Changes

**`packages/core/src/trace.ts`** — `redactEventForTransport` (the SSE-transport scrubber):

```ts
input: compact({ ...event.input, headers: safeHeaders, query: safeQuery })
```

`safeHeaders` / `safeQuery` are `undefined` **exactly when** `event.input` lacked
`headers` / `query` (they're derived from them via the redactors), so `compact` only ever
omits the conditional override — never a key the `...event.input` spread provided. The
no-headers/query path is asserted by `trace-redact-transport.spec.ts` (absent key), and an
absent key vs. an `undefined`-valued key serialize identically over the JSON SSE wire.

**`packages/core/src/seam.ts`** — the `shared: SharedSeam` literal is wrapped in `compact()`
with `secretStore` as a plain key. `stitches` is pinned `[] as Stitch[]` so `compact`'s
`const` generic doesn't freeze it to `readonly []` (mirrors `otlp.ts`'s `events: [] as …`).
Type-check confirms `secretStore?` stays optional and `stitches` stays mutable.

The other truthy spreads are intentionally left alone — they have different semantics
(empty-string suppression signals, arbitrary-string values, `!= null` guards, type guards).

## Verification

- `pnpm --filter stitchapi check:types` — clean
- `pnpm --filter stitchapi test` — 1119 passed, 2 skipped
- Full pre-push gate (whole tree): format, lint, contract, typecheck, typecheck-d, test,
  exports, build-docs — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
