### PR TITLE
fix(deno-kv): incr must not clear the counter's TTL — rate-limit window never expired

### DIFF
--- a/packages/deno-kv/README.md
+++ b/packages/deno-kv/README.md
@@ -56,11 +56,18 @@ another isolate raced us, the versionstamp moved, the commit returns `ok: false`
 and the loop re-reads and retries — so N concurrent increments net **exactly +N**
 (proven by the store contract's "20 concurrent incrs net +20" rule).
 
-The TTL (`expireIn`, which Deno KV measures in **milliseconds** — the same unit as
-the contract's `ttlMs`, no conversion at the seam) is set **only on the increment
-that creates the counter**, never extending it afterwards, so a busy rate window
-can't slide forever and never reset. `maxIncrRetries` (default `100`) bounds the
-loop under pathological contention.
+The counter is a **fixed window** (matching the Redis adapter): the first increment
+pins an absolute deadline `now + ttl`, and every increment inside that window keeps
+the same deadline — so once the window elapses the next increment restarts at `1`.
+Because Deno KV's `set` **replaces the whole entry, clearing any expiry** (unlike
+Redis `INCR`, which _preserves_ the key's TTL), the counter is stored as a
+`{ n, deadline }` value and each commit re-derives `expireIn` from the pinned
+deadline. That keeps the window's expiry alive across every write instead of a
+later increment silently wiping it and leaking the key forever. (`get` unwraps this
+envelope back to the plain count, so nothing downstream sees the internal shape.)
+The TTL unit is **milliseconds** — the same unit as the contract's `ttl`, and Deno
+KV's own `expireIn` unit, so there's no conversion at the seam. `maxIncrRetries`
+(default `100`) bounds the loop under pathological contention.
 
 The store owns no connection: `store.close()` delegates to the handle, so you
 decide when KV shuts down.

--- a/packages/deno-kv/src/index.ts
+++ b/packages/deno-kv/src/index.ts
@@ -81,6 +81,32 @@ export interface DenoKvLike {
 }
 
 // ---------------------------------------------------------------------------
+// the counter window
+// ---------------------------------------------------------------------------
+
+/**
+ * What `incr` stores under a counter key: the running count `n` plus the window's
+ * absolute `deadline` (epoch ms). We keep the deadline in the VALUE — rather than
+ * relying on the key's `expireIn` alone — because Deno KV's `set` replaces the
+ * whole entry (clearing any prior expiry) and `get` never exposes the remaining
+ * TTL. Storing the deadline lets each `incr` re-derive the correct `expireIn` on
+ * every write, so a fixed window's expiry survives later increments intact.
+ */
+interface CounterWindow {
+    n: number;
+    deadline: number;
+}
+
+/** A value is a live {@link CounterWindow} iff it's a `{ n, deadline }` object. */
+function asWindow(value: unknown): CounterWindow | null {
+    if (value == null || typeof value !== 'object') return null;
+    const w = value as { n?: unknown; deadline?: unknown };
+    return typeof w.n === 'number' && typeof w.deadline === 'number'
+        ? { n: w.n, deadline: w.deadline }
+        : null;
+}
+
+// ---------------------------------------------------------------------------
 // the store
 // ---------------------------------------------------------------------------
 
@@ -137,8 +163,14 @@ export function denoKvStore(
         async get(key) {
             const { value } = await kv.get(k(key));
             if (value == null) return undefined;
-            // We always write a JSON string; anything else (e.g. a bare counter
-            // written by `incr`) is handed back as-is.
+            // A counter written by `incr` is a `{ n, deadline }` envelope; the
+            // contract's cross-reads of a counter (e.g. core's cache-generation
+            // number) expect the plain count, so unwrap it back to `n`. A legacy
+            // bare-number counter from before this envelope is returned as-is.
+            const window = asWindow(value);
+            if (window) return window.n;
+            // Everything else is the JSON string `set` wrote (or a bare value a
+            // custom writer left behind) — hand it back decoded.
             if (typeof value !== 'string') return value;
             try {
                 return JSON.parse(value) as unknown;
@@ -158,32 +190,45 @@ export function denoKvStore(
             await kv.set(k(key), JSON.stringify(value), options);
         },
         async incr(key, ttl) {
-            // Atomic counter-with-window via compare-and-set. Read the current
-            // value + its versionstamp, then commit `next` guarded by a `check`
-            // on that versionstamp: if another isolate raced us, the versionstamp
-            // moved, the commit returns `ok: false`, and we re-read and retry —
-            // so N concurrent incrs net exactly +N (the contract's rule).
+            // Atomic FIXED-window counter via compare-and-set. Read the current
+            // value + its versionstamp, then commit the next state guarded by a
+            // `check` on that versionstamp: if another isolate raced us, the
+            // versionstamp moved, the commit returns `ok: false`, and we re-read
+            // and retry — so N concurrent incrs net exactly +N (the contract).
             //
-            // The TTL is set ONLY on the increment that creates the counter (when
-            // the prior versionstamp is `null`), never extending it afterwards —
-            // otherwise a busy rate window would slide forever and never reset,
-            // matching the redis adapter's "PEXPIRE only when v == 1" semantics.
+            // The window is a `{ n, deadline }` envelope, NOT a bare number,
+            // because Deno KV's `set` replaces the whole entry — including its
+            // expiry. (This is the opposite of Redis's INCR, which PRESERVES the
+            // key's TTL, so the redis adapter can set PEXPIRE once at creation.
+            // Here a later `set` without `expireIn` would silently CLEAR the
+            // window, making the counter permanent and the rate limit never
+            // reset.) We store an absolute `deadline`, pinned at the window's
+            // FIRST increment and never extended, and re-derive `expireIn` from
+            // it on every commit so the fixed window always expires on time.
             const kk = k(key);
             for (let attempt = 0; attempt <= maxRetries; attempt++) {
                 const entry = await kv.get(kk);
-                const current =
-                    typeof entry.value === 'number' ? entry.value : 0;
-                const next = current + 1;
+                const now = Date.now();
+                const prev = asWindow(entry.value);
+                // A window past its deadline (or an absent / legacy bare-number
+                // value) starts a fresh window at 1; an old bare counter thus
+                // self-heals into the envelope on its next incr.
+                const live = prev != null && prev.deadline > now;
+                const deadline = live ? prev.deadline : now + ttl;
+                const n = (live ? prev.n : 0) + 1;
+                // Deno KV rejects `expireIn` of 0/negative; keep it ≥ 1 while the
+                // deadline is in the future. `ttl <= 0` means "no window" — write
+                // without an expiry (matching `set`'s no-TTL path).
                 const options =
-                    entry.versionstamp === null && ttl > 0
-                        ? { expireIn: ttl }
+                    ttl > 0
+                        ? { expireIn: Math.max(1, deadline - now) }
                         : undefined;
                 const res = await kv
                     .atomic()
                     .check({ key: kk, versionstamp: entry.versionstamp })
-                    .set(kk, next, options)
+                    .set(kk, { n, deadline }, options)
                     .commit();
-                if (res.ok) return next;
+                if (res.ok) return n;
             }
             throw new Error(
                 `@stitchapi/deno-kv: incr(${key}) lost ${maxRetries + 1} compare-and-set races`,

--- a/packages/deno-kv/test/store-behaviour.spec.ts
+++ b/packages/deno-kv/test/store-behaviour.spec.ts
@@ -1,10 +1,12 @@
 // Targeted behaviour tests for @stitchapi/deno-kv that the conformance proof
-// (`conformance.spec.ts`) does not pin down: the sliding-window TTL rule (the
-// counter's expiry is set only when it is CREATED, never extended on later
-// incrs), the compare-and-set retry EXHAUSTION error, the array-key shape (flat
-// vs prefixed), the cache-delete (`set(k, undefined)`), and `close()` delegation.
-// Driven by a recording fake KV that captures every write's `expireIn` and can be
-// forced to lose every atomic commit.
+// (`conformance.spec.ts`) does not pin down: the FIXED-window TTL rule (the
+// counter's window has an absolute deadline pinned at creation — later incrs in
+// the same window neither extend nor clear it, and a fresh window restarts at 1),
+// the compare-and-set retry EXHAUSTION error, the array-key shape (flat vs
+// prefixed), the cache-delete (`set(k, undefined)`), and `close()` delegation.
+// Driven by two fakes: a recording KV that captures every write's `expireIn`, and
+// a time-travel KV that faithfully models Deno KV expiry so a window's reset is
+// observable (the recording fake never expires anything and so can't see it).
 import { denoKvStore } from '../src';
 import type {
     DenoAtomicCheck,
@@ -15,7 +17,7 @@ import type {
     DenoKvLike,
 } from '../src';
 
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 
 interface Recording {
     kv: DenoKvLike;
@@ -100,8 +102,163 @@ function recordingKv(opts: { failAtomic?: boolean } = {}): Recording {
     return { kv, sets, atomicSets, deletes, closed: () => closedFlag };
 }
 
+// A faithful, time-travellable Deno KV double. Unlike `recordingKv` it models
+// *expiry* exactly the way Deno KV does — which is the whole point of this file:
+//   • `set(key, value, { expireIn })` stamps an absolute `expiresAt`; a `set`
+//     WITHOUT `expireIn` means the key NEVER expires (`expiresAt = Infinity`).
+//     This is the trap: on real Deno KV a bare `set` REPLACES the entry, so it
+//     also clears any expiry the entry had — unlike Redis INCR, which keeps it.
+//   • a key read at/after `expiresAt` comes back as `{ value: null,
+//     versionstamp: null }` (absent), so the next incr sees a fresh window.
+//   • `atomic().check(versionstamp).set(...).commit()` is real optimistic CAS.
+// Virtual time is driven by vitest's fake timers (`vi.setSystemTime`), so the
+// tests never sleep.
+function expiryKv(): DenoKvLike {
+    interface Cell {
+        value: unknown;
+        versionstamp: string;
+        expiresAt: number;
+    }
+    const data = new Map<string, Cell>();
+    let seq = 0;
+    const id = (key: DenoKvKey): string => JSON.stringify(key);
+    // Read-through expiry: a cell past its deadline is indistinguishable from an
+    // absent key (and is dropped), exactly like Deno KV.
+    const live = (key: DenoKvKey): Cell | undefined => {
+        const c = data.get(id(key));
+        if (!c) return undefined;
+        if (c.expiresAt <= Date.now()) {
+            data.delete(id(key));
+            return undefined;
+        }
+        return c;
+    };
+    const write = (
+        key: DenoKvKey,
+        value: unknown,
+        expireIn?: number,
+    ): string => {
+        const versionstamp = String(++seq);
+        // A bare set (no expireIn) => Infinity: the entry is rewritten whole and
+        // any prior expiry is gone. This is the behaviour the bug tripped over.
+        data.set(id(key), {
+            value,
+            versionstamp,
+            expiresAt: expireIn == null ? Infinity : Date.now() + expireIn,
+        });
+        return versionstamp;
+    };
+    return {
+        async get(key): Promise<DenoKvEntryMaybe> {
+            const c = live(key);
+            return c
+                ? { value: c.value, versionstamp: c.versionstamp }
+                : { value: null, versionstamp: null };
+        },
+        async set(key, value, options): Promise<unknown> {
+            return {
+                ok: true,
+                versionstamp: write(key, value, options?.expireIn),
+            };
+        },
+        async delete(key): Promise<void> {
+            data.delete(id(key));
+        },
+        atomic(): DenoAtomicOperation {
+            const checks: DenoAtomicCheck[] = [];
+            let pending:
+                | {
+                      key: DenoKvKey;
+                      value: unknown;
+                      expireIn: number | undefined;
+                  }
+                | undefined;
+            const op: DenoAtomicOperation = {
+                check(...c): DenoAtomicOperation {
+                    checks.push(...c);
+                    return op;
+                },
+                set(key, value, options): DenoAtomicOperation {
+                    pending = { key, value, expireIn: options?.expireIn };
+                    return op;
+                },
+                async commit(): Promise<DenoAtomicCommitResult> {
+                    for (const c of checks) {
+                        const cur = live(c.key)?.versionstamp ?? null;
+                        if (cur !== c.versionstamp) return { ok: false };
+                    }
+                    if (!pending) return { ok: true, versionstamp: '' };
+                    const versionstamp = write(
+                        pending.key,
+                        pending.value,
+                        pending.expireIn,
+                    );
+                    return { ok: true, versionstamp };
+                },
+            };
+            return op;
+        },
+    };
+}
+
 describe('denoKvStore — incr TTL window', () => {
-    test('sets the counter TTL only on creation, never extending it on later incrs', async () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    test('a fixed window RESETS: after the ttl elapses the next incr restarts at 1', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        const store = denoKvStore(expiryKv());
+        const ttl = 200;
+
+        // Two incrs inside one window — the counter must not be permanent.
+        expect(await store.incr('rate', ttl)).toBe(1);
+        expect(await store.incr('rate', ttl)).toBe(2);
+
+        // Advance past the window's absolute deadline (pinned at the FIRST incr).
+        vi.setSystemTime(ttl + 1);
+
+        // The window expired, so the counter starts over. Under the TTL-clearing
+        // bug the 2nd incr wiped the expiry, the key never expired, and this
+        // returned 3 (an ever-growing permanent counter — the rate limit never
+        // reset). It must be 1.
+        expect(await store.incr('rate', ttl)).toBe(1);
+    });
+
+    test('within one window incrs accumulate (1, 2, 3) without any early reset', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        const store = denoKvStore(expiryKv());
+        const ttl = 1000;
+
+        expect(await store.incr('rate', ttl)).toBe(1);
+        // Time advances but stays INSIDE the window — no reset, no extension.
+        vi.setSystemTime(400);
+        expect(await store.incr('rate', ttl)).toBe(2);
+        vi.setSystemTime(900);
+        expect(await store.incr('rate', ttl)).toBe(3);
+    });
+
+    test('the window deadline is FIXED, not sliding: later incrs never push it out', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        const store = denoKvStore(expiryKv());
+        const ttl = 200;
+
+        expect(await store.incr('rate', ttl)).toBe(1); // deadline pinned at 200
+        vi.setSystemTime(150);
+        expect(await store.incr('rate', ttl)).toBe(2); // must NOT reset to t=350
+        // Cross the ORIGINAL deadline. A sliding window would still be alive here
+        // (150 + 200 = 350); a fixed window has already expired at 200.
+        vi.setSystemTime(210);
+        expect(await store.incr('rate', ttl)).toBe(1);
+    });
+
+    test('every commit carries a positive expireIn so the window can always expire', async () => {
+        // The TTL-clearing bug attached `expireIn` only to the creating commit and
+        // left every later commit with `undefined` (no expiry). Assert instead
+        // that EVERY commit expires the key — the window is never left permanent.
         const rec = recordingKv();
         const store = denoKvStore(rec.kv);
 
@@ -109,13 +266,26 @@ describe('denoKvStore — incr TTL window', () => {
         expect(await store.incr('rate', 1000)).toBe(2);
         expect(await store.incr('rate', 1000)).toBe(3);
 
-        // expireIn only on the first (creating) commit — a busy window must reset,
-        // not slide forever (matches redis's "PEXPIRE only when v == 1" rule).
-        expect(rec.atomicSets.map((s) => s.expireIn)).toEqual([
-            1000,
-            undefined,
-            undefined,
-        ]);
+        // No `undefined` — the entry never loses its expiry on a later write.
+        for (const s of rec.atomicSets) {
+            expect(s.expireIn).toBeTypeOf('number');
+            expect(s.expireIn as number).toBeGreaterThan(0);
+        }
+        expect(rec.atomicSets).toHaveLength(3);
+    });
+
+    test('a legacy bare-number counter (pre-upgrade value) self-heals into a fresh window', async () => {
+        // On a deploy transition an old value could be a bare number with no
+        // window envelope. The store must treat it as a fresh window rather than
+        // crash or read NaN — incr returns 1 and the value is now well-formed.
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        const kv = expiryKv();
+        await kv.set(['legacy'], 7); // an old bare counter, no deadline
+        const store = denoKvStore(kv);
+
+        expect(await store.incr('legacy', 200)).toBe(1);
+        expect(await store.incr('legacy', 200)).toBe(2);
     });
 
     test('throws after exhausting maxIncrRetries lost compare-and-set races', async () => {


### PR DESCRIPTION
## The bug (HIGH — correctness)

`denoKvStore().incr` attached `{ expireIn: ttl }` **only** on the counter's first (creating) increment (`entry.versionstamp === null`) and passed `undefined` on every later in-window increment:

```ts
const options =
    entry.versionstamp === null && ttl > 0 ? { expireIn: ttl } : undefined;
await kv.atomic().check(...).set(kk, next, options).commit();
```

**Deno KV's `set` replaces the whole entry — including its expiry** ("If `expireIn` is not specified, the key will not expire"). So the **2nd** increment cleared the TTL and the counter became **permanent**: the rate-limit window never reset, and every per-window key leaked forever in KV — unbounded growth on Deno Deploy under cold-start isolate churn.

Reproduction: `incr('rate', 200)` twice, wait past 200 ms, the next `incr` returns **3** instead of **1**.

The old code comment claimed this matched the Redis adapter's *"PEXPIRE only when v == 1"*. That reasoning is **inverted**: Redis `INCR` **preserves** the key's existing TTL (so Redis sets the expiry once, at creation); Deno KV `set` **clears** it (so the expiry must be re-applied on every write).

## The fix — a fixed window that actually expires (Redis / `memoryStore` parity)

Because Deno KV `set` overwrites expiry and `get` doesn't expose the remaining TTL, a fixed window needs an **absolute deadline stored alongside the count**. `incr` now:

- stores a `{ n, deadline }` envelope instead of a bare number;
- pins `deadline = now + ttl` at the window's **first** increment and **never extends it**;
- re-derives `expireIn = max(1, deadline − now)` on **every** atomic commit, so the window's expiry survives later writes;
- treats a past-deadline / absent / legacy bare-number value as a fresh window (an old bare counter **self-heals** into the envelope on its next incr — handles the deploy transition).

This matches core's `memoryStore` (fixed window: original `expires` preserved, resets to 1 once the window lapses) and the Redis adapter's fixed-window semantics.

`get` unwraps the `{ n, deadline }` envelope back to the plain count, so core's **cache-generation cross-read** (`bumpCacheGeneration` → `store.incr`, then `genPrefix` → `store.get` → `asNum`) still sees a number — verified `incr`→`get`→`asNum` returns the count, not `0`.

The atomic CAS retry loop and its bounded `maxIncrRetries` are unchanged, so the contract's "N concurrent incrs net +N" rule still holds.

Corrected the misleading comment (`src/index.ts`) and the README's fixed-window claim to describe the honest behavior (Deno KV `set` clears expiry vs Redis `INCR` preserving it; the `{ n, deadline }` envelope; `get` unwraps it).

## Regression test (fail-before / pass-after)

The existing TTL test **certified the bug** — it asserted `atomicSets.map(s => s.expireIn) === [1000, undefined, undefined]` and its fake never modelled expiry. That assertion is **replaced**.

New tests are driven by a **time-travellable Deno KV fake** that faithfully models expiry: a bare `set` (no `expireIn`) => `expiresAt = Infinity`, and a key past its deadline reads back as `{ value: null, versionstamp: null }`. Virtual time via `vi.setSystemTime`. They cover: a window **RESETS** after `ttl` (next incr → 1), **accumulates** within a window (1→2→3, no early reset), a **FIXED** (non-sliding) deadline, **every commit carries a positive `expireIn`**, and a **legacy bare counter self-heals**.

**Fail-before** (original `incr`, 4 new tests fail):

```
FAIL  denoKvStore — incr TTL window > a fixed window RESETS: after the ttl elapses the next incr restarts at 1
AssertionError: expected 3 to be 1 // Object.is equality
- Expected  1
+ Received  3

FAIL  ... the window deadline is FIXED, not sliding: later incrs never push it out   expected 3 to be 1
FAIL  ... every commit carries a positive expireIn so the window can always expire    expected undefined to be type of 'number'
FAIL  ... a legacy bare-number counter (pre-upgrade value) self-heals into a fresh window   expected 8 to be 1

 Test Files  1 failed (1)
      Tests  4 failed | 6 passed (10)
```

**Pass-after** (with the fix):

```
 Test Files  2 passed (2)
      Tests  12 passed (12)
```

`pnpm --filter @stitchapi/deno-kv check:types` clean; `prettier --check` clean; conformance (`verifyStoreContract`) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)