### PR TITLE
fix(solid,angular): port #406 cache-key fix — nameless-collision + secret-header leak in queryKey

### DIFF
--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -105,6 +105,85 @@ export interface InjectStitchResult<T> {
 // Shared driver
 // ---------------------------------------------------------------------------
 
+// --- key derivation (shared logic; duplicated in @stitchapi/react) ----------
+// These helpers are intentionally copied verbatim from `@stitchapi/react`'s key
+// derivation: they are separate published packages, so a cross-package import
+// would add a runtime dependency. Keep the copies in lock-step.
+
+/** The `__config` slice a key derives from. Mirrors core's `nameOf`
+ * (`name ?? path ?? 'stitch'`) plus a `url` fallback for URL-configured stitches. */
+type KeyConfig = { name?: string; path?: string; url?: string };
+
+/** A stable, human-meaningful name for the stitch. Mirrors core's `nameOf`
+ * (`packages/core/src/engine.ts`) — `name ?? path ?? url ?? 'stitch'` — so two
+ * DISTINCT nameless stitches (`/users/{id}` vs `/orders/{id}`) don't collapse to
+ * the literal `'stitch'` and collide on one cache entry. */
+function nameOf(stitch: unknown): string {
+    const cfg = (stitch as { __config?: KeyConfig }).__config;
+    return cfg?.name ?? cfg?.path ?? cfg?.url ?? 'stitch';
+}
+
+// Header names whose VALUES are secrets — mirrors core's private `SECRET_HEADERS`
+// trace denylist (`packages/core/src/trace.ts`), which is not exported. We redact
+// the value (rather than dropping the header) so the key stays stable per token
+// AND callers who legitimately vary a response by a non-secret header (e.g.
+// `accept-language`) keep separate cache entries. Compared case-insensitively; the
+// `*-token` / `*-api-key` suffix rules catch vendor spellings without enumerating.
+const SECRET_HEADERS = new Set([
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+    'x-api-key',
+    'x-auth-token',
+]);
+const REDACTED = '[redacted]';
+
+function isSecretHeader(name: string): boolean {
+    const k = name.toLowerCase();
+    return (
+        SECRET_HEADERS.has(k) || k.endsWith('-token') || k.endsWith('-api-key')
+    );
+}
+
+/**
+ * Build the value that goes into a cache/query key from a stitch's per-call input.
+ * Never puts the raw input in the key:
+ *
+ * - drops `signal` / `onProgress` — runtime-only, never-serialised (CONTRACT.md);
+ *   `onProgress` in particular churns identity every render, which would refetch
+ *   forever if it entered the key;
+ * - redacts the VALUES of secret-bearing headers (`authorization`, `cookie`, …)
+ *   so a bearer token can't leak into a persisted / devtools-visible key, while
+ *   keeping non-secret headers so they still vary the cache;
+ * - keeps every other field (`params` / `query` / `body` / `variables` / …) as-is.
+ *
+ * `null` / `undefined` inputs stay `null`; a primitive input is returned unchanged.
+ */
+function keyInputFor(input: unknown): unknown {
+    if (input === null || input === undefined) return null;
+    if (typeof input !== 'object') return input;
+
+    const {
+        signal: _signal,
+        onProgress: _onProgress,
+        ...rest
+    } = input as {
+        signal?: unknown;
+        onProgress?: unknown;
+        headers?: Record<string, unknown>;
+    } & Record<string, unknown>;
+
+    if (rest.headers && typeof rest.headers === 'object') {
+        const headers: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(rest.headers)) {
+            headers[k] = isSecretHeader(k) ? REDACTED : v;
+        }
+        rest.headers = headers;
+    }
+    return rest;
+}
+
 // The store's seed value, surfaced before the first real snapshot (an instant).
 // It matches core's idle snapshot exactly so the signals are well-formed from the
 // start.
