### PR TITLE
fix(core): cap SSE parse buffers (OOM) and cancel the stream on early break

### DIFF
--- a/packages/core/src/line-reader.ts
+++ b/packages/core/src/line-reader.ts
@@ -7,12 +7,42 @@
 // `stream`'s `'lines'` / `'ndjson'` decoders consume these lines directly; `sse`'s frame parser
 // layers the event-stream grammar on top (stripping a trailing `\r`, grouping by blank lines). They
 // share this plumbing, not a decoder — `text/event-stream` is a protocol, "lines" is not.
+import { JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES } from './json-stream';
+
+/**
+ * Read UTF-8 lines off `stream`, splitting on `\n` and yielding each line WITHOUT its terminator.
+ *
+ * `maxBufferBytes` caps the length of a single UN-TERMINATED line held in `buf`: an upstream that
+ * streams bytes with no `\n` would otherwise grow client memory without limit (an OOM DoS), so once
+ * the carry exceeds the cap we throw a descriptive Error instead. This mirrors the `'json'` decoder's
+ * per-value cap (`json-stream.ts`) — same default (~8 MB), same "the engine turns the throw into an
+ * `error` event" contract (`runStreaming`), so an abusive body fails the stream cleanly rather than
+ * OOM-ing. Overridable per-stream via `stream.maxBufferBytes`.
+ *
+ * On any completion — normal end OR an early generator `.return()` (a consumer `break`s without
+ * aborting a signal) — the `finally` proactively `cancel()`s the underlying stream before releasing
+ * the reader lock, so an abandoned SSE/line consumer closes the HTTP connection instead of leaking it
+ * until GC. Aborting via the request signal already tears the body down; this covers break-without-abort.
+ * `cancel()` on an already-closed stream is a spec no-op, so cancelling unconditionally is safe.
+ */
 export async function* lineReader(
     stream: ReadableStream<Uint8Array>,
+    maxBufferBytes: number = JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES,
 ): AsyncGenerator<string, void> {
     const reader = stream.getReader();
     const decoder = new TextDecoder();
     let buf = '';
+    // Guard the un-terminated carry: `buf` here holds only the bytes AFTER the last `\n`, so a
+    // legitimate long-but-terminated line stream never trips it — only a run with no line break does.
+    const guard = (): void => {
+        if (buf.length > maxBufferBytes) {
+            throw new Error(
+                `line reader: un-terminated line exceeded maxBufferBytes (${String(
+                    maxBufferBytes,
+                )}); a stream with no newline was sent`,
+            );
+        }
+    };
     try {
         for (;;) {
             const r = await reader.read();
@@ -24,6 +54,7 @@ export async function* lineReader(
                 buf = buf.slice(nl + 1);
                 nl = buf.indexOf('\n');
             }
+            guard(); // whatever is left after this chunk is an un-terminated carry — cap it
         }
         // Flush any bytes the streaming decoder held back (a split multi-byte char), then drain
         // any remaining complete lines and finally the unterminated trailing line, if any.
@@ -36,6 +67,10 @@ export async function* lineReader(
         }
         if (buf.length > 0) yield buf;
     } finally {
+        // Cancel the body on any exit path (early `break` / error / normal end) so an abandoned
+        // consumer proactively closes the connection; then release the lock. `.catch` swallows a
+        // reject from a body already torn down by an abort.
+        await reader.cancel().catch(() => undefined);
         reader.releaseLock();
     }
 }

--- a/packages/core/src/sse.ts
+++ b/packages/core/src/sse.ts
@@ -10,12 +10,14 @@
 // Bundle-frugal (Decision 10): this module — and the frame parser — is reached only through the
 // `sse` subpath, never from the root entry; `import { stitch }` pulls in no SSE code.
 import type { InputOf, OutputOf } from './infer';
