### PR TITLE
chore(mcp): list @stitchapi/docs-mcp on the docs registry entry (→ Glama)

### DIFF
--- a/server.json
+++ b/server.json
@@ -3,12 +3,22 @@
     "name": "dev.stitchapi/docs",
     "title": "StitchAPI Docs",
     "description": "Search and read the StitchAPI docs: search_docs finds relevant sections, get_doc reads a page.",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "repository": {
         "url": "https://github.com/rejifald/StitchAPI",
         "source": "github"
     },
     "websiteUrl": "https://stitchapi.dev",
+    "packages": [
+        {
+            "registryType": "npm",
+            "identifier": "@stitchapi/docs-mcp",
+            "version": "1.0.0-rc.5",
+            "transport": {
+                "type": "stdio"
+            }
+        }
+    ],
     "remotes": [
         {
             "type": "streamable-http",


### PR DESCRIPTION
## ⚠️ DRAFT — do not merge until `@stitchapi/docs-mcp@1.0.0-rc.5` is live on npm

This registers the local/offline stdio package on the existing `dev.stitchapi/docs` MCP-registry entry so it **cascades to Glama + PulseMCP** (per `docs/MCP-PUBLISHING.md`). The registry publish only fires on **merge to main** (when `server.json`'s version changes), and at that point it verifies npm-package ownership via the `mcpName` field.

**`mcpName` only exists from rc.5** (added in #463; rc.4 predates it). So:

1. Merge #463, cut the rc.5 release, confirm `@stitchapi/docs-mcp@1.0.0-rc.5` is on npm.
2. **Then** mark this PR ready and merge → `publish-mcp.yml` publishes `server.json` v1.1.0 → Glama/PulseMCP cascade.

Merging before rc.5 is on npm would fail the registry publish (unknown/ownership-unverified package version).

## Change
- Add a `packages` entry to `server.json` (npm / `@stitchapi/docs-mcp` / `1.0.0-rc.5` / stdio transport) beside the existing hosted `streamable-http` remote — one logical server, two ways to run it.
- Bump `server.json` `version` `1.0.0 → 1.1.0` (the registry rejects a duplicate version).

## Validation
- Valid JSON; fields match the pinned `2025-12-11` schema (`registryType`, `identifier`, `version`, `transport.type`).
- The `Publish MCP server / validate` check on this PR runs `mcp-publisher validate ./server.json` (offline schema+semantic check — no npm/secret needed), so it goes green now; the npm-ownership check happens only at publish time on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)