### PR TITLE
feat(docs): search_docs P4 — agents MCP page + mcp.json snippets

### DIFF
--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -627,6 +627,13 @@ export const pages: Page[] = [
             'Feed the auto-generated llms.txt and per-page llms.mdx to an agent for context-frugal docs.',
         kind: 'guide',
     },
+    {
+        path: 'agents/search-over-mcp',
+        title: 'Search the docs over MCP',
+        description:
+            'Connect an agent to the hosted docs MCP — search_docs finds the relevant sections, get_doc reads a full page — for context-frugal retrieval when loading the whole corpus is more than you need.',
+        kind: 'guide',
+    },
 
     // ── Reference ───────────────────────────────────────────────────────────
     {

--- a/apps/docs/content/docs/agents/meta.json
+++ b/apps/docs/content/docs/agents/meta.json
@@ -5,6 +5,7 @@
         "run-stitch-tool",
         "author-from-one-example",
         "adopt-in-your-project",
-        "llms-txt"
+        "llms-txt",
+        "search-over-mcp"
     ]
 }

--- a/apps/docs/content/docs/agents/search-over-mcp.mdx
+++ b/apps/docs/content/docs/agents/search-over-mcp.mdx
@@ -1,0 +1,102 @@
+---
+title: 'Search the docs over MCP'
+description: 'Connect an agent to the hosted docs MCP — search_docs finds the relevant sections, get_doc reads a full page — for context-frugal retrieval when loading the whole corpus is more than you need.'
+prerequisites: ['/docs/agents/llms-txt']
+---
+
+This documentation site is itself a hosted MCP server. Point an agent at it and
+it gets two tools: `search_docs`, which returns the handful of relevant doc
+_sections_ for a query — excerpts plus deep links, not whole pages — and
+`get_doc`, which reads one full page as clean Markdown. The agent connects once
+and pulls in exactly the passage it needs, instead of loading the whole manual on
+every turn.
+
+<Callout type="info">
+    This is **not** the library's [`run_stitch` surface](/docs/surfaces/mcp).
+    That MCP server runs on _your_ machine over stdio and calls _your_ stitches.
+    This one is hosted by us at `stitchapi.dev`, speaks MCP Streamable HTTP, and
+    searches _our_ docs — so an agent can learn StitchAPI before it writes a
+    line. They compose: `search_docs` (learn the API) → `get_doc` (read the
+    page) → `run_stitch` (call it).
+</Callout>
+
+## Connect
+
+The server lives at `https://stitchapi.dev/api/mcp`. It needs no key. Drop one of
+these into your agent's config.
+
+**Claude Code** — add it from the CLI:
+
+```bash
+claude mcp add --transport http stitchapi-docs https://stitchapi.dev/api/mcp
+```
+
+or commit it to the project's `.mcp.json`:
+
+```json
+{
+    "mcpServers": {
+        "stitchapi-docs": {
+            "type": "http",
+            "url": "https://stitchapi.dev/api/mcp"
+        }
+    }
+}
+```
+
+**Cursor** — `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global):
+
+```json
+{
+    "mcpServers": {
+        "stitchapi-docs": {
+            "url": "https://stitchapi.dev/api/mcp"
+        }
+    }
+}
+```
+
+**VS Code (Copilot)** — `.vscode/mcp.json`; note the top-level key is `servers`:
+
+```json
+{
+    "servers": {
+        "stitchapi-docs": {
+            "type": "http",
+            "url": "https://stitchapi.dev/api/mcp"
+        }
+    }
+}
+```
+
+## The two tools
+
+`search_docs` takes a natural-language `query` and an optional `limit` (default
+5). It runs hybrid retrieval — keyword and semantic together — over the same
+Markdown that feeds `llms.txt`, and returns each hit as `{ title, url, excerpt,
+score }`. The `url` carries the section anchor, so it deep-links straight to the
+passage. It never returns full pages: that frugality is the whole point.
+
+`get_doc` is the escape hatch for when an excerpt isn't enough. Give it the `url`
+from a `search_docs` hit (or a `slug` like `guides/resilience/throttle`) and it
+returns that page as clean Markdown — the same output as its
+[`llms.mdx`](/docs/agents/llms-txt) route.
+
+## When to reach for it
+
+For a corpus this size, [loading the whole
+`llms-full.txt`](/docs/agents/llms-txt) once is still the simplest correct
+default — it fits a modern context window, so there's nothing to gain from
+retrieval. Reach for `search_docs` when one of two things becomes true: the docs
+outgrow the model's window, or reloading them every turn costs more than a
+targeted lookup is worth. The index is rebuilt from the docs on every deploy — the
+same source a human reads — so a search hit never drifts from the page it cites.
+
+## See also
+
+<Cards>
+    <Card title="Point an agent at llms.txt" href="/docs/agents/llms-txt" />
+    <Card title="run_stitch & code-mode" href="/docs/agents/run-stitch-tool" />
+    <Card title="The MCP surface (run_stitch)" href="/docs/surfaces/mcp" />
+    <Card title="For agents" href="/docs/agents" />
+</Cards>

--- a/apps/docs/lib/source.ts
+++ b/apps/docs/lib/source.ts
@@ -18,6 +18,8 @@ export function llmsPreamble() {
     return `# StitchAPI
 > API stitching: turn any API into a typed, resilient function. Declare an endpoint once — its types, auth, and resilience — and call it like a local function, from your code, the CLI, or an AI agent over MCP, without ever touching a credential. fetch/axios are pluggable adapters underneath; a stitch sits above them, it does not replace them.
 
