### PR TITLE
fix(fingerprint-zod): Zod-4 walker drops refinements/formats/coerce/enum-type → cache-invalidation collisions

### DIFF
--- a/packages/fingerprint-zod/src/index.ts
+++ b/packages/fingerprint-zod/src/index.ts
@@ -77,7 +77,7 @@ function v3(def: any): string {
                 def.catchall && def.catchall._def?.typeName !== 'ZodNever'
                     ? describe(def.catchall)
                     : '';
-            return `obj{${fields.join(',')};unk=${String(def.unknownKeys ?? '')};cat=${catchall}}`;
+            return `obj{${fields.join(',')};unk=${String(def.unknownKeys ?? '')};cat=${catchall}}[${v3Checks(def.checks)}]`;
         }
         case 'ZodString':
             return `str[${v3Checks(def.checks)}${def.coerce ? ';coerce' : ''}]`;
@@ -90,30 +90,30 @@ function v3(def: any): string {
         case 'ZodDate':
             return `date[${v3Checks(def.checks)}]`;
         case 'ZodOptional':
-            return `opt(${describe(def.innerType)})`;
+            return `opt(${describe(def.innerType)})[${v3Checks(def.checks)}]`;
         case 'ZodNullable':
-            return `nul(${describe(def.innerType)})`;
+            return `nul(${describe(def.innerType)})[${v3Checks(def.checks)}]`;
         case 'ZodArray':
             return `arr(${describe(def.type)})[min=${str(def.minLength)},max=${str(def.maxLength)},exact=${str(def.exactLength)}]`;
         case 'ZodTuple':
-            return `tup[${(def.items as unknown[]).map(describe).join(',')}${def.rest ? ';rest=' + describe(def.rest) : ''}]`;
+            return `tup[${(def.items as unknown[]).map(describe).join(',')}${def.rest ? ';rest=' + describe(def.rest) : ''}][${v3Checks(def.checks)}]`;
         case 'ZodRecord':
-            return `rec(${describe(def.keyType)},${describe(def.valueType)})`;
+            return `rec(${describe(def.keyType)},${describe(def.valueType)})[${v3Checks(def.checks)}]`;
         case 'ZodMap':
-            return `map(${describe(def.keyType)},${describe(def.valueType)})`;
+            return `map(${describe(def.keyType)},${describe(def.valueType)})[${v3Checks(def.checks)}]`;
         case 'ZodSet':
-            return `set(${describe(def.valueType)})`;
+            return `set(${describe(def.valueType)})[${v3Checks(def.checks)}]`;
         case 'ZodEnum':
-            return `enum{${[...(def.values as unknown[])].map(String).sort().map(key).join(',')}}`;
+            return `enum{${[...(def.values as unknown[])].map(literal).sort().join(',')}}`;
         case 'ZodLiteral':
             return `lit(${literal(def.value)})`;
         case 'ZodUnion':
         case 'ZodDiscriminatedUnion':
-            return `union{${(def.options as unknown[]).map(describe).sort().join('|')}}`;
+            return `union{${(def.options as unknown[]).map(describe).sort().join('|')}}[${v3Checks(def.checks)}]`;
         case 'ZodIntersection':
-            return `and(${describe(def.left)},${describe(def.right)})`;
+            return `and(${describe(def.left)},${describe(def.right)})[${v3Checks(def.checks)}]`;
         case 'ZodReadonly':
-            return `ro(${describe(def.innerType)})`;
+            return `ro(${describe(def.innerType)})[${v3Checks(def.checks)}]`;
         case 'ZodBranded':
             return `brand(${describe(def.type)})`;
         case 'ZodNull':
@@ -158,6 +158,51 @@ function v4Checks(checks: unknown): string {
         .join(',');
 }
 
+// Zod 4 exposes coercion as `def.coerce` on the primitive node (v3 does the
+// same). It changes what inputs are accepted — `z.coerce.number()` parses
+// `"1"`, `z.number()` rejects it — so it MUST fold into the descriptor, matching
+// the v3 branches.
+const v4Coerce = (def: any): string => (def.coerce ? ';coerce' : '');
+
+// Zod 4 lifts string formats to their own nodes: `z.email()` is a `string` node
+// with `def.format` set (and often `def.pattern`, a RegExp), NOT a check in
+// `def.checks`. Reading only `def.checks` collapses `z.email()`/`z.uuid()`/…
+// and plain `z.string()` to the same descriptor. Fold both in — the pattern via
+// the same RegExp encoding `stableJson` uses, so a chained `z.string().regex(re)`
+// and a format that happens to share a source stay comparable.
+function v4StringFormat(def: any): string {
+    if (def.format == null && def.pattern == null) return '';
+    const fmt = def.format == null ? '' : String(def.format);
+    const pat =
+        def.pattern instanceof RegExp
+            ? `re:${def.pattern.source}/${def.pattern.flags}`
+            : def.pattern == null
+              ? ''
+              : stableJson(def.pattern);
+    return `;fmt=${fmt};pat=${pat}`;
+}
+
+// Canonical members of a Zod 4 enum. `def.entries` is a name→value record, but a
+// numeric TS enum is BIDIRECTIONAL (`{0:'Red','Red':0,…}`); the reverse keys must
+// be dropped or `Object.values` double-counts. What validation actually gates on
+// is the set of accepted VALUES, so encode those — type-preservingly (`literal`,
+// not `String`, so `1` and `'1'` differ), which also keeps a string-member enum
+// identical to the v3 value-list form (cross-version stability).
+function enumMembers(entries: AnyRec): string {
+    const reverse = new Set(
+        Object.values(entries).filter((v) => typeof v === 'number'),
+    );
+    const values: unknown[] = [];
+    for (const [k, v] of Object.entries(entries)) {
+        // Skip the reverse-mapping entry a numeric member adds: a numeric-string
+        // key whose value is another member's name.
+        if (reverse.has(Number(k)) && typeof v === 'string' && v in entries)
+            continue;
+        values.push(v);
+    }
+    return values.map(literal).sort().join(',');
+}
+
 function v4(def: any): string {
     switch (def.type) {
         case 'object': {
@@ -166,48 +211,44 @@ function v4(def: any): string {
                 .sort()
                 .map((k) => `${key(k)}:${describe(shape[k])}`);
             const catchall = def.catchall ? describe(def.catchall) : '';
-            return `obj{${fields.join(',')};cat=${catchall}}`;
+            return `obj{${fields.join(',')};cat=${catchall}}[${v4Checks(def.checks)}]`;
         }
         case 'string':
-            return `str[${v4Checks(def.checks)}]`;
+            return `str[${v4Checks(def.checks)}${v4StringFormat(def)}${v4Coerce(def)}]`;
         case 'number':
-            return `num[${v4Checks(def.checks)}]`;
+            return `num[${v4Checks(def.checks)}${v4Coerce(def)}]`;
         case 'bigint':
-            return `bigint[${v4Checks(def.checks)}]`;
+            return `bigint[${v4Checks(def.checks)}${v4Coerce(def)}]`;
         case 'boolean':
-            return `bool[${v4Checks(def.checks)}]`;
+            return `bool[${v4Checks(def.checks)}${v4Coerce(def)}]`;
         case 'date':
-            return `date[${v4Checks(def.checks)}]`;
+            return `date[${v4Checks(def.checks)}${v4Coerce(def)}]`;
         case 'optional':
-            return `opt(${describe(def.innerType)})`;
+            return `opt(${describe(def.innerType)})[${v4Checks(def.checks)}]`;
         case 'nullable':
-            return `nul(${describe(def.innerType)})`;
+            return `nul(${describe(def.innerType)})[${v4Checks(def.checks)}]`;
         case 'nonoptional':
-            return `req(${describe(def.innerType)})`;
+            return `req(${describe(def.innerType)})[${v4Checks(def.checks)}]`;
         case 'array':
             return `arr(${describe(def.element)})[${v4Checks(def.checks)}]`;
         case 'tuple':
-            return `tup[${(def.items as unknown[]).map(describe).join(',')}${def.rest ? ';rest=' + describe(def.rest) : ''}]`;
+            return `tup[${(def.items as unknown[]).map(describe).join(',')}${def.rest ? ';rest=' + describe(def.rest) : ''}][${v4Checks(def.checks)}]`;
         case 'record':
-            return `rec(${describe(def.keyType)},${describe(def.valueType)})`;
+            return `rec(${describe(def.keyType)},${describe(def.valueType)})[${v4Checks(def.checks)}]`;
         case 'map':
-            return `map(${describe(def.keyType)},${describe(def.valueType)})`;
+            return `map(${describe(def.keyType)},${describe(def.valueType)})[${v4Checks(def.checks)}]`;
         case 'set':
-            return `set(${describe(def.valueType)})`;
+            return `set(${describe(def.valueType)})[${v4Checks(def.checks)}]`;
         case 'enum':
-            return `enum{${Object.values(def.entries as AnyRec)
-                .map(String)
-                .sort()
-                .map(key)
-                .join(',')}}`;
+            return `enum{${enumMembers(def.entries as AnyRec)}}`;
         case 'literal':
-            return `lit{${(def.values as unknown[]).map(literal).sort().join('|')}}`;
+            return `lit{${(def.values as unknown[]).map(literal).sort().join('|')}}[${v4Checks(def.checks)}]`;
         case 'union':
-            return `union{${(def.options as unknown[]).map(describe).sort().join('|')}}`;
+            return `union{${(def.options as unknown[]).map(describe).sort().join('|')}}[${v4Checks(def.checks)}]`;
         case 'intersection':
-            return `and(${describe(def.left)},${describe(def.right)})`;
+            return `and(${describe(def.left)},${describe(def.right)})[${v4Checks(def.checks)}]`;
         case 'readonly':
-            return `ro(${describe(def.innerType)})`;
+            return `ro(${describe(def.innerType)})[${v4Checks(def.checks)}]`;
         case 'null':
             return 'null';
         case 'undefined':

--- a/packages/fingerprint-zod/test/collisions.spec.ts
+++ b/packages/fingerprint-zod/test/collisions.spec.ts
@@ -1,0 +1,99 @@
+// Regression tests for four cache-invalidation COLLISIONS in the Zod-4 walker
+// (StitchAPI ADR 0003/0004). The fingerprint token is a cache key: if two
+// semantically-different schemas hash the same, editing a schema fails to
+// invalidate the validated cache and stale data is served. Each test below
+// FAILS on the pre-fix v4 walker and PASSES after the fix.
+import { zodFingerprinter } from '../src';
+
+import { describe, expect, it } from 'vitest';
+import * as z4 from 'zod/v4';
+
+// The strategy is typed for Standard Schema; the conformance suite casts the
+// same way. We only read `.token` off the result.
+const fp = (schema: unknown): string | null =>
+    zodFingerprinter.fingerprint(schema as never).token;
+
+describe('@stitchapi/fingerprint-zod — Zod-4 collision regressions', () => {
+    // BUG 1 — composite `.refine()` was dropped: the object/record/tuple/map/
+    // set/union branches never folded `def.checks`, so a refined composite
+    // hashed identically to the plain one (and to a DIFFERENT refinement). The
+    // fix folds `v4Checks`, which ABSTAINS on a custom check → token null.
+    describe('composite .refine() is captured (abstains, not dropped)', () => {
+        it('abstains on a refined object', () => {
+            expect(
+                fp(z4.object({ a: z4.number() }).refine(() => true)),
+            ).toBeNull();
+        });
+
+        it('still fingerprints the plain object (non-null)', () => {
+            expect(fp(z4.object({ a: z4.number() }))).not.toBeNull();
+        });
+
+        it('abstains on refined record/tuple/map/set/union too', () => {
+            expect(
+                fp(z4.record(z4.string(), z4.number()).refine(() => true)),
+            ).toBeNull();
+            expect(fp(z4.tuple([z4.string()]).refine(() => true))).toBeNull();
+            expect(
+                fp(z4.map(z4.string(), z4.number()).refine(() => true)),
+            ).toBeNull();
+            expect(fp(z4.set(z4.number()).refine(() => true))).toBeNull();
+            expect(
+                fp(z4.union([z4.string(), z4.number()]).refine(() => true)),
+            ).toBeNull();
+        });
+    });
+
+    // BUG 2 — top-level string formats collided: the `string` branch read only
+    // `def.checks`, ignoring `def.format`/`def.pattern`, so z4.email()/uuid()/
+    // url() and plain z4.string() all hashed the same. A schema tightened from
+    // `string` to `email` would not invalidate its cache.
+    describe('string formats are distinct from plain string and each other', () => {
+        it('email !== string', () => {
+            const email = fp(z4.email());
+            expect(email).not.toBeNull();
+            expect(email).not.toBe(fp(z4.string()));
+        });
+
+        it('email !== url', () => {
+            expect(fp(z4.email())).not.toBe(fp(z4.url()));
+        });
+
+        it('uuid !== string and !== email', () => {
+            expect(fp(z4.uuid())).not.toBe(fp(z4.string()));
+            expect(fp(z4.uuid())).not.toBe(fp(z4.email()));
+        });
+    });
+
+    // BUG 4 — the `coerce` flag was dropped: v4 string/number/bigint/boolean/
+    // date ignored `def.coerce`, so z4.coerce.number() (accepts "1") hashed the
+    // same as z4.number() (rejects "1"). v3 already folded coerce.
+    describe('coercion changes the fingerprint', () => {
+        it('coerce.number !== number', () => {
+            const coerced = fp(z4.coerce.number());
+            expect(coerced).not.toBeNull();
+            expect(coerced).not.toBe(fp(z4.number()));
+        });
+
+        it('coerce.string/boolean/bigint/date each differ from their plain form', () => {
+            expect(fp(z4.coerce.string())).not.toBe(fp(z4.string()));
+            expect(fp(z4.coerce.boolean())).not.toBe(fp(z4.boolean()));
+            expect(fp(z4.coerce.bigint())).not.toBe(fp(z4.bigint()));
+            expect(fp(z4.coerce.date())).not.toBe(fp(z4.date()));
+        });
+    });
+
+    // BUG 3 — enum members were String()-coerced: `Object.values(entries)
+    // .map(String)` collapsed z4.enum({A:1}) (accepts number 1) and
+    // z4.enum({A:'1'}) (accepts string '1'). The fix encodes members with the
+    // type-preserving `literal()` helper.
+    describe('enum member type is preserved', () => {
+        it("enum({A:1}) !== enum({A:'1'})", () => {
+            const numeric = fp(z4.enum({ A: 1 }));
+            const stringy = fp(z4.enum({ A: '1' }));
+            expect(numeric).not.toBeNull();
+            expect(stringy).not.toBeNull();
+            expect(numeric).not.toBe(stringy);
+        });
+    });
+});


### PR DESCRIPTION
## Why

The fingerprint token produced by `@stitchapi/fingerprint-zod` is a **cache-invalidation key** (ADR 0003/0004). If two semantically-different schemas hash to the same token, editing a schema fails to invalidate the validated cache and **stale data is served**.

The Zod-4 walker (`v4(def)` in `packages/fingerprint-zod/src/index.ts`) was added without the v3 path's completeness, so four classes of semantically-distinct schemas collided. These are **cache-soundness bugs**, not cosmetics.

Each fix is proved with a fail-before / pass-after regression test in `packages/fingerprint-zod/test/collisions.spec.ts`; the existing conformance suite stays green.

## The four collisions

**1. CRITICAL — composite `.refine()`/`.check()` was dropped.**
Only the `string`/`number`/`array` branches folded `v4Checks(def.checks)`. `object`/`record`/`tuple`/`map`/`set`/`union` (and the sibling wrapper nodes `optional`/`nullable`/`nonoptional`/`readonly`/`intersection`/`literal`, which in Zod 4 also carry refine-checks) did not. So `z4.object({a:z4.number()}).refine(fn)` hashed **identically to the plain object** *and* to a **different** `.refine()`. A refinement that changes what's valid silently didn't change the cache key.
Fix: fold `v4Checks(def.checks)` into every check-carrying branch. `v4Checks` ABSTAINS (throws) on a `custom` check, so refined composites now correctly return `token: null` (re-validate on hit) instead of a colliding token.

**2. HIGH — top-level string formats collided.**
The `string` branch read only `def.checks`, never `def.format`/`def.pattern`. In Zod 4, `z4.email()`/`z4.uuid()`/`z4.url()`/… are `string` nodes with `def.format` set (and usually a `def.pattern` RegExp), *not* a check in `def.checks` — so all of them, and plain `z4.string()`, produced the identical descriptor `str[]`. Tightening a field from `string` to `email` wouldn't invalidate its cache.
Fix: fold `def.format` + a canonical RegExp encoding of `def.pattern` (the same `re:source/flags` form `stableJson` already uses) into the string descriptor.

**3. MEDIUM — enum `String()` coercion.**
`Object.values(def.entries).map(String)` collapsed `z4.enum({A:1})` (accepts number `1`) and `z4.enum({A:'1'})` (accepts string `'1'`), and it double-counted the **bidirectional** `entries` of a numeric TS enum (`{0:'Red','Red':0,…}`).
Fix: a new `enumMembers()` helper drops the numeric reverse-mapping keys and encodes the forward **values** with the type-preserving `literal()` helper (`JSON.stringify`-based) instead of `String()`. The v3 enum branch gets the same `literal()` treatment; for string members `literal(x)` is byte-identical to the old `key(String(x))`, so **existing v3 fingerprints don't change meaning** and the cross-version `enum(['a','b'])` equivalence (v3 == v4) is preserved.

**4. MEDIUM — `coerce` flag dropped.**
v4 `string`/`number`/`bigint`/`boolean`/`date` ignored `def.coerce`, so `z4.coerce.number()` (accepts `"1"`) hashed the same as `z4.number()` (rejects it). v3 already read `def.coerce`.
Fix: append the coerce flag in each v4 primitive branch, mirroring v3.

## Cross-version symmetry

The v3 composite/wrapper branches gain a symmetric `[${v3Checks(def.checks)}]` suffix so a v3→v4 upgrade of the same shape keeps its fingerprint (this is what keeps the existing `cross-set` / `cross-tuple` conformance pairs equal after the v4 side grew a check suffix). In v3, `.refine()` becomes a `ZodEffects` node that already abstains, so v3 composites never actually carry checks — the suffix is always empty and no existing v3 fingerprint changes meaning.

## Descriptor version (`zfp1|`)

Kept, deliberately. The descriptor **shape** grows, but the conformance contract asserts only **relative** invariants (stable / equivalent / distinct / abstain) and this package commits **no absolute-token snapshots**, so nothing pins an old token. And because abstain-on-change is sound by construction, any real deployment gets at most a one-time, safe re-fingerprint (a cache miss, never a false hit). Bumping the prefix would only add a redundant global re-fingerprint on top of that.

## Tests — fail-before / pass-after

New `test/collisions.spec.ts` (verified failing on the pre-fix walker, passing after):

| Assertion | Before (buggy) | After |
| --- | --- | --- |
| `z4.object({a:z4.number()}).refine(fn)` → `null` | returned a token (`9d5ddeca…`) | `null` (abstains) |
| refined `record`/`tuple`/`map`/`set`/`union` → `null` | returned a token (`ac9178cb…`) | `null` |
| `z4.email() !== z4.string()` | both `cca0391b…` | distinct |
| `z4.email() !== z4.url()` | both `cca0391b…` | distinct |
| `z4.uuid() !== z4.string()` / `!== z4.email()` | all `cca0391b…` | distinct |
| `z4.coerce.number() !== z4.number()` | both `d9f7df2a…` | distinct |
| `z4.coerce.{string,boolean,bigint,date}` differ from plain | collided | distinct |
| `z4.enum({A:1}) !== z4.enum({A:'1'})` | both `8cc0730e…` | distinct |

The existing conformance suite (`stable`/`equivalent`/`distinct`/`abstain`, including cross-version `enum`/`set`/`tuple`/`bigint`/`date`/`null`) stays green. `pnpm --filter @stitchapi/fingerprint-zod test` → **12 passed**; `check:types` clean; Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
