### PR TITLE
docs(readme): simplify demo caption to "Watch more"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 </p>
 
 <p align="center">
-  <sub>20-second cut · <a href="https://stitchapi.dev/demo">watch the full 10-feature tour live</a> — rendered by the docs site itself, <a href="docs/media/README.md">regenerated from source</a></sub>
+  <sub><a href="https://stitchapi.dev/demo">Watch more</a></sub>
 </p>
 
 > [!NOTE]


### PR DESCRIPTION
## Summary
- Replace the demo caption's feature-count claim and internal regen-source detail with a plain "Watch more" link — consumer-facing copy shouldn't promise completeness or expose build plumbing.
- Rebuilt clean off current `main` (supersedes #443, whose branch conflicted after `main` replaced the webp demo with a video-based implementation in #444).

## Test plan
- [x] Verify gate (format/lint/typecheck/test/exports/build-docs) passed on push
- [x] Diff against `main` is limited to the README caption line

🤖 Generated with [Claude Code](https://claude.com/claude-code)