### PR TITLE
fix(next,nest): don't leak raw upstream/transport error messages to the client (topology disclosure)

### DIFF
--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -161,6 +161,14 @@ app.useGlobalFilters(new StitchExceptionFilter(app.getHttpAdapter()));
 `status` takes a fixed number or a `(err) => number` function. Outside a filter, use
 `toHttpException(err, { status })` / `isStitchError(err)` directly.
 
+The client-facing **message** is a fixed `'Upstream request failed'` by default — the raw
+`err.message` is withheld, because it can disclose an internal hostname (a transport
+failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status
+(`HTTP 401`). The original error is always attached as the exception's `cause` for
+server-side logging. Opt in to a message when you need one: `{ exposeMessage: true }` for
+the raw message, or `{ message: 'Payment provider unavailable' }` / `{ message: (e) => … }`
+for a curated one.
+
 ## Streaming → SSE — `stitchSse`
 
 Return a stitch's `stream()` from a Nest `@Sse()` endpoint: `delta` chunks become messages,

--- a/packages/nest/src/exception-filter.ts
+++ b/packages/nest/src/exception-filter.ts
@@ -19,6 +19,9 @@ export function isStitchError(err: unknown): err is StitchErrorLike {
     return err instanceof Error && err.name === 'StitchError';
 }
 
+/** The safe, fixed message the mapped exception carries by default. */
+const SAFE_MESSAGE = 'Upstream request failed';
+
 export interface ToHttpExceptionOptions {
     /**
      * The HTTP status for the mapped exception. Default `502 Bad Gateway` — **every**
@@ -29,21 +32,51 @@ export interface ToHttpExceptionOptions {
      * specific codes (`(e) => (e.status === 429 ? 429 : 502)`).
      */
     status?: number | ((err: StitchErrorLike) => number);
+    /**
+     * Set the client-facing message. **Default: a fixed `'Upstream request failed'`** — the
+     * raw `err.message` is deliberately *not* forwarded, because it can disclose internal
+     * network topology (a transport failure reads like
+     * `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`)
+     * to an untrusted client. The original error is always attached as the exception's
+     * `cause` for server-side logging. Provide a fixed string, or a function for a
+     * per-error message. Prefer this over {@link exposeMessage} when you want a specific,
+     * curated message.
+     */
+    message?: string | ((err: StitchErrorLike) => string);
+    /**
+     * Opt in to forwarding the raw `err.message` as the client-facing message. **Default
+     * `false`** — see {@link message} for why the raw message is withheld by default. Ignored
+     * when {@link message} is set. Only enable this when the upstream messages are known to
+     * be safe to expose to your clients.
+     */
+    exposeMessage?: boolean;
 }
 
 /**
  * Map a thrown stitch failure to a Nest {@link HttpException}, or `undefined` when `err`
  * is not a {@link StitchErrorLike} (so a caller can rethrow it untouched). The status is
  * `502` by default; override it via {@link ToHttpExceptionOptions.status}.
+ *
+ * The client-facing message defaults to a fixed `'Upstream request failed'` — the raw
+ * `err.message` is **not** forwarded, since it can leak internal hostnames or the
+ * upstream's status to an untrusted client. The original error is attached as the
+ * exception's `cause` for server-side logging. Opt in to the raw message with
+ * {@link ToHttpExceptionOptions.exposeMessage}, or set your own with
+ * {@link ToHttpExceptionOptions.message}.
  */
 export function toHttpException(
     err: unknown,
     options: ToHttpExceptionOptions = {},
 ): HttpException | undefined {
     if (!isStitchError(err)) return undefined;
-    const { status = HttpStatus.BAD_GATEWAY } = options;
+    const { status = HttpStatus.BAD_GATEWAY, message, exposeMessage } = options;
     const code = typeof status === 'function' ? status(err) : status;
-    return new HttpException(err.message || 'Upstream request failed', code);
+    const clientMessage =
+        typeof message === 'function'
+            ? message(err)
+            : (message ??
+              (exposeMessage ? err.message || SAFE_MESSAGE : SAFE_MESSAGE));
+    return new HttpException(clientMessage, code, { cause: err });
 }
 
 /**

--- a/packages/nest/test/exception-filter.spec.ts
+++ b/packages/nest/test/exception-filter.spec.ts
@@ -31,7 +31,8 @@ describe('toHttpException', () => {
         const ex = toHttpException(stitchError('rate limited', 429));
         expect(ex).toBeInstanceOf(HttpException);
         expect(ex!.getStatus()).toBe(502);
-        expect(ex!.message).toContain('rate limited'); // message preserved
+        // the raw message is withheld by default (see the leak-regression block below)
+        expect(ex!.message).toBe('Upstream request failed');
         // a network error / timeout (no upstream status) → 502 too
         expect(toHttpException(stitchError('ECONNRESET'))!.getStatus()).toBe(
             502,
@@ -60,6 +61,58 @@ describe('toHttpException', () => {
 
     it('returns undefined for a non-stitch error (so the caller can rethrow)', () => {
         expect(toHttpException(new Error('other'))).toBeUndefined();
+    });
+
+    // Regression: the default response body must not echo the raw upstream/transport
+    // message, which can disclose internal network topology or the upstream's status
+    // semantics to an untrusted client.
+    describe('does not leak the raw error message by default', () => {
+        const bodyOf = (ex: HttpException): string =>
+            JSON.stringify(ex.getResponse());
+
+        it('a transport failure with an internal hostname is not disclosed', () => {
+            const ex = toHttpException(
+                stitchError('getaddrinfo ENOTFOUND payments.internal.corp'),
+            )!;
+            expect(ex.getStatus()).toBe(502);
+            const body = bodyOf(ex);
+            expect(body).not.toContain('payments.internal.corp');
+            expect(body).not.toContain('ENOTFOUND');
+            expect(ex.message).not.toContain('payments.internal.corp');
+        });
+
+        it("an upstream 401 does not surface as 'HTTP 401' in the body", () => {
+            const ex = toHttpException(stitchError('HTTP 401', 401))!;
+            expect(ex.getStatus()).toBe(502); // remapped, not the upstream 401
+            expect(bodyOf(ex)).not.toContain('HTTP 401');
+        });
+
+        it('still exposes the original error as `cause` for server-side logging', () => {
+            const original = stitchError(
+                'getaddrinfo ENOTFOUND payments.internal.corp',
+            );
+            const ex = toHttpException(original)!;
+            expect(ex.cause).toBe(original);
+        });
+
+        it('opt-in `exposeMessage: true` includes the raw message', () => {
+            const ex = toHttpException(
+                stitchError('getaddrinfo ENOTFOUND payments.internal.corp'),
+                { exposeMessage: true },
+            )!;
+            expect(bodyOf(ex)).toContain('payments.internal.corp');
+        });
+
+        it('opt-in `message` override sets a caller-chosen message', () => {
+            const fixed = toHttpException(stitchError('HTTP 401', 401), {
+                message: 'Payment provider unavailable',
+            })!;
+            expect(fixed.message).toBe('Payment provider unavailable');
+            const fromFn = toHttpException(stitchError('HTTP 429', 429), {
+                message: (e) => `upstream said ${e.status}`,
+            })!;
+            expect(fromFn.message).toBe('upstream said 429');
+        });
     });
 });
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -43,7 +43,7 @@ export async function GET(
 }
 ```
 
-`stitchErrorResponse` maps a `StitchError` to `502` by default (never leaking the upstream's status); pass `{ status: (e) => e.status ?? 502 }` to propagate it.
+`stitchErrorResponse` maps a `StitchError` to `502` by default (never leaking the upstream's status); pass `{ status: (e) => e.status ?? 502 }` to propagate it. The body is a generic, status-tied message (`{ error: 'Bad Gateway' }`) — the raw `err.message` is withheld, since it can leak an internal hostname (`getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`). Opt in with `{ body: (e) => ({ error: e.message }) }` when the upstream messages are safe to expose.
 
 ## Streaming with SSE
 

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -155,6 +155,13 @@ export function isStitchError(err: unknown): err is StitchErrorLike {
     return err instanceof Error && err.name === 'StitchError';
 }
 
+// A small map of the statuses this helper emits → their generic reason phrase, used for
+// the default body so the raw error message is never echoed to the client.
+const STATUS_TEXT: Record<number, string> = {
+    500: 'Internal Server Error',
+    502: 'Bad Gateway',
+};
+
 export interface ErrorResponseOptions {
     /**
      * The HTTP status for the mapped failure. Default `502` for a `StitchError` (an
@@ -163,7 +170,15 @@ export interface ErrorResponseOptions {
      * function: propagate the upstream status with `(e) => e.status ?? 502`.
      */
     status?: number | ((err: StitchErrorLike) => number);
-    /** Shape the JSON body. Default `{ error: err.message }`. */
+    /**
+     * Shape the JSON body. **Default: a generic, status-tied message**
+     * (`{ error: 'Bad Gateway' }`) — the raw `err.message` is deliberately *not* echoed,
+     * because it can disclose internal network topology (a transport failure reads like
+     * `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`)
+     * to an untrusted client. Provide this to shape the body yourself; pass
+     * `(e) => ({ error: e.message })` to opt in to the raw message when the upstream
+     * messages are known to be safe to expose.
+     */
     body?: (err: StitchErrorLike, status: number) => unknown;
 }
 
