### PR TITLE
fix(aws-sigv4): sign the bytes the transport sends for form/multipart bodies

### DIFF
--- a/apps/docs/content/docs/integrations/aws-sigv4.mdx
+++ b/apps/docs/content/docs/integrations/aws-sigv4.mdx
@@ -62,8 +62,19 @@ The `x-amz-content-sha256` header is set for you:
 -   **No body** → the empty-payload hash (always correct).
 -   **String body** → its SHA-256 (exact bytes).
 -   **Non-string body** → `UNSIGNED-PAYLOAD` — safe over HTTPS, and what S3 and many
-    services accept. Set `signBody: true` to hash `JSON.stringify(body)` instead (it
-    must match what the transport sends).
+    services accept.
+
+Set `signBody: true` to hash the body instead. The hash is taken over the exact bytes
+the transport sends, chosen by the stitch's
+[`bodyType`](/docs/guides/data/body-encoding):
+
+-   **JSON** (`bodyType: 'json'` or unset) → `JSON.stringify(body)`.
+-   **Form** (`bodyType: 'form'`) → its `application/x-www-form-urlencoded` encoding —
+    e.g. the query-protocol bodies SQS, SNS, and STS use.
+-   **Multipart** (`bodyType: 'multipart'`) → **cannot be payload-signed**: the transport
+    generates a non-deterministic boundary, so the hash could never match the bytes
+    sent. `signBody: true` with a multipart body **throws** — leave it unset to send
+    `UNSIGNED-PAYLOAD`, or pass a pre-serialised string body to sign it.
 
 ## Low-level signer
 

--- a/packages/aws-sigv4/README.md
+++ b/packages/aws-sigv4/README.md
@@ -44,7 +44,13 @@ The `x-amz-content-sha256` header is set automatically:
 
 -   **No body** → the empty-payload hash (always correct).
 -   **String body** → its SHA-256 (exact bytes).
--   **Non-string body** → `UNSIGNED-PAYLOAD` (safe over HTTPS, what S3 and many services accept). Set `signBody: true` to hash `JSON.stringify(body)` instead — it must match what the transport sends.
+-   **Non-string body** → `UNSIGNED-PAYLOAD` (safe over HTTPS, and what S3 and many services accept).
+
+Set `signBody: true` to hash the body instead. The hash is taken over the exact bytes the transport sends, chosen by the stitch's `bodyType`:
+
+-   **JSON** (`bodyType: 'json'` or unset) → `JSON.stringify(body)`.
+-   **Form** (`bodyType: 'form'`) → its `application/x-www-form-urlencoded` encoding (e.g. the query-protocol bodies SQS, SNS, and STS use).
+-   **Multipart** (`bodyType: 'multipart'`) → **cannot be payload-signed**: the transport generates a non-deterministic boundary, so the hash could never match the bytes sent. `signBody: true` with a multipart body **throws** — leave it unset to send `UNSIGNED-PAYLOAD`, or pass a pre-serialised string body to sign it.
 
 ## Low-level signer
 

--- a/packages/aws-sigv4/src/index.ts
+++ b/packages/aws-sigv4/src/index.ts
@@ -217,10 +217,18 @@ export interface AwsSigV4Options {
     /** Optional STS session token (temporary credentials). */
     sessionToken?: Secret;
     /**
-     * Hash the request body into the signature. A **string** body is hashed by
-     * default (exact bytes). A non-string body is sent `UNSIGNED-PAYLOAD` unless
-     * `signBody: true` (then `JSON.stringify(body)` is hashed — it must match what
-     * the transport sends). `false` forces `UNSIGNED-PAYLOAD` for any body.
+     * Hash the request body into the signature (`x-amz-content-sha256`). A **string**
+     * body is hashed by default (exact bytes); a non-string body is sent
+     * `UNSIGNED-PAYLOAD` unless `signBody: true`. `false` forces `UNSIGNED-PAYLOAD` for
+     * any body.
+     *
+     * When `true`, the hash is taken over the exact bytes the transport sends, chosen by
+     * `bodyType`: a JSON body (`bodyType` `'json'` or unset) hashes `JSON.stringify(body)`;
+     * a `'form'` body hashes its `application/x-www-form-urlencoded` encoding. A
+     * `'multipart'` body **cannot** be payload-signed — the transport generates a
+     * non-deterministic boundary — so `signBody: true` with a multipart body **throws**;
+     * leave it unset (or `false`) to send `UNSIGNED-PAYLOAD`, or pass a pre-serialised
+     * string body to sign it.
      */
     signBody?: boolean;
 }
