### PR TITLE
fix(fastify,express): don't leak raw upstream/transport error messages to the client (topology disclosure)

### DIFF
--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -93,12 +93,15 @@ charge):
 
 ```ts
 app.use(stitchErrorHandler());
-// default 502 — an upstream's 401/404/etc. is never leaked to your client.
+// default 502, body `{ error: 'Bad Gateway' }` — neither the upstream's
+// 401/404/etc. status nor the raw error message is leaked to your client (a
+// transport failure would otherwise read like `getaddrinfo ENOTFOUND
+// payments.internal.corp`, disclosing internal topology).
 
 // propagate the upstream status instead:
 app.use(stitchErrorHandler({ status: (e) => e.status ?? 502 }));
 
-// or shape your own error envelope:
+// or shape your own error envelope (this opts in to the raw message):
 app.use(
     stitchErrorHandler({
         body: (e, status) => ({ code: status, msg: e.message }),

--- a/packages/express/src/error.ts
+++ b/packages/express/src/error.ts
@@ -28,13 +28,25 @@ export interface StitchErrorHandlerOptions {
      */
     status?: number | ((err: StitchErrorLike) => number);
     /**
-     * The JSON body for a mapped stitch failure. Default: `{ error: <message> }`. Override to shape
-     * your own error envelope. Receives the mapped status alongside the error.
+     * The JSON body for a mapped stitch failure. **Default: a generic, status-tied message**
+     * (`{ error: 'Bad Gateway' }`) — the raw `err.message` is deliberately *not* echoed, because it
+     * can disclose internal network topology (a transport failure reads like
+     * `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to an
+     * untrusted client. Override to shape your own error envelope; pass `(e) => ({ error: e.message })`
+     * to opt in to the raw message when the upstream messages are known to be safe to expose.
+     * Receives the mapped status alongside the error.
      */
     body?: (err: StitchErrorLike, status: number) => unknown;
 }
 
 const DEFAULT_STATUS = 502;
+
+// A small map of the statuses this middleware emits → their generic reason phrase, used for
+// the default body so the raw error message is never echoed to the client.
+const STATUS_TEXT: Record<number, string> = {
+    500: 'Internal Server Error',
+    502: 'Bad Gateway',
+};
 
 function resolveStatus(
     err: StitchErrorLike,
@@ -74,9 +86,12 @@ export function stitchErrorHandler(
             return;
         }
         const status = resolveStatus(err, options.status);
+        // Default body is a generic, status-tied message — the raw `err.message` is deliberately
+        // withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status
+        // (`HTTP 401`) never reaches the client. Opt in via `options.body`.
         const body = options.body
             ? options.body(err, status)
-            : { error: err.message || 'Upstream request failed' };
+            : { error: STATUS_TEXT[status] ?? 'Error' };
         res.status(status).json(body);
     };
 }

--- a/packages/express/test/express.spec.ts
+++ b/packages/express/test/express.spec.ts
@@ -324,8 +324,68 @@ describe('stitchErrorHandler maps a StitchError to HTTP', () => {
         );
 
         expect(res.statusCode).toBe(502); // gateway default — upstream 503 is not leaked
-        expect(res.jsonBody).toEqual({ error: 'down' });
+        // The default body is the generic, status-tied phrase — NOT the raw upstream message.
+        expect(res.jsonBody).toEqual({ error: 'Bad Gateway' });
         expect(nextedWith).toBe('untouched'); // mapped, so next() was not called
+    });
+
+    test('does not leak a transport failure message (internal hostname) by default', () => {
+        // The exact shape core throws for a BYO-adapter/DNS failure: message carries the host.
+        const err = Object.assign(
+            new Error('getaddrinfo ENOTFOUND payments.internal.corp'),
+            { name: 'StitchError' },
+        );
+        const res = mockRes();
+        stitchErrorHandler()(
+            err,
+            mockReq() as unknown as Request,
+            res as unknown as Response,
+            () => undefined,
+        );
+
+        expect(res.statusCode).toBe(502); // status stays masked
+        const serialized = JSON.stringify(res.jsonBody);
+        expect(serialized).not.toContain('payments.internal.corp');
+        expect(serialized).not.toContain('ENOTFOUND');
+        expect(res.jsonBody).toEqual({ error: 'Bad Gateway' });
+    });
+
+    test('does not leak the upstream status message (`HTTP 401`) by default', () => {
+        // core builds `HTTP <status>` (packages/core/src/engine.ts) for an upstream error.
+        const err = Object.assign(new Error('HTTP 401'), {
+            name: 'StitchError',
+            status: 401,
+        });
+        const res = mockRes();
+        stitchErrorHandler()(
+            err,
+            mockReq() as unknown as Request,
+            res as unknown as Response,
+            () => undefined,
+        );
+
+        expect(res.statusCode).toBe(502);
+        expect(JSON.stringify(res.jsonBody)).not.toContain('HTTP 401');
+        expect(res.jsonBody).toEqual({ error: 'Bad Gateway' });
+    });
+
+    test('the `body` opt-in still includes the raw message', () => {
+        const err = Object.assign(
+            new Error('getaddrinfo ENOTFOUND payments.internal.corp'),
+            { name: 'StitchError' },
+        );
+        const res = mockRes();
+        stitchErrorHandler({ body: (e) => ({ error: e.message }) })(
+            err,
+            mockReq() as unknown as Request,
+            res as unknown as Response,
+            () => undefined,
+        );
+
+        // The escape hatch is preserved — callers who want the message can still opt in.
+        expect(res.jsonBody).toEqual({
+            error: 'getaddrinfo ENOTFOUND payments.internal.corp',
+        });
     });
 
     test('can propagate the upstream status', () => {

--- a/packages/fastify/README.md
+++ b/packages/fastify/README.md
@@ -107,13 +107,19 @@ aborts the upstream stitch generator rather than leaving it running.
 
 The plugin registers a `setErrorHandler` that maps a `StitchError` to an HTTP
 response and rethrows everything else (so Fastify's default handler stays in
-charge):
+charge). By default the status is `502` **and** the body is a generic,
+status-tied message (`{ error: 'Bad Gateway' }`) — the raw `error.message` is
+withheld, because it can leak an internal hostname (`getaddrinfo ENOTFOUND
+payments.internal.corp`) or the upstream's status (`HTTP 401`) to an untrusted
+client:
 
 ```ts
 await app.register(stitchPlugin, {
     seamConfig: { baseUrl: '…' },
     // propagate the upstream status instead of the safe 502 default:
     errorHandler: { status: (e) => e.status ?? 502 },
+    // opt in to the raw message (only when upstream messages are safe to expose):
+    // errorHandler: { body: (e) => ({ error: e.message }) },
 });
 ```
 

--- a/packages/fastify/src/error-handler.ts
+++ b/packages/fastify/src/error-handler.ts
@@ -24,13 +24,25 @@ export interface StitchErrorHandlerOptions {
      */
     status?: number | ((err: StitchErrorLike) => number);
     /**
-     * The JSON body for a mapped stitch failure. Default: `{ error: <message> }`. Override
-     * to shape your own error envelope. Receives the mapped status alongside the error.
+     * The JSON body for a mapped stitch failure. **Default: a generic, status-tied message**
+     * (`{ error: 'Bad Gateway' }`) — the raw `err.message` is deliberately *not* echoed,
+     * because it can disclose internal network topology (a transport failure reads like
+     * `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`)
+     * to an untrusted client. Override to shape your own error envelope; pass
+     * `(e) => ({ error: e.message })` to opt in to the raw message when the upstream
+     * messages are known to be safe to expose. Receives the mapped status alongside the error.
      */
     body?: (err: StitchErrorLike, status: number) => unknown;
 }
 
 const DEFAULT_STATUS = 502;
+
+// A small map of the statuses this handler emits → their generic reason phrase, used for
+// the default body so the raw error message is never echoed to the client.
+const STATUS_TEXT: Record<number, string> = {
+    500: 'Internal Server Error',
+    502: 'Bad Gateway',
+};
 
 function resolveStatus(
     err: StitchErrorLike,
@@ -63,9 +75,12 @@ export function stitchErrorHandler(
             throw error;
         }
         const status = resolveStatus(error, options.status);
+        // Default body is a generic, status-tied message — the raw `error.message` is
+        // deliberately withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the
+        // upstream's status (`HTTP 401`) never reaches the client. Opt in via `options.body`.
         const body = options.body
             ? options.body(error, status)
-            : { error: error.message || 'Upstream request failed' };
+            : { error: STATUS_TEXT[status] ?? 'Error' };
         void reply.status(status).send(body);
     };
 }

--- a/packages/fastify/test/fastify.spec.ts
+++ b/packages/fastify/test/fastify.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../src';
 
 import Fastify from 'fastify';
+import type { FastifyError, FastifyReply, FastifyRequest } from 'fastify';
 import type {
     Adapter,
     AdapterRequest,
@@ -238,7 +239,8 @@ describe('stitchPlugin', () => {
 
         const res = await app.inject({ method: 'GET', url: '/fail' });
         expect(res.statusCode).toBe(502); // gateway default — upstream 503 is not leaked
-        expect(res.json()).toMatchObject({ error: expect.any(String) });
+        // The default body is the generic, status-tied phrase — NOT the raw upstream message.
+        expect(res.json()).toEqual({ error: 'Bad Gateway' });
     });
 
     test('the error handler can propagate the upstream status', async () => {
@@ -306,5 +308,85 @@ describe('isStitchError / stitchErrorHandler unit', () => {
                 } as never,
             ),
         ).toThrow('plain');
+    });
+
+    // A fake reply capturing the `.status(code).send(body)` chain, so the handler can be driven
+    // directly (no Fastify instance) to assert exactly what body leaves the process.
+    function captureReply(): {
+        reply: FastifyReply;
+        statusCode: number | undefined;
+        sent: unknown;
+    } {
+        const captured: { statusCode: number | undefined; sent: unknown } = {
+            statusCode: undefined,
+            sent: undefined,
+        };
+        const reply = {
+            status(code: number) {
+                captured.statusCode = code;
+                return this;
+            },
+            send(body: unknown) {
+                captured.sent = body;
+                return this;
+            },
+        };
+        return {
+            reply: reply as unknown as FastifyReply,
+            get statusCode() {
+                return captured.statusCode;
+            },
+            get sent() {
+                return captured.sent;
+            },
+        };
+    }
+
+    test('does not leak a transport failure message (internal hostname) by default', () => {
+        // The exact shape core throws for a BYO-adapter/DNS failure: message carries the host.
+        const err = Object.assign(
+            new Error('getaddrinfo ENOTFOUND payments.internal.corp'),
+            { name: 'StitchError' },
+        ) as unknown as FastifyError;
+        const cap = captureReply();
+        stitchErrorHandler()(err, {} as FastifyRequest, cap.reply);
+
+        expect(cap.statusCode).toBe(502); // status stays masked
+        const serialized = JSON.stringify(cap.sent);
+        expect(serialized).not.toContain('payments.internal.corp');
+        expect(serialized).not.toContain('ENOTFOUND');
+        expect(cap.sent).toEqual({ error: 'Bad Gateway' });
+    });
+
+    test('does not leak the upstream status message (`HTTP 401`) by default', () => {
+        // core builds `HTTP <status>` (packages/core/src/engine.ts) for an upstream error.
+        const err = Object.assign(new Error('HTTP 401'), {
+            name: 'StitchError',
+            status: 401,
+        }) as unknown as FastifyError;
+        const cap = captureReply();
+        stitchErrorHandler()(err, {} as FastifyRequest, cap.reply);
+
+        expect(cap.statusCode).toBe(502);
+        expect(JSON.stringify(cap.sent)).not.toContain('HTTP 401');
+        expect(cap.sent).toEqual({ error: 'Bad Gateway' });
+    });
+
+    test('the `body` opt-in still includes the raw message', () => {
+        const err = Object.assign(
+            new Error('getaddrinfo ENOTFOUND payments.internal.corp'),
+            { name: 'StitchError' },
+        ) as unknown as FastifyError;
+        const cap = captureReply();
+        stitchErrorHandler({ body: (e) => ({ error: e.message }) })(
+            err,
+            {} as FastifyRequest,
+            cap.reply,
+        );
+
+        // The escape hatch is preserved — callers who want the message can still opt in.
+        expect(cap.sent).toEqual({
+            error: 'getaddrinfo ENOTFOUND payments.internal.corp',
+        });
     });
 });


