### PR TITLE
fix(core): don't forward auth headers across cross-origin redirects (credential leak)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <a href="https://www.npmjs.com/package/stitchapi"><img alt="npm version" src="https://img.shields.io/npm/v/stitchapi?color=2563EB&label=npm" /></a>
   <a href="https://www.npmjs.com/package/stitchapi?activeTab=dependencies"><img alt="Dependencies: 0" src="https://img.shields.io/badge/dependencies-0-brightgreen" /></a>
   <img alt="npm bundle size (minified + gzipped)" src="https://img.shields.io/bundlephobia/minzip/stitchapi" />
-  <img alt="Bundle: ~24 kB min+gzip" src="https://img.shields.io/badge/min%2Bgzip-~24%20kB-2563EB" />
+  <img alt="Bundle: ~25 kB min+gzip" src="https://img.shields.io/badge/min%2Bgzip-~25%20kB-2563EB" />
 </p>
 
 <!-- yakir:readme-badges -->
@@ -36,7 +36,7 @@
 <!-- /yakir:readme-badges -->
 
 <p align="center">
-  <strong>Zero runtime dependencies · ~24&nbsp;kB min+gzip</strong> — a typical <code>import { stitch }</code> tree-shakes to ~20&nbsp;kB, and with no transitive tree there is nothing else to install or audit. The size is an <a href="packages/core/scripts/bundle-size.mjs">enforced budget in CI</a>, not an aspiration.
+  <strong>Zero runtime dependencies · ~25&nbsp;kB min+gzip</strong> — a typical <code>import { stitch }</code> tree-shakes to ~20&nbsp;kB, and with no transitive tree there is nothing else to install or audit. The size is an <a href="packages/core/scripts/bundle-size.mjs">enforced budget in CI</a>, not an aspiration.
 </p>
 
 > [!NOTE]
@@ -149,7 +149,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 -   **Pluggable state store** — throttle counters and sessions behind a 3-method store; swap in Redis/Postgres to go distributed.
 -   **Zero-infra observability** — tracing is **off by default**; opt in per stitch or via `STITCH_TRACE_*` env vars. No collector, no dashboard.
 -   **Four front doors, one definition** — in-process function, CLI (`stitch run`), HTTP (`stitch serve`), and MCP (`stitch mcp`).
--   **Zero runtime dependencies** — `"dependencies": {}`, built on global `fetch`, tree-shakeable; **~24 kB min+gzip** for the whole entry, **~20 kB** for a typical `import { stitch }`.
+-   **Zero runtime dependencies** — `"dependencies": {}`, built on global `fetch`, tree-shakeable; **~25 kB min+gzip** for the whole entry, **~20 kB** for a typical `import { stitch }`.
 
 ## Install
 

--- a/apps/docs/app/(home)/components/metrics.tsx
+++ b/apps/docs/app/(home)/components/metrics.tsx
@@ -5,7 +5,7 @@ const metrics = [
         body: 'Built on the platform’s global fetch — nothing to install, nothing to audit, nothing in your transitive tree.',
     },
     {
-        value: '~24 kB',
+        value: '~25 kB',
         unit: 'min + gzip',
         body: 'The whole stitchapi entry, tree-shaken — and it is an enforced budget in CI, not an aspiration.',
     },

--- a/apps/docs/content/docs/concepts/principles.mdx
+++ b/apps/docs/content/docs/concepts/principles.mdx
@@ -105,7 +105,7 @@ behind its own import — so an app never ships bytes for a CLI it will not run.
 The same frugality the event stream practices with an agent's context, the
 package practices with your bundle.
 
-Concretely, the whole `stitch` entry is **~24 kB minified + gzipped**
+Concretely, the whole `stitch` entry is **~25 kB minified + gzipped**
 (≈61 kB raw), and because every surface beyond `http` is a separate subpath
 import, a typical `import { stitch }` tree-shakes to **~20 kB**. With zero
 runtime dependencies, that figure is the entire cost — not the tip of a

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -5,7 +5,7 @@ description: 'Install stitchapi and set up the zero-dependency runtime in Node o
 
 Install the package, import `stitch`, and turn your first endpoint into a typed,
 callable function. `stitchapi` has zero dependencies and runs anywhere `fetch`
-does — Node, the browser, and edge runtimes. The whole entry is **~24 kB
+does — Node, the browser, and edge runtimes. The whole entry is **~25 kB
 minified + gzipped** — and with no dependencies, there is no transitive tree
 behind it (a typical `import { stitch }` tree-shakes to ~20 kB).
 

--- a/apps/docs/lib/source.ts
+++ b/apps/docs/lib/source.ts
@@ -25,7 +25,7 @@ Search these docs instead of loading the whole file: this site is also a hosted 
 - Capability, not credential: an agent invokes a stitch and gets structured, validated, traceable data; the secret stays behind the boundary.
 - One context-frugal **code-mode** tool (run_stitch + list_stitches + describe_stitch), not one tool per endpoint — adding APIs never floods the context window.
 - No server, no codegen, no config files — a URL and one example response is enough; only explicit composition (no ambient/global config a stitch silently inherits).
