### PR TITLE
fix(docs): externalize transformers.js so the search-docs/mcp routes load

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -66,6 +66,15 @@ const config = {
         '/api/search-docs': ['./.search-index/**'],
         '/api/mcp': ['./.search-index/**'],
     },
+    // Keep the runtime embedder OUT of the server bundle. Those same two routes
+    // load transformers.js (@huggingface/transformers), whose Node backend is the
+    // native `onnxruntime-node` addon (`.node` binaries). Bundling a native addon
+    // breaks its require at function init, so *importing* the route module throws
+    // — which 500s every request (even paths that never embed, like the MCP
+    // `initialize` handshake or an empty query), not just searches. Marking these
+    // external leaves them as a plain runtime require, resolved from the traced
+    // node_modules, so the binary loads. Next externalizes `sharp` by default.
+    serverExternalPackages: ['@huggingface/transformers', 'onnxruntime-node'],
     // The playground consumes the in-repo sandbox engine (@stitchapi/sandbox), a
     // workspace package that ships raw TS/TSX source — Next must transpile it.
     transpilePackages: ['@stitchapi/sandbox'],


### PR DESCRIPTION
## Problem

The hosted docs MCP server (`/api/mcp`, P3) and the site-search REST endpoint (`/api/search-docs`, P2) are both returning **HTTP 500** in production. `claude mcp add … https://stitchapi.dev/api/mcp` connects but every call fails, so no agent can use `search_docs` / `get_doc`. The rest of the site (`/`, `/docs`, `/llms.txt`) is healthy — only these two routes are down.

## Root cause

The failure is at **module import**, not per-request:

- `/api/search-docs` wraps its search in a `try/catch` that degrades to `200 []` "if the index or model isn't available" — yet it returns **500**. The catch never runs.
- The `if (!query) return Response.json([])` early-return — which touches neither the index nor the model — **also 500s**.
- The MCP `initialize` handshake — which never searches — **also 500s**.

The only thing all three paths share is the route module's import graph. Both routes import `lib/search-index/search.ts → embed.ts → @huggingface/transformers`, whose Node backend is the native **`onnxruntime-node`** addon (`.node` binaries). With no `serverExternalPackages`, Next bundles that native addon into each serverless function; the bundled `require` of the `.node` binary breaks at function init, so importing the route module throws → **every request 500s**.

This is the P3 "cold-start / runtime model loading on Vercel" watch-item surfacing as a hard outage.

## Fix

```js
serverExternalPackages: ['@huggingface/transformers', 'onnxruntime-node'],
```

Externalizing keeps both packages as plain runtime `require`s resolved from the traced `node_modules`, so the native binary loads instead of being bundled. One-line config change; no route logic touched.

## Verification

- `node --check`, Prettier, and `tsc` (pre-commit typecheck) all pass.
- Definitive check is this branch's deploy: `POST /api/mcp` `initialize` should return `200` with server capabilities, and `search_docs` should return real hits — I'll confirm against the deploy and re-run the docs-MCP evaluation once it's live.

## Follow-ups (not in this PR)

- Optional hardening so a *future* model/index failure degrades to BM25/empty instead of erroring the MCP tool (the `search_docs` tool handler has no `try/catch`, unlike the P2 route).
- The original P3 cold-start latency measurement still stands once the endpoint is back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
