### PR TITLE
refactor(core)!: drop toValidator from the public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 <!-- /yakir:readme-badges -->
 
 <p align="center">
-  <strong>Zero runtime dependencies · ~24&nbsp;kB min+gzip</strong> — a typical <code>import { stitch }</code> tree-shakes to ~19&nbsp;kB, and with no transitive tree there is nothing else to install or audit. The size is an <a href="packages/core/scripts/bundle-size.mjs">enforced budget in CI</a>, not an aspiration.
+  <strong>Zero runtime dependencies · ~24&nbsp;kB min+gzip</strong> — a typical <code>import { stitch }</code> tree-shakes to ~20&nbsp;kB, and with no transitive tree there is nothing else to install or audit. The size is an <a href="packages/core/scripts/bundle-size.mjs">enforced budget in CI</a>, not an aspiration.
 </p>
 
 > [!NOTE]
@@ -149,7 +149,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 -   **Pluggable state store** — throttle counters and sessions behind a 3-method store; swap in Redis/Postgres to go distributed.
 -   **Zero-infra observability** — tracing is **off by default**; opt in per stitch or via `STITCH_TRACE_*` env vars. No collector, no dashboard.
 -   **Four front doors, one definition** — in-process function, CLI (`stitch run`), HTTP (`stitch serve`), and MCP (`stitch mcp`).
--   **Zero runtime dependencies** — `"dependencies": {}`, built on global `fetch`, tree-shakeable; **~24 kB min+gzip** for the whole entry, **~19 kB** for a typical `import { stitch }`.
+-   **Zero runtime dependencies** — `"dependencies": {}`, built on global `fetch`, tree-shakeable; **~24 kB min+gzip** for the whole entry, **~20 kB** for a typical `import { stitch }`.
 
 ## Install
 

--- a/apps/docs/app/(home)/components/metrics.tsx
+++ b/apps/docs/app/(home)/components/metrics.tsx
@@ -10,7 +10,7 @@ const metrics = [
         body: 'The whole stitchapi entry, tree-shaken — and it is an enforced budget in CI, not an aspiration.',
     },
     {
-        value: '~19 kB',
+        value: '~20 kB',
         unit: 'import { stitch }',
         body: 'Pay only for what you import: every surface beyond http lives behind its own subpath, so the core trims down.',
     },

--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -99,7 +99,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "output",
             type: "property",
             detail: "SchemaLike | DriftSpec",
-            info: "Response schema, or a  for leveled drift detection. Accepts any (raw Zod / Standard Schema / Validator / predicate); the stitch infers its result type from it (see `InferOutput`), so a hand-written generic is rarely needed. No `toValidator()` cast is needed — raw Zod is the visible default, but any Standard Schema validator or a `(value) => boolean` predicate works in the same slot.",
+            info: "Response schema, or a  for leveled drift detection. Accepts any — a raw Zod schema, any Standard Schema (Valibot, ArkType), or a `(value) => boolean` predicate — directly; the stitch infers its result type from it (see `InferOutput`), so a hand-written generic is rarely needed.",
         },
         {
             label: "unwrap",

--- a/apps/docs/app/(home)/playground/playground-examples.ts
+++ b/apps/docs/app/(home)/playground/playground-examples.ts
@@ -54,9 +54,7 @@ const getUser = stitch({
   extends: [api],
   path: '/users/{id}',
   unwrap: 'data',
-  output: toValidator(
-    (u) => !!u && typeof u.id === 'number' && typeof u.email === 'string',
-  ),
+  output: (u) => !!u && typeof u.id === 'number' && typeof u.email === 'string',
 });
 
 // 3 - .with(...) is partial application: bind input now, reuse the call later.
@@ -118,7 +116,7 @@ const getUser = stitch({
   baseUrl: 'https://demo.stitchapi.dev',
   path: '/users/{id}',
   unwrap: 'data', // pull the user out of the { data: ... } envelope
-  // Pass a Zod schema (or any Standard Schema) directly - no toValidator() wrapper.
+  // Pass a Zod schema (or any Standard Schema) directly.
   input: { params: z.object({ id: z.number() }) }, // typed + validated BEFORE the request
   output: z.object({ id: z.number(), email: z.string() }), // typed + validated AFTER
 });
@@ -147,7 +145,7 @@ export const PLAYGROUND_EXAMPLES: PlaygroundExample[] = [
         id: 'validated',
         label: 'Validated',
         description:
-            'Zod schemas on input + output - typed and validated, no toValidator, no codegen.',
+            'Zod schemas on input + output - typed and validated, no codegen.',
         code: VALIDATED_EXAMPLE,
     },
 ];

