### PR TITLE
fix(docs): gate the llms.txt preamble's advertised bundle size

### DIFF
--- a/apps/docs/lib/source.ts
+++ b/apps/docs/lib/source.ts
@@ -23,7 +23,7 @@ export function llmsPreamble() {
 - Capability, not credential: an agent invokes a stitch and gets structured, validated, traceable data; the secret stays behind the boundary.
 - One context-frugal **code-mode** tool (run_stitch + list_stitches + describe_stitch), not one tool per endpoint — adding APIs never floods the context window.
 - No server, no codegen, no config files — a URL and one example response is enough; only explicit composition (no ambient/global config a stitch silently inherits).
-- Zero-dependency core, ~18–22 kB min+gzip, validator-agnostic (bring your own Standard Schema / Zod), and it runs in the browser.
+- Zero-dependency core, ~23 kB min+gzip for the whole entry (~19 kB for a tree-shaken import { stitch }), validator-agnostic (bring your own Standard Schema / Zod), and it runs in the browser.
 - Composes with your data layer: a stitch is the queryFn for TanStack Query / SWR — it owns the call's resilience; your query layer owns view state.
 
 ## Quickstart

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,7 +18,7 @@ pre-commit:
         # CI's `size` job does the authoritative measured check. Keep this glob in
         # sync with the FILES list in scripts/check-size-docs.mjs.
         - name: size-docs
-          glob: '{README.md,packages/core/README.md,apps/docs/**/installation.mdx,apps/docs/**/principles.mdx,apps/docs/**/metrics.tsx,packages/core/scripts/bundle-size.mjs}'
+          glob: '{README.md,packages/core/README.md,apps/docs/**/installation.mdx,apps/docs/**/principles.mdx,apps/docs/**/metrics.tsx,apps/docs/lib/source.ts,packages/core/scripts/bundle-size.mjs}'
           run: pnpm check:size-docs
         # README metrics badge block must match the committed snapshot. Tool-free
         # drift guard (renders from scripts/readme-metrics.snapshot.json) — mirrors

--- a/scripts/check-size-docs.mjs
+++ b/scripts/check-size-docs.mjs
@@ -2,8 +2,9 @@
 // Keep every *advertised* bundle size in sync with the *measured* one.
 //
 // The bundle size is a selling point, so it is quoted in several human-facing
-// places — both READMEs, two docs pages, and the homepage metrics band. Each
-// quote is a hand-typed number, and a hand-typed number drifts: the gate
+// places — both READMEs, two docs pages, the homepage metrics band, and the
+// agent-facing llms.txt preamble. Each quote is a hand-typed number, and a
+// hand-typed number drifts: the gate
 // (packages/core/scripts/bundle-size.mjs) trims the entry to 20.7 kB while a
 // README still brags "~24 kB", or someone bumps the budget and forgets the prose.
 //
@@ -41,6 +42,8 @@ const FILES = [
     },
     { rel: 'apps/docs/content/docs/concepts/principles.mdx', allow: [] },
     { rel: 'apps/docs/app/(home)/components/metrics.tsx', allow: [] },
+    // The llms.txt / llms-full.txt preamble an agent reads before the docs index.
+    { rel: 'apps/docs/lib/source.ts', allow: [] },
 ];
 
 // A bundle-size quote: `~21 kB`. Tolerates the separators used across markdown,


### PR DESCRIPTION
## What

The llms.txt preamble advertised `~18–22 kB` for the core bundle — stale (the budget is now 18.8 / 23.35 kB; the measured-rounded gzip is ~19 / ~23 kB) and in a range format the `check-size-docs.mjs` gate couldn't even parse.

## Why it drifted

The preamble (`llmsPreamble()` in `apps/docs/lib/source.ts`) was the **one** advertised bundle-size quote not in `check-size-docs.mjs`'s `FILES` list. The other five — both READMEs, two docs pages, the homepage metrics band — are gated and stayed in sync; this one silently fell behind.

## Change

- `apps/docs/lib/source.ts` — preamble now reads `~23 kB … (~19 kB for … import { stitch })`: two parseable `~N kB` tokens matching the measured-rounded gzip.
- `scripts/check-size-docs.mjs` — add the preamble to `FILES` (+ header comment).
- `lefthook.yml` — add it to the `size-docs` pre-commit glob.

## Verification

`node scripts/check-size-docs.mjs` → `✓ Advertised bundle size in sync across 6 files (consensus: ~19 kB / ~23 kB).`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
