### PR TITLE
fix(openapi)!: sanitize untrusted spec text in codegen — build-time RCE, credential leak, reserved-word & shared-import & newline breaks

### DIFF
--- a/packages/openapi/src/gen-openapi.ts
+++ b/packages/openapi/src/gen-openapi.ts
@@ -164,9 +164,65 @@ function toKebab(s: string): string {
     return w.length ? w.map((x) => x.toLowerCase()).join('-') : 'item';
 }
 
+// ECMAScript reserved words + module keywords. Any of these emitted bare as an export name
+// (`export const delete = …` / `export { delete }`) is a SyntaxError, so they get the same
+// `op`+Pascal prefix as an invalid first char.
+const RESERVED_WORDS = new Set<string>([
+    // reserved words (ES2015+)
+    'break',
+    'case',
+    'catch',
+    'class',
+    'const',
+    'continue',
+    'debugger',
+    'default',
+    'delete',
+    'do',
+    'else',
+    'enum',
+    'export',
+    'extends',
+    'false',
+    'finally',
+    'for',
+    'function',
+    'if',
+    'import',
+    'in',
+    'instanceof',
+    'new',
+    'null',
+    'return',
+    'super',
+    'switch',
+    'this',
+    'throw',
+    'true',
+    'try',
+    'typeof',
+    'var',
+    'void',
+    'while',
+    'with',
+    // strict-mode / contextual reserved
+    'let',
+    'static',
+    'yield',
+    'await',
+    'implements',
+    'interface',
+    'package',
+    'private',
+    'protected',
+    'public',
+]);
+
 function safeIdent(s: string): string {
     const c = toCamel(s);
-    return /^[A-Za-z_$]/.test(c) ? c : `op${toPascal(c)}`;
+    if (!/^[A-Za-z_$]/.test(c) || RESERVED_WORDS.has(c))
+        return `op${toPascal(c)}`;
+    return c;
 }
 
 // Operation name (ADR 0013 Q4): sanitized operationId, else camelCase(method + path).
@@ -280,8 +336,48 @@ function propKey(k: string): string {
 }
 
 // Single-quoted string literal for emitted source (matches the ecosystem's prettier default).