--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -667,7 +667,7 @@ export const pages: Page[] = [
         path: 'reference/helpers',
         title: 'Helpers',
         description:
-            'fetchAdapter, createTrace, multiplex, the OTLP exporters, memoryStore, and toValidator.',
+            'fetchAdapter, createTrace, multiplex, the OTLP exporters, and memoryStore.',
         kind: 'reference',
     },
     {

--- a/apps/docs/content/blog/validate-api-response-zod.mdx
+++ b/apps/docs/content/blog/validate-api-response-zod.mdx
@@ -55,7 +55,7 @@ const getUser = stitch<{ id: number; name: string }>({
 const user = await getUser({ params: { id: 1 } }); // typed · validated
 ```
 
-`output` takes the `z.object(...)` schema directly — no `toValidator()` cast; any [Standard Schema](/docs/guides/validation/standard-schema) validator (Valibot, ArkType) or a plain predicate goes on the config the same way. The `stitch<{ id: number; name: string }>` generic types the resolved value, so `user` is `{ id: number; name: string }` with no `z.infer` call. A response that doesn't match throws [STITCH_VALIDATION](/docs/errors/stitch-validation) at the boundary — the same failure your `safeParse` branch produced, now uniform across every endpoint instead of re-typed at each one.
+`output` takes the `z.object(...)` schema directly; any [Standard Schema](/docs/guides/validation/standard-schema) validator (Valibot, ArkType) or a plain predicate goes on the config the same way. The `stitch<{ id: number; name: string }>` generic types the resolved value, so `user` is `{ id: number; name: string }` with no `z.infer` call. A response that doesn't match throws [STITCH_VALIDATION](/docs/errors/stitch-validation) at the boundary — the same failure your `safeParse` branch produced, now uniform across every endpoint instead of re-typed at each one.
 
 ### Validate the request too
 

--- a/apps/docs/content/blog/validate-runtime-discovered-schemas.mdx
+++ b/apps/docs/content/blog/validate-runtime-discovered-schemas.mdx
@@ -18,23 +18,22 @@ So stop typing across the boundary and validate at it. The data arrives as JSON;
 
 ## Turn the discovered schema into a validator
 
-The schema reaches you as JSON Schema, whatever delivered it. `jsonSchemaValidator` turns it into a [Standard Schema](https://standardschema.dev); `toValidator` gives you one `validate()` that returns a result and never throws.
+The schema reaches you as JSON Schema, whatever delivered it. `jsonSchemaValidator` turns it into a [Standard Schema](https://standardschema.dev), and you validate through its `~standard` interface — `validate` checks a value and returns a result, never throwing.
 
 ```ts twoslash
 // @noErrors
 import { jsonSchemaValidator } from '@stitchapi/json-schema';
-import { toValidator } from 'stitchapi';
 
 // `schema` is JSON Schema you obtained at runtime — no static shape until now.
-const validate = toValidator(jsonSchemaValidator(schema));
+const validator = jsonSchemaValidator(schema);
 
-const result = await validate.validate(payload);
-if (result.ok) {
+const result = await validator['~standard'].validate(payload);
+if (!result.issues) {
     handle(result.value); // `unknown` — narrow it where you read it
 }
 ```
 
-One interface spans every source. A contract you wrote by hand in Zod and one you received as JSON Schema become the same `validate()` call. **Standard Schema, not a Zod lock-in** — Valibot, ArkType, and a raw JSON Schema all arrive through the same door.
+One interface spans every source. A contract you wrote by hand in Zod and one you received as JSON Schema expose the same `~standard.validate`. **Standard Schema, not a Zod lock-in** — Valibot, ArkType, and a raw JSON Schema all arrive through the same door.
 
 ## The compiler settings this pattern needs
 
@@ -58,16 +57,16 @@ Then keep `any` out with lint, so nobody casts around the boundary you built: `@
 
 ## Return the errors to the sender
 
-The value isn't the boolean; it's the shape of the failure. `validate()` returns issues as `{ path, message }` — a list you hand back to whoever sent the data, not a `ZodError` you catch, stringify, and hope reads well.
+The value isn't the boolean; it's the shape of the failure. `~standard.validate` returns issues as `{ message, path }` — a list you hand back to whoever sent the data, not a `ZodError` you catch, stringify, and hope reads well.
 
 ```ts twoslash
 // @noErrors
-const result = await validate.validate(payload);
-if (!result.ok) {
-    // result.issues → [{ path: ['limit'], message: 'must be <= 50' }]
+const result = await validator['~standard'].validate(payload);
+if (result.issues) {
+    // result.issues → [{ message: 'must be <= 50', path: ['limit'] }]
     return respondWithErrors(
         result.issues
-            .map((issue) => `- ${issue.path.join('.') || '(root)'}: ${issue.message}`)
+            .map((issue) => `- ${(issue.path ?? []).join('.') || '(root)'}: ${issue.message}`)
             .join('\n'),
     );
 }

--- a/apps/docs/content/docs/concepts/principles.mdx
+++ b/apps/docs/content/docs/concepts/principles.mdx
@@ -107,7 +107,7 @@ package practices with your bundle.
 
 Concretely, the whole `stitch` entry is **~24 kB minified + gzipped**
 (≈61 kB raw), and because every surface beyond `http` is a separate subpath
-import, a typical `import { stitch }` tree-shakes to **~19 kB**. With zero
+import, a typical `import { stitch }` tree-shakes to **~20 kB**. With zero
 runtime dependencies, that figure is the entire cost — not the tip of a
 transitive tree.
 

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -7,7 +7,7 @@ Install the package, import `stitch`, and turn your first endpoint into a typed,
 callable function. `stitchapi` has zero dependencies and runs anywhere `fetch`
 does — Node, the browser, and edge runtimes. The whole entry is **~24 kB
 minified + gzipped** — and with no dependencies, there is no transitive tree
-behind it (a typical `import { stitch }` tree-shakes to ~19 kB).
+behind it (a typical `import { stitch }` tree-shakes to ~20 kB).
 
 <Callout type="info">
     **Validators are bring-your-own.** Because `stitchapi` ships with zero

--- a/apps/docs/content/docs/guides/validation/standard-schema.mdx
+++ b/apps/docs/content/docs/guides/validation/standard-schema.mdx
@@ -31,14 +31,13 @@ The `output` schema runs against each response; pairing it with the
 ## Options
 
 A config's `input` and `output` fields accept a raw schema directly — Zod (via
-`safeParse`), any Standard Schema (`~standard`), or an already-built `Validator`.
-Valibot and ArkType implement Standard Schema, so they pass the same way with no
-special handling.
+`safeParse`), any Standard Schema (`~standard`), or a plain predicate
+(`(value) => boolean`). Valibot and ArkType implement Standard Schema, so they
+pass the same way with no special handling.
 
-`toValidator()` covers the cases a raw schema doesn't: wrapping a plain predicate
-(`(value) => boolean`) or normalizing a hand-rolled validator. It coerces any of
-those into a `Validator` and returns `undefined` for `null`/`undefined` — an
-adapter you reach for, not a wrapper the config demands.
+For anything the built-in coercions don't cover, expose the
+[Standard Schema](https://standardschema.dev) `~standard` interface on your own
+object — a stitch checks it exactly like a Zod schema, no wrapper in between.
 
 <Callout type="info">
     Pair the schema with the `stitch<T>()` generic so the typed result and the

--- a/apps/docs/content/docs/guides/validation/validation.mdx
+++ b/apps/docs/content/docs/guides/validation/validation.mdx
@@ -53,13 +53,6 @@ the API would reject.
 ArkType), or a plain predicate. Each slot's type accepts the schema as written,
 and the engine adapts it internally, so there's no cast at the call site.
 
-<Callout type="info">
-    `toValidator()` is an **optional** adapter, not a required wrapper. Reach
-    for it to normalize a hand-rolled validator; a raw Zod or Standard Schema
-    validator goes straight on the config — see [Bring your own
-    validator](/docs/guides/validation/standard-schema).
-</Callout>
-
 See [Reference → Config types](/docs/reference/config-types) for every field on
 `input` and `output`.
 

--- a/apps/docs/content/docs/recipes/typed-json-round-trip.mdx
+++ b/apps/docs/content/docs/recipes/typed-json-round-trip.mdx
@@ -39,7 +39,7 @@ const user = await createUser({ body: { name: 'Ada' } });
 network call. `output` is checked **after** the response returns. Either failure
 throws [`STITCH_VALIDATION`](/docs/errors/stitch-validation). The `stitch<T>`
 generic types the resolved value, and the config takes the `z.object(...)`
-schema directly — no `toValidator()` cast. Any [Standard
+schema directly. Any [Standard
 Schema](/docs/guides/validation/standard-schema) validator (Valibot, ArkType)
 works the same way, passed straight to `input`/`output`.
 

--- a/apps/docs/content/docs/reference/helpers.mdx
+++ b/apps/docs/content/docs/reference/helpers.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Helpers'
-description: 'fetchAdapter, axiosAdapter, xhrAdapter, consoleSink, fileSink, createTrace, multiplex, loggerSink, the OTLP exporters, memoryStore, and toValidator.'
+description: 'fetchAdapter, axiosAdapter, xhrAdapter, consoleSink, fileSink, createTrace, multiplex, loggerSink, the OTLP exporters, and memoryStore.'
 ---
 
 The exported helper functions you wire into a stitch: the default transport, the
@@ -260,22 +260,6 @@ distributed and sessions shared across workers, with no change to the call site.
 import { memoryStore } from 'stitchapi';
 
 const store = memoryStore();
-```
-
-## Validation
-
-### toValidator
-
-Coerce a plain predicate, a Zod schema, any Standard Schema, or an existing
-`Validator` into a `Validator` — returning `undefined` when passed `null` or
-`undefined`. `input`/`output` already accept a raw Zod or Standard Schema, so
-reach for this to wrap a hand-rolled predicate or normalize a validator, not to
-satisfy the config type.
-
-```ts twoslash
-import { toValidator } from 'stitchapi';
-
-const validator = toValidator((value: unknown) => typeof value === 'string');
 ```
 
 ## See also

--- a/apps/docs/lib/source.ts
+++ b/apps/docs/lib/source.ts
@@ -25,7 +25,7 @@ Search these docs instead of loading the whole file: this site is also a hosted 
 - Capability, not credential: an agent invokes a stitch and gets structured, validated, traceable data; the secret stays behind the boundary.
 - One context-frugal **code-mode** tool (run_stitch + list_stitches + describe_stitch), not one tool per endpoint — adding APIs never floods the context window.
 - No server, no codegen, no config files — a URL and one example response is enough; only explicit composition (no ambient/global config a stitch silently inherits).
-- Zero-dependency core, ~24 kB min+gzip for the whole entry (~19 kB for a tree-shaken import { stitch }), validator-agnostic (bring your own Standard Schema / Zod), and it runs in the browser.
+- Zero-dependency core, ~24 kB min+gzip for the whole entry (~20 kB for a tree-shaken import { stitch }), validator-agnostic (bring your own Standard Schema / Zod), and it runs in the browser.
 - Composes with your data layer: a stitch is the queryFn for TanStack Query / SWR — it owns the call's resilience; your query layer owns view state.
 
 ## Quickstart

--- a/docs/sandbox/runtime/stitch-browser.ts
+++ b/docs/sandbox/runtime/stitch-browser.ts
@@ -21,7 +21,7 @@ import type { TraceSink } from 'stitchapi';
  *   Browser-safe (re-exported verbatim from core):
  *     stitch, seam, drift, graphql,
  *     bearer, apiKey, basic, oauth2,
- *     fetchAdapter, toValidator, memoryStore, multiplex, toOtlpJson, + all types
+ *     fetchAdapter, memoryStore, multiplex, toOtlpJson, + all types
  *   Node-only, runs SHIMMED here (with a RunNotice):
  *     keychain, env            → ./shims/node-surfaces  (demo values)
  *     cookieSession            → ./shims/node-surfaces  (in-memory jar)
@@ -42,7 +42,6 @@ export {
     basic,
     oauth2,
     fetchAdapter,
-    toValidator,
     memoryStore,
     // `multiplex` is pure JS (B1-SPIKE §5) — safe to re-export verbatim.
     multiplex,

--- a/docs/sandbox/runtime/transpile.test.ts
+++ b/docs/sandbox/runtime/transpile.test.ts
@@ -183,7 +183,7 @@ async function runTests(): Promise<void> {
         const id = (s: string): string => s;
 
         const named = await transpile(
-            `import { stitch, toValidator } from 'stitchapi';\nstitch();`,
+            `import { stitch, drift } from 'stitchapi';\nstitch();`,
             { _transform: id },
         );
         assert('(d) named import → has .js', 'js' in named, named);
@@ -196,7 +196,7 @@ async function runTests(): Promise<void> {
             );
             assert(
                 '(d) destructures the named bindings',
-                /const \{ stitch, toValidator \} =/.test(named.js),
+                /const \{ stitch, drift \} =/.test(named.js),
                 named.js,
             );
         }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -120,7 +120,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 -   **CLI, HTTP & MCP surfaces** - the definition your code imports is also runnable from the shell (`stitch run <name>` streams JSONL events), served over HTTP (`stitch serve`), or exposed to agents over MCP (`stitch mcp`) — the same stitch behind every front door.
 -   **Typed URLs** - full [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) URI templates (`{id}`, `{+path}`, `{?q,sort}`, explode `*`, prefix `:n`), and a `qs`-style query builder that serializes nested objects (`a[b]=c`) and arrays — both dependency-free.
 -   **Pluggable transport** - `fetch` by default; drop in the shipped `axiosAdapter`, or any `Adapter` function, to route requests through axios or another HTTP client.
--   **Zero runtime dependencies** - `"dependencies": {}`; built on the platform's global `fetch`; tree-shakeable. The whole entry is **~24 kB min+gzip**; a typical `import { stitch }` trims to **~19 kB** — and with no transitive tree, that is the entire cost.
+-   **Zero runtime dependencies** - `"dependencies": {}`; built on the platform's global `fetch`; tree-shakeable. The whole entry is **~24 kB min+gzip**; a typical `import { stitch }` trims to **~20 kB** — and with no transitive tree, that is the entire cost.
 
 ## Documentation
 
@@ -162,7 +162,7 @@ const { stitch } = require("stitchapi");
 
 The runtime ships with zero dependencies. Schema validation is bring-your-own — pass a [Zod](https://zod.dev) schema or any [Standard Schema](https://standardschema.dev) validator ([Valibot](https://valibot.dev), [ArkType](https://arktype.io), …); none of them is bundled. The examples below use Zod for familiarity.
 
-**Bundle size.** The whole `stitchapi` entry is **~24 kB minified + gzipped** (~64 kB raw, ~20 kB brotli); because the package is side-effect-free and every surface beyond `http` lives behind its own subpath import, a typical `import { stitch }` tree-shakes to **~19 kB min+gzip**. With zero dependencies, that is the _whole_ cost — there is no transitive tree to install or audit.
+**Bundle size.** The whole `stitchapi` entry is **~24 kB minified + gzipped** (~64 kB raw, ~20 kB brotli); because the package is side-effect-free and every surface beyond `http` lives behind its own subpath import, a typical `import { stitch }` tree-shakes to **~20 kB min+gzip**. With zero dependencies, that is the _whole_ cost — there is no transitive tree to install or audit.
 
 ## Quick start
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,7 +56,6 @@ export {
     isSecretQueryKey,
     redactSecretsDeep,
 } from './util';
-export { toValidator } from './validator';
 export type { Issue, ValidationResult, Validator } from './validator';
 export type { InferInput, InferOutput, SchemaLike } from './infer';
 export { memoryStore } from './store';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -732,10 +732,9 @@ export interface StitchConfig {
     input?: InputSchemas;
     /**
      * Response schema, or a {@link DriftSpec} for leveled drift detection. Accepts any
-     * {@link SchemaLike} (raw Zod / Standard Schema / Validator / predicate); the stitch infers
-     * its result type from it (see `InferOutput`), so a hand-written generic is rarely needed.
-     * No `toValidator()` cast is needed — raw Zod is the visible default, but any Standard Schema
-     * validator or a `(value) => boolean` predicate works in the same slot.
+     * {@link SchemaLike} — a raw Zod schema, any Standard Schema (Valibot, ArkType), or a
+     * `(value) => boolean` predicate — directly; the stitch infers its result type from it
+     * (see `InferOutput`), so a hand-written generic is rarely needed.
      *
      * @example output: z.object({ id: z.number(), name: z.string() })
      */

--- a/packages/core/test/public-api-surface.spec.ts
+++ b/packages/core/test/public-api-surface.spec.ts
@@ -31,7 +31,6 @@ const FUNCTIONS = [
     'otlpTrace',
     'otlpHttpExporter',
     'toOtlpJson',
-    'toValidator',
     'memoryStore',
     'isStitch',
     'isSeam',

--- a/packages/json-schema/README.md
+++ b/packages/json-schema/README.md
@@ -21,16 +21,15 @@ a plain Standard Schema, usable anywhere Zod is.
 ## Use
 
 ```ts
-import { toValidator } from 'stitchapi';
 import { jsonSchemaValidator } from '@stitchapi/json-schema';
 
 // `discovered` is a JSON Schema you obtained at runtime.
-const validator = toValidator(jsonSchemaValidator(discovered));
+const validator = jsonSchemaValidator(discovered);
 
-const result = await validator.validate(payload);
-if (!result.ok) {
+const result = await validator['~standard'].validate(payload);
+if (result.issues) {
     // Structured, per-path — hand it back to the sender to correct.
-    // [{ path: ['limit'], message: 'must be <= 50' }]
+    // [{ message: 'must be <= 50', path: ['limit'] }]
     return respondWithErrors(result.issues);
 }
 handle(result.value); // `unknown` — a runtime schema carries no static shape

--- a/packages/json-schema/src/index.ts
+++ b/packages/json-schema/src/index.ts
@@ -17,7 +17,7 @@ import addFormats from 'ajv-formats';
 
 // Minimal local copy of the Standard Schema v1 interface (https://standardschema.dev), so
 // this package imports nothing from stitchapi. Zod, Valibot, ArkType and stitchapi all speak
-// this shape; `toValidator()` in core consumes it directly.
+// this shape; a stitch's `output` accepts it directly.
 export interface StandardSchemaV1<Input = unknown, Output = Input> {
     readonly '~standard': {
         readonly version: 1;
@@ -72,12 +72,11 @@ export interface JsonSchemaValidatorOptions {
  * Turn a JSON Schema into a Standard Schema validator.
  *
  * ```ts
- * import { toValidator } from 'stitchapi';
  * import { jsonSchemaValidator } from '@stitchapi/json-schema';
  *
- * const validator = toValidator(jsonSchemaValidator(discoveredSchema));
- * const result = await validator.validate(payload);
- * if (!result.ok) repair(result.issues); // [{ path: ['limit'], message: 'must be <= 50' }]
+ * const validator = jsonSchemaValidator(discoveredSchema);
+ * const result = await validator['~standard'].validate(payload);
+ * if (result.issues) repair(result.issues); // [{ message: 'must be <= 50', path: ['limit'] }]
  * ```
  *
  * The output type is `T` (default `unknown`): a schema discovered at runtime carries no

--- a/packages/json-schema/test/json-schema.spec.ts
+++ b/packages/json-schema/test/json-schema.spec.ts
@@ -1,8 +1,6 @@
 import { type JsonSchemaCheck, jsonSchemaValidator } from '../src/index';
 
-import { toValidator } from 'stitchapi';
-
-// An OpenAI-compatible tool `parameters` schema — the shape a crawl hands you at runtime.
+// A JSON Schema you obtained at runtime — the shape a discovery hands you.
 const toolSchema = {
     type: 'object',
     properties: {
@@ -15,19 +13,19 @@ const toolSchema = {
 
 describe('jsonSchemaValidator (bundled Ajv engine)', () => {
     it('passes valid args through unchanged', async () => {
-        const validator = toValidator(jsonSchemaValidator(toolSchema));
-        const result = await validator!.validate({ query: 'shoes', limit: 5 });
-        expect(result).toEqual({
-            ok: true,
-            value: { query: 'shoes', limit: 5 },
+        const validator = jsonSchemaValidator(toolSchema);
+        const result = await validator['~standard'].validate({
+            query: 'shoes',
+            limit: 5,
         });
+        expect(result).toEqual({ value: { query: 'shoes', limit: 5 } });
     });
 
     it('maps a type mismatch to an issue with a path', async () => {
-        const validator = toValidator(jsonSchemaValidator(toolSchema));
-        const result = await validator!.validate({ query: 42 });
-        expect(result.ok).toBe(false);
-        if (!result.ok) {
+        const validator = jsonSchemaValidator(toolSchema);
+        const result = await validator['~standard'].validate({ query: 42 });
+        expect(result.issues).toBeDefined();
+        if (result.issues) {
             expect(result.issues).toContainEqual(
                 expect.objectContaining({ path: ['query'] }),
             );
@@ -35,15 +33,18 @@ describe('jsonSchemaValidator (bundled Ajv engine)', () => {
     });
 
     it('reports a missing required argument', async () => {
-        const validator = toValidator(jsonSchemaValidator(toolSchema));
-        const result = await validator!.validate({ limit: 3 });
-        expect(result.ok).toBe(false);
+        const validator = jsonSchemaValidator(toolSchema);
+        const result = await validator['~standard'].validate({ limit: 3 });
+        expect(result.issues).toBeDefined();
     });
 
     it('rejects arguments the schema did not declare', async () => {
-        const validator = toValidator(jsonSchemaValidator(toolSchema));
-        const result = await validator!.validate({ query: 'x', rogue: true });
-        expect(result.ok).toBe(false);
+        const validator = jsonSchemaValidator(toolSchema);
+        const result = await validator['~standard'].validate({
+            query: 'x',
+            rogue: true,
+        });
+        expect(result.issues).toBeDefined();
     });
 
     it('flags a nested array index in the path', async () => {
@@ -51,10 +52,12 @@ describe('jsonSchemaValidator (bundled Ajv engine)', () => {
             type: 'object',
             properties: { tags: { type: 'array', items: { type: 'string' } } },
         };
-        const validator = toValidator(jsonSchemaValidator(listSchema));
-        const result = await validator!.validate({ tags: ['ok', 7] });
-        expect(result.ok).toBe(false);
-        if (!result.ok) {
+        const validator = jsonSchemaValidator(listSchema);
+        const result = await validator['~standard'].validate({
+            tags: ['ok', 7],
+        });
+        expect(result.issues).toBeDefined();
+        if (result.issues) {
             expect(result.issues).toContainEqual(
                 expect.objectContaining({ path: ['tags', 1] }),
             );
@@ -68,22 +71,22 @@ describe('jsonSchemaValidator (bring-your-own check)', () => {
             valid: false,
             issues: [{ pointer: '/limit', message: 'must be <= 50' }],
         });
-        const validator = toValidator(
-            jsonSchemaValidator(toolSchema, { check }),
-        );
-        const result = await validator!.validate({ query: 'x', limit: 99 });
+        const validator = jsonSchemaValidator(toolSchema, { check });
+        const result = await validator['~standard'].validate({
+            query: 'x',
+            limit: 99,
+        });
         expect(result).toEqual({
-            ok: false,
-            issues: [{ path: ['limit'], message: 'must be <= 50' }],
+            issues: [{ message: 'must be <= 50', path: ['limit'] }],
         });
     });
 
     it('passes when the injected check reports valid', async () => {
         const check: JsonSchemaCheck = () => ({ valid: true, issues: [] });
-        const validator = toValidator(
-            jsonSchemaValidator<{ query: string }>(toolSchema, { check }),
-        );
-        const result = await validator!.validate({ query: 'x' });
-        expect(result).toEqual({ ok: true, value: { query: 'x' } });
+        const validator = jsonSchemaValidator<{ query: string }>(toolSchema, {
+            check,
+        });
+        const result = await validator['~standard'].validate({ query: 'x' });
+        expect(result).toEqual({ value: { query: 'x' } });
     });
 });

--- a/yakir.json
+++ b/yakir.json
@@ -68,7 +68,7 @@
                         "kind": "pattern",
                         "match": "~(?:\\s|&nbsp;|%20)*(\\d+)(?:\\s|&nbsp;|%20)*kB",
                         "all": true,
-                        "allow": [64, 20]
+                        "allow": [64]
                     },
                     "write": "managed"
                 },


### PR DESCRIPTION
## What

Removes `toValidator` from the public API of `stitchapi`. The function stays **internal** — `stitch()` still normalizes every `input`/`output` schema through it — so nothing about how you configure a stitch changes.

## Why

`toValidator` was ergonomics over the Standard Schema interface, not a capability:

- **In a stitch:** `input`/`output` already accept a raw Zod schema, any Standard Schema (Valibot, ArkType), or a `(value) => boolean` predicate **directly** — the engine coerces internally. `toValidator` was never required there (#420 already stopped the docs from teaching otherwise).
- **Standalone:** validate through the schema's own `~standard.validate`, which every Standard Schema (including `@stitchapi/json-schema`'s output) exposes.

So the export carried no capability of its own — only a normalized `{ ok, issues }` shape you can get from `~standard` directly. Dropping it trims the public surface without removing anything you can do.

`Issue` / `ValidationResult` / `Validator` **types** stay exported — transitively public via `DriftSpec.schema`.

## Consumers migrated

- **Docs:** validation + standard-schema guides, `typed-json-round-trip` recipe, `helpers` reference (drops the `toValidator` entry), the `validate-api-response-zod` + `validate-runtime-discovered-schemas` blogs, the playground example, and the content manifest; regenerated the playground completions.
- **@stitchapi/json-schema:** README, JSDoc, and the test now validate via `validator['~standard'].validate(...)`.
- **Sandbox runtime:** stops re-exporting `toValidator`; transpile fixture updated.
- **public-api-surface test** drops the `toValidator` entry.

## Verified

Workspace typecheck; core (1161) + json-schema (7) + docs (44) + sandbox smoke (11) tests; `build-docs` (twoslash + completions regen, 0 `toValidator` left); `check:release` — all green.

## Note

Breaking (`!`) but pre-release (`rc`), so no stable consumers. Independent of the merged #425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)