@@ -308,8 +387,10 @@ export interface StitchQueryOptions<T> {
  * readonly user = injectQuery(() => stitchQueryOptions(getUser, { params: { id: this.id() } }));
  * ```
  *
- * The `queryFn` awaits the stitch (the validated output); the `queryKey` is the
- * stitch's `name` (when present) plus the input, so TanStack caches per call.
+ * The `queryFn` awaits the stitch (the validated output); the `queryKey` is a
+ * stable name for the stitch plus a sanitised copy of the input (secret header
+ * values redacted, runtime-only `signal`/`onProgress` dropped), so TanStack caches
+ * per call without leaking a bearer token into the key or refetching every render.
  */
 export function stitchQueryOptions<S extends StitchLike<unknown, never>>(
     stitch: S,
@@ -323,9 +404,8 @@ export function stitchQueryOptions<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
 ): StitchQueryOptions<T> {
-    const name = (stitch as { __config?: { name?: string } }).__config?.name;
     return {
-        queryKey: [name ?? 'stitch', input ?? null],
+        queryKey: [nameOf(stitch), keyInputFor(input)],
         queryFn: () => Promise.resolve(stitch(input)),
     };
 }

--- a/packages/angular/test/bindings.spec.ts
+++ b/packages/angular/test/bindings.spec.ts
@@ -20,7 +20,7 @@ import { afterEach, describe, expect, test } from 'vitest';
 /** A unary stitch: resolves (or rejects) after a tick, ignoring streaming. */
 function unaryStitch<T>(
     settle: (input: unknown) => Promise<T>,
-    config?: { name?: string },
+    config?: { name?: string; path?: string; url?: string },
 ): StitchLike<T> {
     const fn = (input?: unknown): StitchCallResult<T> => {
         const promise = settle(input);
@@ -327,5 +327,97 @@ describe('stitchQueryOptions', () => {
 describe('queryOptions (deprecated alias)', () => {
     test('queryOptions stays a deprecated alias of stitchQueryOptions (ADR 0012)', () => {
         expect(queryOptions).toBe(stitchQueryOptions);
+    });
+});
+
+// --- stitchQueryOptions: cache-key derivation regressions ------------------
+// The `queryKey` derivation shared the same three bugs as `@stitchapi/react`'s
+// (fixed there in #406). Each of these FAILED before the port. Keep in lock-step
+// with `@stitchapi/react`'s `packages/react/test/hooks.spec.tsx`.
+
+describe('stitchQueryOptions — no cache collision between nameless stitches', () => {
+    // Bug 1 (correctness): `name ?? 'stitch'` keyed every nameless stitch as the
+    // literal 'stitch', so two distinct endpoints with same-shaped input collided
+    // on one TanStack Query cache entry. Fixed by mirroring core's `nameOf`
+    // (name ?? path ?? url ?? 'stitch').
+    test('two nameless stitches with different paths get DIFFERENT keys', () => {
+        const getUser = unaryStitch(async () => 1, { path: '/users/{id}' });
+        const getOrder = unaryStitch(async () => 1, { path: '/orders/{id}' });
+        const input = { params: { id: '1' } };
+
+        const userKey = stitchQueryOptions(getUser, input).queryKey;
+        const orderKey = stitchQueryOptions(getOrder, input).queryKey;
+
+        expect(userKey).not.toEqual(orderKey);
+        expect(userKey[0]).toBe('/users/{id}');
+        expect(orderKey[0]).toBe('/orders/{id}');
+    });
+});
+
+describe('stitchQueryOptions — no secret leak in the query key', () => {
+    // Bug 2 (security): the raw `input` went straight into the queryKey, so a
+    // per-call `authorization` header serialised the bearer token into the
+    // TanStack Query key (persisted, and shown in the devtools panel). Fixed by
+    // redacting denylisted header VALUES.
+    test('a per-call authorization header does not put the token in the key', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const { queryKey } = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+            headers: { authorization: 'Bearer SECRET123' },
+        });
+
+        expect(JSON.stringify(queryKey)).not.toContain('SECRET123');
+    });
+
+    test('redacts the secret header but keeps a benign one (no fresh collision)', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const [, keyInput] = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+            headers: {
+                authorization: 'Bearer SECRET123',
+                'accept-language': 'en-US',
+            },
+        }).queryKey;
+
+        const headers = (keyInput as { headers: Record<string, string> })
+            .headers;
+        expect(headers['authorization']).not.toContain('SECRET123');
+        expect(headers['accept-language']).toBe('en-US');
+    });
+});
+
+describe('stitchQueryOptions — no refetch storm from runtime-only input fields', () => {
+    // Bug 3 (reliability): `signal`/`onProgress` are runtime-only (never
+    // serialised, per CONTRACT.md). An inline `onProgress` churns identity every
+    // render, so keying it re-fetched forever. Fixed by excluding both fields.
+    test('two distinct inline onProgress functions produce EQUAL keys', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const base = { params: { id: '1' } };
+
+        const keyA = stitchQueryOptions(getUser, {
+            ...base,
+            onProgress: () => {},
+        }).queryKey;
+        const keyB = stitchQueryOptions(getUser, {
+            ...base,
+            onProgress: () => {},
+        }).queryKey;
+
+        expect(keyA).toEqual(keyB);
+    });
+
+    test('a per-call signal does not enter the key', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const controller = new AbortController();
+
+        const withSignal = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+            signal: controller.signal,
+        }).queryKey;
+        const without = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+        }).queryKey;
+
+        expect(withSignal).toEqual(without);
     });
 });

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -70,6 +70,85 @@ export interface CreateStitchOptions<T> extends CreateStitchQueryOptions<T> {}
 // Shared driver
 // ---------------------------------------------------------------------------
 
+// --- key derivation (shared logic; duplicated in @stitchapi/react) ----------
+// These helpers are intentionally copied verbatim from `@stitchapi/react`'s key
+// derivation: they are separate published packages, so a cross-package import
+// would add a runtime dependency. Keep the copies in lock-step.
+
+/** The `__config` slice a key derives from. Mirrors core's `nameOf`
+ * (`name ?? path ?? 'stitch'`) plus a `url` fallback for URL-configured stitches. */
+type KeyConfig = { name?: string; path?: string; url?: string };
+
+/** A stable, human-meaningful name for the stitch. Mirrors core's `nameOf`
+ * (`packages/core/src/engine.ts`) — `name ?? path ?? url ?? 'stitch'` — so two
+ * DISTINCT nameless stitches (`/users/{id}` vs `/orders/{id}`) don't collapse to
+ * the literal `'stitch'` and collide on one cache entry. */
+function nameOf(stitch: unknown): string {
+    const cfg = (stitch as { __config?: KeyConfig }).__config;
+    return cfg?.name ?? cfg?.path ?? cfg?.url ?? 'stitch';
+}
+
+// Header names whose VALUES are secrets — mirrors core's private `SECRET_HEADERS`
+// trace denylist (`packages/core/src/trace.ts`), which is not exported. We redact
+// the value (rather than dropping the header) so the key stays stable per token
+// AND callers who legitimately vary a response by a non-secret header (e.g.
+// `accept-language`) keep separate cache entries. Compared case-insensitively; the
+// `*-token` / `*-api-key` suffix rules catch vendor spellings without enumerating.
+const SECRET_HEADERS = new Set([
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+    'x-api-key',
+    'x-auth-token',
+]);
+const REDACTED = '[redacted]';
+
+function isSecretHeader(name: string): boolean {
+    const k = name.toLowerCase();
+    return (
+        SECRET_HEADERS.has(k) || k.endsWith('-token') || k.endsWith('-api-key')
+    );
+}
+
+/**
+ * Build the value that goes into a cache/query key from a stitch's per-call input.
+ * Never puts the raw input in the key:
+ *
+ * - drops `signal` / `onProgress` — runtime-only, never-serialised (CONTRACT.md);
+ *   `onProgress` in particular churns identity every render, which would refetch
+ *   forever if it entered the key;
+ * - redacts the VALUES of secret-bearing headers (`authorization`, `cookie`, …)
+ *   so a bearer token can't leak into a persisted / devtools-visible key, while
+ *   keeping non-secret headers so they still vary the cache;
+ * - keeps every other field (`params` / `query` / `body` / `variables` / …) as-is.
+ *
+ * `null` / `undefined` inputs stay `null`; a primitive input is returned unchanged.
+ */
+function keyInputFor(input: unknown): unknown {
+    if (input === null || input === undefined) return null;
+    if (typeof input !== 'object') return input;
+
+    const {
+        signal: _signal,
+        onProgress: _onProgress,
+        ...rest
+    } = input as {
+        signal?: unknown;
+        onProgress?: unknown;
+        headers?: Record<string, unknown>;
+    } & Record<string, unknown>;
+
+    if (rest.headers && typeof rest.headers === 'object') {
+        const headers: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(rest.headers)) {
+            headers[k] = isSecretHeader(k) ? REDACTED : v;
+        }
+        rest.headers = headers;
+    }
+    return rest;
+}
+
 // The store's seed value, read before the effect mirrors the first real snapshot
 // (the effect is non-deferred, so this is only ever visible for an instant). It
 // matches core's idle snapshot exactly so `state` is well-formed from the start.
@@ -262,8 +341,10 @@ export interface StitchQueryOptions<T> {
  * const query = createQuery(() => stitchQueryOptions(getUser, { params: { id: id() } }));
  * ```
  *
- * The `queryFn` awaits the stitch (the validated output); the `queryKey` is the
- * stitch's `name` (when present) plus the input, so TanStack caches per call.
+ * The `queryFn` awaits the stitch (the validated output); the `queryKey` is a
+ * stable name for the stitch plus a sanitised copy of the input (secret header
+ * values redacted, runtime-only `signal`/`onProgress` dropped), so TanStack caches
+ * per call without leaking a bearer token into the key or refetching every render.
  */
 export function stitchQueryOptions<S extends StitchLike<unknown, never>>(
     stitch: S,
@@ -277,9 +358,8 @@ export function stitchQueryOptions<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
 ): StitchQueryOptions<T> {
-    const name = (stitch as { __config?: { name?: string } }).__config?.name;
     return {
-        queryKey: [name ?? 'stitch', input ?? null],
+        queryKey: [nameOf(stitch), keyInputFor(input)],
         queryFn: () => Promise.resolve(stitch(input)),
     };
 }

--- a/packages/solid/test/primitives.spec.ts
+++ b/packages/solid/test/primitives.spec.ts
@@ -20,7 +20,7 @@ import { describe, expect, test } from 'vitest';
 /** A unary stitch: resolves (or rejects) after a tick, ignoring streaming. */
 function unaryStitch<T>(
     settle: (input: unknown) => Promise<T>,
-    config?: { name?: string },
+    config?: { name?: string; path?: string; url?: string },
 ): StitchLike<T> {
     const fn = (input?: unknown): StitchCallResult<T> => {
         const promise = settle(input);
@@ -362,5 +362,97 @@ describe('stitchQueryOptions', () => {
 describe('queryOptions (deprecated alias)', () => {
     test('queryOptions stays a deprecated alias of stitchQueryOptions (ADR 0012)', () => {
         expect(queryOptions).toBe(stitchQueryOptions);
+    });
+});
+
+// --- stitchQueryOptions: cache-key derivation regressions ------------------
+// The `queryKey` derivation shared the same three bugs as `@stitchapi/react`'s
+// (fixed there in #406). Each of these FAILED before the port. Keep in lock-step
+// with `@stitchapi/react`'s `packages/react/test/hooks.spec.tsx`.
+
+describe('stitchQueryOptions — no cache collision between nameless stitches', () => {
+    // Bug 1 (correctness): `name ?? 'stitch'` keyed every nameless stitch as the
+    // literal 'stitch', so two distinct endpoints with same-shaped input collided
+    // on one TanStack Query cache entry. Fixed by mirroring core's `nameOf`
+    // (name ?? path ?? url ?? 'stitch').
+    test('two nameless stitches with different paths get DIFFERENT keys', () => {
+        const getUser = unaryStitch(async () => 1, { path: '/users/{id}' });
+        const getOrder = unaryStitch(async () => 1, { path: '/orders/{id}' });
+        const input = { params: { id: '1' } };
+
+        const userKey = stitchQueryOptions(getUser, input).queryKey;
+        const orderKey = stitchQueryOptions(getOrder, input).queryKey;
+
+        expect(userKey).not.toEqual(orderKey);
+        expect(userKey[0]).toBe('/users/{id}');
+        expect(orderKey[0]).toBe('/orders/{id}');
+    });
+});
+
+describe('stitchQueryOptions — no secret leak in the query key', () => {
+    // Bug 2 (security): the raw `input` went straight into the queryKey, so a
+    // per-call `authorization` header serialised the bearer token into the
+    // TanStack Query key (persisted, and shown in the devtools panel). Fixed by
+    // redacting denylisted header VALUES.
+    test('a per-call authorization header does not put the token in the key', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const { queryKey } = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+            headers: { authorization: 'Bearer SECRET123' },
+        });
+
+        expect(JSON.stringify(queryKey)).not.toContain('SECRET123');
+    });
+
+    test('redacts the secret header but keeps a benign one (no fresh collision)', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const [, keyInput] = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+            headers: {
+                authorization: 'Bearer SECRET123',
+                'accept-language': 'en-US',
+            },
+        }).queryKey;
+
+        const headers = (keyInput as { headers: Record<string, string> })
+            .headers;
+        expect(headers['authorization']).not.toContain('SECRET123');
+        expect(headers['accept-language']).toBe('en-US');
+    });
+});
+
+describe('stitchQueryOptions — no refetch storm from runtime-only input fields', () => {
+    // Bug 3 (reliability): `signal`/`onProgress` are runtime-only (never
+    // serialised, per CONTRACT.md). An inline `onProgress` churns identity every
+    // render, so keying it re-fetched forever. Fixed by excluding both fields.
+    test('two distinct inline onProgress functions produce EQUAL keys', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const base = { params: { id: '1' } };
+
+        const keyA = stitchQueryOptions(getUser, {
+            ...base,
+            onProgress: () => {},
+        }).queryKey;
+        const keyB = stitchQueryOptions(getUser, {
+            ...base,
+            onProgress: () => {},
+        }).queryKey;
+
+        expect(keyA).toEqual(keyB);
+    });
+
+    test('a per-call signal does not enter the key', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const controller = new AbortController();
+
+        const withSignal = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+            signal: controller.signal,
+        }).queryKey;
+        const without = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+        }).queryKey;
+
+        expect(withSignal).toEqual(without);
     });
 });