-- Zero-dependency core, ~24 kB min+gzip for the whole entry (~20 kB for a tree-shaken import { stitch }), validator-agnostic (bring your own Standard Schema / Zod), and it runs in the browser.
+- Zero-dependency core, ~25 kB min+gzip for the whole entry (~20 kB for a tree-shaken import { stitch }), validator-agnostic (bring your own Standard Schema / Zod), and it runs in the browser.
 - Composes with your data layer: a stitch is the queryFn for TanStack Query / SWR — it owns the call's resilience; your query layer owns view state.
 
 ## Quickstart

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -120,7 +120,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 -   **CLI, HTTP & MCP surfaces** - the definition your code imports is also runnable from the shell (`stitch run <name>` streams JSONL events), served over HTTP (`stitch serve`), or exposed to agents over MCP (`stitch mcp`) — the same stitch behind every front door.
 -   **Typed URLs** - full [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) URI templates (`{id}`, `{+path}`, `{?q,sort}`, explode `*`, prefix `:n`), and a `qs`-style query builder that serializes nested objects (`a[b]=c`) and arrays — both dependency-free.
 -   **Pluggable transport** - `fetch` by default; drop in the shipped `axiosAdapter`, or any `Adapter` function, to route requests through axios or another HTTP client.
--   **Zero runtime dependencies** - `"dependencies": {}`; built on the platform's global `fetch`; tree-shakeable. The whole entry is **~24 kB min+gzip**; a typical `import { stitch }` trims to **~20 kB** — and with no transitive tree, that is the entire cost.
+-   **Zero runtime dependencies** - `"dependencies": {}`; built on the platform's global `fetch`; tree-shakeable. The whole entry is **~25 kB min+gzip**; a typical `import { stitch }` trims to **~20 kB** — and with no transitive tree, that is the entire cost.
 
 ## Documentation
 
@@ -162,7 +162,7 @@ const { stitch } = require("stitchapi");
 
 The runtime ships with zero dependencies. Schema validation is bring-your-own — pass a [Zod](https://zod.dev) schema or any [Standard Schema](https://standardschema.dev) validator ([Valibot](https://valibot.dev), [ArkType](https://arktype.io), …); none of them is bundled. The examples below use Zod for familiarity.
 
-**Bundle size.** The whole `stitchapi` entry is **~24 kB minified + gzipped** (~64 kB raw, ~20 kB brotli); because the package is side-effect-free and every surface beyond `http` lives behind its own subpath import, a typical `import { stitch }` tree-shakes to **~20 kB min+gzip**. With zero dependencies, that is the _whole_ cost — there is no transitive tree to install or audit.
+**Bundle size.** The whole `stitchapi` entry is **~25 kB minified + gzipped** (~64 kB raw, ~20 kB brotli); because the package is side-effect-free and every surface beyond `http` lives behind its own subpath import, a typical `import { stitch }` tree-shakes to **~20 kB min+gzip**. With zero dependencies, that is the _whole_ cost — there is no transitive tree to install or audit.
 
 ## Quick start
 

--- a/packages/core/scripts/bundle-size.mjs
+++ b/packages/core/scripts/bundle-size.mjs
@@ -105,16 +105,31 @@ const KB = 1024;
 // at the same collapsed `[]` path — so it isn't optional and sits in the shared drift/classify layer
 // that feeds both the `drift` event and `Inspection.findings`; it can't move to a subpath. It adds
 // ~0.04 / ~0.03 KB gzip. The step restores the same tight ~0.2 KB headroom the gate is meant to hold.
+//
+// Budgets raised for the cross-origin-redirect credential-leak fix (24.20→24.80 / 19.70→20.00 KB;
+// measured 24.60 / 19.80). SECURITY (HIGH): auth strategies put credentials in CUSTOM request
+// headers (`apiKey` → `x-api-key`; `awsSigV4` → `authorization` + `x-amz-*`). undici (and axios's
+// follow-redirects) strip `authorization`/`cookie` on a cross-origin redirect but NOT custom
+// headers, so those keys leaked to a redirect target on another origin (open-redirect / compromised
+// endpoint) — a "capability, not a credential" break. The fix makes `fetchAdapter` follow redirects
+// itself (`redirect: 'manual'` + a bounded manual-follow loop) and, on a cross-origin hop, drop
+// every non-CORS-safelisted request header (auth/cookie/custom); `axiosAdapter` does the same via a
+// `beforeRedirect` hook. Both share one tiny origin-check + header-strip helper. This sits on the
+// hot request path (fetchAdapter is the default transport, so it lifts `import { stitch }` as much
+// as the whole entry) and is browser-safe (no node:*), so it cannot move to a subpath. It adds ~0.43
+// / ~0.28 KB gzip. The step restores the same tight ~0.2 KB headroom the gate is meant to hold. The
+// cost buys closing a HIGH credential-exfiltration hole — a deliberate trade the maintainer signs off
+// on by merging (see PR body for the exact before/after/Δ).
 const SCENARIOS = [
     {
         name: 'stitchapi — whole entry',
         code: `export * from './index.mjs';`,
-        budget: 24.2 * KB,
+        budget: 24.8 * KB,
     },
     {
         name: 'import { stitch }',
         code: `export { stitch } from './index.mjs';`,
-        budget: 19.7 * KB,
+        budget: 20.0 * KB,
     },
 ];
 

--- a/packages/core/src/axios-adapter.ts
+++ b/packages/core/src/axios-adapter.ts
@@ -10,7 +10,11 @@
 // bytes (responseType 'arraybuffer') and told never to throw on non-2xx — the engine
 // decides what a given status means.
 import { compact } from './compact';
-import { decodeResponseBody, encodeRequestBody } from './http-adapter';
+import {
+    decodeResponseBody,
+    encodeRequestBody,
+    headersForRedirect,
+} from './http-adapter';
 import type {
     Adapter,
     AdapterProgress,
@@ -103,6 +107,13 @@ export function axiosAdapter(
                 onUploadProgress: progress('upload'),
                 onDownloadProgress: progress('download'),
                 validateStatus: () => true, // never throw on non-2xx; the engine decides
+                // Credential-leak guard on redirects (same policy as fetchAdapter): axios follows
+                // 3xx via follow-redirects, which strips `authorization`/`cookie` cross-origin but
+                // NOT custom auth headers (`x-api-key`, `x-amz-*`) — so a redirect to another host
+                // would leak them. This hook fires before each hop; when the next hop leaves the
+                // ORIGINAL origin we replace the outgoing headers with the CORS-safelisted subset
+                // (headersForRedirect drops everything else). Same-origin hops keep headers intact.
+                beforeRedirect: makeBeforeRedirect(req.url, headers),
             }),
         );
 
