### PR TITLE
fix(pino,sentry): redactUrl must strip URL userinfo, not just the query (credential leak in logs)

### DIFF
--- a/packages/pino/src/index.ts
+++ b/packages/pino/src/index.ts
@@ -77,9 +77,9 @@ export interface PinoSinkOptions {
  * `cookie` and a `delta`'s `chunk` is raw response data. This sink therefore logs
  * **only metadata** — name, method, redacted URL, status, attempt counts, drift
  * path/level/change, phase, waited timing — never `event.input`, `event.data`, a
- * `delta` chunk, or `JSON.stringify(event)`, and it strips the URL query (it can carry
- * `?api_key=…`). That keeps it safe on a secret-bearing seam independent of core's
- * trace redaction.
+ * `delta` chunk, or `JSON.stringify(event)`, and it strips both the URL userinfo
+ * (`user:pass@`) and the query (either can carry a credential — `?api_key=…`). That
+ * keeps it safe on a secret-bearing seam independent of core's trace redaction.
  *
  * @example
  * ```ts
@@ -141,8 +141,21 @@ function levelFor(event: StitchEvent, lifecycle: boolean): PinoLevel | null {
     }
 }
 
-// Drop the query string (it may carry secrets, e.g. `?api_key=…`) before logging.
+// Strip BOTH the URL userinfo (`user:pass@`, e.g. HTTP Basic auth embedded in the
+// baseUrl) and the query string (it may carry secrets, e.g. `?api_key=…`) — either can
+// carry a credential — before logging. Core's own sinks strip userinfo via `scrubUrl`;
+// that helper is internal (not exported from `stitchapi`), so this mirrors it locally.
 function redactUrl(url: string): string {
+    try {
+        const u = new URL(url);
+        if (u.username || u.password) {
+            u.username = '';
+            u.password = '';
+            url = u.toString();
+        }
+    } catch {
+        // not an absolute/parseable URL — fall through to the query-only strip
+    }
     const q = url.indexOf('?');
     return q === -1 ? url : `${url.slice(0, q)}?…`;
 }
@@ -155,7 +168,8 @@ function redactUrl(url: string): string {
 // and a `delta`'s `chunk` is raw response data. It therefore logs **only metadata** —
 // name, method, redacted URL, status, attempt counts, drift path/level/change, phase,
 // waited timing — never `event.input`, `event.data`, a `delta` chunk, or
-// `JSON.stringify(event)`, and it strips the URL query. `null` ⇒ skip the event.
+// `JSON.stringify(event)`, and it strips the URL userinfo + query. `null` ⇒ skip the
+// event.
 function recordFor(
     name: string,
     event: StitchEvent,

--- a/packages/pino/test/pino.spec.ts
+++ b/packages/pino/test/pino.spec.ts
@@ -246,6 +246,28 @@ describe('pinoSink — URL redaction', () => {
 });
 
 describe('pinoSink — secret safety', () => {
+    it('never logs URL-embedded HTTP Basic credentials (userinfo, no query)', () => {
+        // `baseUrl: 'https://alice:s3cr3t@api.example.com'` is a legitimate, supported
+        // way to carry HTTP Basic auth. The `start` event's URL then has NO query, so a
+        // query-only strip leaves `alice:s3cr3t@` in both the message and the obj.
+        const calls = run({
+            type: 'start',
+            name: 'getUser',
+            method: 'GET',
+            url: 'https://alice:s3cr3t@api.example.com/users/1',
+            input: {},
+            at: 0,
+        });
+        expect(calls).toHaveLength(1);
+        const text = loggedText(calls[0]!);
+        expect(text).not.toContain('s3cr3t');
+        expect(text).not.toContain('alice:s3cr3t');
+        // the obj's url field is the userinfo-stripped form
+        expect((calls[0]!.obj as { url: string }).url).toBe(
+            'https://api.example.com/users/1',
+        );
+    });
+
     it('never logs an `input.headers.authorization` secret', () => {
         const calls = run({
             type: 'start',

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -16,7 +16,8 @@
 // own built-in sinks. So this sends **metadata only** (name, method, redacted URL,
 // status, attempt counts, drift path/level/change, phase, timing) and NEVER
 // `event.input` (its headers carry the live `authorization`/`cookie`), `event.data`,
-// or a `delta` chunk. The URL query string is dropped (it can carry `?api_key=…`).
+// or a `delta` chunk. Both the URL userinfo (`user:pass@`) and the query string are
+// dropped — either can carry a credential (`?api_key=…`).
 import type { StitchEvent, TraceContext, TraceSink } from 'stitchapi';
 import { compact } from 'stitchapi';
 
@@ -79,8 +80,23 @@ export interface SentrySinkOptions {
 // helpers
 // ---------------------------------------------------------------------------
 
-/** Drop the query string (it may carry secrets, e.g. `?api_key=…`). */
+/**
+ * Strip BOTH the URL userinfo (`user:pass@`, e.g. HTTP Basic auth embedded in the
+ * baseUrl) and the query string (it may carry secrets, e.g. `?api_key=…`) — either can
+ * carry a credential. Core's own sinks strip userinfo via `scrubUrl`; that helper is
+ * internal (not exported from `stitchapi`), so this mirrors it locally.
+ */
 function redactUrl(url: string): string {
+    try {
+        const u = new URL(url);
+        if (u.username || u.password) {
+            u.username = '';
+            u.password = '';
+            url = u.toString();
+        }
+    } catch {
+        // not an absolute/parseable URL — fall through to the query-only strip
+    }
     const q = url.indexOf('?');
     return q === -1 ? url : `${url.slice(0, q)}?…`;
 }

--- a/packages/sentry/test/sentry.spec.ts
+++ b/packages/sentry/test/sentry.spec.ts
@@ -166,6 +166,31 @@ describe('sentrySink', () => {
         expect(captures).toHaveLength(0);
     });
 
+    test('never sends URL-embedded HTTP Basic credentials (userinfo, no query)', () => {
+        // `baseUrl: 'https://alice:s3cr3t@api.example.com'` is a legitimate, supported
+        // way to carry HTTP Basic auth. The `start` event's URL then has NO query, so a
+        // query-only strip leaves `alice:s3cr3t@` in the breadcrumb message and data.
+        const startWithUserinfo: StitchEvent = {
+            type: 'start',
+            name: 'getUser',
+            method: 'GET',
+            url: 'https://alice:s3cr3t@api.example.com/users/1',
+            input: {} as never,
+            at: 0,
+        };
+        const { sentry, breadcrumbs, captures } = mockSentry();
+        sentrySink(sentry, { lifecycle: true }).handle(startWithUserinfo, ctx);
+
+        expect(breadcrumbs).toHaveLength(1);
+        const dump = JSON.stringify({ breadcrumbs, captures });
+        expect(dump).not.toContain('s3cr3t');
+        expect(dump).not.toContain('alice:s3cr3t');
+        // the breadcrumb's url data is the userinfo-stripped form
+        expect(breadcrumbs[0]!.data).toMatchObject({
+            url: 'https://api.example.com/users/1',
+        });
+    });
+
     test('metadata only: no secret query, no input/value/chunk reaches Sentry', () => {
         const { sentry, breadcrumbs, captures } = mockSentry();
         const sink = sentrySink(sentry, { lifecycle: true });


### PR DESCRIPTION
## The leak (security, HIGH)

`@stitchapi/pino` and `@stitchapi/sentry` each defined an identical `redactUrl` helper
that stripped only the `?query` and **never the URL userinfo**:

```ts
function redactUrl(url: string): string {
    const q = url.indexOf('?');
    return q === -1 ? url : `${url.slice(0, q)}?…`;
}
```

URL-embedded HTTP Basic auth (`baseUrl: 'https://alice:s3cr3t@api.example.com'`) is a
legitimate, supported pattern. On a call, core's `start` event carries
`url: 'https://alice:s3cr3t@api.example.com/users/1'` — **no query**. `redactUrl` finds
no `?`, returns the URL unchanged, and the sink logs the password `s3cr3t` verbatim:

- **pino** — in both the structured `obj.url` and the `msg` string.
- **sentry** — in both the breadcrumb `data.url` and the breadcrumb `message`.

…on every call, contradicting each sink's own "keeps it safe on a secret-bearing seam"
docstring. Both sinks share the same root cause (a copy of the same helper), so this is
one fix in two places.

Core's own console/JSONL/OTLP sinks were **already safe**: they route the URL through
`scrubUrl` (`packages/core/src/util.ts`), which clears `u.username`/`u.password`. So
these two integration sinks were leaking exactly the credential core already redacts.

## The fix

`scrubUrl` is internal to core and **not exported from `stitchapi`** (confirmed: it's
absent from `packages/core/src/index.ts`), so it can't simply be imported. Instead, each
package's local `redactUrl` now parses the URL and clears any userinfo **in addition to**
the query:

```ts
function redactUrl(url: string): string {
    try {
        const u = new URL(url);
        if (u.username || u.password) {
            u.username = '';
            u.password = '';
            url = u.toString();
        }
    } catch {
        // not an absolute/parseable URL — fall through to the query-only strip
    }
    const q = url.indexOf('?');
    return q === -1 ? url : `${url.slice(0, q)}?…`;
}
```

The `start` case is the only place either sink logs `event.url`, and both its log sites
(structured field + message) already route through `redactUrl`, so no call site was
bypassing it. Docstrings in both packages updated to say the URL userinfo + query are
stripped.

## Fail-before / pass-after evidence

One regression test per package drives a `start` event whose `url` is
`https://alice:s3cr3t@api.example.com/users/1` (no query), captures **everything** the
sink logs (structured object *and* message), and asserts `s3cr3t` / `alice:s3cr3t` never
appear.

**pino — before the fix (FAIL, leaks):**
```
AssertionError: expected '→ getUser GET https://alice:s3cr3t@ap…' not to contain 's3cr3t'
Received: "→ getUser GET https://alice:s3cr3t@api.example.com/users/1 {"stitch":"getUser","method":"GET","url":"https://alice:s3cr3t@api.example.com/users/1"}"
```

**sentry — before the fix (FAIL, leaks):**
```
AssertionError: expected '{"breadcrumbs":[{"category":"stitch",…' not to contain 's3cr3t'
Received: {"breadcrumbs":[{"category":"stitch","level":"info","message":"→ getUser GET https://alice:s3cr3t@api.example.com/users/1","data":{"method":"GET","url":"https://alice:s3cr3t@api.example.com/users/1"}}],"captures":[]}
```

**After the fix — both green (full suites):**
```
@stitchapi/pino   — Test Files 1 passed (1)   Tests 13 passed (13)
@stitchapi/sentry — Test Files 1 passed (1)   Tests  9 passed (9)
```

`check:types` passes clean for both packages.

## Follow-up (out of scope here)

A reasonable follow-up is to **export a core `scrubUrl`** and have both sinks unify on it,
so there's a single redaction implementation. Core's `scrubUrl` also goes further than
this local fix: it redacts secret query *values* (`?api_key=REDACTED`) rather than
nuking the whole query string, preserving benign params (`page`, `sort`) for
observability. This PR intentionally keeps the minimal, in-place fix to close the leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
