### PR TITLE
fix(core): harden stitch serve — cap request body (OOM) and tear down SSE on client disconnect

### DIFF
--- a/packages/core/src/serve.ts
+++ b/packages/core/src/serve.ts
@@ -130,8 +130,9 @@ async function streamSse(
     const iterator = stream[Symbol.asyncIterator]();
     try {
         while (!res.writableEnded && !res.destroyed) {
-            const { value: ev, done } = await iterator.next();
-            if (done) break;
+            const result = await iterator.next();
+            if (result.done) break;
+            const ev = result.value;
             // `serve` is unauthenticated (loopback by default; DESIGN.md §10) and the SSE consumer
             // is remote, so scrub credential-bearing metadata a `start` frame would otherwise echo
             // — URL credentials and `authorization`/`cookie` headers — before it leaves the
@@ -234,7 +235,9 @@ export function createServeHandler(
         // engine cancels the in-flight upstream call and stops reconnecting — otherwise an infinite
         // SSE stream would run forever, buffering chunks, for a caller that has already left.
         const controller = new AbortController();
-        const onClose = (): void => controller.abort();
+        const onClose = (): void => {
+            controller.abort();
+        };
         req.on('close', onClose);
         res.on('close', onClose);
         try {

--- a/packages/core/src/serve.ts
+++ b/packages/core/src/serve.ts
@@ -7,6 +7,7 @@
 // With `Accept: text/event-stream` (or `?stream=1`) the response is the live event
 // stream as SSE; otherwise the final validated result is returned as JSON. Reuses the
 // engine through `stitch.stream()` — no framework, no new dependencies.
+import { compact } from './compact';
 import { type StitchRegistry, selectStitch } from './registry';
 import { redactEventForTransport } from './trace';
 import type { StitchEvent, StitchInput } from './types';
@@ -21,6 +22,13 @@ import {
 export interface ServeOptions {
     port?: number; // default 8787; 0 picks an ephemeral port
     host?: string; // default 127.0.0.1
+    /**
+     * Reject a request body larger than this many bytes with 413 (see
+     * {@link MAX_REQUEST_BODY_BYTES}). `serve` is unauthenticated (loopback by default, but
+     * `--host` lets an operator bind a wider interface), so this bounds the memory a single
+     * request can buffer. Default {@link MAX_REQUEST_BODY_BYTES}.
+     */
+    maxBodyBytes?: number;
 }
 
 export interface ServeHandle {
@@ -30,18 +38,63 @@ export interface ServeHandle {
     close(): Promise<void>;
 }
 
+// Default request-body cap. `serve` is unauthenticated (loopback by default; DESIGN.md §10), but
+// `cli.ts --host` lets an operator bind a wider interface, so an unbounded body would let a single
+// large/slow POST buffer the whole payload into memory → OOM. A few MB comfortably fits any real
+// stitch input (JSON params/query/headers/variables) while capping that exposure; the same 2 MB
+// order of magnitude as trace's body-truncation scale (`DEFAULT_MAX_BODY_BYTES`). Override per
+// server via {@link ServeOptions.maxBodyBytes}.
+export const MAX_REQUEST_BODY_BYTES = 2 * 1024 * 1024;
+
+// Thrown by `readBody` when the body exceeds the cap; the handler maps it to 413.
+class PayloadTooLargeError extends Error {
+    constructor(readonly limit: number) {
+        super(`request body exceeds ${limit} bytes`);
+        this.name = 'PayloadTooLargeError';
+    }
+}
+
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
     res.writeHead(status, { 'content-type': 'application/json' });
     res.end(JSON.stringify(body));
 }
 
-function readBody(req: IncomingMessage): Promise<string> {
+// Read the request body, enforcing a byte cap. Rejects with a `PayloadTooLargeError` — before
+// reading anything when `Content-Length` already declares an over-cap body, and mid-stream the
+// moment the accumulated bytes cross the cap. We count bytes on the raw `Buffer` chunks (not
+// decoded string length) so the cap is exact for multi-byte UTF-8, then decode once at the end.
+//
+// The up-front `Content-Length` rejection does NOT destroy the socket, so the handler's 413 still
+// flushes to the client (destroying immediately would race the response away). The mid-stream
+// rejection DOES `req.destroy()` — a chunked/`Content-Length`-lying sender must be cut off so it
+// can't keep pushing bytes we'd otherwise buffer.
+function readBody(
+    req: IncomingMessage,
+    limit: number = MAX_REQUEST_BODY_BYTES,
+): Promise<string> {
     return new Promise((resolve, reject) => {
-        let data = '';
-        req.setEncoding('utf8');
-        req.on('data', (c: string) => (data += c));
+        const declared = Number(req.headers['content-length']);
+        if (Number.isFinite(declared) && declared > limit) {
+            reject(new PayloadTooLargeError(limit));
+            return;
+        }
+        const chunks: Buffer[] = [];
+        let size = 0;
+        req.on('data', (c: Buffer | string) => {
+            // A live HTTP socket emits `Buffer` chunks; some mock streams emit strings. Normalize to
+            // a `Buffer` so the byte count is exact (a decoded string's `.length` counts code units,
+            // not bytes) and `Buffer.concat` always gets buffers.
+            const buf = typeof c === 'string' ? Buffer.from(c, 'utf8') : c;
+            size += buf.length;
+            if (size > limit) {
+                req.destroy();
+                reject(new PayloadTooLargeError(limit));
+                return;
+            }
+            chunks.push(buf);
+        });
         req.on('end', () => {
-            resolve(data);
+            resolve(Buffer.concat(chunks).toString('utf8'));
         });
         req.on('error', reject);
     });
@@ -57,6 +110,14 @@ const wantsSse = (req: IncomingMessage, url: URL): boolean =>
     url.searchParams.get('stream') === '1';
 
 // Stream every event as SSE: `event: <type>` + a JSON `data:` line per event.
+//
+// Tears down on client disconnect. `res.write` on a dead socket returns `false` but never throws,
+// so a `for await` loop alone would spin forever on an infinite stream after the client leaves,
+// keeping the upstream open and accumulating chunks. Two things break that: the handler aborts the
+// run's signal on `req`/`res` 'close' (so the engine cancels the in-flight call and the generator
+// completes), and we iterate manually here — checking `writableEnded`/`destroyed` before each write
+// and calling `iterator.return()` in `finally` to run the generator's cleanup, releasing the
+// upstream. This mirrors the elysia/hono/fastify SSE bridges' `iterator.return()`-on-abort teardown.
 async function streamSse(
     res: ServerResponse,
     stream: AsyncIterable<StitchEvent>,
@@ -66,20 +127,29 @@ async function streamSse(
         'cache-control': 'no-cache',
         connection: 'keep-alive',
     });
+    const iterator = stream[Symbol.asyncIterator]();
     try {
-        // `serve` is unauthenticated (loopback by default; DESIGN.md §10) and the SSE consumer is
-        // remote, so scrub credential-bearing metadata a `start` frame would otherwise echo —
-        // URL credentials and `authorization`/`cookie` headers — before it leaves the process. The
-        // streamed `delta`/`result` payload is preserved (it is what the caller asked for).
-        for await (const ev of stream)
+        while (!res.writableEnded && !res.destroyed) {
+            const { value: ev, done } = await iterator.next();
+            if (done) break;
+            // `serve` is unauthenticated (loopback by default; DESIGN.md §10) and the SSE consumer
+            // is remote, so scrub credential-bearing metadata a `start` frame would otherwise echo
+            // — URL credentials and `authorization`/`cookie` headers — before it leaves the
+            // process. The streamed `delta`/`result` payload is preserved (it is what the caller
+            // asked for).
             res.write(
                 `event: ${ev.type}\ndata: ${JSON.stringify(redactEventForTransport(ev))}\n\n`,
             );
+        }
     } catch (e) {
-        res.write(
-            `event: error\ndata: ${JSON.stringify({ message: (e as Error).message })}\n\n`,
-        );
+        if (!res.writableEnded && !res.destroyed)
+            res.write(
+                `event: error\ndata: ${JSON.stringify({ message: (e as Error).message })}\n\n`,
+            );
     } finally {
+        // Release the upstream: runs the generator's `finally` (which aborts the in-flight call and
+        // stops it reconnecting). Safe to call whether we finished, threw, or the client left.
+        await iterator.return?.(undefined);
         res.end();
     }
 }
@@ -111,9 +181,11 @@ async function runJson(
 }
 
 // A framework-free request handler. Exposed so it can be mounted in an existing
-// server or driven directly in tests.
+// server or driven directly in tests. `maxBodyBytes` caps the request body (413 past it);
+// defaults to {@link MAX_REQUEST_BODY_BYTES}.
 export function createServeHandler(
     registry: StitchRegistry,
+    { maxBodyBytes = MAX_REQUEST_BODY_BYTES }: { maxBodyBytes?: number } = {},
 ): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
     return async (req, res) => {
         const url = new URL(req.url ?? '/', 'http://localhost');
@@ -148,15 +220,34 @@ export function createServeHandler(
 
         let input: StitchInput;
         try {
-            input = parseInput(await readBody(req));
-        } catch {
+            input = parseInput(await readBody(req, maxBodyBytes));
+        } catch (e) {
+            if (e instanceof PayloadTooLargeError) {
+                sendJson(res, 413, { error: e.message });
+                return;
+            }
             sendJson(res, 400, { error: 'invalid JSON body' });
             return;
         }
 
-        const stream = stitch.stream(input) as AsyncIterable<StitchEvent>;
-        if (wantsSse(req, url)) await streamSse(res, stream);
-        else await runJson(res, stream);
+        // Thread cancellation: if the client goes away (`req`/`res` 'close') abort the run so the
+        // engine cancels the in-flight upstream call and stops reconnecting — otherwise an infinite
+        // SSE stream would run forever, buffering chunks, for a caller that has already left.
+        const controller = new AbortController();
+        const onClose = (): void => controller.abort();
+        req.on('close', onClose);
+        res.on('close', onClose);
+        try {
+            const stream = stitch.stream({
+                ...input,
+                signal: controller.signal,
+            }) as AsyncIterable<StitchEvent>;
+            if (wantsSse(req, url)) await streamSse(res, stream);
+            else await runJson(res, stream);
+        } finally {
+            req.off('close', onClose);
+            res.off('close', onClose);
+        }
     };
 }
 
@@ -167,7 +258,10 @@ export function serve(
     opts: ServeOptions = {},
 ): Promise<ServeHandle> {
     const host = opts.host ?? '127.0.0.1';
-    const handle = createServeHandler(registry);
+    const handle = createServeHandler(
+        registry,
+        compact({ maxBodyBytes: opts.maxBodyBytes }),
+    );
     const server = createServer((req, res) => {
         handle(req, res).catch((e: unknown) => {
             if (!res.headersSent)

--- a/packages/core/test/serve-handler.spec.ts
+++ b/packages/core/test/serve-handler.spec.ts
@@ -9,12 +9,17 @@ import type { StitchRegistry } from '../src/registry';
 import { createServeHandler } from '../src/serve';
 import { failStitch, stubStitch } from '../src/test-stub';
 
+import { EventEmitter } from 'node:events';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { Readable } from 'node:stream';
 
-class FakeRes {
+// An EventEmitter so the handler can register its client-disconnect 'close' listeners on it (the
+// SSE-teardown path calls `res.on('close', …)` / `res.off(…)` and reads `writableEnded`/`destroyed`).
+class FakeRes extends EventEmitter {
     statusCode = 0;
     headers: Record<string, string | string[]> = {};
+    writableEnded = false;
+    destroyed = false;
     private chunks: string[] = [];
     writeHead(status: number, headers?: Record<string, string>): this {
         this.statusCode = status;
@@ -27,6 +32,7 @@ class FakeRes {
     }
     end(chunk?: string): this {
         if (chunk !== undefined) this.chunks.push(chunk);
+        this.writableEnded = true;
         return this;
     }
     get body(): string {

--- a/packages/core/test/serve.spec.ts
+++ b/packages/core/test/serve.spec.ts
@@ -294,16 +294,11 @@ describe('serve caps the request body (413), so an unauthenticated server cannot
             duplex: 'half',
         }).catch((e: unknown) => e as Error);
         // Either the server answered 413, or it destroyed the socket mid-upload (a client-visible
-        // network error) — both are the cap doing its job (refusing to buffer unbounded). It must
-        // NOT be a 200 (which is what the unbounded pre-fix `readBody` returned).
-        if (res instanceof Error) {
-            expect(res.message).toBeTruthy(); // socket torn down mid-send: body was refused
-        } else {
-            expect(res.status).toBe(413);
-            await expect(res.json()).resolves.toMatchObject({
-                error: expect.stringContaining('exceeds'),
-            });
-        }
+        // network error) — both are the cap doing its job (refusing to buffer unbounded). What it
+        // must never be is a 200 (which is what the unbounded pre-fix `readBody` returned). The
+        // 413 body + `exceeds` message is asserted deterministically by the Content-Length test below.
+        const refused = res instanceof Error || res.status === 413;
+        expect(refused).toBe(true);
     });
 
     test('a truthful Content-Length over the cap is rejected up front with 413', async () => {
@@ -363,7 +358,7 @@ function fakeReqRes(body: string, headers: Record<string, string>) {
     return {
         req: req as unknown as IncomingMessage,
         res: res as unknown as ServerResponse,
-        closeClient() {
+        closeClient: () => {
             res.destroyed = true;
             req.emit('close');
             res.emit('close');
@@ -401,9 +396,7 @@ describe('serve tears down an SSE stream when the client disconnects (no runaway
             },
         } as unknown as Stitch;
 
-        const registry: StitchRegistry = {
-            infinite: infinite as unknown as StitchRegistry[string],
-        };
+        const registry: StitchRegistry = { infinite };
         const handler = createServeHandler(registry);
         const { req, res, closeClient } = fakeReqRes('{}', {
             accept: 'text/event-stream',

--- a/packages/core/test/serve.spec.ts
+++ b/packages/core/test/serve.spec.ts
@@ -1,13 +1,17 @@
 // Set the trace file before importing ../src so the JSONL sink is captured/quiet.
 import { stitch } from '../src';
-import { serve } from '../src/serve';
+import type { StitchRegistry } from '../src/registry';
+import { createServeHandler, serve } from '../src/serve';
 import type { ServeHandle } from '../src/serve';
 import { sse } from '../src/sse';
+import type { Stitch, StitchEvent } from '../src/types';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
 import { asValidator } from './support/schema';
 import { streamOf } from './support/streams';
 
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
@@ -247,5 +251,179 @@ describe('serve forwards a streaming surface as `event: delta` SSE frames', () =
         ]);
         expect(frames[0]?.event).toBe('start');
         expect(frames.at(-1)?.event).toBe('done');
+    });
+});
+
+describe('serve caps the request body (413), so an unauthenticated server cannot be OOM-ed', () => {
+    // A dedicated server with a tiny cap: we can prove the bound with a small body instead of
+    // shipping megabytes, and the assertion is that it *rejects* — not that a giant body OOMs.
+    const CAP = 64;
+    let capped: ServeHandle;
+    beforeAll(async () => {
+        const ping = stitch({ baseUrl: api.url, path: '/ping' });
+        capped = await serve({ ping }, { port: 0, maxBodyBytes: CAP });
+    });
+    afterAll(async () => {
+        await capped.close();
+    });
+
+    test('a body over the cap is rejected with 413 (streamed, no Content-Length)', async () => {
+        api.route('GET', '/ping', { body: { ok: true } });
+        // A body well past the cap, streamed in fixed chunks — bounded, but sent WITHOUT a
+        // Content-Length header (a stream body forces chunked transfer). This exercises the
+        // mid-stream byte-accumulation guard specifically, not just the up-front header check.
+        // Before the fix `readBody` buffered every chunk and answered 200; after the fix the
+        // accumulator trips the cap mid-stream, the socket is destroyed, and the handler maps
+        // the size error to 413.
+        let sent = 0;
+        const res = await fetch(`${capped.url}/stitch/ping`, {
+            method: 'POST',
+            body: new ReadableStream({
+                pull(controller) {
+                    if (sent >= CAP * 4) {
+                        controller.close();
+                        return;
+                    }
+                    sent += 16;
+                    controller.enqueue(
+                        new TextEncoder().encode('x'.repeat(16)),
+                    );
+                },
+            }),
+            // @ts-expect-error `duplex` is required by Node's fetch for a stream body.
+            duplex: 'half',
+        }).catch((e: unknown) => e as Error);
+        // Either the server answered 413, or it destroyed the socket mid-upload (a client-visible
+        // network error) — both are the cap doing its job (refusing to buffer unbounded). It must
+        // NOT be a 200 (which is what the unbounded pre-fix `readBody` returned).
+        if (res instanceof Error) {
+            expect(res.message).toBeTruthy(); // socket torn down mid-send: body was refused
+        } else {
+            expect(res.status).toBe(413);
+            await expect(res.json()).resolves.toMatchObject({
+                error: expect.stringContaining('exceeds'),
+            });
+        }
+    });
+
+    test('a truthful Content-Length over the cap is rejected up front with 413', async () => {
+        api.route('GET', '/ping', { body: { ok: true } });
+        const res = await fetch(`${capped.url}/stitch/ping`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            // JSON longer than CAP bytes; fetch sets an honest Content-Length.
+            body: JSON.stringify({ query: { pad: 'y'.repeat(CAP) } }),
+        });
+        expect(res.status).toBe(413);
+        await expect(res.json()).resolves.toMatchObject({
+            error: expect.stringContaining('exceeds'),
+        });
+    });
+
+    test('a body within the cap still succeeds (the server survived the rejections)', async () => {
+        api.route('GET', '/ping', { body: { ok: true } });
+        const res = await fetch(`${capped.url}/stitch/ping`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({}), // 2 bytes, well under the cap
+        });
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toEqual({ ok: true });
+    });
+});
+
+// A fake `req`/`res` pair for driving `createServeHandler` without a socket, so a client
+// disconnect can be simulated deterministically by emitting 'close'.
+function fakeReqRes(body: string, headers: Record<string, string>) {
+    // `writableEnded`/`destroyed` are read-only on the real `ServerResponse`, so we type the fake
+    // as a loose mutable record and cast to the Node types only at the boundary.
+    const req = Object.assign(new EventEmitter(), {
+        method: 'POST',
+        url: '/stitch/infinite',
+        headers,
+        setEncoding: () => req, // no-op; body is fed as a Buffer below
+        destroy: () => req,
+    });
+    const res = Object.assign(new EventEmitter(), {
+        writableEnded: false,
+        destroyed: false,
+        writeHead: () => res,
+        write: () => true, // a live socket; the loop must stop by other means, not a throw
+        end: () => {
+            res.writableEnded = true;
+            return res;
+        },
+    });
+
+    // Feed the request body on next tick, as a real socket would.
+    queueMicrotask(() => {
+        req.emit('data', Buffer.from(body, 'utf8'));
+        req.emit('end');
+    });
+    return {
+        req: req as unknown as IncomingMessage,
+        res: res as unknown as ServerResponse,
+        closeClient() {
+            res.destroyed = true;
+            req.emit('close');
+            res.emit('close');
+        },
+    };
+}
+
+describe('serve tears down an SSE stream when the client disconnects (no runaway upstream)', () => {
+    test('a client disconnect aborts the run signal and runs the source generator’s finally', async () => {
+        let returned = false; // did the generator's finally run (i.e. iterator.return())?
+        let seenSignal: AbortSignal | undefined; // the signal serve threaded into the run
+        let emitted = 0; // how many events the generator yielded before teardown
+
+        // A fake stitch whose .stream() is an INFINITE generator: `res.write` on a live socket
+        // never throws, so before the fix this loop would run forever after the client left. The
+        // finally records that `.return()` ran; the signal is captured so we can assert the abort.
+        // It awaits a macrotask between yields (as a real I/O-backed stream does) so the loop
+        // yields to timers — otherwise a tight synchronous `await` loop would starve setTimeout.
+        const infinite: Stitch = {
+            stream: async function* (input?: { signal?: AbortSignal }) {
+                seenSignal = input?.signal;
+                try {
+                    for (let i = 0; ; i++) {
+                        emitted++;
+                        yield {
+                            type: 'delta',
+                            chunk: { n: i },
+                            at: 0,
+                        } as StitchEvent;
+                        await new Promise((r) => setImmediate(r));
+                    }
+                } finally {
+                    returned = true;
+                }
+            },
+        } as unknown as Stitch;
+
+        const registry: StitchRegistry = {
+            infinite: infinite as unknown as StitchRegistry[string],
+        };
+        const handler = createServeHandler(registry);
+        const { req, res, closeClient } = fakeReqRes('{}', {
+            accept: 'text/event-stream',
+        });
+
+        const done = handler(req, res); // starts streaming; would never resolve without teardown
+
+        // Let a few frames stream, then simulate the client going away.
+        await new Promise((r) => setTimeout(r, 10));
+        expect(emitted).toBeGreaterThan(0); // proves the stream was live
+        expect(seenSignal).toBeInstanceOf(AbortSignal); // serve threaded a cancellation signal
+        expect(seenSignal?.aborted).toBe(false);
+
+        closeClient();
+        await done; // resolves only because teardown breaks the loop and ends the response
+
+        expect(seenSignal?.aborted).toBe(true); // the run was cancelled on disconnect
+        expect(returned).toBe(true); // the generator's finally ran (iterator.return fired)
+        const settled = emitted;
+        await new Promise((r) => setTimeout(r, 10));
+        expect(emitted).toBe(settled); // and it stopped — no runaway production after teardown
     });
 });


### PR DESCRIPTION
## Summary

`stitch serve` is a thin, **unauthenticated** local HTTP front door (loopback by default, but `cli.ts --host` lets an operator bind a wider interface). This PR closes two robustness/DoS holes in `packages/core/src/serve.ts` that both trace back to that unauthenticated-server posture and to how the request lifecycle is torn down.

### Bug 1 — unbounded request body → OOM (security, MEDIUM)

`readBody` accumulated the entire body into one string with **no size limit and no `Content-Length` check**, so a single large or slow POST could buffer unbounded and OOM the process.

**Fix:** `readBody` now enforces a byte cap:
- rejects **up front** when `Content-Length` already declares an over-cap body (no socket teardown, so the 413 still flushes to the client);
- rejects **mid-stream** the moment accumulated bytes cross the cap, and `req.destroy()`s the socket so a chunked / `Content-Length`-lying sender can't keep pushing bytes we'd buffer.

The handler maps the size error to **413 Payload Too Large**. Default `MAX_REQUEST_BODY_BYTES = 2 MB` (same order of magnitude as trace's `DEFAULT_MAX_BODY_BYTES`), configurable per server via `ServeOptions.maxBodyBytes`. Bytes are counted on the raw `Buffer` chunks (normalizing string chunks from mock streams), so the cap is exact for multi-byte UTF-8.

### Bug 2 — SSE stream never tears down on client disconnect (reliability, HIGH)

`res.write` on a dead socket returns `false` but **never throws**, so the old `for await (const ev of stream)` loop ran forever after the client left: the async generator's `.return()` never ran, the engine kept the upstream open, kept accumulating chunks (unbounded for infinite streams), and reconnected — all for a caller that had already gone.

**Fix (belt-and-suspenders teardown, matching the theme of releasing resources when the client leaves):**
- the handler creates an `AbortController`, threads its signal into `stitch.stream({ ...input, signal })` (the engine honors `StitchInput.signal`, `engine.ts:244`), and calls `controller.abort()` on `req`/`res` `'close'` — so the engine cancels the in-flight upstream call and stops reconnecting;
- `streamSse` now iterates the generator **manually**, bails when the response is no longer writable (`writableEnded`/`destroyed`), and calls `iterator.return()` in `finally` to run the generator's cleanup and release the upstream.

This mirrors the existing elysia/hono/fastify SSE bridges' `iterator.return()`-on-abort teardown (`packages/fastify/src/sse.ts`, etc.).

## Tests

`packages/core/test/serve.spec.ts` (new):
- **body over the cap → 413**, covering both the streamed / no-`Content-Length` path (mid-stream byte-accumulation guard) and the up-front `Content-Length` path; plus a within-cap body that still succeeds (proves the server survives the rejections). Asserts the server **rejects/limits** — it does not assert an OOM.
- **client disconnect mid-stream**: drives `createServeHandler` directly with a fake **infinite** `AsyncIterable` (records when `.return()` runs) and a fake `req`/`res`; simulates `'close'` and asserts the run's signal is aborted, the source generator's `finally` ran, and production stopped (no runaway).

Both new behaviors **fail before / pass after** the fix (verified by reverting `serve.ts` to HEAD: the 413 tests return 200/400 and the disconnect test finds no threaded `AbortSignal`).

`packages/core/test/serve-handler.spec.ts`: its `FakeRes` gains `EventEmitter` + `writableEnded`/`destroyed` so it models the `'close'` listeners the handler now registers (minimal fixture update).

## Verification

- `pnpm exec vitest run` (full core suite): **1166 passed / 126 files**
- `pnpm run check:types` (src + `tsconfig.test.json`): green
- `node scripts/bundle-size.mjs`: **neutral** — `stitchapi` whole entry `23.99 KB` gzip, `import { stitch }` `19.48 KB` gzip, unchanged before/after (`serve.ts` is Node-only, not in the main browser entry)
- prettier: clean

Not merging — leaving for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)