### PR TITLE
fix(redis): Upstash adapter must re-serialize every reply so JSON-parseable string values round-trip

### DIFF
--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -213,13 +213,16 @@ export function fromUpstash(client: UpstashLike): RedisDriver {
     return {
         async get(key) {
             // The driver contract is "return the raw stored string or null".
-            // Upstash auto-deserializes JSON replies, so a value we wrote as a
-            // JSON envelope can come back already parsed into an object/number;
-            // re-serialize those so `redisStore.get`'s `JSON.parse` round-trips,
-            // and pass strings through untouched (bare counters stay strings).
+            // Upstash auto-deserializes JSON replies, so a value written as a JSON
+            // envelope (or a JSON-parseable string) can come back already parsed.
+            // Re-serialize EVERY non-null reply so `redisStore.get`'s `JSON.parse`
+            // round-trips exactly — including JSON-parseable strings ("null",
+            // "123", '{"x":1}'), which Upstash peels one layer off (the store
+            // wrote '"null"', we get the string `null` back), and bare INCR
+            // counters (Upstash returns 1 -> "1" -> parse -> 1). Passing strings
+            // through untouched would let those cases parse a second time.
             const v = await client.get(key);
-            if (v == null) return null;
-            return typeof v === 'string' ? v : JSON.stringify(v);
+            return v == null ? null : JSON.stringify(v);
         },
         async set(key, value, ttl) {
             if (ttl == null) await client.set(key, value);

--- a/packages/redis/test/upstash-roundtrip.spec.ts
+++ b/packages/redis/test/upstash-roundtrip.spec.ts
@@ -1,0 +1,92 @@
+// Regression: the Upstash adapter must round-trip JSON-parseable STRING values.
+//
+// `redisStore.set(value)` writes `JSON.stringify(value)`. The Upstash REST client
+// auto-deserializes ONE JSON layer on read. So for a value that is itself a
+// JSON-parseable string — "null", "123", '{"x":1}' — the store writes the JSON
+// envelope (e.g. '"null"'), Upstash returns the *string* `null` (one layer
+// peeled), and unless `fromUpstash.get` re-serializes it, `redisStore.get` then
+// `JSON.parse`s that string again and hands back the PARSED value (the real
+// `null`) instead of the string the caller stored. This is an Upstash-only
+// divergence; the ioredis / node-redis adapters return exact bytes and were
+// always correct. The fix re-serializes every non-null reply, so the byte stream
+// `redisStore.get` parses matches exactly what `redisStore.set` wrote.
+import { fromUpstash, redisStore } from '../src';
+import type { UpstashLike } from '../src';
+
+import type { StitchStore } from 'stitchapi';
+import { describe, expect, test } from 'vitest';
+
+// A faithful @upstash/redis test double: `set` stores the raw string it is given;
+// `get` mimics Upstash's automatic JSON deserialization — it returns
+// `JSON.parse(stored)` when the stored string is valid JSON, else the raw string.
+// This is precisely the behavior that makes the bug observable.
+function fakeUpstash(): UpstashLike & { store: Map<string, string> } {
+    const store = new Map<string, string>();
+    return {
+        store,
+        async get(key) {
+            const raw = store.get(key);
+            if (raw == null) return null;
+            // Upstash auto-deserializes JSON string replies.
+            try {
+                return JSON.parse(raw) as unknown;
+            } catch {
+                return raw;
+            }
+        },
+        async set(key, value) {
+            // The real client stores the exact string it is handed.
+            store.set(key, value);
+            return 'OK';
+        },
+        async del(key) {
+            store.delete(key);
+            return 1;
+        },
+        async eval() {
+            // Not exercised by these round-trip assertions.
+            return 1;
+        },
+    };
+}
+
+describe('fromUpstash — JSON-parseable string values round-trip', () => {
+    // Each of these is a STRING whose contents happen to be valid JSON. The store
+    // must hand the identical string back; the bug returned the parsed value.
+    test.each([
+        ['the string "null"', 'null'],
+        ['the string "123"', '123'],
+        ['the string "true"', 'true'],
+        ['a JSON-object string', '{"x":1}'],
+        ['a JSON-array string', '[1,2]'],
+    ])('%s survives set → get unchanged', async (_label, value) => {
+        const store: StitchStore = redisStore(fromUpstash(fakeUpstash()));
+        await store.set('k', value);
+        const back = await store.get('k');
+        expect(back).toBe(value); // strict: same string, not the parsed value
+        expect(typeof back).toBe('string');
+    });
+
+    test('a plain object value still round-trips', async () => {
+        const store = redisStore(fromUpstash(fakeUpstash()));
+        const value = { a: 1, b: ['x', 'y'], c: { d: true } };
+        await store.set('obj', value);
+        expect(await store.get('obj')).toEqual(value);
+    });
+
+    test('a bare INCR counter (Upstash returns a number) round-trips', async () => {
+        // A counter is written by `incr`, not `set`, so the stored value is the
+        // bare string "1"; Upstash's auto-deserialize turns that reply into the
+        // number 1. `fromUpstash.get` must re-serialize it to "1" so
+        // `redisStore.get` reads back the number 1, not `undefined`/a throw.
+        const client = fakeUpstash();
+        client.store.set('c', '1'); // as INCR would leave it (bare counter)
+        const store = redisStore(fromUpstash(client));
+        expect(await store.get('c')).toBe(1);
+    });
+
+    test('an absent key reads back as undefined', async () => {
+        const store = redisStore(fromUpstash(fakeUpstash()));
+        expect(await store.get('missing')).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## The bug (data corruption, Upstash-only)

`redisStore.set` writes the JSON envelope `JSON.stringify(value)`, and the
`@upstash/redis` REST client **auto-deserializes one JSON layer on read**. For a
value that is itself a **JSON-parseable string** — `"null"`, `"true"`, `"123"`,
`'{"x":1}'`, `'[1,2]'` — those two layers cancel and the store hands back the
wrong thing:

1. `store.set('k', 'null')` writes `JSON.stringify('null')` → the bytes `'"null"'`.
2. Upstash's `get` peels one JSON layer → returns the **string** `null`.
3. The old `fromUpstash.get` passed strings through untouched.
4. `redisStore.get` then `JSON.parse('null')` → the **value `null`**.

The caller stored the string `"null"` and got back `null`. Same shape for
`"123"` → `123`, `"true"` → `true`, `'{"x":1}'` → `{ x: 1 }`, etc.

This is an **Upstash-only divergence**: the `ioredis` and `node-redis` adapters
return exact bytes and already round-tripped correctly. Three adapters that are
contracted to behave identically did not.

## The fix

Re-serialize **every** non-null Upstash reply, so the byte stream
`redisStore.get` parses matches exactly what `redisStore.set` wrote:

```ts
async get(key) {
    const v = await client.get(key);
    return v == null ? null : JSON.stringify(v);
},
```

The prior code special-cased strings (`typeof v === 'string' ? v : …`), which is
exactly what let the JSON-parseable-string cases parse a second time. Re-encoding
unconditionally also keeps bare `INCR` counters correct (Upstash returns the
number `1` → `"1"` → `redisStore.get` parses → `1`). Only `fromUpstash` is
touched; the other two adapters are unchanged. The method's comment is updated to
state the new invariant.

## Regression test

New `packages/redis/test/upstash-roundtrip.spec.ts` drives
`redisStore(fromUpstash(fakeUpstash))` where `fakeUpstash` faithfully models
Upstash's behavior — `set` stores the raw string; `get` returns `JSON.parse(stored)`
when the stored string is valid JSON, else the raw string (the real client's
auto-deserialize). It asserts JSON-parseable **strings** (`"null"`, `"123"`,
`"true"`, `'{"x":1}'`, `'[1,2]'`) come back as the **original string**, and that a
plain object, a bare `INCR` counter, and an absent key still round-trip.

### Fail-before (original code)

```
 × the string "null" survives set → get unchanged
 × the string "123" survives set → get unchanged
 × the string "true" survives set → get unchanged
 × a JSON-object string survives set → get unchanged
 × a JSON-array string survives set → get unchanged
AssertionError: expected null to be 'null' // Object.is equality
AssertionError: expected 123 to be '123' // Object.is equality
AssertionError: expected true to be 'true' // Object.is equality
AssertionError: expected { x: 1 } to be '{"x":1}' // Object.is equality
AssertionError: expected [ 1, 2 ] to be '[1,2]' // Object.is equality
      Tests  5 failed | 3 passed (8)
```

### Pass-after (with the fix)

```
 ✓ the string "null" survives set → get unchanged
 ✓ the string "123" survives set → get unchanged
 ✓ the string "true" survives set → get unchanged
 ✓ a JSON-object string survives set → get unchanged
 ✓ a JSON-array string survives set → get unchanged
 ✓ a plain object value still round-trips
 ✓ a bare INCR counter (Upstash returns a number) round-trips
 ✓ an absent key reads back as undefined
      Tests  8 passed (8)
```

Full package suite (`pnpm --filter @stitchapi/redis test`): **17 passed, 1 skipped**
(the opt-in live-Redis test). Typecheck (`check:types`) clean. The existing
conformance proof still passes for all three adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
