### PR TITLE
chore(docs): routable, gated /api/diag probe (replaces broken _diag)

### DIFF
--- a/apps/docs/app/api/diag/route.ts
+++ b/apps/docs/app/api/diag/route.ts
@@ -1,11 +1,15 @@
-// TEMPORARY diagnostic for the search_docs infra outage. Reports, from inside the
-// deployed serverless function, which server-only imports resolve and whether a
-// real search runs end-to-end — so a Vercel-only import/trace failure is visible
-// without runtime-log access. Every probe is wrapped so this route itself never
-// 500s (unlike /api/mcp + /api/search-docs, whose crash is at module import).
-// Remove once those two routes are confirmed healthy.
+// TEMPORARY diagnostic for the search_docs infra outage. Gated behind ?key= so
+// it is not an open debug endpoint (404 without the key). Reports ONLY which
+// server-only imports resolve and whether a search runs — it never reads
+// process.env, secrets, request headers/cookies/body, or user data. The error
+// strings it returns are module-resolution errors (may include internal file
+// paths, no secrets). Delete once /api/mcp + /api/search-docs are healthy.
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
+
+// Throwaway obscurity gate. Server-only (route handler source is never sent to
+// the browser); rotated/removed with this route.
+const DIAG_KEY = 'd1ag-9k2m7q4x8z';
 
 interface Probe {
     mod: string;
@@ -27,12 +31,16 @@ async function probe(
             mod,
             ok: false,
             code: err.code,
-            message: String(err.message).slice(0, 300),
+            message: String(err.message).slice(0, 400),
         };
     }
 }
 
-export async function GET(): Promise<Response> {
+export async function GET(request: Request): Promise<Response> {
+    if (new URL(request.url).searchParams.get('key') !== DIAG_KEY) {
+        return new Response('Not found', { status: 404 });
+    }
+
     const probes: Probe[] = [
         await probe(
             '@huggingface/transformers',
@@ -41,9 +49,7 @@ export async function GET(): Promise<Response> {
         await probe(
             'onnxruntime-node',
             () =>
-                // onnxruntime-node is a transitive native dep of transformers with no
-                // type decls resolvable from apps/docs; we only probe that it loads.
-                // @ts-expect-error -- no types, load-only probe
+                // @ts-expect-error -- transitive native dep, no types; load-only probe
                 import('onnxruntime-node'),
         ),
         await probe('@orama/orama', () => import('@orama/orama')),
@@ -65,24 +71,18 @@ export async function GET(): Promise<Response> {
     try {
         const { searchDocs } = await import('@/lib/search-index/search');
         const hits = await searchDocs('retry flaky upstream', { limit: 2 });
-        search = {
-            ok: true,
-            hitCount: hits.length,
-            first: hits[0]?.pageUrl,
-        };
+        search = { ok: true, hitCount: hits.length, first: hits[0]?.pageUrl };
     } catch (e) {
         const err = e as NodeJS.ErrnoException;
         search = {
             ok: false,
             code: err.code,
-            message: String(err.message).slice(0, 400),
+            message: String(err.message).slice(0, 500),
+            stack: String(err.stack ?? '')
+                .split('\n')
+                .slice(0, 5),
         };
     }
 
-    return Response.json({
-        node: process.version,
-        cwd: process.cwd(),
-        probes,
-        search,
-    });
+    return Response.json({ node: process.version, probes, search });
 }

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -75,8 +75,8 @@ const config = {
     outputFileTracingIncludes: {
         '/api/search-docs': ['./.search-index/**'],
         '/api/mcp': ['./.search-index/**'],
-        // Temporary: lets /api/_diag run a real search end-to-end. Remove with it.
-        '/api/_diag': ['./.search-index/**'],
+        // Temporary: lets /api/diag run a real search end-to-end. Remove with it.
+        '/api/diag': ['./.search-index/**'],
     },
     // Keep the runtime embedder OUT of the server bundle. Those same two routes
     // load transformers.js (@huggingface/transformers), whose Node backend is the


### PR DESCRIPTION
Replaces the non-routable `_diag` (leading-underscore = Next private folder → 404 everywhere) with a routable, `?key=`-gated `/api/diag` that reports which server-only imports resolve inside the deployed function. Pinpoints why /api/mcp + /api/search-docs still 500 after #388/#389. No env/secrets/request data. Temporary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)