### PR TITLE
fix(core): idempotency-override, from-curl newlines, postMessage validator, multipart file-leaf

### DIFF
--- a/packages/core/src/from-curl.ts
+++ b/packages/core/src/from-curl.ts
@@ -565,9 +565,20 @@ function deriveName(method: string, path: string): string {
 }
 
 // A JS object/string literal renderer for emitted config values. Strings are single-quoted with
-// quotes escaped; this is for short, simple example values (header values, body fields).
+// backslashes and quotes escaped; this is for short, simple example values (header values, body
+// fields). A captured value can contain line terminators (a HAR header, a multiline `-d @body`),
+// which are ILLEGAL inside a single-quoted JS literal and would emit source that doesn't parse — so
+// escape the four ES line terminators too: LF, CR, and U+2028/U+2029 (both are string-literal line
+// terminators pre-ES2019). Every other control char (tab, form-feed, …) is legal inside the literal
+// and left as-is. `\\` is escaped FIRST so the escapes we introduce aren't themselves re-escaped.
 function quote(s: string): string {
-    return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+    return `'${s
+        .replace(/\\/g, '\\\\')
+        .replace(/'/g, "\\'")
+        .replace(/\n/g, '\\n')
+        .replace(/\r/g, '\\r')
+        .replace(/\u2028/g, '\\u2028')
+        .replace(/\u2029/g, '\\u2029')}'`;
 }
 
 // Render a JSON value as TS source, indented. Used for a `-d` JSON body example.

--- a/packages/core/src/http-adapter.ts
+++ b/packages/core/src/http-adapter.ts
@@ -254,14 +254,33 @@ export function decodeResponseBody(
 
 // ---- multipart encoding (ADR 0005 Decision 6) -----------------------------
 // A value that becomes a binary file part: a Blob, a raw byte view, or a
-// { value, filename?, type? } wrapper. Anything else is a scalar field.
+// { value, filename?, type? } file wrapper. Anything else is a nested object/scalar.
+//
+// The wrapper is recognised ONLY when it is actually file-ish: `value` is binary (a Blob /
+// Uint8Array / ArrayBuffer), OR an explicit `filename`/`type` marks it a file part (so
+// `{ value: 'text', filename: 'note.txt' }` is still a named text part). A plain domain object that
+// merely HAPPENS to carry a `value` key — e.g. `{ value: 100, currency: 'USD' }` — is NOT a file:
+// treating it as one encoded `value` as a tiny Blob and silently DROPPED its siblings. Such an
+// object falls through here and recurses as a normal nested object instead.
+function isFileWrapper(v: object): boolean {
+    const w = v as { value?: unknown; filename?: unknown; type?: unknown };
+    return (
+        w.value instanceof Blob ||
+        w.value instanceof Uint8Array ||
+        w.value instanceof ArrayBuffer ||
+        w.filename !== undefined ||
+        w.type !== undefined
+    );
+}
+
 function isFileLeaf(v: unknown): boolean {
     return (
         v instanceof Blob ||
         v instanceof Uint8Array ||
         (typeof v === 'object' &&
             v !== null &&
-            'value' in (v as Record<string, unknown>))
+            'value' in (v as Record<string, unknown>) &&
+            isFileWrapper(v))
     );
 }
 

--- a/packages/core/src/postmessage.ts
+++ b/packages/core/src/postmessage.ts
@@ -37,6 +37,7 @@ import type {
     Stitch,
     StitchConfig,
 } from './types';
+import { type Validator, toValidator } from './validator';
 
 // ---------------------------------------------------------------------------
 // the raw channel (transport) + the typed channel (PostMessageChannel)
@@ -95,42 +96,28 @@ interface EventSub {
 }
 
 // A registered responder (from `respond(...)`): answers inbound requests of `type`. `input`/`output`
-// are optional Standard-Schema-ish validators (validated via the engine's coercer is overkill here —
-// we use the same `~standard` validate the schemas already expose); `reply` is the answer's type.
+// are optional {@link Validator}s — `respond` runs the caller's schema through `toValidator` (the
+// same coercion the rest of the surface uses), so EVERY schema flavour the library accepts (a
+// Standard Schema, a Zod `{ safeParse }` — including Zod < 3.24 that predates `~standard` — a plain
+// `{ validate }` Validator from `toValidator`, or a bare predicate) validates uniformly. Storing the
+// raw schema and only handling `~standard` here silently dropped the others (their branch threw →
+// caught → treated as a failure → every inbound request dropped). `reply` is the answer's type.
 interface Responder {
     handler: (payload: unknown) => unknown;
-    input?: SchemaValidate;
-    output?: SchemaValidate;
+    input?: Validator;
+    output?: Validator;
     reply: string;
 }
 
