### PR TITLE
feat(download): @stitchapi/download — batch downloader (FIFO, cancel, ETA, idle-timeout, dedupe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ This repository is a [pnpm](https://pnpm.io) workspace. The published library is
 <tr><td><a href="packages/pino"><code>@stitchapi/pino</code></a></td><td>The stitch event stream as structured Pino logs</td></tr>
 <tr><td><a href="packages/sentry"><code>@stitchapi/sentry</code></a></td><td>Stitch events as Sentry breadcrumbs, with error capture</td></tr>
 <tr><th colspan="2">Surfaces</th></tr>
+<tr><td><a href="packages/download"><code>@stitchapi/download</code></a></td><td>Batch file downloads with FIFO concurrency, cancel, and ETA</td></tr>
 <tr><td><a href="packages/shell"><code>@stitchapi/shell</code></a></td><td>Run a static local command as a stitch (injection-proof)</td></tr>
 <tr><th colspan="2">Cache fingerprint adapters</th></tr>
 <tr><td><a href="packages/fingerprint-arktype"><code>@stitchapi/fingerprint-arktype</code></a></td><td>Cache-fingerprint strategy for ArkType schemas</td></tr>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -929,6 +929,7 @@ StitchAPI ships thin, peer-dependency integration packages — server frameworks
 <tr><td><a href="packages/pino"><code>@stitchapi/pino</code></a></td><td>The stitch event stream as structured Pino logs</td></tr>
 <tr><td><a href="packages/sentry"><code>@stitchapi/sentry</code></a></td><td>Stitch events as Sentry breadcrumbs, with error capture</td></tr>
 <tr><th colspan="2">Surfaces</th></tr>
+<tr><td><a href="packages/download"><code>@stitchapi/download</code></a></td><td>Batch file downloads with FIFO concurrency, cancel, and ETA</td></tr>
 <tr><td><a href="packages/shell"><code>@stitchapi/shell</code></a></td><td>Run a static local command as a stitch (injection-proof)</td></tr>
 <tr><th colspan="2">Cache fingerprint adapters</th></tr>
 <tr><td><a href="packages/fingerprint-arktype"><code>@stitchapi/fingerprint-arktype</code></a></td><td>Cache-fingerprint strategy for ArkType schemas</td></tr>

--- a/packages/download/README.md
+++ b/packages/download/README.md
@@ -1,0 +1,117 @@
+# @stitchapi/download
+
+Batch downloader / manager for [StitchAPI](https://stitchapi.dev), built on core's buffered
+`download()` surface. It sequences a **list** of downloads with bounded concurrency and adds the
+niceties a single `download()` call can't: FIFO admission, per-item settling, cancellation, aggregate
+progress + ETA, a forward-progress **idle timeout**, and opt-in same-URL **dedupe**.
+
+-   **Zero runtime dependencies.** `stitchapi` is a peer dep; nothing else ships.
+-   **Browser-first.** The surface returns `Blob`s and never touches disk — the same code runs in Node
+    and the browser.
+-   **Rides core's resilience.** Every item is a real `download()` stitch, so retry / throttle / timeout
+    / circuit / auth all apply per item — this package only orchestrates the batch.
+
+```bash
+pnpm add @stitchapi/download stitchapi
+```
+
+## One-shot: `downloadAll`
+
+```ts
+import { downloadAll } from '@stitchapi/download';
+
+const batch = downloadAll(
+    ['https://cdn.example.com/a.zip', 'https://cdn.example.com/b.zip'],
+    {
+        concurrency: 4,
+        onProgress: (p) =>
+            console.log(`${p.completed}/${p.count}`, p.etaMs, 'ms left'),
+    },
+);
+
+const results = await batch; // never throws — settles per item, in enqueue order
+for (const r of results) {
+    if (r.status === 'fulfilled') save(r.value.blob, r.value.filename);
+    else if (r.status === 'rejected')
+        console.warn(r.id, r.code, r.retryable ? '(retryable)' : '(terminal)');
+    // r.status === 'cancelled' → skipped
+}
+```
+
+Each item is either a URL string or a partial `download()` config (`{ id?, baseUrl, path, retry, … }`).
+Shared config goes in `defaults`; per-item fields win:
+
+```ts
+downloadAll([{ path: '/a' }, { path: '/b', retry: { attempts: 5 } }], {
+    defaults: {
+        baseUrl: 'https://api.example.com',
+        throttle: { concurrency: 4, pool: 'host' },
+    },
+});
+```
+
+## Control
+
+```ts
+const batch = downloadAll(items, { concurrency: 2 });
+batch.cancel(id); // cancel ONE — in-flight aborts and its slot goes to the next queued item;
+//   a still-queued item just drops (no slot freed, next item not skipped)
+batch.cancelAll(); // cancel everything — in-flight abort, queue drains
+batch.snapshot(); // { progress, items:[{ id, phase, status? }] } — live
+```
+
+Pass an `AbortSignal` as `signal` to wire cancel-all to an external controller.
+
+## Stateful: `DownloadManager`
+
+Enqueue over time (the manager `downloadAll` is built on):
+
+```ts
+import { DownloadManager } from '@stitchapi/download';
+
+const mgr = new DownloadManager({
+    concurrency: 3,
+    onItemSettled: (r) => log(r),
+});
+const handle = mgr.add('https://cdn.example.com/late.bin');
+handle.cancel();
+const result = await handle.done; // this item's ItemResult
+await mgr.idle(); // resolves when the whole queue drains
+```
+
+## Forward-progress idle timeout
+
+`download()`'s `timeout` is wall-clock — it fires on total elapsed time whether or not bytes are
+arriving, so a healthy-but-slow download dies by the same clock as a dead stall. `idleTimeout` is
+different: it resets on **every** progress chunk, so a slow stream survives while a genuinely stalled
+one is aborted (surfacing as a retryable `IDLE_TIMEOUT`).
+
+```ts
+downloadAll(urls, { idleTimeout: 10_000 }); // abort an item after 10s of NO new bytes
+```
+
+## Error classification
+
+The engine drops the underlying transport `cause` before a caller sees it, so an `ECONNRESET` looks
+like any other `fetch failed`. This package captures the raw error per item (via a `hooks.onError`
+seam) and classifies the rejection:
+
+```ts
+{ id, status: 'rejected', reason /* StitchError */, retryable: true, code: 'UND_ERR_SOCKET' }
+```
+
+`retryable` is `true` for transport faults, `5xx`, `429`, `408`, and idle-timeouts; `false` for
+terminal `4xx`. `code` is a best-effort machine code (`UND_ERR_SOCKET`, `HTTP_404`, `IDLE_TIMEOUT`, …).
+
+## Same-URL dedupe
+
+By default every item is an **independent** fetch — predictable, no cross-item coupling. Opt in to
+collapse duplicates onto a single in-flight request:
+
+```ts
+downloadAll([url, url], { dedupe: true }); // one request on the wire; both handles get the same Blob
+```
+
+## License
+
+Apache-2.0

--- a/packages/download/package.json
+++ b/packages/download/package.json
@@ -1,0 +1,76 @@
+{
+    "name": "@stitchapi/download",
+    "version": "1.0.0-rc.4",
+    "type": "commonjs",
+    "description": "Batch downloader / manager for StitchAPI — FIFO concurrency, per-item settling, cancel, aggregate progress + ETA, idle-timeout, and same-URL dedupe on top of the resilient `download()` surface. Zero runtime deps, browser-first.",
+    "main": "lib/index.js",
+    "module": "lib/index.mjs",
+    "types": "lib/index.d.ts",
+    "exports": {
+        ".": {
+            "browser": {
+                "types": "./lib/index.d.mts",
+                "default": "./lib/index.mjs"
+            },
+            "import": {
+                "types": "./lib/index.d.mts",
+                "default": "./lib/index.mjs"
+            },
+            "require": {
+                "types": "./lib/index.d.ts",
+                "default": "./lib/index.js"
+            }
+        }
+    },
+    "sideEffects": false,
+    "files": [
+        "lib"
+    ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "tsup",
+        "test": "vitest run",
+        "check:types": "tsc --noEmit",
+        "check:size": "node scripts/bundle-size.mjs",
+        "size": "tsup --silent && node scripts/bundle-size.mjs",
+        "prepack": "tsup",
+        "prepublishOnly": "node ../../scripts/check-release.mjs --changelog"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rejifald/StitchAPI.git",
+        "directory": "packages/download"
+    },
+    "keywords": [
+        "stitchapi",
+        "download",
+        "batch",
+        "concurrency",
+        "queue",
+        "progress",
+        "eta",
+        "cancel",
+        "blob",
+        "resilient",
+        "typescript"
+    ],
+    "author": "Oleksandr Zhuravlov (rejifald@gmail.com)",
+    "license": "Apache-2.0",
+    "homepage": "https://stitchapi.dev",
+    "engines": {
+        "node": ">=18.18.0"
+    },
+    "peerDependencies": {
+        "stitchapi": "^1.0.0-rc.1"
+    },
+    "devDependencies": {
+        "@types/node": "^22.10.0",
+        "esbuild": "^0.28.1",
+        "stitchapi": "workspace:*",
+        "tsup": "^8.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.8"
+    }
+}

--- a/packages/download/scripts/bundle-size.mjs
+++ b/packages/download/scripts/bundle-size.mjs
@@ -1,0 +1,143 @@
+// Bundle-size budget gate for the `@stitchapi/download` entry.
+//
+// Same discipline as the core gate (packages/core/scripts/bundle-size.mjs): measure
+// the TREE-SHAKEN cost a downstream bundler actually emits — minified + gzipped — and
+// fail if it exceeds the budget. `stitchapi` (and its `stitchapi/*` subpaths) is a peer
+// dependency, so it is externalised: what we budget here is JUST this package's own
+// code — the FIFO scheduler, aggregate progress/ETA, cancel wiring, and error classifier.
+//
+// The budget is a deliberate ceiling. Raising it is a conscious act: edit the number
+// below and justify it in the PR. Prefer trimming, or gating a new capability, over
+// bumping the budget.
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { brotliCompressSync, gzipSync } from 'node:zlib';
+
+// esbuild ships as CommonJS; load it through createRequire so this stays robust
+// regardless of ESM/CJS interop.
+const require = createRequire(import.meta.url);
+const esbuild = require('esbuild');
+
+const libDir = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'lib');
+
+const KB = 1024;
+
+// Budget for 1.0.0-rc.4 — the initial @stitchapi/download entry. The batch
+// orchestrator (FIFO scheduler + progress/ETA + classifier + cancel + idle timer)
+// measures ~2.46 KB gzip with `stitchapi` externalised; the 2.65 KB ceiling keeps the
+// same tight ~0.2 KB headroom core's gate holds, so growth stays deliberate.
+// `stitchapi` and every `stitchapi/*` subpath are external (peer dep).
+const SCENARIOS = [
+    {
+        name: '@stitchapi/download — whole entry',
+        code: `export * from './index.mjs';`,
+        budget: 2.65 * KB,
+    },
+];
+
+function measure(code) {
+    const result = esbuild.buildSync({
+        stdin: {
+            contents: code,
+            resolveDir: libDir,
+            sourcefile: 'entry.mjs',
+            loader: 'js',
+        },
+        bundle: true,
+        minify: true,
+        format: 'esm',
+        treeShaking: true,
+        platform: 'neutral',
+        // Zero deps of our own; `stitchapi` is a peer (externalised), and the
+        // root entry stays browser-safe (no static node:* in shipped code).
+        external: ['node:*', 'stitchapi', 'stitchapi/*'],
+        write: false,
+        logLevel: 'silent',
+    });
+    const out = result.outputFiles[0].contents;
+    return {
+        min: out.length,
+        gzip: gzipSync(out, { level: 9 }).length,
+        brotli: brotliCompressSync(out).length,
+    };
+}
+
+const kb = (bytes) => `${(bytes / KB).toFixed(2)} KB`;
+
+if (!existsSync(resolve(libDir, 'index.mjs'))) {
+    console.error(
+        '✗ lib/index.mjs not found — run `pnpm build` first (or use `pnpm size`).',
+    );
+    process.exit(1);
+}
+
+const rows = SCENARIOS.map((s) => {
+    const m = measure(s.code);
+    return { ...s, ...m, over: m.gzip > s.budget };
+});
+
+const failed = rows.some((r) => r.over);
+
+if (process.argv.includes('--json')) {
+    console.log(
+        JSON.stringify(
+            rows.map(({ name, min, gzip, brotli, budget, over }) => ({
+                name,
+                min,
+                gzip,
+                brotli,
+                kb: Math.round(gzip / KB),
+                budget,
+                over,
+            })),
+            null,
+            2,
+        ),
+    );
+} else {
+    const col = (s, w) => String(s).padStart(w);
+    console.log(
+        '\n  @stitchapi/download bundle budget — tree-shaken, min+gzip\n',
+    );
+    console.log(
+        '  ' +
+            'scenario'.padEnd(36) +
+            col('minified', 11) +
+            col('gzip', 11) +
+            col('brotli', 11) +
+            col('budget', 11) +
+            '   status',
+    );
+    console.log('  ' + '─'.repeat(93));
+    for (const r of rows) {
+        const headroom = r.over
+            ? `OVER by ${kb(r.gzip - r.budget)}`
+            : `${kb(r.budget - r.gzip)} left`;
+        console.log(
+            '  ' +
+                r.name.padEnd(36) +
+                col(kb(r.min), 11) +
+                col(kb(r.gzip), 11) +
+                col(kb(r.brotli), 11) +
+                col(kb(r.budget), 11) +
+                `   ${r.over ? '✗' : '✓'} ${headroom}`,
+        );
+    }
+    console.log('');
+}
+
+if (failed) {
+    console.error(
+        '✗ Bundle budget exceeded.\n' +
+            '  Trim the entry, or gate a new capability behind an option. If the growth is\n' +
+            '  genuinely necessary, raise the budget in packages/download/scripts/bundle-size.mjs\n' +
+            '  and say why in the PR — the budget is the gate, so bumping it must be deliberate.\n',
+    );
+    process.exit(1);
+}
+
+if (!process.argv.includes('--json')) {
+    console.log('✓ @stitchapi/download entry within budget.\n');
+}

--- a/packages/download/src/classify.ts
+++ b/packages/download/src/classify.ts
@@ -1,0 +1,88 @@
+import { StitchError } from 'stitchapi';
+
+/**
+ * Transport-error codes (undici / Node) a retry might plausibly clear — sockets dropped, connections
+ * refused, DNS blips, connect/idle timeouts. Terminal application errors (a 4xx) are NOT here.
+ */
+const RETRYABLE_CODES = new Set<string>([
+    'UND_ERR_SOCKET',
+    'UND_ERR_CONNECT_TIMEOUT',
+    'UND_ERR_HEADERS_TIMEOUT',
+    'UND_ERR_BODY_TIMEOUT',
+    'ECONNRESET',
+    'ECONNREFUSED',
+    'ENOTFOUND',
+    'EAI_AGAIN',
+    'ETIMEDOUT',
+    'EPIPE',
+]);
+
+/** The classification attached to a rejected {@link ItemResult}. */
+export interface Classification {
+    retryable: boolean;
+    code?: string;
+}
+
+/** Coerce any thrown value into a {@link StitchError} (the reason shape callers can rely on). */
+export function toStitchError(e: unknown): StitchError {
+    if (e instanceof StitchError) return e;
+    const message = e instanceof Error ? e.message : String(e);
+    return new StitchError(message, { cause: e });
+}
+
+/** Walk an error's `cause` chain for a string `code` — undici nests the real transport code there. */
+function causeCode(e: unknown): string | undefined {
+    let cur: unknown = e;
+    for (let depth = 0; cur != null && depth < 8; depth++) {
+        const code = (cur as { code?: unknown }).code;
+        if (typeof code === 'string') return code;
+        cur = (cur as { cause?: unknown }).cause;
+    }
+    return undefined;
+}
+
+/** Pull an `HTTP <status>` out of an error message when the status isn't carried structurally. */
+function statusFromMessage(msg: string | undefined): number | undefined {
+    if (msg === undefined) return undefined;
+    const g = /\bHTTP (\d{3})\b/.exec(msg)?.[1];
+    return g !== undefined ? Number(g) : undefined;
+}
+
+/**
+ * Classify a failed download as retryable-vs-terminal with a best-effort machine `code`.
+ *
+ * `raw` is the UNTOUCHED transport error captured via `download()`'s `hooks.onError` — the engine
+ * drops the transport `.cause` before the awaited caller sees it (the download-reset-midbody finding),
+ * so `raw` is the authoritative source for a transport code. `reason` (the flattened
+ * {@link StitchError}) carries the HTTP `status` when the failure came from a response.
+ */
+export function classifyFailure(
+    reason: StitchError,
+    raw: unknown,
+): Classification {
+    const code = causeCode(raw) ?? causeCode(reason);
+    if (code !== undefined && RETRYABLE_CODES.has(code))
+        return { retryable: true, code };
+
+    const status =
+        reason.status ??
+        statusFromMessage(reason.message) ??
+        statusFromMessage(raw instanceof Error ? raw.message : undefined);
+    if (status !== undefined) {
+        // 5xx and the two "try again" 4xx (429 rate-limit, 408 request-timeout) are retryable; every
+        // other 4xx is terminal — a retry can't fix a 404/401/403.
+        const retryable = status >= 500 || status === 429 || status === 408;
+        return { retryable, code: code ?? `HTTP_${status}` };
+    }
+
+    // No status and no known transport code: fall back to the message. A bare `fetch failed` / socket
+    // / network error is a transport fault → retryable; anything else, assume terminal.
+    const msg = (raw instanceof Error ? raw.message : reason.message) ?? '';
+    const transportish =
+        /fetch failed|socket|network|terminated|econn|dns|timeout|timed out|aborted/i.test(
+            msg,
+        );
+    return transportish
+        ? { retryable: true, ...(code !== undefined ? { code } : {}) }
+        : { retryable: false, ...(code !== undefined ? { code } : {}) };
+}

--- a/packages/download/src/download-all.ts
+++ b/packages/download/src/download-all.ts
@@ -1,0 +1,41 @@
+import { DownloadManager } from './manager';
+import type {
+    BatchOptions,
+    DownloadBatch,
+    DownloadRequest,
+    ItemResult,
+} from './types';
+
+/**
+ * Download a list of items with bounded concurrency, returning an awaitable, controllable batch.
+ *
+ * Items start in FIFO order as slots free; each settles on its own — the batch NEVER rejects, so await
+ * it for the per-item results in enqueue order (`Promise.allSettled`-shaped, plus `cancelled`). The
+ * handle also cancels one item or all, and reports a live {@link DownloadBatch.snapshot} with aggregate
+ * progress + ETA.
+ *
+ * ```ts
+ * const batch = downloadAll(urls, { concurrency: 4, onProgress: p => render(p) });
+ * batch.cancel(id);            // cancel one → its slot goes to the next queued item
+ * const results = await batch; // ItemResult[] — never throws
+ * ```
+ */
+export function downloadAll(
+    items: DownloadRequest[],
+    opts: BatchOptions = {},
+): DownloadBatch {
+    const manager = new DownloadManager(opts);
+    for (const item of items) manager.add(item);
+    const done: Promise<ItemResult[]> = manager.results();
+    return {
+        done,
+        then: done.then.bind(done),
+        cancel: (id) => {
+            manager.cancel(id);
+        },
+        cancelAll: () => {
+            manager.cancelAll();
+        },
+        snapshot: () => manager.snapshot(),
+    };
+}

--- a/packages/download/src/errors.ts
+++ b/packages/download/src/errors.ts
@@ -1,0 +1,25 @@
+/**
+ * Aborted into an item when a caller cancels it (`cancel` / `cancelAll`). The batch surfaces the item
+ * as `status: 'cancelled'` — cancellation is not a failure, so it carries no classification.
+ */
+export class DownloadCancelledError extends Error {
+    constructor(message = 'download cancelled') {
+        super(message);
+        this.name = 'DownloadCancelledError';
+    }
+}
+
+/**
+ * Aborted into an item when the idle / forward-progress timeout fires — no byte-chunk arrived within
+ * `idleTimeout`. Distinct from a wall-clock timeout: a slow-but-progressing stream keeps resetting the
+ * timer and never trips it; only a genuinely stalled stream does. Surfaces as a retryable rejection
+ * with code `IDLE_TIMEOUT`.
+ */
+export class DownloadIdleTimeoutError extends Error {
+    readonly idleMs: number;
+    constructor(idleMs: number) {
+        super(`download stalled: no forward progress for ${idleMs}ms`);
+        this.name = 'DownloadIdleTimeoutError';
+        this.idleMs = idleMs;
+    }
+}

--- a/packages/download/src/index.ts
+++ b/packages/download/src/index.ts
@@ -1,0 +1,21 @@
+// @stitchapi/download — a batch downloader / manager on top of core's buffered `download()` surface
+// (`stitchapi/download`). Adds FIFO admission, per-item settling, cancellation, aggregate progress +
+// ETA, a forward-progress idle timeout, and opt-in same-URL dedupe — none of which core's `throttle`
+// can express. Zero runtime deps; browser-first (the Blob surface never touches disk).
+export { downloadAll } from './download-all';
+export { DownloadManager } from './manager';
+export { DownloadCancelledError, DownloadIdleTimeoutError } from './errors';
+export type {
+    BatchOptions,
+    BatchProgress,
+    BatchSnapshot,
+    DownloadBatch,
+    DownloadHandle,
+    DownloadId,
+    DownloadRequest,
+    DownloadResult,
+    ItemPhase,
+    ItemProgress,
+    ItemResult,
+    ItemStatus,
+} from './types';

--- a/packages/download/src/manager.ts
+++ b/packages/download/src/manager.ts
@@ -1,0 +1,407 @@
+import { classifyFailure, toStitchError } from './classify';
+import { DownloadCancelledError, DownloadIdleTimeoutError } from './errors';
+import { ProgressAggregator } from './progress';
+import type {
+    BatchOptions,
+    BatchSnapshot,
+    DownloadHandle,
+    DownloadId,
+    DownloadRequest,
+    ItemPhase,
+    ItemProgress,
+    ItemResult,
+} from './types';
+
+import { systemClock } from 'stitchapi';
+import type {
+    AdapterProgress,
+    Clock,
+    Hooks,
+    StitchConfig,
+    StitchInput,
+} from 'stitchapi';
+import { download } from 'stitchapi/download';
+import type { DownloadResult } from 'stitchapi/download';
+
+interface QueueItem {
+    id: DownloadId;
+    key: string;
+    config: Partial<StitchConfig>;
+}
+
+interface Active {
+    ctrl: AbortController;
+    idleTimer: unknown;
+    /** The latest RAW transport error captured via `hooks.onError` — for classification. */
+    raw: unknown;
+}
+
+interface InternalHandle {
+    external: DownloadHandle;
+    resolve: (result: ItemResult) => void;
+}
+
+/**
+ * The stateful batch engine: a FIFO concurrency scheduler over core's `download()`. Admits up to
+ * `concurrency` items at a time in enqueue order, settles each on its own (one failure never fails the
+ * batch), and layers the two findings the rig surfaced — a forward-progress idle timer and transport
+ * error classification — plus cancellation and aggregate progress/ETA, none of which core's `throttle`
+ * can express (its queue is opaque). {@link downloadAll} is a thin one-shot wrapper over this.
+ */
+export class DownloadManager {
+    readonly #concurrency: number;
+    readonly #defaults: Partial<StitchConfig>;
+    readonly #idleTimeout: number | undefined;
+    readonly #dedupe: boolean;
+    readonly #clock: Clock;
+    readonly #opts: BatchOptions;
+    readonly #progress: ProgressAggregator;
+
+    readonly #queue: QueueItem[] = [];
+    readonly #active = new Map<DownloadId, Active>();
+    readonly #order: DownloadId[] = [];
+    readonly #phase = new Map<DownloadId, ItemPhase>();
+    readonly #results = new Map<DownloadId, ItemResult>();
+    readonly #handles = new Map<DownloadId, InternalHandle>();
+    readonly #lastTotal = new Map<DownloadId, number>();
+    readonly #dedupeInflight = new Map<string, Promise<DownloadResult>>();
+    readonly #cancelled = new Set<DownloadId>();
+    readonly #idledOut = new Set<DownloadId>();
+    #idleWaiters: Array<() => void> = [];
+    #signalAborted = false;
+
+    constructor(opts: BatchOptions = {}) {
+        this.#concurrency = Math.max(1, opts.concurrency ?? 4);
+        this.#defaults = opts.defaults ?? {};
+        this.#idleTimeout = opts.idleTimeout;
+        this.#dedupe = opts.dedupe ?? false;
+        this.#clock = opts.clock ?? systemClock;
+        this.#opts = opts;
+        this.#progress = new ProgressAggregator(this.#clock);
+
+        const signal = opts.signal;
+        if (signal !== undefined) {
+            if (signal.aborted) this.#signalAborted = true;
+            else
+                signal.addEventListener(
+                    'abort',
+                    () => {
+                        this.#signalAborted = true;
+                        this.cancelAll();
+                    },
+                    { once: true },
+                );
+        }
+    }
+
+    /** Enqueue an item. Returns a handle whose `.done` resolves to that item's {@link ItemResult}. */
+    add(item: DownloadRequest): DownloadHandle {
+        const norm = this.#normalize(item);
+        this.#order.push(norm.id);
+        this.#phase.set(norm.id, 'queued');
+        const handle = this.#makeHandle(norm.id);
+        this.#handles.set(norm.id, handle);
+
+        if (this.#signalAborted) {
+            // The batch's external signal already fired — never start; settle straight to cancelled.
+            this.#settle(norm.id, { id: norm.id, status: 'cancelled' });
+        } else {
+            this.#queue.push(norm);
+            this.#pump();
+        }
+        return handle.external;
+    }
+
+    /** Cancel one item. In-flight → abort (its slot goes to the next queued item); queued → drop. */
+    cancel(id: DownloadId): void {
+        if (this.#results.has(id)) return;
+        const phase = this.#phase.get(id);
+        if (phase === undefined) return; // unknown id
+        this.#cancelled.add(id);
+        if (phase === 'active') {
+            // The abort rejects the in-flight download; #onReject settles it 'cancelled', its slot
+            // frees, and #pump admits the next queued item.
+            this.#active.get(id)?.ctrl.abort(new DownloadCancelledError());
+        } else if (phase === 'queued') {
+            // Drop from the queue and settle now. It held no slot, so the next queued item's turn is
+            // unaffected — no freed slot, no skip.
+            const idx = this.#queue.findIndex((q) => q.id === id);
+            if (idx >= 0) this.#queue.splice(idx, 1);
+            this.#settle(id, { id, status: 'cancelled' });
+        }
+    }
+
+    /** Cancel every item — in-flight abort, queue drains. Pooled (`pool:'host'`) budget returns clean. */
+    cancelAll(): void {
+        // Queued items hold no slot — settle them straight away.
+        const queued = this.#queue.splice(0, this.#queue.length);
+        for (const item of queued) {
+            if (this.#results.has(item.id)) continue;
+            this.#cancelled.add(item.id);
+            this.#settle(item.id, { id: item.id, status: 'cancelled' });
+        }
+        // Abort each in-flight item. Aborts reject on a microtask, so snapshot the entries first
+        // rather than mutate #active mid-iteration. Each aborted download releases its engine throttle
+        // slot, so a later batch to the same host isn't starved by leaked in-flight state.
+        for (const [id, active] of [...this.#active.entries()]) {
+            this.#cancelled.add(id);
+            active.ctrl.abort(new DownloadCancelledError());
+        }
+    }
+
+    /** Resolves when the queue is fully drained (all added items settled). */
+    idle(): Promise<void> {
+        if (this.#queue.length === 0 && this.#active.size === 0)
+            return Promise.resolve();
+        return new Promise<void>((resolve) => {
+            this.#idleWaiters.push(resolve);
+        });
+    }
+
+    /** The per-item results so far, in enqueue order. Awaits {@link idle} first. */
+    async results(): Promise<ItemResult[]> {
+        await this.idle();
+        return this.#order.map(
+            (id) => this.#results.get(id) ?? { id, status: 'cancelled' },
+        );
+    }
+
+    /** A live snapshot of per-item phase + aggregate progress. */
+    snapshot(): BatchSnapshot {
+        const items = this.#order.map((id) => {
+            const phase = this.#phase.get(id) ?? 'queued';
+            const status = this.#results.get(id)?.status;
+            return status !== undefined ? { id, phase, status } : { id, phase };
+        });
+        return {
+            progress: this.#progress.snapshot(this.#order.length),
+            items,
+        };
+    }
+
+    // ---- internals --------------------------------------------------------
+
+    #normalize(item: DownloadRequest): QueueItem {
+        const isStr = typeof item === 'string';
+        const url = isStr
+            ? item
+            : typeof item.url === 'string'
+              ? item.url
+              : undefined;
+        const explicitId = isStr ? undefined : item.id;
+        let id: DownloadId = explicitId ?? url ?? this.#order.length;
+        // A duplicate URL/id would collide in the per-item maps — disambiguate by enqueue index.
+        if (this.#phase.has(id)) id = this.#order.length;
+        const key = this.#dedupe ? String(explicitId ?? url ?? id) : String(id);
+        const config: Partial<StitchConfig> = isStr
+            ? { url: item }
+            : this.#stripId(item);
+        return { id, key, config };
+    }
+
+    #stripId(
+        item: Partial<StitchConfig> & { id?: DownloadId },
+    ): Partial<StitchConfig> {
+        const copy: Partial<StitchConfig> & { id?: DownloadId } = { ...item };
+        delete copy.id;
+        return copy;
+    }
+
+    #makeHandle(id: DownloadId): InternalHandle {
+        let resolve!: (result: ItemResult) => void;
+        const done = new Promise<ItemResult>((res) => {
+            resolve = res;
+        });
+        const external: DownloadHandle = {
+            id,
+            done,
+            cancel: () => {
+                this.cancel(id);
+            },
+        };
+        return { external, resolve };
+    }
+
+    #pump(): void {
+        while (
+            !this.#signalAborted &&
+            this.#active.size < this.#concurrency &&
+            this.#queue.length > 0
+        ) {
+            const item = this.#queue.shift();
+            if (item === undefined) break;
+            if (this.#phase.get(item.id) !== 'queued') continue; // cancelled while queued
+            this.#start(item);
+        }
+        this.#maybeIdle();
+    }
+
+    #start(item: QueueItem): void {
+        this.#phase.set(item.id, 'active');
+        this.#opts.onItemStart?.(item.id);
+
+        const ctrl = new AbortController();
+        const active: Active = { ctrl, idleTimer: undefined, raw: undefined };
+        this.#active.set(item.id, active);
+
+        let result: Promise<DownloadResult>;
+        const shared = this.#dedupe
+            ? this.#dedupeInflight.get(item.key)
+            : undefined;
+        if (shared !== undefined) {
+            // Follower: reuse the leader's in-flight fetch — no second request on the wire.
+            result = shared;
+        } else {
+            const input: StitchInput = {
+                signal: ctrl.signal,
+                onProgress: (p: AdapterProgress) => {
+                    if (p.phase === 'download')
+                        this.#onItemProgress(item.id, p);
+                },
+            };
+            // Promise.resolve() subscribes to the COLD StitchResult (nothing runs until a handler
+            // attaches) and yields a real Promise to share for dedupe.
+            result = Promise.resolve(
+                download(this.#configFor(item, active))(input),
+            );
+            if (this.#dedupe) {
+                this.#dedupeInflight.set(item.key, result);
+                void result
+                    .catch(() => undefined)
+                    .finally(() => this.#dedupeInflight.delete(item.key));
+            }
+            this.#armIdle(item.id, active);
+        }
+
+        void result.then(
+            (value) => {
+                this.#settle(item.id, {
+                    id: item.id,
+                    status: 'fulfilled',
+                    value,
+                });
+            },
+            (err: unknown) => {
+                this.#onReject(item.id, err, active);
+            },
+        );
+    }
+
+    #configFor(item: QueueItem, active: Active): Partial<StitchConfig> {
+        const userOnError =
+            item.config.hooks?.onError ?? this.#defaults.hooks?.onError;
+        const hooks: Hooks = {
+            ...this.#defaults.hooks,
+            ...item.config.hooks,
+            onError: (ctx) => {
+                active.raw = ctx.error;
+                return userOnError?.(ctx);
+            },
+        };
+        return { ...this.#defaults, ...item.config, hooks };
+    }
+
+    #onItemProgress(id: DownloadId, p: AdapterProgress): void {
+        const item: ItemProgress =
+            p.total !== undefined
+                ? { loaded: p.loaded, total: p.total }
+                : { loaded: p.loaded };
+        if (p.total !== undefined) this.#lastTotal.set(id, p.total);
+        this.#progress.item(id, item);
+        this.#resetIdle(id);
+        this.#opts.onItemProgress?.(id, item);
+        this.#emitProgress();
+    }
+
+    #armIdle(id: DownloadId, active: Active): void {
+        if (this.#idleTimeout === undefined) return;
+        active.idleTimer = this.#clock.setTimer(
+            () => this.#onIdle(id),
+            this.#idleTimeout,
+        );
+    }
+
+    #resetIdle(id: DownloadId): void {
+        if (this.#idleTimeout === undefined) return;
+        const active = this.#active.get(id);
+        if (active === undefined) return;
+        this.#clearIdle(active);
+        active.idleTimer = this.#clock.setTimer(
+            () => this.#onIdle(id),
+            this.#idleTimeout,
+        );
+    }
+
+    #clearIdle(active: Active): void {
+        if (active.idleTimer !== undefined) {
+            this.#clock.clearTimer(active.idleTimer);
+            active.idleTimer = undefined;
+        }
+    }
+
+    #onIdle(id: DownloadId): void {
+        const active = this.#active.get(id);
+        if (active === undefined) return;
+        this.#idledOut.add(id);
+        active.ctrl.abort(new DownloadIdleTimeoutError(this.#idleTimeout ?? 0));
+    }
+
+    #onReject(id: DownloadId, err: unknown, active: Active): void {
+        if (this.#cancelled.has(id)) {
+            this.#settle(id, { id, status: 'cancelled' });
+            return;
+        }
+        const reason = toStitchError(err);
+        if (this.#idledOut.has(id)) {
+            this.#settle(id, {
+                id,
+                status: 'rejected',
+                reason,
+                retryable: true,
+                code: 'IDLE_TIMEOUT',
+            });
+            return;
+        }
+        const { retryable, code } = classifyFailure(reason, active.raw);
+        this.#settle(
+            id,
+            code !== undefined
+                ? { id, status: 'rejected', reason, retryable, code }
+                : { id, status: 'rejected', reason, retryable },
+        );
+    }
+
+    #settle(id: DownloadId, result: ItemResult): void {
+        if (this.#results.has(id)) return; // guard double-settle (dedupe / abort races)
+        this.#results.set(id, result);
+        this.#phase.set(id, 'settled');
+        const active = this.#active.get(id);
+        if (active !== undefined) {
+            this.#clearIdle(active);
+            this.#active.delete(id);
+        }
+        if (result.status === 'fulfilled')
+            this.#progress.fulfilled(
+                id,
+                result.value.blob.size,
+                this.#lastTotal.get(id),
+            );
+        else this.#progress.dropped(id);
+
+        this.#handles.get(id)?.resolve(result);
+        this.#opts.onItemSettled?.(result);
+        this.#emitProgress();
+        this.#pump();
+    }
+
+    #emitProgress(): void {
+        this.#opts.onProgress?.(this.#progress.snapshot(this.#order.length));
+    }
+
+    #maybeIdle(): void {
+        if (this.#queue.length > 0 || this.#active.size > 0) return;
+        const waiters = this.#idleWaiters;
+        this.#idleWaiters = [];
+        for (const resolve of waiters) resolve();
+    }
+}

