### PR TITLE
fix(fingerprint-arktype): abstain on built-in morph/predicate keywords, not just $ark.fn

### DIFF
--- a/packages/fingerprint-arktype/src/index.ts
+++ b/packages/fingerprint-arktype/src/index.ts
@@ -7,9 +7,17 @@
 // the moment it contains something that can't be soundly captured:
 //
 //   - morphs (`.pipe`) surface as `morphs: ["$ark.fn10"]` and narrows (`.narrow`)
-//     as `predicate: ["$ark.fn12"]`. Those `$ark.fn<n>` strings are opaque (the
-//     closure body is invisible) AND non-deterministic (a global counter, so the
-//     number changes per construction). Either property alone forces an abstain.
+//     as `predicate: ["$ark.fn12"]`. But ArkType also references its BUILT-IN
+//     parsers/predicates the same way — `morphs: ["$ark.parseJson"]` for
+//     `string.json.parse`, `morphs: ["$ark.morphs11"]` for `string.numeric.parse`,
+//     `predicate: [{ predicate: "$ark.isParsableDate" }]` for `string.date`, and
+//     so on. Every such `$ark.<name>` string is opaque (the closure body is
+//     invisible) and often non-deterministic (`$ark.fn<n>`/`$ark.morphs<n>` use a
+//     global counter, so the number changes per construction). Its presence
+//     anywhere forces an abstain — matching the whole `$ark.` namespace, not just
+//     the literal `$ark.fn`, so no built-in morph/predicate slips through with a
+//     token. (Scope/type aliases use a bare `$<alias>` — e.g. `"$node"` — WITHOUT
+//     the `ark.` segment, so pure structural references stay fingerprintable.)
 //   - a property `default` (e.g. `'string = "x"'`) silently changes the value the
 //     cache would store, so trusting a token here would under-invalidate. Abstain.
 //
@@ -29,9 +37,16 @@ import { type SchemaFingerprinter, hash } from 'stitchapi/fingerprint';
 // turned into an abstain. A symbol keeps it distinct from real errors.
 const ABSTAIN = Symbol('abstain');
 
-// Non-deterministic + opaque reference emitted by ArkType for `.pipe` morphs and
-// `.narrow`/predicate closures. Its presence anywhere in the JSON is disqualifying.
-const ARK_FN = '$ark.fn';
+// Namespace prefix ArkType uses for EVERY opaque function reference in its JSON:
+// user `.pipe` morphs / `.narrow` predicates (`$ark.fn<n>`) AND built-in
+// morph/predicate keywords (`$ark.parseJson`, `$ark.morphs<n>`,
+// `$ark.isParsableDate`, `$ark.isParsableUrl`, `$ark.isLuhnValid`, …). Any of
+// these is opaque and value-transforming, so its presence anywhere in the JSON is
+// disqualifying. Matching the prefix (not the exact `$ark.fn`) is deliberately
+// broad so no built-in slips through — and it's the SAFE direction: a false
+// abstain merely falls back to the version/revalidate ladder. Scope/type aliases
+// (`$<alias>`, e.g. `$node`) lack the `ark.` segment, so they are unaffected.
+const ARK_REF = '$ark.';
 
 type AnyRec = Record<string, unknown>;
 