-// The minimal validate surface we need off a schema: a Standard Schema's `~standard.validate`. We
-// accept anything exposing it (Zod ≥3.24 / Valibot / ArkType / a hand-rolled one) and treat a
-// non-conforming value as a validation failure (drop). Pure structural — no validator dependency.
-type SchemaValidate =
-    | { '~standard': { validate: (v: unknown) => StandardResult } }
-    | ((v: unknown) => boolean);
-
-type StandardResult =
-    | { value: unknown; issues?: undefined }
-    | { issues: readonly unknown[] }
-    | Promise<
-          | { value: unknown; issues?: undefined }
-          | { issues: readonly unknown[] }
-      >;
-
-// Run a schema against a value: `true` ⇒ it validates. A Standard Schema returns `{ issues }` on
-// failure; a plain predicate returns a boolean. Async Standard Schemas are awaited. Anything that
-// throws counts as a failure (fail-closed). No schema ⇒ always passes.
+// Run a validator against a value: `true` ⇒ it validates (drop on `false`). Async validators are
+// awaited. Anything that throws counts as a failure (fail-closed). No validator ⇒ always passes.
 async function passes(
-    schema: SchemaValidate | undefined,
+    validator: Validator | undefined,
     value: unknown,
 ): Promise<boolean> {
-    if (schema === undefined) return true;
+    if (validator === undefined) return true;
     try {
-        if (typeof schema === 'function') return schema(value);
-        const out = await schema['~standard'].validate(value);
-        return (out as { issues?: readonly unknown[] }).issues === undefined;
+        return (await validator.validate(value)).ok;
     } catch {
         return false;
     }
@@ -712,10 +699,13 @@ function makeChannel(
             handler: handler as (payload: unknown) => unknown,
             reply: opts?.reply ?? `${type}-result`,
         };
-        if (opts?.input !== undefined)
-            responder.input = opts.input as SchemaValidate;
-        if (opts?.output !== undefined)
-            responder.output = opts.output as SchemaValidate;
+        // Coerce each schema to a Validator up front (the same path `stitch`'s `input`/`output`
+        // take), so `passes` validates every flavour — Standard Schema, Zod, a `toValidator`
+        // Validator, or a predicate — uniformly instead of only `~standard`.
+        const input = toValidator(opts?.input);
+        if (input !== undefined) responder.input = input;
+        const output = toValidator(opts?.output);
+        if (output !== undefined) responder.output = output;
         responders.set(type, responder);
         return () => {
             // Only delete if it is still THIS responder (a later respond(type, …) replaced it).

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -172,6 +172,11 @@ export function compose(config: Fragment): ResolvedStitchConfig {
         delete rest.hooks;
         delete rest.store;
         delete rest.kind;
+        // Capture the raw `idempotency` toggle BEFORE `expandShorthand` normalizes it away — a
+        // child `idempotency: false` must clear an inherited object (see the reconcile below), but
+        // `expandShorthand` deletes `false` from this layer, so `deepMerge` would never see it and
+        // the inherited value would silently survive (P20 violation).
+        const idempotencyToggle = layer.idempotency;
         expandShorthand(rest);
         merged = deepMerge(merged, rest);
         // Endpoint slot: `url` and `baseUrl`/`path` are two spellings of the same target, and
@@ -184,6 +189,12 @@ export function compose(config: Fragment): ResolvedStitchConfig {
         } else if (rest.baseUrl !== undefined || rest.path !== undefined) {
             delete merged.url;
         }
+        // Idempotency slot (P20): last-writer-wins on the on/off toggle, like the endpoint slot
+        // above. `expandShorthand` turns `true`→`{}` (folded by deepMerge) but drops `false`
+        // entirely, so a child `idempotency: false` can't undo an inherited `idempotency: true`
+        // through the merge alone — reconcile it here, clearing the slot when this layer is the
+        // last to set it and set it off.
+        if (idempotencyToggle === false) delete merged.idempotency;
     }
     const hooks = chainHooks(hookLayers);
     if (hooks) merged.hooks = hooks;

--- a/packages/core/test/from-curl-edges.spec.ts
+++ b/packages/core/test/from-curl-edges.spec.ts
@@ -154,3 +154,93 @@ describe('parseHar — body kind and entry selection', () => {
         expect(req.warnings.some((w) => w.includes('out of range'))).toBe(true);
     });
 });
