### PR TITLE
fix(sandbox): make the blog's runtime-schema snippets runnable in the playground

### DIFF
--- a/docs/sandbox/runtime/stitch-browser.ts
+++ b/docs/sandbox/runtime/stitch-browser.ts
@@ -20,6 +20,7 @@ import type { TraceSink } from 'stitchapi';
  * Surface map (SANDBOX §3 table):
  *   Browser-safe (re-exported verbatim from core):
  *     stitch, seam, drift, graphql,
+ *     validate, compile,
  *     bearer, apiKey, basic, oauth2,
  *     fetchAdapter, memoryStore, multiplex, toOtlpJson, + all types
  *   Node-only, runs SHIMMED here (with a RunNotice):
@@ -37,6 +38,11 @@ export {
     seam,
     drift,
     graphql,
+    // `validate`/`compile` are pure schema-normalisation (validator.ts → toValidator);
+    // no Node touch-points — safe to re-export verbatim. Needed so the blog's
+    // runtime-schema snippets (`compile(JsonSchema.adapt(...))`) run in the playground.
+    validate,
+    compile,
     bearer,
     apiKey,
     basic,


### PR DESCRIPTION
Makes the *“Validate calls against schemas you obtain at runtime”* blog snippets — `compile(...)`, `validate(...)`, and `compile(JsonSchema.adapt(schema, { ajv }))` — actually runnable in the [playground](https://stitchapi.dev/playground). They weren't: the playground scope shipped neither the standalone validators nor the json-schema package.

## Two commits

**1. Expose `validate`/`compile` in the playground stitch surface** (`43eea33`)

The playground snippet scope is the curated browser-safe surface in `docs/sandbox/runtime/stitch-browser.ts`, which re-exports core symbols one by one. That allow-list was never updated when `validate`/`compile` landed (#432), so `import { compile } from 'stitchapi'` resolved to a build without them → `compile is undefined`. Fix: add them to the browser-safe re-export (pure schema-normalisation, no Node touch-points).

**2. Bundle `@stitchapi/json-schema` + `ajv` into the sandbox** (`b85926b`)

The module registry was `{ stitchapi, zod }`, so `import { JsonSchema } from '@stitchapi/json-schema'` threw *"Cannot import …"*. Now the blog's real `JsonSchema.adapt(schema, { ajv })` runs in the playground instead of forcing a hand-rolled adapter.

- `worker-main.ts` / `worker-main.node.ts`: register `'@stitchapi/json-schema'` + `'ajv'` in `env.modules`. Both browser-safe — the package imports nothing from ajv (engine passed as an argument); ajv is pure JS and its codegen uses the worker's already-present `unsafe-eval` (same capability the snippet runner needs), so no new CSP requirement.
- `build-sandbox-worker.mjs` / `build-sandbox-mcp.mjs`: alias `'@stitchapi/json-schema'` → its `src` (its published `lib/` isn't built on the sandbox path — same treatment as `stitchapi`→core).
- `docs/sandbox/package.json`: add `@stitchapi/json-schema` (workspace) + `ajv ^8`.

## Verification

- Ran the real pipeline (transpile + `__stitchImport` registry) with ajv v8: named import (`JsonSchema`) and **default** import (`Ajv`) both resolve; `compile(JsonSchema.adapt(...))` returns `{ ok, value }` / `{ ok, issues }` with per-path issues (`allErrors: true`).
- Executed the standalone `compile` surface: valid/invalid both correct.
- Browser + node worker bundles build clean (worker ~712 → 961 KB, ajv).
- Sandbox smoke **11/11**; pre-commit + pre-push gate (format / lint / contract / typecheck / test / exports / build-docs / yakir) all green.

Notes: worker bundle grows ~250 KB (ajv) — acceptable for a dev playground. Pin is `ajv ^8` (the package reads v8's `error.instancePath`; ajv v6's `dataPath` would crash the error mapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)