### PR DESCRIPTION
## The leak

Both `@stitchapi/fastify` and `@stitchapi/express` map a thrown `StitchError` to a **client-facing** HTTP response and, **by default**, forwarded the raw `error.message` straight into the response body. The status is safely remapped to `502`, but the message is not — and the message is attacker-relevant:

- an upstream **`401`** surfaces as the string **`HTTP 401`** (core builds it in `packages/core/src/engine.ts`), re-exposing the upstream status the `502` remap was meant to hide;
- a transport / BYO-adapter failure reads like **`getaddrinfo ENOTFOUND payments.internal.corp`**, disclosing an **internal hostname / network topology** to an untrusted client.

This directly contradicts each package's own docs, which claimed the `502` default "never leaks an upstream's `401`/`404`/etc. semantics to your client."

This is the **same bug class already fixed for next+nest in #407** (`fix/next-nest-error-response-leak`). fastify and express are the two remaining instances; this PR is a fresh branch and does not touch #407.

The leak sites (before this PR):
- fastify — `packages/fastify/src/error-handler.ts`: `... : { error: error.message || 'Upstream request failed' }` (the handler is auto-registered by the plugin at `plugin.ts:156`, so it leaked **by default**).
- express — `packages/express/src/error.ts`: `... : { error: err.message || 'Upstream request failed' }`.

