### PR TITLE
fix(elysia,hono): don't leak raw upstream/transport error messages to the client (topology disclosure)

### DIFF
--- a/packages/elysia/README.md
+++ b/packages/elysia/README.md
@@ -88,8 +88,11 @@ forwarded.
 ## Error handling
 
 The plugin registers an `.onError` that maps a `StitchError` to an HTTP response
-(`502` by default, so an upstream's status is never leaked) and lets every other
-error fall through to Elysia's default handling:
+and lets every other error fall through to Elysia's default handling. By default
+the status is `502` **and** the body is a generic, status-tied message
+(`{ error: 'Bad Gateway' }`) — the raw `err.message` is withheld, because it can
+leak an internal hostname (`getaddrinfo ENOTFOUND payments.internal.corp`) or the
+upstream's status (`HTTP 401`) to an untrusted client:
 
 ```ts
 new Elysia().use(
@@ -97,6 +100,8 @@ new Elysia().use(
         seam: api,
         // propagate the upstream status instead of the safe 502 default:
         errorHandler: { status: (e) => e.status ?? 502 },
+        // opt in to the raw message (only when upstream messages are safe to expose):
+        // errorHandler: { body: (e) => ({ error: e.message }) },
     }),
 );
 ```

--- a/packages/elysia/src/error.ts
+++ b/packages/elysia/src/error.ts
@@ -26,13 +26,25 @@ export interface StitchErrorOptions {
      */
     status?: number | ((err: StitchErrorLike) => number);
     /**
-     * The JSON body for a mapped failure. Default: `{ error: <message> }`. Override to shape your
-     * own error envelope. Receives the mapped status alongside the error.
+     * The JSON body for a mapped failure. **Default: a generic, status-tied message**
+     * (`{ error: 'Bad Gateway' }`) — the raw `err.message` is deliberately *not* echoed, because it
+     * can disclose internal network topology (a transport failure reads like
+     * `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to an
+     * untrusted client. Override to shape your own error envelope; pass `(e) => ({ error: e.message })`
+     * to opt in to the raw message when the upstream messages are known to be safe to expose.
+     * Receives the mapped status alongside the error.
      */
     body?: (err: StitchErrorLike, status: number) => unknown;
 }
 
 const BAD_GATEWAY = 502;
+
+// A small map of the statuses this helper emits → their generic reason phrase, used for
+// the default body so the raw error message is never echoed to the client.
+const STATUS_TEXT: Record<number, string> = {
+    500: 'Internal Server Error',
+    502: 'Bad Gateway',
+};
 
 function resolveStatus(
     err: StitchErrorLike,
@@ -59,9 +71,12 @@ export function stitchErrorResponse(
 ): Response | undefined {
     if (!isStitchError(err)) return undefined;
     const status = resolveStatus(err, options.status);
+    // Default body is a generic, status-tied message — the raw `err.message` is deliberately
+    // withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status
+    // (`HTTP 401`) never reaches the client. Opt in via `options.body`.
     const body = options.body
         ? options.body(err, status)
-        : { error: err.message || 'Upstream request failed' };
+        : { error: STATUS_TEXT[status] ?? 'Error' };
     return Response.json(body, { status });
 }
 

--- a/packages/elysia/test/elysia.spec.ts
+++ b/packages/elysia/test/elysia.spec.ts
@@ -229,7 +229,54 @@ describe('stitchOnError / stitchErrorResponse map a StitchError to HTTP', () => 
             { status: (e) => e.status ?? 502 },
         );
         expect(mapped?.status).toBe(503);
-        expect(await mapped?.json()).toEqual({ error: 'upstream' });
+        // The default body is a generic phrase — the raw `upstream` message is NOT echoed.
+        expect(await mapped?.json()).toEqual({ error: 'Error' });
+    });
+
+    // Regression: the default response body must not echo the raw upstream/transport message,
+    // which can disclose internal network topology (a transport error names the host it failed
+    // to reach) or the upstream's status semantics to an untrusted client.
+    describe('does not leak the raw error message by default', () => {
+        test('a transport failure with an internal hostname is not disclosed', async () => {
+            // The exact shape core throws for a BYO-adapter/DNS failure: message carries the host.
+            const res = stitchErrorResponse(
+                Object.assign(
+                    new Error('getaddrinfo ENOTFOUND payments.internal.corp'),
+                    { name: 'StitchError' },
+                ),
+            );
+            expect(res?.status).toBe(502); // status stays masked
+            const body = await res!.text();
+            expect(body).not.toContain('payments.internal.corp');
+            expect(body).not.toContain('ENOTFOUND');
+            expect(JSON.parse(body)).toEqual({ error: 'Bad Gateway' });
+        });
+
+        test("an upstream 401 does not surface as 'HTTP 401' in the body", async () => {
+            // core builds `HTTP <status>` (packages/core/src/engine.ts) for an upstream error.
+            const res = stitchErrorResponse(
+                Object.assign(new Error('HTTP 401'), {
+                    name: 'StitchError',
+                    status: 401,
+                }),
+            );
+            expect(res?.status).toBe(502);
+            expect(await res!.text()).not.toContain('HTTP 401');
+        });
+
+        test('the `body` opt-in still includes the raw message', async () => {
+            const res = stitchErrorResponse(
+                Object.assign(
+                    new Error('getaddrinfo ENOTFOUND payments.internal.corp'),
+                    { name: 'StitchError' },
+                ),
+                { body: (e) => ({ error: e.message }) },
+            );
+            // The escape hatch is preserved — callers who want the message can still opt in.
+            expect(await res!.json()).toEqual({
+                error: 'getaddrinfo ENOTFOUND payments.internal.corp',
+            });
+        });
     });
 
     test('isStitchError discriminates by name', () => {

--- a/packages/hono/README.md
+++ b/packages/hono/README.md
@@ -77,10 +77,16 @@ try/catch:
 
 ```ts
 app.onError(stitchOnError());
-// default 502 — an upstream's 401/404/etc. is never leaked to your client.
+// default 502, body `{ error: 'Bad Gateway' }` — neither the upstream's
+// 401/404/etc. status nor the raw error message is leaked to your client (a
+// transport failure would otherwise read like `getaddrinfo ENOTFOUND
+// payments.internal.corp`, disclosing internal topology).
 
 // propagate the upstream status instead:
 app.onError(stitchOnError({ status: (e) => e.status ?? 502 }));
+
+// or shape your own error envelope (this opts in to the raw message):
+app.onError(stitchOnError({ body: (e) => ({ error: e.message }) }));
 ```
 
 Or map a single error by hand — `stitchError` returns a Hono `HTTPException`, or

--- a/packages/hono/src/error.ts
+++ b/packages/hono/src/error.ts
@@ -25,9 +25,26 @@ export interface StitchErrorOptions {
      * `(e) => e.status ?? 502`, or remap specific codes (`(e) => (e.status === 429 ? 429 : 502)`).
      */
     status?: number | ((err: StitchErrorLike) => number);
+    /**
+     * The JSON body for a mapped failure. **Default: a generic, status-tied message**
+     * (`{ error: 'Bad Gateway' }`) — the raw `err.message` is deliberately *not* echoed, because it
+     * can disclose internal network topology (a transport failure reads like
+     * `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to an
+     * untrusted client. Override to shape your own error envelope; pass `(e) => ({ error: e.message })`
+     * to opt in to the raw message when the upstream messages are known to be safe to expose.
+     * Receives the mapped status alongside the error.
+     */
+    body?: (err: StitchErrorLike, status: number) => unknown;
 }
 
 const BAD_GATEWAY = 502;
+
+// A small map of the statuses this helper emits → their generic reason phrase, used for
+// the default body so the raw error message is never echoed to the client.
+const STATUS_TEXT: Record<number, string> = {
+    500: 'Internal Server Error',
+    502: 'Bad Gateway',
+};
 
 /**
  * Map a thrown stitch failure to a Hono {@link HTTPException}, or `undefined` when `err` is not a
@@ -49,8 +66,16 @@ export function stitchError(
     if (!isStitchError(err)) return undefined;
     const { status = BAD_GATEWAY } = options;
     const code = typeof status === 'function' ? status(err) : status;
+    // Default body is a generic, status-tied message — the raw `err.message` is deliberately
+    // withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status
+    // (`HTTP 401`) never reaches the client. Opt in via `options.body`. Carry it on the
+    // exception's `res` so `getResponse()` renders THIS body (a bare `message` would be echoed
+    // verbatim into the response body, which is exactly the leak we're closing).
+    const body = options.body
+        ? options.body(err, code)
+        : { error: STATUS_TEXT[code] ?? 'Error' };
     return new HTTPException(code as ContentfulStatusCode, {
-        message: err.message || 'Upstream request failed',
+        res: Response.json(body, { status: code }),
     });
 }
 

--- a/packages/hono/test/hono.spec.ts
+++ b/packages/hono/test/hono.spec.ts
@@ -184,6 +184,11 @@ describe('stitchError / stitchOnError map a StitchError to HTTP', () => {
         const res = await app.request('/boom');
         // 502 by default — the upstream 404 is NOT leaked to the client.
         expect(res.status).toBe(502);
+        // The default body is the generic, status-tied phrase — NOT the raw upstream message
+        // (core throws `HTTP 404` for the upstream error; that must not reach the client).
+        const body = await res.text();
+        expect(body).not.toContain('HTTP 404');
+        expect(JSON.parse(body)).toEqual({ error: 'Bad Gateway' });
         await api.close();
     });
 
@@ -215,5 +220,54 @@ describe('stitchError / stitchOnError map a StitchError to HTTP', () => {
             { status: (e) => e.status ?? 502 },
         );
         expect(mapped?.status).toBe(503);
+    });
+
+    // Regression: the rendered response body must not echo the raw upstream/transport message,
+    // which can disclose internal network topology (a transport error names the host it failed
+    // to reach) or the upstream's status semantics to an untrusted client. `stitchError` returns
+    // an `HTTPException`; `.getResponse()` is exactly what Hono sends, so we assert on that body.
+    describe('does not leak the raw error message by default', () => {
+        test('a transport failure with an internal hostname is not disclosed', async () => {
+            // The exact shape core throws for a BYO-adapter/DNS failure: message carries the host.
+            const mapped = stitchError(
+                Object.assign(
+                    new Error('getaddrinfo ENOTFOUND payments.internal.corp'),
+                    { name: 'StitchError' },
+                ),
+            );
+            const res = mapped!.getResponse();
+            expect(res.status).toBe(502); // status stays masked
+            const body = await res.text();
+            expect(body).not.toContain('payments.internal.corp');
+            expect(body).not.toContain('ENOTFOUND');
+            expect(JSON.parse(body)).toEqual({ error: 'Bad Gateway' });
+        });
+
+        test("an upstream 401 does not surface as 'HTTP 401' in the body", async () => {
+            // core builds `HTTP <status>` (packages/core/src/engine.ts) for an upstream error.
+            const mapped = stitchError(
+                Object.assign(new Error('HTTP 401'), {
+                    name: 'StitchError',
+                    status: 401,
+                }),
+            );
+            const res = mapped!.getResponse();
+            expect(res.status).toBe(502);
+            expect(await res.text()).not.toContain('HTTP 401');
+        });
+
+        test('the `body` opt-in still includes the raw message', async () => {
+            const mapped = stitchError(
+                Object.assign(
+                    new Error('getaddrinfo ENOTFOUND payments.internal.corp'),
+                    { name: 'StitchError' },
+                ),
+                { body: (e) => ({ error: e.message }) },
+            );
+            // The escape hatch is preserved — callers who want the message can still opt in.
+            expect(await mapped!.getResponse().json()).toEqual({
+                error: 'getaddrinfo ENOTFOUND payments.internal.corp',
+            });
+        });
     });
 });


### PR DESCRIPTION
## The leak

Both `@stitchapi/elysia` and `@stitchapi/hono` map a thrown `StitchError` to a **client-facing** HTTP response and, **by default**, forwarded the raw `err.message` straight into the response body. The status is safely remapped to `502`, but the message is not — and the message is attacker-relevant:

- an upstream **4xx/5xx** surfaces as the string **`HTTP <status>`** (core builds it in `packages/core/src/engine.ts`), re-exposing the upstream status the `502` remap was meant to hide;
- a transport / BYO-adapter failure reads like **`getaddrinfo ENOTFOUND payments.internal.corp`**, disclosing an **internal hostname / network topology** to an untrusted client.

This directly contradicts each package's own docs, which claimed the `502` default "never leaks an upstream's `401`/`404`/etc. semantics to your client" — but only the **status line** was masked, not the body.

This is the **same bug class already fixed for next+nest in #407 and fastify+express in #408**. elysia and hono were the two remaining instances; this PR is a fresh branch and does not touch #407/#408.

The leak sites (before this PR):
- **elysia** — `packages/elysia/src/error.ts`: `stitchErrorResponse` with no `options.body` returned `Response.json({ error: err.message || 'Upstream request failed' }, { status })`. It already had a `body` opt-in, but the **default** leaked.
- **hono** — `packages/hono/src/error.ts`: `stitchError`/`stitchOnError` built `new HTTPException(502, { message: err.message || … })`, and `HTTPException.getResponse()` renders `message` verbatim as the body. hono had **no `body` option at all** — a user couldn't even opt out.

Confirmed by the fail-before evidence below: the serialized bodies were literally `{"error":"getaddrinfo ENOTFOUND payments.internal.corp"}`, `{"error":"HTTP 401"}`, and `HTTP 404`.

## The fix (mirrors #408; backward-compatible except the intended default change)

The default response body no longer contains the raw upstream/internal message; the raw message becomes **opt-in**.

**elysia — `stitchErrorResponse`** (`packages/elysia/src/error.ts`)
- The default body is now a generic, status-tied message via a small `STATUS_TEXT` map (`500: 'Internal Server Error'`, `502: 'Bad Gateway'`) → `{ error: STATUS_TEXT[status] ?? 'Error' }`. For the `502` default that's `{ error: 'Bad Gateway' }`.
- The pre-existing `body?: (err, status) => unknown` option is **preserved** as the escape hatch — pass `(e) => ({ error: e.message })` to opt back in to the raw message.

**hono — `stitchError` / `stitchOnError`** (`packages/hono/src/error.ts`)
- A **new** `body?: (err, status) => unknown` option is added to `StitchErrorOptions` (hono previously had none), so callers can opt in to the raw message or their own envelope.
- The `HTTPException` is now built with a **`res`** carrying the generic status-tied JSON body (`Response.json({ error: STATUS_TEXT[code] ?? 'Error' }, { status: code })`) instead of `message: err.message`. `HTTPException.getResponse()` renders the provided `res`'s body (and JSON content-type), so the raw `message` never reaches the client. (`getResponse()` re-wraps with the exception's own status, so the status remap is unchanged.)

Status resolution and the `undefined`-for-non-`StitchError` rethrow path are **untouched** in both. Public APIs stay backward-compatible; the only behaviour change is the intended one — the **default** body no longer echoes the raw message. JSDoc on `StitchErrorOptions.body` + both package READMEs updated to describe the new default (status masked **and** message not echoed; use `body` to include it).

## Regression tests — fail-before / pass-after

One leak-regression block added per package, plus the pre-existing tests that asserted (or implied) the old body were strengthened to inspect the body:
- **elysia**: the `stitchErrorResponse` default-body test now asserts the generic phrase (a `status`-override to 503 → `{ error: 'Error' }`, not the raw `upstream` message).
- **hono**: the `502 by default` test previously asserted **only** `res.status === 502` — it now also inspects the body (`not.toContain('HTTP 404')`, equals `{ error: 'Bad Gateway' }`).

For **each** package the mapper is driven directly with a `StitchError`:
- message `getaddrinfo ENOTFOUND payments.internal.corp` → sent body contains **neither** `payments.internal.corp` **nor** `ENOTFOUND`, status stays `502`;
- message `HTTP 401` → body does **not** contain `HTTP 401`, status stays `502`;
- the `body` opt-in still includes the raw message.

(elysia asserts on the returned `Response`; hono asserts on `stitchError(...)!.getResponse()`, which is exactly what Hono sends.)

```
FAIL-BEFORE (original source restored, new tests in place — message leaks)
  elysia:  Test Files 1 failed | 1 passed (2)   Tests 3 failed | 18 passed (21)
  hono:    Test Files 1 failed | 1 passed (2)   Tests 4 failed | 13 passed (17)
    e.g. Received: {"error":"getaddrinfo ENOTFOUND payments.internal.corp"}
         Received: {"error":"HTTP 401"}
         Received: HTTP 404
    (hono's `body` opt-in test also fails-before — original hono had no `body` option.)

PASS-AFTER (fix applied)
  elysia:  Test Files 2 passed (2)   Tests 21 passed (21)   check:types OK
  hono:    Test Files 2 passed (2)   Tests 17 passed (17)   check:types OK
```

`prettier --check` passes on all six changed files, and the full-tree lefthook pre-commit gate (format + lint + typecheck) passed.

## Related follow-up (intentionally not in this PR)

The **SSE `error` frame** in both packages still forwards the raw `event.message` into the `event: error` data frame (`streamStitchSse` — the existing tests assert an `event: error` frame). As with #407/#408's note on the next/fastify/express SSE `error` frames, that is an explicit stream error-event contract and sanitizing it is a separate, tracked decision (it may want the same opt-in treatment, or a documented "SSE frames carry the message" stance). Left **untouched** here and flagged for the follow-up sub-class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
