### PR TITLE
docs: retrieval tuning for search_docs + no-regression ratchet

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -184,3 +184,32 @@ jobs:
             - run: pnpm install --frozen-lockfile
             - run: pnpm --filter @stitchapi/docs test:e2e:install
             - run: pnpm --filter @stitchapi/docs test:e2e
+
+    # Docs search-relevance ratchet (apps/docs/scripts/search-eval.mts --assert): builds the
+    # semantic search index the deploy builds, then asserts every natural question in
+    # apps/docs/test/search-golden.json still finds its page within reach (#5) and that the
+    # aggregate Relevance@1 / MRR hold above their floors. This is the regression guard for
+    # search_docs — it catches a content edit that silently drops a page out of its own
+    # question's results (the >8/>30 misranks this ratchet was tuned to fix). It builds the
+    # docs app and loads the local embedding model, so — like size/sandbox/e2e — it runs as
+    # its own job rather than in the fast `verify` gate. Make it a required check once it has
+    # settled in CI.
+    search-relevance:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - uses: actions/checkout@v4
+            - uses: pnpm/action-setup@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version-file: .nvmrc
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile
+            # Cache the local embedding model (all-MiniLM-L6-v2, ~23 MB) transformers.js pulls
+            # into node_modules on the first index build, so a HuggingFace CDN hiccup can't flake
+            # a required check. Keyed on the lockfile, so a transformers version bump re-fetches.
+            - uses: actions/cache@v4
+              with:
+                  path: node_modules/.pnpm/@huggingface+transformers@*/node_modules/@huggingface/transformers/.cache
+                  key: transformers-model-${{ hashFiles('pnpm-lock.yaml') }}
+            - run: pnpm --filter @stitchapi/docs check:search-relevance

--- a/apps/docs/content/docs/concepts/capability-not-credential.mdx
+++ b/apps/docs/content/docs/concepts/capability-not-credential.mdx
@@ -3,9 +3,11 @@ title: 'Capability, not credential'
 description: 'How a stitch holds the secret and hands the caller a capability, so an agent invoking it never sees the token.'
 ---
 
-A stitch holds its credential; what it hands the caller is a capability — a
-callable that, when invoked, returns data. The caller gets the ability to make
-the authenticated call, never the secret that authorizes it.
+Hand an agent — or any caller — a stitch and it can call your authenticated API
+without ever seeing the secret. A stitch holds its credential; what it hands the
+caller is a capability — a callable that, when invoked, returns data. The caller
+gets the ability to make the authenticated call, never the token or API key that
+authorizes it.
 
 ## Why it's shaped this way
 
@@ -44,11 +46,13 @@ token) without the caller doing anything. Attach, detect, refresh: all of it
 happens behind the capability, so the caller never sees the token even when the
 token is rotating underneath them.
 
-That is the security boundary that makes a stitch safe to expose to an agent.
-You can hand an agent a stitch and let it invoke the call without granting it the
-credential — the agent operates with a capability scoped to exactly that
-endpoint, and a leak in the agent's context can't leak a secret that was never
-in it.
+### Safe to hand to an agent
+
+That is the security boundary that lets an agent call your API without ever
+seeing the secret. Hand an agent a stitch and it invokes the authenticated call
+without being granted the credential — the agent operates with a capability
+scoped to exactly that endpoint, and a leak in the agent's context can't leak a
+token that was never in it.
 
 ## How it relates
 

--- a/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
+++ b/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
@@ -4,10 +4,12 @@ description: 'Stop hammering a failing dependency by opening a circuit after rep
 prerequisites: ['/docs/concepts/the-stitch']
 ---
 
-Add `circuit` when a dependency is failing and you want the stitch to stop
-hammering it — after a run of failures the breaker opens and calls fast-fail
-for a cooldown, giving the dependency room to recover before a single trial
-call probes it again.
+Add `circuit` when an upstream API is flaky or failing and you want the stitch
+to **stop hammering it**. After a run of failures the breaker _opens_ and calls
+fast-fail for a cooldown: the stitch backs off, giving the unhealthy dependency
+room to recover before a single trial call probes it again — and shielding your
+app from the slow, cascading failures a dead upstream would otherwise pull it
+into.
 
 ## Example
 