--- a/packages/download/src/progress.ts
+++ b/packages/download/src/progress.ts
@@ -1,0 +1,92 @@
+import type { BatchProgress, DownloadId, ItemProgress } from './types';
+
+import type { Clock } from 'stitchapi';
+
+/**
+ * Rolls per-item byte progress up into a batch-wide {@link BatchProgress} with a throughput rate and
+ * ETA. Reads time from an injected {@link Clock} so the rate/ETA math is deterministic under
+ * `manualClock()`.
+ *
+ * `loaded` counts in-flight + fulfilled items; a failed or cancelled item's partial bytes are
+ * discarded via {@link dropped} (they never contribute), so one dead/stalled stream can plateau its
+ * own term but never corrupts the siblings' aggregate. `total` is the sum of known per-item totals and
+ * goes `undefined` the moment any started item is indeterminate (chunked / no `Content-Length`).
+ */
+export class ProgressAggregator {
+    readonly #clock: Clock;
+    /** Live per-item progress for the currently-active items. */
+    readonly #live = new Map<DownloadId, ItemProgress>();
+    /** Sum of fulfilled items' final byte counts. */
+    #doneBytes = 0;
+    /** Sum of fulfilled items' known totals. */
+    #doneTotal = 0;
+    /** Settled items (any status). */
+    #completed = 0;
+    /** A started item reported no total (chunked) — the aggregate total is then indeterminate. */
+    #anyIndeterminate = false;
+    /** Clock time of the first byte across the batch — the ETA baseline. */
+    #firstByteAt: number | undefined;
+
+    constructor(clock: Clock) {
+        this.#clock = clock;
+    }
+
+    /** An active item reported a chunk. */
+    item(id: DownloadId, p: ItemProgress): void {
+        if (this.#firstByteAt === undefined && p.loaded > 0)
+            this.#firstByteAt = this.#clock.now();
+        this.#live.set(id, p);
+        if (p.total === undefined) this.#anyIndeterminate = true;
+    }
+
+    /** An item fulfilled with `finalBytes` (and, when the server declared one, its `total`). */
+    fulfilled(
+        id: DownloadId,
+        finalBytes: number,
+        total: number | undefined,
+    ): void {
+        this.#live.delete(id);
+        this.#doneBytes += finalBytes;
+        if (total !== undefined) this.#doneTotal += total;
+        else this.#anyIndeterminate = true;
+        this.#completed += 1;
+    }
+
+    /** An item failed or was cancelled — its partial bytes are discarded from the aggregate. */
+    dropped(_id: DownloadId): void {
+        this.#live.delete(_id);
+        this.#completed += 1;
+    }
+
+    /** Build the aggregate for `count` total items. */
+    snapshot(count: number): BatchProgress {
+        let loaded = this.#doneBytes;
+        let total = this.#doneTotal;
+        let totalKnown = !this.#anyIndeterminate;
+        for (const p of this.#live.values()) {
+            loaded += p.loaded;
+            if (p.total !== undefined) total += p.total;
+            else totalKnown = false;
+        }
+
+        const progress: BatchProgress = {
+            loaded,
+            completed: this.#completed,
+            count,
+        };
+        if (totalKnown) progress.total = total;
+
+        if (this.#firstByteAt !== undefined) {
+            const elapsedMs = this.#clock.now() - this.#firstByteAt;
+            if (elapsedMs > 0) {
+                const ratePerSec = (loaded / elapsedMs) * 1000;
+                progress.ratePerSec = ratePerSec;
+                if (totalKnown && ratePerSec > 0) {
+                    const remaining = Math.max(0, total - loaded);
+                    progress.etaMs = (remaining / ratePerSec) * 1000;
+                }
+            }
+        }
+        return progress;
+    }
+}

--- a/packages/download/src/types.ts
+++ b/packages/download/src/types.ts
@@ -1,0 +1,134 @@
+import type { Clock, StitchConfig, StitchError } from 'stitchapi';
+import type { DownloadResult } from 'stitchapi/download';
+
+export type { DownloadResult };
+
+/** Stable identity for an item — correlates progress, cancellation, results, and dedupe. */
+export type DownloadId = string | number;
+
+/**
+ * One item in a batch. Either a URL string (shorthand for `{ url }`), or a partial `download()`
+ * config with an optional stable `id`. When `id` is omitted it defaults to the item's URL, falling
+ * back to the enqueue index if that URL is already used — so give colliding URLs explicit ids if you
+ * need to tell them apart.
+ */
+export type DownloadRequest =
+    | string
+    | (Partial<StitchConfig> & { id?: DownloadId });
+
+/** Per-item byte progress. `total` is present only when the server declared a `Content-Length`. */
+export interface ItemProgress {
+    loaded: number;
+    total?: number;
+}
+
+/** Aggregate progress across the whole batch. */
+export interface BatchProgress {
+    /**
+     * Bytes downloaded so far — summed across in-flight + fulfilled items. A failed or cancelled
+     * item's partial bytes are discarded (they never contribute), so one dead stream can't inflate
+     * the aggregate.
+     */
+    loaded: number;
+    /**
+     * Sum of known per-item totals; `undefined` while any *started* item is indeterminate (chunked /
+     * no `Content-Length`). Firms up as items are admitted — a queued item's size is unknown until
+     * it starts.
+     */
+    total?: number;
+    /** Items that have settled — fulfilled + rejected + cancelled. */
+    completed: number;
+    /** Total items in the batch. */
+    count: number;
+    /** Smoothed throughput in bytes/sec since the first byte; `undefined` before any bytes arrive. */
+    ratePerSec?: number;
+    /** Estimated time to completion in ms; `undefined` when `total` is unknown or the rate is zero. */
+    etaMs?: number;
+}
+
+/** The phase an item is in, for {@link BatchSnapshot}. */
+export type ItemPhase = 'queued' | 'active' | 'settled';
+
+/** How an item finished. */
+export type ItemStatus = 'fulfilled' | 'rejected' | 'cancelled';
+
+/**
+ * A settled item. Shaped like `Promise.allSettled`, plus a `cancelled` arm, and — on a rejection —
+ * a classification (`retryable` + a best-effort machine `code`) recovered from the transport error.
+ */
+export type ItemResult<T = DownloadResult> =
+    | { id: DownloadId; status: 'fulfilled'; value: T }
+    | {
+          id: DownloadId;
+          status: 'rejected';
+          reason: StitchError;
+          /** Whether a retry might plausibly succeed: transport faults, 5xx/429/408, idle-timeout — vs terminal 4xx. */
+          retryable: boolean;
+          /** Best-effort code: an undici transport code (`UND_ERR_SOCKET`…), `HTTP_<status>`, `IDLE_TIMEOUT`, or `TIMEOUT`. */
+          code?: string;
+      }
+    | { id: DownloadId; status: 'cancelled' };
+
+/** Options shared by {@link downloadAll} and {@link DownloadManager}. */
+export interface BatchOptions {
+    /** Max downloads running concurrently. Default 4. Enforced by the batch's own FIFO scheduler. */
+    concurrency?: number;
+    /** Config merged UNDER every item (the item's own fields win). e.g. `{ baseUrl, retry, throttle }`. */
+    defaults?: Partial<StitchConfig>;
+    /**
+     * Forward-progress timeout in ms: abort an item if no `onProgress` byte-chunk arrives within this
+     * window. Resets on every chunk, so a slow-but-alive stream survives while a dead stall is cut.
+     * Distinct from `download()`'s wall-clock `timeout` (which fires on total elapsed regardless of
+     * progress). Off when unset.
+     */
+    idleTimeout?: number;
+    /**
+     * Reuse a single in-flight download for items that share a key (their `id`, else URL) instead of
+     * fetching independently. Default `false` — every item is its own request (predictable, no
+     * cross-item coupling). With dedupe on, followers share the leader's result and progress; a
+     * follower cannot be cancelled independently of the shared fetch.
+     */
+    dedupe?: boolean;
+    /** Aggregate progress across all items (summed bytes + ETA). Fires on every per-item chunk. */
+    onProgress?: (progress: BatchProgress) => void;
+    /** Per-item progress. */
+    onItemProgress?: (id: DownloadId, progress: ItemProgress) => void;
+    /** Fires when an item is admitted (leaves the queue for a slot) — in FIFO order. */
+    onItemStart?: (id: DownloadId) => void;
+    /** Fires as each item settles. */
+    onItemSettled?: (result: ItemResult) => void;
+    /** External cancel-all: aborting this signal cancels the whole batch. */
+    signal?: AbortSignal;
+    /** Time seam (ADR 0010) for the idle-timer + ETA math. Defaults to `systemClock`; tests pass `manualClock()`. */
+    clock?: Clock;
+}
+
+/** A live snapshot of a batch's per-item phases + aggregate progress. */
+export interface BatchSnapshot {
+    progress: BatchProgress;
+    items: { id: DownloadId; phase: ItemPhase; status?: ItemStatus }[];
+}
+
+/** A handle to one enqueued item (returned by {@link DownloadManager.add}). */
+export interface DownloadHandle {
+    readonly id: DownloadId;
+    /** Resolves when this item settles. Never rejects — read `.status`. */
+    readonly done: Promise<ItemResult>;
+    /** Cancel just this item. */
+    cancel(): void;
+}
+
+/**
+ * The handle returned by {@link downloadAll}. Awaitable — resolves to the per-item results in enqueue
+ * order and NEVER rejects (per-item settling) — plus batch-wide control.
+ */
+export interface DownloadBatch extends PromiseLike<ItemResult[]> {
+    /** The per-item results, in enqueue order. Same as awaiting the batch. */
+    readonly done: Promise<ItemResult[]>;
+    /** Cancel one item — in-flight aborts (its slot goes to the next queued item); a queued item just drops. */
+    cancel(id: DownloadId): void;
+    /** Cancel every item — in-flight abort, queue drains. */
+    cancelAll(): void;
+    /** A live snapshot of per-item phase + aggregate progress. */
+    snapshot(): BatchSnapshot;
+}

--- a/packages/download/test/gaps/download-batch-cancel.spec.ts
+++ b/packages/download/test/gaps/download-batch-cancel.spec.ts
@@ -1,0 +1,164 @@
+// Pins P10/P11/P12/P13 at the batch layer — the cancellation surface core's download-concurrency-
+// stall-isolation.spec explicitly DEFERRED ("properties of a batch controller's AbortSignal wiring, not
+// of a single download() call"):
+//   • cancel ONE in-flight → only it aborts; its slot returns to the FIFO queue (P10).
+//   • cancel a QUEUED item → frees no slot, never hits the wire, doesn't skip the next (P11).
+//   • CANCEL-ALL → every in-flight aborts, the queue drains (P12), and the pooled `pool:'host'` budget
+//     is left CLEAN — a later batch to the same host isn't starved (P13).
+//
+// Real-timer, LOOSE bounds (a socket test): a long `ttfbDelayMs` holds the "in-flight" item so the
+// cancel lands while it is genuinely active; no wall-clock duration is asserted. Held sockets are
+// force-destroyed at teardown.
+import { downloadAll } from '../../src';
+import type { DownloadResult, ItemResult } from '../../src';
+import { startMockServer } from '../support/mock-server';
+import type { MockServer } from '../support/mock-server';
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+const blobText = async (b: Blob): Promise<string> =>
+    new TextDecoder().decode(await b.arrayBuffer());
+
+const okValue = (r: ItemResult): DownloadResult => {
+    if (r.status !== 'fulfilled')
+        throw new Error(`expected fulfilled but got ${r.status}`);
+    return r.value;
+};
+const byId = (results: ItemResult[]): Map<ItemResult['id'], ItemResult> =>
+    new Map(results.map((r) => [r.id, r]));
+
+test('cancel ONE in-flight item — only it aborts; its slot returns to the queue for the next item (P10)', async () => {
+    // concurrency 1: A is admitted (in-flight, held long), B & C queued. Cancelling A frees its slot.
+    server.route('GET', '/a', {
+        statuses: [200],
+        rawBody: 'a-body',
+        ttfbDelayMs: 2000,
+    });
+    server.route('GET', '/b', { statuses: [200], rawBody: 'b-body' });
+    server.route('GET', '/c', { statuses: [200], rawBody: 'c-body' });
+
+    const started: string[] = [];
+    const batch = downloadAll(
+        [
+            { path: '/a', id: 'a' },
+            { path: '/b', id: 'b' },
+            { path: '/c', id: 'c' },
+        ],
+        {
+            concurrency: 1,
+            defaults: { baseUrl: server.url, retry: { attempts: 1 } },
+            onItemStart: (id) => {
+                started.push(id as string);
+            },
+        },
+    );
+
+    // A is active synchronously; cancel it. Its slot returns to FIFO → B (then C) run.
+    batch.cancel('a');
+    const map = byId(await batch);
+
+    expect(map.get('a')!.status).toBe('cancelled');
+    expect(map.get('b')!.status).toBe('fulfilled');
+    expect(map.get('c')!.status).toBe('fulfilled');
+    // B & C could only START once A's slot freed (concurrency 1) → proof the slot returned to the queue.
+    expect(started).toEqual(['a', 'b', 'c']);
+    expect(await blobText(okValue(map.get('b')!).blob)).toBe('b-body');
+});
+
+test('cancel a QUEUED item — frees no slot, never hits the wire, does not skip the next (P11)', async () => {
+    // concurrency 1: A in-flight (finishes normally), B queued (cancelled), C queued (must still run).
+    server.route('GET', '/a', {
+        statuses: [200],
+        rawBody: 'a-body',
+        ttfbDelayMs: 60,
+    });
+    server.route('GET', '/b', { statuses: [200], rawBody: 'b-body' });
+    server.route('GET', '/c', { statuses: [200], rawBody: 'c-body' });
+
+    const started: string[] = [];
+    const batch = downloadAll(
+        [
+            { path: '/a', id: 'a' },
+            { path: '/b', id: 'b' },
+            { path: '/c', id: 'c' },
+        ],
+        {
+            concurrency: 1,
+            defaults: { baseUrl: server.url, retry: { attempts: 1 } },
+            onItemStart: (id) => {
+                started.push(id as string);
+            },
+        },
+    );
+
+    // B is queued (A holds the only slot). Cancel B while it is still queued.
+    batch.cancel('b');
+    const map = byId(await batch);
+
+    expect(map.get('a')!.status).toBe('fulfilled');
+    expect(map.get('b')!.status).toBe('cancelled');
+    expect(map.get('c')!.status).toBe('fulfilled'); // C was NOT skipped
+    // B never started; A then C ran (B dropped from the queue without consuming a slot).
+    expect(started).toEqual(['a', 'c']);
+    expect(server.callCount('/b')).toBe(0);
+});
+
+test('CANCEL-ALL aborts every in-flight + drains the queue; the host pool is left clean (P12/P13)', async () => {
+    for (const p of ['/x0', '/x1', '/x2', '/x3'])
+        server.route('GET', p, {
+            statuses: [200],
+            rawBody: `body${p}`,
+            ttfbDelayMs: 500, // all hold, so 2 are in-flight and 2 are queued when we cancel
+        });
+
+    const batch = downloadAll(
+        ['/x0', '/x1', '/x2', '/x3'].map((p) => ({ path: p })),
+        {
+            concurrency: 2,
+            defaults: {
+                baseUrl: server.url,
+                throttle: { concurrency: 2, pool: 'host' },
+                retry: { attempts: 1 },
+            },
+        },
+    );
+
+    batch.cancelAll();
+    const results = await batch;
+    // Every item cancelled (2 in-flight aborted + 2 queued drained), promptly — no hang.
+    expect(results.every((r) => r.status === 'cancelled')).toBe(true);
+
+    // P13: a FRESH batch to the same host reaches full concurrency (2 open on the wire) — the engine's
+    // pool:'host' budget was released on abort, not leaked. reset() gives the probe a clean baseline
+    // (and, per the M5 fix, leaves idle keep-alive sockets alive so the next request isn't a stale one).
+    server.reset();
+    for (const p of ['/y0', '/y1', '/y2', '/y3'])
+        server.route('GET', p, {
+            statuses: [200],
+            rawBody: `body${p}`,
+            ttfbDelayMs: 120,
+        });
+
+    const results2 = await downloadAll(
+        ['/y0', '/y1', '/y2', '/y3'].map((p) => ({ path: p })),
+        {
+            concurrency: 2,
+            defaults: {
+                baseUrl: server.url,
+                throttle: { concurrency: 2, pool: 'host' },
+                retry: { attempts: 1 },
+            },
+        },
+    );
+    expect(results2.every((r) => r.status === 'fulfilled')).toBe(true);
+    expect(server.maxOpen()).toBe(2); // reached full concurrency → the pool budget was left clean
+});

--- a/packages/download/test/gaps/download-batch-ceiling.spec.ts
+++ b/packages/download/test/gaps/download-batch-ceiling.spec.ts
@@ -1,0 +1,77 @@
+// Pins P1/P6/P14 (download-test-rig-spec §2.8) at the @stitchapi/download BATCH layer: the batch's own
+// FIFO scheduler holds the wire to ≤ `concurrency` requests open at once (P1) AND admits queued items in
+// strict ENQUEUE ORDER as slots free (P6/P14). Core's download-concurrency-ceiling.spec explicitly
+// DEFERRED proving per-item order to this package ("proving per-item order needs the batch API's stable
+// item identity + start events, which don't exist yet") — `onItemStart` is that event.
+//
+// Real-timer, LOOSE bounds (a socket test): each route holds its admitted slot with `ttfbDelayMs` so the
+// K requests overlap on the wire long enough for the server's `maxOpen` probe to see the peak; no
+// wall-clock gap is asserted, only a COUNT + an order. Held sockets are force-destroyed at teardown.
+import { downloadAll } from '../../src';
+import type { DownloadResult, ItemResult } from '../../src';
+import { startMockServer } from '../support/mock-server';
+import type { MockServer } from '../support/mock-server';
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+const blobText = async (b: Blob): Promise<string> =>
+    new TextDecoder().decode(await b.arrayBuffer());
+
+// Narrow to the fulfilled arm by THROWING (not a conditional `expect`, which the lint forbids).
+const okValue = (r: ItemResult): DownloadResult => {
+    if (r.status !== 'fulfilled')
+        throw new Error(`expected fulfilled but got ${r.status}`);
+    return r.value;
+};
+
+test('the batch caps the wire at `concurrency` and admits queued items in FIFO order', async () => {
+    const K = 2;
+    const N = 6;
+    const paths = Array.from({ length: N }, (_, i) => `/file-${i}`);
+    for (const p of paths)
+        server.route('GET', p, {
+            statuses: [200],
+            rawBody: `body${p}`,
+            ttfbDelayMs: 120, // hold each admitted slot open long enough to observe the peak overlap
+        });
+
+    const started: number[] = [];
+    const batch = downloadAll(
+        paths.map((p) => ({ path: p })),
+        {
+            concurrency: K,
+            defaults: { baseUrl: server.url, retry: { attempts: 1 } },
+            onItemStart: (id) => {
+                started.push(id as number);
+            },
+        },
+    );
+    const results = await batch;
+
+    // THE CEILING: never more than K requests open on the wire at any instant (the server's own probe),
+    // and genuinely SATURATED (the peak reached K) so "≤ K" isn't passing vacuously at 1.
+    expect(server.maxOpen()).toBeLessThanOrEqual(K);
+    expect(server.maxOpen()).toBe(K);
+
+    // FIFO ADMISSION: the six items started in strict enqueue order 0..5 — no queue-jumping. (Ids
+    // default to the enqueue index when an item carries no explicit id / url.)
+    expect(started).toEqual([0, 1, 2, 3, 4, 5]);
+
+    // Every file downloaded completely; the cap PACES work, it never drops it.
+    expect(results).toHaveLength(N);
+    expect(results.every((r) => r.status === 'fulfilled')).toBe(true);
+    for (let i = 0; i < N; i++)
+        expect(await blobText(okValue(results[i]!).blob)).toBe(
+            `body${paths[i]!}`,
+        );
+    expect(server.callCount()).toBe(N);
+});

--- a/packages/download/test/gaps/download-batch-dedupe.spec.ts
+++ b/packages/download/test/gaps/download-batch-dedupe.spec.ts
@@ -1,0 +1,70 @@
+// Pins P18 at the batch layer: the same-URL DEDUPE contract. Core's partial-failure spec DEFERRED this
+// as "NEW batch-layer code (StitchAPI's only coalescing is cache-gated, and blobs are typically
+// uncacheable); the batch API picks the contract (recommended default: independent fetches)". Here we
+// prove BOTH sides with the server's hit-counter: default = two independent requests; `dedupe: true` =
+// one in-flight request shared by both handles.
+import { downloadAll } from '../../src';
+import type { DownloadResult, ItemResult } from '../../src';
+import { startMockServer } from '../support/mock-server';
+import type { MockServer } from '../support/mock-server';
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+const blobText = async (b: Blob): Promise<string> =>
+    new TextDecoder().decode(await b.arrayBuffer());
+
+const okValue = (r: ItemResult): DownloadResult => {
+    if (r.status !== 'fulfilled')
+        throw new Error(`expected fulfilled but got ${r.status}`);
+    return r.value;
+};
+
+test('by DEFAULT, duplicate URLs are INDEPENDENT fetches — two requests on the wire', async () => {
+    server.route('GET', '/dup', {
+        statuses: [200],
+        rawBody: 'dup-body',
+        ttfbDelayMs: 40, // hold both slots open together so a dedupe (if any) would collapse them
+    });
+    const url = `${server.url}/dup`;
+
+    const results = await downloadAll([{ url }, { url }], {
+        concurrency: 2,
+        defaults: { retry: { attempts: 1 } },
+    });
+
+    expect(results.every((r) => r.status === 'fulfilled')).toBe(true);
+    expect(server.callCount('/dup')).toBe(2); // independent → two wire requests
+    expect(await blobText(okValue(results[0]!).blob)).toBe('dup-body');
+    expect(await blobText(okValue(results[1]!).blob)).toBe('dup-body');
+});
+
+test('dedupe:true collapses concurrent duplicate URLs onto ONE in-flight request', async () => {
+    server.route('GET', '/dup', {
+        statuses: [200],
+        rawBody: 'dup-body',
+        ttfbDelayMs: 40,
+    });
+    const url = `${server.url}/dup`;
+
+    const results = await downloadAll([{ url }, { url }], {
+        concurrency: 2,
+        dedupe: true,
+        defaults: { retry: { attempts: 1 } },
+    });
+
+    expect(results.every((r) => r.status === 'fulfilled')).toBe(true);
+    expect(server.callCount('/dup')).toBe(1); // deduped → ONE wire request
+    // Both handles resolved to the SAME underlying result (one fetch, shared).
+    expect(await blobText(okValue(results[0]!).blob)).toBe('dup-body');
+    expect(await blobText(okValue(results[1]!).blob)).toBe('dup-body');
+    expect(okValue(results[0]!).blob).toBe(okValue(results[1]!).blob);
+});

--- a/packages/download/test/gaps/download-batch-idle-timeout.spec.ts
+++ b/packages/download/test/gaps/download-batch-idle-timeout.spec.ts
@@ -1,0 +1,127 @@
+// Pins THE FINDING core's download-slow-vs-stall.spec surfaced (no idle/forward-progress timeout in the
+// engine — TimeoutOptions is all wall-clock) + P9, at the batch layer. `idleTimeout` resets on every
+// onProgress chunk, so a DEAD stall is aborted (retryable IDLE_TIMEOUT) while a slow-but-progressing
+// sibling SURVIVES — the distinction the wall-clock timeout cannot make. And a stalled item under
+// concurrency times out ALONE: siblings finish with intact blobs.
+//
+// Real-timer, LOOSE bounds (a socket test): the idle timer runs on the default `systemClock`; the stall
+// hold and chunk cadence are set with wide margins vs the idle window. Held sockets are force-destroyed
+// at teardown.
+import { downloadAll } from '../../src';
+import type { DownloadResult, ItemResult } from '../../src';
+import { startMockServer } from '../support/mock-server';
+import type { MockServer } from '../support/mock-server';
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+const blobText = async (b: Blob): Promise<string> =>
+    new TextDecoder().decode(await b.arrayBuffer());
+
+const okValue = (r: ItemResult): DownloadResult => {
+    if (r.status !== 'fulfilled')
+        throw new Error(`expected fulfilled but got ${r.status}`);
+    return r.value;
+};
+const asRejected = (
+    r: ItemResult,
+): Extract<ItemResult, { status: 'rejected' }> => {
+    if (r.status !== 'rejected')
+        throw new Error(`expected rejected but got ${r.status}`);
+    return r;
+};
+
+test('a dead stall trips the idle timeout and is cut ALONE — siblings finish with intact blobs', async () => {
+    server.route('GET', '/well-0', {
+        statuses: [200],
+        rawBody: 'well-0-body',
+        ttfbDelayMs: 30,
+    });
+    server.route('GET', '/stalls', {
+        statuses: [200],
+        rawBody: 'x'.repeat(64),
+        declaredLength: 64, // advertise 64…
+        stallAfterBytes: 8, // …write 8, then hold the socket open forever
+    });
+    server.route('GET', '/well-1', {
+        statuses: [200],
+        rawBody: 'well-1-body',
+        ttfbDelayMs: 30,
+    });
+    server.route('GET', '/well-2', {
+        statuses: [200],
+        rawBody: 'well-2-body',
+        ttfbDelayMs: 30,
+    });
+
+    // The stall sits second → admitted in the first wave (K=2) alongside a healthy item; it then pins
+    // one slot until its idle timeout while the other slot drains the rest.
+    const results = await downloadAll(
+        [
+            { path: '/well-0' },
+            { path: '/stalls' },
+            { path: '/well-1' },
+            { path: '/well-2' },
+        ],
+        {
+            concurrency: 2,
+            idleTimeout: 200,
+            defaults: { baseUrl: server.url, retry: { attempts: 1 } },
+        },
+    );
+
+    expect(results.map((r) => r.status)).toEqual([
+        'fulfilled', // well-0
+        'rejected', // stalls → idle timeout
+        'fulfilled', // well-1
+        'fulfilled', // well-2
+    ]);
+
+    // The stall was cut by the IDLE timer (retryable), not resolved as a partial Blob.
+    const stall = asRejected(results[1]!);
+    expect(stall.code).toBe('IDLE_TIMEOUT');
+    expect(stall.retryable).toBe(true);
+
+    // Siblings' bytes are COMPLETE and uncorrupted — the stall did not distort their result.
+    expect(await blobText(okValue(results[0]!).blob)).toBe('well-0-body');
+    expect(await blobText(okValue(results[2]!).blob)).toBe('well-1-body');
+    expect(await blobText(okValue(results[3]!).blob)).toBe('well-2-body');
+});
+
+test('a slow-but-alive stream SURVIVES an idle timeout that a dead stall trips', async () => {
+    // slow: 60 bytes as 6 × 10-byte chunks, 40ms apart (~240ms streaming). Each gap (40ms) is well under
+    // the 120ms idle window, so the timer keeps resetting and the item FINISHES.
+    server.route('GET', '/slow', {
+        statuses: [200],
+        rawBody: 'x'.repeat(60),
+        chunkBytes: 10,
+        chunkDelayMs: 40,
+    });
+    // stall: write 8, then hold forever → no progress for > 120ms → trips.
+    server.route('GET', '/stall', {
+        statuses: [200],
+        rawBody: 'y'.repeat(64),
+        declaredLength: 64,
+        stallAfterBytes: 8,
+    });
+
+    const results = await downloadAll([{ path: '/slow' }, { path: '/stall' }], {
+        concurrency: 2,
+        idleTimeout: 120,
+        defaults: { baseUrl: server.url, retry: { attempts: 1 } },
+    });
+
+    // slow-but-alive survived (bytes kept arriving); the dead stall tripped the same idle window.
+    expect(results[0]!.status).toBe('fulfilled');
+    expect(await blobText(okValue(results[0]!).blob)).toBe('x'.repeat(60));
+    const stall = asRejected(results[1]!);
+    expect(stall.code).toBe('IDLE_TIMEOUT');
+});

--- a/packages/download/test/gaps/download-batch-progress.spec.ts
+++ b/packages/download/test/gaps/download-batch-progress.spec.ts
@@ -1,0 +1,120 @@
+// Pins P8/P17 at the batch API: aggregate progress + ETA across N concurrent streams, correct under a
+// KNOWN byte schedule and driven by the injected Clock (`manualClock`) so the rate/ETA MATH is
+// deterministic with ZERO wall-clock. Core's ceiling spec DEFERRED this as "a batch-level roll-up, not a
+// property of a single download()". A stalled sibling plateaus its own term but never corrupts the
+// aggregate; a failed/cancelled item's partial bytes are discarded (P9).
+import { downloadAll } from '../../src';
+import type { BatchProgress, DownloadResult, ItemResult } from '../../src';
+import { ProgressAggregator } from '../../src/progress';
+import { startMockServer } from '../support/mock-server';
+import type { MockServer } from '../support/mock-server';
+
+import { manualClock } from 'stitchapi/testing';
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+const okValue = (r: ItemResult): DownloadResult => {
+    if (r.status !== 'fulfilled')
+        throw new Error(`expected fulfilled but got ${r.status}`);
+    return r.value;
+};
+
+test('aggregate loaded/total/rate/ETA are EXACT under a known byte schedule (manualClock)', async () => {
+    const clock = manualClock(0);
+    const agg = new ProgressAggregator(clock);
+
+    // Two 1000-byte streams. First bytes at t=0 (loaded > 0 sets the ETA baseline).
+    agg.item('a', { loaded: 100, total: 1000 });
+    agg.item('b', { loaded: 100, total: 1000 });
+    await clock.advance(1000); // one second of virtual time, by hand (advance() is async)
+    agg.item('a', { loaded: 600, total: 1000 });
+    agg.item('b', { loaded: 400, total: 1000 });
+
+    const s = agg.snapshot(2);
+    expect(s.loaded).toBe(1000); // 600 + 400
+    expect(s.total).toBe(2000); // 1000 + 1000
+    expect(s.count).toBe(2);
+    expect(s.completed).toBe(0);
+    // 1000 bytes in 1000ms → 1000 B/s; remaining 1000 bytes → ETA exactly 1000ms. No wall-clock.
+    expect(s.ratePerSec).toBe(1000);
+    expect(s.etaMs).toBe(1000);
+});
+
+test('a stalled sibling plateaus its own term; a dropped item discards its partial bytes', async () => {
+    const clock = manualClock(0);
+    const agg = new ProgressAggregator(clock);
+    agg.item('fast', { loaded: 500, total: 1000 });
+    agg.item('stall', { loaded: 200, total: 1000 });
+    await clock.advance(1000);
+    agg.item('fast', { loaded: 1000, total: 1000 }); // 'stall' never reports again — frozen at 200
+
+    const s = agg.snapshot(2);
+    expect(s.loaded).toBe(1200); // 1000 + 200 — the stall contributes ONLY what it truly pulled
+    expect(s.total).toBe(2000);
+
+    // fast fulfils; stall times out and is dropped → its 200 partial bytes vanish from the aggregate.
+    agg.fulfilled('fast', 1000, 1000);
+    agg.dropped('stall');
+    const s2 = agg.snapshot(2);
+    expect(s2.loaded).toBe(1000); // only fast's final bytes; the stall's partial is discarded
+    expect(s2.completed).toBe(2);
+});
+
+test('an indeterminate (chunked) item makes the aggregate total + ETA undefined, rate still known', async () => {
+    const clock = manualClock(0);
+    const agg = new ProgressAggregator(clock);
+    agg.item('chunked', { loaded: 50 }); // no total (chunked / no Content-Length)
+    await clock.advance(500);
+
+    const s = agg.snapshot(1);
+    expect(s.loaded).toBe(50);
+    expect(s.total).toBeUndefined();
+    expect(s.etaMs).toBeUndefined(); // no total ⇒ no ETA…
+    expect(s.ratePerSec).toBe(100); // …but the rate is still known: 50 bytes in 0.5s = 100 B/s
+});
+
+test('downloadAll rolls per-item progress into a correct aggregate across concurrent streams', async () => {
+    const sizes: Record<string, number> = {
+        '/p0': 300,
+        '/p1': 500,
+        '/p2': 700,
+    };
+    for (const [p, n] of Object.entries(sizes))
+        server.route('GET', p, {
+            statuses: [200],
+            rawBody: 'x'.repeat(n),
+            chunkBytes: 100,
+            chunkDelayMs: 5,
+        });
+
+    let last: BatchProgress | undefined;
+    const results = await downloadAll(
+        Object.keys(sizes).map((p) => ({ path: p })),
+        {
+            concurrency: 3,
+            defaults: { baseUrl: server.url, retry: { attempts: 1 } },
+            onProgress: (p) => {
+                last = p;
+            },
+        },
+    );
+
+    expect(results.every((r) => r.status === 'fulfilled')).toBe(true);
+    expect(last).toBeDefined();
+    // The final aggregate accounts for every byte and every item — a truthful roll-up of N streams.
+    expect(last!.completed).toBe(3);
+    expect(last!.count).toBe(3);
+    expect(last!.loaded).toBe(300 + 500 + 700);
+    // Sanity: the fulfilled blobs are the exact sizes we streamed.
+    expect(okValue(results[0]!).blob.size).toBe(300);
+    expect(okValue(results[2]!).blob.size).toBe(700);
+});

--- a/packages/download/test/gaps/download-batch-settle.spec.ts
+++ b/packages/download/test/gaps/download-batch-settle.spec.ts
@@ -1,0 +1,104 @@
+// Pins P4 at the batch API: downloadAll SETTLES PER ITEM — one bad URL (a 404, or a mid-body RST) never
+// fails the others, and the returned promise NEVER rejects (unlike `Promise.all`, which would collapse
+// on the first reject). Core's download-concurrency-partial-failure.spec proved this on the raw
+// download()+throttle substrate and DEFERRED making it the batch API's contract. Results come back in
+// ENQUEUE ORDER; each failure carries a classification.
+import { downloadAll } from '../../src';
+import type { DownloadResult, ItemResult } from '../../src';
+import { startMockServer } from '../support/mock-server';
+import type { MockServer } from '../support/mock-server';
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+const blobText = async (b: Blob): Promise<string> =>
+    new TextDecoder().decode(await b.arrayBuffer());
+
+const okValue = (r: ItemResult): DownloadResult => {
+    if (r.status !== 'fulfilled')
+        throw new Error(`expected fulfilled but got ${r.status}`);
+    return r.value;
+};
+const asRejected = (
+    r: ItemResult,
+): Extract<ItemResult, { status: 'rejected' }> => {
+    if (r.status !== 'rejected')
+        throw new Error(`expected rejected but got ${r.status}`);
+    return r;
+};
+
+// A mixed batch: good / 404 / good / RST / good — failures interleaved with successes, all sharing one
+// budget of 2, so isolation must survive real concurrency (not just a serial run).
+const ITEMS = [
+    { path: '/ok-0', kind: 'ok' },
+    { path: '/bad-404', kind: 'notfound' },
+    { path: '/ok-1', kind: 'ok' },
+    { path: '/bad-rst', kind: 'reset' },
+    { path: '/ok-2', kind: 'ok' },
+] as const;
+
+test('downloadAll settles per item and never rejects — a 404 + a RST are isolated from successes', async () => {
+    for (const it of ITEMS) {
+        if (it.kind === 'ok')
+            server.route('GET', it.path, {
+                statuses: [200],
+                rawBody: `ok${it.path}`,
+                ttfbDelayMs: 40,
+            });
+        else if (it.kind === 'notfound')
+            server.route('GET', it.path, {
+                statuses: [404],
+                body: { error: 'not_found' },
+            });
+        else
+            server.route('GET', it.path, {
+                statuses: [200],
+                rawBody: 'ABCDEFGHIJKLMNOP', // 16 bytes advertised…
+                declaredLength: 16,
+                resetAfterBytes: 4, // …only 4 written, then a real ECONNRESET mid-body
+            });
+    }
+
+    // Awaiting the batch RESOLVES (never throws) even though two items fail terminally.
+    const results = await downloadAll(
+        ITEMS.map((it) => ({ path: it.path })),
+        {
+            concurrency: 2,
+            defaults: { baseUrl: server.url, retry: { attempts: 1 } },
+        },
+    );
+
+    // Each item settled strictly on its OWN outcome, in enqueue order.
+    expect(results.map((r) => r.status)).toEqual([
+        'fulfilled',
+        'rejected',
+        'fulfilled',
+        'rejected',
+        'fulfilled',
+    ]);
+
+    // Successful items carry their COMPLETE, uncorrupted bytes despite failing siblings sharing the run.
+    expect(await blobText(okValue(results[0]!).blob)).toBe('ok/ok-0');
+    expect(await blobText(okValue(results[2]!).blob)).toBe('ok/ok-1');
+    expect(await blobText(okValue(results[4]!).blob)).toBe('ok/ok-2');
+
+    // The failures are classified: a terminal 404, and a retryable transport RST (undici "fetch failed").
+    const e404 = asRejected(results[1]!);
+    expect(e404.retryable).toBe(false);
+    expect(e404.code).toBe('HTTP_404');
+
+    const eRst = asRejected(results[3]!);
+    expect(eRst.retryable).toBe(true);
+    expect(eRst.code).toBeDefined();
+    expect(eRst.reason.message).toMatch(/fetch failed/i);
+
+    expect(server.callCount()).toBe(ITEMS.length);
+});

--- a/packages/download/test/gaps/download-classify.spec.ts
+++ b/packages/download/test/gaps/download-classify.spec.ts
@@ -1,0 +1,77 @@
+// Pins finding #2 (the engine DROPS the transport `.cause` before a caller sees it — the
+// download-reset-midbody finding — so a RST is indistinguishable from a generic 'fetch failed').
+// @stitchapi/download recovers it: a per-item `hooks.onError` seam captures the RAW transport error
+// BEFORE the engine flattens it, and each rejection is classified — retryable-vs-terminal + a
+// best-effort machine `code`. Real sockets (mock-server + the hostile-net raw-socket hatch) so the
+// codes are genuine, not mocked.
+import { downloadAll } from '../../src';
+import type { ItemResult } from '../../src';
+import { unusedPort } from '../support/hostile-net';
+import { startMockServer } from '../support/mock-server';
+import type { MockServer } from '../support/mock-server';
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+const asRejected = (
+    r: ItemResult,
+): Extract<ItemResult, { status: 'rejected' }> => {
+    if (r.status !== 'rejected')
+        throw new Error(`expected rejected but got ${r.status}`);
+    return r;
+};
+
+test('a mid-body RST is retryable with a transport code; a 404 is terminal (HTTP_404)', async () => {
+    server.route('GET', '/rst', {
+        statuses: [200],
+        rawBody: 'ABCDEFGHIJKLMNOP',
+        declaredLength: 16,
+        resetAfterBytes: 4, // real ECONNRESET mid-body
+    });
+    server.route('GET', '/404', {
+        statuses: [404],
+        body: { error: 'nope' },
+    });
+
+    const results = await downloadAll([{ path: '/rst' }, { path: '/404' }], {
+        concurrency: 2,
+        defaults: { baseUrl: server.url, retry: { attempts: 1 } },
+    });
+
+    // The RST: the raw undici error (captured via hooks.onError) carries a transport code the flattened
+    // StitchError does not — so we classify it retryable even though its message is just "fetch failed".
+    const rst = asRejected(results[0]!);
+    expect(rst.retryable).toBe(true);
+    expect(rst.code).toBeDefined();
+    expect(rst.reason.message).toMatch(/fetch failed/i);
+
+    // The 404: a response-level failure → terminal, coded from its status.
+    const e404 = asRejected(results[1]!);
+    expect(e404.retryable).toBe(false);
+    expect(e404.code).toBe('HTTP_404');
+});
+
+test('ECONNREFUSED (nothing listening) is classified retryable', async () => {
+    const port = await unusedPort();
+
+    const results = await downloadAll([{ url: `http://127.0.0.1:${port}/x` }], {
+        concurrency: 1,
+        defaults: { retry: { attempts: 1 } },
+    });
+
+    const refused = asRejected(results[0]!);
+    expect(refused.retryable).toBe(true);
+    // The connect refusal surfaces its code (ECONNREFUSED) via the captured cause chain, or at least a
+    // transport-shaped message — never a terminal classification.
+    expect(refused.code ?? refused.reason.message).toMatch(
+        /ECONNREFUSED|refused|fetch failed/i,
+    );
+});

--- a/packages/download/test/support/hostile-net.ts
+++ b/packages/download/test/support/hostile-net.ts
@@ -1,0 +1,4 @@
+// Re-export the core raw-socket escape hatch (ECONNREFUSED / immediate-FIN / accept-then-silence)
+// so @stitchapi/download specs can drive connection-level faults through the batch layer. Same
+// re-export pattern as ./mock-server.
+export * from '../../../core/test/support/hostile-net';

--- a/packages/download/test/support/mock-server.ts
+++ b/packages/download/test/support/mock-server.ts
@@ -1,0 +1,5 @@
+// Re-export the core download rig so @stitchapi/download specs prove the batch layer against the SAME
+// adversary the buffered surface was hardened against (rig spec §6 — "it gets its own test/support/
+// that imports/re-exports the core fixture"). Mirrors how core's test/support/streams.ts re-exports
+// from ../../src/test-stream: one source of truth for the mock server, shared across packages.
+export * from '../../../core/test/support/mock-server';

--- a/packages/download/tsconfig.json
+++ b/packages/download/tsconfig.json
@@ -1,0 +1,36 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "lib": ["ES2022", "DOM"],
+        "module": "ESNext",
+        "moduleResolution": "Bundler",
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+
+        "strict": true,
+        "noUncheckedIndexedAccess": true,
+        "exactOptionalPropertyTypes": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "verbatimModuleSyntax": true,
+        "isolatedModules": true,
+
+        "types": ["node", "vitest/globals"],
+
+        // Resolve the workspace package to its SOURCE so typecheck + tests don't
+        // depend on `stitchapi` being built first (the pre-push gate typechecks
+        // before it builds). The published `exports` map still points at `lib/`.
+        // Most-specific subpaths first.
+        "baseUrl": ".",
+        "paths": {
+            "stitchapi/testing": ["../core/src/testing.ts"],
+            "stitchapi/download": ["../core/src/download.ts"],
+            "stitchapi": ["../core/src/index.ts"]
+        }
+    },
+    "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/packages/download/tsup.config.ts
+++ b/packages/download/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+// Single dual-format entry; `stitchapi` (and its `stitchapi/download` subpath) is a
+// peer dep, externalised by tsup, so the bundle is just the batch orchestrator —
+// the FIFO scheduler, aggregate progress/ETA, cancel wiring, and error classifier.
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    minify: true,
+    outDir: 'lib',
+    clean: true,
+});

