### PR TITLE
fix(express,fastify,hono): don't leak raw upstream/transport error messages over SSE (topology disclosure)

### DIFF
--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -56,10 +56,11 @@ mirroring StitchAPI's borrow-don't-own rule.
 
 Stream a streaming/SSE stitch's `.stream()` to `res` as Server-Sent Events, by
 writing `text/event-stream` frames straight to the socket. Each `delta` becomes a
-`data:` frame; a terminal `error` event becomes a final `event: error` frame;
-control events (`start`/`progress`/`result`/`done`/…) are consumed but not
-forwarded. On client disconnect (`res` — or `req`, when passed — emits `close`)
-the upstream stitch stream is aborted.
+`data:` frame; a terminal `error` event becomes a final `event: error` frame (a
+generic `data: error` by default — see below); control events
+(`start`/`progress`/`result`/`done`/…) are consumed but not forwarded. On client
+disconnect (`res` — or `req`, when passed — emits `close`) the upstream stitch
+stream is aborted.
 
 ```ts
 import { sseSurface } from 'stitchapi/sse';
@@ -82,6 +83,18 @@ app.get('/chat', (req, res) => {
 
 Do not also `res.send()`/`res.json()` from the same handler — the helper owns the
 response.
+
+By default the `error` frame carries a generic `data: error` token, **not** the raw
+error message — echoing it can disclose internal network topology (a transport
+failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's
+status (`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream
+messages are known safe to expose:
+
+```ts
+streamStitchSse(res, completion.stream({ body: { prompt: req.query.q } }), {
+    errorData: (e) => e.message, // opt in to the raw upstream message
+});
+```
 
 ## Errors: `stitchErrorHandler(options?)`
 

--- a/packages/express/src/sse.ts
+++ b/packages/express/src/sse.ts
@@ -12,6 +12,9 @@ export type StitchEventSource<T> =
     | AsyncIterable<StitchEvent<T>>
     | AsyncGenerator<StitchEvent<T>, void>;
 
