### PR TITLE
feat(docs): search_docs P2 — /api/search-docs + site search

### DIFF
--- a/apps/docs/app/api/search-docs/route.ts
+++ b/apps/docs/app/api/search-docs/route.ts
@@ -1,0 +1,28 @@
+// Semantic docs search (search_docs P2). Hybrid BM25 + vector retrieval over the
+// build-time index, returned as fumadocs' SortedResult[] so the site's search
+// dialog renders it (see RootProvider `search.options.api` in app/layout.tsx).
+//
+// The MCP wrapper (P3) reuses the same searchDocs() engine with its own tool
+// shape. Deploy-time index build + runtime model loading / cold-start are
+// hardened in P3.
+import { searchDocs } from '@/lib/search-index/search';
+import { toSortedResults } from '@/lib/search-index/sorted-result';
+
+// transformers.js + onnxruntime-node + fs — Node runtime, never prerendered.
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request): Promise<Response> {
+    const query = new URL(request.url).searchParams.get('query')?.trim() ?? '';
+    if (!query) return Response.json([]);
+
+    try {
+        const hits = await searchDocs(query, { limit: 8 });
+        return Response.json(toSortedResults(hits));
+    } catch (error) {
+        // Degrade to "no results" rather than 500-ing the search box if the
+        // index or model isn't available (e.g. index not built for this env).
+        console.error('[search-docs] query failed:', error);
+        return Response.json([]);
+    }
+}