--- a/packages/download/vitest.config.ts
+++ b/packages/download/vitest.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+// Alias the workspace package to core SOURCE (more specific subpaths first), so
+// tests run without `stitchapi` being built. Mirrors tsconfig `paths`.
+const src = (p: string): string =>
+    fileURLToPath(new URL(`../core/src/${p}`, import.meta.url));
+
+export default defineConfig({
+    resolve: {
+        alias: [
+            { find: /^stitchapi\/testing$/, replacement: src('testing.ts') },
+            { find: /^stitchapi\/download$/, replacement: src('download.ts') },
+            { find: /^stitchapi$/, replacement: src('index.ts') },
+        ],
+    },
+    test: {
+        globals: true,
+        environment: 'node',
+        include: ['test/**/*.spec.ts'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,6 +389,27 @@ importers:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/download:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.21
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
+      stitchapi:
+        specifier: workspace:*
+        version: link:../core
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.21)(@vitest/coverage-v8@4.1.8)(jsdom@25.0.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/elysia:
     devDependencies:
       '@types/node':

--- a/scripts/gen-readme-metrics.mjs
+++ b/scripts/gen-readme-metrics.mjs
@@ -99,6 +99,7 @@ const GROUP_BY_DIR = {
     pino: 'observability',
     sentry: 'observability',
     shell: 'surface',
+    download: 'surface',
 };
 
 function groupFor(dir) {
@@ -352,6 +353,7 @@ const TABLE_DESCRIPTIONS = {
     sentry: 'Stitch events as Sentry breadcrumbs, with error capture',
     // Surfaces
     shell: 'Run a static local command as a stitch (injection-proof)',
+    download: 'Batch file downloads with FIFO concurrency, cancel, and ETA',
     // Cache fingerprint adapters
     'fingerprint-arktype': 'Cache-fingerprint strategy for ArkType schemas',
     'fingerprint-effect': 'Cache-fingerprint strategy for Effect Schema',


### PR DESCRIPTION
The batch downloader / manager the download test rig (PRs #447 M1–M3, #448 M4–M5) was built to prove. A new zero-runtime-dep, browser-first `@stitchapi/download` workspace package that sequences a **list** of downloads on top of core's buffered `download()` surface — turning every `// Deferred:` comment the rig left into a real, tested contract.

> **Stacked on #448.** Base is `claude/download-m4-batch` (the rig). Retarget to `main` once #447/#448 merge.

## API

`downloadAll(items, opts)` — one-shot, awaitable (resolves to per-item results in enqueue order, **never rejects**) + controllable. Plus the stateful `DownloadManager` it's built on (enqueue over time).

```ts
const batch = downloadAll(urls, { concurrency: 4, onProgress: (p) => render(p) });
batch.cancel(id);            // cancel one → its slot goes to the next queued item
const results = await batch; // ItemResult[] — settles per item
```

The package runs its **own FIFO concurrency scheduler** over `download()` (core's `throttle` pools a budget but can't express FIFO order, start events, or clean cancel-queued — its queue is opaque).

## What it adds — and proves against the rig

| Contract | Rig req | Spec |
|---|---|---|
| ≤ `concurrency` open on the wire + FIFO admission order | P1/P6/P14 | `download-batch-ceiling` |
| Per-item settling — batch promise never rejects | P4 | `download-batch-settle` |
| Cancel one / queued / all; `pool:'host'` left clean | P10–P13 | `download-batch-cancel` |
| Aggregate progress + ETA (deterministic, manualClock); stall never distorts | P8/P9/P17 | `download-batch-progress` |
| Same-URL dedupe — independent default, opt-in collapse | P18 | `download-batch-dedupe` |

## The two findings — solved in the package (core untouched)

1. **Idle / forward-progress timeout.** The engine's `timeout` is all wall-clock, so a healthy-but-slow download dies by the same clock as a dead stall. `idleTimeout` resets on each `onProgress` chunk — a slow-but-alive stream survives while a genuine stall is cut (retryable `IDLE_TIMEOUT`). (`download-batch-idle-timeout`)
2. **Transport error classification.** The engine drops the transport `.cause` before a caller sees it, so an RST is indistinguishable from a generic `fetch failed`. The package captures the raw error via a per-item `hooks.onError` seam and reports `retryable` + a machine `code` (`UND_ERR_SOCKET` / `HTTP_404` / `IDLE_TIMEOUT`). (`download-classify`)

> A companion **core PR carries the transport `.cause` through the engine's error event** for *all* stitch callers (opened separately). This package does not depend on it — it stays self-contained via the hook.

## Verification

- `pnpm run check:types` — **0 errors, all 38 packages**.
- `@stitchapi/download` suite — **15 tests / 7 files green** (3× consecutively, no flake).
- Build + `check:size` — **2.46 KB gzip / 2.65 KB budget**; core bundle unchanged at **24.58 / 19.80**.
- **Zero runtime dependencies** (`stitchapi` peer-only); prettier clean.

## Test approach

`test/support/` re-exports the core rig (`mock-server` + `hostile-net`), mirroring `test/support/streams.ts`. Specs mirror the existing `download-*.spec.ts` patterns exactly: assert on-wire **overlap** via the server's `maxOpen` probe (never a wall-clock gap), `manualClock` for pure ETA math, real timers with loose bounds for socket tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)