Confirmed by the fail-before evidence below: the serialized bodies were literally `{"error":"getaddrinfo ENOTFOUND payments.internal.corp"}` and `{"error":"HTTP 401"}`.

## The fix (both packages, backward-compatible except the intended default change)

The default response body no longer contains the raw upstream/internal message; the raw message becomes **opt-in**. This mirrors #407's `next` fix exactly.

- The default body is now a generic, status-tied message via a small `STATUS_TEXT` map (`500: 'Internal Server Error'`, `502: 'Bad Gateway'`) → `{ error: STATUS_TEXT[status] ?? 'Error' }`. For the `502` default that's `{ error: 'Bad Gateway' }`.
- The pre-existing `body?: (err, status) => unknown` option is **preserved** as the escape hatch — pass `(e) => ({ error: e.message })` to opt back in to the raw message when the upstream messages are known safe.
- Status resolution and the rethrow (fastify) / `next(err)` (express) behaviour for non-`StitchError`s are **untouched**.
- JSDoc on `StitchErrorHandlerOptions.body` + both package READMEs updated to describe the new default (status masked **and** message not echoed; use `body` to include it).

Public APIs stay backward-compatible; the only behaviour change is the intended one — the **default** body no longer echoes the raw message.

## Regression tests — fail-before / pass-after