+Search these docs instead of loading the whole file: this site is also a hosted MCP server (search_docs + get_doc) at https://stitchapi.dev/api/mcp — see /docs/agents/search-over-mcp.
+
 ## What an agent needs to know
 - API stitching, not an HTTP client: a **stitch** takes one endpoint (HTTP, GraphQL, SSE, an LLM, even a shell command) and hands back a callable. Keep the fetch/axios you already have — it is the adapter underneath.
 - Capability, not credential: an agent invokes a stitch and gets structured, validated, traceable data; the secret stays behind the boundary.


### PR DESCRIPTION
## search_docs P4 — agents "Search the docs over MCP" page + `mcp.json` snippets

The **final phase** of the [`search_docs` proposal](docs/proposals/search-docs.md) (§9), completing P1 (build-time index) → P2 (search route + site search) → P3 (MCP server) → **P4 (agent-facing docs)**.

### What's here

- **New page** [`content/docs/agents/search-over-mcp.mdx`](apps/docs/content/docs/agents/search-over-mcp.mdx) — "Search the docs over MCP": documents the hosted docs MCP (`search_docs` + `get_doc`), explicitly distinguished from the library's `run_stitch` (that's _your_ stitches over stdio; this is _our_ docs, hosted, over Streamable HTTP). Includes **drop-in `mcp.json` snippets** for **Claude Code** (`claude mcp add` + `.mcp.json`), **Cursor**, and **VS Code** — config syntax verified against each tool's current docs.
- **Manifest + meta** — registered in [`content.manifest.ts`](apps/docs/content.manifest.ts); `agents/meta.json` regenerated by `gen:docs`.
- **llms.txt pointer** — a one-line pointer in the [`llmsPreamble`](apps/docs/lib/source.ts) so an agent reading `/llms.txt` learns it can search the docs over MCP instead of loading the whole file.

### Consistency

Framed as the **additive frugal path** — loading `llms-full.txt` wholesale stays the documented default for a corpus this size; `search_docs` is for when it outgrows the window or per-turn load costs too much. (Matches the existing [Point an agent at llms.txt](apps/docs/content/docs/agents/llms-txt.mdx) page and the `llms-full.txt`-default that already merged.)

### Verification

- content-manifest two-way-sync + prerequisites gates ✓ · `check:docs-links` ✓ (108 pages) · `gen:docs` idempotent ✓ · `tsc` ✓ · `eslint` ✓ · `next build` ✓ (382 pages, the new page renders) · `prettier` ✓ · `check-size-docs` ✓.

### search_docs complete 🎉

With P1–P4 merged, the full loop ships: build-time index → hybrid `/api/search-docs` + semantic site search → `/api/mcp` server → this agents page. The one open follow-up is still the P3 cold-start **measurement**, which needs a real Vercel deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
