### PR TITLE
feat(sandbox): list-driven playground module registry (one line to add a package)

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -14,7 +14,7 @@
         "gen:completions": "node scripts/gen-stitch-completions.mjs",
         "build:core": "pnpm --filter stitchapi build",
         "build:typed-deps": "pnpm --filter stitchapi --filter @stitchapi/nest --filter @stitchapi/pino --filter @stitchapi/query-core --filter @stitchapi/react --filter @stitchapi/fastify --filter @stitchapi/hono build",
-        "build:sandbox": "node scripts/gen-stitch-completions.mjs && node ../../docs/sandbox/runtime/build-sandbox-worker.mjs",
+        "build:sandbox": "node scripts/gen-stitch-completions.mjs && node ../../docs/sandbox/runtime/gen-sandbox-modules.mjs && node ../../docs/sandbox/runtime/build-sandbox-worker.mjs",
         "build:search-index": "pnpm run build:typed-deps && fumadocs-mdx && node --import tsx/esm scripts/build-search-index.mjs",
         "check:search-relevance": "pnpm run build:search-index && node --import tsx scripts/search-eval.mts --assert",
         "test": "vitest run",

--- a/docs/sandbox/package.json
+++ b/docs/sandbox/package.json
@@ -13,7 +13,7 @@
         "stitch-sandbox": "./dist/mcp.mjs"
     },
     "scripts": {
-        "build:mcp": "node runtime/build-sandbox-mcp.mjs",
+        "build:mcp": "node runtime/gen-sandbox-modules.mjs && node runtime/build-sandbox-mcp.mjs",
         "test:smoke": "node tests/run-all.mjs",
         "test:mcp": "pnpm run build:mcp && node mcp/smoke.mjs"
     },

--- a/docs/sandbox/runtime/build-sandbox-mcp.mjs
+++ b/docs/sandbox/runtime/build-sandbox-mcp.mjs
@@ -16,6 +16,8 @@
  *
  * Usage:  pnpm --filter @stitchapi/sandbox run build:mcp
  */
+import { PLAYGROUND_PACKAGES } from './playground-packages.mjs';
+
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -27,11 +29,15 @@ const pkgRoot = resolve(__dirname, '..'); // docs/sandbox
 const OUTDIR = process.env.OUT ?? resolve(pkgRoot, 'dist');
 const CORE =
     process.env.CORE ?? resolve(repoRoot, 'packages/core/src/index.ts');
