### PR TITLE
test(core): cross-surface credential-leak guard (class guard behind scrubUrl)

### DIFF
--- a/packages/core/src/openapi.ts
+++ b/packages/core/src/openapi.ts
@@ -23,6 +23,7 @@ import type {
     SecurityScheme,
     StitchConfig,
 } from './types';
+import { scrubUrl } from './util';
 
 export interface OpenApiInfo {
     title: string;
@@ -355,7 +356,12 @@ export function toOpenApi(
             continue;
         }
         const { server, path: rawPath } = splitServer(endpoint.value);
-        if (server) servers.add(server);
+        // Scrub the origin before it lands in `servers[].url`: `splitServer` captures the whole
+        // authority incl. userinfo (`https://user:pass@host`), and this document is often
+        // published/shared, so a URL basic-auth credential must not survive. `scrubUrl` strips
+        // userinfo and redacts secret query values — the same treatment every other url-emitting
+        // sink in core gives a URL (trace.ts, otlp.ts, the console renderer).
+        if (server) servers.add(scrubUrl(server));
         const { path, parameters } = parsePath(rawPath);
         const method = (cfg.method ?? 'get').toLowerCase();
         const item = (paths[path] ??= {});

--- a/packages/core/test/no-credential-leak.spec.ts
+++ b/packages/core/test/no-credential-leak.spec.ts
@@ -1,0 +1,145 @@
+// Cross-surface invariant: a stitch endpoint URL carrying a credential — URL basic-auth userinfo
+// (`https://user:pass@host`) and/or a secret query value (`?access_token=…`) — must NEVER survive
+// into an artifact `@stitchapi/core` emits. Every URL-emitting sink already routes its URL through
+// `scrubUrl` (or, for the event stream, `redactEventForTransport`); this test is the CLASS GUARD
+// behind that per-sink discipline.
+//
+// It exists because the leak #415 fixed (`toOpenApi`'s `servers[].url`) was the one URL sink that
+// forgot to scrub — a whack-a-mole bug that recurs the moment a NEW emit surface is added and the
+// author forgets. So the rule here is: every core surface that serializes a stitch's endpoint URL
+// into output MUST be registered as a case below. A future config-exporter — `stitch gen` /
+// client publishing (ADR 0013/0014) — that forgets to scrub will fail THIS test instead of baking
+// a password into a shared document. Add the surface here in the same PR that adds the surface.
+import { otlpTrace, stitch } from '../src';
+import type { OtelSpan, SpanExporter, StitchEvent } from '../src';
+import { toOpenApi } from '../src/openapi';
+import type { StitchRegistry } from '../src/registry';
+import { redactEventForTransport } from '../src/trace';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Keep this suite's own trace sink quiet/captured, like the other trace/otlp specs.
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-no-leak-${process.pid}.jsonl`,
+);
+
+// The credential material. `USERNAME` alone is deliberately NOT scanned for — a bare `svc` token
+// could legitimately appear as a substring elsewhere. We scan for the parts that unambiguously
+// identify a leak: the password, the secret-query value, and the intact `user:pass` userinfo pair.
+const USERNAME = 'svc';
+const PASSWORD = 's3cr3t';
+const SECRET_QUERY_VALUE = 'leaktok'; // rides `?access_token=…` (matches the `token` secret stem)
+const HOST = 'api.internal'; // must be PRESERVED — scrubbing strips the credential, not the target
+
+const LEAK_MARKERS = [
+    PASSWORD, // the password
+    SECRET_QUERY_VALUE, // the secret query value
+    `${USERNAME}:${PASSWORD}`, // the intact userinfo pair
+    `${USERNAME}:${PASSWORD}@`, // …with the userinfo delimiter
+];
+
+// A full endpoint URL with BOTH credential vectors, for the surfaces that emit the whole URL.
+const POISONED_URL = `https://${USERNAME}:${PASSWORD}@${HOST}/v1/users/1?access_token=${SECRET_QUERY_VALUE}`;
+// The origin+path form `toOpenApi` consumes (it emits only the origin into `servers[].url`).
+const POISONED_BASE_URL = `https://${USERNAME}:${PASSWORD}@${HOST}/v1`;
+
+const startEvent = (): StitchEvent => ({
+    type: 'start',
+    name: 'getUser',
+    method: 'GET',
+    url: POISONED_URL,
+    input: { query: { access_token: SECRET_QUERY_VALUE } }, // also exercises the structured-query scrub
+    at: 1,
+});
+
+// Drive the OTLP sink with the poisoned start event and return the exported spans (which carry
+// `url.full` / `server.address`). A stub exporter captures in memory — no collector, no network.
+function otlpSpans(): OtelSpan[] {
+    const spans: OtelSpan[] = [];
+    const exporter: SpanExporter = {
+        export(batch) {
+            spans.push(...batch);
+        },
+    };
+    const sink = otlpTrace({ exporter });
+    const name = 'getUser';
+    sink.handle(startEvent(), { name });
+    sink.handle(
+        { type: 'result', data: {}, status: 200, attempts: 1, at: 2 },
+        { name },
+    );
+    sink.handle(
+        { type: 'done', ok: true, elapsed: 1, attempts: 1, at: 2 },
+        { name },
+    );
+    return spans;
+}
+
+// Each case serializes one URL-emitting surface fed the poisoned URL, and returns the artifact as a
+// string to scan. `emitsHost` marks surfaces that keep the target host (a positive check that the
+// scrub removed the credential, not the whole URL).
+interface Surface {
+    name: string;
+    serialize: () => string;
+    emitsHost: boolean;
+}
+
+const SURFACES: Surface[] = [
+    {
+        // Config export — the family the #415 leak lived in. `stitch export --openapi`.
+        name: 'toOpenApi → servers[].url',
+        serialize: () => {
+            const registry: StitchRegistry = {
+                getUser: stitch({
+                    baseUrl: POISONED_BASE_URL,
+                    path: '/users/{id}',
+                }),
+            };
+            return JSON.stringify(toOpenApi(registry).document);
+        },
+        emitsHost: true,
+    },
+    {
+        // The event-stream choke-point: `stitch serve`'s SSE `start` frame and every trace sink
+        // (file/logger/console) run each event through this before it leaves the process.
+        name: 'redactEventForTransport → start frame',
+        serialize: () => JSON.stringify(redactEventForTransport(startEvent())),
+        emitsHost: false, // scrubUrl keeps the host, but we assert the class markers, not the host
+    },
+    {
+        // OTLP export — `url.full` / `server.address` on the exported CLIENT span.
+        name: 'otlpTrace → span url.full',
+        serialize: () => JSON.stringify(otlpSpans()),
+        emitsHost: true,
+    },
+];
+
+describe('no credential leaks in emitted artifacts (class guard behind per-sink scrubUrl)', () => {
+    // A tripwire: if the surface list is ever emptied (a bad refactor), the guard would vacuously
+    // pass. Pin that it covers the config-export surface the leak lived in.
+    test('the surface registry is populated and covers config export', () => {
+        expect(SURFACES.length).toBeGreaterThanOrEqual(3);
+        expect(SURFACES.map((s) => s.name)).toContain(
+            'toOpenApi → servers[].url',
+        );
+    });
+
+    test.each(SURFACES)('$name emits no credential', ({ serialize }) => {
+        const artifact = serialize();
+        for (const marker of LEAK_MARKERS) {
+            expect(artifact).not.toContain(marker);
+        }
+    });
+
+    // The target host is preserved where the surface emits a whole URL — proof the scrub stripped
+    // the credential rather than discarding the URL wholesale (kept a separate case so the
+    // assertion isn't guarded by a per-surface conditional).
+    test.each(SURFACES.filter((s) => s.emitsHost))(
+        '$name preserves the target host',
+        ({ serialize }) => {
+            expect(serialize()).toContain(HOST);
+        },
+    );
+});

--- a/packages/core/test/openapi.spec.ts
+++ b/packages/core/test/openapi.spec.ts
@@ -49,6 +49,27 @@ describe('toOpenApi', () => {
         ]);
     });
 