@@ -178,6 +193,11 @@ export interface ErrorResponseOptions {
  *     throw err;
  * }
  * ```
+ *
+ * The default body is a generic, status-tied message (`{ error: 'Bad Gateway' }`) — the
+ * raw `err.message` is **not** echoed, since it can leak internal hostnames or the
+ * upstream's status to an untrusted client. Opt in to a custom (or the raw) message with
+ * {@link ErrorResponseOptions.body}.
  */
 export function stitchErrorResponse(
     err: unknown,
@@ -190,6 +210,8 @@ export function stitchErrorResponse(
         typeof options.status === 'function'
             ? options.status(e)
             : (options.status ?? fallback);
-    const body = options.body ? options.body(e, status) : { error: e.message };
+    const body = options.body
+        ? options.body(e, status)
+        : { error: STATUS_TEXT[status] ?? 'Error' };
     return Response.json(body, { status });
 }

--- a/packages/next/test/next.spec.ts
+++ b/packages/next/test/next.spec.ts
@@ -135,11 +135,12 @@ describe('sseResponse', () => {
 // --- stitchErrorResponse ---------------------------------------------------
 
 describe('stitchErrorResponse', () => {
-    test('a StitchError maps to 502 by default with a JSON body', async () => {
+    test('a StitchError maps to 502 by default with a generic JSON body', async () => {
         const res = stitchErrorResponse(stitchError('upstream down', 503));
         expect(res.status).toBe(502);
         expect(res.headers.get('content-type')).toContain('application/json');
-        expect(await res.json()).toEqual({ error: 'upstream down' });
+        // the raw message is withheld by default (see the leak-regression block below)
+        expect(await res.json()).toEqual({ error: 'Bad Gateway' });
     });
 
     test('status can propagate the upstream status', async () => {
@@ -152,6 +153,35 @@ describe('stitchErrorResponse', () => {
     test('a non-StitchError defaults to 500', async () => {
         const res = stitchErrorResponse(new Error('oops'));
         expect(res.status).toBe(500);
+    });
+
+    // Regression: the default body must not echo the raw upstream/transport message,
+    // which can leak internal network topology (a transport error names the host it
+    // failed to reach) or the upstream's status semantics to an untrusted client.
+    describe('does not leak the raw error message by default', () => {
+        test('a transport failure with an internal hostname is not disclosed', async () => {
+            const res = stitchErrorResponse(
+                stitchError('getaddrinfo ENOTFOUND payments.internal.corp'),
+            );
+            expect(res.status).toBe(502);
+            const body = await res.text();
+            expect(body).not.toContain('payments.internal.corp');
+            expect(body).not.toContain('ENOTFOUND');
+        });
+
+        test("an upstream 401 does not surface as 'HTTP 401' in the body", async () => {
+            const res = stitchErrorResponse(stitchError('HTTP 401', 401));
+            expect(res.status).toBe(502);
+            expect(await res.text()).not.toContain('HTTP 401');
+        });
+
+        test('the `body` opt-in can still include the raw message', async () => {
+            const res = stitchErrorResponse(
+                stitchError('getaddrinfo ENOTFOUND payments.internal.corp'),
+                { body: (e) => ({ error: e.message }) },
+            );
+            expect(await res.text()).toContain('payments.internal.corp');
+        });
     });
 });
 


### PR DESCRIPTION
## The leak

Both `@stitchapi/next` and `@stitchapi/nest` map a thrown `StitchError` to a **client-facing** HTTP response and, **by default**, forward the raw `error.message` straight into the response body. The status is safely remapped to `502`, but the message is not — and the message is attacker-relevant:

- an upstream **`401`** surfaces as the string **`HTTP 401`** (core builds it in `packages/core/src/engine.ts`), re-exposing the upstream status the `502` remap was meant to hide;
- a transport / BYO-adapter failure reads like **`getaddrinfo ENOTFOUND payments.internal.corp`**, disclosing an **internal hostname / network topology** to an untrusted client.

This directly contradicts both packages' own docs — nest's filter claimed the `502` default "never leaks an upstream's `401`/`404`", and next's `stitchErrorResponse` claimed the same.

Confirmed by the fail-before evidence below: the serialized bodies were literally `{"error":"getaddrinfo ENOTFOUND payments.internal.corp"}` and `{"error":"HTTP 401"}`.

## The fix (both packages, backward-compatible except the intended default change)

The default response body no longer contains the raw upstream/internal message. The raw message becomes **opt-in**.

**nest — `toHttpException` / `StitchExceptionFilter`** (`packages/nest/src/exception-filter.ts`)
- Default client-facing message is now a fixed **`'Upstream request failed'`**.
- The original error is attached as the `HttpException` **`cause`**, so it's still available for server-side logging/observability without going in the client body.
- Two opt-ins added to `ToHttpExceptionOptions`:
  - `exposeMessage?: boolean` (default `false`) — forward the raw `err.message`;
  - `message?: string | ((err) => string)` — a curated message (takes precedence over `exposeMessage`).

**next — `stitchErrorResponse`** (`packages/next/src/index.ts`)
- `ErrorResponseOptions` **already had** a `body?: (err, status) => unknown` escape hatch. The fix is simply to **stop defaulting** that body to `{ error: e.message }`.
- The default body is now a generic, status-tied message: `{ error: 'Bad Gateway' }` (502) / `{ error: 'Internal Server Error' }` (500).
- Opt-in path (unchanged API): `stitchErrorResponse(err, { body: (e) => ({ error: e.message }) })`.

Public APIs stay backward-compatible; the only behavior change is the intended one — the **default** body no longer echoes the raw message. JSDoc + both READMEs updated to match.

## Regression tests — fail-before / pass-after

One leak-regression block added per package (plus the two pre-existing tests that asserted the old leaking body were updated to the safe default).

**nest** (`packages/nest/test/exception-filter.spec.ts`): a `StitchError` whose message is `getaddrinfo ENOTFOUND payments.internal.corp` → rendered body (`getResponse()`) contains neither `payments.internal.corp` nor `ENOTFOUND` (and `.message` doesn't either); a `HTTP 401` message → body does not contain `HTTP 401` (status still `502`); the original error is exposed as `cause`; `exposeMessage: true` and the `message` override both include/set the message.

**next** (`packages/next/test/next.spec.ts`): the same transport `StitchError` → serialized JSON body contains neither `payments.internal.corp` nor `ENOTFOUND` (status `502`); `HTTP 401` withheld; the `body` opt-in still includes the raw message.

```
FAIL-BEFORE (original code — message leaks, opt-ins absent)
  nest:  Test Files 1 failed | 3 passed (4)   Tests 4 failed | 43 passed (47)
  next:  Test Files 1 failed (1)               Tests 2 failed | 14 passed (16)
    e.g. Received: {"error":"getaddrinfo ENOTFOUND payments.internal.corp"}
         Received: {"error":"HTTP 401"}

PASS-AFTER (fix applied)
  nest:  Test Files 4 passed (4)   Tests 47 passed (47)   check:types OK
  next:  Test Files 1 passed (1)   Tests 16 passed (16)   check:types OK
```

The full-tree lefthook pre-commit gate (format + lint + typecheck across all 35 workspace projects) also passed.

## Related follow-up (intentionally not in this PR)

The next SSE **`error` frame** (`packages/next/src/index.ts`, in `sseResponse`) still forwards `event.message` into the `event: error` data. That is an explicit stream error-event contract — sanitizing it is a separate decision (it may want the same opt-in treatment, or a documented "SSE frames carry the message" stance). Left untouched here and flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