+// Spec text is UNTRUSTED: a raw newline (LF, CR, U+2028, U+2029) inside a `'...'` literal is an
+// unterminated-string SyntaxError (denial-of-build), so every line terminator is escaped too.
 function q(s: string): string {
-    return `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+    return `'${s
+        .replace(/\\/g, '\\\\')
+        .replace(/'/g, "\\'")
+        .replace(/\n/g, '\\n')
+        .replace(/\r/g, '\\r')
+        .replace(
+            /[\u2028\u2029]/g,
+            (m) => `\\u${m.charCodeAt(0).toString(16)}`,
+        )}'`;
+}
+
+// Neutralize UNTRUSTED spec text destined for a generated `//` (or `/* */`) comment. A raw newline
+// would end the comment and let the remainder of the string become top-level TS that RUNS when the
+// developer compiles the generated file (build-time RCE). Collapse every line terminator (LF, CR,
+// U+2028, U+2029) to a space and defang the block-comment terminator so text can't escape a comment.
+function comment(s: string): string {
+    return s.replace(/[\r\n\u2028\u2029]+/g, ' ').replace(/\*\//g, '* /');
+}
+
+// Strip HTTP basic-auth userinfo (`user:pass@`) from a URL before it is emitted into a file the
+// user commits — the README promises "the secret is never emitted". Returns the sanitized URL and
+// whether credentials were removed. Falls back to a regex for non-absolute/relative server URLs
+// that `URL` rejects.
+function stripUserinfo(url: string): { url: string; stripped: boolean } {
+    try {
+        const u = new URL(url);
+        if (u.username || u.password) {
+            u.username = '';
+            u.password = '';
+            return { url: u.toString(), stripped: true };
+        }
+        return { url, stripped: false };
+    } catch {
+        // Relative / template server URLs (e.g. `/api`, `{scheme}://…`) aren't absolute URLs.
+        // Match an authority userinfo (`scheme://user:pass@host`) textually and drop it.
+        const m = /^([A-Za-z][A-Za-z0-9+.-]*:\/\/)[^/@]*@(.*)$/.exec(url);
+        if (m) return { url: `${m[1]}${m[2]}`, stripped: true };
+        return { url, stripped: false };
+    }
 }
 
 // Direct component refs reachable from a schema node (one hop into the doc's component graph).
@@ -323,7 +419,18 @@ export function planGen(doc: OpenApiDoc, opts: GenOptions = {}): GenResult {
 
     const components = doc.components?.schemas ?? {};
     const securitySchemes = doc.components?.securitySchemes ?? {};
-    const baseUrl = doc.servers?.[0]?.url;
+    // Strip any `user:pass@` from the server URL BEFORE it reaches a file the user commits or a
+    // warning message — the secret is never emitted (README contract).
+    const rawBaseUrl = doc.servers?.[0]?.url;
+    let baseUrl = rawBaseUrl;
+    if (rawBaseUrl !== undefined) {
+        const s = stripUserinfo(rawBaseUrl);
+        baseUrl = s.url;
+        if (s.stripped)
+            warnings.push(
+                'stripped embedded credentials from the server URL; set client.ts auth via env() instead of committing them',
+            );
+    }
     if ((doc.servers?.length ?? 0) > 1)
         warnings.push(
             `spec has ${doc.servers?.length} servers; used the first (${baseUrl}). Edit client.ts to switch.`,
@@ -685,8 +792,17 @@ function emitOperation(o: SelectedOp, ctx: EmitOpCtx): GenFile {
     const wantType = (comp: string): void => {
         const p = ctx.placement.get(comp);
         if (ctx.layout === 'flat' && p && !p.shared) {
-            // inline the private component (and its private transitive closure)
-            collectInlinePrivate(comp, ctx, inlinedPrivate, new Set());
+            // inline the private component (and its private transitive closure). Any SHARED
+            // component it transitively references still needs an `import type` in this file,
+            // else the inlined `type` refers to an undeclared name (TS2304).
+            collectInlinePrivate(
+                comp,
+                ctx,
+                inlinedPrivate,
+                new Set(),
+                selfPath,
+                typeImports,
+            );
             return;
         }
         const loc = ctx.fileOfComponent(comp);
@@ -707,15 +823,17 @@ function emitOperation(o: SelectedOp, ctx: EmitOpCtx): GenFile {
         lines.push(...inlinedPrivate);
         lines.push('');
     }
-    if (o.op.summary) lines.push(`// ${o.op.summary}`);
-    lines.push(`// ${o.method} ${o.path}`);
+    if (o.op.summary) lines.push(`// ${comment(o.op.summary)}`);
+    lines.push(`// ${o.method} ${comment(o.path)}`);
 
     const cfg: string[] = [];
     cfg.push(`    path: ${q(o.path)},`);
     if (o.method !== 'GET') cfg.push(`    method: ${q(o.method)},`);
     const queryParams = (o.op.parameters ?? [])
         .filter((p) => p.in === 'query')
-        .map((p) => p.name);
+        .map((p) => p.name)
+        .filter((n): n is string => typeof n === 'string')
+        .map(comment);
     if (queryParams.length)
         cfg.push(
             `    // query params: ${queryParams.join(', ')} — pass them in the call's \`query\``,
@@ -730,12 +848,16 @@ function emitOperation(o: SelectedOp, ctx: EmitOpCtx): GenFile {
 }
 
 // For flat layout: render a private component (and any private components it references) as inline
-// `type` declarations, so deleting the operation file deletes them too.
+// `type` declarations, so deleting the operation file deletes them too. Transitive refs that are
+// NOT inlined here (shared components — and dir-layout private ones) are added to `typeImports`
+// so the inlined `type`s resolve, instead of being silently dropped.
 function collectInlinePrivate(
     comp: string,
     ctx: EmitOpCtx,
     out: string[],
     seen: Set<string>,
+    selfPath: string,
+    typeImports: Map<string, string>,
 ): void {
     if (seen.has(comp)) return;
     seen.add(comp);
@@ -745,9 +867,15 @@ function collectInlinePrivate(
     const expr = tsType(schema, tctx);
     out.push(`type ${toPascal(comp)} = ${expr};`);
     for (const u of tctx.used) {
+        if (u === comp) continue;
         const p = ctx.placement.get(u);
-        if (u !== comp && p && !p.shared)
-            collectInlinePrivate(u, ctx, out, seen);
+        if (p && !p.shared) {
+            collectInlinePrivate(u, ctx, out, seen, selfPath, typeImports);
+        } else {
+            // Shared component (or an unplaced ref → shared file): import it, don't inline.
+            const loc = ctx.fileOfComponent(u);
+            typeImports.set(toPascal(u), relImport(selfPath, loc.import));
+        }
     }
 }
 

--- a/packages/openapi/test/gen-openapi.spec.ts
+++ b/packages/openapi/test/gen-openapi.spec.ts
@@ -202,3 +202,252 @@ describe('planGen — naming, typing, auth, notice', () => {
         );
     });
 });
+
+// The codegen turns an UNTRUSTED OpenAPI document into TS source the developer compiles. Spec text
+// (summary, path, param names, server URL, operationId) is attacker-controlled input. These guard
+// against injection / credential-leak / crash-the-build regressions (review-sweep on merged #328).
+describe('planGen — untrusted-spec safety', () => {
+    // F1 (CRITICAL, build-time RCE): a `\n` in `summary` must NOT let the remainder of the string
+    // escape the `//` comment and become top-level TS that RUNS when the generated file is compiled.
+    test('F1: newline in summary cannot break out of the // comment (no injected top-level code)', () => {
+        const evil: OpenApiDoc = {
+            openapi: '3.0.0',
+            info: { title: 'T', version: '1' },
+            paths: {
+                '/pets': {
+                    get: {
+                        operationId: 'listPets',
+                        summary:
+                            "List pets\nexport {};\nglobalThis.PWNED=1;\nrequire('child_process').execSync('id');\n// x",
+                        responses: { '200': {} },
+                    },
+                },
+            },
+        };
+        const r = planGen(evil, { all: true });
+        const src = file(r, 'list-pets/index.ts');
+        expect(src).toBeDefined();
+        // The injected payload must never appear as executable top-level code — only inside a comment.
+        // The generator only ever emits `import`/`export const <name>` lines itself, so `globalThis`,
+        // `require(`, and a bare `export {}` are unambiguous tells of an escaped injection.
+        for (const raw of (src as string).split('\n')) {
+            const line = raw.trim();
+            if (line.startsWith('//')) continue; // comment lines are safe (that's the point)
+            expect(line).not.toMatch(/^globalThis\b/);
+            expect(line).not.toMatch(/^require\(/);
+            expect(line).not.toMatch(/^export\s*\{\s*\}\s*;?$/);
+        }
+        // The whole summary is collapsed onto the single `// ` comment line.
+        expect(src).toMatch(/\/\/ List pets export \{\}; globalThis\.PWNED=1;/);
+    });
+
+    // F1 (also): a `\n` in a path is emitted into `// <METHOD> <path>` and must not break out either.
+    test('F1: newline in path cannot break out of the // comment', () => {
+        const evil: OpenApiDoc = {
+            openapi: '3.0.0',
+            info: { title: 'T', version: '1' },
+            paths: {
+                '/evil\nexport const PWNED = 1;\n//': {
+                    get: { operationId: 'evilPath', responses: { '200': {} } },
+                },
+            },
+        };
+        const r = planGen(evil, { all: true });
+        const src = file(r, 'evil-path/index.ts') as string;
+        expect(src).toBeDefined();
+        for (const line of src.split('\n')) {
+            expect(line).not.toMatch(/^\s*export\s+const\s+PWNED/);
+        }
+    });
+
+    // F1 (also): a `\n` in a query-parameter name is echoed into the `// query params:` comment.
+    test('F1: newline in a query-param name cannot break out of the // comment', () => {
+        const evil: OpenApiDoc = {
+            openapi: '3.0.0',
+            info: { title: 'T', version: '1' },
+            paths: {
+                '/search': {
+                    get: {
+                        operationId: 'search',
+                        parameters: [
+                            {
+                                name: 'q\nexport const PWNED = 2;\n// ',
+                                in: 'query',
+                                schema: { type: 'string' },
+                            },
+                        ],
+                        responses: { '200': {} },
+                    },
+                },
+            },
+        };
+        const r = planGen(evil, { all: true });
+        const src = file(r, 'search/index.ts') as string;
+        expect(src).toBeDefined();
+        for (const line of src.split('\n')) {
+            expect(line).not.toMatch(/^\s*export\s+const\s+PWNED/);
+        }
+    });
+
+    // F2 (HIGH, credential leak): `user:pass@` embedded in a server URL must never be baked into the
+    // committed client.ts. README promises "the secret is never emitted".
+    test('F2: server-url userinfo is stripped from the emitted baseUrl', () => {
+        const withCreds: OpenApiDoc = {
+            openapi: '3.0.0',
+            info: { title: 'T', version: '1' },
+            servers: [{ url: 'https://admin:s3cr3t@internal/api' }],
+            paths: {
+                '/x': {
+                    get: { operationId: 'getX', responses: { '200': {} } },
+                },
+            },
+        };
+        const r = planGen(withCreds, { all: true });
+        const client = file(r, 'client.ts') as string;
+        expect(client).toBeDefined();
+        expect(client).toMatch(/baseUrl:/); // baseUrl is still emitted…
+        expect(client).not.toContain('s3cr3t'); // …but with no secret
+        expect(client).not.toContain('admin:s3cr3t');
+        expect(client).not.toMatch(/admin:s3cr3t@/);
+        expect(client).toContain('internal/api'); // host/path preserved
+        // And the leak isn't laundered through any other emitted file either.
+        for (const f of r.files) expect(f.contents).not.toContain('s3cr3t');
+    });
+
+    // F3 (MEDIUM, reserved word): operationId "delete" must not emit `export const delete` /
+    // `export { delete }` (both SyntaxErrors).
+    test('F3: reserved-word operationId is prefixed, not emitted bare', () => {
+        const reserved: OpenApiDoc = {
+            openapi: '3.0.0',
+            info: { title: 'T', version: '1' },
+            paths: {
+                '/pets/{id}': {
+                    delete: {
+                        operationId: 'delete',
+                        responses: { '200': {} },
+                    },
+                },
+            },
+        };
+        const r = planGen(reserved, { all: true });
+        expect(r.selected.map((s) => s.name)).toContain('opDelete');
+        expect(r.selected.map((s) => s.name)).not.toContain('delete');
+        const index = file(r, 'index.ts') as string;
+        expect(index).toMatch(/export \{ opDelete \}/);
+        // No bare reserved word as an export identifier.
+        expect(index).not.toMatch(/export \{ delete \}/);
+        expect(index).not.toMatch(/\bconst delete\b/);
+    });
+
+    // F4 (MEDIUM, flat-layout shared-import gap): a PRIVATE inlined component that references a
+    // SHARED component must still get an `import type { Shared }` in the op file, else TS2304.
+    test('F4: flat-layout inlined private type imports the shared type it references', () => {
+        // Wrapper is private (one op). Shared is used by two ops → placed in _shared/. Wrapper
+        // references Shared, so the flat op file that inlines Wrapper must import Shared.
+        const d: OpenApiDoc = {
+            openapi: '3.0.0',
+            info: { title: 'T', version: '1' },
+            components: {
+                schemas: {
+                    Shared: {
+                        type: 'object',
+                        properties: { id: { type: 'integer' } },
+                    },
+                    Wrapper: {
+                        type: 'object',
+                        properties: {
+                            item: { $ref: '#/components/schemas/Shared' },
+                        },
+                    },
+                },
+            },
+            paths: {
+                '/wrapped': {
+                    get: {
+                        operationId: 'getWrapped',
+                        responses: {
+                            '200': {
+                                content: {
+                                    'application/json': {
+                                        schema: {
+                                            $ref: '#/components/schemas/Wrapper',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                // Second consumer of Shared → forces Shared to be shared, not inlined.
+                '/direct': {
+                    get: {
+                        operationId: 'getDirect',
+                        responses: {
+                            '200': {
+                                content: {
+                                    'application/json': {
+                                        schema: {
+                                            $ref: '#/components/schemas/Shared',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const r = planGen(d, { all: true, layout: 'flat' });
+        const src = file(r, 'get-wrapped.ts') as string;
+        expect(src).toBeDefined();
+        expect(src).toMatch(/type Wrapper =/); // Wrapper is inlined…
+        // …and the shared type it references is imported (was silently dropped before the fix).
+        expect(src).toMatch(
+            /import type \{ Shared \} from '\.\/_shared\/shared';/,
+        );
+    });
+
+    // F5 (MEDIUM, denial-of-build): a `\n` in a spec string emitted through a `'...'` literal
+    // (baseUrl, path) must be escaped, not left raw (which is an unterminated-string SyntaxError).
+    test('F5: newline in a path literal is escaped, not a raw newline', () => {
+        const d: OpenApiDoc = {
+            openapi: '3.0.0',
+            info: { title: 'T', version: '1' },
+            paths: {
+                '/a\nb': {
+                    get: { operationId: 'ab', responses: { '200': {} } },
+                },
+            },
+        };
+        const r = planGen(d, { all: true });
+        const src = file(r, 'ab/index.ts') as string;
+        expect(src).toBeDefined();
+        // The `path: '...'` literal must contain an escaped `\n`, never a raw one.
+        const m = /path: '((?:[^'\\]|\\.)*)'/.exec(src);
+        expect(m).not.toBeNull();
+        expect((m as RegExpExecArray)[1]).toContain('\\n');
+        expect((m as RegExpExecArray)[1]).not.toContain('\n');
+        // Round-trip: the emitted literal parses back to the original path.
+        // eslint-disable-next-line no-eval
+        expect(eval(`'${(m as RegExpExecArray)[1]}'`)).toBe('/a\nb');
+    });
+
+    // F5 (also): a `\n` in the server URL literal is escaped too.
+    test('F5: newline in a baseUrl literal is escaped, not a raw newline', () => {
+        const d: OpenApiDoc = {
+            openapi: '3.0.0',
+            info: { title: 'T', version: '1' },
+            servers: [{ url: 'https://api.example.com\nBROKEN' }],
+            paths: {
+                '/x': {
+                    get: { operationId: 'getX', responses: { '200': {} } },
+                },
+            },
+        };
+        const r = planGen(d, { all: true });
+        const client = file(r, 'client.ts') as string;
+        const m = /baseUrl: '((?:[^'\\]|\\.)*)'/.exec(client);
+        expect(m).not.toBeNull();
+        expect((m as RegExpExecArray)[1]).not.toContain('\n');
+    });
+});


### PR DESCRIPTION
## Summary — **security** (build-time RCE + credential leak)

The `@stitchapi/openapi` codegen turns an **UNTRUSTED** OpenAPI document into TS source the developer compiles, so spec text (summary, path, param names, server URL, `operationId`) is attacker-controlled input. This is a **review-sweep finding on merged #328** — a CRITICAL build-time RCE and a HIGH credential leak are **live in `main`**.

All five defects fixed minimally in `packages/openapi/src/gen-openapi.ts`, each with a regression test that fails before / passes after (confirmed red→green by reverting each fix individually).

> ⚠️ **Human-merge only — do not auto-merge.** Marked `!` (breaking) because generated identifiers/comments/baseUrl change for hostile-or-reserved specs.

## Findings

### F1 — CRITICAL (security): build-time RCE via comment newline injection
`summary`, `path`, and query-param `name`s were interpolated into `//` comments in the generated source **without stripping newlines**. A `summary: "List pets\nexport {};\nglobalThis.PWNED=1;\nrequire('child_process').execSync('id');\n// x"` emitted those lines as **top-level TS that RUNS when the developer compiles/imports** the generated file.
**Fix:** shared `comment(s)` helper collapses every line terminator (LF, CR, U+2028, U+2029) to a space and defangs `*/`; routed all three comment sites (summary, path, query-param names) through it. Verified `gen-openapi.ts` is the only emission point (`cli.ts` just calls `planGen`).

### F2 — HIGH (security): credential leak in emitted `baseUrl`
`server.url` was emitted verbatim as `baseUrl`, baking `admin:s3cr3t` from `servers:[{url:'https://admin:s3cr3t@internal/api'}]` into the committed `client.ts` — contradicting the README's "the secret is never emitted".
**Fix:** `stripUserinfo()` (via `URL`, with a regex fallback for relative/template server URLs) sanitizes the server URL **at the source**, before both the emit and the multi-server warning; emits a warning when credentials are stripped. Host/path preserved.

### F3 — MEDIUM (correctness): reserved-word identifier
`safeIdent` guaranteed only a valid first char, so `operationId: "delete"` emitted `export const delete` **and** `export { delete }` (both SyntaxErrors).
**Fix:** reserved words / module keywords now get the same `op`+Pascal prefix as an invalid first char (`delete` → `opDelete`).

### F4 — MEDIUM (correctness): flat-layout shared-import gap
`collectInlinePrivate` recursed only into other *private* refs, so a private inlined component referencing a **SHARED** component emitted the inline `type` but no `import type { Shared }` → TS2304 in flat layout.
**Fix:** it now adds `import type` lines (via `fileOfComponent`/`relImport`) for transitive shared (and dir-private) refs instead of dropping them.

### F5 — MEDIUM: denial-of-build via unescaped newline in string literal
`q()` escaped `\` and `'` but **not** line terminators, so a `\n` in a spec string (baseUrl, path) became a raw newline inside a `'...'` literal → unterminated-string SyntaxError.
**Fix:** `q()` now escapes `\n`, `\r`, and U+2028/U+2029. (Distinct from F1, which is about comments.)

## Regression tests
`packages/openapi/test/gen-openapi.spec.ts` → `describe('planGen — untrusted-spec safety')`. Each confirmed **red before / green after** by reverting its fix:

| Test | Finding | Red→green evidence |
|---|---|---|
| `F1: newline in summary cannot break out of the // comment (no injected top-level code)` | F1 | RED w/o `comment()` (injected `export {}`/`globalThis` become top-level) → GREEN |
| `F1: newline in path cannot break out of the // comment` | F1 | RED (`export const PWNED` top-level) → GREEN |
| `F1: newline in a query-param name cannot break out of the // comment` | F1 | RED (`export const PWNED` top-level) → GREEN |
| `F2: server-url userinfo is stripped from the emitted baseUrl` | F2 | RED (`s3cr3t` in client.ts) → GREEN |
| `F3: reserved-word operationId is prefixed, not emitted bare` | F3 | RED (name is bare `delete`) → GREEN |
| `F4: flat-layout inlined private type imports the shared type it references` | F4 | RED (no `import type { Shared }`) → GREEN |
| `F5: newline in a path literal is escaped, not a raw newline` | F5 | RED (raw `\n` in literal) → GREEN |
| `F5: newline in a baseUrl literal is escaped, not a raw newline` | F5 | RED (raw `\n` in literal) → GREEN |

## Verification
- `pnpm test` (packages/openapi): **18 passed** (10 pre-existing + 8 new).
- `pnpm check:types`: clean.
- `pnpm build`: success (CJS + ESM + DTS).
- `prettier --check` on both changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)