### PR DESCRIPTION
Ports the #406 cache-key-derivation fix to **@stitchapi/solid** and **@stitchapi/angular**. The same class of bug was fixed for `@stitchapi/react` + `@stitchapi/swr` in #406 but was never ported to these two adapters. **Security fix** (secret-in-key) — do not squash-merge without review; a human should merge.

## The bugs (confirmed in both)

Each adapter's `stitchQueryOptions` derived its TanStack `queryKey` with the pre-#406 pattern `[name ?? 'stitch', input ?? null]`:

- **Secret-in-key (HIGH, security):** the raw `input` — including a per-call `headers.authorization` — was serialised verbatim into the `queryKey`, so a bearer token leaked into the TanStack cache, the devtools panel, and any persisted key surface.
- **Nameless-stitch collision (HIGH/MED):** `__config.name ?? 'stitch'` with no path/url fallback keyed every nameless stitch as the literal `'stitch'`, so two distinct endpoints with same-shaped input collided on one cache entry and could serve each other's data.
- **Runtime-field refetch storm (MED):** `signal` / inline `onProgress` were serialised into the key, so their per-render identity churn re-fetched forever.

## The fix

Copy react's #406 helpers verbatim into each package (these are separate published packages, so a cross-package import would add a runtime dependency — the logic is duplicated and kept in lock-step with `@stitchapi/react`):

