### PR TITLE
refactor(json-schema)!: adapt via JsonSchema.adapt + caller-supplied engine

### DIFF
--- a/apps/docs/content/blog/validate-runtime-discovered-schemas.mdx
+++ b/apps/docs/content/blog/validate-runtime-discovered-schemas.mdx
@@ -18,14 +18,16 @@ So stop typing across the boundary and validate at it. The data arrives as JSON;
 
 ## Turn the discovered schema into a validator
 
-The schema reaches you as JSON Schema, whatever delivered it. `jsonSchemaValidator` turns it into a [Standard Schema](https://standardschema.dev), and you validate through its `~standard` interface — `validate` checks a value and returns a result, never throwing.
+The schema reaches you as JSON Schema, whatever delivered it. `JsonSchema.adapt` turns it into a [Standard Schema](https://standardschema.dev) using an engine you supply, and you validate through its `~standard` interface — `validate` checks a value and returns a result, never throwing.
 
 ```ts twoslash
 // @noErrors
-import { jsonSchemaValidator } from '@stitchapi/json-schema';
+import { JsonSchema } from '@stitchapi/json-schema';
+import Ajv from 'ajv';
 
+const ajv = new Ajv(); // your app's configured engine — formats, keywords, $refs, draft
 // `schema` is JSON Schema you obtained at runtime — no static shape until now.
-const validator = jsonSchemaValidator(schema);
+const validator = JsonSchema.adapt(schema, { ajv });
 
 const result = await validator['~standard'].validate(payload);
 if (!result.issues) {
@@ -80,13 +82,15 @@ The data you validate often came back from a request you also make. When you hol
 
 ```ts twoslash
 // @noErrors
-import { jsonSchemaValidator } from '@stitchapi/json-schema';
+import { JsonSchema } from '@stitchapi/json-schema';
+import Ajv from 'ajv';
 import { stitch } from 'stitchapi';
 
+const ajv = new Ajv();
 const call = stitch({
     url: endpoint,
     method: 'POST',
-    output: jsonSchemaValidator(responseSchema),
+    output: JsonSchema.adapt(responseSchema, { ajv }),
 });
 
 const inspection = await call.inspect({ body: payload });

--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -146,6 +146,19 @@ into a shared backend — fleet-wide, with no call-site change.
     />
 </Cards>
 
+## Validation
+
+Adapt a schema you only obtain at runtime — delivered as JSON Schema — into the
+same Standard Schema contract a stitch validates through.
+
+<Cards>
+    <Card
+        title="JSON Schema"
+        href="/docs/integrations/json-schema"
+        description="JsonSchema.adapt turns a runtime-discovered JSON Schema into a StitchSchema — validated with an Ajv instance (or any check) you supply, so it bundles no engine."
+    />
+</Cards>
+
 ## Auth
 
 Core ships bearer / apiKey / basic / cookieSession / oauth2 built in; companions

--- a/apps/docs/content/docs/integrations/json-schema.mdx
+++ b/apps/docs/content/docs/integrations/json-schema.mdx
@@ -1,0 +1,121 @@
+---
+title: JSON Schema
+description: JsonSchema.adapt turns a runtime-discovered JSON Schema into a StitchSchema (a Standard Schema) a stitch accepts — validated with an engine you supply, so it ships none of its own.
+prerequisites:
+    ['/docs/concepts/the-stitch', '/docs/guides/validation/standard-schema']
+---
+
+A stitch's `input`/`output` accepts any [Standard Schema](/docs/guides/validation/standard-schema) —
+Zod, Valibot, ArkType — but those describe schemas you **wrote**. Sometimes the schema shows up at
+**runtime**: you fetch it, a tenant registers it, a config push delivers it, as JSON Schema you
+didn't have when you compiled. You can't generate a type for a schema that doesn't exist yet — so
+you don't type across that boundary, you validate at it.
+
+`@stitchapi/json-schema` adapts that JSON Schema into a `StitchSchema` (a Standard Schema) a stitch
+accepts directly. It ships **no validation engine** — you bring your own, so the schema is checked
+with exactly the keywords, formats, `$ref`s, and draft your app already uses.
+
+## Example
+
+```package-install
+@stitchapi/json-schema stitchapi ajv
+```
+
+`stitchapi` is a peer; `ajv` is an optional peer, needed only for the `{ ajv }` engine.
+
+## Adapt a schema
+
+Pass your configured engine as the second argument. With `{ ajv }`, the adapter calls
+`.compile()` on the instance you hand it — reusing all of its configuration:
+
+```ts
+import { JsonSchema } from '@stitchapi/json-schema';
+import Ajv from 'ajv';
+import { stitch } from 'stitchapi';
+
+const ajv = new Ajv(); // your app's engine — formats, keywords, $refs, draft
+
+// `discovered` is a JSON Schema you obtained at runtime.
+const search = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/search',
+    output: JsonSchema.adapt(discovered, { ajv }),
+});
+```
+
+Used standalone, the returned validator exposes the Standard Schema `~standard.validate`, which
+checks a value and returns a result — never throwing:
+
+```ts
+const validator = JsonSchema.adapt(discovered, { ajv });
+
+const result = await validator['~standard'].validate(payload);
+if (result.issues) {
+    // Structured, per-path — hand it back to the sender to correct.
+    // [{ message: 'must be <= 50', path: ['limit'] }]
+    return respondWithErrors(result.issues);
+}
+handle(result.value); // `unknown` — a runtime schema carries no static shape
+```
+
+`JsonSchema.adapt<T>()` takes an optional type argument. Leave it `unknown` for a runtime-obtained
+schema; pass `T` only when you already know the shape at authoring time.
+
+## Why you pass the engine
+
+Ajv configuration is stateful and app-specific — custom keywords, formats, `$ref` resolvers, the
+draft you target. An engine this package instantiated itself would **throw or silently mis-validate**
+a schema that relies on your setup: "works everywhere except through the adapter." So the engine
+isn't hidden — you pass the instance you already use, and the schema is checked with those exact
+semantics. It also keeps `ajv` out of this package's bundle (the adapter is ~800 bytes) and off your
+dependency tree unless you use it.
+
+## Bring your own engine
+
+Not on Ajv? Pass a compiled `check` instead — a Workers-safe validator, a draft-2020-12 engine, a
+shared instance. Return `valid` plus a JSON Pointer + message per failure; the issue-path mapping
+into `{ message, path }` stays identical.
+
+```ts
+JsonSchema.adapt(discovered, {
+    check: (value) => {
+        const { valid, errors } = myEngine.validate(value);
+        return {
+            valid,
+            issues: errors.map((e) => ({
+                pointer: e.instanceLocation, // JSON Pointer, e.g. '/limit'
+                message: e.message,
+            })),
+        };
+    },
+});
+```
+
+<Callout type="info">
+    The output type is `unknown` by design: a schema you only learn at runtime
+    carries no compile-time shape, so the honest result is `unknown` — narrow it
+    where you read it. Anchoring a stitch's `output` to the same schema also
+    lets [`inspect()`](/docs/guides/validation/drift) report where the live
+    service drifts from the contract it handed you.
+</Callout>
+
+## See also
+
+<Cards>
+    <Card
+        title="Standard Schema"
+        href="/docs/guides/validation/standard-schema"
+        description="The one interface a stitch validates through — Zod, Valibot, ArkType, and this adapter all speak it."
+    />
+    <Card
+        title="Validation"
+        href="/docs/guides/validation/validation"
+        description="How input and output validation runs, and the typed error it raises."
+    />
+    <Card
+        title="Schema drift"
+        href="/docs/guides/validation/drift"
+        description="What inspect() surfaces when a live service stops honouring the schema it declared."
+    />
+    <Card title="The stitch primitive" href="/docs/concepts/the-stitch" />
+</Cards>

--- a/apps/docs/content/docs/integrations/meta.json
+++ b/apps/docs/content/docs/integrations/meta.json
@@ -23,6 +23,8 @@
         "tanstack-query",
         "---State stores---",
         "stores",
+        "---Validation---",
+        "json-schema",
         "---Auth---",
         "aws-sigv4",
         "---AI---",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,9 @@ export {
     redactSecretsDeep,
 } from './util';
 export type { Issue, ValidationResult, Validator } from './validator';
+// The canonical schema contract a stitch accepts (a Standard Schema, https://standardschema.dev).
+// Named export so schema adapters like `@stitchapi/json-schema` build against one documented type.
+export type { StitchSchema } from './standard-schema';
 export type { InferInput, InferOutput, SchemaLike } from './infer';
 export { memoryStore } from './store';
 // The default Clock (ADR 0010) — wall-clock + global timers. Inject a custom `Clock` (or a

--- a/packages/core/src/standard-schema.ts
+++ b/packages/core/src/standard-schema.ts
@@ -22,6 +22,17 @@ export interface StandardSchemaV1<Input = unknown, Output = Input> {
     };
 }
 
+/**
+ * The schema shape a stitch's `input`/`output` accepts — structurally the ecosystem-standard
+ * {@link https://standardschema.dev | Standard Schema} v1 ({@link StandardSchemaV1}). Zod, Valibot,
+ * ArkType and the `@stitchapi/*` schema adapters all speak it. Exported under this name so an
+ * adapter has one canonical, documented target to build against instead of inlining its own copy.
+ */
+export type StitchSchema<Input = unknown, Output = Input> = StandardSchemaV1<
+    Input,
+    Output
+>;
+
 export type StandardResult<Output> =
     | { readonly value: Output; readonly issues?: undefined }
     | { readonly issues: readonly StandardIssue[] };

--- a/packages/json-schema/README.md
+++ b/packages/json-schema/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@stitchapi/json-schema?color=2563EB&label=npm)](https://www.npmjs.com/package/@stitchapi/json-schema)
 
-Turn a **runtime-discovered JSON Schema** — one you fetch, receive, or have registered by a
+Adapt a **runtime-discovered JSON Schema** — one you fetch, receive, or have registered by a
 tenant, whatever delivered it — into a [Standard Schema](https://standardschema.dev) validator
 that [StitchAPI](https://stitchapi.dev) (or any Standard-Schema consumer) accepts directly.
 
@@ -12,19 +12,22 @@ type across that boundary — you validate at it.
 ## Install
 
 ```sh
-pnpm add @stitchapi/json-schema@rc stitchapi@rc
+pnpm add @stitchapi/json-schema@rc stitchapi@rc ajv
 ```
 
-`ajv` is the bundled default engine. `stitchapi` is an **optional** peer — the adapter emits
-a plain Standard Schema, usable anywhere Zod is.
+This package ships **no validation engine** — you bring your own. `ajv` is an optional peer (needed
+only for the `{ ajv }` engine); `stitchapi` is a peer. The adapter emits a plain Standard Schema,
+usable anywhere a Standard Schema is — not only with StitchAPI.
 
 ## Use
 
 ```ts
-import { jsonSchemaValidator } from '@stitchapi/json-schema';
+import Ajv from 'ajv';
+import { JsonSchema } from '@stitchapi/json-schema';
 
+const ajv = new Ajv(); // your app's configured engine — formats, keywords, $refs, draft
 // `discovered` is a JSON Schema you obtained at runtime.
-const validator = jsonSchemaValidator(discovered);
+const validator = JsonSchema.adapt(discovered, { ajv });
 
 const result = await validator['~standard'].validate(payload);
 if (result.issues) {
@@ -35,17 +38,26 @@ if (result.issues) {
 handle(result.value); // `unknown` — a runtime schema carries no static shape
 ```
 
-`jsonSchemaValidator<T>()` takes an optional type argument. Leave it `unknown` for a
+`JsonSchema.adapt<T>()` takes an optional type argument. Leave it `unknown` for a
 runtime-obtained schema; pass `T` only when you already know the shape at authoring time.
+
+## Why you pass the engine
+
+Ajv configuration is stateful and app-specific — custom keywords, formats, `$ref` resolvers, the
+draft you target. A vanilla engine this package instantiated itself would **throw or silently
+mis-validate** a schema that relies on your setup: "works everywhere except through the adapter."
+So the engine isn't optional and isn't hidden — you pass the instance you already use, and the
+schema is checked with exactly those semantics. It also keeps `ajv` out of this package's bundle
+and off your dependency tree unless you actually use it.
 
 ## Bring your own engine
 
-The default engine is Ajv (draft-07 and up, lenient about unknown keywords/formats so
-runtime-obtained schemas don't throw). Swap it — a Workers-safe validator, a draft-2020-12 engine, a shared
-instance — through `check`; the issue-path mapping stays identical.
+Not on Ajv? Pass a compiled `check` instead — a Workers-safe validator, a draft-2020-12 engine, a
+shared instance. Return `valid` plus a JSON Pointer + message per failure; the issue-path mapping
+stays identical.
 
 ```ts
-jsonSchemaValidator(discovered, {
+JsonSchema.adapt(discovered, {
     check: (value) => {
         const { valid, errors } = myEngine.validate(value);
         return {

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -51,20 +51,18 @@
     "engines": {
         "node": ">=18.18.0"
     },
-    "dependencies": {
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1"
-    },
     "peerDependencies": {
+        "ajv": "^8.0.0",
         "stitchapi": "^1.0.0-rc.1"
     },
     "peerDependenciesMeta": {
-        "stitchapi": {
+        "ajv": {
             "optional": true
         }
     },
     "devDependencies": {
         "@types/node": "^22.10.0",
+        "ajv": "^8.17.1",
         "stitchapi": "workspace:*",
         "tsup": "^8.3.0",
         "typescript": "^5.9.3",

--- a/packages/json-schema/src/index.ts
+++ b/packages/json-schema/src/index.ts
@@ -1,109 +1,113 @@
-// @stitchapi/json-schema — turn a runtime-discovered JSON Schema into a Standard Schema
-// validator that stitchapi (or any Standard-Schema consumer) accepts directly.
+// @stitchapi/json-schema — adapt a runtime-discovered JSON Schema into a StitchSchema
+// (a Standard Schema, https://standardschema.dev) that stitchapi accepts directly.
 //
 // The problem it solves: a validation schema is discovered at runtime — fetched, received, or
 // registered by a tenant, whatever delivered it — and arrives as JSON Schema, unknown until it
-// reaches you. You can't generate TypeScript types for a schema that doesn't exist when you
-// write the code. So you don't type across that boundary; you validate at it.
-// `jsonSchemaValidator(schema)` returns a Standard Schema (https://standardschema.dev) whose
-// `~standard.validate` checks a value and reports structured issues (path + message) — the
-// shape you hand back to whoever sent the data so they can correct it.
+// reaches you. You can't generate TypeScript types for a schema that doesn't exist when you write
+// the code. So you don't type across that boundary; you validate at it.
 //
-// The bundled engine is Ajv. Bring your own check — a Workers-safe validator, a shared Ajv
-// instance, a draft-2020-12 engine — through the `check` option; the wrapping and the
-// issue-path mapping stay identical.
-import Ajv, { type ErrorObject, type SchemaObject } from 'ajv';
-import addFormats from 'ajv-formats';
+// This package ships NO validation engine. You bring your own — a configured Ajv instance, or any
+// compiled `check` — so the schema is validated with exactly the keywords, formats, `$ref`s and
+// draft your app already uses everywhere else. A vanilla engine we instantiated ourselves would
+// mis-handle a schema that relies on your custom keywords/formats, so we don't guess: you pass the
+// engine. `JsonSchema.adapt(schema, engine)` wraps it into a StitchSchema whose `~standard.validate`
+// reports structured issues (path + message) — the shape you hand back to whoever sent the data.
+import type { StitchSchema } from 'stitchapi';
 
-// Minimal local copy of the Standard Schema v1 interface (https://standardschema.dev), so
-// this package imports nothing from stitchapi. Zod, Valibot, ArkType and stitchapi all speak
-// this shape; a stitch's `output` accepts it directly.
-export interface StandardSchemaV1<Input = unknown, Output = Input> {
-    readonly '~standard': {
-        readonly version: 1;
-        readonly vendor: string;
-        readonly validate: (
-            value: unknown,
-        ) => StandardResult<Output> | Promise<StandardResult<Output>>;
-        readonly types?: {
-            readonly input: Input;
-            readonly output: Output;
-        };
-    };
-}
+/** A JSON Schema document to validate against. */
+export type JsonSchemaObject = Record<string, unknown>;
 
-export type StandardResult<Output> =
-    | { readonly value: Output; readonly issues?: undefined }
-    | { readonly issues: readonly StandardIssue[] };
-
-export interface StandardIssue {
-    readonly message: string;
-    readonly path?: readonly (string | number)[];
-}
-
-/** A JSON Schema object describing the data to validate. */
-export type JsonSchema = Record<string, unknown>;
-
-/** One failure from a JSON Schema engine, normalised to a JSON Pointer + a message. */
+/** One failure from a validation engine, normalised to a JSON Pointer + a message. */
 export interface JsonSchemaIssue {
     /** JSON Pointer to the offending value, e.g. `/limit`, or `` (empty) for the root. */
     readonly pointer: string;
     readonly message: string;
 }
 
-/** A compiled JSON Schema check — the seam that lets you swap the validation engine. */
+/**
+ * A compiled JSON Schema check — the engine seam. Bring any engine that can answer "is this value
+ * valid, and if not, which paths failed?"; the wrapping and issue-path mapping stay identical.
+ */
 export type JsonSchemaCheck = (value: unknown) => {
     readonly valid: boolean;
     readonly issues: readonly JsonSchemaIssue[];
 };
 
-export interface JsonSchemaValidatorOptions {
-    /**
-     * Bring your own compiled check instead of the bundled Ajv engine — a Workers-safe
-     * validator, a draft-2020-12 engine, or a shared instance. When set, the schema is not
-     * compiled here.
-     */
-    readonly check?: JsonSchemaCheck;
-    /** Collect every failing path (default `true`) or stop at the first failure. */
-    readonly allErrors?: boolean;
+/**
+ * The slice of an Ajv instance we use — just `ajv.compile(schema)`. Declared structurally so this
+ * package imports nothing from `ajv`: your configured instance satisfies it, and a `{ check }`-only
+ * consumer needs `ajv` neither installed nor in their type graph.
+ */
+export interface AjvInstance {
+    compile(schema: JsonSchemaObject): AjvValidate;
+}
+interface AjvValidate {
+    (value: unknown): boolean;
+    errors?: readonly AjvError[] | null;
+}
+interface AjvError {
+    readonly instancePath: string;
+    readonly keyword: string;
+    readonly message?: string;
+    readonly params: Record<string, unknown>;
 }
 
 /**
- * Turn a JSON Schema into a Standard Schema validator.
+ * The validation engine — required, because this package bundles none. Bring a configured Ajv
+ * instance (we call `.compile()` on it, reusing its formats/keywords/`$ref`s/draft), or a fully
+ * custom compiled `check` (a Workers-safe validator, a draft-2020-12 engine, a shared instance).
+ */
+export type JsonSchemaEngine =
+    | { readonly ajv: AjvInstance }
+    | { readonly check: JsonSchemaCheck };
+
+/**
+ * Adapt a JSON Schema into a {@link StitchSchema} — a Standard Schema (https://standardschema.dev)
+ * a stitch's `input`/`output` accepts directly.
  *
  * ```ts
- * import { jsonSchemaValidator } from '@stitchapi/json-schema';
+ * import Ajv from 'ajv';
+ * import { JsonSchema } from '@stitchapi/json-schema';
  *
- * const validator = jsonSchemaValidator(discoveredSchema);
+ * const ajv = new Ajv();                               // your app's configured engine
+ * const validator = JsonSchema.adapt(discovered, { ajv });
  * const result = await validator['~standard'].validate(payload);
- * if (result.issues) repair(result.issues); // [{ message: 'must be <= 50', path: ['limit'] }]
+ * if (result.issues) repair(result.issues);           // [{ message: 'must be <= 50', path: ['limit'] }]
  * ```
  *
- * The output type is `T` (default `unknown`): a schema discovered at runtime carries no
- * static shape, so the honest result is `unknown` — validate it, don't pretend to type it.
- * Pass `T` explicitly only when you already know the shape at authoring time.
+ * The output type is `T` (default `unknown`): a schema discovered at runtime carries no static
+ * shape, so the honest result is `unknown` — validate it, don't pretend to type it. Pass `T`
+ * explicitly only when you already know the shape at authoring time.
  */
-export function jsonSchemaValidator<T = unknown>(
-    schema: JsonSchema,
-    options: JsonSchemaValidatorOptions = {},
-): StandardSchemaV1<T, T> {
-    const check = options.check ?? ajvCheck(schema, options.allErrors ?? true);
+function adapt<T = unknown>(
+    schema: JsonSchemaObject,
+    engine: JsonSchemaEngine,
+): StitchSchema<T, T> {
+    const check =
+        'check' in engine ? engine.check : ajvCheck(engine.ajv, schema);
     return {
         '~standard': {
             version: 1,
             vendor: 'stitchapi-json-schema',
-            validate(value): StandardResult<T> {
+            validate(value) {
                 const result = check(value);
                 if (result.valid) return { value: value as T };
-                return { issues: result.issues.map(toStandardIssue) };
+                return {
+                    issues: result.issues.map((issue) => ({
+                        message: issue.message,
+                        path: pointerToPath(issue.pointer),
+                    })),
+                };
             },
         },
     };
 }
 
-function toStandardIssue(issue: JsonSchemaIssue): StandardIssue {
-    return { message: issue.message, path: pointerToPath(issue.pointer) };
-}
+/**
+ * Operations on runtime-discovered JSON Schemas. `adapt` bridges a schema (+ your engine) into a
+ * StitchSchema; the namespace leaves room for more verbs (`is`, `deref`) as they earn their place.
+ */
+export const JsonSchema = { adapt };
 
 /** Decode a JSON Pointer (`/items/0/name`) into a Standard Schema path (`['items', 0, 'name']`). */
 function pointerToPath(pointer: string): (string | number)[] {
@@ -118,10 +122,8 @@ function pointerToPath(pointer: string): (string | number)[] {
         });
 }
 
-function ajvCheck(schema: JsonSchema, allErrors: boolean): JsonSchemaCheck {
-    const ajv = new Ajv({ allErrors, strict: false });
-    addFormats(ajv);
-    const validate = ajv.compile(schema as SchemaObject);
+function ajvCheck(ajv: AjvInstance, schema: JsonSchemaObject): JsonSchemaCheck {
+    const validate = ajv.compile(schema);
     return (value) => {
         if (validate(value)) return { valid: true, issues: [] };
         const errors = validate.errors ?? [];
@@ -129,7 +131,7 @@ function ajvCheck(schema: JsonSchema, allErrors: boolean): JsonSchemaCheck {
     };
 }
 
-function ajvError(error: ErrorObject): JsonSchemaIssue {
+function ajvError(error: AjvError): JsonSchemaIssue {
     if (error.keyword === 'additionalProperties') {
         const extra = (error.params as { additionalProperty?: unknown })
             .additionalProperty;

--- a/packages/json-schema/test/json-schema.spec.ts
+++ b/packages/json-schema/test/json-schema.spec.ts
@@ -1,4 +1,6 @@
-import { type JsonSchemaCheck, jsonSchemaValidator } from '../src/index';
+import { JsonSchema, type JsonSchemaCheck } from '../src/index';
+
+import Ajv from 'ajv';
 
 // A JSON Schema you obtained at runtime — the shape a discovery hands you.
 const toolSchema = {
@@ -11,9 +13,12 @@ const toolSchema = {
     additionalProperties: false,
 };
 
-describe('jsonSchemaValidator (bundled Ajv engine)', () => {
+// The engine is supplied by the caller — this stands in for your app's configured Ajv.
+const ajv = new Ajv({ allErrors: true, strict: false });
+
+describe('JsonSchema.adapt (caller-supplied Ajv instance)', () => {
     it('passes valid args through unchanged', async () => {
-        const validator = jsonSchemaValidator(toolSchema);
+        const validator = JsonSchema.adapt(toolSchema, { ajv });
         const result = await validator['~standard'].validate({
             query: 'shoes',
             limit: 5,
@@ -22,7 +27,7 @@ describe('jsonSchemaValidator (bundled Ajv engine)', () => {
     });
 
     it('maps a type mismatch to an issue with a path', async () => {
-        const validator = jsonSchemaValidator(toolSchema);
+        const validator = JsonSchema.adapt(toolSchema, { ajv });
         const result = await validator['~standard'].validate({ query: 42 });
         expect(result.issues).toBeDefined();
         if (result.issues) {
@@ -33,13 +38,13 @@ describe('jsonSchemaValidator (bundled Ajv engine)', () => {
     });
 
     it('reports a missing required argument', async () => {
-        const validator = jsonSchemaValidator(toolSchema);
+        const validator = JsonSchema.adapt(toolSchema, { ajv });
         const result = await validator['~standard'].validate({ limit: 3 });
         expect(result.issues).toBeDefined();
     });
 
     it('rejects arguments the schema did not declare', async () => {
-        const validator = jsonSchemaValidator(toolSchema);
+        const validator = JsonSchema.adapt(toolSchema, { ajv });
         const result = await validator['~standard'].validate({
             query: 'x',
             rogue: true,
@@ -52,7 +57,7 @@ describe('jsonSchemaValidator (bundled Ajv engine)', () => {
             type: 'object',
             properties: { tags: { type: 'array', items: { type: 'string' } } },
         };
-        const validator = jsonSchemaValidator(listSchema);
+        const validator = JsonSchema.adapt(listSchema, { ajv });
         const result = await validator['~standard'].validate({
             tags: ['ok', 7],
         });
@@ -65,13 +70,13 @@ describe('jsonSchemaValidator (bundled Ajv engine)', () => {
     });
 });
 
-describe('jsonSchemaValidator (bring-your-own check)', () => {
+describe('JsonSchema.adapt (bring-your-own check)', () => {
     it('wraps any engine that yields a JSON Pointer + message', async () => {
         const check: JsonSchemaCheck = () => ({
             valid: false,
             issues: [{ pointer: '/limit', message: 'must be <= 50' }],
         });
-        const validator = jsonSchemaValidator(toolSchema, { check });
+        const validator = JsonSchema.adapt(toolSchema, { check });
         const result = await validator['~standard'].validate({
             query: 'x',
             limit: 99,
@@ -83,7 +88,7 @@ describe('jsonSchemaValidator (bring-your-own check)', () => {
 
     it('passes when the injected check reports valid', async () => {
         const check: JsonSchemaCheck = () => ({ valid: true, issues: [] });
-        const validator = jsonSchemaValidator<{ query: string }>(toolSchema, {
+        const validator = JsonSchema.adapt<{ query: string }>(toolSchema, {
             check,
         });
         const result = await validator['~standard'].validate({ query: 'x' });

--- a/packages/json-schema/tsup.config.ts
+++ b/packages/json-schema/tsup.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'tsup';
 
-// Single dual-format entry. `ajv`, `ajv-formats` and `stitchapi` are external (deps / optional
-// peer), externalised by tsup, so the bundle is just the adapter.
+// Single dual-format entry. The bundle is just the adapter: it ships no validation engine, and
+// the only imports are type-only (`stitchapi` for the StitchSchema type; `ajv` is a structural
+// interface, not imported), so nothing external lands in the runtime bundle.
 export default defineConfig({
     entry: ['src/index.ts'],
     format: ['cjs', 'esm'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -645,17 +645,13 @@ importers:
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/json-schema:
-    dependencies:
-      ajv:
-        specifier: ^8.17.1
-        version: 8.20.0
-      ajv-formats:
-        specifier: ^3.0.1
-        version: 3.0.1(ajv@8.20.0)
     devDependencies:
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.21
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
       stitchapi:
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## What & why

`@stitchapi/json-schema` turned a runtime-discovered JSON Schema into a validator via `jsonSchemaValidator(schema, opts)`, shipping its own Ajv and instantiating it vanilla. Two problems hid in that:

- **Correctness.** A self-instantiated engine mis-validates any schema that relies on the consumer's custom keywords/formats/`$ref`s/draft — "works everywhere except through the adapter."
- **Duplication.** The package inlined its own copy of the Standard Schema interface, a contract core should own.

This reworks both, and along the way removes the call-site ceremony that started the discussion.

## Changes

**`@stitchapi/json-schema`**
- API: `jsonSchemaValidator(schema, opts)` → **`JsonSchema.adapt(schema, engine)`** — namespace value `JsonSchema`, verb `adapt` (leaves room for `is`/`deref`).
- Engine is **external and required**: `{ ajv } | { check }`. Pass your configured Ajv instance (we call `.compile()` on it, reusing its config) or a fully custom compiled `check`.
- **Ajv unbundled**: `dependencies` → optional peer; `ajv-formats` dropped. `AjvInstance` is a **structural** interface, so the package imports nothing from ajv and a `{ check }`-only consumer needs it neither installed nor in its type graph.
- Runtime bundle: **~30–40 KB → 803 B**.
- Input type `JsonSchema` → **`JsonSchemaObject`** (frees the name for the namespace; avoids a value/type merge).

**core**
- Export `type StitchSchema = StandardSchemaV1` — one canonical, documented target for schema adapters. **Type-only, zero runtime/bundle cost** (size tether unmoved). json-schema imports it and `stitchapi` becomes a required peer, matching the ecosystem norm.

**docs**
- Package README rewritten (bring-your-engine + "why you pass it"); blog twoslash samples updated; tsup comment updated.

## Breaking

- `jsonSchemaValidator(...)` → `JsonSchema.adapt(..., engine)`; the engine argument is now **required**.
- `ajv` is no longer bundled — install it (or pass `{ check }`).
- Exported type `JsonSchema` renamed to `JsonSchemaObject`; the inlined `StandardSchemaV1`/`StandardResult`/`StandardIssue` exports are removed (use `StitchSchema` from `stitchapi`).

Pre-1.0 (`@rc`), so acceptable now.

## Verification
- `pnpm -r check:types` (all 36 packages incl. `apps/docs` MDX gen) → 0 errors
- Package tests **7/7**
- `check:contract` clean · attw (core) green · core `check:size` within budget · `gen:readme` current · prettier clean
- Built output confirmed: `ajv` absent from the runtime bundle (803 B)
- Full pre-commit + pre-push verify passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)