### PR TITLE
fix(vue,svelte): port #406 cache-key fix — nameless-collision + secret-header leak in queryKey

### DIFF
--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -200,6 +200,86 @@ export const useStitchStream = stitchStreamStore;
 // the POJO is framework-neutral and feeds `@tanstack/svelte-query`'s
 // `createQuery` exactly as it feeds React's `useQuery`.
 
+// --- key derivation (shared logic; duplicated in @stitchapi/react + swr) ----
+// These helpers are intentionally copied verbatim from `@stitchapi/react`
+// (`packages/react/src/index.ts`, landed in #406) and `@stitchapi/swr`: they are
+// separate published packages, so a cross-package import would add a runtime
+// dependency. Keep the copies in lock-step.
+
+/** The `__config` slice a key derives from. Mirrors core's `nameOf`
+ * (`name ?? path ?? 'stitch'`) plus a `url` fallback for URL-configured stitches. */
+type KeyConfig = { name?: string; path?: string; url?: string };
+
+/** A stable, human-meaningful name for the stitch. Mirrors core's `nameOf`
+ * (`packages/core/src/engine.ts`) — `name ?? path ?? url ?? 'stitch'` — so two
+ * DISTINCT nameless stitches (`/users/{id}` vs `/orders/{id}`) don't collapse to
+ * the literal `'stitch'` and collide on one cache entry. */
+function nameOf(stitch: unknown): string {
+    const cfg = (stitch as { __config?: KeyConfig }).__config;
+    return cfg?.name ?? cfg?.path ?? cfg?.url ?? 'stitch';
+}
+
+// Header names whose VALUES are secrets — mirrors core's private `SECRET_HEADERS`
+// trace denylist (`packages/core/src/trace.ts`), which is not exported. We redact
+// the value (rather than dropping the header) so the key stays stable per token
+// AND callers who legitimately vary a response by a non-secret header (e.g.
+// `accept-language`) keep separate cache entries. Compared case-insensitively; the
+// `*-token` / `*-api-key` suffix rules catch vendor spellings without enumerating.
+const SECRET_HEADERS = new Set([
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+    'x-api-key',
+    'x-auth-token',
+]);
+const REDACTED = '[redacted]';
+
+function isSecretHeader(name: string): boolean {
+    const k = name.toLowerCase();
+    return (
+        SECRET_HEADERS.has(k) || k.endsWith('-token') || k.endsWith('-api-key')
+    );
+}
+
+/**
+ * Build the value that goes into a cache/query key from a stitch's per-call input.
+ * Never puts the raw input in the key:
+ *
+ * - drops `signal` / `onProgress` — runtime-only, never-serialised (CONTRACT.md);
+ *   `onProgress` in particular churns identity every render, which would refetch
+ *   forever if it entered the key;
+ * - redacts the VALUES of secret-bearing headers (`authorization`, `cookie`, …)
+ *   so a bearer token can't leak into a persisted / devtools-visible key, while
+ *   keeping non-secret headers so they still vary the cache;
+ * - keeps every other field (`params` / `query` / `body` / `variables` / …) as-is.
+ *
+ * `null` / `undefined` inputs stay `null`; a primitive input is returned unchanged.
+ */
+function keyInputFor(input: unknown): unknown {
+    if (input === null || input === undefined) return null;
+    if (typeof input !== 'object') return input;
+
+    const {
+        signal: _signal,
+        onProgress: _onProgress,
+        ...rest
+    } = input as {
+        signal?: unknown;
+        onProgress?: unknown;
+        headers?: Record<string, unknown>;
+    } & Record<string, unknown>;
+
+    if (rest.headers && typeof rest.headers === 'object') {
+        const headers: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(rest.headers)) {
+            headers[k] = isSecretHeader(k) ? REDACTED : v;
+        }
+        rest.headers = headers;
+    }
+    return rest;
+}
+
 /** The plain object {@link stitchQueryOptions} returns — structurally compatible with
  * TanStack Query's `createQuery(options)` without importing the library. */
 export interface StitchQueryOptions<T> {
@@ -219,8 +299,10 @@ export interface StitchQueryOptions<T> {
  * const query = createQuery(stitchQueryOptions(getUser, { params: { id } }));
  * ```
  *
- * The `queryFn` awaits the stitch (the validated output); the `queryKey` is the
- * stitch's `name` (when present) plus the input, so TanStack caches per call.
+ * The `queryFn` awaits the stitch (the validated output); the `queryKey` is a
+ * stable name for the stitch plus a sanitised copy of the input (secret header
+ * values redacted, runtime-only `signal`/`onProgress` dropped), so TanStack caches
+ * per call without leaking a bearer token into the key or refetching every render.
  */
 export function stitchQueryOptions<S extends StitchLike<unknown, never>>(
     stitch: S,
@@ -234,9 +316,8 @@ export function stitchQueryOptions<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
 ): StitchQueryOptions<T> {
-    const name = (stitch as { __config?: { name?: string } }).__config?.name;
     return {
-        queryKey: [name ?? 'stitch', input ?? null],
+        queryKey: [nameOf(stitch), keyInputFor(input)],
         queryFn: () => Promise.resolve(stitch(input)),
     };
 }

--- a/packages/svelte/test/stores.spec.ts
+++ b/packages/svelte/test/stores.spec.ts
@@ -18,7 +18,7 @@ import { describe, expect, test, vi } from 'vitest';
 
 function unaryStitch<T>(
     settle: (input: unknown) => Promise<T>,
-    config?: { name?: string },
+    config?: { name?: string; path?: string; url?: string },
 ): StitchLike<T> {
     const fn = (input?: unknown): StitchCallResult<T> => {
         const promise = settle(input);
@@ -284,15 +284,113 @@ describe('stitchQueryOptions', () => {
         await expect(opts.queryFn()).resolves.toEqual({ ok: true });
     });
 
-    test('falls back to "stitch" when no __config.name', () => {
+    test('falls back to "stitch" only when name, path AND url are all absent', () => {
         const stitch = unaryStitch(async () => 1);
         const opts = stitchQueryOptions(stitch, null);
         expect(opts.queryKey[0]).toBe('stitch');
+    });
+
+    test('a plain (non-secret) input is carried into the key unchanged', () => {
+        const stitch = unaryStitch(async () => 1, { name: 'getThing' });
+        const opts = stitchQueryOptions(stitch, { params: { id: '7' } });
+        expect(opts.queryKey[1]).toEqual({ params: { id: '7' } });
     });
 });
 
 describe('queryOptions (deprecated alias)', () => {
     test('queryOptions stays a deprecated alias of stitchQueryOptions (ADR 0012)', () => {
         expect(queryOptions).toBe(stitchQueryOptions);
+    });
+});
+
+// --- stitchQueryOptions: cache-key derivation regressions ------------------
+// The `queryKey` derivation shared the same three bugs @stitchapi/react fixed in
+// #406 (nameless-collision, secret-header leak, refetch storm). Each of these
+// FAILED before the port. Kept in lock-step with `packages/react/test/hooks.spec.tsx`.
+
+describe('stitchQueryOptions — no cache collision between nameless stitches', () => {
+    // Bug 1 (correctness): `name ?? 'stitch'` keyed every nameless stitch as the
+    // literal 'stitch', so two distinct endpoints with same-shaped input collided
+    // on one TanStack Query cache entry. Fixed by mirroring core's `nameOf`
+    // (name ?? path ?? url ?? 'stitch').
+    test('two nameless stitches with different paths get DIFFERENT keys', () => {
+        const getUser = unaryStitch(async () => 1, { path: '/users/{id}' });
+        const getOrder = unaryStitch(async () => 1, { path: '/orders/{id}' });
+        const input = { params: { id: '1' } };
+
+        const userKey = stitchQueryOptions(getUser, input).queryKey;
+        const orderKey = stitchQueryOptions(getOrder, input).queryKey;
+
+        expect(userKey).not.toEqual(orderKey);
+        expect(userKey[0]).toBe('/users/{id}');
+        expect(orderKey[0]).toBe('/orders/{id}');
+    });
+});
+
+describe('stitchQueryOptions — no secret leak in the query key', () => {
+    // Bug 2 (security): the raw `input` went straight into the queryKey, so a
+    // per-call `authorization` header serialised the bearer token into the
+    // TanStack Query key (persisted, and shown in the devtools panel). Fixed by
+    // redacting denylisted header VALUES.
+    test('a per-call authorization header does not put the token in the key', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const { queryKey } = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+            headers: { authorization: 'Bearer SECRET123' },
+        });
+
+        expect(JSON.stringify(queryKey)).not.toContain('SECRET123');
+    });
+
+    test('redacts the secret header but keeps a benign one (no fresh collision)', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const [, keyInput] = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+            headers: {
+                authorization: 'Bearer SECRET123',
+                'accept-language': 'en-US',
+            },
+        }).queryKey;
+
+        const headers = (keyInput as { headers: Record<string, string> })
+            .headers;
+        expect(headers['authorization']).not.toContain('SECRET123');
+        expect(headers['accept-language']).toBe('en-US');
+    });
+});
+
+describe('stitchQueryOptions — no refetch storm from runtime-only input fields', () => {
+    // Bug 3 (reliability): `signal`/`onProgress` are runtime-only (never
+    // serialised, per CONTRACT.md). An inline `onProgress` churns identity every
+    // render, so keying it re-fetched forever. Fixed by excluding both fields.
+    test('two distinct inline onProgress functions produce EQUAL keys', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const base = { params: { id: '1' } };
+
+        const keyA = stitchQueryOptions(getUser, {
+            ...base,
+            onProgress: () => {},
+        }).queryKey;
+        const keyB = stitchQueryOptions(getUser, {
+            ...base,
+            onProgress: () => {},
+        }).queryKey;
+
+        expect(keyA).toEqual(keyB);
+    });
+
+    test('a per-call signal does not enter the key', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const controller = new AbortController();
+
+        const withSignal = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+            signal: controller.signal,
+        }).queryKey;
+        const without = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+        }).queryKey;
+
+        expect(withSignal).toEqual(without);
     });
 });

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -75,11 +75,95 @@ export interface UseStitchReturn<T> {
 
 interface UseStitchOptions<T> extends CreateStitchQueryOptions<T> {}
 
+// --- key derivation (shared logic; duplicated in @stitchapi/react + swr) ----
+// These helpers are intentionally copied verbatim from `@stitchapi/react`
+// (`packages/react/src/index.ts`, landed in #406) and `@stitchapi/swr`: they are
+// separate published packages, so a cross-package import would add a runtime
+// dependency. Keep the copies in lock-step. Used BOTH by the reactive dep key
+// below and by `stitchQueryOptions`.
+
+/** The `__config` slice a key derives from. Mirrors core's `nameOf`
+ * (`name ?? path ?? 'stitch'`) plus a `url` fallback for URL-configured stitches. */
+type KeyConfig = { name?: string; path?: string; url?: string };
+
+/** A stable, human-meaningful name for the stitch. Mirrors core's `nameOf`
+ * (`packages/core/src/engine.ts`) — `name ?? path ?? url ?? 'stitch'` — so two
+ * DISTINCT nameless stitches (`/users/{id}` vs `/orders/{id}`) don't collapse to
+ * the literal `'stitch'` and collide on one cache entry. */
+function nameOf(stitch: unknown): string {
+    const cfg = (stitch as { __config?: KeyConfig }).__config;
+    return cfg?.name ?? cfg?.path ?? cfg?.url ?? 'stitch';
+}
+
+// Header names whose VALUES are secrets — mirrors core's private `SECRET_HEADERS`
+// trace denylist (`packages/core/src/trace.ts`), which is not exported. We redact
+// the value (rather than dropping the header) so the key stays stable per token
+// AND callers who legitimately vary a response by a non-secret header (e.g.
+// `accept-language`) keep separate cache entries. Compared case-insensitively; the
+// `*-token` / `*-api-key` suffix rules catch vendor spellings without enumerating.
+const SECRET_HEADERS = new Set([
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+    'x-api-key',
+    'x-auth-token',
+]);
+const REDACTED = '[redacted]';
+
+function isSecretHeader(name: string): boolean {
+    const k = name.toLowerCase();
+    return (
+        SECRET_HEADERS.has(k) || k.endsWith('-token') || k.endsWith('-api-key')
+    );
+}
+
+/**
+ * Build the value that goes into a cache/query key from a stitch's per-call input.
+ * Never puts the raw input in the key:
+ *
+ * - drops `signal` / `onProgress` — runtime-only, never-serialised (CONTRACT.md);
+ *   `onProgress` in particular churns identity every render, which would refetch
+ *   forever if it entered the key;
+ * - redacts the VALUES of secret-bearing headers (`authorization`, `cookie`, …)
+ *   so a bearer token can't leak into a persisted / devtools-visible key, while
+ *   keeping non-secret headers so they still vary the cache;
+ * - keeps every other field (`params` / `query` / `body` / `variables` / …) as-is.
+ *
+ * `null` / `undefined` inputs stay `null`; a primitive input is returned unchanged.
+ */
+function keyInputFor(input: unknown): unknown {
+    if (input === null || input === undefined) return null;
+    if (typeof input !== 'object') return input;
+
+    const {
+        signal: _signal,
+        onProgress: _onProgress,
+        ...rest
+    } = input as {
+        signal?: unknown;
+        onProgress?: unknown;
+        headers?: Record<string, unknown>;
+    } & Record<string, unknown>;
+
+    if (rest.headers && typeof rest.headers === 'object') {
+        const headers: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(rest.headers)) {
+            headers[k] = isSecretHeader(k) ? REDACTED : v;
+        }
+        rest.headers = headers;
+    }
+    return rest;
+}
+
 // A structural key of the input so an equal-shaped literal does not re-create the
-// handle, but `{ id: 1 }` → `{ id: 2 }` does. Mirrors `@stitchapi/react`.
+// handle, but `{ id: 1 }` → `{ id: 2 }` does. Mirrors `@stitchapi/react`. Sanitises
+// first via `keyInputFor` so an inline `onProgress` (fresh identity per render)
+// can't churn the key and loop, and a per-call `signal` adds no non-deterministic
+// noise — both are runtime-only.
 function defaultKey(input: unknown): string {
     try {
-        return JSON.stringify(input ?? null);
+        return JSON.stringify(keyInputFor(input));
     } catch {
         // Non-serialisable input (a function, a cyclic object) → opt out of
         // structural keying; falling back to a fresh key re-creates each time.
@@ -141,13 +225,15 @@ function useStitchInternal<T>(
     build();
 
     // Re-create the handle (and re-fetch) when a structural key of the input or
-    // the streaming-relevant options change. The stitch's stable `__config.name`
-    // joins the key so two stitches with the same input still differ.
-    const name = (stitch as { __config?: { name?: string } }).__config?.name;
+    // the streaming-relevant options change. A stable name for the stitch (via
+    // `nameOf`, NOT the raw `name` — so two nameless stitches on different paths
+    // don't share a dep key) joins the key so two stitches with the same input
+    // still differ.
+    const name = nameOf(stitch);
     const depKey = (): string => {
         const opts = toValue(options);
         return JSON.stringify([
-            name ?? '',
+            name,
             defaultKey(toValue(input)),
             stream,
             opts.mode ?? null,
@@ -290,8 +376,10 @@ export interface StitchQueryOptions<T> {
  * const { data } = useQuery(stitchQueryOptions(getUser, { params: { id } }));
  * ```
  *
- * The `queryFn` awaits the stitch (the validated output); the `queryKey` is the
- * stitch's `name` (when present) plus the input, so TanStack caches per call.
+ * The `queryFn` awaits the stitch (the validated output); the `queryKey` is a
+ * stable name for the stitch plus a sanitised copy of the input (secret header
+ * values redacted, runtime-only `signal`/`onProgress` dropped), so TanStack caches
+ * per call without leaking a bearer token into the key or refetching every render.
  */
 export function stitchQueryOptions<S extends StitchLike<unknown, never>>(
     stitch: S,
@@ -305,9 +393,8 @@ export function stitchQueryOptions<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
 ): StitchQueryOptions<T> {
-    const name = (stitch as { __config?: { name?: string } }).__config?.name;
     return {
-        queryKey: [name ?? 'stitch', input ?? null],
+        queryKey: [nameOf(stitch), keyInputFor(input)],
         queryFn: () => Promise.resolve(stitch(input)),
     };
 }

--- a/packages/vue/test/composables.spec.ts
+++ b/packages/vue/test/composables.spec.ts
@@ -19,7 +19,7 @@ import { type EffectScope, effectScope, ref } from 'vue';
 
 function unaryStitch<T>(
     settle: (input: unknown) => Promise<T>,
-    config?: { name?: string },
+    config?: { name?: string; path?: string; url?: string },
 ): StitchLike<T> {
     const fn = (input?: unknown): StitchCallResult<T> => {
         const promise = settle(input);
@@ -296,5 +296,97 @@ describe('stitchQueryOptions', () => {
 describe('queryOptions (deprecated alias)', () => {
     test('queryOptions stays a deprecated alias of stitchQueryOptions (ADR 0012)', () => {
         expect(queryOptions).toBe(stitchQueryOptions);
+    });
+});
+
+// --- stitchQueryOptions: cache-key derivation regressions ------------------
+// The `queryKey` derivation shared the same three bugs @stitchapi/react fixed in
+// #406 (nameless-collision, secret-header leak, refetch storm). Each of these
+// FAILED before the port. Kept in lock-step with `packages/react/test/hooks.spec.tsx`.
+
+describe('stitchQueryOptions — no cache collision between nameless stitches', () => {
+    // Bug 1 (correctness): `name ?? 'stitch'` keyed every nameless stitch as the
+    // literal 'stitch', so two distinct endpoints with same-shaped input collided
+    // on one TanStack Query cache entry. Fixed by mirroring core's `nameOf`
+    // (name ?? path ?? url ?? 'stitch').
+    test('two nameless stitches with different paths get DIFFERENT keys', () => {
+        const getUser = unaryStitch(async () => 1, { path: '/users/{id}' });
+        const getOrder = unaryStitch(async () => 1, { path: '/orders/{id}' });
+        const input = { params: { id: '1' } };
+
+        const userKey = stitchQueryOptions(getUser, input).queryKey;
+        const orderKey = stitchQueryOptions(getOrder, input).queryKey;
+
+        expect(userKey).not.toEqual(orderKey);
+        expect(userKey[0]).toBe('/users/{id}');
+        expect(orderKey[0]).toBe('/orders/{id}');
+    });
+});
+
+describe('stitchQueryOptions — no secret leak in the query key', () => {
+    // Bug 2 (security): the raw `input` went straight into the queryKey, so a
+    // per-call `authorization` header serialised the bearer token into the
+    // TanStack Query key (persisted, and shown in the devtools panel). Fixed by
+    // redacting denylisted header VALUES.
+    test('a per-call authorization header does not put the token in the key', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const { queryKey } = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+            headers: { authorization: 'Bearer SECRET123' },
+        });
+
+        expect(JSON.stringify(queryKey)).not.toContain('SECRET123');
+    });
+
+    test('redacts the secret header but keeps a benign one (no fresh collision)', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const [, keyInput] = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+            headers: {
+                authorization: 'Bearer SECRET123',
+                'accept-language': 'en-US',
+            },
+        }).queryKey;
+
+        const headers = (keyInput as { headers: Record<string, string> })
+            .headers;
+        expect(headers['authorization']).not.toContain('SECRET123');
+        expect(headers['accept-language']).toBe('en-US');
+    });
+});
+
+describe('stitchQueryOptions — no refetch storm from runtime-only input fields', () => {
+    // Bug 3 (reliability): `signal`/`onProgress` are runtime-only (never
+    // serialised, per CONTRACT.md). An inline `onProgress` churns identity every
+    // render, so keying it re-fetched forever. Fixed by excluding both fields.
+    test('two distinct inline onProgress functions produce EQUAL keys', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const base = { params: { id: '1' } };
+
+        const keyA = stitchQueryOptions(getUser, {
+            ...base,
+            onProgress: () => {},
+        }).queryKey;
+        const keyB = stitchQueryOptions(getUser, {
+            ...base,
+            onProgress: () => {},
+        }).queryKey;
+
+        expect(keyA).toEqual(keyB);
+    });
+
+    test('a per-call signal does not enter the key', () => {
+        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
+        const controller = new AbortController();
+
+        const withSignal = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+            signal: controller.signal,
+        }).queryKey;
+        const without = stitchQueryOptions(getUser, {
+            params: { id: '1' },
+        }).queryKey;
+
+        expect(withSignal).toEqual(without);
     });
 });


