### PR TITLE
fix(sandbox): rebind playground imports instead of require(); bundle zod

### DIFF
--- a/apps/docs/app/(home)/playground/playground-examples.ts
+++ b/apps/docs/app/(home)/playground/playground-examples.ts
@@ -107,6 +107,28 @@ const res = await getUser();
 console.log(res);
 `;
 
+const VALIDATED_EXAMPLE = `// Validate what you send AND what you receive with a real schema library.
+// Runs in a sandboxed Web Worker against the in-browser fake API - no real
+// network, nothing installed. The imports resolve to the bundled 'stitchapi'
+// and 'zod', so you can paste snippets straight from the docs.
+import { stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const getUser = stitch({
+  baseUrl: 'https://demo.stitchapi.dev',
+  path: '/users/{id}',
+  unwrap: 'data', // pull the user out of the { data: ... } envelope
+  // Pass a Zod schema (or any Standard Schema) directly - no toValidator() wrapper.
+  input: { params: z.object({ id: z.number() }) }, // typed + validated BEFORE the request
+  output: z.object({ id: z.number(), email: z.string() }), // typed + validated AFTER
+});
+
+// The argument is typed from \`input\`; \`user\` is typed { id: number; email: string }
+// straight from \`output\`. No cast, no codegen - both validated at runtime.
+const user = await getUser({ params: { id: 2 } });
+console.log(user);
+`;
+
 export const PLAYGROUND_EXAMPLES: PlaygroundExample[] = [
     {
         id: 'complete',
@@ -120,5 +142,12 @@ export const PLAYGROUND_EXAMPLES: PlaygroundExample[] = [
         label: 'Simple',
         description: 'One URL in, typed data out.',
         code: SIMPLE_EXAMPLE,
+    },
+    {
+        id: 'validated',
+        label: 'Validated',
+        description:
+            'Zod schemas on input + output - typed and validated, no toValidator, no codegen.',
+        code: VALIDATED_EXAMPLE,
     },
 ];

--- a/docs/sandbox/package.json
+++ b/docs/sandbox/package.json
@@ -20,7 +20,8 @@
     "dependencies": {
         "mermaid": "^11.15.0",
         "stitchapi": "workspace:*",
-        "sucrase": "^3.35.1"
+        "sucrase": "^3.35.1",
+        "zod": "^4.4.3"
     },
     "devDependencies": {
         "@types/node": "^22.10.0",

--- a/docs/sandbox/runtime/transpile.test.ts
+++ b/docs/sandbox/runtime/transpile.test.ts
@@ -176,6 +176,80 @@ async function runTests(): Promise<void> {
         }
     }
 
+    /* (d) ESM imports are REBOUND to __stitchImport, never `require` ---------- */
+    {
+        // Identity transform: exercise the shared import-rebinding pass in
+        // isolation (no real transpiler needed) on already-"transpiled" JS.
+        const id = (s: string): string => s;
+
+        const named = await transpile(
+            `import { stitch, toValidator } from 'stitchapi';\nstitch();`,
+            { _transform: id },
+        );
+        assert('(d) named import → has .js', 'js' in named, named);
+        if ('js' in named) {
+            assert(
+                '(d) rewrites to __stitchImport (no require)',
+                named.js.includes('__stitchImport("stitchapi")') &&
+                    !named.js.includes('require('),
+                named.js,
+            );
+            assert(
+                '(d) destructures the named bindings',
+                /const \{ stitch, toValidator \} =/.test(named.js),
+                named.js,
+            );
+        }
+
+        const aliased = await transpile(`import { z as zod } from 'zod';`, {
+            _transform: id,
+        });
+        if ('js' in aliased) {
+            assert(
+                '(d) aliased import → `z: zod`',
+                /const \{ z: zod \} = __stitchImport\("zod"\);/.test(
+                    aliased.js,
+                ),
+                aliased.js,
+            );
+        }
+
+        const ns = await transpile(`import * as z from 'zod';`, {
+            _transform: id,
+        });
+        if ('js' in ns) {
+            assert(
+                '(d) namespace import → whole registry entry',
+                /const z = __stitchImport\("zod"\);/.test(ns.js),
+                ns.js,
+            );
+        }
+
+        const side = await transpile(`import 'stitchapi';`, { _transform: id });
+        if ('js' in side) {
+            assert(
+                '(d) side-effect import → bare registry call',
+                /__stitchImport\("stitchapi"\);/.test(side.js),
+                side.js,
+            );
+        }
+    }
+
+    /* (e) dynamic import() is rejected (SEC-31 module-loader escape) ---------- */
+    {
+        const dyn = await transpile(`const m = await import('node:fs');`, {
+            _transform: (s) => s,
+        });
+        assert('(e) dynamic import → { error }', 'error' in dyn, dyn);
+        if ('error' in dyn) {
+            assert(
+                "(e) error.phase === 'transpile'",
+                dyn.error.phase === 'transpile',
+                dyn.error,
+            );
+        }
+    }
+
     /* Summary --------------------------------------------------------------- */
     console.log(`\n${passed} passed, ${failed} failed\n`);
 

--- a/docs/sandbox/runtime/transpile.ts
+++ b/docs/sandbox/runtime/transpile.ts
@@ -5,8 +5,17 @@
  * and returns runnable JS.  Both transpilers are lazy-loaded so prose pages pay
  * nothing (NFR1).
  *
- * Primary:  Sucrase  (`transform(code, { transforms: ['typescript','jsx','imports'] })`)
+ * Primary:  Sucrase  (`transform(code, { transforms: ['typescript','jsx'] })`)
  * Fallback: @babel/standalone  (if Sucrase fails to *load* — engine/internal error)
+ *
+ * NOTE the transform list intentionally OMITS Sucrase's `imports` transform: the
+ * snippet runs as an `AsyncFunction` body where every name it may use is injected
+ * as a parameter and there is NO module loader (`require` is `undefined`, SEC-31).
+ * So an `import` must be *erased* and rebound to the injected scope, never
+ * rewritten to `require(...)` (that is the "require is not a function" crash). A
+ * shared final pass ({@link rebindModuleImports}) rebinds each ESM `import` to the
+ * curated in-worker registry (`__stitchImport`, wired by worker-entry) and rejects
+ * dynamic `import()` (an SEC-31 module-loader escape).
  *
  * Transpile *syntax* errors from the snippet are returned as
  * `{ error: RunError(phase:'transpile') }` — they never throw (FR6, CodeRunner contract).
@@ -49,6 +58,17 @@ export type TranspileResult = { js: string } | { error: RunError };
 export async function transpile(
     code: string,
     opts: TranspileOptions = {},
+): Promise<TranspileResult> {
+    const base = await transpileBase(code, opts);
+    // Type/JSX erasure done — now erase & rebind ESM imports to the injected
+    // scope (shared across every transpiler path, incl. the unit-test hatch).
+    return 'error' in base ? base : rebindModuleImports(base.js);
+}
+
+/** Erase TS + JSX only. Imports are handled downstream by rebindModuleImports. */
+async function transpileBase(
+    code: string,
+    opts: TranspileOptions,
 ): Promise<TranspileResult> {
     const { transpiler = 'sucrase', _transform } = opts;
 
@@ -152,8 +172,13 @@ async function transpileWithSucrase(code: string): Promise<TranspileResult> {
     return applyTransform(
         code,
         (src) =>
+            // No `imports` transform — see the file header: imports are erased and
+            // rebound to the injected scope by rebindModuleImports, not rewritten
+            // to `require(...)`. Sucrase's typescript pass already elides
+            // `import type` and inline `type` specifiers, leaving only value
+            // imports for the rebinder.
             transform(src, {
-                transforms: ['typescript', 'jsx', 'imports'],
+                transforms: ['typescript', 'jsx'],
             }).code,
     );
 }
@@ -200,4 +225,121 @@ async function transpileWithBabel(code: string): Promise<TranspileResult> {
         }
         return result.code;
     });
+}
+
+/* -- ESM import rebinding ---------------------------------------------------
+ * The snippet runs as an `AsyncFunction` body: its identifiers resolve to the
+ * scope names worker-entry injects (`stitch`, `bearer`, …), and there is no
+ * module loader — `require` is `undefined` (SEC-31). This pass takes the
+ * type/JSX-erased JS and:
+ *   1. rejects dynamic `import()` (it would reach a real loader in the Worker),
+ *   2. rewrites each static `import` into `const … = __stitchImport('<spec>')`
+ *      destructuring, and
+ *   3. strips `export` (a snippet returns its last value; exports never ran).
+ * `__stitchImport` is the curated registry worker-entry binds into scope; only
+ * allow-listed specifiers (`stitchapi`, `zod`) resolve, everything else throws.
+ * -------------------------------------------------------------------------*/
+
+/** The scope-injected module registry a rebound import calls. */
+const IMPORT_REGISTRY = '__stitchImport';
+
+function rebindModuleImports(js: string): TranspileResult {
+    // (1) Reject dynamic import() before the static rewrite strips `import`
+    // keywords. `import(` (not a `.import(` member) is always the dynamic form.
+    if (/(^|[^.\w])import\s*\(/.test(js)) {
+        return {
+            error: {
+                name: 'UnsupportedImportError',
+                message:
+                    "Dynamic import() isn't available in the playground. " +
+                    "Everything from 'stitchapi' is already in scope; use a static " +
+                    "`import { … } from 'stitchapi'` (or 'zod') instead.",
+                phase: 'transpile',
+            },
+        };
+    }
+
+    let out = js;
+
+    // (2a) `import <clause> from '<spec>';` → const bindings from the registry.
+    // The lazy `[\s\S]*?` lets a multi-line clause span newlines up to `from`.
+    out = out.replace(
+        /^[ \t]*import\b([\s\S]*?)\bfrom\s*(['"])([^'"]+)\2[ \t]*;?/gm,
+        (_m, clause: string, _q: string, spec: string) =>
+            emitImportBindings(clause, spec),
+    );
+
+    // (2b) side-effect `import '<spec>';` → validate the module, bind nothing.
+    out = out.replace(
+        /^[ \t]*import\s*(['"])([^'"]+)\1[ \t]*;?/gm,
+        (_m, _q: string, spec: string) =>
+            `${IMPORT_REGISTRY}(${JSON.stringify(spec)});`,
+    );
+
+    // (3) Strip `export` — snippets can't export from a function body, and these
+    // never worked before (they compiled to writes on an undefined `exports`).
+    out = out
+        .replace(/^[ \t]*export\s+default\s+/gm, '')
+        .replace(
+            /^[ \t]*export\s*\{[^}]*\}[ \t]*(from\s*['"][^'"]+['"])?[ \t]*;?/gm,
+            '',
+        )
+        .replace(/^[ \t]*export\s*\*[^;\n]*;?/gm, '')
+        .replace(
+            /^([ \t]*)export\s+(?=(?:const|let|var|function|class|async|abstract|enum)\b)/gm,
+            '$1',
+        );
+
+    return { js: out };
+}
+
+/**
+ * Turn an import clause into `const` bindings that read from the registry, e.g.
+ *   `{ a, b as c }`   → `const { a, b: c } = __stitchImport('m');`
+ *   `* as ns`         → `const ns = __stitchImport('m');`
+ *   `Def, { a }`      → `const Def = __stitchImport('m').default; const { a } = …`
+ * A stray `type X` specifier (Babel path may keep it) is dropped. The registry
+ * call is side-effect-free, so repeating it for the default + named case is fine.
+ */
+function emitImportBindings(clauseRaw: string, spec: string): string {
+    const call = `${IMPORT_REGISTRY}(${JSON.stringify(spec)})`;
+    const parts: string[] = [];
+    let clause = clauseRaw.trim();
+
+    // Named group: `{ a, b as c }`.
+    const named = clause.match(/\{([\s\S]*)\}/);
+    if (named) {
+        const pairs = named[1]
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+            .filter((s) => !/^type\s/.test(s))
+            .map((s) => {
+                const alias = s.match(/^(\S+)\s+as\s+(\S+)$/);
+                return alias ? `${alias[1]}: ${alias[2]}` : s;
+            });
+        parts.push(
+            pairs.length
+                ? `const { ${pairs.join(', ')} } = ${call};`
+                : `${call};`,
+        );
+        clause = clause.replace(named[0], '');
+    }
+
+    // Whatever remains is a default import and/or `* as ns` (comma-separated).
+    for (const tok of clause
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)) {
+        const ns = tok.match(/^\*\s+as\s+(\S+)$/);
+        if (ns) {
+            parts.push(`const ${ns[1]} = ${call};`);
+        } else if (/^[A-Za-z_$][\w$]*$/.test(tok)) {
+            parts.push(`const ${tok} = ${call}.default;`);
+        }
+    }
+
+    // `import {} from 'm'` / unparseable clause: still resolve the module so an
+    // unknown specifier errors rather than silently vanishing.
+    return parts.length ? parts.join(' ') : `${call};`;
 }

--- a/docs/sandbox/runtime/worker-entry.ts
+++ b/docs/sandbox/runtime/worker-entry.ts
@@ -70,6 +70,15 @@ export interface WorkerEnv {
      */
     stitchBuild: Record<string, unknown>;
     /**
+     * OPTIONAL curated module namespaces a snippet may `import` from, keyed by
+     * bare specifier (e.g. `{ zod }`). `stitchapi` is ALWAYS importable (it maps
+     * to {@link stitchBuild}); this adds the rest. transpile rebinds a snippet's
+     * `import { z } from 'zod'` to `__stitchImport('zod')`, which returns this
+     * namespace. An unknown specifier throws — there is no real module loader and
+     * `require` stays `undefined` (SEC-31). Values are in-memory only, never fs.
+     */
+    modules?: Record<string, unknown>;
+    /**
      * The S5 simulator fetch shim — the snippet's ONLY `fetch`. No real socket
      * is reachable (SEC-01..04).
      */
@@ -335,6 +344,33 @@ export async function runSnippetInWorker(
     for (const name of msg.extraScopeNames) {
         if (!(name in scope)) scope[name] = env.stitchBuild[name];
     }
+
+    // Curated module registry (SEC-31). transpile rebinds a snippet's ESM
+    // `import { … } from '<spec>'` to `__stitchImport('<spec>')`; only these
+    // in-memory namespaces resolve — `stitchapi` (the whole build) plus whatever
+    // `env.modules` adds (e.g. `zod`). There is NO real module loader and
+    // `require` stays `undefined` above; an unknown specifier throws a clear
+    // error. Bound LAST so a snippet can't shadow it via `extraScopeNames`.
+    const importable: Record<string, unknown> = {
+        stitchapi: env.stitchBuild,
+        ...(env.modules ?? {}),
+    };
+    scope.__stitchImport = (specifier: unknown): unknown => {
+        if (
+            typeof specifier === 'string' &&
+            Object.prototype.hasOwnProperty.call(importable, specifier)
+        ) {
+            return importable[specifier];
+        }
+        const available = Object.keys(importable)
+            .map((s) => `'${s}'`)
+            .join(', ');
+        throw new Error(
+            `Cannot import from '${String(specifier)}' in the playground. ` +
+                `Available modules: ${available}. Everything exported from ` +
+                `'stitchapi' is also in scope without importing.`,
+        );
+    };
 
     const names = Object.keys(scope);
     const values = names.map((n) => scope[n]);

--- a/docs/sandbox/runtime/worker-main.node.ts
+++ b/docs/sandbox/runtime/worker-main.node.ts
@@ -27,6 +27,8 @@ import {
 
 import { parentPort } from 'node:worker_threads';
 import * as stitchBuild from 'stitchapi';
+// Bundled so a snippet's `import { z } from 'zod'` resolves (via __stitchImport).
+import * as zod from 'zod';
 
 // Baseline knobs for the current run, mutated by `env.applyKnobs`; the shim
 // reads it on every request. URL-explicit knobs still win (see dispatch).
@@ -44,6 +46,8 @@ const simFetch = createFetchShim(allHandlers, () => currentKnobs);
 const env: WorkerEnv = {
     // The whole real `stitchapi` surface, exposed name-by-name into the snippet.
     stitchBuild: stitchBuild as unknown as Record<string, unknown>,
+    // Modules a snippet may `import` beyond 'stitchapi' (rebound via __stitchImport).
+    modules: { zod },
     fetch: simFetch as unknown as WorkerEnv['fetch'],
     // A clean `process` shadow for the snippet scope (no host env leakage). Core
     // itself still reads the real `process` in its own module scope.

--- a/docs/sandbox/runtime/worker-main.ts
+++ b/docs/sandbox/runtime/worker-main.ts
@@ -31,6 +31,11 @@ import {
     installWorkerEntry,
 } from './worker-entry';
 
+// Bundled so a snippet's `import { z } from 'zod'` resolves (via __stitchImport).
+// zod is pure JS / browser-safe; esbuild bundles it into the Worker (no runtime
+// module loader exists here — SEC-31).
+import * as zod from 'zod';
+
 // Baseline knobs for the current run (the "Response knobs" panel). Mutated by
 // `env.applyKnobs` before each run; the shim reads it on every request so a
 // configured knob shapes the whole run. URL-explicit knobs still win (dispatch).
@@ -61,6 +66,8 @@ const env: WorkerEnv = {
         ...stitchBuild,
         stitch: traceCollector.stitch,
     } as unknown as Record<string, unknown>,
+    // Modules a snippet may `import` beyond 'stitchapi' (rebound via __stitchImport).
+    modules: { zod },
     // The snippet's `fetch` (cast: createFetchShim is precisely `fetch`-typed,
     // WorkerEnv.fetch is the loose (unknown, unknown) wire shape).
     fetch: simFetch as unknown as WorkerEnv['fetch'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       sucrase:
         specifier: ^3.35.1
         version: 3.35.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^22.10.0


### PR DESCRIPTION
## Problem

Pasting the canonical example into the live playground threw **`TypeError: require is not a function`**.

The sandbox transpiled snippets with Sucrase's `imports` transform, which rewrites every ESM `import` into CommonJS `require(...)`. But the worker deliberately binds `require: undefined` (SEC-31), so **any** pasted snippet containing an `import` crashed — the import-free seed examples only worked by avoiding imports entirely. Worse, `zod` was never in the snippet scope, so `import { z } from 'zod'` would have failed next.

## Fix — erase & rebind, don't `require()`

- **`transpile.ts`**: drop the `imports` transform; add a shared `rebindModuleImports` pass that rewrites each static `import` to `const … = __stitchImport('<spec>')`, **rejects dynamic `import()`** (the SEC-31 module-loader escape the `require` path used to block), and strips `export`.
- **`worker-entry.ts`**: a curated `__stitchImport` registry — allow-list is `stitchapi` + `env.modules`; unknown specifiers throw a clear error. `require` stays `undefined`, so **SEC-31 is unchanged**.
- **`worker-main.ts` / `worker-main.node.ts`**: bundle `zod` into both workers so `import { z } from 'zod'` resolves; declared as a `docs/sandbox` dep.
- **`playground-examples.ts`**: new **"Validated"** preset — input+output Zod schemas passed **directly**, no `toValidator`, no codegen.

## Why no `toValidator`

`stitch`'s `input`/`output` accept a raw Zod / any Standard Schema / a predicate directly — `SchemaLike` in `packages/core/src/infer.ts` already covers it and the engine wraps internally. Verified: raw `z.object(...)` validates at runtime **and** infers types under `tsc --strict`. (The docs still teach the opposite in ~8 files — tracked separately.)

## Verification

- transpile unit tests **21/21** (new coverage: named/aliased/namespace/side-effect rebinding + dynamic-import rejection)
- sandbox smoke suite **11/11**, including the SEC-31 `require: undefined` assertion
- security: dynamic `import()` rejected, disallowed specifiers throw, `typeof require === "undefined"`
- browser + node worker esbuild bundles build with zod
- `apps/docs check:types` clean (twoslash docs included)
- end-to-end: the canonical Zod example runs in the real worker and returns validated `{ id, email }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)