### PR TITLE
fix(docs): lower BM25 hybrid weight so 'API' stops out-ranking the right page

### DIFF
--- a/apps/docs/lib/search-index/search.ts
+++ b/apps/docs/lib/search-index/search.ts
@@ -14,6 +14,25 @@ import { INDEX_DIR, INDEX_FILE, VECTOR_FIELD } from './config';
 import { embedOne } from './embed';
 import { type DocSearchHit } from './sorted-result';
 
+// Hybrid retrieval knobs, kept as named exports so the search-eval harness can
+// sweep them and the CI ratchet pins the shipped values.
+//
+// Vector-dominant at 0.8: BM25 still adds literal recall (error codes, fn names
+// the small model misses), but at the earlier 0.3 a common token — "API" in a
+// title like `apiKey` — pulled that page to #1 for unrelated resilience/agent
+// queries. Lowering BM25's share demotes that spurious literal match while
+// leaving the boosts (a page *about* a term beats a passing mention) intact.
+// Swept over the golden set: R@1 0.880→0.920, MRR 0.927→0.953, no regressions.
+export const HYBRID_WEIGHTS = { text: 0.2, vector: 0.8 };
+export const FIELD_BOOST = { pageTitle: 3, heading: 2 };
+
+/** Options for {@link searchDocs}. Weights/boosts default to the shipped values. */
+export interface SearchOptions {
+    limit?: number;
+    hybridWeights?: { text: number; vector: number };
+    boost?: { pageTitle: number; heading: number };
+}
+
 let cached: Promise<AnyOrama> | undefined;
 
 function indexPath(): string {
@@ -33,7 +52,11 @@ export function loadIndex(): Promise<AnyOrama> {
 /** Hybrid (BM25 + vector) search; returns the top section hits for a query. */
 export async function searchDocs(
     query: string,
-    { limit = 8 }: { limit?: number } = {},
+    {
+        limit = 8,
+        hybridWeights = HYBRID_WEIGHTS,
+        boost = FIELD_BOOST,
+    }: SearchOptions = {},
 ): Promise<DocSearchHit[]> {
     const term = query.trim();
     if (!term) return [];
@@ -49,9 +72,9 @@ export async function searchDocs(
         // stop-word noise top the results), while BM25 still adds literal-term
         // recall (error codes, fn names) the small model misses. Title/heading
         // are boosted so a page that is *about* the term beats a passing mention
-        // in body text.
-        hybridWeights: { text: 0.3, vector: 0.7 },
-        boost: { pageTitle: 3, heading: 2 },
+        // in body text. See HYBRID_WEIGHTS / FIELD_BOOST for the tuned values.
+        hybridWeights,
+        boost,
         similarity: 0,
         includeVectors: false,
         limit,

--- a/apps/docs/scripts/search-eval.mts
+++ b/apps/docs/scripts/search-eval.mts
@@ -42,8 +42,8 @@ const DIAG_LIMIT = 30;
 const ASSERT = process.argv.includes('--assert');
 const TARGET_RANK = 3; // what we tune for; queries past it are reported, not failed
 const HARD_MAX_RANK = 5; // fail if any expected page ranks worse than this (or is missing)
-const MIN_RELEVANCE_AT_1 = 0.78; // floor; current 0.880 (25-query golden)
-const MIN_MRR = 0.85; // floor; current 0.927
+const MIN_RELEVANCE_AT_1 = 0.84; // floor; current 0.920 (25-query golden)
+const MIN_MRR = 0.9; // floor; current 0.953
 
 const here = dirname(fileURLToPath(import.meta.url));
 const golden: GoldenCase[] = JSON.parse(


### PR DESCRIPTION
## Fix the api-key ranking attractor in `search_docs`

Follow-up to #398. That PR tuned doc *content* to rank #1 for natural questions and
left two queries stuck at #3, blocked by `guides/auth/api-key` winning on the bare
token **"API"** — a *ranking* problem content edits couldn't fix without gaming an
unrelated page. This fixes the ranking itself.

### Root cause

The hybrid blend weighted BM25 at `text: 0.3`. That's enough for a common token —
"API", appearing in a title like `apiKey` (boosted ×3) — to pull the api-key page to
#1 for unrelated resilience/agent queries. Vector similarity ranked the *right* page
high; BM25's literal over-match buried it.

### Fix

Lower BM25's share to `text: 0.2` (`vector: 0.8`). The literal recall BM25 is actually
there for — error codes (`STITCH_TIMEOUT`), fn names — survives (all still #1); the
spurious common-token match doesn't. Field boosts unchanged, so "a page *about* a term
beats a passing mention" still holds.

Found by grid-sweeping weights × boosts over the 25-query golden with the eval harness
— `text: 0.2` is the minimal change that wins, and it holds even with the `pageTitle`
boost left at 3, so only one number moves.

### Results (25-query golden, `main` vs this branch)

| Metric      |  #398 (main)  |      This PR      |
| ----------- | :-----------: | :---------------: |
| Relevance@1 | 0.880 (22/25) | **0.920 (23/25)** |
| Top-3       |     1.000     |       1.000       |
| MRR         |     0.927     |     **0.953**     |

`guides/resilience/circuit-breaker` for "stop a stitch hammering a flaky or failing
upstream API": **#3 → #1**. The other 22 that were already #1 stayed #1.

### The two still at top-3 are genuine overlaps, not gamed

- `concepts/capability-not-credential` stays **#3** for "let an agent call my API
  without ever seeing the secret" — but the pages ahead are now *legitimately* relevant,
  not the spurious attractor: `guides/auth/api-key`'s intro is literally *"resolved at
  call time so the caller never sees the secret"* (a near-exact match to the query), and
  #2 is the recipe *"Let an agent call your API without handing it the key."* No weight
  setting dislodges it (even the aggressive `text:0.15` / `pageTitle:1.5` corner leaves
  it #3), so 0.920 is the honest ceiling for weight tuning.
- `guides/state/distributed-throttle` stays **#2** behind its near-verbatim recipe —
  the same legitimate guide-vs-recipe overlap noted in #398.

### Mechanics

- `HYBRID_WEIGHTS` / `FIELD_BOOST` are now named exports; `searchDocs` takes optional
  overrides (defaults = the shipped values) so `search-eval.mts` can sweep them.
- Ratchet floors raised to lock in the gain: `Relevance@1 ≥ 0.84`, `MRR ≥ 0.90` (kept
  under the achieved 0.920 / 0.953 for cross-arch margin; the #5 per-query gate is
  unchanged).
- No index rebuild — the weights are query-time. The live search reflects this after
  the docs redeploy.

### Scope note

This intentionally edits `apps/docs/lib/search-index/search.ts` — the retrieval
weighting the #398 content pass was fenced out of. Per-request ranking only; no schema,
index format, or embedding-model change, and the `search-relevance` CI ratchet gates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
