### PR TITLE
ci(release): raise publish-npm timeout 10 → 25 min

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -97,7 +97,12 @@ jobs:
     publish-npm:
         needs: [verify, e2e]
         runs-on: ubuntu-latest
-        timeout-minutes: 10
+        # 34 packages publish in one lockstep run, and @stitchapi/docs-mcp rebuilds its
+        # bundled docs (a ~90 MB model download) at pack time — 10 min clipped the tail
+        # in the rc.5 run (everything past `rtk-query` never published, and docs-mcp's own
+        # slow pack pushed it over). 25 gives comfortable headroom; it's a ceiling, not a
+        # target — a healthy run still finishes in ~10-13 min.
+        timeout-minutes: 25
         permissions:
             contents: read
             id-token: write # mint the OIDC token npm exchanges for publish auth (+ provenance)


### PR DESCRIPTION
## Why

The `1.0.0-rc.5` lockstep release exposed that the `publish-npm` job's `timeout-minutes: 10` is too tight for a full 34-package release:

- The job hit the 10-min ceiling and was **cancelled after `rtk-query`**, so the alphabetical tail (`sentry`, `shell`, `solid`, `svelte`, `swr`, `vercel-ai`, `vue`) never published.
- `@stitchapi/docs-mcp` compounds it — its `pnpm pack` re-runs `copy-bundle` (rebuilding the docs search index + a ~90 MB embedding-model download), which is slow.

Result: rc.5 landed 25/33 packages on the first run and needed a manual re-run of the publish job to finish. The re-run only fit because it had just 8 packages left to publish.

## Change

Bump the `publish-npm` job timeout `10 → 25` minutes (with an explanatory comment). It's a ceiling, not a target — a healthy full-set run still finishes in ~10–13 min; this just stops a full release from clipping the tail again (next up: `rc.6` / `1.0.0`).

Only the `publish-npm` job is touched; `preflight` (5), `verify` (10), and `e2e` (15) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)