@@ -127,6 +138,54 @@ export function axiosAdapter(
 
 const hasHeader = (headers: Record<string, string>, name: string): boolean =>
     Object.keys(headers).some((k) => k.toLowerCase() === name.toLowerCase());
+
+// Build the axios/follow-redirects `beforeRedirect(options)` hook that enforces the
+// cross-origin credential-strip policy shared with fetchAdapter. `options` describes the NEXT
+// request; follow-redirects lets the hook mutate `options.headers` in place. We reconstruct the
+// destination URL from `options` and, when it leaves the ORIGINAL request origin, overwrite the
+// header set with only the CORS-safelisted subset (headersForRedirect) — dropping every
+// credential/custom header. Comparing each hop against the original origin is correct: once a
+// chain leaves the origin, the original credentials must never reappear downstream.
+function makeBeforeRedirect(
+    originalUrl: string,
+    originalHeaders: Record<string, string>,
+): (options: Record<string, unknown>) => void {
+    return (options) => {
+        // follow-redirects carries the next hop's headers on `options.headers`; use them when
+        // present, else the headers we sent. Reassign the whole object (the documented way to
+        // change headers from beforeRedirect) — no dynamic delete, and it replaces the reference
+        // follow-redirects reads. Unknown destination shape → dest '' fails safe (cross-origin).
+        const current = options['headers'];
+        const from: Record<string, string> = isStringRecord(current)
+            ? current
+            : originalHeaders;
+        options['headers'] = headersForRedirect(
+            from,
+            originalUrl,
+            redirectHref(options) ?? '',
+        );
+    };
+}
+
+// Narrow an unknown to a string-keyed header record (a plain object). Used to read the outgoing
+// headers off the follow-redirects `options` bag without an unchecked assertion.
+function isStringRecord(v: unknown): v is Record<string, string> {
+    return typeof v === 'object' && v !== null;
+}
+
+// Reconstruct the absolute destination URL from a follow-redirects `options` bag. It exposes the
+// parsed target as `href`, or as `protocol` + `host`/`hostname`(+`port`) + `path`. Returns
+// undefined if nothing usable is present (caller then fails safe and strips).
+function redirectHref(options: Record<string, unknown>): string | undefined {
+    const href = options['href'];
+    if (typeof href === 'string' && href) return href;
+    const protocol = options['protocol'];
+    const host = options['host'] ?? options['hostname'];
+    if (typeof protocol === 'string' && typeof host === 'string' && host) {
+        return `${protocol}//${host}`;
+    }
+    return undefined;
+}
 
 // Lowercase header keys to match fetchAdapter; join a multi-valued set-cookie with ', '.
 function normalizeHeaders(

--- a/packages/core/src/http-adapter.ts
+++ b/packages/core/src/http-adapter.ts
@@ -48,17 +48,26 @@ export function fetchAdapter(opts?: FetchAdapterOptions): Adapter {
 
         // Build the init as a typed local; `compact` drops `body`/`dispatcher` when absent,
         // so the non-standard `dispatcher` key stays off unless a dispatcher is supplied.
+        // `redirect: 'manual'` — we follow redirects ourselves (see followRedirects) so a
+        // cross-origin hop drops the auth/custom headers instead of leaking them.
         const init: FetchInitWithDispatcher = compact({
             method,
             headers,
             body,
             signal: req.signal,
             dispatcher: opts?.dispatcher,
+            redirect: 'manual',
         });
 
-        // Send the request. Network/abort errors propagate to the caller. The local init type
-        // (with the undici-only `dispatcher`) widens cleanly to the RequestInit fetch expects.
-        const response = await fetchImpl(req.url, init);
+        // Send the request and follow any redirects ourselves, stripping credential/custom
+        // headers on cross-origin hops. Network/abort errors propagate to the caller. The
+        // local init type (with the undici-only `dispatcher`) widens cleanly to RequestInit.
+        const { response, url: finalUrl } = await followRedirects(
+            fetchImpl,
+            req.url,
+            init,
+            headers,
+        );
 
         // Collect response headers with lowercased keys; join multiple set-cookie with ', '.
         const resHeaders: Record<string, string> = {};
@@ -85,7 +94,7 @@ export function fetchAdapter(opts?: FetchAdapterOptions): Adapter {
                 status: response.status,
                 headers: resHeaders,
                 body: response.body,
-                url: response.url,
+                url: finalUrl,
             };
         }
 
@@ -98,7 +107,7 @@ export function fetchAdapter(opts?: FetchAdapterOptions): Adapter {
                 status: response.status,
                 headers: resHeaders,
                 body: decodeResponseBody(req.responseType, contentType, bytes),
-                url: response.url,
+                url: finalUrl,
             };
         }
 
@@ -132,7 +141,7 @@ export function fetchAdapter(opts?: FetchAdapterOptions): Adapter {
             status: response.status,
             headers: resHeaders,
             body: parsed,
-            url: response.url,
+            url: finalUrl,
         };
     };
     // `fetch` streams a response (so `stream`/`sse` ride it) and reports `phase: 'download'`
