### PR TITLE
docs(agents): add a "tell your agent to use it" rule for the docs MCP

### DIFF
--- a/apps/docs/content/docs/agents/index.mdx
+++ b/apps/docs/content/docs/agents/index.mdx
@@ -80,11 +80,20 @@ Drop a short rule into your repo and any agent working in it reaches for a typed
 API. Hand-copy the rule, or run `npx stitch init` to write it as `AGENTS.md`, a
 Cursor rule, or a `CLAUDE.md` section.
 
+That rule teaches an agent to _write_ stitches. A companion rule teaches it to
+_look up_ how — point it at these docs over MCP so it searches the current API
+before answering instead of guessing from training data.
+
 <Cards>
     <Card
         title="Adopt in your project"
         href="/docs/agents/adopt-in-your-project"
         description="The consumer rule agents follow, plus npx stitch init."
+    />
+    <Card
+        title="Search the docs over MCP"
+        href="/docs/agents/search-over-mcp"
+        description="Give the agent a rule to search_docs before it answers."
     />
 </Cards>
 

--- a/apps/docs/content/docs/agents/search-over-mcp.mdx
+++ b/apps/docs/content/docs/agents/search-over-mcp.mdx
@@ -69,6 +69,32 @@ or commit it to the project's `.mcp.json`:
 }
 ```
 
+## Tell your agent to use it
+
+Connecting the server is only half of it — an agent won't reach for a tool it
+forgets it has. Give it a standing rule so it searches the docs on its own. Drop
+this into whichever convention your agent reads — `AGENTS.md`, a `CLAUDE.md`
+section, a file under `.cursor/rules/`, or `.windsurfrules`:
+
+```md
+# Using the StitchAPI docs MCP
+
+For any question about StitchAPI — its API, configuration, errors, or runtime
+behavior — use the `stitchapi-docs` MCP server before answering:
+
+-   Call `search_docs` with a natural-language query first, and read the excerpts
+    and links it returns.
+-   Call `get_doc` to read a full page when an excerpt is not enough.
+-   Prefer these tools over prior knowledge. StitchAPI is newer and moves faster
+    than model training data, so the docs are the source of truth — when they
+    disagree with memory, follow the docs.
+```
+
+Keep it short: it names the server, the two tools, and the one judgment call that
+matters — prefer the live docs to a stale guess. It pairs with the [consumer
+rule](/docs/agents/adopt-in-your-project), which teaches the same agent to
+_write_ stitches; this one teaches it to _look up_ how.
+
 ## The two tools
 
 `search_docs` takes a natural-language `query` and an optional `limit` (default


### PR DESCRIPTION
## What

Adds a **"Tell your agent to use it"** section to the *Search the docs over MCP*
agents page, with a short, copy-pasteable rule block for `AGENTS.md`,
`CLAUDE.md`, `.cursor/rules/`, or `.windsurfrules`:

- `search_docs` before answering,
- `get_doc` for full pages,
- prefer the live docs over prior knowledge (StitchAPI ships faster than model
  training data, so the docs are the source of truth).

Cross-links it from the agents index under **Adopt in your project**, pairing it
with the existing *consumer* rule (write stitches, not `fetch`) — one teaches an
agent to _write_ stitches, the companion teaches it to _look up_ how.

## Why

Connecting the hosted docs MCP is only half the job; an agent won't reach for a
tool it forgets it has. A standing rule in the repo is what actually gets the
tool used once the server is wired up.

## Scope & gates

Docs-only — two `.mdx` files, no lib/manifest/frontmatter changes.

- `pnpm check:docs-links` ✓ (every `/docs/...` link resolves, incl. the two new ones)
- `pnpm --filter @stitchapi/docs gen:docs` → no diff (no manifest change)
- `prettier` ✓
- `content-manifest` + `prerequisites` specs ✓

Leaving the merge to you — each merge is a prod deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