-// Resolve `@stitchapi/json-schema` from source too (its published `lib/` isn't built on
-// this path); the node worker imports it for `JsonSchema.adapt(...)` snippets.
-const JSON_SCHEMA =
-    process.env.JSON_SCHEMA ??
-    resolve(repoRoot, 'packages/json-schema/src/index.ts');
+// Alias each workspace `@stitchapi/*` playground package to its source (its published
+// `lib/` isn't built on this path); the node worker bundles them for snippet imports.
+// Derived from the one package list — adding a package needs no edit here.
+const WORKSPACE_ALIASES = Object.fromEntries(
+    PLAYGROUND_PACKAGES.filter((p) => p.src).map((p) => [
+        p.specifier,
+        resolve(repoRoot, p.src),
+    ]),
+);
 
 async function loadEsbuild() {
     try {
@@ -75,7 +81,7 @@ const shared = {
     sourcemap: false,
     // Resolve the real core from source (no build:core needed). Node built-ins
     // stay external automatically under platform:node.
-    alias: { stitchapi: CORE, '@stitchapi/json-schema': JSON_SCHEMA },
+    alias: { stitchapi: CORE, ...WORKSPACE_ALIASES },
     // transpile.ts prefers sucrase (bundled) and only dynamically imports
     // @babel/standalone if sucrase fails to LOAD — never on this path. Keep it
     // external so the build doesn't require the heavy Babel bundle.

--- a/docs/sandbox/runtime/build-sandbox-worker.mjs
+++ b/docs/sandbox/runtime/build-sandbox-worker.mjs
@@ -26,6 +26,8 @@
  * Usage:
  *   node docs/sandbox/runtime/build-sandbox-worker.mjs
  */
+import { PLAYGROUND_PACKAGES } from './playground-packages.mjs';
+
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -39,13 +41,16 @@ const OUT =
     resolve(repoRoot, 'apps/docs/public/sandbox/sandbox-worker.mjs');
 const CORE =
     process.env.CORE ?? resolve(repoRoot, 'packages/core/src/index.ts');
-// Resolve `@stitchapi/json-schema` to its SOURCE too — its published entry is a built
-// `lib/`, which the docs `build:sandbox` flow never builds. The source is a single
-// self-contained file (its only import is a type-only `StitchSchema` from stitchapi,
-// erased at bundle time), so aliasing to src keeps the worker build publish-free.
-const JSON_SCHEMA =
-    process.env.JSON_SCHEMA ??
-    resolve(repoRoot, 'packages/json-schema/src/index.ts');
+// Alias every workspace `@stitchapi/*` playground package to its SOURCE: its
+// published entry is a built `lib/` the docs `build:sandbox` flow never builds, so
+// resolving src keeps the worker build publish-free (the same trick as `stitchapi`
+// → core). Derived from the ONE package list so adding a package needs no edit here.
+const WORKSPACE_ALIASES = Object.fromEntries(
+    PLAYGROUND_PACKAGES.filter((p) => p.src).map((p) => [
+        p.specifier,
+        resolve(repoRoot, p.src),
+    ]),
+);
 
 async function loadEsbuild() {
     // 1. Bare import — works if esbuild sits on a node_modules path above this
@@ -100,7 +105,7 @@ await esbuild.build({
     // shims are required — this is the only alias the bundle needs.
     alias: {
         stitchapi: CORE,
-        '@stitchapi/json-schema': JSON_SCHEMA,
+        ...WORKSPACE_ALIASES,
     },
     logLevel: 'info',
 });

--- a/docs/sandbox/runtime/gen-sandbox-modules.mjs
+++ b/docs/sandbox/runtime/gen-sandbox-modules.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+/**
+ * Generate `sandbox-modules.generated.ts` from `playground-packages.mjs`.
+ *
+ * esbuild can only bundle a package it sees as a STATIC `import * as … from
+ * '<specifier>'` — you can't build the registry from a runtime loop. So this
+ * emits one static namespace import per declared package plus the specifier →
+ * namespace map the worker exposes as its module registry (worker-entry's
+ * `__stitchImport`). Run by `build:sandbox` and `build:mcp` before the esbuild
+ * bundle; the output is committed (prettier-ignored via `**\/*.generated.ts`)
+ * so tsc/dev see it without a pre-step.
+ *
+ * Usage:  node docs/sandbox/runtime/gen-sandbox-modules.mjs
+ *         node docs/sandbox/runtime/gen-sandbox-modules.mjs --emit   (stdout only)
+ */
+import { PLAYGROUND_PACKAGES } from './playground-packages.mjs';
+
+import { writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUT = resolve(__dirname, 'sandbox-modules.generated.ts');
+
+function render() {
+    const imports = PLAYGROUND_PACKAGES.map(
+        (p, i) => `import * as m${i} from ${JSON.stringify(p.specifier)};`,
+    ).join('\n');
+    const entries = PLAYGROUND_PACKAGES.map(
+        (p, i) => `    ${JSON.stringify(p.specifier)}: m${i},`,
+    ).join('\n');
+
+    return `// @generated — do not edit by hand.
+// Regenerate: node docs/sandbox/runtime/gen-sandbox-modules.mjs
+// Source of truth: docs/sandbox/runtime/playground-packages.mjs
+//
+// The curated module registry a playground snippet's \`import { x } from
+// '<specifier>'\` resolves against (worker-entry's \`__stitchImport\`), beyond the
+// core \`stitchapi\` surface which is injected name-by-name separately.
+${imports}
+
+export const sandboxModules: Record<string, unknown> = {
+${entries}
+};
+`;
+}
+
+const out = render();
+if (process.argv.includes('--emit')) {
+    process.stdout.write(out);
+} else {
+    writeFileSync(OUT, out);
+    console.log(
+        `[sandbox-modules] wrote ${PLAYGROUND_PACKAGES.length} modules → ${OUT}`,
+    );
+}

--- a/docs/sandbox/runtime/playground-packages.mjs
+++ b/docs/sandbox/runtime/playground-packages.mjs
@@ -1,0 +1,42 @@
+/**
+ * Single source of truth for the packages a playground snippet may `import`
+ * BEYOND the core `stitchapi` surface (which is injected separately as the
+ * curated browser build — see worker-main.ts).
+ *
+ * Add a package here (ONE line) and `build:sandbox` / `build:mcp` wire it
+ * everywhere:
+ *   1. `gen-sandbox-modules.mjs` regenerates `sandbox-modules.generated.ts`
+ *      with a static `import * as … from '<specifier>'` (esbuild needs the
+ *      specifier statically to bundle it) and the `<specifier>` → namespace
+ *      registry the snippet's `__stitchImport` resolves against.
+ *   2. the two esbuild builds (`build-sandbox-worker.mjs`,
+ *      `build-sandbox-mcp.mjs`) read this list and, for any entry with `src`,
+ *      alias the specifier to that source path — a workspace `@stitchapi/*`
+ *      package's published `lib/` is NOT built on the sandbox path, so we
+ *      resolve its source directly (the same trick used for `stitchapi` → core).
+ *
+ * Ground rules for what belongs here:
+ *   - Browser-safe ONLY. The worker is Node-free (no `node:*`, no bare
+ *     `process`). A package that statically imports a Node built-in will break
+ *     the bundle. `@stitchapi/*` runtime adapters (redis, cloudflare-kv, …) are
+ *     server-tier — do not add them.
+ *   - Bundled into the worker, so each entry grows the worker bundle. Curate;
+ *     this is the docs playground, not a package zoo.
+ *   - Third-party packages (zod, ajv) resolve from node_modules → no `src`.
+ *     They must also be a dependency of `@stitchapi/sandbox` (docs/sandbox
+ *     package.json) so both builds can resolve them.
+ *
+ * @typedef {{ specifier: string, src?: string }} PlaygroundPackage
+ *   specifier — how a snippet imports it (`import … from '<specifier>'`).
+ *   src        — repo-root-relative source entry to alias to (workspace pkgs only).
+ *
+ * @type {PlaygroundPackage[]}
+ */
+export const PLAYGROUND_PACKAGES = [
+    { specifier: 'zod' },
+    { specifier: 'ajv' },
+    {
+        specifier: '@stitchapi/json-schema',
+        src: 'packages/json-schema/src/index.ts',
+    },
+];

--- a/docs/sandbox/runtime/sandbox-modules.generated.ts
+++ b/docs/sandbox/runtime/sandbox-modules.generated.ts
@@ -1,0 +1,16 @@
+// @generated — do not edit by hand.
+// Regenerate: node docs/sandbox/runtime/gen-sandbox-modules.mjs
+// Source of truth: docs/sandbox/runtime/playground-packages.mjs
+//
+// The curated module registry a playground snippet's `import { x } from
+// '<specifier>'` resolves against (worker-entry's `__stitchImport`), beyond the
+// core `stitchapi` surface which is injected name-by-name separately.
+import * as m0 from "zod";
+import * as m1 from "ajv";
+import * as m2 from "@stitchapi/json-schema";
+
+export const sandboxModules: Record<string, unknown> = {
+    "zod": m0,
+    "ajv": m1,
+    "@stitchapi/json-schema": m2,
+};

--- a/docs/sandbox/runtime/worker-main.node.ts
+++ b/docs/sandbox/runtime/worker-main.node.ts
@@ -20,21 +20,18 @@ import { createFetchShim } from '../../../packages/sandbox-sim/src/adapters/node
 import { allHandlers } from '../../../packages/sandbox-sim/src/handlers';
 import type { SimKnobs } from '../contracts/sim';
 import { hardenWorkerGlobal } from './harden-worker-global';
+// The curated importable-module registry (zod, ajv, `@stitchapi/json-schema`, …),
+// generated from `playground-packages.mjs` — same set the browser entry exposes,
+// so a snippet runs identically on either tier. See gen-sandbox-modules.mjs.
+import { sandboxModules } from './sandbox-modules.generated';
 import {
     type WorkerEnv,
     type WorkerGlobal,
     installWorkerEntry,
 } from './worker-entry';
 
-// Runtime-schema pair, same as the browser entry: `@stitchapi/json-schema` (pure
-// wrapper, engine passed in) + `ajv` (pure JS) so `JsonSchema.adapt(schema, { ajv })`
-// snippets resolve their imports via __stitchImport.
-import * as jsonSchema from '@stitchapi/json-schema';
-import * as ajv from 'ajv';
 import { parentPort } from 'node:worker_threads';
 import * as stitchBuild from 'stitchapi';
-// Bundled so a snippet's `import { z } from 'zod'` resolves (via __stitchImport).
-import * as zod from 'zod';
 
 // Baseline knobs for the current run, mutated by `env.applyKnobs`; the shim
 // reads it on every request. URL-explicit knobs still win (see dispatch).
@@ -62,7 +59,7 @@ const env: WorkerEnv = {
     // The whole real `stitchapi` surface, exposed name-by-name into the snippet.
     stitchBuild: stitchBuild as unknown as Record<string, unknown>,
     // Modules a snippet may `import` beyond 'stitchapi' (rebound via __stitchImport).
-    modules: { zod, '@stitchapi/json-schema': jsonSchema, ajv },
+    modules: sandboxModules,
     fetch: simFetch as unknown as WorkerEnv['fetch'],
     // A clean `process` shadow for the snippet scope (no host env leakage). Core
     // itself still reads the real `process` in its own module scope.

--- a/docs/sandbox/runtime/worker-main.ts
+++ b/docs/sandbox/runtime/worker-main.ts
@@ -23,6 +23,13 @@ import { createFetchShim } from '../../../packages/sandbox-sim/src/adapters/brow
 import { allHandlers } from '../../../packages/sandbox-sim/src/handlers';
 import type { SimKnobs } from '../contracts/sim';
 import { hardenWorkerGlobal } from './harden-worker-global';
+// The curated set of packages a snippet may `import` beyond the core `stitchapi`
+// surface — zod, ajv, `@stitchapi/json-schema`, and any others declared in
+// `playground-packages.mjs`. Each is bundled statically into the Worker (no
+// runtime module loader — SEC-31) and exposed via __stitchImport. The registry
+// (with its static namespace imports) is generated from that list so adding a
+// package is a one-line edit; see gen-sandbox-modules.mjs.
+import { sandboxModules } from './sandbox-modules.generated';
 import { browserProcess } from './shims/process';
 import * as stitchBuild from './stitch-browser';
 import { createTraceCollector } from './trace-collector';
@@ -31,17 +38,6 @@ import {
     type WorkerGlobal,
     installWorkerEntry,
 } from './worker-entry';
-
-// Same deal for the runtime-schema pair the blog's `compile(JsonSchema.adapt(...))`
-// snippet needs: `@stitchapi/json-schema` is a pure wrapper (it takes the engine as an
-// argument — no Node) and `ajv` is pure JS. Bundled so `import { JsonSchema } from
-// '@stitchapi/json-schema'` and `import Ajv from 'ajv'` resolve via __stitchImport.
-import * as jsonSchema from '@stitchapi/json-schema';
-import * as ajv from 'ajv';
-// Bundled so a snippet's `import { z } from 'zod'` resolves (via __stitchImport).
-// zod is pure JS / browser-safe; esbuild bundles it into the Worker (no runtime
-// module loader exists here — SEC-31).
-import * as zod from 'zod';
 
 // Baseline knobs for the current run (the "Response knobs" panel). Mutated by
 // `env.applyKnobs` before each run; the shim reads it on every request so a
@@ -81,7 +77,7 @@ const env: WorkerEnv = {
         stitch: traceCollector.stitch,
     } as unknown as Record<string, unknown>,
     // Modules a snippet may `import` beyond 'stitchapi' (rebound via __stitchImport).
-    modules: { zod, '@stitchapi/json-schema': jsonSchema, ajv },
+    modules: sandboxModules,
     // The snippet's `fetch` (cast: createFetchShim is precisely `fetch`-typed,
     // WorkerEnv.fetch is the loose (unknown, unknown) wire shape).
     fetch: simFetch as unknown as WorkerEnv['fetch'],


### PR DESCRIPTION
Makes any (browser-safe) `@stitchapi/*` package runnable in docs/playground snippets via a **one-line** edit, instead of hand-wiring it across four files. Follow-up to #433/#434, which added `@stitchapi/json-schema` + ajv the manual way.

## Before

Exposing a package to the playground meant editing both worker entries (`import * as X` + registry map) **and** both esbuild build scripts (the src alias), then rebuilding. That's what json-schema/ajv cost.

## After

One declared list drives everything:

- **`docs/sandbox/runtime/playground-packages.mjs`** — the source of truth. One entry per package: `{ specifier, src? }`. `src` marks a workspace `@stitchapi/*` package whose **source** the bundlers alias (its published `lib/` isn't built on the sandbox path — same trick as `stitchapi` → core).
- **`gen-sandbox-modules.mjs`** — emits `sandbox-modules.generated.ts`: a static `import * as` per package (esbuild needs the specifier statically to bundle it) + the `specifier → namespace` registry `worker-entry`'s `__stitchImport` resolves against.
- **`worker-main.ts` / `worker-main.node.ts`** — `modules: sandboxModules` (generated), replacing the per-package imports + inline map.
- **`build-sandbox-worker.mjs` / `build-sandbox-mcp.mjs`** — derive the src aliases from the same list.
- `build:sandbox` / `build:mcp` run `gen-sandbox-modules` before bundling. Generated file is committed (prettier-ignored via `**/*.generated.ts`, `// @generated` header).

Adding a package is now:

```js
// playground-packages.mjs
{ specifier: '@stitchapi/vue', src: 'packages/vue/src/index.ts' },
```

## Same security model

This does **not** open the sandbox to arbitrary npm. It's still a closed allow-list: no runtime module loader (`require` is `undefined`, dynamic `import()` rejected by the transpiler), everything bundled at build time, zero egress (worker `fetch` = sim shim only; CSP `connect-src 'self'`). The change only makes the allow-list one-line-extensible. Ground rule documented in the list: **browser-safe packages only** (no `node:*`) — server-tier adapters (redis, cloudflare-kv, …) would break the bundle.

## Verification

- One-line add of `@stitchapi/query-core` → bundled via the derived alias (worker 961 → 965 KB, `createStitchQuery` present) and `import { createStitchQuery } from '@stitchapi/query-core'` resolved through the **real transpile + `__stitchImport`** pipeline. Reverted — shipped list stays at zod / ajv / `@stitchapi/json-schema`.
- Generated registry runs the `JsonSchema.adapt` snippet unchanged (no regression); browser + node worker bundles build clean (961 KB unchanged); smoke **11/11**.
- Pre-commit + pre-push gate (format / lint / contract / typecheck / test / exports / build-docs / yakir) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)