@@ -187,8 +196,121 @@ async function readWithProgress(
     return out.buffer;
 }
 
+// Hop cap — matches the platform default (Node/undici stop at 20) so a redirect loop can't spin.
+const MAX_REDIRECTS = 20;
+
+// Send a request with `redirect: 'manual'` and follow any redirects OURSELVES, so a cross-origin
+// hop drops the auth/custom headers (headersForRedirect) instead of leaking them — undici/axios
+// only strip `authorization`/`cookie`, never custom headers like `x-api-key`/`x-amz-*`.
+//
+// Browser semantics: with `redirect: 'manual'` a browser returns an OPAQUE-redirect response
+// (`type: 'opaqueredirect'`, status 0, no readable Location) that cannot be followed from JS. We
+// detect that (no `location`) and return it as-is — the browser is already following the redirect
+// under CORS, which itself prevents the cross-origin custom-header leak (preflight). So:
+// manual-follow where the 3xx is readable (Node/undici), platform-safe otherwise. Returns the
+// final response and the URL it came from (for AdapterResponse.url).
+async function followRedirects(
+    fetchImpl: typeof fetch,
+    startUrl: string,
+    init: FetchInitWithDispatcher,
+    startHeaders: Record<string, string>,
+): Promise<{ response: Response; url: string }> {
+    let url = startUrl;
+    let headers = startHeaders;
+    let method = init.method ?? 'GET';
+    let body = init.body;
+    for (let hop = 0; ; hop++) {
+        const response = await fetchImpl(
+            url,
+            compact({ ...init, method, headers, body }),
+        );
+        const status = response.status;
+        const location =
+            status >= 300 && status < 400
+                ? response.headers.get('location')
+                : null;
+        // Not a followable redirect (normal response, an opaque-redirect in the browser, or a
+        // 3xx with no Location) → hand it back. Stop before exceeding the hop cap too.
+        if (location === null || hop >= MAX_REDIRECTS) return { response, url };
+        const next = new URL(location, url).toString();
+        // Strip credential/custom headers when the next hop leaves the origin (the whole point).
+        headers = headersForRedirect(headers, url, next);
+        // Fetch redirect model: 303 (and 301/302 on a non-GET/HEAD) become a bodyless GET; 307/308
+        // keep method and body. Rebuild headers without content-type when the body is dropped —
+        // and always via a fresh object, since a same-origin headersForRedirect aliased the input.
+        if (
+            status === 303 ||
+            (status < 303 && method !== 'GET' && method !== 'HEAD')
+        ) {
+            method = 'GET';
+            body = undefined;
+            const stripped: Record<string, string> = {};
+            for (const [k, v] of Object.entries(headers))
+                if (k.toLowerCase() !== 'content-type') stripped[k] = v;
+            headers = stripped;
+        }
+        url = next;
+    }
+}
+
 const hasHeader = (headers: Record<string, string>, name: string): boolean =>
     Object.keys(headers).some((k) => k.toLowerCase() === name.toLowerCase());
+
+// ---- cross-origin redirect credential guard -------------------------------
+// Auth strategies put credentials in CUSTOM request headers (`apiKey` → `x-api-key`;
+// `awsSigV4` → `authorization` + `x-amz-*`). The default HTTP redirect policy re-sends
+// every request header to the redirect target. undici/axios strip `authorization`/`cookie`
+// on a cross-origin hop but NOT custom headers, so `x-api-key`/`x-amz-*` would leak to an
+// unintended host (open-redirect / compromised endpoint) — the "capability, not a
+// credential" invariant. So on a CROSS-origin hop we keep only the CORS request-header
+// safelist (accept / accept-language / content-language / content-type) and drop the rest
+// — which covers `authorization`, `cookie`, `proxy-authorization`, and every custom auth
+// header at once. Same-origin hops keep headers intact (the common case; auth continues).
+// This is the browser's own fetch redirect model, applied on Node where the platform
+// wouldn't. Shared by both the fetch manual-follow loop and the axios `beforeRedirect` hook
+// so the policy is identical (and to keep the added bundle cost to one tiny function).
+
+// Same origin = same scheme + host + port. `URL.host` includes the port, so comparing
+// protocol + host covers all three (an implicit-vs-explicit default port like :443 is the one
+// edge this over-strips — acceptable, it only ever errs toward dropping credentials). `a` is
+// the current absolute request URL, `b` the resolved (absolute) redirect target.
+const sameOrigin = (a: string, b: string): boolean => {
+    try {
+        const ua = new URL(a);
+        const ub = new URL(b);
+        return ua.protocol === ub.protocol && ua.host === ub.host;
+    } catch {
+        return false; // unparseable → treat as cross-origin (fail safe: strip)
+    }
+};
+
+// The CORS-safelisted request header names — the only ones a browser forwards on a
+// cross-origin redirect. Everything else (auth/cookie/custom) is dropped.
+const CORS_SAFELIST = new Set([
+    'accept',
+    'accept-language',
+    'content-language',
+    'content-type',
+]);
+
+/**
+ * Given the headers for the hop from `from` to `to`, return the headers to actually send:
+ * unchanged when same-origin, or only the CORS-safelisted subset when cross-origin (dropping
+ * every credential/custom header). Exported for the axios adapter's `beforeRedirect` hook and
+ * the fetch manual-follow loop to share one policy.
+ */
+export function headersForRedirect(
+    headers: Record<string, string>,
+    from: string,
+    to: string,
+): Record<string, string> {
+    if (sameOrigin(from, to)) return headers;
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(headers)) {
+        if (CORS_SAFELIST.has(k.toLowerCase())) out[k] = v;
+    }
+    return out;
+}
 
 // Encode a request body per `bodyType` (default 'json'). Shared across transports so
 // form/multipart/json encoding is identical regardless of the underlying HTTP client.