+
+describe('toStitchSource — emitted string literals stay valid TS', () => {
+    const harWith = (entry: unknown) => ({ log: { entries: [entry] } });
+
+    // The emitted source is an ESM module (`import`/`export`/top-level `await`), which
+    // `new Function` can't host — neutralize just that scaffolding so `new Function` sees the
+    // remaining statements and throws on any *syntax* error (an unterminated string literal being
+    // the bug under test). Semantics are checked separately by the round-trip assertions below.
+    const parses = (source: string): void => {
+        const body = source
+            .replace(/^import .*$/gm, '')
+            .replace(/^export /gm, '')
+            .replace(/^await /gm, '');
+        // Parsing the neutralized module IS the assertion — a syntax error (an unterminated string
+        // literal) throws at construction time.
+        // eslint-disable-next-line @typescript-eslint/no-implied-eval
+        expect(() => new Function(body)).not.toThrow();
+    };
+
+    it('escapes a newline in a header value so the emitted source parses', () => {
+        const { source } = toStitchSource(
+            parseHar(
+                harWith({
+                    request: {
+                        method: 'GET',
+                        url: 'https://api.example.com/x',
+                        headers: [{ name: 'X-Multi', value: 'line1\nline2' }],
+                    },
+                }),
+            ),
+        );
+        // Before the fix this emitted a raw newline inside `'…'` — an unterminated literal.
+        expect(source).toContain("'line1\\nline2'");
+        parses(source);
+    });
+
+    it('escapes a newline in a JSON body value so the emitted source parses', () => {
+        const { source } = toStitchSource(
+            parseHar(
+                harWith({
+                    request: {
+                        method: 'POST',
+                        url: 'https://api.example.com/x',
+                        headers: [],
+                        postData: {
+                            mimeType: 'application/json',
+                            // Valid JSON (the LF is escaped in the wire text) → parsed to an
+                            // object, so the field value rides through `quote()`.
+                            text: JSON.stringify({ note: 'a\nb' }),
+                        },
+                    },
+                }),
+            ),
+        );
+        expect(source).toContain("note: 'a\\nb'");
+        parses(source);
+    });
+
+    it('escapes every ES line terminator (LF, CR, U+2028, U+2029) and round-trips the value', () => {
+        // A backslash and a single quote too, to prove the escape order is right.
+        const value = "a\rb\r\nc\u2028d\u2029e\\f'g";
+        const { source } = toStitchSource(
+            parseHar(
+                harWith({
+                    request: {
+                        method: 'GET',
+                        url: 'https://api.example.com/y',
+                        headers: [{ name: 'X-Nasty', value }],
+                    },
+                }),
+            ),
+        );
+        parses(source);
+        // No raw line terminator survives inside the emitted literal.
+        const literal = /'X-Nasty':\s*('(?:[^'\\]|\\.)*')/.exec(source)?.[1];
+        expect(literal).toBeDefined();
+        expect(literal).not.toMatch(/[\n\r\u2028\u2029]/);
+        // …and it evaluates back to exactly the captured value (semantics preserved).
+        // eslint-disable-next-line @typescript-eslint/no-implied-eval
+        const evalLiteral = new Function(`return ${literal}`) as () => unknown;
+        expect(evalLiteral()).toBe(value);
+    });
+
+    it('leaves the common case single-quoted (no needless escaping)', () => {
+        const { source } = toStitchSource(
+            parseCurl("curl 'https://api.example.com/users/1'"),
+        );
+        expect(source).toContain("baseUrl: 'https://api.example.com'");
+    });
+});

--- a/packages/core/test/idempotency.spec.ts
+++ b/packages/core/test/idempotency.spec.ts
@@ -200,6 +200,63 @@ test('does not inject on GET (writes only)', async () => {
     ).toBeUndefined();
 });
 