@@ -47,7 +62,7 @@ function canon(node: unknown): string {
     if (node === null) return 'null';
     const t = typeof node;
     if (t === 'string') {
-        if ((node as string).includes(ARK_FN)) throw ABSTAIN;
+        if ((node as string).includes(ARK_REF)) throw ABSTAIN;
         return JSON.stringify(node);
     }
     if (t === 'number' || t === 'boolean') return JSON.stringify(node);
@@ -67,7 +82,7 @@ function canon(node: unknown): string {
     const parts = Object.keys(o)
         .sort()
         .map((k) => {
-            if (k.includes(ARK_FN)) throw ABSTAIN;
+            if (k.includes(ARK_REF)) throw ABSTAIN;
             return `${JSON.stringify(k)}:${canon(o[k])}`;
         });
     return `{${parts.join(',')}}`;
@@ -80,9 +95,10 @@ function describe(schema: unknown): string {
         throw ABSTAIN;
     const j = (schema as any).json;
     if (j === undefined) throw ABSTAIN;
-    // Fast disqualifier: any opaque/non-deterministic morph or predicate ref.
+    // Fast disqualifier: any opaque/non-deterministic morph or predicate ref
+    // anywhere in the JSON — user `.pipe`/`.narrow` OR a built-in keyword.
     // (canon also catches these, but this keeps the intent obvious.)
-    if (JSON.stringify(j).includes(ARK_FN)) throw ABSTAIN;
+    if (JSON.stringify(j).includes(ARK_REF)) throw ABSTAIN;
     return canon(j);
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/packages/fingerprint-arktype/test/conformance.spec.ts
+++ b/packages/fingerprint-arktype/test/conformance.spec.ts
@@ -93,6 +93,46 @@ const fixtures: FingerprintFixtures = {
             label: 'default',
             schema: () => type({ name: 'string = "x"' }),
         },
+        // BUILT-IN morph/predicate keywords. ArkType represents these with opaque
+        // `$ark.*` references that are NOT the literal `$ark.fn` — e.g.
+        // `morphs:["$ark.parseJson"]`, `morphs:["$ark.morphs<n>"]`,
+        // `predicate:"$ark.isParsableDate"`. They carry value-transforming /
+        // opaque-closure logic the walker can't faithfully capture, so a stable
+        // token would under-invalidate the cache (ADR 0004). All must abstain.
+        {
+            // morphs: ["$ark.parseJson"] — a named built-in parser.
+            label: 'string.json.parse',
+            schema: () => type('string.json.parse'),
+        },
+        {
+            // morphs: ["$ark.morphs<n>"] — counter-based, non-deterministic.
+            label: 'string.numeric.parse',
+            schema: () => type('string.numeric.parse'),
+        },
+        {
+            label: 'string.integer.parse',
+            schema: () => type('string.integer.parse'),
+        },
+        {
+            // Both a morph AND a `$ark.isParsableDate` predicate.
+            label: 'string.date.parse',
+            schema: () => type('string.date.parse'),
+        },
+        {
+            // predicate: "$ark.isParsableDate" — opaque predicate, no morph.
+            label: 'string.date',
+            schema: () => type('string.date'),
+        },
+        {
+            // predicate: "$ark.isParsableUrl" — opaque predicate.
+            label: 'string.url',
+            schema: () => type('string.url'),
+        },
+        {
+            // morphs: ["$ark.morphs<n>"] — a value-transforming format morph.
+            label: 'string.lower',
+            schema: () => type('string.lower'),
+        },
     ],
 };
 
@@ -121,5 +161,34 @@ describe('@stitchapi/fingerprint-arktype', () => {
         );
         expect(base.token).not.toBeNull();
         expect(morphed.token).toBeNull();
+    });
+
+    it('abstains on BUILT-IN morph/predicate keywords (not just $ark.fn)', () => {
+        // ArkType emits opaque `$ark.*` refs for its built-in parsers/predicates
+        // (e.g. `$ark.parseJson`, `$ark.morphs<n>`, `$ark.isParsableDate`) that
+        // are NOT the literal `$ark.fn`. Each carries value-transforming/opaque
+        // logic the walker can't capture, so a token would under-invalidate the
+        // cache (ADR 0004). All must abstain.
+        const builtins = [
+            'string.json.parse', // morphs: ["$ark.parseJson"]
+            'string.numeric.parse', // morphs: ["$ark.morphs<n>"]
+            'string.integer.parse',
+            'string.date.parse', // morph + "$ark.isParsableDate" predicate
+            'string.date', // predicate: "$ark.isParsableDate"
+            'string.url', // predicate: "$ark.isParsableUrl"
+            'string.lower', // morphs: ["$ark.morphs<n>"] (format morph)
+        ] as const;
+        for (const keyword of builtins) {
+            const f = arktypeFingerprinter.fingerprint(type(keyword) as never);
+            expect(f.token, `${keyword} should abstain`).toBeNull();
+        }
+
+        // A pure structural keyword carrying no opaque logic still fingerprints —
+        // the fix must not over-abstain. (`string.email` is a plain regex pattern;
+        // its JSON contains no `$ark.` reference at all.)
+        const structural = arktypeFingerprinter.fingerprint(
+            type('string.email') as never,
+        );
+        expect(structural.token).not.toBeNull();
     });
 });