--- a/packages/core/src/xhr-adapter.ts
+++ b/packages/core/src/xhr-adapter.ts
@@ -4,6 +4,14 @@
 // behaviour matches fetchAdapter exactly. It is buffered-only — it rejects `req.stream` (use
 // fetchAdapter to stream). Like axiosAdapter takes its client, this takes an optional XHR
 // constructor (default `globalThis.XMLHttpRequest`) so it is testable off-browser.
+//
+// CROSS-ORIGIN REDIRECT credential leak (the fetch/axios adapters guard against this explicitly):
+// xhr needs NO such guard. The browser follows redirects internally and re-applies CORS on the
+// resulting cross-origin request — a custom request header like `x-api-key`/`x-amz-*` is not on
+// the CORS-safelist, so the browser only sends it after a successful preflight the target host
+// opted into (Access-Control-Allow-Headers). It is never silently forwarded to an unintended
+// origin from JS. (JS also can't read Location or intercept the hop here, so there's nothing to
+// strip.) Same protection fetchAdapter reconstructs by hand on Node, where the platform doesn't.
 import { decodeResponseBody, encodeRequestBody } from './http-adapter';
 import type { Adapter, AdapterRequest, AdapterResponse } from './types';
 

--- a/packages/core/test/gaps/redirect-credential-leak.spec.ts
+++ b/packages/core/test/gaps/redirect-credential-leak.spec.ts
@@ -1,0 +1,333 @@
+// SECURITY (HIGH) — credential exfiltration on a cross-origin redirect.
+//
+// Auth strategies put credentials in CUSTOM request headers: `apiKey` → `x-api-key`, `awsSigV4`
+// → `authorization` + `x-amz-*`. When an endpoint answers a request with a 3xx redirect, the
+// DEFAULT HTTP redirect policy re-sends every request header to the target. undici (Node's fetch)
+// and axios's follow-redirects strip `authorization`/`cookie` on a CROSS-origin hop but NOT custom
+// headers — so `x-api-key` / `x-amz-*` would leak to an attacker-controlled or unintended host
+// (open-redirect, compromised endpoint). That breaks the "capability, not a credential" invariant.
+//
+// The fix: fetchAdapter follows redirects itself (`redirect: 'manual'` + a bounded loop) and, on a
+// cross-origin hop, drops every non-CORS-safelisted request header; axiosAdapter installs a
+// `beforeRedirect` hook that applies the same policy. Same-origin redirects keep the headers (the
+// common case — auth must keep working).
+//
+// These tests FAIL before the fix (the second, redirect-target request still carries the
+// credential) and PASS after. A same-origin companion asserts we don't OVER-strip.
+import { apiKey, axiosAdapter, env, fetchAdapter, stitch } from '../../src';
+import type { AxiosLikeConfig, AxiosLikeResponse } from '../../src';
+import { headersForRedirect } from '../../src/http-adapter';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Keep this suite's trace sink quiet/captured (matches the other adapter specs).
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-redirect-leak-${process.pid}.jsonl`,
+);
+
+// The sensitive headers that must never survive a cross-origin hop.
+const API_KEY = 'sk-secret-key-value';
+const AWS_AUTH = 'AWS4-HMAC-SHA256 Credential=AKIA.../...';
+
+// A fetch spy that returns a scripted redirect chain. Each entry is the (status, headers) of the
+// next response; a 3xx entry must carry a `location`. It records the headers of every request so a
+// test can assert what the redirect target actually received. Typed as `typeof fetch` (the arrow is
+// structurally assignable, so no cast is needed).
+function redirectingFetch(
+    steps: { status: number; headers?: Record<string, string> }[],
+): {
+    fetch: typeof fetch;
+    requests: { url: string; headers: Record<string, string> }[];
+} {
+    const requests: { url: string; headers: Record<string, string> }[] = [];
+    let i = 0;
+    const fetch: typeof globalThis.fetch = (input, init) => {
+        // fetchAdapter always calls fetch with a string URL as the first arg (never a Request).
+        const url = input as string;
+        const headers = (init?.headers ?? {}) as Record<string, string>;
+        requests.push({ url, headers: { ...headers } });
+        const step = steps[Math.min(i, steps.length - 1)];
+        i++;
+        const h = new Headers(step?.headers ?? {});
+        // A terminal 200 returns a tiny JSON body so the adapter's parser has something to read.
+        const body =
+            step && step.status >= 300 && step.status < 400
+                ? ''
+                : '{"ok":true}';
+        if (!h.has('content-type') && body)
+            h.set('content-type', 'application/json');
+        return Promise.resolve(
+            new Response(body || null, {
+                status: step?.status ?? 200,
+                headers: h,
+            }),
+        );
+    };
+    return { fetch, requests };
+}
+
+// Pull a header case-insensitively from a recorded request.
+const hdr = (h: Record<string, string>, name: string): string | undefined => {
+    const k = Object.keys(h).find(
+        (x) => x.toLowerCase() === name.toLowerCase(),
+    );
+    return k ? h[k] : undefined;
+};
+
+describe('fetchAdapter — cross-origin redirect must not forward auth/custom headers', () => {
+    test('a 302 to ANOTHER origin drops x-api-key / authorization / x-amz-* on the second request', async () => {
+        const { fetch: spy, requests } = redirectingFetch([
+            {
+                status: 302,
+                headers: { location: 'https://evil.example.com/steal' },
+            },
+            { status: 200 },
+        ]);
+
+        const res = await fetchAdapter({ fetch: spy })({
+            url: 'https://api.trusted.com/data',
+            method: 'GET',
+            headers: {
+                'x-api-key': API_KEY,
+                authorization: AWS_AUTH,
+                'x-amz-date': '20260703T000000Z',
+                'x-amz-content-sha256': 'abc123',
+            },
+        });
+
+        // Two hops happened: the original request, then the redirect target.
+        expect(requests).toHaveLength(2);
+        expect(requests[0]?.url).toBe('https://api.trusted.com/data');
+        expect(requests[1]?.url).toBe('https://evil.example.com/steal');
+
+        // The whole point: NONE of the credential/custom headers reached the other origin.
+        const leaked = requests[1]?.headers ?? {};
+        expect(hdr(leaked, 'x-api-key')).toBeUndefined();
+        expect(hdr(leaked, 'authorization')).toBeUndefined();
+        expect(hdr(leaked, 'x-amz-date')).toBeUndefined();
+        expect(hdr(leaked, 'x-amz-content-sha256')).toBeUndefined();
+
+        // The response still flowed back, and url reflects the final hop.
+        expect(res.status).toBe(200);
+        expect(res.url).toBe('https://evil.example.com/steal');
+    });
+
+    test('end-to-end: a stitch with apiKey() auth does not leak the key across origins', async () => {
+        const { fetch: spy, requests } = redirectingFetch([
+            {
+                status: 307,
+                headers: { location: 'https://cdn.other.com/mirror' },
+            },
+            { status: 200 },
+        ]);
+        process.env['REDIRECT_TEST_KEY'] = API_KEY;
+
+        const call = stitch({
+            url: 'https://api.trusted.com/thing',
+            method: 'GET',
+            auth: apiKey({ value: env('REDIRECT_TEST_KEY') }),
+            adapter: fetchAdapter({ fetch: spy }),
+        });
+        await call();
+
+        expect(requests).toHaveLength(2);
+        // First (trusted) request carried the key; the cross-origin hop must NOT.
+        expect(hdr(requests[0]?.headers ?? {}, 'x-api-key')).toBe(API_KEY);
+        expect(hdr(requests[1]?.headers ?? {}, 'x-api-key')).toBeUndefined();
+    });
+
+    test('a SAME-origin redirect KEEPS the headers (auth must keep working — do not over-strip)', async () => {
+        const { fetch: spy, requests } = redirectingFetch([
+            {
+                status: 302,
+                headers: { location: 'https://api.trusted.com/v2/data' },
+            },
+            { status: 200 },
+        ]);
+
+        await fetchAdapter({ fetch: spy })({
+            url: 'https://api.trusted.com/data',
+            method: 'GET',
+            headers: { 'x-api-key': API_KEY, authorization: AWS_AUTH },
+        });
+
+        expect(requests).toHaveLength(2);
+        // Same origin → the credential still rides the second request.
+        expect(hdr(requests[1]?.headers ?? {}, 'x-api-key')).toBe(API_KEY);
+        expect(hdr(requests[1]?.headers ?? {}, 'authorization')).toBe(AWS_AUTH);
+    });
+
+    test('a same-origin redirect on a DIFFERENT PORT is treated as cross-origin (host includes port)', async () => {
+        const { fetch: spy, requests } = redirectingFetch([
+            {
+                status: 302,
+                headers: { location: 'https://api.trusted.com:8443/data' },
+            },
+            { status: 200 },
+        ]);
+
+        await fetchAdapter({ fetch: spy })({
+            url: 'https://api.trusted.com/data',
+            method: 'GET',
+            headers: { 'x-api-key': API_KEY },
+        });
+
+        expect(hdr(requests[1]?.headers ?? {}, 'x-api-key')).toBeUndefined();
+    });
+
+    test('caps redirect hops so a redirect loop cannot spin forever', async () => {
+        // Every response is a same-origin 302 → an infinite loop if uncapped. The loop stops at the
+        // hop cap (~20) and returns the last 3xx instead of hanging.
+        const { fetch: spy, requests } = redirectingFetch([
+            {
+                status: 302,
+                headers: { location: 'https://api.trusted.com/loop' },
+            },
+        ]);
+
+        const res = await fetchAdapter({ fetch: spy })({
+            url: 'https://api.trusted.com/loop',
+            method: 'GET',
+            headers: {},
+        });
+
+        expect(res.status).toBe(302);
+        // Bounded: first request + at most 20 follows.
+        expect(requests.length).toBeLessThanOrEqual(21);
+        expect(requests.length).toBeGreaterThan(1);
+    });
+});
+
+// A fake axios instance that captures the config it was handed (so we can drive the installed
+// `beforeRedirect` hook exactly as follow-redirects would) and returns a scripted response.
+function recordingAxios(respond: (cfg: AxiosLikeConfig) => AxiosLikeResponse): {
+    request: (cfg: AxiosLikeConfig) => Promise<AxiosLikeResponse>;
+    calls: AxiosLikeConfig[];
+} {
+    const calls: AxiosLikeConfig[] = [];
+    return {
+        calls,
+        request: async (cfg) => {
+            calls.push(cfg);
+            return respond(cfg);
+        },
+    };
+}
+
+describe('axiosAdapter — beforeRedirect enforces the same cross-origin strip policy', () => {
+    // Drive the adapter once to capture the beforeRedirect hook it installs, then invoke that hook
+    // the way follow-redirects does — with an `options` bag describing the next hop.
+    async function captureHook(): Promise<
+        (options: Record<string, unknown>) => void
+    > {
+        const client = recordingAxios(() => ({
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+            data: Buffer.from('{"ok":true}'),
+        }));
+        await axiosAdapter(client)({
+            url: 'https://api.trusted.com/data',
+            method: 'GET',
+            headers: { 'x-api-key': API_KEY, authorization: AWS_AUTH },
+        });
+        const hook = client.calls[0]?.['beforeRedirect'] as
+            | ((options: Record<string, unknown>) => void)
+            | undefined;
+        if (!hook)
+            throw new Error(
+                'axiosAdapter did not install a beforeRedirect hook',
+            );
+        return hook;
+    }
+
+    test('a cross-origin next hop strips x-api-key + authorization from the outgoing headers', async () => {
+        const hook = await captureHook();
+        // follow-redirects passes the outgoing headers on `options.headers`; the hook resets that
+        // property (the documented way to change headers from beforeRedirect).
+        const options: Record<string, unknown> = {
+            headers: {
+                'x-api-key': API_KEY,
+                authorization: AWS_AUTH,
+                accept: 'application/json',
+            },
+            protocol: 'https:',
+            host: 'evil.example.com',
+            href: 'https://evil.example.com/steal',
+        };
+        hook(options);
+        const sent = options['headers'] as Record<string, string>;
+
+        expect(sent['x-api-key']).toBeUndefined();
+        expect(sent['authorization']).toBeUndefined();
+        // A CORS-safelisted header survives.
+        expect(sent['accept']).toBe('application/json');
+    });
+
+    test('a same-origin next hop KEEPS the headers (does not over-strip)', async () => {
+        const hook = await captureHook();
+        const options: Record<string, unknown> = {
+            headers: { 'x-api-key': API_KEY, authorization: AWS_AUTH },
+            protocol: 'https:',
+            host: 'api.trusted.com',
+            href: 'https://api.trusted.com/v2/data',
+        };
+        hook(options);
+        const sent = options['headers'] as Record<string, string>;
+
+        expect(sent['x-api-key']).toBe(API_KEY);
+        expect(sent['authorization']).toBe(AWS_AUTH);
+    });
+});
+
+describe('headersForRedirect — the shared origin-check + strip policy', () => {
+    const secret = {
+        'x-api-key': API_KEY,
+        authorization: AWS_AUTH,
+        cookie: 'session=abc',
+        'x-amz-date': '20260703T000000Z',
+        accept: 'application/json',
+        'content-type': 'application/json',
+    };
+
+    test('same origin → identical headers (returned by reference for zero-copy)', () => {
+        const out = headersForRedirect(
+            secret,
+            'https://h.example/a',
+            'https://h.example/b',
+        );
+        expect(out).toBe(secret);
+    });
+
+    test('cross origin → only CORS-safelisted headers survive', () => {
+        const out = headersForRedirect(
+            secret,
+            'https://h.example/a',
+            'https://other.example/b',
+        );
+        expect(out).toEqual({
+            accept: 'application/json',
+            'content-type': 'application/json',
+        });
+    });
+
+    test('cross scheme (https→http, same host) is cross-origin', () => {
+        const out = headersForRedirect(
+            secret,
+            'https://h.example/a',
+            'http://h.example/a',
+        );
+        expect(out['x-api-key']).toBeUndefined();
+    });
+
+    test('an unparseable target fails safe (treated as cross-origin, headers stripped)', () => {
+        const out = headersForRedirect(
+            secret,
+            'https://h.example/a',
+            'not a url',
+        );
+        expect(out['x-api-key']).toBeUndefined();
+        expect(out['authorization']).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Security (HIGH) — credential exfiltration on a cross-origin redirect

Auth strategies put credentials in **custom** request headers: `apiKey` → `x-api-key`; `awsSigV4` → `authorization` + `x-amz-*`. When an endpoint answered a request with an HTTP 3xx redirect, both built-in adapters followed it under the **default** redirect policy, which re-sends every request header to the redirect target.

Node's undici (the platform `fetch`) and axios's `follow-redirects` strip `authorization`/`cookie` on a **cross-origin** hop but **not** custom headers — so `x-api-key` / `x-amz-*` leaked to an attacker-controlled or unintended host (open-redirect on the API, or a compromised endpoint that answers `302 Location: https://evil.example.com/...`). That silently breaks StitchAPI's **"capability, not a credential"** invariant (docs/CONTRACT.md, docs/DESIGN.md §5).

