### PR TITLE
fix(docs): pin outputFileTracingRoot so the search fns ship their native deps

### DIFF
--- a/apps/docs/app/api/_diag/route.ts
+++ b/apps/docs/app/api/_diag/route.ts
@@ -1,0 +1,88 @@
+// TEMPORARY diagnostic for the search_docs infra outage. Reports, from inside the
+// deployed serverless function, which server-only imports resolve and whether a
+// real search runs end-to-end — so a Vercel-only import/trace failure is visible
+// without runtime-log access. Every probe is wrapped so this route itself never
+// 500s (unlike /api/mcp + /api/search-docs, whose crash is at module import).
+// Remove once those two routes are confirmed healthy.
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface Probe {
+    mod: string;
+    ok: boolean;
+    code?: string;
+    message?: string;
+}
+
+async function probe(
+    mod: string,
+    load: () => Promise<unknown>,
+): Promise<Probe> {
+    try {
+        await load();
+        return { mod, ok: true };
+    } catch (e) {
+        const err = e as NodeJS.ErrnoException;
+        return {
+            mod,
+            ok: false,
+            code: err.code,
+            message: String(err.message).slice(0, 300),
+        };
+    }
+}
+
+export async function GET(): Promise<Response> {
+    const probes: Probe[] = [
+        await probe(
+            '@huggingface/transformers',
+            () => import('@huggingface/transformers'),
+        ),
+        await probe(
+            'onnxruntime-node',
+            () =>
+                // onnxruntime-node is a transitive native dep of transformers with no
+                // type decls resolvable from apps/docs; we only probe that it loads.
+                // @ts-expect-error -- no types, load-only probe
+                import('onnxruntime-node'),
+        ),
+        await probe('@orama/orama', () => import('@orama/orama')),
+        await probe(
+            '@orama/plugin-data-persistence',
+            () => import('@orama/plugin-data-persistence'),
+        ),
+        await probe(
+            '@/lib/search-index/search',
+            () => import('@/lib/search-index/search'),
+        ),
+        await probe(
+            '@/lib/search-index/get-doc',
+            () => import('@/lib/search-index/get-doc'),
+        ),
+    ];
+
+    let search: unknown;
+    try {
+        const { searchDocs } = await import('@/lib/search-index/search');
+        const hits = await searchDocs('retry flaky upstream', { limit: 2 });
+        search = {
+            ok: true,
+            hitCount: hits.length,
+            first: hits[0]?.pageUrl,
+        };
+    } catch (e) {
+        const err = e as NodeJS.ErrnoException;
+        search = {
+            ok: false,
+            code: err.code,
+            message: String(err.message).slice(0, 400),
+        };
+    }
+
+    return Response.json({
+        node: process.version,
+        cwd: process.cwd(),
+        probes,
+        search,
+    });
+}

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -58,6 +58,16 @@ const withMDX = createMDX();
 /** @type {import('next').NextConfig} */
 const config = {
     reactStrictMode: true,
+    // Trace from the pnpm workspace root, not Next's inferred app dir. The search
+    // routes' externalized native deps (transformers.js + onnxruntime-node) are
+    // hoisted to <workspaceRoot>/node_modules/.pnpm, so their trace paths climb
+    // seven levels up to the workspace root. Next only *infers* that root (it warns
+    // when it can't be sure), and on Vercel it can land on a narrower dir — then
+    // those hoisted files fall outside the trace scope and are never copied into
+    // the function, so the runtime require throws at import and the route 500s.
+    // (Works locally only because `next start` runs from the full node_modules.)
+    // Pinning the root makes the deployed function include them.
+    outputFileTracingRoot: repoRoot,
     // Bundle the build-time search index into the serverless functions that
     // restore the Orama dump at runtime — the human search route (P2) and the MCP
     // server (P3). The file is generated at deploy by scripts/prebuild-search-index.mjs
@@ -65,6 +75,8 @@ const config = {
     outputFileTracingIncludes: {
         '/api/search-docs': ['./.search-index/**'],
         '/api/mcp': ['./.search-index/**'],
+        // Temporary: lets /api/_diag run a real search end-to-end. Remove with it.
+        '/api/_diag': ['./.search-index/**'],
     },
     // Keep the runtime embedder OUT of the server bundle. Those same two routes
     // load transformers.js (@huggingface/transformers), whose Node backend is the

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -66,6 +66,15 @@ const config = {
         '/api/search-docs': ['./.search-index/**'],
         '/api/mcp': ['./.search-index/**'],
     },
+    // Keep the runtime embedder OUT of the server bundle. Those same two routes
+    // load transformers.js (@huggingface/transformers), whose Node backend is the
+    // native `onnxruntime-node` addon (`.node` binaries). Bundling a native addon
+    // breaks its require at function init, so *importing* the route module throws
+    // — which 500s every request (even paths that never embed, like the MCP
+    // `initialize` handshake or an empty query), not just searches. Marking these
+    // external leaves them as a plain runtime require, resolved from the traced
+    // node_modules, so the binary loads. Next externalizes `sharp` by default.
+    serverExternalPackages: ['@huggingface/transformers', 'onnxruntime-node'],
     // The playground consumes the in-repo sandbox engine (@stitchapi/sandbox), a
     // workspace package that ships raw TS/TSX source — Next must transpile it.
     transpilePackages: ['@stitchapi/sandbox'],


### PR DESCRIPTION
Follow-up to #388. Externalizing got transformers + onnxruntime-node marked external, but /api/mcp and /api/search-docs still 500'd on Vercel.

**Root cause (from the local build's trace manifest):** those native packages are hoisted to the pnpm workspace root (`node_modules/.pnpm`); their trace paths climb 7 levels up. Next only *infers* the tracing root (and warns it may be wrong); on Vercel it lands on a narrower dir, so the hoisted native files fall outside the trace scope and are never copied into the function → the runtime require throws at import → every request 500s. Local `next start` works only because it runs from the full node_modules, masking the gap.

**Fix:** pin `outputFileTracingRoot` to the workspace root.

**Temporary:** adds `/api/_diag` which reports, from inside the function, which imports resolve + whether a real search runs — to confirm the fix on Vercel without runtime-log access. Removed once the two routes are healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)