### PR TITLE
fix(next,nest): don't leak raw upstream/transport error messages over SSE

### DIFF
--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -172,7 +172,8 @@ for a curated one.
 ## Streaming → SSE — `stitchSse`
 
 Return a stitch's `stream()` from a Nest `@Sse()` endpoint: `delta` chunks become messages,
-an `error` event errors the stream, and a client disconnect aborts the upstream generator.
+an `error` event errors the stream (a fixed, safe message by default — see below), and a
+client disconnect aborts the upstream generator.
 
 ```ts
 @Sse('chat')
@@ -182,6 +183,14 @@ chat(@Query('q') q: string) {
     });
 }
 ```
+
+Nest renders an errored `@Sse()` observable's message to the client as the final `event: error`
+frame, so the client-facing **message** defaults to a fixed `'Upstream request failed'` — the raw
+`event.message` is withheld, since it can disclose an internal hostname (a transport failure reads
+like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`). The
+original error is always attached as the errored observable's `cause` for server-side logging. Opt
+in when you need a message: `{ exposeMessage: true }` for the raw message, or
+`{ message: 'Stream unavailable' }` / `{ message: (e) => … }` for a curated one.
 
 ## Testing
 

--- a/packages/nest/src/sse.ts
+++ b/packages/nest/src/sse.ts
@@ -5,6 +5,12 @@
 import { Observable } from 'rxjs';
 import type { StitchEvent } from 'stitchapi';
 
+/** The terminal `error` event a stitch stream emits — carries `message`, `status`, `attempts`. */
+type StitchErrorEvent = Extract<StitchEvent, { type: 'error' }>;
+
+/** The safe, fixed message the errored observable carries by default (mirrors the exception filter). */
+const SAFE_MESSAGE = 'Upstream request failed';
+
 /**
  * The SSE message shape Nest's `@Sse()` consumes — declared structurally so this
  * package does not import Nest's `MessageEvent` type (one less coupling); Nest's
@@ -24,14 +30,67 @@ export interface StitchSseOptions {
      * the text out of a structured chunk, e.g. `data: (c) => c.choices[0].delta`.
      */
     data?: (chunk: unknown) => string | object;
+    /**
+     * Set the client-facing message for a terminal `error` event. Nest renders an errored
+     * `@Sse()` observable's `message` to the client as the final `event: error` frame's data,
+     * so this controls what the browser's `EventSource` receives. **Default: a fixed
+     * `'Upstream request failed'`** — the raw `event.message` is deliberately *not* forwarded,
+     * because it can disclose internal network topology (a transport failure reads like
+     * `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to
+     * an untrusted client. The original error is always attached as the errored observable's
+     * `cause` for server-side logging. Provide a fixed string, or a function for a per-error
+     * message. Prefer this over {@link exposeMessage} when you want a specific, curated message.
+     */
+    message?: string | ((event: StitchErrorEvent) => string);
+    /**
+     * Opt in to forwarding the raw `event.message` as the client-facing message. **Default
+     * `false`** — see {@link message} for why the raw message is withheld by default. Ignored
+     * when {@link message} is set. Only enable this when the upstream messages are known to be
+     * safe to expose to your clients.
+     */
+    exposeMessage?: boolean;
+}
+
+// Normalise a thrown value into the terminal `error` event shape, so a `message` opt-in sees a
+// consistent argument whether the failure arrived as a surfaced `error` event or an unexpected
+// throw. `attempts`/`at` are best-effort placeholders — a `message` hook keys off `name`/`message`.
+function toErrorEvent(err: unknown): StitchErrorEvent {
+    const e = err instanceof Error ? err : new Error(String(err));
+    return {
+        type: 'error',
+        name: e.name,
+        message: e.message,
+        attempts: 0,
+        at: 0,
+    };
+}
+
+// The Error the observable is errored with. By default it carries the safe, fixed message — the
+// raw `event.message` is withheld, since Nest writes an errored observable's `message` straight to
+// the client (an internal hostname / `HTTP 401` would leak). `exposeMessage`/`message` opt in; the
+// original failure is always attached as `cause` for server-side logging.
+function clientError(
+    event: StitchErrorEvent,
+    options: StitchSseOptions,
+    cause: unknown,
+): Error {
+    const { message, exposeMessage } = options;
+    const text =
+        typeof message === 'function'
+            ? message(event)
+            : (message ??
+              (exposeMessage ? event.message || SAFE_MESSAGE : SAFE_MESSAGE));
+    return new Error(text, { cause });
 }
 
 /**
  * Adapt a stitch's `stream()` (or any `AsyncIterable<StitchEvent>`) into an
  * `Observable<MessageEventLike>` for an `@Sse()` endpoint: each `delta` becomes a
- * message, an `error` event errors the observable, and stream end completes it. The
- * non-output events (`start` / `progress` / `drift` / `result` / `done`) are control
- * signals and are not forwarded to the client.
+ * message, an `error` event errors the observable (Nest renders that to the client as a
+ * final `event: error` frame — a fixed, safe message by default, the raw message withheld to
+ * avoid disclosing internal topology; opt in via `exposeMessage`/`message`), and stream end
+ * completes it. The non-output events (`start` / `progress` / `drift` / `result` / `done`) are
+ * control signals and are not forwarded to the client.
  *
  * ```ts
  * @Sse('chat')
@@ -61,13 +120,21 @@ export function stitchSse<T>(
                     if (event.type === 'delta') {
                         subscriber.next({ data: toData(event.chunk) });
                     } else if (event.type === 'error') {
-                        subscriber.error(new Error(event.message));
+                        // Error the observable — but by default with a safe, fixed message, never
+                        // the raw `event.message`: Nest writes an errored `@Sse()` observable's
+                        // `message` straight to the client, so echoing it would disclose an internal
+                        // hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`).
+                        // The event is attached as `cause`; opt in via `exposeMessage`/`message`.
+                        subscriber.error(clientError(event, options, event));
                         return;
                     }
                 }
                 subscriber.complete();
             } catch (err) {
-                subscriber.error(err);
+                // A throw (not a surfaced `error` event): withhold the raw message the same way —
+                // normalise it to an error event so a `message` opt-in sees a consistent shape, and
+                // attach the original as `cause`.
+                subscriber.error(clientError(toErrorEvent(err), options, err));
             }
         })();
         // Teardown on unsubscribe (client disconnect): stop consuming and abort upstream.

--- a/packages/nest/test/sse.spec.ts
+++ b/packages/nest/test/sse.spec.ts
@@ -45,23 +45,101 @@ describe('stitchSse', () => {
         expect(data).toEqual(['a', 'b']); // control events not forwarded
     });
 
-    it('errors the observable on an error event, after any prior deltas', async () => {
+    it('by default errors the observable with a safe message, withholding the raw upstream message', async () => {
         const { data, error } = await collect(
             stitchSse(
                 events(
                     { type: 'delta', chunk: 'a', at: 0 },
                     {
                         type: 'error',
-                        name: 'x',
-                        message: 'boom',
+                        name: 'StitchError',
+                        // Discloses an internal hostname — must NOT reach the client (topology
+                        // disclosure; same class the exception filter fixed on the HTTP surface).
+                        message: 'getaddrinfo ENOTFOUND payments.internal.corp',
+                        status: 502,
                         attempts: 1,
                         at: 0,
                     },
                 ),
             ),
         );
+        expect(data).toEqual(['a']); // prior deltas are still delivered
+        // Nest renders an errored observable's `message` to the client, so it must be the safe token.
+        expect(error?.message).toBe('Upstream request failed');
+        expect(error?.message).not.toContain('payments.internal.corp');
+        // …but the raw failure is preserved server-side as the error's `cause`.
+        expect(
+            (error?.cause as { message?: string } | undefined)?.message,
+        ).toBe('getaddrinfo ENOTFOUND payments.internal.corp');
+    });
+
+    it('exposeMessage opts in to forwarding the raw upstream message', async () => {
+        const { data, error } = await collect(
+            stitchSse(
+                events(
+                    { type: 'delta', chunk: 'a', at: 0 },
+                    {
+                        type: 'error',
+                        name: 'StitchError',
+                        message: 'upstream blew up',
+                        attempts: 1,
+                        at: 0,
+                    },
+                ),
+                { exposeMessage: true },
+            ),
+        );
         expect(data).toEqual(['a']);
-        expect(error?.message).toBe('boom');
+        expect(error?.message).toBe('upstream blew up');
+    });
+
+    it('message sets a curated client-facing message (string or function), overriding exposeMessage', async () => {
+        const fixed = await collect(
+            stitchSse(
+                events({
+                    type: 'error',
+                    name: 'StitchError',
+                    message: 'getaddrinfo ENOTFOUND payments.internal.corp',
+                    attempts: 1,
+                    at: 0,
+                }),
+                {
+                    message: 'Payment provider unavailable',
+                    exposeMessage: true,
+                },
+            ),
+        );
+        expect(fixed.error?.message).toBe('Payment provider unavailable');
+        expect(fixed.error?.message).not.toContain('payments.internal.corp');
+
+        const dynamic = await collect(
+            stitchSse(
+                events({
+                    type: 'error',
+                    name: 'StitchError',
+                    message: 'boom',
+                    status: 503,
+                    attempts: 1,
+                    at: 0,
+                }),
+                { message: (e) => `upstream ${e.status ?? '???'}` },
+            ),
+        );
+        expect(dynamic.error?.message).toBe('upstream 503');
+    });
+
+    it('by default withholds the raw message on a thrown error too, preserving it as cause', async () => {
+        async function* boom(): AsyncGenerator<StitchEvent, void> {
+            yield { type: 'delta', chunk: 'a', at: 0 };
+            throw new Error('getaddrinfo ENOTFOUND payments.internal.corp');
+        }
+        const { data, error } = await collect(stitchSse(boom()));
+        expect(data).toEqual(['a']);
+        expect(error?.message).toBe('Upstream request failed');
+        expect(error?.message).not.toContain('payments.internal.corp');
+        expect((error?.cause as Error | undefined)?.message).toBe(
+            'getaddrinfo ENOTFOUND payments.internal.corp',
+        );
     });
 
     it('applies the data mapper to each chunk', async () => {

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -47,7 +47,7 @@ export async function GET(
 
 ## Streaming with SSE
 
-`sseResponse` streams a stitch's events as `text/event-stream`. Each `delta` becomes one frame; an `error` event ends with a named `event: error` frame:
+`sseResponse` streams a stitch's events as `text/event-stream`. Each `delta` becomes one frame; an `error` event ends with a named `event: error` frame (a generic `data: error` by default — see below):
 
 ```ts
 // app/api/chat/route.ts
@@ -65,6 +65,14 @@ export async function POST(request: Request) {
 ```
 
 Pass `request.signal` so a client disconnect tears the stitch down rather than leaving it running.
+
+By default the `error` frame carries a generic `data: error` token, **not** the raw error message — echoing it can disclose internal network topology (a transport failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream messages are known safe to expose:
+
+```ts
+return sseResponse(chat({ body: { prompt } }).stream(), {
+    errorData: (e) => e.message, // opt in to the raw upstream message
+});
+```
 
 ## License
 

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -15,7 +15,6 @@
 // `next` import — so the same helpers work in Next route handlers, Remix, SvelteKit
 // endpoints, Bun, Deno, and Workers. `stitchapi` is the only peer dependency.
 import type { StitchEvent } from 'stitchapi';
-import { compact } from 'stitchapi';
 
 // ---------------------------------------------------------------------------
 // SSE Response
@@ -26,6 +25,9 @@ import { compact } from 'stitchapi';
 export type StitchEventSource<T> =
     | AsyncIterable<StitchEvent<T>>
     | AsyncGenerator<StitchEvent<T>, void>;
+
+/** The terminal `error` event a stitch stream emits — carries `message`, `status`, `attempts`. */
+type StitchErrorEvent = Extract<StitchEvent, { type: 'error' }>;
 
 export interface SseResponseOptions {
     /**
@@ -38,6 +40,17 @@ export interface SseResponseOptions {
     event?: string;
     /** Provide an `id:` line per frame (the SSE last-event id), for resumable streams. */
     id?: (chunk: unknown, index: number) => string;
+    /**
+     * Shape the SSE `data` written for a terminal `error` event (or an uncaught throw
+     * mid-stream, normalised to an error event). **Default: a generic token (`data: error`)**
+     * — the raw `event.message` is deliberately *not* echoed, because it can disclose internal
+     * network topology (a transport failure reads like
+     * `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to
+     * an untrusted client. Opt in with `(e) => e.message` when the upstream messages are known
+     * safe, or return your own payload (e.g. `() => JSON.stringify({ error: 'stream failed' })`).
+     * A multi-line return gets one `data:` line each (SSE spec); the `event: error` name is fixed.
+     */
+    errorData?: (event: StitchErrorEvent) => string;
     /** Extra response headers (merged over the SSE defaults). */
     headers?: Record<string, string>;
     /** Abort the upstream iterator when this fires — pass the route handler's
@@ -64,10 +77,39 @@ function frame(
     return `${out}\n`;
 }
 
+// The generic token written as an `error` frame's `data` by default: the raw upstream message
+// is withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status
+// (`HTTP 401`) never reaches the client. Override with `options.errorData`.
+const DEFAULT_ERROR_DATA = 'error';
+
+// The terminal `error` frame: the fixed `event: error` name plus a (multi-line-safe) data
+// payload — every line of `data` gets its own `data:` prefix so a multi-line opt-in payload
+// can't break the SSE framing.
+function errorFrame(data: string): string {
+    let out = 'event: error\n';
+    for (const line of data.split('\n')) out += `data: ${line}\n`;
+    return `${out}\n`;
+}
+
+// Normalise a thrown value into the terminal `error` event shape, so an `errorData` opt-in sees
+// a consistent argument whether the failure arrived as a surfaced `error` event or an unexpected
+// throw. `attempts`/`at` are best-effort placeholders — an `errorData` hook keys off `name`/`message`.
+function toErrorEvent(reason: unknown): StitchErrorEvent {
+    const e = reason instanceof Error ? reason : new Error(String(reason));
+    return {
+        type: 'error',
+        name: e.name,
+        message: e.message,
+        attempts: 0,
+        at: 0,
+    };
+}
+
 /**
  * Stream a stitch's events as a `text/event-stream` `Response`. Each `delta` becomes
- * one frame; an `error` event ends the stream with a named `event: error` frame; the
- * terminal `result`/`done` closes it.
+ * one frame; an `error` event ends the stream with a named `event: error` frame (a generic
+ * `data: error` by default — the raw message is withheld to avoid disclosing internal topology;
+ * opt in via `errorData`); the terminal `result`/`done` closes it.
  *
  * ```ts
  * // app/api/chat/route.ts
@@ -100,15 +142,17 @@ export function sseResponse<T>(
                             ),
                         );
                     } else if (event.type === 'error') {
+                        // Surface the failure as a named `error` frame, then stop — but by default
+                        // write a generic token, never the raw `event.message`, so an internal
+                        // hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`)
+                        // is not disclosed. Opt in to the real message via `options.errorData`.
                         controller.enqueue(
                             encoder.encode(
-                                `event: error\ndata: ${JSON.stringify(
-                                    compact({
-                                        name: event.name,
-                                        message: event.message,
-                                        status: event.status,
-                                    }),
-                                )}\n\n`,
+                                errorFrame(
+                                    options.errorData
+                                        ? options.errorData(event)
+                                        : DEFAULT_ERROR_DATA,
+                                ),
                             ),
                         );
                         break;
@@ -117,14 +161,16 @@ export function sseResponse<T>(
                     // ends when the iterator does.
                 }
             } catch (reason) {
+                // A throw (not a surfaced `error` event): still withhold the raw message by
+                // default — normalise it to an error event so an `errorData` opt-in sees a
+                // consistent shape.
                 controller.enqueue(
                     encoder.encode(
-                        `event: error\ndata: ${JSON.stringify({
-                            message:
-                                reason instanceof Error
-                                    ? reason.message
-                                    : String(reason),
-                        })}\n\n`,
+                        errorFrame(
+                            options.errorData
+                                ? options.errorData(toErrorEvent(reason))
+                                : DEFAULT_ERROR_DATA,
+                        ),
                     ),
                 );
             } finally {

--- a/packages/next/test/next.spec.ts
+++ b/packages/next/test/next.spec.ts
@@ -62,21 +62,42 @@ describe('sseResponse', () => {
         expect(await res.text()).toBe('data: hi\n\n');
     });
 
-    test('an error event ends the stream with a named error frame', async () => {
+    test('by default an error event yields a named event: error frame with a generic token, never the raw message', async () => {
         const res = sseResponse(
             events(delta('a'), {
                 type: 'error',
                 name: 'StitchError',
-                message: 'boom',
-                status: 500,
+                // A transport failure whose message discloses an internal hostname — it must NOT
+                // reach the client (topology disclosure; same class PR #407/#408 fixed on the
+                // error-handler surface).
+                message: 'getaddrinfo ENOTFOUND payments.internal.corp',
+                status: 502,
                 attempts: 1,
                 at: 0,
             }),
         );
         const body = await res.text();
-        expect(body).toContain('data: a\n\n');
-        expect(body).toContain('event: error');
-        expect(body).toContain('"message":"boom"');
+        // The stream still ends with a named `error` frame, but the data is a generic token.
+        expect(body).toBe('data: a\n\nevent: error\ndata: error\n\n');
+        expect(body).not.toContain('payments.internal.corp');
+        expect(body).not.toContain('ENOTFOUND');
+    });
+
+    test('errorData opts in to the raw message on the error frame', async () => {
+        const res = sseResponse(
+            events(delta('a'), {
+                type: 'error',
+                name: 'StitchError',
+                message: 'upstream blew up',
+                attempts: 1,
+                at: 0,
+            }),
+            { errorData: (e) => e.message },
+        );
+        const body = await res.text();
+        expect(body).toBe(
+            'data: a\n\nevent: error\ndata: upstream blew up\n\n',
+        );
     });
 
     test('the event option labels each frame', async () => {
@@ -119,16 +140,27 @@ describe('sseResponse', () => {
         expect(await res.text()).toBe('');
     });
 
-    test('a throw mid-stream ends with an error frame carrying the message', async () => {
+    test('by default a throw mid-stream ends with a generic error frame (raw message withheld)', async () => {
+        async function* boom(): AsyncGenerator<StitchEvent, void> {
+            yield delta('a');
+            // A transport failure disclosing an internal hostname must not reach the client.
+            throw new Error('getaddrinfo ENOTFOUND payments.internal.corp');
+        }
+        const res = sseResponse(boom());
+        const body = await res.text();
+        expect(body).toBe('data: a\n\nevent: error\ndata: error\n\n');
+        expect(body).not.toContain('payments.internal.corp');
+        expect(body).not.toContain('ENOTFOUND');
+    });
+
+    test('errorData opts in to the raw message on the throw path too', async () => {
         async function* boom(): AsyncGenerator<StitchEvent, void> {
             yield delta('a');
             throw new Error('stream blew up');
         }
-        const res = sseResponse(boom());
+        const res = sseResponse(boom(), { errorData: (e) => e.message });
         const body = await res.text();
-        expect(body).toContain('data: a\n\n');
-        expect(body).toContain('event: error');
-        expect(body).toContain('"message":"stream blew up"');
+        expect(body).toBe('data: a\n\nevent: error\ndata: stream blew up\n\n');
     });
 });
 


### PR DESCRIPTION
## What & why

The SSE bridges in `@stitchapi/next` (`sseResponse`) and `@stitchapi/nest` (`stitchSse`) forwarded the raw `StitchError` `message` from a streamed `error` event straight to the client — the **two remaining instances** of the topology-disclosure class already fixed on the HTTP error-handler surface (#407 next/nest, #408 fastify/express) and on the express/fastify/hono SSE surface (#422, which explicitly deferred these two).

The leaked message is attacker-relevant:

- a transport / BYO-adapter failure reads like `getaddrinfo ENOTFOUND payments.internal.corp` — an internal hostname / topology;
- an upstream `401` surfaces as `HTTP 401` (core builds it in `engine.ts`), re-exposing the status the 502 remap is meant to hide.

Both reach the browser `EventSource` verbatim today.

## Changes

**`@stitchapi/next` — `packages/next/src/index.ts`** (mirrors #422's `errorData` pattern exactly):

- Default `error` frame is now a generic `data: error` token via a multi-line-safe `errorFrame` — `event.message`/`status` are no longer echoed.
- New opt-in `errorData?: (event) => string` to restore/shape the message when upstream messages are known safe (`(e) => e.message`).
- The `catch` (throw) path is normalised through the same withholding via `toErrorEvent`.
- Removed the now-unused `compact` import.

**`@stitchapi/nest` — `packages/nest/src/sse.ts`** (mirrors this package's own `exception-filter.ts`, **not** `errorData`, to keep the HTTP and SSE surfaces consistent):

- Default: the observable is errored with a fixed `'Upstream request failed'`. Nest's `@Sse()` `catchError` writes an errored observable's `.message` straight to the client (confirmed in `@nestjs/core` `router-response-controller.js`), so the raw message is withheld.
- New opt-ins `message` (`string | (event) => string`) and `exposeMessage` (matching `toHttpException`); the original failure is attached as the error's `cause` for server-side logging.
- Both the `error`-event path and the `catch` throw path route through the shared withholding helper.

Tests, JSDoc, and both package READMEs updated.

## Behavior change (intentional)

The default `error`-frame payload changes:

- next: from `data: {"name":…,"message":…,"status":…}` → `data: error`;
- nest: from the raw upstream message → `Upstream request failed`.

Callers who relied on the raw message opt back in — next via `errorData: (e) => e.message`, nest via `{ exposeMessage: true }` or `{ message }`. The nest `loggerSink` bridge (server-side) still receives the real message — only the client frame is withheld.

## Verification

- Per-package `check:types` + `test` (next 18/18, nest 50/50) + `build` + `prettier` — green.
- Whole-tree pre-push gate (format, lint, contract, typecheck, typecheck-d, test, exports, build-docs) — green.

Branched off `origin/main`; merges cleanly (the six files don't overlap the commits main gained since branching).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