Two sinks:
- `packages/core/src/http-adapter.ts` (`fetchAdapter`) — built `init` with no `redirect` option → defaulted to `'follow'`, and undici re-sent custom headers cross-origin.
- `packages/core/src/axios-adapter.ts` — axios followed redirects (follow-redirects on Node) forwarding custom headers.

## Fix — manual follow + cross-origin header strip (one shared policy)

- **`fetchAdapter` (Node + edge/browser):** set `redirect: 'manual'` and follow redirects ourselves in a **bounded loop** (cap **20** hops). On each 3xx with a readable `Location`: resolve the target; **same-origin** → re-issue with headers intact (the common case — auth keeps working); **cross-origin** → re-issue keeping only the **CORS-safelisted** request headers (`accept` / `accept-language` / `content-language` / `content-type`) and dropping everything else — which covers `authorization`, `cookie`, `proxy-authorization`, and every custom auth header at once. Also applies the fetch method rewrite (303, and 301/302 on a non-GET/HEAD, become a bodyless GET).
- **`axiosAdapter`:** installs a `beforeRedirect(options)` hook that applies the **identical** policy (reassigns `options.headers` to the safe subset when the next hop leaves the original origin).
- **`xhrAdapter`:** no change — **documented why**. The browser follows redirects internally and re-applies CORS to the resulting cross-origin request; a custom header is not on the CORS-safelist, so it is only sent after a successful preflight the target opted into (`Access-Control-Allow-Headers`), never silently forwarded from JS. (JS also can't read `Location` or intercept the hop, so there's nothing to strip.)
- Both adapters share **one tiny helper** — `headersForRedirect(headers, from, to)` + `sameOrigin` — so the policy is identical and the added bundle cost is a single function.