+test('a child `idempotency: false` disables idempotency inherited from a base fragment (P20)', async () => {
+    server.route('POST', '/no-idem', { body: { ok: true } });
+    const base = {
+        idempotency: true,
+        method: 'POST',
+        path: '/no-idem',
+    } as const;
+    const create = stitch({
+        extends: [base],
+        baseUrl: server.url,
+        idempotency: false, // last writer wins: this turns it OFF
+    });
+
+    // The resolved public config must report idempotency OFF, not the inherited `{}` (ON).
+    expect(
+        (create as { __config: { idempotency?: unknown } }).__config
+            .idempotency,
+    ).toBeUndefined();
+
+    // …and end-to-end, no Idempotency-Key header is injected on the write.
+    await expect(create({ body: { x: 1 } })).resolves.toEqual({ ok: true });
+    expect(
+        server.calls('/no-idem')[0]!.headers['idempotency-key'],
+    ).toBeUndefined();
+});
+
+test('a child `idempotency: false` also clears an inherited idempotency *object* (P20)', () => {
+    const base = {
+        idempotency: { header: 'X-Idem' },
+        method: 'POST',
+        path: '/x',
+    } as const;
+    const create = stitch({
+        extends: [base],
+        baseUrl: 'https://x',
+        idempotency: false,
+    });
+    expect(
+        (create as { __config: { idempotency?: unknown } }).__config
+            .idempotency,
+    ).toBeUndefined();
+});
+
+test('a child `idempotency: true` still re-enables it over an inherited `false` (last writer, both directions)', () => {
+    const base = { idempotency: false, method: 'POST', path: '/x' } as const;
+    const create = stitch({
+        extends: [base],
+        baseUrl: 'https://x',
+        idempotency: true,
+    });
+    // `true` normalizes to the all-defaults object form the engine reads.
+    expect(
+        (create as { __config: { idempotency?: unknown } }).__config
+            .idempotency,
+    ).toEqual({});
+});
+
 test('the opaque `idempotency: {}` is a type error — use `true` for defaults (P20)', () => {
     const enableWithDefaults = () =>
         stitch({

--- a/packages/core/test/multipart-nesting.spec.ts
+++ b/packages/core/test/multipart-nesting.spec.ts
@@ -148,6 +148,68 @@ describe('multipart nesting (ADR 0005 Decision 6)', () => {
         expect(raw).toContain('filename="a.bin"');
     });
 
+    // A plain domain object that merely carries a `value` key (e.g. money `{ value, currency }`) is
+    // NOT a file part. The old `isFileLeaf` treated ANY `{ value }` object as a file, so it encoded
+    // `value` as a tiny Blob and silently DROPPED the siblings; it must recurse as a nested object.
+    test('a { value, ... } object without binary/filename is a nested object, not a file (siblings survive)', async () => {
+        server.route('POST', '/u', { body: { ok: true } });
+        const upload = stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/u',
+            bodyType: 'multipart',
+        });
+
+        await upload({ body: { amount: { value: 100, currency: 'USD' } } });
+
+        const raw = rawOf('/u');
+        // Both fields survive as normal string parts…
+        expect(raw).toContain('name="amount[value]"');
+        expect(raw).toContain('100');
+        expect(raw).toContain('name="amount[currency]"');
+        expect(raw).toContain('USD');
+        // …and `amount` is NOT a file part (the old bug encoded it as a 3-byte Blob, losing currency).
+        expect(raw).not.toContain('name="amount"');
+        expect(raw).not.toContain('filename=');
+    });
+
+    test('a real { value: <Uint8Array>, filename } wrapper is still a file part', async () => {
+        server.route('POST', '/u', { body: { ok: true } });
+        const upload = stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/u',
+            bodyType: 'multipart',
+        });
+
+        await upload({ body: { doc: { value: bytes, filename: 'a.bin' } } });
+
+        const raw = rawOf('/u');
+        expect(raw).toContain('name="doc"');
+        expect(raw).toContain('filename="a.bin"');
+        // it did NOT recurse into value/filename string fields
+        expect(raw).not.toContain('doc[value]');
+        expect(raw).not.toContain('doc[filename]');
+    });
+
+    test('an explicit { value: "text", filename } is a named file part even with a string body', async () => {
+        server.route('POST', '/u', { body: { ok: true } });
+        const upload = stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/u',
+            bodyType: 'multipart',
+        });
+
+        await upload({ body: { note: { value: 'hello', filename: 'n.txt' } } });
+
+        const raw = rawOf('/u');
+        expect(raw).toContain('name="note"');
+        expect(raw).toContain('filename="n.txt"');
+        expect(raw).toContain('hello');
+        expect(raw).not.toContain('note[value]');
+    });
+
     // contract-not-dependency gate: the capability is a plain config key (not a closure), so a
     // stitch's declaration still serialises losslessly to JSON.
     test('contract gate: multipart.nesting round-trips through __config as JSON', () => {

--- a/packages/core/test/postmessage.spec.ts
+++ b/packages/core/test/postmessage.spec.ts
@@ -12,6 +12,7 @@ import {
     postMessageSurface,
     windowChannel,
 } from '../src/postmessage';
+import { toValidator } from '../src/validator';
 import { asValidator } from './support/schema';
 import { collectEvents } from './support/streams';
 
@@ -280,6 +281,73 @@ describe('validation on both boundaries', () => {
         // The reply correlates, but the buffered `output` contract rejects it → StitchError (drift).
         await expect(call({ body: {} })).rejects.toMatchObject({
             name: 'StitchError',
+        });
+        closeBoth();
+    });
+
+    // A plain `Validator` (from `toValidator(...)`) exposes `.validate()` but neither `~standard`
+    // nor `safeParse` — the same shape a Zod < 3.24 schema has. `respond` must accept it: the old
+    // `passes()` only handled `~standard`, so a Validator threw → was caught → treated as a
+    // failure → EVERY inbound request was silently dropped and the requester timed out.
+    test('a responder accepts a `toValidator(...)` input schema — a valid payload is NOT dropped', async () => {
+        const { parent, iframe, closeBoth } = channelPair();
+        // `toValidator` of a defined predicate always yields a Validator — a `{ validate() }`
+        // object with NO `~standard` and NO `safeParse` (the exact shape the old `passes` dropped).
+        const inputSchema = toValidator(
+            (v: unknown): boolean =>
+                typeof (v as { n?: unknown }).n === 'number',
+        )!;
+        expect('~standard' in inputSchema).toBe(false); // pins the bug's precondition
+        expect('safeParse' in inputSchema).toBe(false);
+        iframe.respond('dbl', (p: { n: number }) => ({ doubled: p.n * 2 }), {
+            input: inputSchema,
+        });
+        const call = parent.request({
+            type: 'dbl',
+            timeout: { perAttempt: 200 },
+        });
+        await expect(call({ body: { n: 21 } })).resolves.toEqual({
+            doubled: 42,
+        });
+        closeBoth();
+    });
+
+    test('a `toValidator(...)` input schema still DROPS an invalid payload (fail-closed preserved)', async () => {
+        const { parent, iframe, closeBoth } = channelPair();
+        const inputSchema = toValidator(
+            (v: unknown): boolean =>
+                typeof (v as { n?: unknown }).n === 'number',
+        )!;
+        iframe.respond('dbl2', (p: { n: number }) => ({ doubled: p.n * 2 }), {
+            input: inputSchema,
+        });
+        const call = parent.request({
+            type: 'dbl2',
+            timeout: { perAttempt: 40 },
+        });
+        await expect(
+            call({ body: { n: 'not-a-number' } }),
+        ).rejects.toMatchObject({ name: 'StitchError' });
+        closeBoth();
+    });
+
+    // `output` rides the same coercion — a `toValidator(...)` responder output that the result
+    // satisfies must let the reply through (before the fix it threw in `passes` → no reply posted).
+    test('a responder accepts a `toValidator(...)` output schema — a valid reply is posted', async () => {
+        const { parent, iframe, closeBoth } = channelPair();
+        const outputSchema = toValidator(
+            (v: unknown): boolean =>
+                typeof (v as { doubled?: unknown }).doubled === 'number',
+        )!;
+        iframe.respond('dbl3', (p: { n: number }) => ({ doubled: p.n * 2 }), {
+            output: outputSchema,
+        });
+        const call = parent.request({
+            type: 'dbl3',
+            timeout: { perAttempt: 200 },
+        });
+        await expect(call({ body: { n: 5 } })).resolves.toEqual({
+            doubled: 10,
         });
         closeBoth();
     });


### PR DESCRIPTION
Four independent, confirmed **MEDIUM** correctness bugs in `@stitchapi/core`, each fixed in its own file with its own regression test. All bugs were reproduced before the fix and verified after.

Full core suite green (**1174 tests / 126 files**), `check:types` clean, bundle within budget (no budget bump):

| scenario | before | after | budget | headroom |
| --- | --- | --- | --- | --- |
| whole entry (gzip) | 23.99 KB | 24.03 KB | 24.20 KB | 0.17 KB |
| `import { stitch }` (gzip) | 19.48 KB | 19.53 KB | 19.70 KB | 0.17 KB |

---

### 1. idempotency override — `packages/core/src/stitch.ts` (`compose` / `expandShorthand`)

A child fragment's `idempotency: false` did **not** disable idempotency inherited from a base fragment. `expandShorthand` deletes `false` from the current layer *before* the `deepMerge`, so an inherited `idempotency: true` (normalized to `{}`) survived and the Idempotency-Key header was still injected — a **P20** violation.

**Fix:** reconcile the idempotency slot by last-writer at merge time, mirroring the existing `url`/`baseUrl` last-writer reconciliation — when the last layer that sets `idempotency` sets it to `false`, clear the slot.

- **Fail-before:** `compose({ extends: [{ idempotency: true, method: 'POST', path: '/x' }], idempotency: false })` resolved to `__config.idempotency === {}` (ON).
- **Pass-after:** resolves to `undefined` (off); end-to-end, no `Idempotency-Key` header on the write. Last-writer still works both directions (`false` base + `true` child → `{}`), and a child `false` also clears an inherited idempotency **object**.
- Regression tests: `test/idempotency.spec.ts` (3 new; the 2 `false`-override cases fail on unpatched `src`).

### 2. from-curl newlines — `packages/core/src/from-curl.ts` (`quote`)

`quote()` escaped `\` and `'` but not line terminators, so a captured value containing a newline (HAR import, `-d @body.json`, a multiline header) emitted an **unterminated single-quoted literal** → the generated stitch source didn't compile. (Not an injection — `'`/`\` were already escaped.)

**Fix:** additionally escape the four ES string-literal line terminators — LF, CR, U+2028, U+2029 — appended to the existing `\`/`'` chain (backslash first). The common case stays single-quoted; the emitted literal round-trips to the original value.

- **Fail-before:** a header/body value with a newline emitted `'line1<LF>line2'`; neutralized-and-`new Function(...)` threw `SyntaxError`.
- **Pass-after:** emits `'line1\nline2'`; the source parses; a value with LF/CR/CRLF/U+2028/U+2029/`\`/`'` round-trips exactly.
- Regression tests: `test/from-curl-edges.spec.ts` (4 new; 3 fail on unpatched `src`).

### 3. postMessage respond() fail-closed — `packages/core/src/postmessage.ts` (`passes`)

`respond({ input, output })` accepts the full `SchemaLike` union, but `passes()` only handled Standard-Schema + predicate. A plain `Validator` (from `toValidator(...)` — a `{ validate() }` object with no `~standard`) or a Zod < 3.24 schema threw in the Standard-Schema branch → `catch` returned `false` → **every inbound request was silently dropped** and the requester timed out.

**Fix:** route `respond`'s `input`/`output` through `toValidator(...)` (the same coercion the rest of the surface uses) and validate via `(await v.validate(value)).ok`, so every schema flavour — Standard Schema, Zod (incl. < 3.24), a `toValidator` Validator, a bare predicate — validates uniformly. Removes the fragile local `SchemaValidate`/`StandardResult` types.

- **Fail-before:** a `toValidator(...)`-wrapped `input` on a responder dropped a **valid** message → the caller timed out with a StitchError.
- **Pass-after:** a valid message passes through; an invalid one is still dropped (fail-closed preserved); Standard-Schema/Zod/predicate paths unchanged.
- Regression tests: `test/postmessage.spec.ts` (3 new; the 2 "not dropped" cases fail on unpatched `src`).

### 4. multipart file-leaf — `packages/core/src/http-adapter.ts` (`isFileLeaf`)

`isFileLeaf` returned `true` for **any** object merely having a `value` key, so a `multipart` body `{ amount: { value: 100, currency: 'USD' } }` encoded `amount` as a 3-byte Blob and silently **dropped** the sibling `currency`.

**Fix:** only treat a `{ value, ... }` node as a file part when it's actually file-ish — `value` is a Blob/Uint8Array/ArrayBuffer, or an explicit `filename`/`type` is present — otherwise recurse it as a normal nested object.

- **Fail-before:** the money object encoded `amount` as `Blob(3)`; `currency` never appeared in the form.
- **Pass-after:** both `amount[value]` and `amount[currency]` survive as normal fields; a real `{ value: <Blob/Uint8Array/ArrayBuffer>, filename }` (and an explicit `{ value: 'text', filename }`) still becomes a file part; all four nestings (bracket/dot/json/none) behave.
- Regression tests: `test/multipart-nesting.spec.ts` (3 new; the "siblings survive" case fails on unpatched `src`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