### PR DESCRIPTION
## Problem

The abstain guard in `@stitchapi/fingerprint-arktype` (`src/index.ts`) only matched the literal substring **`$ark.fn`**. ArkType's **built-in** morph/predicate keyword references use a wider `$ark.` namespace — so they bypassed the guard and received a `strong` fingerprint even though they carry opaque, value-transforming logic the walker can't faithfully represent.

Verified against **arktype 2.2.0**, these all slipped through with a stable token:

| keyword | JSON reference |
| --- | --- |
| `string.json.parse` | `morphs: ["$ark.parseJson"]` |
| `string.numeric.parse` | `morphs: ["$ark.morphs<n>"]` (counter-based) |
| `string.integer.parse` | `morphs: ["$ark.morphs<n>"]` |
| `string.date.parse` | morph + `predicate: "$ark.isParsableDate"` |
| `string.date` | `predicate: "$ark.isParsableDate"` |
| `string.url` | `predicate: "$ark.isParsableUrl"` |
| `string.lower` / `upper` / `trim` / `capitalize` / `normalize` | format morphs `$ark.morphs<n>` |
| `string.creditCard` | `predicate: "$ark.isLuhnValid"` |

**Consequence (ADR 0004 cache soundness):** a schema like `type('string.json.parse')` (or `string.numeric.parse`, `string.integer.parse`, `string.date.parse`) got a stable token, so swapping it for a different morph/parse keyword may not invalidate the cache. `$ark.fn<n>` / `$ark.morphs<n>` are also counter-based (non-deterministic).

## Fix

Broaden the abstain guard from the exact string `$ark.fn` to the whole **`$ark.` prefix** (`ARK_FN` → `ARK_REF = '$ark.'`), applied at all three existing check sites (string values, object keys, and the fast whole-JSON disqualifier). Any `$ark.*` opaque function/morph/predicate reference now triggers ABSTAIN.

This is drift-proof (matches the namespace, not an exact-string allowlist that would rot as ArkType adds keywords) and it's the **safe direction**: a false abstain merely falls back to the version/revalidate ladder. Pure structural keywords stay fingerprintable — they emit no `$ark.` reference at all (`string.email`, `string.uuid`, `string.semver`, `string.ip`, `number.integer`, plain domains, objects, tuples…). Scope/type aliases use a bare `$<alias>` (e.g. `$node`) **without** the `ark.` segment, so recursive/aliased structural references are unaffected.

## Tests (fail-before / pass-after)

- New focused regression test asserts the seven built-in morph/predicate keywords yield token `null` (abstain) while `string.email` (a plain structural keyword) still fingerprints.
- Added the same built-ins to the `abstain` conformance fixtures (they previously covered only user-defined `.pipe`/`.narrow`/`default`).

**Before the fix** (unchanged `src`): both new checks fail — e.g. `string.json.parse (returned 363203ed…, expected null)` across all seven keywords.
**After the fix:** all 4 tests green; `check:types` clean; full existing suite (conformance contract, `distinct`/`stable`/`equivalent` structural fixtures) unchanged. Pre-commit `format` + tree-wide `lint` + `typecheck` all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)