### Browser vs Node semantics
In a browser, `redirect: 'manual'` yields an **opaque-redirect** response (`type: 'opaqueredirect'`, status 0, no readable `Location`) that JS can't read or follow. The loop detects that (no matched 3xx / no `Location`) and returns it as-is — the browser is already following the redirect **under CORS**, which itself prevents the cross-origin custom-header leak. So: **manual-follow where the 3xx is readable (Node/undici), platform-safe otherwise.** No `node:*` import touches the hot path — the browser-bundle guard (`test/gaps/browser-bundle.spec.ts`) stays green (21/21), including the "executes a stitch with zero Node globals" case.

## Regression tests — red → green verified

New: `packages/core/test/gaps/redirect-credential-leak.spec.ts` (11 tests). Confirmed **fail-before / pass-after** by neutering the strip in both adapters (4 fail) and restoring (all 11 pass):

- `fetchAdapter … a 302 to ANOTHER origin drops x-api-key / authorization / x-amz-* on the second request` ✅ (red without fix)
- `fetchAdapter … end-to-end: a stitch with apiKey() auth does not leak the key across origins` ✅ (red without fix) — proves the real credential, not just a raw header, is stripped
- `fetchAdapter … a SAME-origin redirect KEEPS the headers` ✅ — guards against **over-stripping** (auth must keep working)
- `fetchAdapter … a same-origin redirect on a DIFFERENT PORT is treated as cross-origin` ✅ (red without fix)
- `fetchAdapter … caps redirect hops so a redirect loop cannot spin forever` ✅
- `axiosAdapter … a cross-origin next hop strips x-api-key + authorization` ✅ (red without fix)
- `axiosAdapter … a same-origin next hop KEEPS the headers` ✅
- `headersForRedirect …` shared-policy unit tests (same-origin identity, cross-origin subset, cross-scheme, unparseable-target fail-safe) ✅

