### PR TITLE
fix(core): cache LRU eviction must not crash the process on a rejecting store

### DIFF
--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -399,7 +399,9 @@ export function createCache(opts: CacheControllerOptions): CacheController {
             const oldest = lru.keys().next().value;
             if (oldest === undefined) break;
             lru.delete(oldest);
-            void store.set(oldest, undefined); // evict from the store (best-effort)
+            // evict from the store (best-effort); a rejecting async store (e.g. Redis) must never
+            // become an unhandled rejection — swallow it (matches pipe.ts / postmessage.ts).
+            void store.set(oldest, undefined).catch(() => undefined);
         }
     };
 

--- a/packages/core/test/cache.spec.ts
+++ b/packages/core/test/cache.spec.ts
@@ -301,6 +301,48 @@ describe('cache — LRU bound', () => {
         await s({ query: { id: 3 } }); // still resident → hit
         expect(calls()).toBe(4);
     });
+
+    test('a rejecting store at eviction does not crash the process (best-effort)', async () => {
+        // A BYO async store (e.g. Redis) can transiently reject. Eviction is fire-and-forget
+        // (`void store.set(oldest, undefined)`); without a `.catch` that rejection is an unhandled
+        // promise rejection → Node ≥15 terminates the process, despite the "best-effort" intent.
+        // Eviction is the only write whose value is `undefined` (a delete) on this call path, so a
+        // store that rejects exactly those calls isolates the eviction hazard while normal
+        // (defined-value) cache writes still succeed.
+        const backing = memoryStore();
+        const rejectingOnEvict: typeof backing = {
+            ...backing,
+            set: (key, value, ttl) =>
+                value === undefined
+                    ? Promise.reject(new Error('store down at eviction'))
+                    : backing.set(key, value, ttl),
+        };
+
+        const unhandled: unknown[] = [];
+        const onUnhandled = (reason: unknown): void => {
+            unhandled.push(reason);
+        };
+        process.on('unhandledRejection', onUnhandled);
+        try {
+            const { adapter } = counting();
+            const s = stitch({
+                url: URL,
+                adapter,
+                trace: false,
+                store: rejectingOnEvict,
+                cache: { ttl: '60s', scope: 'app', entries: 1 },
+            });
+            // entries:1 → the second distinct key evicts the first via `store.set(oldest, undefined)`.
+            await expect(s({ query: { id: 1 } })).resolves.toEqual({ n: 1 });
+            await expect(s({ query: { id: 2 } })).resolves.toEqual({ n: 2 });
+            // Let the fire-and-forget eviction promise settle so any unhandled rejection can surface.
+            await new Promise((r) => setTimeout(r, 0));
+        } finally {
+            process.off('unhandledRejection', onUnhandled);
+        }
+        // Fails BEFORE the fix (the eviction rejection surfaces here); passes AFTER (`.catch` swallows it).
+        expect(unhandled).toEqual([]);
+    });
 });
 
 describe('cache — sensitive bypass', () => {


### PR DESCRIPTION
## The bug (HIGH reliability)

`packages/core/src/cache.ts` — the response cache's LRU eviction (ADR 0003) discards the store-delete promise with `void` and **no `.catch`**:

```ts
void store.set(oldest, undefined); // evict from the store (best-effort)
```

With the default in-memory store this is harmless. But the store is a **BYO seam** — swap in Redis (or any async backend) and `set()` can reject transiently. Once more than `entries` (default **1000**) distinct keys have been written, **every** subsequent `remember(...)` evicts this way, so a single transient rejection at eviction time becomes an **unhandled promise rejection**. Under **Node ≥ 15 that terminates the process** — flatly contradicting the `// best-effort` comment right next to it.

## The fix

Attach the codebase's own fire-and-forget idiom:

```ts
void store.set(oldest, undefined).catch(() => undefined);
```

The exact same pattern is already used at `pipe.ts:90` (`swallowLateRejections`, `void p.catch(() => undefined)`) and documented at `postmessage.ts:208` for driving a fire-and-forget send. This is a one-line idiom match.

**Zero behaviour change.** The eviction was always meant to be best-effort, and the cache's correctness never depended on the store delete landing: the entry is already gone from the in-process LRU regardless, and any lingering store entry is either overwritten or TTL-expired later.

## Regression test

`packages/core/test/cache.spec.ts` (in the existing `cache — LRU bound` block) drives the cache through a `StitchStore` that rejects **exactly** the eviction call — a `set` whose value is `undefined`, which on this path is only ever the eviction/delete — while letting normal defined-value writes through. It sets `entries: 1`, writes two distinct keys to force one eviction, installs an `unhandledRejection` listener, and asserts none fires and both calls still resolve.

- **Fails before** the fix: `expected [ Error: store down at eviction ] to deeply equal []` — the eviction rejection escapes.
- **Passes after**: the `.catch` swallows it.

Full core suite stays green (**1162 passing**), `check:types` clean, whole-tree lefthook format/lint/typecheck green at commit.

## Bundle (CORE — mind the budget)

Bundle-neutral. gzip/brotli are **byte-identical** before and after; the minified delta is ~10 bytes:

| scenario | before (gzip) | after (gzip) | budget |
| --- | --- | --- | --- |
| `stitchapi` — whole entry | 23.99 KB | 23.99 KB | 24.20 KB ✓ |
| `import { stitch }` | 19.48 KB | 19.48 KB | 19.70 KB ✓ |

Both scenarios stay within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)