@@ -230,6 +238,21 @@ function amzDateOf(d: Date): string {
         .toISOString()
         .replace(/[:-]/g, '')
         .replace(/\.\d{3}/, '');
+}
+
+/**
+ * Serialise a non-string `bodyType: 'form'` body to `application/x-www-form-urlencoded`
+ * for payload signing. A byte-for-byte mirror of core's transport — `encodeRequestBody`
+ * in `packages/core/src/http-adapter.ts` (a `URLSearchParams`, `String(v)`, null/undefined
+ * skipped). It MUST stay identical to that encoding, or a signed form payload hash won't
+ * match the bytes the transport actually sends. Only reached with `signBody: true`.
+ */
+function formEncode(body: unknown): string {
+    const params = new URLSearchParams();
+    for (const [k, v] of Object.entries(body as Record<string, unknown>)) {
+        if (v !== undefined && v !== null) params.append(k, String(v));
+    }
+    return params.toString();
 }
 
 /**
@@ -274,11 +297,38 @@ export function awsSigV4(opts: AwsSigV4Options): AuthStrategy {
             if (body === undefined || body === null || body === '') {
                 payloadHash = EMPTY_PAYLOAD_SHA256;
             } else if (typeof body === 'string') {
+                // Every transport sends a string body verbatim, so its bytes are
+                // known exactly — hash them unless signing is opted out.
                 payloadHash =
                     opts.signBody === false
                         ? 'UNSIGNED-PAYLOAD'
                         : await sha256Hex(body);
+            } else if (req.bodyType === 'form') {
+                // Core serialises a form body as `application/x-www-form-urlencoded`
+                // (URLSearchParams), NOT JSON. Hashing JSON here would sign bytes the
+                // transport never sends → 403 SignatureDoesNotMatch. Mirror the exact
+                // wire encoding so the signed hash matches (see `formEncode`).
+                payloadHash =
+                    opts.signBody === true
+                        ? await sha256Hex(formEncode(body))
+                        : 'UNSIGNED-PAYLOAD';
+            } else if (req.bodyType === 'multipart') {
+                // A multipart body is sent as FormData; the transport picks the
+                // boundary at send time, so the exact bytes are not knowable here and
+                // the payload cannot be signed. Refuse loudly rather than emit a hash
+                // that is guaranteed not to match (a silent 403 at AWS is worse).
+                if (opts.signBody === true)
+                    throw new Error(
+                        'awsSigV4: signBody:true cannot sign a multipart body — the ' +
+                            'transport generates the multipart boundary at send time, ' +
+                            'so the payload hash can never match the bytes sent. Use ' +
+                            'signBody:false (UNSIGNED-PAYLOAD is accepted over HTTPS) ' +
+                            'or send a pre-serialised string body to sign it.',
+                    );
+                payloadHash = 'UNSIGNED-PAYLOAD';
             } else {
+                // JSON (`bodyType: 'json'` or unset): core sends `JSON.stringify(body)`,
+                // so the JSON hash matches the wire bytes when signing is requested.
                 payloadHash =
                     opts.signBody === true
                         ? await sha256Hex(JSON.stringify(body))

--- a/packages/aws-sigv4/src/index.ts
+++ b/packages/aws-sigv4/src/index.ts
@@ -328,7 +328,11 @@ export function awsSigV4(opts: AwsSigV4Options): AuthStrategy {
                 payloadHash = 'UNSIGNED-PAYLOAD';
             } else {
                 // JSON (`bodyType: 'json'` or unset): core sends `JSON.stringify(body)`,
-                // so the JSON hash matches the wire bytes when signing is requested.
+                // so re-serialising the SAME object with the SAME call here yields the
+                // exact wire bytes. Keep this a literal re-serialisation, NOT a
+                // canonical/sorted "stable" object hash — `x-amz-content-sha256` must be
+                // the SHA-256 of the bytes actually sent (insertion-order JSON), so
+                // sorting keys would itself cause SignatureDoesNotMatch.
                 payloadHash =
                     opts.signBody === true
                         ? await sha256Hex(JSON.stringify(body))

--- a/packages/aws-sigv4/test/sigv4.spec.ts
+++ b/packages/aws-sigv4/test/sigv4.spec.ts
@@ -9,15 +9,23 @@ import { describe, expect, test } from 'vitest';
 const ACCESS_KEY = 'AKIDEXAMPLE';
 const SECRET_KEY = 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY';
 
-// A minimal request/context to drive the strategy's `apply`.
+// A minimal request/context to drive the strategy's `apply`. `bodyType` mirrors
+// core's `AdapterRequest.bodyType`, which the engine threads onto the request the
+// auth strategy signs (engine.ts) — the signer reads it to match the wire encoding.
 function fakeReq(
-    over: Partial<{ url: string; method: string; body: unknown }> = {},
+    over: Partial<{
+        url: string;
+        method: string;
+        body: unknown;
+        bodyType: 'json' | 'form' | 'multipart';
+    }> = {},
 ) {
     return {
         url: over.url ?? 'https://example.amazonaws.com/',
         method: over.method ?? 'GET',
         headers: {} as Record<string, string>,
         ...(over.body !== undefined ? { body: over.body } : {}),
+        ...(over.bodyType !== undefined ? { bodyType: over.bodyType } : {}),
     };
 }
 const fakeCtx = { emit: (): void => {} };
@@ -233,6 +241,106 @@ describe('awsSigV4 strategy', () => {
         );
         expect(reqObj.headers['x-amz-content-sha256']).toBe(
             reqStr.headers['x-amz-content-sha256'],
+        );
+    });
+
+    // Regression (SignatureDoesNotMatch): with `bodyType: 'form'` the transport sends
+    // `application/x-www-form-urlencoded` bytes (URLSearchParams), NOT JSON. signBody:true
+    // must hash those exact wire bytes — hashing JSON.stringify(body) signs bytes that are
+    // never sent, so AWS returns 403. Assert parity with the equivalent string body.
+    test('signBody:true on a form body signs the URL-encoded wire bytes, not JSON', async () => {
+        const body = { Action: 'SendMessage', MessageBody: 'two words' };
+        // What core's transport actually sends: 'Action=SendMessage&MessageBody=two+words'.
+        const wire = new URLSearchParams(
+            body as Record<string, string>,
+        ).toString();
+
+        const form = awsSigV4({
+            region: 'us-east-1',
+            service: 'sqs',
+            accessKeyId: ACCESS_KEY,
+            secretAccessKey: SECRET_KEY,
+            signBody: true,
+        });
+        const reqForm = fakeReq({ method: 'POST', body, bodyType: 'form' });
+        await form.apply(reqForm, fakeCtx as never);
+
+        // A string body is hashed verbatim; the form path must hash the SAME wire bytes.
+        const str = awsSigV4({
+            region: 'us-east-1',
+            service: 'sqs',
+            accessKeyId: ACCESS_KEY,
+            secretAccessKey: SECRET_KEY,
+        });
+        const reqStr = fakeReq({ method: 'POST', body: wire });
+        await str.apply(reqStr, fakeCtx as never);
+
+        expect(reqForm.headers['x-amz-content-sha256']).toBe(
+            reqStr.headers['x-amz-content-sha256'],
+        );
+
+        // …and it must NOT be the (buggy) JSON hash the transport never sends.
+        const jsonStrategy = awsSigV4({
+            region: 'us-east-1',
+            service: 'sqs',
+            accessKeyId: ACCESS_KEY,
+            secretAccessKey: SECRET_KEY,
+        });
+        const reqJson = fakeReq({ method: 'POST', body: JSON.stringify(body) });
+        await jsonStrategy.apply(reqJson, fakeCtx as never);
+        expect(reqForm.headers['x-amz-content-sha256']).not.toBe(
+            reqJson.headers['x-amz-content-sha256'],
+        );
+    });
+
+    // Regression (SignatureDoesNotMatch): a multipart body is sent as FormData with a
+    // transport-generated boundary, so its exact bytes are unknowable at sign time — the
+    // payload cannot be signed. signBody:true must refuse loudly rather than emit a hash
+    // (JSON of the body) that is guaranteed not to match.
+    test('signBody:true on a multipart body throws (boundary is transport-generated)', async () => {
+        const strategy = awsSigV4({
+            region: 'us-east-1',
+            service: 's3',
+            accessKeyId: ACCESS_KEY,
+            secretAccessKey: SECRET_KEY,
+            signBody: true,
+        });
+        const req = fakeReq({
+            method: 'POST',
+            body: { file: 'x' },
+            bodyType: 'multipart',
+        });
+        await expect(strategy.apply(req, fakeCtx as never)).rejects.toThrow(
+            /multipart/i,
+        );
+    });
+
+    // The default (no signBody) is unchanged for form/multipart: UNSIGNED-PAYLOAD, no throw.
+    test('form/multipart bodies without signBody stay UNSIGNED-PAYLOAD', async () => {
+        const strategy = awsSigV4({
+            region: 'us-east-1',
+            service: 's3',
+            accessKeyId: ACCESS_KEY,
+            secretAccessKey: SECRET_KEY,
+        });
+        const reqForm = fakeReq({
+            method: 'POST',
+            body: { a: 1 },
+            bodyType: 'form',
+        });
+        await strategy.apply(reqForm, fakeCtx as never);
+        expect(reqForm.headers['x-amz-content-sha256']).toBe(
+            'UNSIGNED-PAYLOAD',
+        );
+
+        const reqMultipart = fakeReq({
+            method: 'POST',
+            body: { file: 'x' },
+            bodyType: 'multipart',
+        });
+        await strategy.apply(reqMultipart, fakeCtx as never);
+        expect(reqMultipart.headers['x-amz-content-sha256']).toBe(
+            'UNSIGNED-PAYLOAD',
         );
     });
 });


### PR DESCRIPTION
## Problem

`awsSigV4()` with `signBody: true` hashed `JSON.stringify(body)` for **every** non-string body. But core's transport (`encodeRequestBody`, `packages/core/src/http-adapter.ts`) serialises by `bodyType`:

- `bodyType: 'form'` → `application/x-www-form-urlencoded` (`URLSearchParams`), e.g. `a=1&b=two+words`
- `bodyType: 'multipart'` → `FormData` (boundary generated by the transport at send time)

So for a `form`/`multipart` body with `signBody: true`, the signed `x-amz-content-sha256` was computed over the JSON encoding while the transport sent different bytes → **AWS `403 SignatureDoesNotMatch`**. The strategy's own doc-comment even asserted the JSON hash "must match what the transport sends" — silently violated.

Found via a review-sweep dry-run; both premises verified against `aws-sigv4/src/index.ts` and `core/src/http-adapter.ts`. Correctness bug, not a vulnerability.

## Fix

Branch the payload hash on `req.bodyType` (the engine threads it onto the signed request and `cloneReq` preserves it):

| `bodyType` | `signBody: true` behaviour |
|---|---|
| string / `json` / unset | hash exact bytes — **unchanged** (already correct) |
| **`form`** | hash the `application/x-www-form-urlencoded` encoding via a byte-for-byte mirror of core's `encodeRequestBody` → payload signing now works (SQS/SNS/STS query protocol) |
| **`multipart`** | **throws** — the transport picks a non-deterministic boundary at send time, so the payload can never be signed. Default (no `signBody`) still sends `UNSIGNED-PAYLOAD`, unchanged. |

Deliberately **not** mirroring "verbatim bytes for binary": core's default adapter `JSON.stringify`s a non-string/non-form/non-multipart body, which the strategy already matches — so binary is not a mismatch, and hashing raw bytes would have introduced one. `encodeRequestBody` is mirrored (not imported) because it isn't in the public `stitchapi` entry; the coupling is called out in a code comment.

## Tests

Added regression tests to `packages/aws-sigv4/test/sigv4.spec.ts` that **fail before / pass after**:

- `form` + `signBody: true` signs the URL-encoded wire bytes (parity with the equivalent string body; ≠ the buggy JSON hash)
- `multipart` + `signBody: true` throws
- `form`/`multipart` without `signBody` stay `UNSIGNED-PAYLOAD` (guards against over-throwing)

## Docs

Rewrote the "Payload signing" section in the README and `apps/docs/content/docs/integrations/aws-sigv4.mdx` to document the per-`bodyType` behaviour and the multipart restriction.

## Verification

Full pre-push gate green: format, lint, contract, typecheck, typecheck-d, **test** (whole tree), exports, **build-docs** (full Next build — validates the new docs link), yakir drift check. Package: 13/13 tests, `check:types` clean, `tsup` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)