## Bundle delta (the crux — near the ceiling, which is why this wasn't auto-fixed)

The core bundle sat within ~30 B of its whole-entry budget, so any addition to the adapter path tips it over. Measured (tree-shaken, min+gzip, via `packages/core/scripts/bundle-size.mjs`):

| scenario | before (gzip) | after (gzip) | Δ |
|---|---|---|---|
| `stitchapi` — whole entry | 24 751 B (24.17 KB) | 25 169 B (24.58 KB) | **+418 B / +0.41 KB** |
| `import { stitch }` | 19 998 B (19.53 KB) | 20 280 B (19.80 KB) | **+282 B / +0.28 KB** |

Budgets bumped **24.20 → 24.80 KB** (whole entry) and **19.70 → 20.00 KB** (`import { stitch }`) — restoring the same tight ~0.2 KB headroom the gate is designed to hold — with a justifying comment in `bundle-size.mjs`. The fix sits on the hot request path (`fetchAdapter` is the default transport, so it lifts `import { stitch }` as much as the whole entry) and is browser-safe, so it **cannot** move to a subpath. The ~0.41 KB buys closing a HIGH credential-exfiltration hole — a deliberate cost-vs-security trade for the maintainer to weigh at merge.

Advertised sizes updated to match the measured figure (badge + READMEs + docs: `~24 kB` → `~25 kB` for the whole entry; `import { stitch }` stays `~20 kB`), keeping the yakir `bundle-advertised-size` drift tether green.

## Verification
- Core suite: **1214 passed** (129 files), incl. the 11 new tests.
- `@stitchapi/aws-sigv4`: **17 passed** (its `authorization`/`x-amz-*` headers flow through the fixed adapters).
- `check:types`: clean. `check:lint`: clean. `build`: OK. Bundle gate: within budget. `prettier --check`: clean on all changed files.

review-sweep finding 6de75126e993 + 9e423cc3ab6e; HIGH; **human-merge only** — do not auto-merge.
