### PR TITLE
fix(docs): emit JSON-LD as @context + @graph, not a top-level array

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -110,30 +110,38 @@ export const metadata: Metadata = {
 };
 
 /* Structured data — lets search engines model StitchAPI as a developer tool
-   (rich results / knowledge panel) rather than an anonymous docs page. */
-const jsonLd = [
-    {
-        '@context': 'https://schema.org',
-        '@type': 'WebSite',
-        name: appName,
-        url: siteUrl,
-        description: defaultDescription,
-    },
-    {
-        '@context': 'https://schema.org',
-        '@type': 'SoftwareApplication',
-        name: appName,
-        applicationCategory: 'DeveloperApplication',
-        operatingSystem: 'Node.js, Deno, Bun, browsers, edge runtimes',
-        description: defaultDescription,
-        url: siteUrl,
-        downloadUrl: 'https://www.npmjs.com/package/stitchapi',
-        codeRepository: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
-        license: 'https://www.apache.org/licenses/LICENSE-2.0',
-        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
-        author: { '@type': 'Person', name: 'Oleksandr Zhuravlov' },
-    },
-];
+   (rich results / knowledge panel) rather than an anonymous docs page.
+
+   Emitted as ONE object with a top-level `@context` + `@graph`, not a bare array
+   of `@context`-bearing nodes. Both are valid JSON-LD, but `@graph` is Google's
+   recommended multi-entity shape AND it keeps a top-level `@context` present: some
+   third-party structured-data readers (SEO extensions, Safari content blockers)
+   do `data['@context'].toLowerCase()` and throw on a top-level array (no
+   `@context` there). Single-context + `@graph` avoids handing them that trap. */
+const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+        {
+            '@type': 'WebSite',
+            name: appName,
+            url: siteUrl,
+            description: defaultDescription,
+        },
+        {
+            '@type': 'SoftwareApplication',
+            name: appName,
+            applicationCategory: 'DeveloperApplication',
+            operatingSystem: 'Node.js, Deno, Bun, browsers, edge runtimes',
+            description: defaultDescription,
+            url: siteUrl,
+            downloadUrl: 'https://www.npmjs.com/package/stitchapi',
+            codeRepository: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
+            license: 'https://www.apache.org/licenses/LICENSE-2.0',
+            offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+            author: { '@type': 'Person', name: 'Oleksandr Zhuravlov' },
+        },
+    ],
+};
 
 export default function Layout({ children }: LayoutProps<'/'>) {
     return (


### PR DESCRIPTION
## Problem

The site's structured data (`layout.tsx`) was a bare top-level **array** of two `@context`-bearing nodes:

```json
[{ "@context": "https://schema.org", "@type": "WebSite", … },
 { "@context": "https://schema.org", "@type": "SoftwareApplication", … }]
```

Valid JSON-LD, but the **top level has no `@context`**. Any consumer that does `data["@context"].toLowerCase()` gets `undefined` and throws:

```
TypeError: undefined is not an object (evaluating 'r["@context"].toLowerCase')
```

That's the error some third-party structured-data readers (SEO extensions, **Safari content blockers** — which run even in private windows) throw on our pages. It surfaced in the **playground**: rendering a stitch-trace DAG injects nodes into the DOM, the reader re-scans structured data on the mutation, and chokes. Pages that don't render a DAG never trigger it.

The offending code is the extension's, not ours (`@context`/`toLowerCase` appear nowhere in our bundle, chunks, worker, or deps — verified by crawling the live page). But our array shape is what it trips on, so we can defuse it.

## Fix

Emit **one object** with a top-level `@context` + `@graph` (Google's recommended multi-entity shape):

```json
{ "@context": "https://schema.org",
  "@graph": [ { "@type": "WebSite", … }, { "@type": "SoftwareApplication", … } ] }
```

`data["@context"]` is now the string `"https://schema.org"`, so `.toLowerCase()` is safe. Same entities, same fields; `jsonLdHtml` serialization unchanged.

## Verify

- `JSON.parse(jsonLdHtml(jsonLd))["@context"].toLowerCase()` → `"https://schema.org"` (no throw); `@graph` preserves both entities.
- Pre-commit + pre-push gate green (format / typecheck / test / build-docs / yakir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)