--- a/apps/docs/content/docs/guides/resilience/idempotency.mdx
+++ b/apps/docs/content/docs/guides/resilience/idempotency.mdx
@@ -4,10 +4,11 @@ description: "Attach idempotency keys to writes so safe retries don't duplicate 
 prerequisites: ['/docs/concepts/the-stitch']
 ---
 
-Add `idempotency` to a write stitch so each logical call carries a stable
-`Idempotency-Key` header — when a retry replays the same write, the server sees
-the same key and dedupes the side effect instead of running it twice. Reach for
-it on `POST`/`PUT` where a duplicate would double-charge, double-ship, or
+Make retries on writes safe, so a replayed write settles once and never becomes
+a duplicate. Add `idempotency` to a write stitch and each logical call carries a
+stable `Idempotency-Key` header — when a retry replays the same write, the server
+sees the same key and dedupes the side effect instead of running it twice. Reach
+for it on `POST`/`PUT` where a duplicate would double-charge, double-ship, or
 double-create.
 
 ## Example

--- a/apps/docs/content/docs/guides/state/distributed-throttle.mdx
+++ b/apps/docs/content/docs/guides/state/distributed-throttle.mdx
@@ -4,12 +4,13 @@ description: 'Share one rate budget across workers by pointing the throttle at a
 prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
-By default a stitch keeps its throttle counters in the in-memory store, so the
-rate budget is per process. With `scope: 'host'` every stitch in that process
-already pools into one budget per host (see [Throttle](/docs/guides/resilience/throttle));
-the in-memory store just keeps that pooling within a single process — each worker
-gets its own. Point the throttle at a shared `store` and one budget spans every
-worker that uses it.
+Share one rate limit across every worker or server by pointing the throttle at a
+shared `store`. By default a stitch keeps its throttle counters in the in-memory
+store, so the rate budget is per process: with `scope: 'host'` every stitch in
+that process already pools into one budget per host (see
+[Throttle](/docs/guides/resilience/throttle)), but the in-memory store keeps that
+pooling within a single process — each worker gets its own. Point the throttle at
+a shared store and one budget spans every worker that uses it.
 
 ## Example
 

--- a/apps/docs/content/docs/guides/validation/standard-schema.mdx
+++ b/apps/docs/content/docs/guides/validation/standard-schema.mdx
@@ -4,10 +4,11 @@ description: 'Bring any Standard Schema validator — Zod, Valibot, ArkType — 
 prerequisites: ['/docs/concepts/the-stitch']
 ---
 
