### PR TITLE
docs(errors): point agents to the docs MCP at the moment they fail

### DIFF
--- a/apps/docs/content/docs/errors/index.mdx
+++ b/apps/docs/content/docs/errors/index.mdx
@@ -85,6 +85,13 @@ resolves.
 
 ## Every coded failure
 
+<Callout type="info">
+    Debugging one of these with an agent? Connect the [docs
+    MCP](/docs/agents/search-over-mcp) and it can pull any error page on demand
+    — `search_docs('STITCH_DRIFT')`, `search_docs('rate limit')` — instead of
+    guessing from stale training data.
+</Callout>
+
 <Cards>
     <Card title="STITCH_VALIDATION" href="/docs/errors/stitch-validation">
         A response failed its output schema — the shape you asked for isn't the

--- a/apps/docs/content/docs/errors/rate-limit.mdx
+++ b/apps/docs/content/docs/errors/rate-limit.mdx
@@ -68,6 +68,12 @@ purpose.
     `throttle.delegate` and use [retry](/docs/guides/resilience/retry) +
     [throttle](/docs/guides/resilience/throttle).
 
+<Callout type="info">
+    Stuck, or debugging with an agent? Ask the [docs
+    MCP](/docs/agents/search-over-mcp) — `search_docs('RateLimitError')` pulls
+    this page and the related guides straight into context.
+</Callout>
+
 ## Related
 
 <Cards>

--- a/apps/docs/content/docs/errors/stitch-auth-wall.mdx
+++ b/apps/docs/content/docs/errors/stitch-auth-wall.mdx
@@ -60,6 +60,12 @@ const me = stitch({
 });
 ```
 
+<Callout type="info">
+    Stuck, or debugging with an agent? Ask the [docs
+    MCP](/docs/agents/search-over-mcp) — `search_docs('STITCH_AUTH_WALL')` pulls
+    this page and the related guides straight into context.
+</Callout>
+
 ## Related
 
 <Cards>

--- a/apps/docs/content/docs/errors/stitch-circuit-open.mdx
+++ b/apps/docs/content/docs/errors/stitch-circuit-open.mdx
@@ -51,6 +51,12 @@ Pair the breaker with [retry](/docs/guides/resilience/retry) and
 [timeout](/docs/guides/resilience/timeout): timeouts and retries absorb the
 transient failures, and the breaker steps in only once those keep failing.
 
+<Callout type="info">
+    Stuck, or debugging with an agent? Ask the [docs
+    MCP](/docs/agents/search-over-mcp) — `search_docs('STITCH_CIRCUIT_OPEN')`
+    pulls this page and the related guides straight into context.
+</Callout>
+
 ## Related
 
 <Cards>

--- a/apps/docs/content/docs/errors/stitch-drift.mdx
+++ b/apps/docs/content/docs/errors/stitch-drift.mdx
@@ -68,6 +68,12 @@ See the [drift guide](/docs/guides/validation/drift) for how the schema's
 required/optional structure maps to finding levels, and how `severity` and
 `ignore` filter soft findings.
 
+<Callout type="info">
+    Stuck, or debugging with an agent? Ask the [docs
+    MCP](/docs/agents/search-over-mcp) — `search_docs('STITCH_DRIFT')` pulls
+    this page and the related guides straight into context.
+</Callout>
+
 ## Related
 
 <Cards>

--- a/apps/docs/content/docs/errors/stitch-graphql.mdx
+++ b/apps/docs/content/docs/errors/stitch-graphql.mdx
@@ -65,6 +65,12 @@ status: a `200` is not proof of success. See the
 [GraphQL guide](/docs/guides/data/graphql) for how `graphql()` posts the
 operation and unwraps `data` on the success path.
 
+<Callout type="info">
+    Stuck, or debugging with an agent? Ask the [docs
+    MCP](/docs/agents/search-over-mcp) — `search_docs('STITCH_GRAPHQL')` pulls
+    this page and the related guides straight into context.
+</Callout>
+
 ## Related
 
 <Cards>

--- a/apps/docs/content/docs/errors/stitch-timeout.mdx
+++ b/apps/docs/content/docs/errors/stitch-timeout.mdx
@@ -58,6 +58,12 @@ dependency that is genuinely failing, pair the timeout with
 [circuit breaker](/docs/guides/resilience/circuit-breaker) to fast-fail once it
 stops responding, instead of waiting out the timeout on every call.
 
+<Callout type="info">
+    Stuck, or debugging with an agent? Ask the [docs
+    MCP](/docs/agents/search-over-mcp) — `search_docs('STITCH_TIMEOUT')` pulls
+    this page and the related guides straight into context.
+</Callout>
+
 ## Related
 
 <Cards>

--- a/apps/docs/content/docs/errors/stitch-validation.mdx
+++ b/apps/docs/content/docs/errors/stitch-validation.mdx
@@ -77,6 +77,12 @@ See [Bring your own validator](/docs/guides/validation/standard-schema) for
 adapting non-Zod schemas, and [Validation](/docs/guides/validation/validation)
 for how `input` and `output` are checked.
 
+<Callout type="info">
+    Stuck, or debugging with an agent? Ask the [docs
+    MCP](/docs/agents/search-over-mcp) — `search_docs('STITCH_VALIDATION')`
+    pulls this page and the related guides straight into context.
+</Callout>
+
 ## Related
 
 <Cards>


### PR DESCRIPTION
## What

Adds a small `<Callout type="info">` to every `/docs/errors/*` page — the 7
coded-failure pages and the section index — pointing the reader (especially an
agent) at the hosted docs MCP at the moment they're debugging a failure:

> Stuck, or debugging with an agent? Ask the [docs MCP](/docs/agents/search-over-mcp) — `search_docs('STITCH_DRIFT')` pulls this page and the related guides straight into context.

Each page names its own error code in the example query.

## Why

This is the "teach at the point of failure" idea: an agent that surfaces
`STITCH_DRIFT` and lands on this page gets nudged toward the tool that pulls the
page — plus the related guides — into context, instead of guessing from stale
training data.

## Verified

Every `search_docs('CODE')` example was run against the live server
(`stitchapi.dev/api/mcp`) — each code returns its own error page as the **top
hit** (including `RateLimitError` → the rate-limit page at score 0.98). So the
examples aren't aspirational; they work today.

## Scope & gates

Docs-only — 8 `.mdx` files, no lib/manifest/frontmatter changes. Placement is
uniform (just before each page's `## Related`), so it doesn't collide with the
existing top-of-page callouts.

- `pnpm check:docs-links` ✓ (108 routes; the new `/docs/agents/search-over-mcp` links resolve)
- `pnpm --filter @stitchapi/docs gen:docs` → no diff
- `prettier` ✓
- `content-manifest` + `prerequisites` specs ✓

Leaving the merge to you — each merge is a prod deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