+    test('scrubs userinfo credentials from a baseUrl before emitting servers[].url', () => {
+        // A stitch whose baseUrl carries URL basic-auth (accepted + used by the engine). The
+        // generated OpenAPI document is "often published/shared", so the password must not survive
+        // into servers[].url. The server origin is routed through scrubUrl like every other
+        // url-emitting sink in core.
+        const registry: StitchRegistry = {
+            secretSvc: stitch({
+                baseUrl: 'https://svc:s3cr3t@api.internal/v1',
+                path: '/users/{id}',
+            }),
+        };
+        const { document } = toOpenApi(registry);
+        const serverUrl = document.servers?.[0]?.url ?? '';
+        expect(serverUrl).not.toContain('s3cr3t'); // password
+        expect(serverUrl).not.toContain('svc:'); // username:password userinfo
+        expect(serverUrl).not.toContain('@'); // userinfo delimiter
+        expect(serverUrl).toContain('api.internal'); // host is preserved
+        // And the credential must not leak anywhere else in the serialized document either.
+        expect(JSON.stringify(document)).not.toContain('s3cr3t');
+    });
+
     test('defaults info when no title/version is given', () => {
         const { document } = toOpenApi({});
         expect(document.info).toEqual({


### PR DESCRIPTION
> **Stacked on #415** (base = `fix/core-openapi-server-userinfo-scrub`). Merge #415 first, then retarget this to `main`. The `toOpenApi` case below depends on #415's scrub fix.

## What

A single cross-surface **invariant** (`packages/core/test/no-credential-leak.spec.ts`) that feeds a poisoned endpoint URL — URL basic-auth userinfo **and** a secret query value — through every core surface that serializes a stitch's URL, and asserts the credential never survives into the emitted artifact.

## Why (the bug class, not the one bug)

#415 fixes a real HIGH-severity leak: `toOpenApi`'s `servers[].url` was the **one** URL sink that didn't route through `scrubUrl` (`trace.ts`, `otlp.ts`, the console renderer all do). That's whack-a-mole — the class recurs the moment a **new** emit surface is added and the author forgets to scrub.

This test turns *"did the author remember to scrub?"* into a CI gate. A future config-exporter — `stitch gen` / client publishing (ADR 0013/0014) — that forgets will **fail this test** instead of baking a password into a document the module docstring notes is *"often published/shared."*

## Surfaces registered

| Surface | Family | Notes |
|---|---|---|
| `toOpenApi → servers[].url` | config export | where the #415 leak lived |
| `redactEventForTransport → SSE start frame` | runtime event | the choke-point `stitch serve` + every trace sink share |
| `otlpTrace → span url.full` | runtime event | OTLP's only secret-bearing attribute |

The rule: **every surface that serializes a stitch's endpoint URL into output must be registered here, in the same PR that adds the surface.** A tripwire test pins that the registry can't be silently emptied.

## Verification

- 6/6 pass on this branch; **fail-before proven** by reverting #415's one-line `openapi.ts` change (the `toOpenApi` case fails; the event-family cases stay green, confirming they're already centrally scrubbed).
- `check:types`, ESLint, Prettier clean. Net **zero `src` change** (test-only).

## Follow-up

The durable form of this guard — a `CONTRACT.md` principle + `check-contract` ratchet — belongs on the #352 contract work once it's on `main` (`CONTRACT.md` doesn't exist there yet). This test is the version that can land now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