- `nameOf(stitch)` → `name ?? path ?? url ?? 'stitch'`, mirroring core's `nameOf`.
- `keyInputFor(input)` → drops `signal` / `onProgress`; redacts the **values** of secret-bearing headers via the `SECRET_HEADERS` denylist (`authorization` / `proxy-authorization` / `cookie` / `set-cookie` / `x-api-key` / `x-auth-token`, plus the `*-token` / `*-api-key` suffix rules), while keeping non-secret headers so they still vary the cache.

`queryKey` is now `[nameOf(stitch), keyInputFor(input)]`. Each adapter builds a key **only** in `stitchQueryOptions`; the reactive recreate paths key by reference (solid `on(() => [access(input), …])`, angular `toObservable(computed)` + `switchMap`), so no other site changed. Nothing else touched.

## Regression tests (fail-before / pass-after)

Ported react's three `hooks.spec.tsx` blocks into each package's spec (solid `test/primitives.spec.ts`, angular `test/bindings.spec.ts`), and widened each package's `unaryStitch` fake to accept `path` / `url`:

1. two nameless stitches with different `path` → **DIFFERENT** keys;
2. a per-call `authorization` header → **not** in the serialised key (and a benign `accept-language` is kept);
3. distinct inline `onProgress` / `signal` inputs → **EQUAL** keys.

Both packages, `pnpm --filter … test`:

| package | before | after |
| --- | --- | --- |
| `@stitchapi/solid` | 5 failed \| 15 passed | **20 passed** |
| `@stitchapi/angular` | 5 failed \| 15 passed | **20 passed** |

The two pre-existing `stitchQueryOptions` tests in each package still pass unchanged (their benign inputs sanitise to themselves, and a truly nameless stitch still falls back to `'stitch'`), so no existing assertion needed updating.

`pnpm --filter @stitchapi/solid check:types` and `pnpm --filter @stitchapi/angular check:types` both clean.

Relates to #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