+import { JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES } from './json-stream';
 import { lineReader } from './line-reader';
 import { seam as makeSeam } from './seam';
 import { makeStitch } from './stitch';
 import type { Surface } from './surface';
 import {
     type AdapterResponse,
+    type ResolvedStitchConfig,
     type Seam,
     type SeamOptions,
     type Stitch,
@@ -98,12 +100,21 @@ function dispatchFrame(frame: SseFrame): SseEvent | undefined {
 // `event:` / `data:` / `id:` / `retry:` fields accumulate (multiple `data:` lines join with `\n`);
 // `:`-prefixed lines are comments; exactly one leading space after the field colon is stripped. A
 // trailing event with no terminating blank line is discarded (spec), as is a block with no `data:`.
+//
+// `maxBufferBytes` bounds the accumulated `data:` payload of a SINGLE in-progress frame (a run of
+// `data:` lines with no dispatching blank line): without this an upstream that streams endless
+// `data:` fields — or one giant unterminated line — would grow client memory without limit (an OOM
+// DoS). `lineReader` caps a single un-terminated LINE with the same knob; this caps the frame that
+// spans many terminated lines. Same default (~8 MB) and thrown-error → `error` event contract as the
+// `'json'` decoder (`json-stream.ts` / `runStreaming`). Overridable per-stream via `stream.maxBufferBytes`.
 async function* parseEventStream(
     body: ReadableStream<Uint8Array>,
+    maxBufferBytes: number = JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES,
 ): AsyncGenerator<SseEvent, void> {
     let frame = freshFrame();
+    let frameBytes = 0; // accumulated length of the current frame's data lines (+1 per join `\n`)
 
-    for await (const raw of lineReader(body)) {
+    for await (const raw of lineReader(body, maxBufferBytes)) {
         // lineReader splits on `\n`; strip a trailing `\r` so CRLF streams parse (the SSE plumbing
         // shared with `stream`'s `'lines'` stays a literal `\n` split — Q3).
         const line = raw.endsWith('\r') ? raw.slice(0, -1) : raw;
@@ -112,8 +123,24 @@ async function* parseEventStream(
             const ev = dispatchFrame(frame);
             if (ev !== undefined) yield ev;
             frame = freshFrame();
+            frameBytes = 0;
         } else if (!line.startsWith(':')) {
+            const before = frame.dataLines.length;
             applyFieldLine(frame, line); // non-comment field line
+            // Track only `data:` growth (the only field that accumulates): the pushed value plus the
+            // `\n` that `dispatchFrame` joins it with. A frame that never sees a blank line can't grow
+            // past the cap.
+            if (frame.dataLines.length > before) {
+                const added = frame.dataLines[frame.dataLines.length - 1] ?? '';
+                frameBytes += added.length + (before > 0 ? 1 : 0);
+                if (frameBytes > maxBufferBytes) {
+                    throw new Error(
+                        `sse parser: un-dispatched event data exceeded maxBufferBytes (${String(
+                            maxBufferBytes,
+                        )}); a frame with no terminating blank line was streamed`,
+                    );
+                }
+            }
         }
     }
 }
@@ -126,10 +153,13 @@ async function* parseEventStream(
  */
 export const sseSurface: Surface<StitchInput, SseEvent[]> = {
     id: 'sse',
-    async *stream(res: AdapterResponse) {
+    async *stream(res: AdapterResponse, cfg: ResolvedStitchConfig) {
         const body = res.body;
         if (body instanceof ReadableStream)
-            yield* parseEventStream(body as ReadableStream<Uint8Array>);
+            yield* parseEventStream(
+                body as ReadableStream<Uint8Array>,
+                cfg.stream?.maxBufferBytes,
+            );
     },
     contractValue: (chunk) => (chunk as SseEvent).data,
     // Resumable-SSE hooks (issue #71). The engine reads the last `id:` and server `retry:` off each

--- a/packages/core/src/stream.ts
+++ b/packages/core/src/stream.ts
@@ -69,12 +69,16 @@ async function* decodeStream(
     const stream = body as ReadableStream<Uint8Array>;
     const decode = cfg.stream?.decode ?? 'bytes';
 
+    // `maxBufferBytes` caps a single un-terminated line for the line-based decoders too (an upstream
+    // that never sends a `\n` would otherwise grow memory without limit); a throw becomes an `error`
+    // event in the engine. Same default (~8 MB) / knob as the `'json'` decoder below.
+    const maxBufferBytes = cfg.stream?.maxBufferBytes;
     if (decode === 'lines') {
-        yield* lineReader(stream);
+        yield* lineReader(stream, maxBufferBytes);
         return;
     }
     if (decode === 'ndjson') {
-        for await (const line of lineReader(stream)) {
+        for await (const line of lineReader(stream, maxBufferBytes)) {
             if (line.trim() === '') continue; // tolerate blank lines between records
             const parsed: unknown = JSON.parse(line);
             yield parsed;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -136,10 +136,13 @@ export interface StreamOptions {
     /** Decoder for a `stream` surface body. Default `'bytes'` (total + lossless). */
     decode?: StreamDecode;
     /**
-     * Max bytes the `'json'` decoder will buffer for a single in-progress value before throwing
-     * (the engine turns the throw into an `error` event). Guards against a malformed / never-closing
-     * value growing without limit. Default ~8 MB (see `json-stream.ts`). Only meaningful for
-     * `decode: 'json'`.
+     * Max bytes a streaming decoder will buffer for a single un-terminated unit before throwing (the
+     * engine turns the throw into an `error` event). Guards every un-framed / never-closing case
+     * against growing client memory without limit (an OOM DoS):
+     *   - `'json'` — a single in-progress value (e.g. an unclosed `[`).
+     *   - `'lines'` / `'ndjson'` — a single un-terminated line (a run of bytes with no `\n`).
+     *   - the `sse` surface — one un-dispatched event's `data:` payload (a frame with no blank line).
+     * Default ~8 MB (see `json-stream.ts`). Not meaningful for `decode: 'bytes'` (raw, unbuffered).
      */
     maxBufferBytes?: number;
 }

--- a/packages/core/test/sse.spec.ts
+++ b/packages/core/test/sse.spec.ts
@@ -3,6 +3,7 @@
 // and yields one parsed event per `delta` chunk. Most cases drive the frame parser directly over a
 // fake stream (precise chunk boundaries); the engine spine + a real-fetch case round it out.
 import { seam, stitch } from '../src';
+import { lineReader } from '../src/line-reader';
 import { sse, sseSurface } from '../src/sse';
 import type { SseEvent } from '../src/sse';
 import { startMockServer } from './support/mock-server';
@@ -17,12 +18,17 @@ import {
 
 import { z } from 'zod';
 
-// Run the SSE frame parser over the given chunk boundaries and collect the parsed events.
-async function parse(chunks: string[]): Promise<SseEvent[]> {
+// Run the SSE frame parser over the given chunk boundaries and collect the parsed events. A small
+// `maxBufferBytes` cap can be threaded through `stream.maxBufferBytes` (unbounded-buffer guard).
+async function parse(
+    chunks: string[],
+    cfg: { stream?: { maxBufferBytes?: number } } = {},
+): Promise<SseEvent[]> {
     const res = { status: 200, headers: {}, body: streamOf(chunks) };
     const out: SseEvent[] = [];
-    // `stream` is defined on a streaming surface; tests may assert non-null.
-    for await (const ev of sseSurface.stream!(res, {}))
+    // `stream` is defined on a streaming surface; tests may assert non-null. Only `stream.maxBufferBytes`
+    // is read off `cfg`, so this partial config (a resolved config's fields are all optional) suffices.
+    for await (const ev of sseSurface.stream!(res, cfg))
         out.push(ev as SseEvent);
     return out;
 }
@@ -106,6 +112,56 @@ describe('sse frame parser (Decision 4)', () => {
     });
 });
 
+describe('sse buffer cap — an unbounded body fails instead of OOM-ing (security)', () => {
+    // Parity with the `'json'` decoder's per-value cap (json-stream.ts): a malformed / never-closing
+    // body is bounded and throws a descriptive Error rather than growing client memory without limit.
+    // The engine (runStreaming) turns the throw into an error+done event, so the stream fails cleanly.
+    const CAP = 64; // a tiny cap so the test stays fast; the real default is ~8 MB
+
+    test('a long run with NO newline past the cap throws (line-reader guard)', async () => {
+        // One chunk of bytes with no `\n` at all — lineReader can never split it, so the un-terminated
+        // carry grows past the cap. Without the cap this would buffer the whole (unbounded) body.
+        const noNewline = 'data: ' + 'x'.repeat(CAP * 4); // no trailing "\n\n"
+        await expect(
+            parse([noNewline], { stream: { maxBufferBytes: CAP } }),
+        ).rejects.toThrow(/un-terminated line exceeded maxBufferBytes/);
+    });
+
+    test('endless data: lines with NO dispatching blank line past the cap throws (frame guard)', async () => {
+        // Every line IS newline-terminated (so the line-reader guard never trips), but the frame is
+        // never dispatched (no blank line), so `frame.dataLines` accumulates without bound. The
+        // per-frame guard catches this case the line guard cannot.
+        const manyDataLines =
+            Array.from({ length: 200 }, () => 'data: chunk').join('\n') + '\n'; // no blank line ⇒ never dispatched
+        await expect(
+            parse([manyDataLines], { stream: { maxBufferBytes: CAP } }),
+        ).rejects.toThrow(/un-dispatched event data exceeded maxBufferBytes/);
+    });
+
+    test('a normal stream UNDER the cap still parses (no false positive)', async () => {
+        // Well under 64 bytes of data per frame, each properly blank-line terminated.
+        expect(
+            await parse(['data: {"n":1}\n\ndata: {"n":2}\n\n'], {
+                stream: { maxBufferBytes: CAP },
+            }),
+        ).toEqual([{ data: { n: 1 } }, { data: { n: 2 } }]);
+    });
+
+    test('a frame at the cap boundary across many small lines is bounded', async () => {
+        // Sanity: the frame guard sums data-line bytes (+1 per join), so several small un-dispatched
+        // `data:` lines that together exceed the cap still throw — the attack is many lines, not one.
+        const lines = Array.from(
+            { length: 30 },
+            () => 'data: ' + 'y'.repeat(8),
+        );
+        await expect(
+            parse([lines.join('\n') + '\n'], {
+                stream: { maxBufferBytes: CAP },
+            }),
+        ).rejects.toThrow(/un-dispatched event data exceeded maxBufferBytes/);
+    });
+});
+
 describe('sse over the engine (event spine + await)', () => {
     test('emits start → request → delta-per-event → result (collected) → done', async () => {
         const s = sse({
@@ -172,6 +228,22 @@ describe('sse over the engine (event spine + await)', () => {
         const ev = await collectEvents(s.stream());
         expect(ev.deltas).toEqual([{ data: 1 }, { data: 2 }]);
         expect(ev.types).toContain('error');
+        expect(ev.done?.ok).toBe(false);
+    });
+
+    test('an unbounded body past maxBufferBytes fails the stream with error+done (not OOM)', async () => {
+        // A body that streams a long run with no newline / no dispatching blank line. The parser's
+        // buffer cap throws; runStreaming turns the throw into error+done — a clean failure, not an
+        // unbounded-memory grow. (This is the engine-spine counterpart to the frame-parser unit tests.)
+        const s = sse({
+            url: 'https://x.test/flood',
+            stream: { maxBufferBytes: 64 },
+            adapter: streamAdapter(streamOf(['data: ' + 'x'.repeat(4096)])), // no "\n\n" terminator
+        });
+        const ev = await collectEvents(s.stream());
+        expect(ev.deltas).toEqual([]); // nothing was ever dispatched
+        expect(ev.types).toContain('error');
+        expect(ev.error?.message).toMatch(/maxBufferBytes/);
         expect(ev.done?.ok).toBe(false);
     });
 });
@@ -331,21 +403,27 @@ describe('sse over real fetch + Web Streams (browser-first gate)', () => {
         expect(doneOk).toBe(false);
     });
 
-    test('breaking out of .stream() early stops consumption cleanly', async () => {
-        // Early break releases the reader lock and stops iteration; proactively cancelling the
-        // underlying response body on early break is a tracked follow-up (no reader.cancel() yet).
-        server.route('GET', '/breakable', {
-            headers: { 'content-type': 'text/event-stream' },
-            stream: {
-                chunks: [
-                    'data: {"n":1}\n\n',
-                    'data: {"n":2}\n\n',
-                    'data: {"n":3}\n\n',
-                ],
-                chunkDelayMs: 15,
+    test('breaking out of .stream() early cancels the underlying body (no leak)', async () => {
+        // Early break `.return()`s the generator chain down to lineReader, whose `finally` now
+        // `cancel()`s the underlying stream before releasing the lock — so an abandoned consumer
+        // proactively closes the connection instead of leaking it until GC (previously a tracked
+        // follow-up: only releaseLock() ran, never cancel()). A cancel-recording stream (fed through
+        // streamAdapter) makes the client-side cancel observable, which a real HTTP body can't.
+        let cancelled = false;
+        const body = new ReadableStream<Uint8Array>({
+            pull(controller) {
+                controller.enqueue(
+                    new TextEncoder().encode('data: {"n":1}\n\n'),
+                );
+            },
+            cancel() {
+                cancelled = true;
             },
         });
-        const events = sse({ baseUrl: server.url, path: '/breakable' });
+        const events = sse({
+            url: 'https://x.test/breakable',
+            adapter: streamAdapter(body),
+        });
         const deltas: unknown[] = [];
         for await (const e of events.stream()) {
             if (e.type === 'delta') {
@@ -354,6 +432,52 @@ describe('sse over real fetch + Web Streams (browser-first gate)', () => {
             }
         }
         expect(deltas).toEqual([{ data: { n: 1 } }]);
+        expect(cancelled).toBe(true); // the body was cancelled, not just abandoned
+    });
+});
+
+describe('lineReader teardown + cap (shared streaming plumbing)', () => {
+    // lineReader is the byte→line plumbing shared by `sse` and `stream`'s `'lines'`/`'ndjson'`. The
+    // two hardenings are proven here at the plumbing level too, independent of the sse frame layer.
+
+    test('an early break cancels the underlying stream before releasing the lock', async () => {
+        // A consumer that reads one line then `break`s triggers the generator `.return()`; the
+        // `finally` must cancel() the body (proactively closing the connection), not just releaseLock().
+        let cancelled = false;
+        const stream = new ReadableStream<Uint8Array>({
+            pull(controller) {
+                controller.enqueue(new TextEncoder().encode('line\n'));
+            },
+            cancel() {
+                cancelled = true;
+            },
+        });
+        const lines: string[] = [];
+        for await (const line of lineReader(stream)) {
+            lines.push(line);
+            break; // abandon after the first line
+        }
+        expect(lines).toEqual(['line']);
+        expect(cancelled).toBe(true);
+    });
+
+    test('a normal drain still cancels (a no-op on a closed stream) and yields all lines', async () => {
+        // Cancelling unconditionally in `finally` is safe: cancel() on an already-closed stream is a
+        // spec no-op, so a fully-consumed stream still delivers every line.
+        const lines: string[] = [];
+        for await (const line of lineReader(streamOf(['a\nb\n', 'c']))) {
+            lines.push(line);
+        }
+        expect(lines).toEqual(['a', 'b', 'c']);
+    });
+
+    test('a single un-terminated line past maxBufferBytes throws a descriptive error', async () => {
+        // No `\n` ever arrives, so the carry grows unbounded — the cap turns that into a clean throw.
+        await expect(async () => {
+            for await (const _ of lineReader(streamOf(['x'.repeat(200)]), 64)) {
+                void _;
+            }
+        }).rejects.toThrow(/un-terminated line exceeded maxBufferBytes/);
     });
 });
 


### PR DESCRIPTION
Hardens `@stitchapi/core`'s SSE / line streaming plumbing against two confirmed issues. Both live behind the `./sse` and `./stream` subpaths, so the **core bundle budget is unchanged** (23.99 / 19.48 KB gzip, same as `main` — headroom 0.21 / 0.22 KB).

## Bug 1 — unbounded SSE buffer → OOM DoS (security, MEDIUM)

`lineReader` did `buf += decoder.decode(...)` and only sliced on `'\n'`; `parseEventStream` pushed onto `frame.dataLines` and only reset on a blank line. **Neither had a size cap**, so an upstream that streams bytes with no newline — or endless `data:` lines with no dispatching blank line — grows client memory without limit (an OOM DoS).

This is exactly the vector the sibling `'json'` stream decoder already guards: it caps a single in-progress value at `JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES` (~8 MB, `json-stream.ts:26`) and throws. **This PR brings SSE/line buffering to the same parity:**

- `lineReader` now caps the **un-terminated line carry** (`buf` after the last `\n`) and throws a descriptive `Error` once it exceeds `maxBufferBytes`.
- `parseEventStream` caps the **accumulated `data:` payload of a single un-dispatched frame** — the "many newline-terminated `data:` lines, no blank line" case the line cap can't see (each line *is* terminated). The two caps compose to cover both shapes.

Both reuse the same knob, plumbed from `cfg.stream?.maxBufferBytes` (default ~8 MB), threaded at both call sites (`stream`'s `'lines'`/`'ndjson'` and `sse`'s frame parser). `runStreaming` already turns a thrown stream error into an **error+done** event, so an abusive body **fails the stream cleanly instead of OOM-ing** — no engine change needed.

An endless `id:`/`retry:`-only stream (no `data:`) is *not* an OOM vector: `dispatchFrame` drops a no-`data` frame and the frame only ever stores the latest scalar (O(1)); a single huge un-terminated `id:`/`event:` line is caught by the line cap.

## Bug 2 — connection not cancelled on early break (reliability, LOW)

On an early generator `.return()` (a consumer `break`s **without** aborting a signal), `lineReader`'s `finally` called only `reader.releaseLock()`, never `reader.cancel()` — so the fetch response body wasn't cancelled and the **HTTP connection leaked until GC**. (Aborting via the request signal already tears the body down; only break-without-abort leaked — `test/sse.spec.ts:334` tracked this as a known follow-up.)

The `finally` now `await reader.cancel().catch(() => undefined)` before releasing the lock, so an abandoned SSE/line consumer **proactively closes the connection**. `cancel()` on an already-closed stream is a spec no-op, so cancelling on every exit path (normal end / error / early break) is safe — same **teardown theme** as the existing abort path.

## Tests (`packages/core/test/sse.spec.ts`) — fail-before / pass-after

Verified by stashing only the `src/` changes and re-running: **7 new tests fail against unfixed source, all pass after.** Full core suite: **1170 passing**, `check:types` and `check:lint` green.

- **Cap:** an un-terminated line and an endless-`data:` frame past the cap each throw their descriptive error; a normal stream under the cap still parses (no false positive); a many-small-lines frame is bounded; the **engine spine** turns the throw into error+done (not OOM).
- **Cancel:** an early `break` cancels the underlying body — driven with a cancel-recording `ReadableStream` so the client-side cancel is observable (a real HTTP body can't expose it). The `:334` follow-up test is updated from *"no reader.cancel() yet"* to assert the cancel fires. Plumbing-level `lineReader` tests cover both the cancel-on-break and the line cap directly.

## Bundle

| scenario | main | this PR | budget |
|---|---|---|---|
| whole entry | 23.99 KB | 23.99 KB | 24.20 KB |
| `import { stitch }` | 19.48 KB | 19.48 KB | 19.70 KB |

Unchanged — the SSE/line code is not on the root entry or `import { stitch }` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)