--- a/apps/docs/app/api/search/route.ts
+++ b/apps/docs/app/api/search/route.ts
@@ -1,8 +1,0 @@
-import { source } from '@/lib/source';
-
-import { createFromSource } from 'fumadocs-core/search/server';
-
-export const { GET } = createFromSource(source, {
-    // https://docs.orama.com/docs/orama-js/supported-languages
-    language: 'english',
-});

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -143,7 +143,14 @@ export default function Layout({ children }: LayoutProps<'/'>) {
                     type="application/ld+json"
                     dangerouslySetInnerHTML={{ __html: jsonLdHtml(jsonLd) }}
                 />
-                <RootProvider>
+                <RootProvider
+                    search={{
+                        // Semantic site search (search_docs P2): the dialog's
+                        // fetch client queries this hybrid route instead of the
+                        // default keyword /api/search.
+                        options: { api: '/api/search-docs' },
+                    }}
+                >
                     <Banner
                         variant="normal"
                         className="gap-2 border-b border-stitch-border bg-stitch-soft text-fd-foreground"

--- a/apps/docs/lib/search-index/search.ts
+++ b/apps/docs/lib/search-index/search.ts
@@ -1,0 +1,65 @@
+// Hybrid (BM25 + vector) search over the persisted docs index. Restores the
+// Orama dump built by scripts/build-search-index.ts (once, cached), embeds the
+// query with the SAME local model the index used, and runs Orama in hybrid mode.
+// Consumed by app/api/search-docs/route.ts (P2) and the MCP server (P3).
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { type AnyOrama, type SearchParams, search } from '@orama/orama';
+import { restore } from '@orama/plugin-data-persistence';
+
+import { INDEX_DIR, INDEX_FILE, VECTOR_FIELD } from './config';
+import { embedOne } from './embed';
+import { type DocSearchHit } from './sorted-result';
+
+let cached: Promise<AnyOrama> | undefined;
+
+function indexPath(): string {
+    // this file: apps/docs/lib/search-index/search.ts → apps/docs/.search-index/<file>
+    const here = dirname(fileURLToPath(import.meta.url));
+    return resolve(here, '..', '..', INDEX_DIR, INDEX_FILE);
+}
+
+/** Restore (once) the persisted Orama index. Throws if it hasn't been built. */
+export function loadIndex(): Promise<AnyOrama> {
+    if (!cached) {
+        cached = restore('json', readFileSync(indexPath(), 'utf8'));
+    }
+    return cached;
+}
+
+/** Hybrid (BM25 + vector) search; returns the top section hits for a query. */
+export async function searchDocs(
+    query: string,
+    { limit = 8 }: { limit?: number } = {},
+): Promise<DocSearchHit[]> {
+    const term = query.trim();
+    if (!term) return [];
+
+    const db = await loadIndex();
+    const vector = await embedOne(term);
+    const params: SearchParams<AnyOrama> = {
+        mode: 'hybrid',
+        term,
+        vector: { value: vector, property: VECTOR_FIELD },
+        properties: ['pageTitle', 'heading', 'text'],
+        // Vector-dominant: semantic match leads (equal weighting let BM25
+        // stop-word noise top the results), while BM25 still adds literal-term
+        // recall (error codes, fn names) the small model misses. Title/heading
+        // are boosted so a page that is *about* the term beats a passing mention
+        // in body text.
+        hybridWeights: { text: 0.3, vector: 0.7 },
+        boost: { pageTitle: 3, heading: 2 },
+        similarity: 0,
+        includeVectors: false,
+        limit,
+    };
+    const results = await search(db, params);
+
+    return results.hits.map((hit) => {
+        const doc = hit.document as unknown as Omit<DocSearchHit, 'score'>;
+        return { ...doc, score: hit.score };
+    });
+}

--- a/apps/docs/lib/search-index/sorted-result.ts
+++ b/apps/docs/lib/search-index/sorted-result.ts
@@ -1,0 +1,58 @@
+// Map hybrid-search hits to fumadocs' SortedResult[] — the shape the docs
+// search dialog (the `fetch` client) renders. Pure (no model/Orama imports) so
+// it's cheap to unit-test. One `page` entry per matched page, then a
+// `heading`/`text` entry per matched section so each result links to its anchor.
+
+/** A single section hit from the hybrid search engine. */
+export interface DocSearchHit {
+    pageUrl: string;
+    pageTitle: string;
+    /** Section heading (equals pageTitle for a page's intro chunk). */
+    heading: string;
+    /** github-slug anchor (`''` for the intro / top of page). */
+    anchor: string;
+    text: string;
+    score: number;
+}
+
+/** fumadocs-core `SortedResult` (see fumadocs-core/search). */
+export interface SortedResult {
+    id: string;
+    url: string;
+    type: 'page' | 'heading' | 'text';
+    content: string;
+}
+
+const EXCERPT_LEN = 160;
+
+function excerpt(text: string): string {
+    const flat = text.replace(/\s+/g, ' ').trim();
+    return flat.length > EXCERPT_LEN ? `${flat.slice(0, EXCERPT_LEN)}…` : flat;
+}
+
+export function toSortedResults(hits: DocSearchHit[]): SortedResult[] {
+    const out: SortedResult[] = [];
+    const seenPages = new Set<string>();
+
+    hits.forEach((hit, i) => {
+        if (!seenPages.has(hit.pageUrl)) {
+            seenPages.add(hit.pageUrl);
+            out.push({
+                id: `page:${hit.pageUrl}`,
+                url: hit.pageUrl,
+                type: 'page',
+                content: hit.pageTitle,
+            });
+        }
+
+        const isIntro = hit.anchor === '';
+        out.push({
+            id: `hit:${i}:${hit.pageUrl}#${hit.anchor}`,
+            url: isIntro ? hit.pageUrl : `${hit.pageUrl}#${hit.anchor}`,
+            type: isIntro ? 'text' : 'heading',
+            content: isIntro ? excerpt(hit.text) : hit.heading,
+        });
+    });
+
+    return out;
+}

--- a/apps/docs/lib/source.ts
+++ b/apps/docs/lib/source.ts
@@ -23,7 +23,7 @@ export function llmsPreamble() {
 - Capability, not credential: an agent invokes a stitch and gets structured, validated, traceable data; the secret stays behind the boundary.
 - One context-frugal **code-mode** tool (run_stitch + list_stitches + describe_stitch), not one tool per endpoint — adding APIs never floods the context window.
 - No server, no codegen, no config files — a URL and one example response is enough; only explicit composition (no ambient/global config a stitch silently inherits).
-- Zero-dependency core, ~23 kB min+gzip for the whole entry (~19 kB for a tree-shaken import { stitch }), validator-agnostic (bring your own Standard Schema / Zod), and it runs in the browser.
+- Zero-dependency core, ~24 kB min+gzip for the whole entry (~19 kB for a tree-shaken import { stitch }), validator-agnostic (bring your own Standard Schema / Zod), and it runs in the browser.
 - Composes with your data layer: a stitch is the queryFn for TanStack Query / SWR — it owns the call's resilience; your query layer owns view state.
 
 ## Quickstart

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -58,6 +58,13 @@ const withMDX = createMDX();
 /** @type {import('next').NextConfig} */
 const config = {
     reactStrictMode: true,
+    // Bundle the build-time search index into the /api/search-docs serverless
+    // function so it can restore the Orama dump at runtime. The file is generated
+    // at deploy by scripts/prebuild-search-index.mjs (never committed); runtime
+    // model loading / cold-start is hardened in P3.
+    outputFileTracingIncludes: {
+        '/api/search-docs': ['./.search-index/**'],
+    },
     // The playground consumes the in-repo sandbox engine (@stitchapi/sandbox), a
     // workspace package that ships raw TS/TSX source — Next must transpile it.
     transpilePackages: ['@stitchapi/sandbox'],

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,7 +6,7 @@
     "description": "StitchAPI documentation site — Fumadocs (Next.js App Router). Content lands in follow-up PRs.",
     "scripts": {
         "dev": "pnpm run build:typed-deps && pnpm run build:sandbox && next dev",
-        "build": "pnpm run build:typed-deps && pnpm run build:sandbox && next build",
+        "build": "pnpm run build:typed-deps && pnpm run build:sandbox && node scripts/prebuild-search-index.mjs && next build",
         "start": "next start",
         "check:types": "pnpm run build:typed-deps && fumadocs-mdx && next typegen && tsc --noEmit",
         "check:lint": "eslint .",

--- a/apps/docs/scripts/prebuild-search-index.mjs
+++ b/apps/docs/scripts/prebuild-search-index.mjs
@@ -1,0 +1,29 @@
+// Build the semantic search index as a `next build` step — but ONLY at deploy
+// (Vercel) or when explicitly forced, so GitHub CI's `verify` build stays fast
+// and network-free (no ~90 MB model download). Locally, run
+// `pnpm --filter @stitchapi/docs build:search-index` by hand to populate
+// apps/docs/.search-index/ for testing the route.
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+if (!process.env.VERCEL && !process.env.BUILD_SEARCH_INDEX) {
+    console.log(
+        '[search-index] skipped — set VERCEL or BUILD_SEARCH_INDEX to build it (deploy only).',
+    );
+    process.exit(0);
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appRoot = resolve(here, '..');
+
+// `.source` (fumadocs collections) must exist before the index build reads
+// getText('processed'); generate it, then embed + persist the dump.
+const steps = [
+    ['pnpm', ['exec', 'fumadocs-mdx']],
+    ['node', ['--import', 'tsx/esm', resolve(here, 'build-search-index.mjs')]],
+];
+for (const [bin, args] of steps) {
+    const result = spawnSync(bin, args, { cwd: appRoot, stdio: 'inherit' });
+    if (result.status !== 0) process.exit(result.status ?? 1);
+}

--- a/apps/docs/test/sorted-result.spec.ts
+++ b/apps/docs/test/sorted-result.spec.ts
@@ -1,0 +1,90 @@
+// Unit coverage for the search_docs P2 result mapping: hybrid hits → fumadocs
+// SortedResult[]. Pure (no model, no index), so it runs in the normal vitest job.
+import {
+    type DocSearchHit,
+    toSortedResults,
+} from '../lib/search-index/sorted-result';
+
+import { describe, expect, it } from 'vitest';
+
+function hit(overrides: Partial<DocSearchHit>): DocSearchHit {
+    return {
+        pageUrl: '/docs/x',
+        pageTitle: 'X',
+        heading: 'X',
+        anchor: '',
+        text: 'body',
+        score: 1,
+        ...overrides,
+    };
+}
+
+describe('toSortedResults', () => {
+    it('emits one page entry per page, before its sections', () => {
+        const out = toSortedResults([
+            hit({
+                pageUrl: '/docs/a',
+                pageTitle: 'A',
+                heading: 'First',
+                anchor: 'first',
+            }),
+            hit({
+                pageUrl: '/docs/a',
+                pageTitle: 'A',
+                heading: 'Second',
+                anchor: 'second',
+            }),
+        ]);
+        expect(out.filter((r) => r.type === 'page')).toHaveLength(1);
+        expect(out[0]).toMatchObject({
+            type: 'page',
+            url: '/docs/a',
+            content: 'A',
+        });
+        expect(out[1]).toMatchObject({
+            type: 'heading',
+            url: '/docs/a#first',
+            content: 'First',
+        });
+    });
+
+    it('links a section hit to its anchor', () => {
+        const [, section] = toSortedResults([
+            hit({
+                pageUrl: '/docs/guides/throttle',
+                pageTitle: 'Throttle',
+                heading: 'Options',
+                anchor: 'options',
+            }),
+        ]);
+        expect(section).toMatchObject({
+            type: 'heading',
+            url: '/docs/guides/throttle#options',
+            content: 'Options',
+        });
+    });
+
+    it('renders an intro chunk (no anchor) as a text excerpt at the page url', () => {
+        const [, intro] = toSortedResults([
+            hit({
+                pageUrl: '/docs/p',
+                pageTitle: 'P',
+                heading: 'P',
+                anchor: '',
+                text: 'Intro paragraph that orients the reader.',
+            }),
+        ]);
+        expect(intro.type).toBe('text');
+        expect(intro.url).toBe('/docs/p');
+        expect(intro.content).toContain('Intro paragraph');
+    });
+
+    it('gives every result a unique id', () => {
+        const out = toSortedResults([
+            hit({ pageUrl: '/docs/a', anchor: 'x', heading: 'X' }),
+            hit({ pageUrl: '/docs/a', anchor: 'y', heading: 'Y' }),
+            hit({ pageUrl: '/docs/b', anchor: 'z', heading: 'Z' }),
+        ]);
+        expect(new Set(out.map((r) => r.id)).size).toBe(out.length);
+    });
+});


### PR DESCRIPTION
## search_docs P2 — `/api/search-docs` hybrid route + semantic site search

Second phase of the [`search_docs` proposal](docs/proposals/search-docs.md) (§9): the **hybrid retrieval route**, with the human site search **swapped onto it**. Independently shippable — semantic search for human visitors. Built on the index from [P1 (#383)](https://github.com/rejifald/StitchAPI/pull/383).

### What's here

- **Hybrid search engine** ([`lib/search-index/search.ts`](apps/docs/lib/search-index/search.ts)) — restores the persisted Orama dump once (cached), embeds the query with the same local model the index used, and runs Orama in **hybrid mode (BM25 + vector)**. Weighting is **vector-dominant (0.3 / 0.7)** with title/heading **boost**, so semantic matches lead while BM25 still adds literal-term recall (error codes, fn names). Reused by the P3 MCP server.
- **Result mapping** ([`lib/search-index/sorted-result.ts`](apps/docs/lib/search-index/sorted-result.ts)) — hits → fumadocs `SortedResult[]` (one `page` entry per page, then `heading`/`text` entries deep-linked to anchors). Pure and unit-tested.
- **Route** ([`app/api/search-docs/route.ts`](apps/docs/app/api/search-docs/route.ts)) — `GET ?query=` → hybrid search → `SortedResult[]`. Node runtime; degrades to `[]` (never 500s the search box) if the index/model isn't available.
- **UI swap** ([`app/layout.tsx`](apps/docs/app/layout.tsx)) — `RootProvider`'s search dialog now queries `/api/search-docs` instead of the keyword `/api/search` (which is removed).

### Deploy wiring

- [`scripts/prebuild-search-index.mjs`](apps/docs/scripts/prebuild-search-index.mjs) builds the index during `next build` **only on Vercel** (gated by the `VERCEL` env) — so GitHub CI's `verify` build stays fast and network-free (no ~90 MB model download). Locally: `pnpm --filter @stitchapi/docs build:search-index` populates it for testing.
- `next.config.mjs` traces `.search-index/**` into the route's serverless function.

### Scope / guardrails

- **apps/docs only**; `packages/core` untouched, so the library bundle gates are unaffected.
- Reuses Orama with the vector field added in P1 — no external vector DB.
- **Deferred to P3** (per the proposal): runtime model loading / cold-start on Vercel, and validating the file-tracing/build-command on a real deploy.

### Verification

- Hybrid relevance (tuned params) returns the right pages: _"stop hammering a flaky upstream"_ → `make-a-flaky-call-succeed` / `survive-a-flaky-dependency`; _"let an agent call my API without exposing the secret"_ → `api-key` / `bearer` / `expose-a-stitch-to-an-agent`; _"retry a failed request"_ → `retry`.
- Route serves `SortedResult[]` over HTTP (`next start` + curl), `[]` for empty queries.
- `tsc --noEmit` ✓ · `eslint .` ✓ · `vitest run` ✓ (37 tests, incl. the new mapping spec) · `next build` ✓ (378 pages; prebuild correctly skips locally) · `prettier --check` ✓.

### Not in this phase

`/api/mcp` Streamable HTTP server + cold-start measurement (P3); agents docs page + `mcp.json` snippets (P4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
