### PR TITLE
feat(core): standalone validate() + compile() for uniform schema consumption

### DIFF
--- a/apps/docs/content/blog/validate-runtime-discovered-schemas.mdx
+++ b/apps/docs/content/blog/validate-runtime-discovered-schemas.mdx
@@ -18,24 +18,25 @@ So stop typing across the boundary and validate at it. The data arrives as JSON;
 
 ## Turn the discovered schema into a validator
 
-The schema reaches you as JSON Schema, whatever delivered it. `JsonSchema.adapt` turns it into a [Standard Schema](https://standardschema.dev) using an engine you supply, and you validate through its `~standard` interface — `validate` checks a value and returns a result, never throwing.
+The schema reaches you as JSON Schema, whatever delivered it. `JsonSchema.adapt` turns it into a [Standard Schema](https://standardschema.dev) using an engine you supply. `compile` turns that schema into a reusable checker — a function that validates a value and returns a result, never throwing, whatever the schema's source.
 
 ```ts twoslash
 // @noErrors
 import { JsonSchema } from '@stitchapi/json-schema';
 import Ajv from 'ajv';
+import { compile } from 'stitchapi';
 
 const ajv = new Ajv(); // your app's configured engine — formats, keywords, $refs, draft
 // `schema` is JSON Schema you obtained at runtime — no static shape until now.
-const validator = JsonSchema.adapt(schema, { ajv });
+const check = compile(JsonSchema.adapt(schema, { ajv }));
 
-const result = await validator['~standard'].validate(payload);
-if (!result.issues) {
+const result = await check(payload);
+if (result.ok) {
     handle(result.value); // `unknown` — narrow it where you read it
 }
 ```
 
-One interface spans every source. A contract you wrote by hand in Zod and one you received as JSON Schema expose the same `~standard.validate`. **Standard Schema, not a Zod lock-in** — Valibot, ArkType, and a raw JSON Schema all arrive through the same door.
+That `check` is nothing special — the schema behind it is the same `SchemaLike` a stitch accepts in `input` or `output`, and the `.inspect()` example below hands this very adapter to `output`. One schema, whichever door you send it through: `compile` for a standalone check, a stitch for a live call. A contract you wrote by hand in Zod and one you received as JSON Schema compile the same way — **Standard Schema, not a Zod lock-in**, with Valibot, ArkType, and a raw JSON Schema all arriving through the same door.
 
 ## The compiler settings this pattern needs
 
@@ -59,16 +60,16 @@ Then keep `any` out with lint, so nobody casts around the boundary you built: `@
 
 ## Return the errors to the sender
 
-The value isn't the boolean; it's the shape of the failure. `~standard.validate` returns issues as `{ message, path }` — a list you hand back to whoever sent the data, not a `ZodError` you catch, stringify, and hope reads well.
+The value isn't the boolean; it's the shape of the failure. On `ok: false`, the result carries issues as `{ message, path }` — a list you hand back to whoever sent the data, not a `ZodError` you catch, stringify, and hope reads well.
 
 ```ts twoslash
 // @noErrors
-const result = await validator['~standard'].validate(payload);
-if (result.issues) {
+const result = await check(payload);
+if (!result.ok) {
     // result.issues → [{ message: 'must be <= 50', path: ['limit'] }]
     return respondWithErrors(
         result.issues
-            .map((issue) => `- ${(issue.path ?? []).join('.') || '(root)'}: ${issue.message}`)
+            .map((issue) => `- ${issue.path.join('.') || '(root)'}: ${issue.message}`)
             .join('\n'),
     );
 }
@@ -105,7 +106,7 @@ The schema told you what the service claims to accept and return. Drift tells yo
 
 ## Validate where you know, type where you don't
 
-A runtime-obtained schema has no compile-time shape, so the compiler can't guard it and pretending it can costs you casts. A validator can guard it: it turns the incoming JSON into either data you narrow or errors you return. One Standard Schema interface covers the schemas you write and the schemas you receive; one `validate()` gives you the same result shape for both; the same schema that checks the incoming data also catches the service drifting underneath it.
+A runtime-obtained schema has no compile-time shape, so the compiler can't guard it and pretending it can costs you casts. A validator can guard it: it turns the incoming JSON into either data you narrow or errors you return. One Standard Schema interface covers the schemas you write and the schemas you receive; whether you `validate` in one shot or `compile` a checker you reuse, the result is the same `{ ok, value }`-or-`{ ok, issues }` shape; the same schema that checks the incoming data also catches the service drifting underneath it.
 
 ## Try it
 

--- a/apps/docs/content/docs/integrations/json-schema.mdx
+++ b/apps/docs/content/docs/integrations/json-schema.mdx
@@ -43,14 +43,17 @@ const search = stitch({
 });
 ```
 
-Used standalone, the returned validator exposes the Standard Schema `~standard.validate`, which
-checks a value and returns a result — never throwing:
+Used standalone, hand the adapted schema to `compile` for a reusable checker (or `validate` for a
+one-off) — the same functions a stitch validates through internally. They take any schema a stitch
+accepts and return a result, never throwing:
 
 ```ts
-const validator = JsonSchema.adapt(discovered, { ajv });
+import { compile } from 'stitchapi';
 
-const result = await validator['~standard'].validate(payload);
-if (result.issues) {
+const check = compile(JsonSchema.adapt(discovered, { ajv }));
+
+const result = await check(payload);
+if (!result.ok) {
     // Structured, per-path — hand it back to the sender to correct.
     // [{ message: 'must be <= 50', path: ['limit'] }]
     return respondWithErrors(result.issues);

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -394,6 +394,31 @@ field is gone. The **wire** side still follows its own standard — W3C Trace Co
 [ADR 0017 Decision 7](adr/0017-outbound-trace-context-propagation.md) and the
 `concepts/run-identity` page.
 
+### P23 · One schema intake; foreign formats enter through one adapter
+
+Every place that consumes a validation schema — a stitch's `input`/`output`, and the
+standalone `validate`/`compile` — **MUST** accept the same `SchemaLike` union and yield the
+same `ValidationResult` shape. Standalone validation is the check a stitch runs internally,
+exposed — never a second, differently-shaped path (reaching into a schema's `['~standard']`
+namespace is a protocol detail, not a consumer API). A format that is not already a Standard
+Schema — a JSON Schema obtained at runtime — enters through **one** adapter that mints a
+`SchemaLike` (`JsonSchema.adapt`); no consumer accepts a foreign format directly, and no
+consumer grows a bespoke intake of its own.
+
+_Why:_ [P21](#p21--every-contract-has-an-extension-seam) keeps the validation seam **open**
+(any Standard Schema is accepted); P23 keeps it **uniform** — one intake type and one result
+shape across every consumer, so what a stitch can validate and what you can validate standalone
+are the same set, learned once. A per-consumer intake, or a raw foreign-format path bolted onto
+a single consumer, splits that knowledge and re-introduces the casts the boundary exists to kill.
+The lone adapter is the only ceremony the format genuinely needs — a JSON Schema requires a
+validation engine and core ships none, so the engine is caller-supplied at `adapt` — so that step
+stays visible while everything downstream of it is uniform.
+
+_Canonical case:_ `stitch({ input, output })`, `validate(schema, value)`, and `compile(schema)`
+all take `SchemaLike` and return `ValidationResult`; `JsonSchema.adapt(json, { ajv })` is the sole
+bridge from JSON Schema, producing a `SchemaLike` those consumers treat identically. The standalone
+`validate`/`compile` verbs replaced app-level `schema['~standard'].validate(…)`.
+
 ---
 
 ## 6. Migration backlog (proposed renames — confirm during sweep)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,10 @@ export {
     redactSecretsDeep,
 } from './util';
 export type { Issue, ValidationResult, Validator } from './validator';
+// Standalone validation, uniform with what `input`/`output` consume: `validate(schema, value)`
+// checks a value now; `compile(schema)` coerces once and returns a reusable checker. Both take any
+// `SchemaLike` and return a `ValidationResult` — no reaching into a schema's `['~standard']`.
+export { validate, compile } from './validate';
 // The canonical schema contract a stitch accepts (a Standard Schema, https://standardschema.dev).
 // Named export so schema adapters like `@stitchapi/json-schema` build against one documented type.
 export type { StitchSchema } from './standard-schema';

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -1,0 +1,56 @@
+// Standalone validation for any schema a stitch accepts. This is the same normalisation `input`/
+// `output` run internally (`toValidator` in validator.ts), exposed as two plain verbs so validating
+// a value outside a call is uniform with validating inside one — same {@link SchemaLike} intake,
+// same {@link ValidationResult} shape. It replaces reaching into a schema's `['~standard'].validate`,
+// which is a protocol-level detail, not an app-facing API (and whose raw result carries no `ok`
+// discriminant and can hold non-array issue paths — both normalised here).
+import type { InferOutput, SchemaLike } from './infer';
+import { type ValidationResult, toValidator } from './validator';
+
+const UNSUPPORTED =
+    'validate()/compile() received a value that is not a schema. Fix: pass a Standard Schema, a Zod-style {parse}, a {validate} object, or a (value) => boolean predicate.';
+
+/**
+ * Compile a schema into a reusable checker. The schema is coerced ONCE (via the same normalisation
+ * a stitch's `input`/`output` use); the returned function validates a value against it and returns
+ * `{ ok: true, value }` or `{ ok: false, issues }` — never throwing on invalid data.
+ *
+ * Reach for this when you validate many values against one schema: the coercion is paid here, not
+ * on every call. For a one-off check, {@link validate} is the more direct spelling.
+ *
+ * `schema` is any {@link SchemaLike} — a hand-written Zod / Valibot / ArkType schema, any Standard
+ * Schema (including one from `JsonSchema.adapt`), a `(value) => boolean` predicate, or a
+ * {@link Validator}. It is the identical set of schemas a stitch accepts.
+ *
+ * @example
+ * const check = compile(userSchema);
+ * const result = await check(payload);
+ * if (result.ok) use(result.value); // else result.issues → [{ message, path }]
+ */
+export function compile<S extends SchemaLike>(
+    schema: S,
+): (value: unknown) => Promise<ValidationResult<InferOutput<S>>> {
+    const validator = toValidator(schema);
+    if (!validator) throw new TypeError(UNSUPPORTED);
+    return (value) =>
+        validator.validate(value) as Promise<ValidationResult<InferOutput<S>>>;
+}
+
+/**
+ * Validate a value against a schema and return the result — `{ ok: true, value }` or
+ * `{ ok: false, issues }`, never throwing on invalid data. The standalone counterpart to the check
+ * a stitch runs on `input`/`output`: the same schema, the same result shape.
+ *
+ * For repeated checks against one schema, {@link compile} coerces once and hands back a reusable
+ * checker; `validate(schema, value)` is `compile(schema)(value)` for the single-shot case.
+ *
+ * @example
+ * const result = await validate(userSchema, payload);
+ * if (result.ok) use(result.value); // else result.issues → [{ message, path }]
+ */
+export function validate<S extends SchemaLike>(
+    schema: S,
+    value: unknown,
+): Promise<ValidationResult<InferOutput<S>>> {
+    return compile(schema)(value);
+}

--- a/packages/core/test/public-api-surface.spec.ts
+++ b/packages/core/test/public-api-surface.spec.ts
@@ -32,6 +32,8 @@ const FUNCTIONS = [
     'otlpHttpExporter',
     'toOtlpJson',
     'memoryStore',
+    'validate',
+    'compile',
     'isStitch',
     'isSeam',
 ] as const;

--- a/packages/core/test/validate.spec.ts
+++ b/packages/core/test/validate.spec.ts
@@ -1,0 +1,108 @@
+// `validate(schema, value)` and `compile(schema)` — the standalone counterparts to the check a
+// stitch runs on `input`/`output`. The point under test is UNIFORMITY: one intake (any SchemaLike:
+// raw Zod, a JsonSchema.adapt-style Standard Schema, a predicate) and one result shape
+// (`{ ok, value } | { ok, issues }`), identical to what a stitch validates internally. Plus the two
+// guarantees the wrapper adds over reaching into `['~standard'].validate` directly: an `ok`
+// discriminant, and normalised array issue paths.
+import { compile, validate } from '../src';
+
+import { z } from 'zod';
+
+// A hand-built Standard Schema, shaped exactly like `JsonSchema.adapt(...)`'s output: the raw result
+// is `{ value } | { issues }` (no `ok`), which `validate`/`compile` normalise to the `ok` form.
+const adaptLike = {
+    '~standard': {
+        version: 1 as const,
+        vendor: 'stitchapi-json-schema',
+        validate: (v: unknown) => {
+            const limit = (v as { limit?: number }).limit;
+            return limit !== undefined && limit <= 50
+                ? { value: v }
+                : { issues: [{ message: 'must be <= 50', path: ['limit'] }] };
+        },
+    },
+};
+
+describe('validate: one intake, one result shape', () => {
+    test('accepts a raw Zod schema — success is { ok: true, value }', async () => {
+        const User = z.object({ name: z.string() });
+        const r = await validate(User, { name: 'Ada' });
+        expect(r).toEqual({ ok: true, value: { name: 'Ada' } });
+    });
+
+    test('accepts a raw Zod schema — failure is { ok: false, issues } with an array path', async () => {
+        const User = z.object({ name: z.string() });
+        const r = await validate(User, { name: 42 });
+        if (r.ok) throw new Error('expected failure');
+        expect(r.issues).toHaveLength(1);
+        expect(Array.isArray(r.issues[0]?.path)).toBe(true);
+        expect(r.issues[0]?.path).toEqual(['name']);
+    });
+
+    test('accepts a JsonSchema.adapt-style Standard Schema', async () => {
+        expect(await validate(adaptLike, { limit: 10 })).toEqual({
+            ok: true,
+            value: { limit: 10 },
+        });
+        expect(await validate(adaptLike, { limit: 99 })).toEqual({
+            ok: false,
+            issues: [{ message: 'must be <= 50', path: ['limit'] }],
+        });
+    });
+
+    test('accepts a bare predicate', async () => {
+        const isString = (v: unknown): v is string => typeof v === 'string';
+        expect(await validate(isString, 'ok')).toEqual({
+            ok: true,
+            value: 'ok',
+        });
+        expect((await validate(isString, 7)).ok).toBe(false);
+    });
+
+    test('rejects a non-schema with a TypeError', () => {
+        // @ts-expect-error — null is not a SchemaLike; the guard is for JS callers.
+        expect(() => validate(null, 1)).toThrow(TypeError);
+    });
+});
+
+describe('compile: reusable checker, coerced once', () => {
+    test('returns the same result as validate()', async () => {
+        const User = z.object({ name: z.string() });
+        const check = compile(User);
+        expect(await check({ name: 'Ada' })).toEqual(
+            await validate(User, { name: 'Ada' }),
+        );
+    });
+
+    test('coerces the schema ONCE across many checks (validate() coerces per call)', async () => {
+        // A `safeParse` getter counts each coercion: `toValidator` reads it exactly once per coerce.
+        // `_output` makes the fake a valid SchemaLike (Zod-phantom branch); the extra `safeParse`
+        // drives the runtime Zod arm.
+        const zodLike = (counter: {
+            n: number;
+        }): { readonly _output: unknown; safeParse: unknown } => ({
+            _output: undefined,
+            get safeParse() {
+                counter.n++;
+                return (v: unknown) => ({ success: true, data: v });
+            },
+        });
+
+        const compiled = { n: 0 };
+        const check = compile(zodLike(compiled));
+        await check('a');
+        await check('b');
+        expect(compiled.n).toBe(1); // bound once at compile time
+
+        const oneShot = { n: 0 };
+        const schema = zodLike(oneShot);
+        await validate(schema, 'a');
+        await validate(schema, 'b');
+        expect(oneShot.n).toBe(2); // re-coerced each call
+    });
+
+    test('rejects a non-schema with a TypeError', () => {
+        // @ts-expect-error — null is not a SchemaLike.
+        expect(() => compile(null)).toThrow(TypeError);
+    });
+});


### PR DESCRIPTION
## What

Two standalone validation primitives in `stitchapi` core, so validating a value **outside** a stitch call is uniform with validating **inside** one:

- **`validate(schema, value)`** → `Promise<ValidationResult>` — one-shot check.
- **`compile(schema)`** → `(value) => Promise<ValidationResult>` — coerces the schema once, returns a reusable checker.

Both accept any `SchemaLike` (raw Zod / Valibot / ArkType / any Standard Schema / a `JsonSchema.adapt` output / a predicate / a hand-rolled `Validator`) and return the existing `{ ok, value } | { ok, issues }` `ValidationResult`. They reuse the same internal `toValidator` coercion a stitch's `input`/`output` already run.

## Why

Standalone validation previously meant reaching into a schema's `['~standard'].validate(value)` — a protocol-level detail, not a consumer API, whose raw result has no `ok` discriminant and can carry non-array issue paths. `validate`/`compile` make the standalone path identical to the in-stitch one: same intake, same result shape. "What a stitch can validate" and "what you can validate standalone" are now the same set, learned once.

## Design notes

- **Free functions, not methods** — a method can't span schemas we don't own (a hand-written `z.object(...)`), so only a free function unifies every source.
- **`compile` amortizes coercion** — `toValidator` runs once at bind time; the returned checker skips it per call (pinned by a test). `validate(schema, value)` is `compile(schema)(value)` for the single-shot case.
- **No throwing twin** — failures come back as values, per the repo's typed-errors line.
- **`JsonSchema.adapt` stays the single, explicit bridge** for JSON Schema (core ships no engine; the engine is caller-supplied at `adapt`).

## Docs

Migrated the **stitchapi-side** docs to the new idiom: the `validate-runtime-discovered-schemas` blog and the `docs/integrations/json-schema` guide. The standalone `@stitchapi/json-schema` package (README + JSDoc + tests) deliberately keeps the raw `['~standard']` interface — it markets itself as StitchAPI-independent, so its own examples shouldn't import `stitchapi`.

## Contract

Adds **P23 · One schema intake; foreign formats enter through one adapter** — complements P21 (the validation seam is _open_) with the uniformity half (the seam is _one shape_). Doc-only; the ratchet scans source, so no baseline change.

## Verification

Full local pre-push gate green: format, lint, contract, types, type-d (tsd), whole test suite (+8 new cases in `validate.spec.ts`), attw exports, `next build` (docs / twoslash), and the measured bundle tether — advertised 24/20 kB unchanged (`import { stitch }` = 19.53 KB gzip → rounds to 20, no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
