### PR TITLE
fix(swr,react): cache-key derivation collides nameless stitches and leaks per-call auth headers

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -52,13 +52,95 @@ export interface UseStitchResult<T> extends StitchQueryState<T> {
 // Shared driver
 // ---------------------------------------------------------------------------
 
+// --- key derivation (shared logic; duplicated in @stitchapi/swr) -----------
+// These helpers are intentionally copied verbatim into `@stitchapi/swr`'s
+// `swrKey`: they are separate published packages, so a cross-package import would
+// add a runtime dependency. Keep the two copies in lock-step.
+
+/** The `__config` slice a key derives from. Mirrors core's `nameOf`
+ * (`name ?? path ?? 'stitch'`) plus a `url` fallback for URL-configured stitches. */
+type KeyConfig = { name?: string; path?: string; url?: string };
+
+/** A stable, human-meaningful name for the stitch. Mirrors core's `nameOf`
+ * (`packages/core/src/engine.ts`) — `name ?? path ?? url ?? 'stitch'` — so two
+ * DISTINCT nameless stitches (`/users/{id}` vs `/orders/{id}`) don't collapse to
+ * the literal `'stitch'` and collide on one cache entry. */
+function nameOf(stitch: unknown): string {
+    const cfg = (stitch as { __config?: KeyConfig }).__config;
+    return cfg?.name ?? cfg?.path ?? cfg?.url ?? 'stitch';
+}
+
+// Header names whose VALUES are secrets — mirrors core's private `SECRET_HEADERS`
+// trace denylist (`packages/core/src/trace.ts`), which is not exported. We redact
+// the value (rather than dropping the header) so the key stays stable per token
+// AND callers who legitimately vary a response by a non-secret header (e.g.
+// `accept-language`) keep separate cache entries. Compared case-insensitively; the
+// `*-token` / `*-api-key` suffix rules catch vendor spellings without enumerating.
+const SECRET_HEADERS = new Set([
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+    'x-api-key',
+    'x-auth-token',
+]);
+const REDACTED = '[redacted]';
+
+function isSecretHeader(name: string): boolean {
+    const k = name.toLowerCase();
+    return (
+        SECRET_HEADERS.has(k) || k.endsWith('-token') || k.endsWith('-api-key')
+    );
+}
+
+/**
+ * Build the value that goes into a cache/query key from a stitch's per-call input.
+ * Never puts the raw input in the key:
+ *
+ * - drops `signal` / `onProgress` — runtime-only, never-serialised (CONTRACT.md);
+ *   `onProgress` in particular churns identity every render, which would refetch
+ *   forever if it entered the key;
+ * - redacts the VALUES of secret-bearing headers (`authorization`, `cookie`, …)
+ *   so a bearer token can't leak into a persisted / devtools-visible key, while
+ *   keeping non-secret headers so they still vary the cache;
+ * - keeps every other field (`params` / `query` / `body` / `variables` / …) as-is.
+ *
+ * `null` / `undefined` inputs stay `null`; a primitive input is returned unchanged.
+ */
+function keyInputFor(input: unknown): unknown {
+    if (input === null || input === undefined) return null;
+    if (typeof input !== 'object') return input;
+
+    const {
+        signal: _signal,
+        onProgress: _onProgress,
+        ...rest
+    } = input as {
+        signal?: unknown;
+        onProgress?: unknown;
+        headers?: Record<string, unknown>;
+    } & Record<string, unknown>;
+
+    if (rest.headers && typeof rest.headers === 'object') {
+        const headers: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(rest.headers)) {
+            headers[k] = isSecretHeader(k) ? REDACTED : v;
+        }
+        rest.headers = headers;
+    }
+    return rest;
+}
+
 // `deps` lets the caller control when the query handle is re-created. By default
 // we derive a stable identity from the stitch + a structural key of the input, so
 // `{ id: 1 }` !== `{ id: 2 }` re-fetches but a re-render with an equal-shaped
 // literal does not. A caller who keys differently passes explicit `deps`.
 function defaultKey(input: unknown): string {
     try {
-        return JSON.stringify(input ?? null);
+        // Sanitise first: an inline `onProgress` (fresh identity per render) would
+        // otherwise churn the structural key and loop; a per-call `signal` would
+        // add non-deterministic noise. Both are runtime-only, so drop them.
+        return JSON.stringify(keyInputFor(input));
     } catch {
         // Non-serialisable input (a function, a cyclic object) → opt out of
         // structural keying; the caller should pass explicit `deps`.
@@ -101,12 +183,12 @@ function useStitchInternal<T>(
     ).current;
 
     // The dependency list that triggers a fresh handle (and re-fetch). Default: a
-    // structural key of the input + the stitch's stable `__config.name` (NOT its
-    // function identity) + the streaming flags. Pass `options.deps` to override.
-    const name = (stitch as { __config?: { name?: string } }).__config?.name;
+    // structural key of the input + a stable name for the stitch (NOT its function
+    // identity; via `nameOf`, so two nameless stitches on different paths don't
+    // share a dep key) + the streaming flags. Pass `options.deps` to override.
     const depKey = deps
         ? deps
-        : [name ?? '', defaultKey(input), stream, mode, enabled];
+        : [nameOf(stitch), defaultKey(input), stream, mode, enabled];
 
     const query: StitchQuery<T> = useMemo(
         () =>
@@ -241,8 +323,10 @@ export interface StitchQueryOptions<T> {
  * const { data } = useQuery(stitchQueryOptions(getUser, { params: { id } }));
  * ```
  *
- * The `queryFn` awaits the stitch (the validated output); the `queryKey` is the
- * stitch's `name` (when present) plus the input, so TanStack caches per call.
+ * The `queryFn` awaits the stitch (the validated output); the `queryKey` is a
+ * stable name for the stitch plus a sanitised copy of the input (secret header
+ * values redacted, runtime-only `signal`/`onProgress` dropped), so TanStack caches
+ * per call without leaking a bearer token into the key or refetching every render.
  *
  * Named `stitchQueryOptions` (not a bare `queryOptions`) because TanStack Query
  * itself exports a `queryOptions` — the bare name would clash on import. See
@@ -260,9 +344,8 @@ export function stitchQueryOptions<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
 ): StitchQueryOptions<T> {
-    const name = (stitch as { __config?: { name?: string } }).__config?.name;
     return {
-        queryKey: [name ?? 'stitch', input ?? null],
+        queryKey: [nameOf(stitch), keyInputFor(input)],
         queryFn: () => Promise.resolve(stitch(input)),
     };
 }

--- a/packages/react/test/hooks.spec.tsx
+++ b/packages/react/test/hooks.spec.tsx
@@ -20,7 +20,7 @@ afterEach(cleanup);
 
 function unaryStitch<T>(
     settle: (input: unknown) => Promise<T>,
-    config?: { name?: string },
+    config?: { name?: string; path?: string; url?: string },
 ): StitchLike<T> {
     const fn = (input?: unknown): StitchCallResult<T> => {
         const promise = settle(input);
@@ -308,5 +308,96 @@ describe('stitchQueryOptions', () => {
 
     test('queryOptions stays a deprecated alias of stitchQueryOptions (ADR 0012)', () => {
         expect(queryOptions).toBe(stitchQueryOptions);
+    });
+});
+
+// --- stitchQueryOptions: cache-key derivation regressions ------------------
+// The `queryKey` derivation shared the same three bugs as `@stitchapi/swr`'s
+// `swrKey`. Each of these FAILED before the fix.
+
+describe('stitchQueryOptions — no cache collision between nameless stitches', () => {
+    // Bug 1 (correctness): `name ?? 'stitch'` keyed every nameless stitch as the
+    // literal 'stitch', so two distinct endpoints with same-shaped input collided
+    // on one TanStack Query cache entry. Fixed by mirroring core's `nameOf`
+    // (name ?? path ?? url ?? 'stitch').
+    test('two nameless stitches with different paths get DIFFERENT keys', () => {
+        const getUser = unaryStitch(async () => 1, { path: '/users/{id}' });
+        const getOrder = unaryStitch(async () => 1, { path: '/orders/{id}' });
+        const input = { params: { id: '1' } };
+
+        const userKey = stitchQueryOptions(getUser, input).queryKey;
+        const orderKey = stitchQueryOptions(getOrder, input).queryKey;
+
+        expect(userKey).not.toEqual(orderKey);
+        expect(userKey[0]).toBe('/users/{id}');
+        expect(orderKey[0]).toBe('/orders/{id}');
+    });
+});
+
+describe('stitchQueryOptions — no secret leak in the query key', () => {
+    // Bug 2 (security): the raw `input` went straight into the queryKey, so a
+    // per-call `authorization` header serialised the bearer token into the
+    // TanStack Query key (persisted, and shown in the devtools panel). Fixed by
+    // redacting denylisted header VALUES.
+    test('a per-call authorization header does not put the token in the key', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const { queryKey } = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+            headers: { authorization: 'Bearer SECRET123' },
+        });
+
+        expect(JSON.stringify(queryKey)).not.toContain('SECRET123');
+    });
+
+    test('redacts the secret header but keeps a benign one (no fresh collision)', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const [, keyInput] = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+            headers: {
+                authorization: 'Bearer SECRET123',
+                'accept-language': 'en-US',
+            },
+        }).queryKey;
+
+        const headers = (keyInput as { headers: Record<string, string> })
+            .headers;
+        expect(headers['authorization']).not.toContain('SECRET123');
+        expect(headers['accept-language']).toBe('en-US');
+    });
+});
+
+describe('stitchQueryOptions — no refetch storm from runtime-only input fields', () => {
+    // Bug 2 (reliability): `signal`/`onProgress` are runtime-only (never
+    // serialised, per CONTRACT.md). An inline `onProgress` churns identity every
+    // render, so keying it re-fetched forever. Fixed by excluding both fields.
+    test('two distinct inline onProgress functions produce EQUAL keys', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const base = { params: { id: '1' } };
+
+        const keyA = stitchQueryOptions(getUser, {
+            ...base,
+            onProgress: () => {},
+        }).queryKey;
+        const keyB = stitchQueryOptions(getUser, {
+            ...base,
+            onProgress: () => {},
+        }).queryKey;
+
+        expect(keyA).toEqual(keyB);
+    });
+
+    test('a per-call signal does not enter the key', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const controller = new AbortController();
+
+        const withSignal = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+            signal: controller.signal,
+        }).queryKey;
+        const without = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+        }).queryKey;
+
+        expect(withSignal).toEqual(without);
     });
 });

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -47,9 +47,89 @@ export type QueryInput<S> =
 // swrKey
 // ---------------------------------------------------------------------------
 
-/** The SWR cache key a stitch+input maps to: the stitch's `name` (when present)
- * plus the input, so SWR caches and dedupes per call. */
+/** The SWR cache key a stitch+input maps to: a stable name for the stitch plus a
+ * sanitised copy of the input (secret header values redacted, runtime-only fields
+ * dropped), so SWR caches and dedupes per call without leaking or churning. */
 export type StitchSWRKey = readonly [name: string, input: unknown];
+
+// --- key derivation (shared logic; duplicated in @stitchapi/react) ---------
+// These two helpers are intentionally copied verbatim into `@stitchapi/react`'s
+// `stitchQueryOptions`: they are separate published packages, so a cross-package
+// import would add a runtime dependency. Keep the two copies in lock-step.
+
+/** The `__config` slice a key derives from. Mirrors core's `nameOf`
+ * (`name ?? path ?? 'stitch'`) plus a `url` fallback for URL-configured stitches. */
+type KeyConfig = { name?: string; path?: string; url?: string };
+
+/** A stable, human-meaningful name for the stitch. Mirrors core's `nameOf`
+ * (`packages/core/src/engine.ts`) — `name ?? path ?? url ?? 'stitch'` — so two
+ * DISTINCT nameless stitches (`/users/{id}` vs `/orders/{id}`) don't collapse to
+ * the literal `'stitch'` and collide on one cache entry. */
+function nameOf(stitch: unknown): string {
+    const cfg = (stitch as { __config?: KeyConfig }).__config;
+    return cfg?.name ?? cfg?.path ?? cfg?.url ?? 'stitch';
+}
+
+// Header names whose VALUES are secrets — mirrors core's private `SECRET_HEADERS`
+// trace denylist (`packages/core/src/trace.ts`), which is not exported. We redact
+// the value (rather than dropping the header) so the key stays stable per token
+// AND callers who legitimately vary a response by a non-secret header (e.g.
+// `accept-language`) keep separate cache entries. Compared case-insensitively; the
+// `*-token` / `*-api-key` suffix rules catch vendor spellings without enumerating.
+const SECRET_HEADERS = new Set([
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+    'x-api-key',
+    'x-auth-token',
+]);
+const REDACTED = '[redacted]';
+
+function isSecretHeader(name: string): boolean {
+    const k = name.toLowerCase();
+    return (
+        SECRET_HEADERS.has(k) || k.endsWith('-token') || k.endsWith('-api-key')
+    );
+}
+
+/**
+ * Build the value that goes into the cache key from a stitch's per-call input.
+ * Never puts the raw input in the key:
+ *
+ * - drops `signal` / `onProgress` — runtime-only, never-serialised (CONTRACT.md);
+ *   `onProgress` in particular churns identity every render, which would refetch
+ *   forever if it entered the key;
+ * - redacts the VALUES of secret-bearing headers (`authorization`, `cookie`, …)
+ *   so a bearer token can't leak into a persisted / devtools-visible key, while
+ *   keeping non-secret headers so they still vary the cache;
+ * - keeps every other field (`params` / `query` / `body` / `variables` / …) as-is.
+ *
+ * `null` / `undefined` inputs stay `null`; a primitive input is returned unchanged.
+ */
+function keyInputFor(input: unknown): unknown {
+    if (input === null || input === undefined) return null;
+    if (typeof input !== 'object') return input;
+
+    const {
+        signal: _signal,
+        onProgress: _onProgress,
+        ...rest
+    } = input as {
+        signal?: unknown;
+        onProgress?: unknown;
+        headers?: Record<string, unknown>;
+    } & Record<string, unknown>;
+
+    if (rest.headers && typeof rest.headers === 'object') {
+        const headers: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(rest.headers)) {
+            headers[k] = isSecretHeader(k) ? REDACTED : v;
+        }
+        rest.headers = headers;
+    }
+    return rest;
+}
 
 /**
  * Build the SWR key for a stitch call — use it for conditional fetching or a
@@ -77,8 +157,7 @@ export function swrKey<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
 ): StitchSWRKey {
-    const name = (stitch as { __config?: { name?: string } }).__config?.name;
-    return [name ?? 'stitch', input ?? null];
+    return [nameOf(stitch), keyInputFor(input)];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/swr/test/swr.spec.tsx
+++ b/packages/swr/test/swr.spec.tsx
@@ -12,10 +12,11 @@ import { describe, expect, test } from 'vitest';
 // --- fakes -----------------------------------------------------------------
 
 /** A unary stitch: resolves (or rejects) after a tick. SWR only needs the
- * awaitable side, so the fake is just a thenable. */
+ * awaitable side, so the fake is just a thenable. `config` mirrors the real
+ * `__config` slice `swrKey` reads (`name`, and — after the fix — `path`/`url`). */
 function unaryStitch<T>(
     settle: (input: unknown) => Promise<T>,
-    config?: { name?: string },
+    config?: { name?: string; path?: string; url?: string },
 ): StitchLike<T> {
     const fn = (input?: unknown): PromiseLike<T> => ({
         then: (onf, onr) => settle(input).then(onf, onr),
@@ -47,6 +48,95 @@ describe('swrKey', () => {
     test('falls back to "stitch" and normalises undefined input to null', () => {
         const stitch = unaryStitch(async () => 1);
         expect(swrKey(stitch, undefined)).toEqual(['stitch', null]);
+    });
+});
+
+// --- swrKey: cache-key derivation regressions ------------------------------
+// These pin the three bugs the derivation used to have (all shared with
+// `@stitchapi/react`'s `stitchQueryOptions`). Each FAILED before the fix.
+
+describe('swrKey — no cache collision between nameless stitches', () => {
+    // Bug 1 (correctness): `name ?? 'stitch'` keyed EVERY nameless stitch as the
+    // literal 'stitch', so two distinct endpoints with same-shaped input collided
+    // on one SWR entry and served each other's data. The fix mirrors core's
+    // `nameOf` (name ?? path ?? url ?? 'stitch').
+    test('two nameless stitches with different paths get DIFFERENT keys', () => {
+        const getUser = unaryStitch(async () => 1, { path: '/users/{id}' });
+        const getOrder = unaryStitch(async () => 1, { path: '/orders/{id}' });
+        const input = { params: { id: '1' } };
+
+        const userKey = swrKey(getUser, input);
+        const orderKey = swrKey(getOrder, input);
+
+        // Distinct endpoints must not share a cache entry.
+        expect(userKey).not.toEqual(orderKey);
+        expect(userKey[0]).toBe('/users/{id}');
+        expect(orderKey[0]).toBe('/orders/{id}');
+    });
+});
+
+describe('swrKey — no secret leak in the cache key', () => {
+    // Bug 2 (security): the raw `input` went straight into the key, so a per-call
+    // `authorization` header serialised the bearer token into the SWR key — which
+    // is persisted by cache providers and shown in devtools. The fix redacts
+    // denylisted header VALUES (keeping the header present so it still varies the
+    // cache), never the token itself.
+    test('a per-call authorization header does not put the token in the key', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const key = swrKey(getUser, {
+            params: { id: '1' },
+            headers: { authorization: 'Bearer SECRET123' },
+        });
+
+        expect(JSON.stringify(key)).not.toContain('SECRET123');
+    });
+
+    test('redacts the secret header but keeps a benign one (no fresh collision)', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const [, keyInput] = swrKey(getUser, {
+            params: { id: '1' },
+            headers: {
+                authorization: 'Bearer SECRET123',
+                'accept-language': 'en-US',
+            },
+        });
+
+        const headers = (keyInput as { headers: Record<string, string> })
+            .headers;
+        // Secret value gone, header slot retained…
+        expect(headers['authorization']).not.toContain('SECRET123');
+        // …and the non-secret header is preserved so callers who legitimately
+        // vary by `accept-language` still get separate cache entries.
+        expect(headers['accept-language']).toBe('en-US');
+    });
+});
+
+describe('swrKey — no refetch storm from runtime-only input fields', () => {
+    // Bug 2 (reliability): `signal`/`onProgress` are runtime-only (never
+    // serialised, per CONTRACT.md). An inline `onProgress` mints a fresh function
+    // identity every render, so serialising it churned the key every render →
+    // endless refetch. The fix excludes both fields from the key.
+    test('two distinct inline onProgress functions produce EQUAL keys', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const base = { params: { id: '1' } };
+
+        const keyA = swrKey(getUser, { ...base, onProgress: () => {} });
+        const keyB = swrKey(getUser, { ...base, onProgress: () => {} });
+
+        expect(keyA).toEqual(keyB);
+    });
+
+    test('a per-call signal does not enter the key', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const controller = new AbortController();
+
+        const withSignal = swrKey(getUser, {
+            params: { id: '1' },
+            signal: controller.signal,
+        });
+        const without = swrKey(getUser, { params: { id: '1' } });
+
+        expect(withSignal).toEqual(without);
     });
 });
 


### PR DESCRIPTION
## Summary

`swrKey` (`@stitchapi/swr`) and `stitchQueryOptions` (`@stitchapi/react`) derived their cache key with the **exact same** two-line expression:

```ts
const name = (stitch as { __config?: { name?: string } }).__config?.name;
return [name ?? 'stitch', input ?? null]; // swr: StitchSWRKey | react: queryKey
```

That expression carries two bugs — one a **correctness** cache collision, one a **security** leak of per-call auth headers. Because both adapters copied the derivation verbatim, both are affected. This PR fixes both with one shared piece of logic (duplicated per package — see the maintainer note) plus fail-before / pass-after regression tests in each.

## Bug 1 — cache collision between nameless stitches (correctness, HIGH)

`name ?? 'stitch'` keys **every** stitch that lacks an explicit `__config.name` as the literal string `'stitch'`. The README's own pattern is nameless:

```ts
const getUser  = stitch({ baseUrl, path: '/users/{id}' });
const getOrder = stitch({ baseUrl, path: '/orders/{id}' });

swrKey(getUser,  { params: { id: '1' } }); // ['stitch', { params: { id: '1' } }]
swrKey(getOrder, { params: { id: '1' } }); // ['stitch', { params: { id: '1' } }]  ← SAME KEY
```

Two distinct endpoints with same-shaped input collapse onto **one** cache entry and serve each other's data. Core's own `nameOf` (`packages/core/src/engine.ts:138`) falls back through `name ?? path ?? 'stitch'`; these adapters dropped the `path` fallback (a P9/P16 divergence from core).

## Bug 2 — per-call auth headers leak into the key + refetch storm (security/reliability, MEDIUM)

`input ?? null` puts the **entire raw per-call input** into the key. Per-call `headers` are a supported input (the engine merges `input.headers`), so:

```ts
useStitchSWR(getUser, { params: { id }, headers: { authorization: 'Bearer <token>' } });
// key → ['getUser', { params: { id }, headers: { authorization: 'Bearer <token>' } }]
```

The bearer token is now serialized into the SWR / TanStack Query key — which is **persisted** by cache providers, exposed via cache snapshots, and shown in **devtools / logs**.

The same raw-input passthrough also serializes runtime-only fields the contract says are **never serialized** (`signal`, `onProgress` — `packages/core/src/types.ts:29-40`). An **inline** `onProgress` gets a fresh function identity on every render, so the key changes every render → **endless refetch storm**.

## Shared root cause

Both functions derive the key the same way, so both share both bugs. The fix applies identical logic to `packages/swr/src/index.ts` and `packages/react/src/index.ts`.

## The fix

1. **Name fallback** — mirror core's `nameOf`, extended with a `url` fallback:
   ```ts
   const name = cfg?.name ?? cfg?.path ?? cfg?.url ?? 'stitch';
   ```
2. **Sanitize the key input** — never put the raw `input` in the key. Build `keyInput` that:
   - **excludes** `signal` and `onProgress` (runtime-only, never-serialized — excluding `onProgress` fixes the refetch storm);
   - **redacts the VALUES** of denylisted secret headers (`authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-api-key`, `x-auth-token`, plus any `*-token` / `*-api-key`) to `'[redacted]'`, keeping non-secret headers as-is;
   - keeps all cache-relevant fields (`params` / `query` / `body` / `variables` / any other non-excluded field) unchanged;
   - preserves `null`/`undefined` → `null` and primitives → as-is.
3. **Return shapes are unchanged** — swr still returns `[name, keyInput]` as `StitchSWRKey`; react still returns `queryKey: [name, keyInput]`.
4. In `@stitchapi/react` the `useStitchInternal` dep key (the re-fetch trigger) now routes through the same `nameOf` + sanitizing `defaultKey`, closing the same collision/churn there too.

### Maintainer decision needed — the headers policy

I chose to **redact secret header VALUES** rather than **drop the whole `headers` object**, because dropping all headers would re-introduce a *different* collision: two calls that legitimately differ only by a non-secret header (e.g. `accept-language`) would then share one cache entry and serve each other's data. Redacting also de-fragments the cache per-token (desirable — you don't want one entry per rotated token). The trade-off:

- **Redact secret values (this PR):** non-secret headers still vary the cache; only the denylisted values are masked. Relies on the denylist being complete.
- **Whitelist `params`/`query`/`body`/`variables` only (the alternative):** simplest and leak-proof by construction, but silently ignores *any* header for cache purposes — a correctness regression for header-varying reads.

Longer term, routing this through a future `__config.keyOf` on the stitch would let the stitch itself declare its cache key once and unify both adapters (and core) — at which point this local denylist goes away. Flagging for a maintainer call.

### Reused vs local denylist

Core's header denylist (`SECRET_HEADERS` in `packages/core/src/trace.ts`) is **not exported**, and the exported `redactSecretsDeep` / `isSecretKey` use the **query-param** denylist, which does **not** match `authorization` / `cookie` / `x-api-key`. So I defined a **small local header denylist** in each package (the task's stated fallback), mirroring core's `SECRET_HEADERS` and extending it with the `*-token` / `*-api-key` suffix rules.

## Fail-before / pass-after evidence

Three regression assertions were added to **each** package (`test/swr.spec.tsx`, `test/hooks.spec.tsx`): no collision, no secret leak, no refetch storm. Each **fails on the original derivation** and **passes after the fix**.

**Before (original code) — both packages, 5 new tests fail:**
```
× two nameless stitches with different paths get DIFFERENT keys
    → expected ['stitch', …] to not deeply equal ['stitch', …]
× a per-call authorization header does not put the token in the key
    → received '["getUser",{…,"headers":{"authorization":"Bearer SECRET123"}}]'
× redacts the secret header but keeps a benign one (no fresh collision)
    → expected 'Bearer SECRET123' not to contain 'SECRET123'
× two distinct inline onProgress functions produce EQUAL keys
    → the two keys are not deeply equal
× a per-call signal does not enter the key
    → received key still carries the AbortSignal
```

**After (this PR) — both packages green:**
```
@stitchapi/swr    Tests  11 passed (11)   (6 pre-existing + 5 new)
@stitchapi/react  Tests  16 passed (16)   (11 pre-existing + 5 new)
```

`pnpm --filter @stitchapi/swr check:types` and `pnpm --filter @stitchapi/react check:types` both pass; the whole-tree lefthook gate (format + lint + typecheck across all 35 workspace projects, incl. the `apps/docs` typed-deps rebuild of `@stitchapi/react`) passed on commit.

## Final key-derivation diff (both files)

```ts
// packages/swr/src/index.ts — swrKey()
- const name = (stitch as { __config?: { name?: string } }).__config?.name;
- return [name ?? 'stitch', input ?? null];
+ return [nameOf(stitch), keyInputFor(input)];

// packages/react/src/index.ts — stitchQueryOptions()
- const name = (stitch as { __config?: { name?: string } }).__config?.name;
- return { queryKey: [name ?? 'stitch', input ?? null], queryFn: … };
+ return { queryKey: [nameOf(stitch), keyInputFor(input)], queryFn: … };
```

where `nameOf` = `name ?? path ?? url ?? 'stitch'` and `keyInputFor` drops `signal`/`onProgress` and redacts secret header values (identical helper duplicated in each package).

## Not merged

Opened for review only, per the review-sweep remediation policy — a human merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
