### PR TITLE
fix(core): redact request body & GraphQL variables in trace transport frames (serve SSE credential leak)

### DIFF
--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -2,7 +2,14 @@
 // optionally, print a compact colored one-line-per-event summary to stderr. No deps.
 import { compact } from './compact';
 import type { DriftLevel, StitchEvent, TraceContext, TraceSink } from './types';
-import { dirnameOf, isSecretQueryKey, nodeFs, readEnv, scrubUrl } from './util';
+import {
+    dirnameOf,
+    isSecretQueryKey,
+    nodeFs,
+    readEnv,
+    redactSecretsDeep,
+    scrubUrl,
+} from './util';
 
 export interface TraceOptions {
     console?: boolean; // pretty one-line-per-event to stderr (default true)
@@ -36,13 +43,20 @@ const SECRET_HEADERS = [
 const REDACTED = '[REDACTED]';
 
 // Redact an event for delivery over an UNTRUSTED transport — the `stitch serve` SSE stream, which
-// is unauthenticated and may be fronted. Unlike the built-in sinks this PRESERVES the payload
-// (`delta`/`result` — a streaming consumer asked for it); it only scrubs the credential-bearing
-// metadata a `start` frame echoes back: URL credentials + secret query values in the URL string
-// (via `scrubUrl`), the SAME secret query values in the structured `input.query` (via
-// `redactSecretQuery` — `scrubUrl` reaches only the URL string, so the parsed query must be
-// scrubbed too, exactly as the JSONL sink does), and any denylisted header value in `input.headers`
-// (`authorization` / `cookie` / …). Every other event type passes through untouched.
+// is unauthenticated and may be fronted. Unlike the built-in sinks this PRESERVES the response
+// payload (`delta`/`result` — a streaming consumer asked for it); it only scrubs the credential-
+// bearing metadata a `start` frame echoes back from the caller's own request input:
+//   - URL credentials + secret query values in the URL string (via `scrubUrl`);
+//   - the SAME secret query values in the structured `input.query` (via `redactSecretQuery` —
+//     `scrubUrl` reaches only the URL string, so the parsed query must be scrubbed too);
+//   - any denylisted header value in `input.headers` (`authorization` / `cookie` / …);
+//   - secret-named fields anywhere in the request `input.body` and GraphQL `input.variables`
+//     (via `redactSecretsDeep` — the shared deep secret-key redactor, keyed on the same
+//     `isSecretKey` set: `password` / `client_secret` / `token` / `api_key` / …). A `start`
+//     frame echoes the request input verbatim, so an OAuth password-grant body
+//     (`{ grant_type, client_secret, password }`) or a GraphQL `login($password:)` variable
+//     would otherwise ride the unauthenticated stream in the clear.
+// Every other event type passes through untouched.
 export function redactEventForTransport(event: StitchEvent): StitchEvent {
     if (event.type !== 'start') return event;
     const headers = event.input.headers;
@@ -56,17 +70,28 @@ export function redactEventForTransport(event: StitchEvent): StitchEvent {
         : undefined;
     const query = event.input.query;
     const safeQuery = query ? redactSecretQuery(query) : undefined;
+    // Deep-scrub secret-named fields in the echoed request body / GraphQL variables.
+    // `redactSecretsDeep(undefined) === undefined`, so an absent `body`/`variables` yields
+    // `undefined` and is dropped by `compact` below — matching the pre-fix behaviour of the
+    // `...event.input` spread. A present-but-falsy body (`null`/`''`/`0`) redacts to itself and
+    // is kept. `variables` is a plain object; the cast restores its declared shape.
+    const safeBody = redactSecretsDeep(event.input.body);
+    const safeVariables = redactSecretsDeep(event.input.variables) as
+        | Record<string, unknown>
+        | undefined;
     return {
         ...event,
         url: scrubUrl(event.url),
-        // `compact` drops `headers`/`query` when their redacted values are undefined —
-        // which is exactly when `event.input` lacked them (safeHeaders/safeQuery are derived
-        // from event.input.headers/.query), so it only ever omits the conditional override,
-        // never a key the `...event.input` spread provided.
+        // `compact` drops `headers`/`query`/`body`/`variables` when their redacted values are
+        // undefined — which is exactly when `event.input` lacked them (each safe* value is derived
+        // from the corresponding `event.input` field), so it only ever omits the conditional
+        // override, never a key the `...event.input` spread provided.
         input: compact({
             ...event.input,
             headers: safeHeaders,
             query: safeQuery,
+            body: safeBody,
+            variables: safeVariables,
         }),
     };
 }

--- a/packages/core/test/serve.spec.ts
+++ b/packages/core/test/serve.spec.ts
@@ -141,6 +141,36 @@ test('SSE start frame scrubs a secret query param the caller echoed (structured 
     expect(text).not.toContain('SQLEAK'); // the secret never rides the wire (url OR structured input)
 });
 
+test('SSE start frame deep-redacts a secret in the echoed request body & GraphQL variables (serve is unauthenticated)', async () => {
+    api.route('GET', '/ping', { body: { ok: true } });
+    const res = await fetch(`${base}/stitch/ping`, {
+        method: 'POST',
+        headers: { accept: 'text/event-stream' },
+        // An OAuth password-grant-shaped body + a GraphQL login variable: credentials the caller
+        // put in the request input, echoed back in the `start` frame.
+        body: JSON.stringify({
+            body: { password: 'BODYLEAK', client_secret: 'CSLEAK', keep: 'ok' },
+            variables: { password: 'VARLEAK', user: 'alice' },
+        }),
+    });
+    const text = await res.text();
+    const start = parseSse(text).find((f) => f.event === 'start');
+    const echoed = start?.data?.['input'] as
+        | {
+              body?: Record<string, unknown>;
+              variables?: Record<string, unknown>;
+          }
+        | undefined;
+    expect(echoed?.body?.['password']).toBe('REDACTED'); // secret body field scrubbed before it leaves
+    expect(echoed?.body?.['client_secret']).toBe('REDACTED');
+    expect(echoed?.body?.['keep']).toBe('ok'); // benign body field preserved
+    expect(echoed?.variables?.['password']).toBe('REDACTED'); // secret GraphQL variable scrubbed
+    expect(echoed?.variables?.['user']).toBe('alice'); // benign variable preserved
+    expect(text).not.toContain('BODYLEAK'); // no body/variable secret rides the wire
+    expect(text).not.toContain('CSLEAK');
+    expect(text).not.toContain('VARLEAK');
+});
+
 test('an unknown stitch is a 404 with a listing message', async () => {
     const res = await fetch(`${base}/stitch/nope`, {
         method: 'POST',

--- a/packages/core/test/trace-redact-transport.spec.ts
+++ b/packages/core/test/trace-redact-transport.spec.ts
@@ -97,11 +97,57 @@ describe('redactEventForTransport', () => {
         expect(out.input.headers).toBeUndefined();
     });
 
+    test('deep-redacts secret-named fields in the echoed request body and GraphQL variables, keeping benign ones', () => {
+        // A `start` frame echoes the caller's request input verbatim. On the unauthenticated
+        // `serve` SSE stream a credential-bearing body (OAuth password grant) or GraphQL variable
+        // must not ride the wire in the clear — headers/query redaction alone left this gap.
+        const out = asStart(
+            redactEventForTransport(
+                startEvent({
+                    input: {
+                        body: {
+                            grant_type: 'password',
+                            password: 'hunter2',
+                            client_secret: 's3cr3t',
+                            keep: 'ok',
+                        },
+                        variables: { password: 'hunter2', user: 'alice' },
+                    },
+                }),
+            ),
+        );
+        const body = out.input.body as Record<string, unknown>;
+        expect(body['password']).toBe('REDACTED'); // secret body field scrubbed
+        expect(body['client_secret']).toBe('REDACTED'); // `secret` stem caught
+        expect(body['keep']).toBe('ok'); // benign body field preserved
+        expect(body['grant_type']).toBe('password'); // benign field whose *value* is "password" kept
+        expect(out.input.variables!['password']).toBe('REDACTED'); // secret GraphQL variable scrubbed
+        expect(out.input.variables!['user']).toBe('alice'); // benign variable preserved
+        // Belt-and-braces: the serialized event carries neither plaintext secret anywhere.
+        const serialized = JSON.stringify(out);
+        expect(serialized).not.toContain('hunter2');
+        expect(serialized).not.toContain('s3cr3t');
+    });
+
+    test('does not add a `body`/`variables` key when the caller sent none', () => {
+        const out = asStart(redactEventForTransport(startEvent({ input: {} })));
+        expect('body' in out.input).toBe(false);
+        expect('variables' in out.input).toBe(false);
+    });
+
     test('does not mutate the original event', () => {
         const orig = startEvent({
-            input: { headers: { authorization: 'Bearer tok' } },
+            input: {
+                headers: { authorization: 'Bearer tok' },
+                body: { password: 'hunter2' },
+                variables: { token: 'v-tok' },
+            },
         });
         redactEventForTransport(orig);
         expect(orig.input.headers!['authorization']).toBe('Bearer tok');
+        expect((orig.input.body as Record<string, unknown>)['password']).toBe(
+            'hunter2',
+        ); // engine keeps the real body
+        expect(orig.input.variables!['token']).toBe('v-tok'); // and the real variables
     });
 });


### PR DESCRIPTION
## The leak

`redactEventForTransport` (`packages/core/src/trace.ts`) is the sanitizer every event passes through before it leaves over the **unauthenticated** `stitch serve` SSE stream (`serve.ts` → `streamSse` calls it per event; the server is loopback-by-default but may be fronted, and the SSE consumer is remote).

For a `start` event it scrubbed the URL (`scrubUrl`), secret headers (the `SECRET_HEADERS` denylist), and secret query params (`redactSecretQuery`) — but built the returned input as:

```ts
input: compact({ ...event.input, headers: safeHeaders, query: safeQuery })
```

It spread `...event.input` and overrode **only** `headers` + `query`. So the echoed **`input.body`** and GraphQL **`input.variables`** passed through **verbatim**.

A `start` frame echoes the caller's request input, so an OAuth password-grant body:

```json
{ "body": { "grant_type": "password", "client_secret": "s3cr3t", "password": "hunter2" } }
```

or a GraphQL `login($password:)` variable rode the `start` SSE frame **in the clear** to any stream observer / fronting proxy — a body-borne credential leak on the transport path.

### The asymmetry

The trace surfaces disagreed on the body. `redactEventForTransport` (the SSE transport) redacted headers/query/URL but not body/variables, so body-borne secrets leaked on that unauthenticated path. This change closes that gap by scrubbing the body/variables there too, using the same secret-key redactor the rest of the codebase already relies on.

## The fix

Deep-scrub `input.body` and `input.variables` through the **existing** shared `redactSecretsDeep` helper (`util.ts`) — the same `isSecretKey` secret-key set (`password` / `client_secret` (via the `secret` stem) / `token` / `api_key` / …) used by `.inspect({ redact })`. Added `body` + `variables` to the `compact({...})` override:

- `redactSecretsDeep(undefined) === undefined`, so an **absent** `body`/`variables` yields `undefined` and is dropped by `compact` — identical to the pre-fix `...event.input` spread (no new key appears).
- A **present-but-falsy** body (`null`/`''`/`0`) redacts to itself and is kept.
- **Benign** fields survive (`grant_type: 'password'` — a benign *key* whose value happens to be `"password"` — is kept; `keep: 'ok'` is kept).
- Headers / query / URL handling is **unchanged**.

No new denylist, no new redactor, no dependency. Reuses a helper already reachable on the core path, so the bundle barely moves.

## Bundle-size gate (`node packages/core/scripts/bundle-size.mjs`)

Gate measures tree-shaken **min+gzip**; budgets 24.20 KB whole / 19.70 KB `import { stitch }`.

| scenario | gzip before | gzip after | budget | status |
| --- | --- | --- | --- | --- |
| `stitchapi` — whole entry | 23.99 KB | 23.99 KB | 24.20 KB | ✓ 0.21 KB left |
| `import { stitch }` | 19.48 KB | 19.48 KB | 19.70 KB | ✓ 0.22 KB left |

**Zero gzip delta** (the reused helper was already bundled). No budget bump.

## Fail-before / pass-after evidence

Added a direct case to `test/trace-redact-transport.spec.ts` and an SSE-level assertion to `test/serve.spec.ts` (both mirror the existing header/query scrubbing tests).

**Before the fix** (src reverted, new tests present):

```
FAIL test/trace-redact-transport.spec.ts > … deep-redacts secret-named fields in the echoed request body and GraphQL variables …
  AssertionError: expected 'hunter2' to be 'REDACTED'

FAIL test/serve.spec.ts > SSE start frame deep-redacts a secret in the echoed request body & GraphQL variables …
  AssertionError: expected 'BODYLEAK' to be 'REDACTED'

Test Files  2 failed (2)
     Tests  2 failed | 18 passed (20)
```

The plaintext secret rides the frame — the leak, reproduced.

**After the fix:**

```
Test Files  2 passed (2)
     Tests  20 passed (20)
```

Full core suite: **1159 passed | 2 skipped**. `check:types` clean, `check:lint` clean, Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
