### PR TITLE
fix(core): scrub userinfo from OpenAPI servers[].url (credential leak in generated doc)

### DIFF
--- a/packages/core/src/openapi.ts
+++ b/packages/core/src/openapi.ts
@@ -23,6 +23,7 @@ import type {
     SecurityScheme,
     StitchConfig,
 } from './types';
+import { scrubUrl } from './util';
 
 export interface OpenApiInfo {
     title: string;
@@ -355,7 +356,12 @@ export function toOpenApi(
             continue;
         }
         const { server, path: rawPath } = splitServer(endpoint.value);
-        if (server) servers.add(server);
+        // Scrub the origin before it lands in `servers[].url`: `splitServer` captures the whole
+        // authority incl. userinfo (`https://user:pass@host`), and this document is often
+        // published/shared, so a URL basic-auth credential must not survive. `scrubUrl` strips
+        // userinfo and redacts secret query values — the same treatment every other url-emitting
+        // sink in core gives a URL (trace.ts, otlp.ts, the console renderer).
+        if (server) servers.add(scrubUrl(server));
         const { path, parameters } = parsePath(rawPath);
         const method = (cfg.method ?? 'get').toLowerCase();
         const item = (paths[path] ??= {});

--- a/packages/core/test/openapi.spec.ts
+++ b/packages/core/test/openapi.spec.ts
@@ -49,6 +49,27 @@ describe('toOpenApi', () => {
         ]);
     });
 
+    test('scrubs userinfo credentials from a baseUrl before emitting servers[].url', () => {
+        // A stitch whose baseUrl carries URL basic-auth (accepted + used by the engine). The
+        // generated OpenAPI document is "often published/shared", so the password must not survive
+        // into servers[].url. The server origin is routed through scrubUrl like every other
+        // url-emitting sink in core.
+        const registry: StitchRegistry = {
+            secretSvc: stitch({
+                baseUrl: 'https://svc:s3cr3t@api.internal/v1',
+                path: '/users/{id}',
+            }),
+        };
+        const { document } = toOpenApi(registry);
+        const serverUrl = document.servers?.[0]?.url ?? '';
+        expect(serverUrl).not.toContain('s3cr3t'); // password
+        expect(serverUrl).not.toContain('svc:'); // username:password userinfo
+        expect(serverUrl).not.toContain('@'); // userinfo delimiter
+        expect(serverUrl).toContain('api.internal'); // host is preserved
+        // And the credential must not leak anywhere else in the serialized document either.
+        expect(JSON.stringify(document)).not.toContain('s3cr3t');
+    });
+
     test('defaults info when no title/version is given', () => {
         const { document } = toOpenApi({});
         expect(document.info).toEqual({


### PR DESCRIPTION
## Security fix — HIGH: credential leak in the generated OpenAPI document

`toOpenApi` (`stitch export --openapi`) built `servers[].url` from the **raw origin** returned by `splitServer`, whose regex `^([a-z][a-z0-9+.-]*:\/\/[^/]+)(\/.*)?$` captures the whole authority — **including userinfo**.

A stitch with a URL basic-auth `baseUrl` (accepted and used by the engine), e.g.:

```ts
stitch({ baseUrl: 'https://svc:s3cr3t@api.internal/v1', path: '/users/{id}' })
```

made `toOpenApi` emit:

```jsonc
"servers": [{ "url": "https://svc:s3cr3t@api.internal" }]  // 🔴 password baked in
```

— baking the password into the generated OpenAPI document, which the module docstring notes is *"often published/shared"*.

`openapi.ts` was the **one** URL-emitting sink in core that did not run its URL through `scrubUrl` (`trace.ts`, `otlp.ts`, and the console renderer all do).

## The fix

Route the server origin through the existing `scrubUrl` helper (util.ts) before adding it to the `servers` set:

```ts
if (server) servers.add(scrubUrl(server));
```

`scrubUrl` strips userinfo (`username`/`password`) and redacts secret-bearing query values, while returning a clean origin **unchanged** (so no existing output is reformatted). After the fix the same stitch emits `servers: [{ url: "https://api.internal/" }]` — host preserved, credential gone.

## Verification

- **Regression test** (`packages/core/test/openapi.spec.ts`): a registry with a userinfo-bearing `baseUrl` must not leak the username or password into `document.servers[].url`, nor anywhere in the serialized document.
  - **Fail-before:** `AssertionError: expected 'https://svc:s3cr3t@api.internal' not to contain 's3cr3t'`
  - **Pass-after:** all 19 `openapi.spec.ts` tests pass.
- Full core suite: **1161 passed** (2 pre-existing skips).
- `check:types`: clean.
- **Bundle: unchanged** — `scrubUrl` is already on the core path, so the reference costs nothing. Whole entry **23.99 KB** gzip (budget 24.20), `import { stitch }` **19.48 KB** (budget 19.70). Both within budget, before == after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)