### PR TITLE
ci(mcp): auto-publish server.json to the MCP registry (+ Smithery)

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,102 @@
+# Publishes the StitchAPI docs MCP (dev.stitchapi/docs) to the official MCP
+# registry and — if configured — to Smithery. The registry publish CASCADES to
+# Glama and PulseMCP automatically, so those need no separate step.
+#
+# One-time setup lives in docs/MCP-PUBLISHING.md (generate an Ed25519 key,
+# publish the public half as a DNS TXT record at the stitchapi.dev apex, and
+# store the private key hex as the MCP_PRIVATE_KEY repo secret; optionally mint a
+# Smithery token into SMITHERY_API_KEY).
+#
+# To publish an update: bump "version" in server.json and merge to main — each
+# publish needs a UNIQUE version — or trigger this workflow manually.
+name: Publish MCP server
+
+on:
+    pull_request:
+        paths: ['server.json']
+    push:
+        branches: [main]
+        paths: ['server.json']
+    workflow_dispatch:
+
+permissions:
+    contents: read
+
+concurrency:
+    group: publish-mcp
+    cancel-in-progress: false
+
+jobs:
+    # Offline schema + semantic validation. Runs on PRs too, so a bad server.json
+    # is caught before merge (no secrets required).
+    validate:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+            - name: Install mcp-publisher
+              run: |
+                  curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+            - name: Validate server.json
+              run: ./mcp-publisher validate ./server.json
+
+    # Publish to the official registry. Never runs on a PR, and stays green/inert
+    # until MCP_PRIVATE_KEY is set. On push it publishes only when the version in
+    # server.json changed (the registry rejects a duplicate version);
+    # workflow_dispatch forces a publish.
+    registry:
+        needs: validate
+        if: github.event_name != 'pull_request'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+              with:
+                  fetch-depth: 2
+            - name: Decide whether to publish
+              id: ver
+              env:
+                  MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
+              run: |
+                  NEW=$(jq -r .version server.json)
+                  OLD=$(git show HEAD^:server.json 2>/dev/null | jq -r .version || echo "")
+                  echo "version=$NEW" >> "$GITHUB_OUTPUT"
+                  if [ -z "$MCP_PRIVATE_KEY" ]; then
+                    echo "publish=false" >> "$GITHUB_OUTPUT"
+                    echo "reason=MCP_PRIVATE_KEY is not set — configure it to enable publishing (see docs/MCP-PUBLISHING.md)." >> "$GITHUB_OUTPUT"
+                  elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || [ "$NEW" != "$OLD" ]; then
+                    echo "publish=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "publish=false" >> "$GITHUB_OUTPUT"
+                    echo "reason=version $NEW is unchanged — bump server.json to publish." >> "$GITHUB_OUTPUT"
+                  fi
+            - name: Install mcp-publisher
+              if: steps.ver.outputs.publish == 'true'
+              run: |
+                  curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+            - name: Authenticate (DNS domain auth for the dev.stitchapi/* namespace)
+              if: steps.ver.outputs.publish == 'true'
+              run: ./mcp-publisher login dns --domain stitchapi.dev --private-key "${{ secrets.MCP_PRIVATE_KEY }}"
+            - name: Publish to the official MCP registry
+              if: steps.ver.outputs.publish == 'true'
+              run: ./mcp-publisher publish ./server.json
+            - name: Nothing to publish
+              if: steps.ver.outputs.publish != 'true'
+              run: echo "Skipped — ${{ steps.ver.outputs.reason }}"
+
+    # Publish to Smithery (idempotent upsert by name). No-ops until SMITHERY_API_KEY
+    # is set, so it never breaks CI before you opt in. Smithery does NOT cascade
+    # from the official registry, so this is the only way to keep it current.
+    smithery:
+        needs: validate
+        if: github.event_name != 'pull_request'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Publish to Smithery
+              env:
+                  SMITHERY_API_KEY: ${{ secrets.SMITHERY_API_KEY }}
+              run: |
+                  if [ -z "$SMITHERY_API_KEY" ]; then
+                    echo "SMITHERY_API_KEY not set — skipping Smithery publish."
+                    exit 0
+                  fi
+                  # Adjust the -n owner/name to your Smithery namespace (see docs/MCP-PUBLISHING.md).
+                  npx -y @smithery/cli mcp publish https://stitchapi.dev/api/mcp -n rejifald/stitchapi-docs

--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,11 @@ web_modules/
 .env.production.local
 .env.local
 
+# Signing keys — e.g. the MCP registry key generated per docs/MCP-PUBLISHING.md.
+# Never commit private keys; they live in GitHub Actions secrets, not the repo.
+*.pem
+*.key
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache

--- a/docs/MCP-PUBLISHING.md
+++ b/docs/MCP-PUBLISHING.md
@@ -1,0 +1,73 @@
+# Publishing the docs MCP to the registries
+
+The hosted docs MCP (`https://stitchapi.dev/api/mcp`, tools `search_docs` +
+`get_doc`) is listed in MCP registries from [`server.json`](../server.json) at the
+repo root. [`.github/workflows/publish-mcp.yml`](../.github/workflows/publish-mcp.yml)
+publishes it automatically.
+
+## What the CI does
+
+-   **Official MCP registry** (`dev.stitchapi/docs`) — published on every push to
+    `main` that changes `server.json`'s `version`. This **cascades automatically**
+    to **Glama** (minutes) and **PulseMCP** (~weekly) — no separate step for those.
+-   **Smithery** — published in the same run (idempotent upsert), but only once you
+    set `SMITHERY_API_KEY` (the step no-ops until then).
+-   **PRs** that touch `server.json` run `mcp-publisher validate` only — a bad
+    `server.json` is caught before merge, and nothing is published.
+
+`mcp.so` and `cursor.directory` have no API — submit those once by hand (see the
+tracking notes).
+
+## One-time setup
+
+### 1. Generate a signing key (Ed25519)
+
+```bash
+# Ed25519 needs OpenSSL 3+. macOS ships LibreSSL, which fails on Ed25519 —
+# use `brew install openssl@3` and call it explicitly, e.g.
+#   /opt/homebrew/opt/openssl@3/bin/openssl genpkey ...
+openssl genpkey -algorithm Ed25519 -out key.pem
+
+# Private key as hex (this is the value for the MCP_PRIVATE_KEY secret):
+openssl pkey -in key.pem -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n'; echo
+```
+
+### 2. Verify the domain (DNS TXT at the apex)
+
+```bash
+PUBLIC_KEY="$(openssl pkey -in key.pem -pubout -outform DER | tail -c 32 | base64)"
+echo "v=MCPv1; k=ed25519; p=${PUBLIC_KEY}"
+```
+
+Add that string as a **TXT record on the apex** `stitchapi.dev` — **not** under a
+`_mcp`/selector subdomain (the registry only reads the apex; a selector record
+fails auth). Keep the record in place permanently: CI re-verifies on every publish,
+and if you rotate the key, replace the record and delete the old one (a stale apex
+record is tried first and breaks auth).
+
+> Alternative to DNS: host the same one line at
+> `https://stitchapi.dev/.well-known/mcp-registry-auth` and switch the workflow's
+> auth step to `login http --domain stitchapi.dev`. DNS also authorizes
+> sub-namespaces; HTTP authorizes only the exact domain.
+
+### 3. Add repo secrets
+
+-   **`MCP_PRIVATE_KEY`** — the hex private key from step 1 (the only secret the
+    registry publish needs).
+-   **`SMITHERY_API_KEY`** _(optional)_ — mint with `npx -y @smithery/cli auth token`,
+    then confirm the `-n <owner>/<name>` in the workflow matches your Smithery
+    namespace.
+
+## Publishing an update
+
+The registry treats every `version` as immutable and unique, so:
+
+1. Bump `version` in `server.json` (semver; ranges like `^1.2.3` are rejected).
+   For metadata-only changes, use a prerelease bump, e.g. `1.0.0-1`.
+2. Merge to `main` (or run the workflow via **Actions → Publish MCP server → Run
+   workflow**).
+
+Validate locally first with `mcp-publisher validate ./server.json`. Note
+`description` is capped at **100 characters**. The registry is officially in
+preview; a staging registry (`--registry https://staging.registry.modelcontextprotocol.io`)
+is available for dry runs.

--- a/docs/MCP-PUBLISHING.md
+++ b/docs/MCP-PUBLISHING.md
@@ -20,23 +20,40 @@ tracking notes).
 
 ## One-time setup
 
-### 1. Generate a signing key (Ed25519)
+### 1. Generate a signing key
+
+macOS ships **LibreSSL**, which fails Ed25519 with `Algorithm Ed25519 not found`.
+Use OpenSSL 3 (recommended), or the ECDSA fallback if you can't install it.
 
 ```bash
-# Ed25519 needs OpenSSL 3+. macOS ships LibreSSL, which fails on Ed25519 —
-# use `brew install openssl@3` and call it explicitly, e.g.
-#   /opt/homebrew/opt/openssl@3/bin/openssl genpkey ...
-openssl genpkey -algorithm Ed25519 -out key.pem
+brew install openssl@3
+OSSL="$(brew --prefix openssl@3)/bin/openssl" # arch-independent path
 
-# Private key as hex (this is the value for the MCP_PRIVATE_KEY secret):
-openssl pkey -in key.pem -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n'; echo
+$OSSL genpkey -algorithm Ed25519 -out key.pem
+
+# Private key as hex → the MCP_PRIVATE_KEY secret:
+$OSSL pkey -in key.pem -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n'; echo
 ```
+
+<details>
+<summary>No-install fallback: ECDSA P-384 (works with macOS system LibreSSL)</summary>
+
+```bash
+openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:secp384r1 -out key.pem
+
+# Private key as hex → the MCP_PRIVATE_KEY secret:
+openssl ec -in key.pem -noout -text | grep -A4 "priv:" | tail -n +2 | tr -d ' :\n'; echo
+
+# DNS TXT value (note k=ecdsap384) — use this in place of the step-2 command:
+echo "v=MCPv1; k=ecdsap384; p=$(openssl ec -in key.pem -text -noout -conv_form compressed | grep -A4 "pub:" | tail -n +2 | tr -d ' :\n' | xxd -r -p | base64)"
+```
+
+</details>
 
 ### 2. Verify the domain (DNS TXT at the apex)
 
 ```bash
-PUBLIC_KEY="$(openssl pkey -in key.pem -pubout -outform DER | tail -c 32 | base64)"
-echo "v=MCPv1; k=ed25519; p=${PUBLIC_KEY}"
+echo "v=MCPv1; k=ed25519; p=$($OSSL pkey -in key.pem -pubout -outform DER | tail -c 32 | base64)"
 ```
 
 Add that string as a **TXT record on the apex** `stitchapi.dev` — **not** under a

--- a/server.json
+++ b/server.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+    "name": "dev.stitchapi/docs",
+    "title": "StitchAPI Docs",
+    "description": "Search and read the StitchAPI docs: search_docs finds relevant sections, get_doc reads a page.",
+    "version": "1.0.0",
+    "repository": {
+        "url": "https://github.com/rejifald/StitchAPI",
+        "source": "github"
+    },
+    "websiteUrl": "https://stitchapi.dev",
+    "remotes": [
+        {
+            "type": "streamable-http",
+            "url": "https://stitchapi.dev/api/mcp"
+        }
+    ]
+}


### PR DESCRIPTION
## What

Automates publishing the hosted **docs MCP** to the MCP registries.

- **`server.json`** (repo root) — the registry manifest for **`dev.stitchapi/docs`**, a remote Streamable-HTTP server (tools `search_docs` + `get_doc`).
- **`.github/workflows/publish-mcp.yml`** — on a `server.json` version bump merged to `main` (or a manual dispatch), publishes to the **official MCP registry** via domain auth, and to **Smithery** (idempotent upsert). The registry publish **cascades to Glama + PulseMCP** automatically, so those need no step.
- **`docs/MCP-PUBLISHING.md`** — the one-time setup (key generation, the `stitchapi.dev` apex DNS-TXT record, the two secrets).

## Behavior & safety

- **PRs** touching `server.json` run `mcp-publisher validate` only — an invalid manifest is caught before merge; nothing is published. (This PR self-validates.)
- The publish jobs **never run on a PR** and are **green-and-inert until the secrets exist** (`MCP_PRIVATE_KEY` for the registry, `SMITHERY_API_KEY` for Smithery). So merging this won't produce a red run or an accidental publish.
- Each registry publish needs a **unique `version`** (the registry rejects duplicates); the workflow guards on that, and `workflow_dispatch` is the explicit "publish now" once your domain is verified.

## To go live (one-time, yours — you said you can do the domain verification)

1. Generate an Ed25519 key; add the public half as a TXT record on the **apex** `stitchapi.dev` — `v=MCPv1; k=ed25519; p=…` (apex, **not** a `_mcp` selector).
2. Add `MCP_PRIVATE_KEY` (hex) as a repo secret.
3. *(optional)* Mint a Smithery token → `SMITHERY_API_KEY`, confirm the `-n owner/name`.
4. Run **Actions → Publish MCP server → Run workflow**.

Exact commands are in `docs/MCP-PUBLISHING.md`; the flow is verified against `modelcontextprotocol/registry` (mcp-publisher v1.7.9). Registry is officially in preview.

Merge is yours — publishing only starts once you add the secret + DNS record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