+/** The terminal `error` event a stitch stream emits — carries `message`, `status`, `attempts`. */
+type StitchErrorEvent = Extract<StitchEvent, { type: 'error' }>;
+
 export interface StreamStitchSseOptions {
     /**
      * Map a `delta` chunk to the SSE frame `data`. Default: the chunk itself (a string is sent
@@ -29,6 +32,16 @@ export interface StreamStitchSseOptions {
      * Receives the chunk and the zero-based frame index.
      */
     id?: (chunk: unknown, index: number) => string;
+    /**
+     * Shape the SSE `data` written for a terminal `error` event. **Default: a generic token
+     * (`data: error`)** — the raw `event.message` is deliberately *not* echoed, because it can
+     * disclose internal network topology (a transport failure reads like
+     * `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to an
+     * untrusted client. Opt in with `(e) => e.message` when the upstream messages are known safe,
+     * or return your own payload (e.g. `() => JSON.stringify({ error: 'stream failed' })`). A
+     * multi-line return gets one `data:` line each (SSE spec); the `event: error` name is fixed.
+     */
+    errorData?: (event: StitchErrorEvent) => string;
     /**
      * The Express request, when available. Express normally fires `close` on the *response* on
      * disconnect, but passing `req` lets the helper also listen on the request socket for
@@ -54,12 +67,27 @@ function frame(
     return `${lines.join('\n')}\n\n`;
 }
 
+// The generic token written as an `error` frame's `data` by default: the raw upstream message is
+// withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`)
+// never reaches the client. Override with `options.errorData`.
+const DEFAULT_ERROR_DATA = 'error';
+
+// The terminal `error` frame: the fixed `event: error` name plus a (multi-line-safe) data payload —
+// every line of `data` gets its own `data:` prefix so a multi-line opt-in payload can't break the
+// SSE framing.
+function errorFrame(data: string): string {
+    const lines = ['event: error'];
+    for (const dataLine of data.split('\n')) lines.push(`data: ${dataLine}`);
+    return `${lines.join('\n')}\n\n`;
+}
+
 /**
  * Stream a stitch's output to an Express {@link Response} as Server-Sent Events. Pass the stitch's
  * `.stream()` generator (or any `AsyncIterable<StitchEvent>`): each `delta` becomes one SSE frame, an
- * `error` event ends the stream with a named `event: error` frame, and stream end closes the
- * response. The non-output events (`start` / `progress` / `drift` / `result` / `done`) are control
- * signals and are not forwarded to the client.
+ * `error` event ends the stream with a named `event: error` frame (a generic `data: error` by
+ * default — the raw message is withheld to avoid disclosing internal topology; opt in via
+ * `errorData`), and stream end closes the response. The non-output events (`start` / `progress` /
+ * `drift` / `result` / `done`) are control signals and are not forwarded to the client.
  *
  * Writes raw frames straight to the socket, so do **not** also `res.send()`/`res.json()` from the
  * same handler. Resolves once the response is fully written (or the client disconnects). On
@@ -110,8 +138,17 @@ export async function streamStitchSse<T>(
                 res.write(frame(event.chunk, index, options));
                 index += 1;
             } else if (event.type === 'error') {
-                // Surface the failure to the client as a named `error` SSE frame, then stop.
-                res.write(`event: error\ndata: ${event.message}\n\n`);
+                // Surface the failure to the client as a named `error` SSE frame, then stop — but by
+                // default write a generic token, never the raw `event.message`, so an internal
+                // hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`) is not
+                // disclosed. Opt in to the real message via `options.errorData`.
+                res.write(
+                    errorFrame(
+                        options.errorData
+                            ? options.errorData(event)
+                            : DEFAULT_ERROR_DATA,
+                    ),
+                );
                 break;
             }
             // start / progress / info / drift / result / done are control signals: not forwarded.

--- a/packages/express/test/express.spec.ts
+++ b/packages/express/test/express.spec.ts
@@ -182,7 +182,35 @@ describe('streamStitchSse writes SSE frames to res', () => {
         expect(res.ended).toBe(true);
     });
 
-    test('an error event ends the stream with a named event: error frame', async () => {
+    test('by default an error event yields a named event: error frame with a generic token, never the raw message', async () => {
+        async function* events(): AsyncGenerator<StitchEvent<unknown>> {
+            yield { type: 'delta', chunk: 'partial', at: 1 };
+            yield {
+                type: 'error',
+                name: 'StitchError',
+                // A transport failure whose message discloses an internal hostname — it must NOT
+                // reach the client (topology disclosure; same class PR #408 fixed on the
+                // error-handler surface).
+                message: 'getaddrinfo ENOTFOUND payments.internal.corp',
+                status: 502,
+                attempts: 1,
+                at: 2,
+            };
+            // Never reached: the helper stops on `error`.
+            yield { type: 'delta', chunk: 'unreachable', at: 3 };
+        }
+        const res = mockRes();
+        await streamStitchSse(res as unknown as Response, events());
+
+        // The stream still ends with a named `error` frame, but the data is a generic token.
+        expect(res.body()).toBe(
+            'data: partial\n\nevent: error\ndata: error\n\n',
+        );
+        expect(res.body()).not.toContain('payments.internal.corp');
+        expect(res.body()).not.toContain('ENOTFOUND');
+    });
+
+    test('errorData opts in to the raw message on the error frame', async () => {
         async function* events(): AsyncGenerator<StitchEvent<unknown>> {
             yield { type: 'delta', chunk: 'partial', at: 1 };
             yield {
@@ -192,11 +220,11 @@ describe('streamStitchSse writes SSE frames to res', () => {
                 attempts: 1,
                 at: 2,
             };
-            // Never reached: the helper stops on `error`.
-            yield { type: 'delta', chunk: 'unreachable', at: 3 };
         }
         const res = mockRes();
-        await streamStitchSse(res as unknown as Response, events());
+        await streamStitchSse(res as unknown as Response, events(), {
+            errorData: (e) => e.message,
+        });
 
         expect(res.body()).toBe(
             'data: partial\n\nevent: error\ndata: upstream blew up\n\n',

--- a/packages/fastify/README.md
+++ b/packages/fastify/README.md
@@ -103,6 +103,18 @@ Each `delta` chunk becomes one SSE frame; an `error` event ends the stream as a
 named `error` frame; stream end closes the response; and a client disconnect
 aborts the upstream stitch generator rather than leaving it running.
 
+By default the `error` frame carries a generic `data: error` token, **not** the raw
+error message — echoing it can disclose internal network topology (a transport
+failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's
+status (`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream
+messages are known safe to expose:
+
+```ts
+sendStitchSse(reply, chat.stream({ query: { q: String(req.query.q) } }), {
+    errorData: (e) => e.message, // opt in to the raw upstream message
+});
+```
+
 ## Error handling
 
 The plugin registers a `setErrorHandler` that maps a `StitchError` to an HTTP

--- a/packages/fastify/src/sse.ts
+++ b/packages/fastify/src/sse.ts
@@ -7,6 +7,9 @@
 import type { FastifyReply } from 'fastify';
 import type { StitchEvent } from 'stitchapi';
 
+/** The terminal `error` event a stitch stream emits — carries `message`, `status`, `attempts`. */
+type StitchErrorEvent = Extract<StitchEvent, { type: 'error' }>;
+
 export interface SendStitchSseOptions {
     /**
      * Map a `delta` chunk to the SSE frame `data`. Default: the chunk itself (a string is
@@ -24,6 +27,16 @@ export interface SendStitchSseOptions {
      * Receives the chunk and the zero-based frame index.
      */
     id?: (chunk: unknown, index: number) => string;
+    /**
+     * Shape the SSE `data` written for a terminal `error` event. **Default: a generic token
+     * (`data: error`)** — the raw `event.message` is deliberately *not* echoed, because it can
+     * disclose internal network topology (a transport failure reads like
+     * `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to
+     * an untrusted client. Opt in with `(e) => e.message` when the upstream messages are known
+     * safe, or return your own payload (e.g. `() => JSON.stringify({ error: 'stream failed' })`).
+     * A multi-line return gets one `data:` line each (SSE spec); the `event: error` name is fixed.
+     */
+    errorData?: (event: StitchErrorEvent) => string;
 }
 
 // One delta chunk → an SSE frame string. A multi-line payload is split so every line gets its
@@ -43,12 +56,27 @@ function frame(
     return `${lines.join('\n')}\n\n`;
 }
 
+// The generic token written as an `error` frame's `data` by default: the raw upstream message is
+// withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`)
+// never reaches the client. Override with `options.errorData`.
+const DEFAULT_ERROR_DATA = 'error';
+
+// The terminal `error` frame: the fixed `event: error` name plus a (multi-line-safe) data payload —
+// every line of `data` gets its own `data:` prefix so a multi-line opt-in payload can't break the
+// SSE framing.
+function errorFrame(data: string): string {
+    const lines = ['event: error'];
+    for (const dataLine of data.split('\n')) lines.push(`data: ${dataLine}`);
+    return `${lines.join('\n')}\n\n`;
+}
+
 /**
  * Stream a stitch's output to a Fastify {@link FastifyReply} as Server-Sent Events. Pass the
  * stitch's `.stream()` generator (or any `AsyncIterable<StitchEvent>`): each `delta` becomes
- * one SSE frame, an `error` event ends the stream, and stream end closes the response. The
- * non-output events (`start` / `progress` / `drift` / `result` / `done`) are control signals
- * and are not forwarded to the client.
+ * one SSE frame, an `error` event ends the stream with a named `event: error` frame (a generic
+ * `data: error` by default — the raw message is withheld to avoid disclosing internal topology;
+ * opt in via `errorData`), and stream end closes the response. The non-output events (`start` /
+ * `progress` / `drift` / `result` / `done`) are control signals and are not forwarded to the client.
  *
  * Takes over the reply via `reply.hijack()` and writes raw frames, so do **not** also `send()`
  * from the same handler. Resolves once the response is fully written (or the client
@@ -97,8 +125,17 @@ export async function sendStitchSse<T>(
                 res.write(frame(event.chunk, index, options));
                 index += 1;
             } else if (event.type === 'error') {
-                // Surface the failure to the client as a named `error` SSE frame, then stop.
-                res.write(`event: error\ndata: ${event.message}\n\n`);
+                // Surface the failure to the client as a named `error` SSE frame, then stop — but by
+                // default write a generic token, never the raw `event.message`, so an internal
+                // hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`) is not
+                // disclosed. Opt in to the real message via `options.errorData`.
+                res.write(
+                    errorFrame(
+                        options.errorData
+                            ? options.errorData(event)
+                            : DEFAULT_ERROR_DATA,
+                    ),
+                );
                 break;
             }
         }

--- a/packages/fastify/test/fastify.spec.ts
+++ b/packages/fastify/test/fastify.spec.ts
@@ -183,7 +183,47 @@ describe('stitchPlugin', () => {
         expect(res.body).toBe('data: hello\n\ndata: world\n\n');
     });
 
-    test('sendStitchSse surfaces an error event as an SSE error frame', async () => {
+    test('by default an error event yields a named event: error frame with a generic token, never the raw message', async () => {
+        async function* events(): AsyncGenerator<StitchEvent<unknown>> {
+            yield { type: 'delta', chunk: 'partial', at: 1 };
+            yield {
+                type: 'error',
+                name: 'StitchError',
+                // A transport failure whose message discloses an internal hostname — it must NOT
+                // reach the client (topology disclosure; same class PR #408 fixed on the
+                // error-handler surface).
+                message: 'getaddrinfo ENOTFOUND payments.internal.corp',
+                status: 502,
+                attempts: 1,
+                at: 2,
+            };
+        }
+        const app = Fastify();
+        apps.push(app);
+        await app.register(stitchPlugin, {
+            seamConfig: {
+                baseUrl: 'https://api.test',
+                adapter: fakeAdapter(() => ({
+                    status: 200,
+                    headers: {},
+                    body: {},
+                })).adapter,
+            },
+            logger: false,
+        });
+        app.get('/sse-err', (_request, reply) =>
+            sendStitchSse(reply, events()),
+        );
+        await app.ready();
+
+        const res = await app.inject({ method: 'GET', url: '/sse-err' });
+        // The stream still ends with a named `error` frame, but the data is a generic token.
+        expect(res.body).toBe('data: partial\n\nevent: error\ndata: error\n\n');
+        expect(res.body).not.toContain('payments.internal.corp');
+        expect(res.body).not.toContain('ENOTFOUND');
+    });
+
+    test('errorData opts in to the raw message on the error frame', async () => {
         async function* events(): AsyncGenerator<StitchEvent<unknown>> {
             yield { type: 'delta', chunk: 'partial', at: 1 };
             yield {
@@ -208,7 +248,7 @@ describe('stitchPlugin', () => {
             logger: false,
         });
         app.get('/sse-err', (_request, reply) =>
-            sendStitchSse(reply, events()),
+            sendStitchSse(reply, events(), { errorData: (e) => e.message }),
         );
         await app.ready();
 

--- a/packages/hono/README.md
+++ b/packages/hono/README.md
@@ -48,7 +48,8 @@ mirroring StitchAPI's borrow-don't-own rule.
 
 Stream a streaming/SSE stitch's `.stream()` to the client as Server-Sent Events,
 via Hono's `streamSSE`. Each `delta` becomes a `data:` message; a terminal
-`error` event (or a throw) becomes a final `event: error` message; control events
+`error` event (or a throw) becomes a final `event: error` message (a generic
+`data: error` by default — see below); control events
 (`start`/`progress`/`result`/`done`/…) are consumed but not forwarded. On client
 disconnect the upstream stitch stream is aborted.
 
@@ -66,6 +67,20 @@ app.get('/chat', (c) => {
             data: (chunk: any) => chunk.data, // pull the parsed event payload out of each delta
         },
     );
+});
+```
+
+By default the `error` message carries a generic `data: error` token, **not** the
+raw error message — echoing it can disclose internal network topology (a transport
+failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's
+status (`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream
+messages are known safe; `onError` still receives the real failure server-side for
+logging:
+
+```ts
+return streamStitchSse(c, completion.stream({ body: { prompt: c.req.query('q') } }), {
+    errorData: (e) => e.message, // opt in to the raw upstream message
+    onError: (err) => c.get('log').error(err), // real failure, server-side only
 });
 ```
 

--- a/packages/hono/src/sse.ts
+++ b/packages/hono/src/sse.ts
@@ -16,6 +16,9 @@ export type StitchEventSource<T> =
     | AsyncIterable<StitchEvent<T>>
     | AsyncGenerator<StitchEvent<T>, void>;
 
+/** The terminal `error` event a stitch stream emits — carries `message`, `status`, `attempts`. */
+type StitchErrorEvent = Extract<StitchEvent, { type: 'error' }>;
+
 export interface StreamStitchSseOptions {
     /**
      * Map a `delta` chunk to the SSE message `data` string. The default JSON-stringifies the chunk
@@ -29,14 +32,45 @@ export interface StreamStitchSseOptions {
      */
     event?: string;
     /**
-     * Called once if the underlying stream errors (a stitch `error` event, or a throw). After it
-     * runs, an `error`-typed SSE message carrying the error text is written and the stream closes.
+     * Shape the SSE `data` written for a terminal `error` event (or an uncaught throw mid-stream,
+     * normalised to an error event). **Default: a generic token (`data: error`)** — the raw
+     * `event.message` is deliberately *not* echoed, because it can disclose internal network
+     * topology (a transport failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or
+     * the upstream's status (`HTTP 401`) to an untrusted client. Opt in with `(e) => e.message`
+     * when the upstream messages are known safe, or return your own payload
+     * (e.g. `() => JSON.stringify({ error: 'stream failed' })`).
+     */
+    errorData?: (event: StitchErrorEvent) => string;
+    /**
+     * Called once, server-side, if the underlying stream errors (a stitch `error` event, or a
+     * throw) — use it to observe/log the real failure. It does **not** shape the client-facing
+     * frame: the SSE `data` sent to the client is controlled by `errorData` (a generic token by
+     * default), so the raw message reaches your logs here but not the client.
      */
     onError?: (err: unknown) => void;
 }
 
 function defaultData(chunk: unknown): string {
     return typeof chunk === 'string' ? chunk : JSON.stringify(chunk);
+}
+
+// The generic token written as an `error` message's `data` by default: the raw upstream message is
+// withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`)
+// never reaches the client. Override with `options.errorData`.
+const DEFAULT_ERROR_DATA = 'error';
+
+// Normalise a thrown value into the terminal `error` event shape, so an `errorData` opt-in sees a
+// consistent argument whether the failure arrived as a surfaced `error` event or an unexpected
+// throw. `attempts`/`at` are best-effort placeholders — an `errorData` hook keys off `name`/`message`.
+function toErrorEvent(err: unknown): StitchErrorEvent {
+    const e = err instanceof Error ? err : new Error(String(err));
+    return {
+        type: 'error',
+        name: e.name,
+        message: e.message,
+        attempts: 0,
+        at: 0,
+    };
 }
 
 /**
@@ -55,9 +89,10 @@ function defaultData(chunk: unknown): string {
  * ```
  *
  * Each `delta` becomes a `data:` message; a terminal `error` event (or a throw) becomes a final
- * `event: error` message and ends the stream; every control event (`start`/`progress`/`result`/
- * `done`/…) is consumed but not forwarded. On client disconnect the upstream iterator is
- * `return()`-ed so the stitch stream is aborted.
+ * `event: error` message and ends the stream — a generic `data: error` by default, the raw message
+ * withheld to avoid disclosing internal topology (opt in via `errorData`); every control event
+ * (`start`/`progress`/`result`/`done`/…) is consumed but not forwarded. On client disconnect the
+ * upstream iterator is `return()`-ed so the stitch stream is aborted.
  */
 export function streamStitchSse<T>(
     c: Context,
@@ -67,6 +102,15 @@ export function streamStitchSse<T>(
     const toData = options.data ?? defaultData;
     return streamSSE(c, async (stream: SSEStreamingApi) => {
         const iterator = source[Symbol.asyncIterator]();
+        // Write the terminal `error` message: a generic token by default so a raw message
+        // (`getaddrinfo ENOTFOUND …` / `HTTP 401`) is never disclosed; `errorData` opts in.
+        const writeErrorFrame = (event: StitchErrorEvent): Promise<void> =>
+            stream.writeSSE({
+                event: 'error',
+                data: options.errorData
+                    ? options.errorData(event)
+                    : DEFAULT_ERROR_DATA,
+            });
         // Client disconnect: stop pulling and tear down the upstream stitch stream.
         stream.onAbort(() => {
             void iterator.return?.(undefined);
@@ -81,21 +125,19 @@ export function streamStitchSse<T>(
                         message.event = options.event;
                     await stream.writeSSE(message);
                 } else if (event.type === 'error') {
+                    // `onError` gets the real failure server-side; the client frame is shaped by
+                    // `errorData` (generic by default), never the raw `event.message`.
                     options.onError?.(new Error(event.message));
-                    await stream.writeSSE({
-                        event: 'error',
-                        data: event.message,
-                    });
+                    await writeErrorFrame(event);
                     return;
                 }
                 // start / progress / info / drift / result / done are control signals: not forwarded.
             }
         } catch (err) {
+            // A throw (not a surfaced `error` event): still withhold the raw message by default —
+            // normalise it to an error event so an `errorData` opt-in sees a consistent shape.
             options.onError?.(err);
-            await stream.writeSSE({
-                event: 'error',
-                data: err instanceof Error ? err.message : String(err),
-            });
+            await writeErrorFrame(toErrorEvent(err));
         } finally {
             await iterator.return?.(undefined);
         }

--- a/packages/hono/test/hono.spec.ts
+++ b/packages/hono/test/hono.spec.ts
@@ -163,6 +163,9 @@ describe('streamStitchSse bridges a stitch stream to an SSE body', () => {
         const res = await app.request('/events');
         const body = await res.text();
         expect(body).toContain('event: error');
+        // By default the raw upstream message (`HTTP 500`) is withheld — a generic token is sent.
+        expect(body).toContain('data: error');
+        expect(body).not.toContain('HTTP 500');
     });
 });
 

--- a/packages/hono/test/sse.spec.ts
+++ b/packages/hono/test/sse.spec.ts
@@ -124,7 +124,7 @@ describe('streamStitchSse — control events', () => {
 });
 
 describe('streamStitchSse — error paths', () => {
-    test('an error event writes an event: error frame, invokes onError, and stops forwarding', async () => {
+    test('by default an error event writes a generic event: error frame (raw message withheld), while onError still gets the real failure', async () => {
         let captured: unknown;
         const app = new Hono();
         app.get('/x', (c) =>
@@ -135,7 +135,10 @@ describe('streamStitchSse — error paths', () => {
                     {
                         type: 'error',
                         name: 'StitchError',
-                        message: 'upstream failed',
+                        // Discloses an internal hostname — must NOT reach the client (topology
+                        // disclosure; same class PR #408 fixed on the error-handler surface).
+                        message: 'getaddrinfo ENOTFOUND payments.internal.corp',
+                        status: 502,
                         attempts: 1,
                         at: 0,
                     },
@@ -153,17 +156,47 @@ describe('streamStitchSse — error paths', () => {
         const body = await (await app.request('/x')).text();
         expect(body).toContain('data: a');
         expect(body).toContain('event: error');
-        expect(body).toContain('upstream failed');
+        expect(body).toContain('data: error');
+        // The raw message is withheld from the client by default …
+        expect(body).not.toContain('payments.internal.corp');
+        expect(body).not.toContain('ENOTFOUND');
         expect(body).not.toContain('never');
+        // … but onError still observes the real failure server-side (for logging).
         expect(captured).toBeInstanceOf(Error);
-        expect((captured as Error).message).toBe('upstream failed');
+        expect((captured as Error).message).toBe(
+            'getaddrinfo ENOTFOUND payments.internal.corp',
+        );
     });
 
-    test('a throw mid-stream is caught: onError fires and a final event: error frame is written', async () => {
+    test('errorData opts in to the raw message on the error frame', async () => {
+        const app = new Hono();
+        app.get('/x', (c) =>
+            streamStitchSse(
+                c,
+                gen([
+                    { type: 'delta', chunk: 'a', at: 0 },
+                    {
+                        type: 'error',
+                        name: 'StitchError',
+                        message: 'upstream failed',
+                        attempts: 1,
+                        at: 0,
+                    },
+                ]),
+                { errorData: (e) => e.message },
+            ),
+        );
+
+        const body = await (await app.request('/x')).text();
+        expect(body).toContain('event: error');
+        expect(body).toContain('data: upstream failed');
+    });
+
+    test('a throw mid-stream is caught: onError fires and a final generic event: error frame is written (raw message withheld)', async () => {
         let captured: unknown;
         async function* boom(): AsyncGenerator<StitchEvent, void> {
             yield { type: 'delta', chunk: 'a', at: 0 };
-            throw new Error('stream blew up');
+            throw new Error('getaddrinfo ENOTFOUND payments.internal.corp');
         }
 
         const app = new Hono();
@@ -178,7 +211,28 @@ describe('streamStitchSse — error paths', () => {
         const body = await (await app.request('/x')).text();
         expect(body).toContain('data: a');
         expect(body).toContain('event: error');
-        expect(body).toContain('stream blew up');
-        expect((captured as Error).message).toBe('stream blew up');
+        expect(body).toContain('data: error');
+        expect(body).not.toContain('payments.internal.corp');
+        expect(body).not.toContain('ENOTFOUND');
+        // onError still sees the real thrown error server-side.
+        expect((captured as Error).message).toBe(
+            'getaddrinfo ENOTFOUND payments.internal.corp',
+        );
+    });
+
+    test('errorData opts in on the throw path too (thrown error normalised to an error event)', async () => {
+        async function* boom(): AsyncGenerator<StitchEvent, void> {
+            yield { type: 'delta', chunk: 'a', at: 0 };
+            throw new Error('stream blew up');
+        }
+
+        const app = new Hono();
+        app.get('/x', (c) =>
+            streamStitchSse(c, boom(), { errorData: (e) => e.message }),
+        );
+
+        const body = await (await app.request('/x')).text();
+        expect(body).toContain('event: error');
+        expect(body).toContain('data: stream blew up');
     });
 });


### PR DESCRIPTION
## What

The SSE bridges in `@stitchapi/express`, `@stitchapi/fastify`, and `@stitchapi/hono` forwarded the raw `StitchError` `message` from a streamed `error` event straight to the client (`event: error\ndata: <message>\n\n`), re-introducing the topology-disclosure class that **#408** (fastify/express) and **#407** (next/nest) fixed on the HTTP error-handler surface.

Concrete leak: a streaming stitch whose upstream host is unresolvable produces a core `error` event with `message = "getaddrinfo ENOTFOUND payments.internal.corp"` — written verbatim to the browser `EventSource`, disclosing an internal hostname. For an upstream HTTP failure the string `HTTP 401` re-exposes the status the 502 remap hides.

## Fix

Applies the same **generic-by-default + opt-in hook** pattern #408 established (its `body` option), now for the SSE surface:

- **Default (the one intended behavior change):** the `error` frame writes a generic `data: error` token — the raw `event.message` is no longer echoed.
- **Opt-in:** a new `errorData?: (event) => string` option on each SSE options type restores/shapes the message when the upstream messages are known safe — `errorData: (e) => e.message`.
- The hand-built express/fastify error frame is now **multi-line-safe** (one `data:` per line) so an opt-in multi-line payload can't break SSE framing.
- **hono:** both leak sites are closed — the `error`-event path *and* the `catch` throw path (normalised via `toErrorEvent`). Its existing `onError` stays a **server-side** log hook that still receives the real failure; it does not shape the client frame.

Backward-compatible except the intended default change — every existing option (`data`/`event`/`id`/`req`/`onError`) is untouched; `errorData` is additive.

## Tests

The tests that previously **locked in the leak** (`data: upstream blew up`) now assert the message is withheld by default — using a real `getaddrinfo ENOTFOUND …` / `HTTP 500` message — and is present only via the `errorData` opt-in. Each package also gains an opt-in test; hono additionally verifies the throw-path withholding and that `onError` still observes the real error. JSDoc + all three READMEs updated.

Verified: whole-tree pre-push gate green (format, lint, contract, typecheck, typecheck-d, **test**, exports, build-docs).

## Follow-up (not in this PR)

The same class remains on two more SSE surfaces, tracked separately:
- `packages/next/src/index.ts` — the SSE writer forwards `event.message` / `reason.message` (#407's own commit explicitly deferred this).
- `packages/nest/src/sse.ts` — `subscriber.error(new Error(event.message))`, rendered by `@Sse()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)