One leak-regression block added per package, plus the two pre-existing tests that asserted the old leaking body were strengthened to the safe default (fastify's `error handler maps a StitchError to 502` had only asserted `error: expect.any(String)`; express's had asserted `{ error: 'down' }`).

For **each** package the handler/middleware is driven directly with a `StitchError`:
- message `getaddrinfo ENOTFOUND payments.internal.corp` → sent body contains **neither** `payments.internal.corp` **nor** `ENOTFOUND`, status stays `502`;
- message `HTTP 401` → body does **not** contain `HTTP 401`, status stays `502`;
- the `body` opt-in still includes the raw message.

(Fastify drives `stitchErrorHandler(opts)(error, req, reply)` with a fake `reply` capturing `.status()`/`.send()`; express drives the middleware with the existing `mockRes()` capturing `.status()`/`.json()`.)

```
FAIL-BEFORE (original code — message leaks)
  fastify:  Test Files 1 failed | 1 passed (2)   Tests 3 failed | 18 passed (21)
  express:  Test Files 1 failed (1)               Tests 3 failed | 14 passed (17)
    e.g. Received: {"error":"getaddrinfo ENOTFOUND payments.internal.corp"}
         Received: {"error":"HTTP 401"}
         Received: {"error":"HTTP 503"} / {"error":"down"}   (strengthened default-body tests)
  (the `body` opt-in test passes in both — that path is unchanged.)

PASS-AFTER (fix applied)
  fastify:  Test Files 2 passed (2)   Tests 21 passed (21)   check:types OK
  express:  Test Files 1 passed (1)   Tests 17 passed (17)   check:types OK
```

`prettier --check` passes on all six changed files.

## Related follow-up (intentionally not in this PR)

The **SSE `error` frame** in both packages still forwards the raw `event.message` into the `event: error` data frame (`data: <message>` — see `sendStitchSse` / `streamStitchSse`; the existing tests assert `event: error\ndata: upstream blew up`). Like #407's note on next's SSE `error` frame, that is an explicit stream error-event contract and sanitizing it is a separate decision (it may want the same opt-in treatment, or a documented "SSE frames carry the message" stance). Left **untouched** here and flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)