### PR DESCRIPTION
`@stitchapi/vue` and `@stitchapi/svelte` derived their TanStack `queryKey` (and vue's reactive dep key) with the **pre-#406 pattern** (`name ?? 'stitch'` + raw `input`), so they carried the *same class of cache-key bugs* already fixed for `@stitchapi/react` + `@stitchapi/swr` in #406 — but never ported. This is a **security fix** (secret-in-key). This PR ports the #406 fix verbatim to both packages.

## The bugs (confirmed in both packages)

- **Secret-in-key — HIGH (security).** The raw per-call `input` was serialised verbatim into the key, so `headers: { authorization: 'Bearer …' }` leaked the token into TanStack's cache / devtools panel / persisted (`localStorage` / `IndexedDB`) key surface.
- **Nameless-stitch collision — HIGH/MED.** The key used `__config.name ?? 'stitch'` with **no path/url fallback**, so two distinct nameless stitches (`stitch({ path: '/users/{id}' })` vs `stitch({ path: '/orders/{id}' })`) with same-shaped input collided on one cache entry and could serve each other's data.
- **Runtime-fields refetch-storm — MED.** Runtime-only `signal` / inline `onProgress` got serialised into the key, so it churned every render.

Locations fixed:
- `packages/vue/src/index.ts` — `stitchQueryOptions` **and** the reactive `defaultKey` / dep key.
- `packages/svelte/src/index.ts` — `stitchQueryOptions`.

## The fix — react's #406 helpers, copied verbatim

Ported react's canonical `nameOf(stitch)` (= `name ?? path ?? url ?? 'stitch'`) and `keyInputFor(input)` (drops `signal` / `onProgress`; **redacts the VALUES** of secret-bearing headers via the `SECRET_HEADERS` denylist — `authorization` / `proxy-authorization` / `cookie` / `set-cookie` / `x-api-key` / `x-auth-token` + `*-token` / `*-api-key` suffixes; keeps non-secret fields) into **each** package. These are separate published packages, so the helpers are duplicated (a cross-package import would add a runtime dependency) and kept **byte-for-byte in lock-step** with react's exact logic — verified by diffing the `nameOf`…`keyInputFor` region against `packages/react/src/index.ts`.

Every key site now routes through them:

```diff
- queryKey: [name ?? 'stitch', input ?? null],
+ queryKey: [nameOf(stitch), keyInputFor(input)],
```

and vue's reactive dep key additionally routes the stitch name through `nameOf` and the input through `keyInputFor` (via `defaultKey`):

```diff
- const name = (stitch as { __config?: { name?: string } }).__config?.name;
+ const name = nameOf(stitch);
  ...
-         name ?? '',
+         name,
          defaultKey(toValue(input)),   // defaultKey now JSON.stringify(keyInputFor(input))
```

Nothing else about the adapters changed.

## Regression tests (fail-before / pass-after)

Ported react's three describe blocks (`packages/react/test/hooks.spec.tsx`) to each package — (1) two nameless stitches with different `path` → **different** keys; (2) a per-call `authorization` header → token **absent** from the serialised key (+ a benign `accept-language` header is **kept**); (3) two distinct inline `onProgress` / a per-call `signal` → **equal** keys. Also updated the existing svelte test that asserted the buggy `'stitch'` fallback + raw-input key.

Each of the **5 new regression tests per package failed before the source fix and passes after**:

| package | before | after |
| --- | --- | --- |
| `@stitchapi/vue` | 5 failed, 13 passed | **18 passed** |
| `@stitchapi/svelte` | 5 failed, 15 passed | **20 passed** |

`pnpm --filter @stitchapi/vue test && check:types` and `pnpm --filter @stitchapi/svelte test && check:types` both green; whole-tree `format` / `lint` / `typecheck` gate green (ran via pre-commit).

Same class as #406 (react + swr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)