### PR TITLE
fix(sandbox): rebind the first import when Sucrase glues a helper to it (playground SyntaxError)

### DIFF
--- a/docs/sandbox/runtime/transpile.test.ts
+++ b/docs/sandbox/runtime/transpile.test.ts
@@ -233,6 +233,30 @@ async function runTests(): Promise<void> {
                 side.js,
             );
         }
+
+        // (d') REAL Sucrase path: a snippet using `?.` makes Sucrase prepend an
+        // `_optionalChain` helper glued (no newline) to the first import, which the
+        // line-anchored rewrite used to miss → a live `import` survived and threw
+        // "Cannot use import statement outside a module" at runtime. The first
+        // import MUST still be rebound, and NO `import … from` may remain.
+        const glued = await transpile(
+            `import { stitch } from 'stitchapi';\n` +
+                `const f = (x) => x?.y;\nstitch();\nf({});`,
+        );
+        if ('js' in glued) {
+            assert(
+                "(d') `?.`-helper-glued first import is still rebound",
+                glued.js.includes('__stitchImport("stitchapi")'),
+                glued.js,
+            );
+            assert(
+                "(d') no leftover static `import … from` survives",
+                !/(^|[^\w$."'])import\b[^\n]*\bfrom\b/.test(glued.js),
+                glued.js,
+            );
+        } else {
+            assert("(d') glued-import snippet transpiles", false, glued);
+        }
     }
 
     /* (e) dynamic import() is rejected (SEC-31 module-loader escape) ---------- */

--- a/docs/sandbox/runtime/transpile.ts
+++ b/docs/sandbox/runtime/transpile.ts
@@ -375,6 +375,17 @@ function rebindModuleImports(js: string): TranspileResult {
 
     let out = js;
 
+    // (2·0) Un-glue imports Sucrase pushed mid-line. Sucrase prepends transform
+    // helpers (e.g. `_optionalChain` for `?.`, `_asyncNullishCoalesce`, …) to the
+    // TOP of its output with no trailing newline, so the helper's closing `}` sticks
+    // to the first statement — usually the first `import` (`…return v; }import { x }
+    // from 'y'`). The rewrites below are line-anchored (`^…import`), so that first
+    // import isn't seen, survives into the AsyncFunction body, and throws at runtime
+    // ("Cannot use import statement outside a module" / "import call expects one or
+    // two arguments"). Put any import/export a `}`/`;` glued onto the same line back
+    // on its own line first. (Snippets using `?.` in a hook are the common trigger.)
+    out = out.replace(/([};])[ \t]*(import|export)\b/g, '$1\n$2');
+
     // (2a) `import <clause> from '<spec>';` → const bindings from the registry.
     // The lazy `[\s\S]*?` lets a multi-line clause span newlines up to `from`.
     out = out.replace(


### PR DESCRIPTION
## Symptom

A playground snippet using **optional chaining** (`?.` — e.g. `res?.status` in a stitch `hooks` callback) throws at runtime:

- Chrome/V8: `SyntaxError: Cannot use import statement outside a module`
- Safari/JSC: `SyntaxError: … import call expects one or two arguments`

A near-identical snippet **without** `?.` runs fine. Reproduces in every browser (private windows included); no dependency on extensions.

## Root cause

Snippets run as an `AsyncFunction` body, so `rebindModuleImports` rewrites every `import` to `__stitchImport(...)`. When a snippet uses `?.`, **Sucrase prepends an `_optionalChain` helper to the top of its output with no trailing newline**, so the helper's closing `}` glues to the first statement:

```
… return value; }import { stitch } from 'stitchapi';
const { JsonSchema } = __stitchImport("@stitchapi/json-schema");   // ← these got rewritten
const Ajv = __stitchImport("ajv").default;
```

The rewrites are **line-anchored** (`/^[ \t]*import\b…/gm`), so the first import — now mid-line after `}` — isn't matched. It survives into the runner as a live `import` statement → the SyntaxError. That's the whole Part-1-works / Part-2-fails split: only the `?.` variant triggers the helper injection.

## Fix

Before the line-anchored rewrites, put any `import`/`export` that a `}`/`;` glued onto the same line back on its own line:

```ts
out = out.replace(/([};])[ \t]*(import|export)\b/g, '$1\n$2');
```

One regex, ahead of the existing passes; imports already at a line start are untouched.

## Verification

- New regression test `(d')`: real Sucrase path, `?.` + a leading import → first import is still rebound to `__stitchImport`, no `import … from` survives.
- Ran the full `?.`-using Part 2 (JsonSchema.adapt + ajv + retry hooks) through the real node-runner worker pipeline: retry recovers (503, 503 → 201), result validates, no error.
- Smoke **11/11**; pre-commit + pre-push gate (format / lint / contract / typecheck / test / build-docs / yakir) all green.

Note: the transpiler runs on the main thread (browser-runner step 1, bundled into the docs app), so this ships in the app bundle and takes effect on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)