### PR TITLE
feat(docs): search_docs P1 — build-time index pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,4 +137,9 @@ lib
 # apps/docs/lib/ is Fumadocs source (lib/source.ts, lib/shared.ts, …), not build
 # output — exempt it from the generic `lib` rule above.
 !apps/docs/lib/
+
+# Build-time semantic docs search index (search_docs): regenerated every deploy
+# from the MDX, same source as llms.txt — never committed.
+# See docs/proposals/search-docs.md.
+apps/docs/.search-index/
 .DS_Store

--- a/apps/docs/lib/search-index/chunk.ts
+++ b/apps/docs/lib/search-index/chunk.ts
@@ -1,0 +1,99 @@
+// Split a page's *processed* markdown into self-contained, citeable section
+// chunks. The input is `page.data.getText('processed')` — the exact text that
+// feeds llms.txt — so the index can never drift from the docs.
+//
+// One chunk per H2/H3 section, plus a "top of page" chunk for any intro text
+// before the first heading. H4+ subheadings stay inside their parent section.
+// `#` inside fenced code blocks is never mistaken for a heading.
+
+import { Slugger } from './slugger';
+
+export interface PageInput {
+    /** Canonical page route, e.g. `/docs/guides/resilience/throttle`. */
+    url: string;
+    /** Page title (frontmatter) — also the heading of the intro chunk. */
+    title: string;
+    /** `page.data.getText('processed')`. */
+    processed: string;
+}
+
+export interface DocChunk {
+    pageUrl: string;
+    pageTitle: string;
+    /** Section heading text (the page title for the intro chunk). */
+    heading: string;
+    /** github-slug of the heading (`''` for the intro / top of page). */
+    anchor: string;
+    /** Section body markdown, heading line excluded. */
+    text: string;
+}
+
+// A fenced code block opener/closer: three or more backticks or tildes,
+// possibly indented. We only need the fence run to match opener with closer.
+const FENCE = /^\s*(`{3,}|~{3,})/;
+// An ATX heading: `## Heading`, tolerating trailing `#`s.
+const HEADING = /^(#{1,6})\s+(.+?)\s*#*\s*$/;
+// An explicit heading id: `## Title [#custom-id]` (fumadocs/remark syntax).
+const HEADING_ID = /\s*\[#([^\]]+)\]\s*$/;
+
+/** The text we actually embed: page + heading breadcrumb prepended for context. */
+export function embeddingInput(chunk: DocChunk): string {
+    return chunk.heading === chunk.pageTitle
+        ? `${chunk.pageTitle}\n\n${chunk.text}`
+        : `${chunk.pageTitle} — ${chunk.heading}\n\n${chunk.text}`;
+}
+
+export function chunkPage(page: PageInput): DocChunk[] {
+    const slugger = new Slugger();
+    const chunks: DocChunk[] = [];
+
+    let heading = page.title;
+    let anchor = '';
+    let body: string[] = [];
+    let fence: string | null = null;
+
+    const flush = () => {
+        const text = body.join('\n').trim();
+        body = [];
+        if (!text) return;
+        chunks.push({
+            pageUrl: page.url,
+            pageTitle: page.title,
+            heading,
+            anchor,
+            text,
+        });
+    };
+
+    for (const line of page.processed.split('\n')) {
+        const fenceMatch = line.match(FENCE);
+        if (fenceMatch) {
+            if (fence && line.trimStart().startsWith(fence)) fence = null;
+            else if (!fence) fence = fenceMatch[1];
+            body.push(line);
+            continue;
+        }
+
+        const headingMatch = fence ? null : line.match(HEADING);
+        if (
+            headingMatch &&
+            (headingMatch[1].length === 2 || headingMatch[1].length === 3)
+        ) {
+            flush();
+            // A heading may carry an explicit id (`## Title [#custom-id]`). When
+            // present that id IS the rendered anchor and the bracket is not part
+            // of the visible title; otherwise slug the text github-style.
+            let text = headingMatch[2].trim();
+            const explicit = text.match(HEADING_ID);
+            if (explicit) text = text.slice(0, explicit.index).trim();
+            heading = text;
+            anchor = explicit ? explicit[1].trim() : slugger.slug(text);
+            continue; // heading line is metadata, not body
+        }
+
+        body.push(line);
+    }
+    flush();
+
+    return chunks;
+}

--- a/apps/docs/lib/search-index/config.ts
+++ b/apps/docs/lib/search-index/config.ts
@@ -1,0 +1,42 @@
+// Shared configuration for the build-time semantic docs index (P1) and the
+// retrieval route that will consume it (P2). Kept in one place so the build
+// pipeline and the serving path can never disagree on the model, the vector
+// dimension, or the Orama schema.
+//
+// See docs/proposals/search-docs.md.
+
+// Local-open embedding model (transformers.js). Self-contained: no API key, no
+// third-party service in the build. all-MiniLM-L6-v2 is 384-dim and is what the
+// proposal's §6 spike measured.
+export const EMBED_MODEL = 'Xenova/all-MiniLM-L6-v2';
+
+// fp32 (not a quantized variant) so the same text embeds to the same vector
+// build-to-build — the determinism the index build asserts. Quantization is a
+// P3 cold-start lever, not a P1 default.
+export const EMBED_DTYPE = 'fp32' as const;
+
+// all-MiniLM-L6-v2 emits 384-dim sentence embeddings.
+export const EMBED_DIM = 384;
+
+// The Orama field that holds each chunk's embedding. Hybrid search (P2) reads
+// BM25 over the text fields and ANN over this one.
+export const VECTOR_FIELD = 'embedding';
+
+// Orama collection schema. The text fields back BM25; `embedding` backs vector
+// search. `as const` keeps `vector[384]` a literal so it satisfies Orama's
+// `vector[${number}]` field type. Reused verbatim by the P2 route when it
+// restores the persisted index.
+export const ORAMA_SCHEMA = {
+    pageUrl: 'string',
+    pageTitle: 'string',
+    heading: 'string',
+    anchor: 'string',
+    text: 'string',
+    embedding: 'vector[384]',
+} as const;
+
+// Build artifact location, relative to apps/docs. Regenerated every deploy from
+// the MDX (same source as llms.txt) and never committed — see .gitignore.
+export const INDEX_DIR = '.search-index';
+export const INDEX_FILE = 'docs-index.json';
+export const MANIFEST_FILE = 'manifest.json';

--- a/apps/docs/lib/search-index/embed.ts
+++ b/apps/docs/lib/search-index/embed.ts
@@ -1,0 +1,47 @@
+// Local-open text embeddings via transformers.js. Shared by the build pipeline
+// (P1, embeds every chunk) and, later, the retrieval route (P2, embeds the
+// query). The model loads lazily and is reused across calls.
+
+import { pipeline, type FeatureExtractionPipeline } from '@huggingface/transformers';
+
+import { EMBED_DTYPE, EMBED_MODEL } from './config';
+
+// Embed in modest batches: one call per chunk is slow, but one call for the
+// whole corpus builds a single enormous tensor that thrashes memory. 32 balances
+// throughput against footprint.
+const BATCH_SIZE = 32;
+
+let extractor: Promise<FeatureExtractionPipeline> | undefined;
+
+/** Lazily load (and cache) the feature-extraction pipeline. */
+export function getEmbedder(): Promise<FeatureExtractionPipeline> {
+    if (!extractor) {
+        extractor = pipeline('feature-extraction', EMBED_MODEL, {
+            dtype: EMBED_DTYPE,
+        });
+    }
+    return extractor;
+}
+
+/** Embed texts into mean-pooled, L2-normalized vectors, batched. */
+export async function embed(
+    texts: string[],
+    onProgress?: (done: number, total: number) => void,
+): Promise<number[][]> {
+    if (texts.length === 0) return [];
+    const run = await getEmbedder();
+    const vectors: number[][] = [];
+    for (let i = 0; i < texts.length; i += BATCH_SIZE) {
+        const batch = texts.slice(i, i + BATCH_SIZE);
+        const output = await run(batch, { pooling: 'mean', normalize: true });
+        vectors.push(...(output.tolist() as number[][]));
+        onProgress?.(vectors.length, texts.length);
+    }
+    return vectors;
+}
+
+/** Embed a single text. */
+export async function embedOne(text: string): Promise<number[]> {
+    const [vector] = await embed([text]);
+    return vector;
+}

--- a/apps/docs/lib/search-index/slugger.ts
+++ b/apps/docs/lib/search-index/slugger.ts
@@ -1,0 +1,48 @@
+// A faithful re-implementation of github-slugger — the slugger `rehype-slug`
+// uses — so the anchors we attach to chunks match the heading ids fumadocs
+// actually renders on the page. That is what makes a search hit's
+// `url#anchor` a working deep link.
+//
+// Slugging is stateful per page: a heading that repeats gets `-1`, `-2` …
+// suffixes, exactly as on the rendered page. Construct one Slugger per page.
+
+// The punctuation github-slugger strips (its classic character class), built via
+// `new RegExp` so the \u escapes stay plain ASCII in source. Anything matched is
+// removed; whitespace then collapses to single hyphens. Covers the General and
+// Supplemental Punctuation blocks (em dash, smart quotes, …) so a heading like
+// "Setup — advanced" slugs the same way the rendered page does.
+const SPECIALS = new RegExp(
+    "[\\u2000-\\u206F\\u2E00-\\u2E7F\\\\'!\"#$%&()*+,./:;<=>?@\\[\\]^`{|}~]",
+    'g',
+);
+const WHITESPACE = /\s/g;
+
+/** Slug a single string with no de-duplication (github-slugger's `slug()`). */
+export function slugSegment(value: string): string {
+    return value
+        .toLowerCase()
+        .trim()
+        .replace(SPECIALS, '')
+        .replace(WHITESPACE, '-');
+}
+
+/** Stateful slugger: repeated slugs gain a numeric suffix, like the rendered page. */
+export class Slugger {
+    private occurrences = new Map<string, number>();
+
+    slug(value: string): string {
+        const base = slugSegment(value);
+        let result = base;
+        while (this.occurrences.has(result)) {
+            const next = (this.occurrences.get(base) ?? 0) + 1;
+            this.occurrences.set(base, next);
+            result = `${base}-${next}`;
+        }
+        this.occurrences.set(result, 0);
+        return result;
+    }
+
+    reset(): void {
+        this.occurrences.clear();
+    }
+}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -2,6 +2,7 @@
     "name": "@stitchapi/docs",
     "version": "0.0.0",
     "private": true,
+    "type": "module",
     "description": "StitchAPI documentation site — Fumadocs (Next.js App Router). Content lands in follow-up PRs.",
     "scripts": {
         "dev": "pnpm run build:typed-deps && pnpm run build:sandbox && next dev",
@@ -14,6 +15,7 @@
         "build:core": "pnpm --filter stitchapi build",
         "build:typed-deps": "pnpm --filter stitchapi --filter @stitchapi/nest --filter @stitchapi/pino --filter @stitchapi/query-core --filter @stitchapi/react --filter @stitchapi/fastify --filter @stitchapi/hono build",
         "build:sandbox": "node scripts/gen-stitch-completions.mjs && node ../../docs/sandbox/runtime/build-sandbox-worker.mjs",
+        "build:search-index": "pnpm run build:typed-deps && fumadocs-mdx && node --import tsx/esm scripts/build-search-index.mjs",
         "test": "vitest run",
         "test:e2e": "playwright test",
         "test:e2e:install": "playwright install chromium"
@@ -41,9 +43,12 @@
         "zod": "^4.4.3"
     },
     "devDependencies": {
+        "@huggingface/transformers": "^4.2.0",
         "@nestjs/common": "^11.0.0",
         "@nestjs/config": "^4.0.0",
         "@nestjs/core": "^11.0.0",
+        "@orama/orama": "3.1.18",
+        "@orama/plugin-data-persistence": "3.1.18",
         "@playwright/test": "^1.49.1",
         "@stitchapi/completions-plugin": "workspace:*",
         "@stitchapi/fastify": "workspace:*",
@@ -68,6 +73,7 @@
         "eslint-config-next": "16.2.7",
         "postcss": "^8.5.15",
         "tailwindcss": "^4.3.0",
+        "tsx": "^4.22.4",
         "typescript": "^6.0.3",
         "vitest": "^4.1.8"
     }

--- a/apps/docs/scripts/build-search-index.mjs
+++ b/apps/docs/scripts/build-search-index.mjs
@@ -1,0 +1,26 @@
+// Bootstrap for the build-time search index (search_docs P1). Runs the fumadocs
+// `source` outside Next, which plain `node` can't do alone:
+//
+//   1. Launched via `node --import tsx/esm` (see the build:search-index npm
+//      script) so the generated `.source/*.ts` load as ESM — their top-level
+//      `await` works — with the `collections/*` / `@/*` tsconfig path aliases and
+//      the `?collection=…` query strings on the MDX imports preserved.
+//   2. fumadocs-mdx/node `register()` — a Node module hook so those modules can
+//      import their `*.mdx?collection=…` content the way webpack does during
+//      `next build`, honoring the `docs` collection's `includeProcessedMarkdown`
+//      (what getText('processed') reads).
+//
+// Keeping this here means the app itself stays plain CJS — only this script opts
+// into the richer loaders.
+import { register } from 'fumadocs-mdx/node';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Must precede any import that pulls in `.source`. Point it at source.config.ts
+// so the loader applies the `docs` collection's `includeProcessedMarkdown`.
+register({ configPath: resolve(appRoot, 'source.config.ts') });
+
+const { main } = await import('./build-search-index.ts');
+await main();

--- a/apps/docs/scripts/build-search-index.ts
+++ b/apps/docs/scripts/build-search-index.ts
@@ -1,0 +1,135 @@
+// Build-time semantic search index (search_docs P1).
+//
+// Iterates the SAME pages and processed markdown that feed llms.txt
+// (`source.getPages()` → `page.data.getText('processed')`), splits each page
+// into H2/H3 section chunks, embeds them locally, and persists an Orama index
+// (text fields for BM25 + a vector field) as an uncommitted build artifact under
+// apps/docs/.search-index/. No serving here — the P2 route restores this dump.
+//
+// Run from apps/docs:  pnpm run build:search-index
+// The npm wrapper runs `fumadocs-mdx` first so `.source` — and thus
+// `getText('processed')` — exists, then launches scripts/build-search-index.mjs,
+// which runs this module via tsx (ESM, so the generated source's top-level await
+// works) with the fumadocs-mdx Node loader registered to import the MDX content.
+//
+// See docs/proposals/search-docs.md §3, §9 (P1).
+import {
+    type DocChunk,
+    chunkPage,
+    embeddingInput,
+} from '../lib/search-index/chunk';
+import {
+    EMBED_DIM,
+    EMBED_MODEL,
+    INDEX_DIR,
+    INDEX_FILE,
+    MANIFEST_FILE,
+    ORAMA_SCHEMA,
+} from '../lib/search-index/config';
+import { embed, embedOne } from '../lib/search-index/embed';
+import { source } from '../lib/source';
+
+import { create, insertMultiple } from '@orama/orama';
+import { persist } from '@orama/plugin-data-persistence';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const outDir = join(appRoot, INDEX_DIR);
+
+// In-process determinism: a tiny epsilon to absorb float noise while still
+// failing if the same text ever embeds to a meaningfully different vector.
+const DETERMINISM_EPSILON = 1e-9;
+
+export async function main(): Promise<void> {
+    // 1. Chunk every page from the processed markdown — the llms.txt source.
+    const pages = source.getPages();
+    const chunks: DocChunk[] = [];
+    for (const page of pages) {
+        const processed = await page.data.getText('processed');
+        chunks.push(
+            ...chunkPage({
+                url: page.url,
+                title: page.data.title,
+                processed,
+            }),
+        );
+    }
+    console.log(
+        `[search-index] ${pages.length} pages → ${chunks.length} chunks`,
+    );
+    if (chunks.length === 0) {
+        throw new Error(
+            '[search-index] no chunks produced — run `fumadocs-mdx` first so .source exists',
+        );
+    }
+
+    // 2. Determinism gate: the same text must embed to the same vector, or the
+    //    index is not reproducible build-to-build.
+    const sample = embeddingInput(chunks[0]);
+    const first = await embedOne(sample);
+    const second = await embedOne(sample);
+    const maxDiff = first.reduce(
+        (max, value, i) => Math.max(max, Math.abs(value - second[i])),
+        0,
+    );
+    if (first.length !== EMBED_DIM) {
+        throw new Error(
+            `[search-index] expected ${EMBED_DIM}-dim vectors, got ${first.length}`,
+        );
+    }
+    if (maxDiff > DETERMINISM_EPSILON) {
+        throw new Error(
+            `[search-index] embeddings not deterministic (maxDiff ${maxDiff})`,
+        );
+    }
+    console.log(
+        `[search-index] embeddings deterministic ✓ (dim ${first.length}, maxDiff ${maxDiff}, model ${EMBED_MODEL})`,
+    );
+
+    // 3. Embed every chunk (batched, with progress).
+    const vectors = await embed(chunks.map(embeddingInput), (done, total) => {
+        if (done === total || done % 96 === 0) {
+            console.log(`[search-index] embedded ${done}/${total} chunks`);
+        }
+    });
+
+    // 4. Build the Orama index (BM25 text fields + a vector field) and persist.
+    const db = create({ schema: ORAMA_SCHEMA });
+    await insertMultiple(
+        db,
+        chunks.map((chunk, i) => ({ ...chunk, embedding: vectors[i] })),
+    );
+    const dump = await persist(db, 'json');
+
+    mkdirSync(outDir, { recursive: true });
+    // persist('json') returns a string; the wider type also allows binary
+    // formats, so narrow to something writeFileSync accepts.
+    const serialized =
+        typeof dump === 'string'
+            ? dump
+            : dump instanceof ArrayBuffer
+              ? Buffer.from(dump)
+              : dump;
+    writeFileSync(join(outDir, INDEX_FILE), serialized);
+    writeFileSync(
+        join(outDir, MANIFEST_FILE),
+        `${JSON.stringify(
+            {
+                model: EMBED_MODEL,
+                dim: EMBED_DIM,
+                pages: pages.length,
+                chunks: chunks.length,
+            },
+            null,
+            2,
+        )}\n`,
+    );
+    console.log(
+        `[search-index] wrote ${join(INDEX_DIR, INDEX_FILE)} (${chunks.length} chunks)`,
+    );
+}
+
+// Executed by scripts/build-search-index.mjs (a jiti bootstrap), which awaits
+// main() and sets a non-zero exit code on failure.

--- a/apps/docs/test/search-index.spec.ts
+++ b/apps/docs/test/search-index.spec.ts
@@ -1,0 +1,128 @@
+// Unit coverage for the search_docs P1 chunk pipeline: deterministic chunking
+// and github-slugger-compatible anchors. Pure functions only — no model load,
+// no network — so this runs in the normal `vitest run` test job. (Embedding
+// determinism is asserted by the index build itself; see scripts/build-search-index.ts.)
+import { chunkPage, embeddingInput } from '../lib/search-index/chunk';
+import { Slugger, slugSegment } from '../lib/search-index/slugger';
+
+import { describe, expect, it } from 'vitest';
+
+const SAMPLE = [
+    'Intro paragraph that orients the reader.',
+    '',
+    'More intro.',
+    '',
+    '## First Section',
+    '',
+    'Body of first section.',
+    '',
+    '### A Sub-Heading',
+    '',
+    'Sub body.',
+    '',
+    '## Second Section',
+    '',
+    '```ts',
+    '// ## not a heading inside a fence',
+    'const x = 1;',
+    '```',
+    '',
+    'After the fence.',
+    '',
+    '## Second Section',
+    '',
+    'Duplicate heading body.',
+    '',
+].join('\n');
+
+describe('chunkPage', () => {
+    const chunks = chunkPage({
+        url: '/docs/example',
+        title: 'Example Page',
+        processed: SAMPLE,
+    });
+
+    it('captures intro text before the first heading as a top-of-page chunk', () => {
+        expect(chunks[0]).toMatchObject({
+            pageUrl: '/docs/example',
+            pageTitle: 'Example Page',
+            heading: 'Example Page',
+            anchor: '',
+        });
+        expect(chunks[0].text).toContain('Intro paragraph');
+        expect(chunks[0].text).toContain('More intro.');
+    });
+
+    it('emits one chunk per H2/H3 in document order', () => {
+        expect(chunks.map((c) => c.heading)).toEqual([
+            'Example Page',
+            'First Section',
+            'A Sub-Heading',
+            'Second Section',
+            'Second Section',
+        ]);
+    });
+
+    it('never mistakes `#` inside a fenced code block for a heading', () => {
+        const fenced = chunks.find(
+            (c) =>
+                c.anchor === 'second-section' && c.heading === 'Second Section',
+        );
+        expect(fenced?.text).toContain('## not a heading inside a fence');
+        expect(
+            chunks.some((c) => c.heading === 'not a heading inside a fence'),
+        ).toBe(false);
+    });
+
+    it('de-dupes repeated heading anchors like github-slugger', () => {
+        const seconds = chunks.filter((c) => c.heading === 'Second Section');
+        expect(seconds.map((c) => c.anchor)).toEqual([
+            'second-section',
+            'second-section-1',
+        ]);
+    });
+
+    it('excludes the heading line from the section body', () => {
+        const first = chunks[1];
+        expect(first.text).toBe('Body of first section.');
+    });
+
+    it('prepends a breadcrumb to the embedding input', () => {
+        expect(embeddingInput(chunks[1])).toBe(
+            'Example Page — First Section\n\nBody of first section.',
+        );
+        // intro chunk: heading === title, so no duplicated breadcrumb
+        expect(embeddingInput(chunks[0]).startsWith('Example Page\n\n')).toBe(
+            true,
+        );
+    });
+
+    it('honors explicit heading ids and strips them from the title', () => {
+        const [section] = chunkPage({
+            url: '/docs/agents',
+            title: 'Agents',
+            processed:
+                '## Adopt in your project [#adopt-in-your-project]\n\nBody text.',
+        });
+        expect(section.heading).toBe('Adopt in your project');
+        expect(section.anchor).toBe('adopt-in-your-project');
+        expect(section.text).toBe('Body text.');
+    });
+});
+
+describe('slugger', () => {
+    it('lowercases, strips punctuation, and hyphenates whitespace', () => {
+        expect(slugSegment('Hello, World!')).toBe('hello-world');
+    });
+
+    it('strips Unicode punctuation (em dash) the way the rendered page does', () => {
+        expect(slugSegment('Setup — advanced')).toBe('setup--advanced');
+    });
+
+    it('suffixes repeats within a page', () => {
+        const slugger = new Slugger();
+        expect(slugger.slug('Setup')).toBe('setup');
+        expect(slugger.slug('Setup')).toBe('setup-1');
+        expect(slugger.slug('Setup')).toBe('setup-2');
+    });
+});

--- a/docs/proposals/search-docs.md
+++ b/docs/proposals/search-docs.md
@@ -1,0 +1,182 @@
+# Proposal — `search_docs`: a hosted docs-retrieval MCP
+
+**Status:** proposed · **Scope:** `apps/docs` (build-time index + `/api/search-docs` + `/api/mcp`); no `packages/core` change · **Target branch:** `main`
+**Relates:** `content/docs/agents/llms-txt.mdx` ("Default: load the whole corpus"); the agent-native thesis (`DESIGN.md`, `FEATURE-LENSES.md`). **Complements, does not replace** the library MCP `stitchapi/mcp` (`run_stitch`).
+
+> [!NOTE]
+>
+> A design record, not yet implemented. It folds in the one open design fork —
+> the embedding model (local-open vs. hosted API) — and resolves it with a
+> measured spike (§6), not a guess.
+
+---
+
+## TL;DR
+
+Today an agent has two ways to consume our docs: scrape rendered HTML (wasteful),
+or load `/llms-full.txt` — the **whole ~84k-token corpus** — into context every
+turn. The second is correct (the corpus fits a 200k window) but expensive: it
+costs prefill tokens on every turn and crowds out the agent's working memory. Our
+existing site search (`/api/search`, Orama) is keyword-only **and not
+agent-reachable**.
+
+Propose a **hosted docs-retrieval MCP** at `stitchapi.dev`: a `search_docs` tool
+that returns just the handful of relevant doc _sections_ for a query (~1k
+tokens), plus `get_doc` to pull a full page when the agent wants it. Retrieval is
+**hybrid** (BM25 + vector) layered onto the **Orama index we already build**, and
+the chunk index is generated at deploy from the **same processed MDX that feeds
+`llms.txt`** — so it cannot drift.
+
+A measured spike over the live docs (§6) shows **~85× fewer tokens per lookup**
+(≈990 vs ≈84k) at **~3.5 ms warm retrieval**, with genuinely semantic matches
+(it found Throttle / circuit-breaker for _"stop hammering a flaky upstream"_ — no
+shared keywords).
+
+This is **not** `stitchapi/mcp`. That is a _library_ surface users run over
+_their_ stitches; this is a _docs service_ we host. Together they close the loop:
+`search_docs` (learn the API) → `get_doc` (read the page) → `run_stitch` (call
+it).
+
+---
+
+## 1. Problem, and why now
+
+-   **Load-it-all has a per-turn tax.** `llms-full.txt` fits in context, so it is
+    the right default today (and stays the default for small corpora — see §8). But
+    an agent that reloads ~84k tokens every turn pays for them every turn, in money
+    and in prefill latency, and has that much less room for its own reasoning. A
+    targeted lookup returns ~1k tokens instead.
+-   **Orama is keyword-only and invisible to agents.** The site's human search
+    can't match on meaning (a query phrased in the user's words misses the page
+    that uses ours), and there is no tool an agent can call to reach it.
+-   **Dual value.** The same retrieval engine upgrades the **human** site search
+    from keyword to semantic _and_ gives **agents** a context-frugal tool. That
+    second beneficiary is why this is worth building before the corpus outgrows the
+    window: §6's P2 stands on its own even if P3 never ships.
+
+## 2. Not the same as `run_stitch`
+
+|            | `stitchapi/mcp` (exists)                  | `search_docs` (this)          |
+| ---------- | ----------------------------------------- | ----------------------------- |
+| Audience   | The user's agent, calling the user's APIs | Any agent, learning StitchAPI |
+| Runs where | The user's machine/server (stdio)         | We host it (stitchapi.dev)    |
+| Over what  | The user's stitch registry                | Our docs corpus               |
+| Transport  | stdio JSON-RPC                            | MCP Streamable HTTP           |
+
+They are siblings, not substitutes. Documenting the distinction is part of P4 so
+nobody wires the wrong one.
+
+## 3. Architecture — four layers, reusing what we have
+
+1. **Index pipeline (build-time).** A step in `next build` iterates
+   `source.getPages()` → `page.data.getText('processed')` — the _same_ processed
+   markdown `getLLMText` already emits for `llms.txt` — splits each page on H2/H3
+   into self-contained chunks (`{ pageUrl, title, heading, anchor, text }`), and
+   embeds each. Built from MDX every deploy, never committed → it can't drift,
+   same cadence and source as `llms.txt`.
+2. **Store — extend Orama, don't add a vector DB.** We already run Orama for
+   `/api/search`. Add a vector field per chunk and persist the index
+   (`@orama/plugin-data-persistence`) as a build artifact the route loads. Search
+   runs Orama **hybrid** (BM25 + vector). No Pinecone, no external store — on
+   brand with zero-infra. (Integration note: hybrid may require building the
+   index against `@orama/orama` directly rather than the fumadocs search wrapper;
+   confirm in P1.)
+3. **Serving — one engine, two consumers.** `app/api/search-docs/route.ts`
+   embeds the query, runs hybrid search, returns top-k `{ title, url#anchor,
+excerpt, score }`. Point the existing human search UI at it too → semantic
+   site search, free.
+4. **MCP wrapper.** `app/api/mcp/route.ts` speaks **MCP Streamable HTTP**
+   (network transport, unlike the library's stdio) and exposes the two tools.
+
+## 4. Tool contract
+
+```ts
+// Context-frugal by design: excerpts + links, NOT full pages. That frugality is
+// the entire reason this beats `llms-full.txt`.
+declare function search_docs(input: {
+    query: string;
+    limit?: number; // default 5
+}): Array<{ title: string; url: string; excerpt: string; score: number }>; // url incl. #anchor
+
+// The "read the whole thing" escape hatch — wraps the existing /llms.mdx route.
+declare function get_doc(input: { url: string } | { slug: string }): {
+    title: string;
+    markdown: string;
+};
+```
+
+## 5. Decisions (recommended defaults)
+
+| Decision        | Recommended                                                                         | Why                                                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Embedding model | **Local-open small** (MiniLM/`bge-small` via transformers.js); hosted API as opt-in | Self-contained, no external key/service. It's the _docs app_, not the shipped lib, so a build dep is fine. Validated in §6. |
+| Retrieval       | **Hybrid (BM25 + vector)** over Orama                                               | Reuses infra; BM25 catches literal terms the small model misses (§6)                                                        |
+| Chunking        | **Section-level (H2/H3) + page breadcrumb**                                         | Pages are already self-contained; precise, citeable anchors                                                                 |
+| Transport       | **Both** — HTTP engine + MCP Streamable HTTP wrapper                                | One engine serves humans and agents                                                                                         |
+| Index storage   | **Build-at-deploy, not committed**                                                  | No binary diffs; regenerates from MDX like `llms.txt`                                                                       |
+
+## 6. The embedding model — measured, not assumed
+
+A throwaway spike (transformers.js + `all-MiniLM-L6-v2`, 384-dim/~23 MB, over the
+live 105-page corpus) settles the fork in favour of a **local-open** model:
+
+| Metric                    | Result                                                                                                                                                                           |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Corpus                    | 105 pages → 451 section-chunks, ~84k tokens                                                                                                                                      |
+| One-time index build      | model load ~22 s (incl. download) + embed ~11 s (25 ms/chunk) — **per deploy**                                                                                                   |
+| Per-lookup latency (warm) | **median ~3.5 ms** (~2–3 ms query embed + <1 ms search)                                                                                                                          |
+| Tokens per lookup         | **~990 avg vs ~84k full-load → ~85× reduction** (249× best case)                                                                                                                 |
+| Relevance                 | semantic: _"stop hammering a flaky upstream"_ → Throttle, RateLimitError, circuit-breaker; _"agent call my API without exposing the secret"_ → bearer, capability-not-credential |
+
+**What the spike also exposed (and why we still want hybrid):** the small model's
+weakest query was _"cache responses and invalidate when the schema changes"_ — it
+surfaced Drift/Validation before the literal **Cache** pages. BM25 catches the
+exact term `cache`; a stronger model (`bge-small`/`gte-small`) lifts semantic
+recall. Hybrid gets both — hence the §5 default.
+
+**The one watch-item — serverless cold start.** Warm query-embed is ~2–3 ms, but
+the model must be _loaded_ in the function; a cold start pays seconds. The index
+build's ~11 s embed runs in **CI**, not per request, so it's amortized — only the
+query path is affected. Mitigations, in order of preference: keep-warm / move to
+an edge runtime; a smaller quantized model; or a hosted embedding API for
+**queries only** (opt-in, the §5 fallback). Resolve during P3 with a real
+cold-start measurement on Vercel.
+
+## 7. Anti-drift & gates
+
+-   **Built from the one source.** The index derives from `getText('processed')`,
+    same as `llms.txt` and the HTML — edit an MDX file and all three move together.
+    Regenerated every deploy; nothing to hand-sync.
+-   **A build gate**, mirroring the `gen:docs` diff gate: CI fails if the index
+    step errors or a chunk has no `description`/title (the manifest already makes
+    descriptions mandatory).
+-   **No core impact.** Everything lives in `apps/docs`; `packages/core` gains no
+    dependency and the bundle gates are untouched. (This is server-only docs infra,
+    so the browser-first / bundle-frugal gates that govern the _library_ don't
+    apply.)
+
+## 8. What to hold the line on
+
+-   **Stay context-frugal.** `search_docs` returns excerpts + links, never full
+    pages. The moment it dumps whole pages it's just a slower `llms-full.txt`.
+-   **Don't add an external vector DB.** Extend Orama. Self-contained is the brand.
+-   **Self-contained by default.** A local model means no key, no third-party
+    service in the request path. A hosted embedding API is an opt-in upgrade, never
+    the default.
+-   **Keep `llms.txt` / `llms-full.txt`.** `search_docs` is additive. For a corpus
+    this size, "just load it all" remains the documented default (see the agents
+    page); retrieval is the path for scale and per-turn frugality, not a
+    replacement.
+-   **Don't conflate with `run_stitch`** (see §2).
+
+## 9. Phasing (one PR each, stop between)
+
+1. **P1** — Build-time index pipeline: chunk on H2/H3 from `getText('processed')`,
+   embed locally, persist an Orama dump. No serving yet; verify chunk count +
+   embedding determinism.
+2. **P2** — `/api/search-docs` hybrid route **and swap the site search UI onto
+   it.** Independently shippable: semantic search for human visitors.
+3. **P3** — `/api/mcp` Streamable HTTP server exposing `search_docs` + `get_doc`;
+   resolve the cold-start question with a real Vercel measurement.
+4. **P4** — `agents/` docs page ("Search the docs over MCP") + drop-in `mcp.json`
+   snippets (Claude/Cursor) + a one-line pointer in the `llms.txt` preamble.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@huggingface/transformers':
+        specifier: ^4.2.0
+        version: 4.2.0
       '@nestjs/common':
         specifier: ^11.0.0
         version: 11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -104,6 +107,12 @@ importers:
       '@nestjs/core':
         specifier: ^11.0.0
         version: 11.1.27(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@orama/orama':
+        specifier: 3.1.18
+        version: 3.1.18
+      '@orama/plugin-data-persistence':
+        specifier: 3.1.18
+        version: 3.1.18
       '@playwright/test':
         specifier: ^1.49.1
         version: 1.60.0
@@ -176,6 +185,9 @@ importers:
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -2018,6 +2030,16 @@ packages:
       tailwindcss:
         optional: true
 
+  '@huggingface/jinja@0.5.9':
+    resolution: {integrity: sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==}
+    engines: {node: '>=18'}
+
+  '@huggingface/tokenizers@0.1.3':
+    resolution: {integrity: sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==}
+
+  '@huggingface/transformers@4.2.0':
+    resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -2259,6 +2281,10 @@ packages:
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
+  '@msgpack/msgpack@3.1.3':
+    resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
+    engines: {node: '>= 18'}
+
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
     peerDependencies:
@@ -2384,6 +2410,9 @@ packages:
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
     engines: {node: '>= 20.0.0'}
 
+  '@orama/plugin-data-persistence@3.1.18':
+    resolution: {integrity: sha512-pfBbpK96VRW/7IkdMHn2HaW3/+4k2C9Uwyup0IONNuz5bG3L1orCNFZPBmu+zcokOU2YH+IAVuQz6MlvqOe3iw==}
+
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
@@ -2394,6 +2423,33 @@ packages:
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@radix-ui/number@1.1.2':
     resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
@@ -3955,6 +4011,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adm-zip@0.5.18:
+    resolution: {integrity: sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==}
+    engines: {node: '>=12.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -4197,6 +4257,10 @@ packages:
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
+
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   bplist-creator@0.1.0:
     resolution: {integrity: sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==}
@@ -4775,6 +4839,9 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
@@ -4813,6 +4880,9 @@ packages:
   dotenv@17.4.1:
     resolution: {integrity: sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==}
     engines: {node: '>=12'}
+
+  dpack@0.6.22:
+    resolution: {integrity: sha512-WGPNlW2OAE7Bj0eODMpAHUcEqxrlg01e9OFZDxQodminIgC194/cRHT7K04Z1j7AUEWTeeplYGrIv/xRdwU9Hg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -4918,6 +4988,9 @@ packages:
 
   es-toolkit@1.47.1:
     resolution: {integrity: sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==}
+
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -5345,6 +5418,9 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flatbuffers@25.9.23:
+    resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
+
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
@@ -5604,6 +5680,10 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
+
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
@@ -5630,6 +5710,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  guid-typescript@1.0.9:
+    resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
@@ -6110,6 +6193,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -6349,6 +6435,9 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -6425,6 +6514,10 @@ packages:
 
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
+
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -6921,6 +7014,19 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
+    resolution: {integrity: sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==}
+
+  onnxruntime-common@1.24.3:
+    resolution: {integrity: sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==}
+
+  onnxruntime-node@1.24.3:
+    resolution: {integrity: sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==}
+    os: [win32, darwin, linux]
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
+
   open@7.4.2:
     resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
     engines: {node: '>=8'}
@@ -7053,6 +7159,9 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
+
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
@@ -7150,6 +7259,10 @@ packages:
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  protobufjs@7.6.4:
+    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -7429,6 +7542,10 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
+
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
@@ -7507,6 +7624,9 @@ packages:
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
@@ -7528,9 +7648,17 @@ packages:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
 
+  seqproto@0.2.3:
+    resolution: {integrity: sha512-HpNyPYl7DJa2a6XQJ+MJAc6ft6Y9ZU+zRiuvTHFpLPeqvapcTAGFJyhMEIN7Y7VXhWT6NEdNVhbXFHwtaCOfCw==}
+    engines: {node: '>= 20.0.0'}
+
   serialize-error@2.1.0:
     resolution: {integrity: sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==}
     engines: {node: '>=0.10.0'}
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
 
   seroval-plugins@1.5.4:
     resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
@@ -7671,6 +7799,9 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -7997,6 +8128,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
 
   type-fest@0.18.1:
     resolution: {integrity: sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==}
@@ -9733,6 +9868,18 @@ snapshots:
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
 
+  '@huggingface/jinja@0.5.9': {}
+
+  '@huggingface/tokenizers@0.1.3': {}
+
+  '@huggingface/transformers@4.2.0':
+    dependencies:
+      '@huggingface/jinja': 0.5.9
+      '@huggingface/tokenizers': 0.1.3
+      onnxruntime-node: 1.24.3
+      onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
+      sharp: 0.34.5
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -9757,8 +9904,7 @@ snapshots:
       '@iconify/types': 2.0.0
       import-meta-resolve: 4.2.0
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -9953,6 +10099,8 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
+  '@msgpack/msgpack@3.1.3': {}
+
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -10039,6 +10187,13 @@ snapshots:
 
   '@orama/orama@3.1.18': {}
 
+  '@orama/plugin-data-persistence@3.1.18':
+    dependencies:
+      '@msgpack/msgpack': 3.1.3
+      '@orama/orama': 3.1.18
+      dpack: 0.6.22
+      seqproto: 0.2.3
+
   '@oxc-project/types@0.133.0': {}
 
   '@pinojs/redact@0.4.0': {}
@@ -10046,6 +10201,26 @@ snapshots:
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@radix-ui/number@1.1.2': {}
 
@@ -11607,6 +11782,8 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  adm-zip@0.5.18: {}
+
   agent-base@7.1.4: {}
 
   ai@6.0.208(zod@4.4.3):
@@ -11914,6 +12091,8 @@ snapshots:
       type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  boolean@3.2.0: {}
 
   bplist-creator@0.1.0:
     dependencies:
@@ -12493,6 +12672,8 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
+  detect-node@2.1.0: {}
+
   devalue@5.8.1: {}
 
   devlop@1.1.0:
@@ -12524,6 +12705,8 @@ snapshots:
   dotenv@16.6.1: {}
 
   dotenv@17.4.1: {}
+
+  dpack@0.6.22: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -12685,6 +12868,8 @@ snapshots:
       is-symbol: 1.1.1
 
   es-toolkit@1.47.1: {}
+
+  es6-error@4.1.1: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -13311,6 +13496,8 @@ snapshots:
       flatted: 3.4.2
       keyv: 4.5.4
 
+  flatbuffers@25.9.23: {}
+
   flatted@3.4.2: {}
 
   flow-enums-runtime@0.0.6: {}
@@ -13562,6 +13749,15 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.8.4
+      serialize-error: 7.0.1
+
   globals@11.12.0: {}
 
   globals@14.0.0: {}
@@ -13585,6 +13781,8 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  guid-typescript@1.0.9: {}
 
   hachure-fill@0.5.2: {}
 
@@ -14136,6 +14334,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-safe@5.0.1: {}
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
@@ -14324,6 +14524,8 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  long@5.3.2: {}
+
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -14390,6 +14592,10 @@ snapshots:
   marked@9.1.6: {}
 
   marky@1.3.0: {}
+
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
 
   math-intrinsics@1.1.0: {}
 
@@ -15290,6 +15496,25 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322: {}
+
+  onnxruntime-common@1.24.3: {}
+
+  onnxruntime-node@1.24.3:
+    dependencies:
+      adm-zip: 0.5.18
+      global-agent: 3.0.0
+      onnxruntime-common: 1.24.3
+
+  onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
+    dependencies:
+      flatbuffers: 25.9.23
+      guid-typescript: 1.0.9
+      long: 5.3.2
+      onnxruntime-common: 1.24.0-dev.20251116-b39e144322
+      platform: 1.3.6
+      protobufjs: 7.6.4
+
   open@7.4.2:
     dependencies:
       is-docker: 2.2.1
@@ -15435,6 +15660,8 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
+  platform@1.3.6: {}
+
   playwright-core@1.60.0: {}
 
   playwright@1.60.0:
@@ -15519,6 +15746,20 @@ snapshots:
       react-is: 16.13.1
 
   property-information@7.2.0: {}
+
+  protobufjs@7.6.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 25.9.3
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -15883,6 +16124,15 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
+
   robust-predicates@3.0.3: {}
 
   rolldown@1.0.3:
@@ -16011,6 +16261,8 @@ snapshots:
 
   secure-json-parse@4.1.0: {}
 
+  semver-compare@1.0.0: {}
+
   semver@5.7.2: {}
 
   semver@6.3.1: {}
@@ -16051,7 +16303,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  seqproto@0.2.3: {}
+
   serialize-error@2.1.0: {}
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
 
   seroval-plugins@1.5.4(seroval@1.5.4):
     dependencies:
@@ -16133,7 +16391,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -16242,6 +16499,8 @@ snapshots:
   spdx-license-ids@3.0.23: {}
 
   split2@4.2.0: {}
+
+  sprintf-js@1.1.3: {}
 
   stable-hash@0.0.5: {}
 
@@ -16604,6 +16863,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@0.13.1: {}
 
   type-fest@0.18.1: {}
 


### PR DESCRIPTION
## search_docs P1 — build-time semantic index pipeline

First phase of the [`search_docs` proposal](docs/proposals/search-docs.md) (§9): the **build-time index pipeline**. **No serving yet** — P2 adds the `/api/search-docs` route that restores this index and swaps the human site search onto it.

### What's here

- **Chunking** ([`apps/docs/lib/search-index/chunk.ts`](apps/docs/lib/search-index/chunk.ts)) — splits each page's _processed_ markdown (`page.data.getText('processed')`, the exact source that feeds `llms.txt`, so the index can't drift) on H2/H3 into self-contained `{ pageUrl, pageTitle, heading, anchor, text }` chunks. Honors explicit heading ids (`## Title [#custom-id]`) and reproduces github-slugger anchors (dedupe + Unicode punctuation) so a hit's `url#anchor` is a working deep link.
- **Embedding** ([`apps/docs/lib/search-index/embed.ts`](apps/docs/lib/search-index/embed.ts)) — local, key-free embeddings via transformers.js (`Xenova/all-MiniLM-L6-v2`, 384-dim), batched.
- **Index build** ([`apps/docs/scripts/build-search-index.ts`](apps/docs/scripts/build-search-index.ts)) — builds an Orama index with a vector field (text fields → BM25, vector → ANN, ready for hybrid in P2) and persists a JSON dump to `apps/docs/.search-index/` as an **uncommitted** build artifact (gitignored). Asserts embedding determinism and logs the chunk count.

Run it:

```
pnpm --filter @stitchapi/docs build:search-index
```

### Notes / decisions

- **apps/docs only.** New build deps: `@huggingface/transformers`, `@orama/orama`, `@orama/plugin-data-persistence`, `tsx` — all devDependencies in apps/docs. **`packages/core` is untouched**, so the library bundle gates stay green.
- **Reuses Orama** (already present via fumadocs) with an added vector field — no external vector DB, per the proposal.
- The index is **built from MDX and never committed** (same cadence/source as `llms.txt`).
- `apps/docs` is now `"type": "module"` (it was already ESM-only — no `.js`/`.cjs` files) so a small bootstrap can run the fumadocs `source` outside Next (the generated source uses top-level `await`) via `tsx` + the `fumadocs-mdx` Node loader (`register()`). `next build` verified unaffected.

### Verification

- `build:search-index`: **107 pages → 569 chunks**, embeddings **deterministic** (`maxDiff 0`, dim 384); the persisted dump restores and searches.
- `tsc --noEmit` ✓ · `eslint .` ✓ · `next build` ✓ (379 pages) · `vitest run` ✓ (33 tests, incl. the new chunk/slugger spec) · `prettier --check` ✓ · `node scripts/check-size-docs.mjs` ✓.

### Not in this phase

`/api/search-docs` + site-search swap (P2), `/api/mcp` Streamable HTTP (P3), agents docs page + `mcp.json` snippets (P4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