-Reach for this when you already have a schema and want a stitch to validate
-against it — StitchAPI is validator-agnostic, so any [Standard Schema](https://standardschema.dev)
-validator (Zod, Valibot, ArkType), a plain predicate, or a `Validator` works,
-adapted by the single `toValidator()` helper.
+Validate an API response with Zod — or Valibot, ArkType, a plain predicate, or
+any [Standard Schema](https://standardschema.dev) validator. StitchAPI is
+validator-agnostic: bring the schema you already have, wrap it once with the
+single `toValidator()` helper, and the stitch checks each response against it —
+inferring the result type from the same schema.
 
 ## Example
 

--- a/apps/docs/content/docs/integrations/tanstack-query.mdx
+++ b/apps/docs/content/docs/integrations/tanstack-query.mdx
@@ -3,10 +3,12 @@ title: 'TanStack Query'
 description: 'A stitch is the queryFn. StitchAPI owns the call’s resilience; TanStack Query (or SWR) owns view state — they compose, they do not compete.'
 ---
 
-TanStack Query is not an alternative to StitchAPI — it sits one layer up, and the
-two fit together cleanly. A stitch is a typed, resilient **function**; TanStack
-Query is the thing that calls functions from your components and manages the
-result as view state. So the join is the obvious one:
+Use a stitch as your TanStack Query `queryFn` in React — declare the endpoint
+once, pass it straight to `useQuery`, and there's no glue code. TanStack Query is
+not an alternative to StitchAPI — it sits one layer up, and the two fit together
+cleanly. A stitch is a typed, resilient **function**; TanStack Query is the thing
+that calls functions from your components and manages the result as view state.
+So the join is the obvious one:
 
 <Callout type="info">
     **A stitch _is_ the `queryFn`.** Pass the stitch straight to `useQuery`. The

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,6 +16,7 @@
         "build:typed-deps": "pnpm --filter stitchapi --filter @stitchapi/nest --filter @stitchapi/pino --filter @stitchapi/query-core --filter @stitchapi/react --filter @stitchapi/fastify --filter @stitchapi/hono build",
         "build:sandbox": "node scripts/gen-stitch-completions.mjs && node ../../docs/sandbox/runtime/build-sandbox-worker.mjs",
         "build:search-index": "pnpm run build:typed-deps && fumadocs-mdx && node --import tsx/esm scripts/build-search-index.mjs",
+        "check:search-relevance": "pnpm run build:search-index && node --import tsx scripts/search-eval.mts --assert",
         "test": "vitest run",
         "test:e2e": "playwright test",
         "test:e2e:install": "playwright install chromium"

--- a/apps/docs/scripts/search-eval.mts
+++ b/apps/docs/scripts/search-eval.mts
@@ -32,6 +32,19 @@ interface GoldenCase {
 const METRIC_LIMIT = Number(process.env.LIMIT ?? 8);
 const DIAG_LIMIT = 30;
 
+// --- No-regression ratchet (CI: `--assert`) --------------------------------
+// The gate is deliberately fuzzy-tolerant: embeddings are deterministic in a
+// single build, but the ONNX model can differ by ~1e-6 across architectures
+// (arm64 dev vs the x64 CI runner), enough to flip a borderline rank by one. So
+// the hard gate is generous — it catches a page falling OUT of reach (the
+// >8/>30 regressions this PR fixed), not a ±1 wobble at the edge — while the
+// TARGET below is the standard every query is actually tuned to.
+const ASSERT = process.argv.includes('--assert');
+const TARGET_RANK = 3; // what we tune for; queries past it are reported, not failed
+const HARD_MAX_RANK = 5; // fail if any expected page ranks worse than this (or is missing)
+const MIN_RELEVANCE_AT_1 = 0.78; // floor; current 0.880 (25-query golden)
+const MIN_MRR = 0.85; // floor; current 0.927
+
 const here = dirname(fileURLToPath(import.meta.url));
 const golden: GoldenCase[] = JSON.parse(
     readFileSync(resolve(here, '..', 'test', 'search-golden.json'), 'utf8'),
@@ -110,9 +123,12 @@ async function run(): Promise<void> {
 
     const n = outcomes.length;
     const rel1 = outcomes.filter((o) => o.rank === 1).length;
-    const top3 = outcomes.filter((o) => o.rank >= 1 && o.rank <= 3).length;
+    const topT = outcomes.filter(
+        (o) => o.rank >= 1 && o.rank <= TARGET_RANK,
+    ).length;
     const mrr =
         outcomes.reduce((s, o) => s + (o.rank > 0 ? 1 / o.rank : 0), 0) / n;
+    const rel1Frac = rel1 / n;
 
     // Worst-first, so the loop's "pick the worst query" is a glance away.
     const worst = [...outcomes]
@@ -125,8 +141,8 @@ async function run(): Promise<void> {
 
     console.log(`\n${'─'.repeat(60)}`);
     console.log(
-        `Relevance@1: ${(rel1 / n).toFixed(3)}  (${rel1}/${n})` +
-            `   Top-3: ${(top3 / n).toFixed(3)}  (${top3}/${n})` +
+        `Relevance@1: ${rel1Frac.toFixed(3)}  (${rel1}/${n})` +
+            `   Top-${TARGET_RANK}: ${(topT / n).toFixed(3)}  (${topT}/${n})` +
             `   MRR: ${mrr.toFixed(3)}`,
     );
     if (worst.length) {
@@ -140,6 +156,60 @@ async function run(): Promise<void> {
         console.log(`\nAll queries rank #1. ✓`);
     }
     console.log('');
+
+    if (ASSERT) assertNoRegression(outcomes, rel1Frac, mrr);
+}
+
+/**
+ * Hard no-regression gate for CI (`--assert`). Fails (non-zero exit) when a
+ * documented question can no longer find its page within reach (`HARD_MAX_RANK`),
+ * or when aggregate quality drops below the committed floors. Queries between the
+ * TARGET and the hard bound are reported, not failed — see the constants above.
+ */
+function assertNoRegression(
+    outcomes: Outcome[],
+    rel1Frac: number,
+    mrr: number,
+): void {
+    const failures: string[] = [];
+
+    for (const o of outcomes) {
+        if (o.rank < 1 || o.rank > HARD_MAX_RANK) {
+            failures.push(
+                `rank ${fmtRank(o)} > #${HARD_MAX_RANK}  ${o.expect}  —  “${o.query}”`,
+            );
+        }
+    }
+    if (rel1Frac < MIN_RELEVANCE_AT_1) {
+        failures.push(
+            `Relevance@1 ${rel1Frac.toFixed(3)} < floor ${MIN_RELEVANCE_AT_1}`,
+        );
+    }
+    if (mrr < MIN_MRR) {
+        failures.push(`MRR ${mrr.toFixed(3)} < floor ${MIN_MRR}`);
+    }
+
+    const offTarget = outcomes.filter(
+        (o) => o.rank < 1 || o.rank > TARGET_RANK,
+    ).length;
+    if (offTarget) {
+        console.log(
+            `note: ${offTarget} query(ies) outside top-${TARGET_RANK} but within ` +
+                `the #${HARD_MAX_RANK} gate — tune toward #1 when a natural edit allows.`,
+        );
+    }
+
+    if (failures.length) {
+        console.error('\n✗ search relevance regressed:');
+        for (const f of failures) console.error(`  - ${f}`);
+        console.error('');
+        process.exitCode = 1;
+    } else {
+        console.log(
+            `✓ ratchet OK: every query ≤ #${HARD_MAX_RANK}, ` +
+                `Relevance@1 ≥ ${MIN_RELEVANCE_AT_1}, MRR ≥ ${MIN_MRR}.`,
+        );
+    }
 }
 
 run().catch((err) => {

--- a/apps/docs/scripts/search-eval.mts
+++ b/apps/docs/scripts/search-eval.mts
@@ -1,0 +1,148 @@
+// Retrieval-quality harness for search_docs (the hosted hybrid BM25+vector docs
+// search). Loads the golden query set (test/search-golden.json), runs each query
+// through the SAME searchDocs() the site + MCP serve, and reports how well the
+// expected page ranks:
+//
+//   Relevance@1 — fraction of queries whose expected page is the #1 result
+//   MRR         — mean reciprocal rank of the expected page
+//
+// Rank is measured over DISTINCT pages in hit order (the search dialog and MCP
+// dedupe section hits to one entry per page, so page rank is what a user sees).
+//
+// Run from the repo root, against the locally-built index:
+//   pnpm --filter @stitchapi/docs run build:search-index   # once per content change
+//   node --import tsx apps/docs/scripts/search-eval.mts
+//
+// This reads only content — it never touches the index build, the schema, or the
+// hybrid weights. Tune the .mdx, rebuild, re-run, keep the win.
+import { searchDocs } from '../lib/search-index/search';
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface GoldenCase {
+    query: string;
+    expect: string; // slug, e.g. "guides/resilience/throttle"
+}
+
+// The limit the product serves with; the headline metric is measured here so it
+// stays comparable across iterations. A deeper pass only locates where a missing
+// page actually sits, for diagnosis.
+const METRIC_LIMIT = Number(process.env.LIMIT ?? 8);
+const DIAG_LIMIT = 30;
+
+const here = dirname(fileURLToPath(import.meta.url));
+const golden: GoldenCase[] = JSON.parse(
+    readFileSync(resolve(here, '..', 'test', 'search-golden.json'), 'utf8'),
+);
+
+/** `/docs/guides/x` (or `/docs/guides/x#a`) → `guides/x`; slug passes through. */
+function toSlug(pageUrlOrSlug: string): string {
+    return pageUrlOrSlug
+        .split(/[#?]/)[0]
+        .replace(/^\/+/, '')
+        .replace(/^docs\//, '')
+        .replace(/\/$/, '');
+}
+
+/** Distinct page slugs in hit order (dedupe section hits, keep first-seen). */
+async function rankedPages(query: string, limit: number): Promise<string[]> {
+    const hits = await searchDocs(query, { limit });
+    const seen = new Set<string>();
+    const pages: string[] = [];
+    for (const hit of hits) {
+        const slug = toSlug(hit.pageUrl);
+        if (!seen.has(slug)) {
+            seen.add(slug);
+            pages.push(slug);
+        }
+    }
+    return pages;
+}
+
+interface Outcome {
+    query: string;
+    expect: string;
+    rank: number; // 1-based page rank within METRIC_LIMIT hits; 0 = not found
+    deepRank: number; // rank within DIAG_LIMIT hits; 0 = still not found
+    pages: string[]; // distinct pages within METRIC_LIMIT, for diagnosis
+}
+
+async function evaluate(c: GoldenCase): Promise<Outcome> {
+    const pages = await rankedPages(c.query, METRIC_LIMIT);
+    const rank = pages.indexOf(c.expect) + 1;
+    let deepRank = rank;
+    if (rank === 0) {
+        const deep = await rankedPages(c.query, DIAG_LIMIT);
+        deepRank = deep.indexOf(c.expect) + 1;
+    }
+    return { query: c.query, expect: c.expect, rank, deepRank, pages };
+}
+
+function fmtRank(o: Outcome): string {
+    if (o.rank > 0) return `#${o.rank}`;
+    if (o.deepRank > 0) return `>${METRIC_LIMIT} (deep #${o.deepRank})`;
+    return `>${DIAG_LIMIT}`;
+}
+
+async function run(): Promise<void> {
+    console.log(
+        `\nsearch-eval · ${golden.length} queries · metric limit ${METRIC_LIMIT}\n`,
+    );
+
+    const outcomes: Outcome[] = [];
+    for (let i = 0; i < golden.length; i++) {
+        const o = await evaluate(golden[i]);
+        outcomes.push(o);
+        const mark = o.rank === 1 ? '✓' : o.rank > 0 ? '·' : '✗';
+        const n = String(i + 1).padStart(2, ' ');
+        console.log(`${mark} [${n}] ${fmtRank(o).padEnd(18)} ${o.expect}`);
+        console.log(`        “${o.query}”`);
+        if (o.rank !== 1) {
+            const top = o.pages
+                .slice(0, 6)
+                .map((p, j) => `${j + 1}. ${p === o.expect ? `» ${p} «` : p}`)
+                .join('   ');
+            console.log(`        top: ${top || '(no hits)'}`);
+        }
+    }
+
+    const n = outcomes.length;
+    const rel1 = outcomes.filter((o) => o.rank === 1).length;
+    const top3 = outcomes.filter((o) => o.rank >= 1 && o.rank <= 3).length;
+    const mrr =
+        outcomes.reduce((s, o) => s + (o.rank > 0 ? 1 / o.rank : 0), 0) / n;
+
+    // Worst-first, so the loop's "pick the worst query" is a glance away.
+    const worst = [...outcomes]
+        .filter((o) => o.rank !== 1)
+        .sort((a, b) => {
+            const ar = a.rank || a.deepRank || 999;
+            const br = b.rank || b.deepRank || 999;
+            return br - ar;
+        });
+
+    console.log(`\n${'─'.repeat(60)}`);
+    console.log(
+        `Relevance@1: ${(rel1 / n).toFixed(3)}  (${rel1}/${n})` +
+            `   Top-3: ${(top3 / n).toFixed(3)}  (${top3}/${n})` +
+            `   MRR: ${mrr.toFixed(3)}`,
+    );
+    if (worst.length) {
+        console.log(`\nNot #1 (worst first):`);
+        for (const o of worst) {
+            console.log(
+                `  ${fmtRank(o).padEnd(18)} ${o.expect}  —  “${o.query}”`,
+            );
+        }
+    } else {
+        console.log(`\nAll queries rank #1. ✓`);
+    }
+    console.log('');
+}
+
+run().catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+});

--- a/apps/docs/test/search-golden.json
+++ b/apps/docs/test/search-golden.json
@@ -50,5 +50,13 @@
     {
         "query": "test API code without hitting the real network",
         "expect": "guides/testing/mocking"
+    },
+    {
+        "query": "share one rate limit across multiple workers or servers",
+        "expect": "guides/state/distributed-throttle"
+    },
+    {
+        "query": "run a stitch from the command line as a CLI tool",
+        "expect": "surfaces/cli"
     }
 ]

--- a/apps/docs/test/search-golden.json
+++ b/apps/docs/test/search-golden.json
@@ -1,0 +1,54 @@
+[
+    {
+        "query": "stop a stitch hammering a flaky or failing upstream API",
+        "expect": "guides/resilience/circuit-breaker"
+    },
+    {
+        "query": "rate-limit or cap the concurrency of my outgoing API calls",
+        "expect": "guides/resilience/throttle"
+    },
+    {
+        "query": "safe retries for writes without making duplicate writes",
+        "expect": "guides/resilience/idempotency"
+    },
+    {
+        "query": "validate an API response with Zod",
+        "expect": "guides/validation/standard-schema"
+    },
+    {
+        "query": "paginate a cursor endpoint into one array",
+        "expect": "recipes/paginate-into-one-array"
+    },
+    {
+        "query": "what does STITCH_DRIFT mean and how do I fix it",
+        "expect": "errors/stitch-drift"
+    },
+    {
+        "query": "let an agent call my API without ever seeing the secret",
+        "expect": "concepts/principles"
+    },
+    {
+        "query": "retry a failed HTTP request with exponential backoff",
+        "expect": "guides/resilience/retry"
+    },
+    {
+        "query": "set a timeout so a slow API call gives up",
+        "expect": "guides/resilience/timeout"
+    },
+    {
+        "query": "call a GraphQL API with typed variables",
+        "expect": "guides/data/graphql"
+    },
+    {
+        "query": "expose a stitch as an MCP tool an agent can call",
+        "expect": "surfaces/mcp"
+    },
+    {
+        "query": "authenticate requests with a bearer token",
+        "expect": "guides/auth/bearer"
+    },
+    {
+        "query": "test API code without hitting the real network",
+        "expect": "guides/testing/mocking"
+    }
+]

--- a/apps/docs/test/search-golden.json
+++ b/apps/docs/test/search-golden.json
@@ -58,5 +58,45 @@
     {
         "query": "run a stitch from the command line as a CLI tool",
         "expect": "surfaces/cli"
+    },
+    {
+        "query": "what does STITCH_TIMEOUT mean and how do I handle it",
+        "expect": "errors/stitch-timeout"
+    },
+    {
+        "query": "authenticate with OAuth2 client credentials",
+        "expect": "guides/auth/oauth2"
+    },
+    {
+        "query": "unwrap the data field out of a JSON envelope response",
+        "expect": "guides/data/unwrap"
+    },
+    {
+        "query": "reshape or transform a response body before it returns",
+        "expect": "guides/data/transform"
+    },
+    {
+        "query": "send traces to an OpenTelemetry OTLP collector",
+        "expect": "guides/observability/otlp"
+    },
+    {
+        "query": "use a stitch as a TanStack Query queryFn in React",
+        "expect": "integrations/tanstack-query"
+    },
+    {
+        "query": "call a stitch from a Next.js route handler",
+        "expect": "integrations/next"
+    },
+    {
+        "query": "what is a stitch",
+        "expect": "concepts/the-stitch"
+    },
+    {
+        "query": "share configuration across stitches with extends",
+        "expect": "guides/authoring/extends"
+    },
+    {
+        "query": "serve a stitch as an HTTP endpoint",
+        "expect": "surfaces/http-serve"
     }
 ]

--- a/apps/docs/test/search-golden.json
+++ b/apps/docs/test/search-golden.json
@@ -25,7 +25,7 @@
     },
     {
         "query": "let an agent call my API without ever seeing the secret",
-        "expect": "concepts/principles"
+        "expect": "concepts/capability-not-credential"
     },
     {
         "query": "retry a failed HTTP request with exponential backoff",


### PR DESCRIPTION
## Retrieval tuning for `search_docs` + a no-regression ratchet

A **content-only** pass to make each doc rank #1 for the natural questions users
and agents actually type into the hosted `search_docs` (the hybrid BM25+vector
search) — plus an eval harness and a CI gate so retrieval can't silently rot. No
index, schema, or hybrid-weight changes — only `.mdx` prose and test/CI infra.

### The harness

- **`apps/docs/test/search-golden.json`** — 25 natural questions mapped to the
  page that should win, drawn from the docs' own recipe/guide titles, spanning
  resilience, validation, auth, data, state, observability, integrations,
  concepts, authoring, errors, and surfaces.
- **`apps/docs/scripts/search-eval.mts`** — runs each query through the same
  `searchDocs()` the site and MCP serve, reporting **Relevance@1**, **Top-3**, and
  **MRR** (rank over distinct pages, matching the deduped result surface).

```
pnpm --filter @stitchapi/docs run build:search-index
node --import tsx apps/docs/scripts/search-eval.mts          # report
node --import tsx apps/docs/scripts/search-eval.mts --assert # CI gate
```

### Results (same 25-query golden, `main` content vs this branch)

| Metric        | Before (main) | After (this PR) |
| ------------- | :-----------: | :-------------: |
| Relevance@1   | 0.760 (19/25) |  0.880 (22/25)  |
| Top-3         | 0.880 (22/25) | **1.000 (25/25)** |
| MRR           |     0.821     |    **0.927**    |

Every golden query now ranks **top-3**; six mis-ranking pages are fixed.

### Per-page rank change

| Query | Expected page | Before | After |
| ----- | ------------- | :----: | :---: |
| "let an agent call my API without ever seeing the secret" | `concepts/capability-not-credential` | **>30** | **#3** |
| "stop a stitch hammering a flaky or failing upstream API" | `guides/resilience/circuit-breaker` | **#22** | **#3** |
| "validate an API response with Zod" | `guides/validation/standard-schema` | #5 | **#1** |
| "use a stitch as a TanStack Query queryFn in React" | `integrations/tanstack-query` | #2 | **#1** |
| "safe retries for writes without making duplicate writes" | `guides/resilience/idempotency` | #2 | **#1** |
| "share one rate limit across multiple workers or servers" | `guides/state/distributed-throttle` | #3 | #2 |

The other 19 queries already ranked #1 on `main` and stayed there.

### What each edit does

Every fix is the same shape — **front-load the page's opening with the question in
the user's own words**, using accurate synonyms already true of the feature. The
frontmatter `description` isn't indexed, so intent has to live in the body's first
sentence (its highest-weighted text).

- **capability-not-credential** — was *invisible* (>30) for its own defining query
  because its intro never said "agent" or "API" (both appeared halfway down). Lead
  with the agent-calling-without-the-secret framing; promote the security-boundary
  paragraph to its own `### Safe to hand to an agent` heading.
- **circuit-breaker** — ranked #22 (a page about *API keys* won on the bare token
  "API"). The intro now names a *flaky / failing / unhealthy upstream* and
  *cascading failure*.
- **standard-schema** — the Zod how-to opened "Reach for this when…"; now leads with
  "Validate an API response with Zod".
- **tanstack-query** — opened with positioning ("*not an alternative*…") so the
  React integration won; now leads with "Use a stitch as your TanStack Query
  `queryFn` in React".
- **idempotency** / **distributed-throttle** — both guides opened mechanism-first;
  now lead with intent ("safe retries on writes that never duplicate"; "share one
  rate limit across every worker or server").

### The no-regression ratchet (CI)

`search-eval.mts --assert` is wired into `verify.yml` as a new `search-relevance`
job. It builds the same index the deploy builds and **fails the check** if any
golden query's expected page falls past **#5** (the >8/>30 misranks above), or if
aggregate Relevance@1 / MRR drop below committed floors.

The per-query bound is #5, looser than the #3 we tune to, on purpose: embeddings
are deterministic within a build, but the ONNX model can differ by ~1e-6 across
architectures (arm64 dev vs the x64 runner) — enough to wobble a borderline rank by
one. The gate catches a page falling *out of reach*, not an edge flutter; anything
between #3 and #5 is reported, not failed. The embedding model is cached so a
HuggingFace hiccup can't flake a required check.

### Two remaining top-3 (deliberately not gamed)

- `circuit-breaker` and `capability-not-credential` sit at **#3**, blocked at #1 by
  `guides/auth/api-key` — a *spurious* BM25 match on the literal token "API". The
  right fix is to strengthen the target page (done: #22→#3, >30→#3), not to sabotage
  an unrelated page's rank.
- `distributed-throttle` sits at **#2** behind `recipes/one-rate-limit-across-workers`,
  whose title is a near-verbatim match — a *legitimate* guide-vs-recipe overlap left
  as-is rather than gamed.

### One golden correction

The seed mapped "let an agent call my API without ever seeing the secret" to
`concepts/principles`, but the dedicated `concepts/capability-not-credential` page
is the genuinely-correct home (the synthesis page covers it in one sentence out of
ten). The golden target was corrected to the page that should win — which also
surfaced the >30 blind spot the content edit fixes.

### Notes

- The **live** search only reflects these edits after this PR deploys — the index
  rebuilds at deploy from `getText('processed')`.
- Guardrails honored: no changes to `lib/search-index/*`, `next.config`, or the
  hybrid weights/boosts; prose kept natural and accurate (no keyword-stuffing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
