### PR TITLE
chore(glama): add root glama.json to claim StitchAPI on Glama's directory

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://glama.ai/mcp/schemas/server.json",
+    "maintainers": ["rejifald"]
+}


### PR DESCRIPTION
## Why

Glama has two surfaces: the registry-sourced **connector** (already live via the MCP-registry cascade) and the GitHub-crawled **server directory** (`glama.ai/mcp/servers`). The [awesome-mcp-servers listing #9027](https://github.com/punkpeye/awesome-mcp-servers/pull/9027) (punkpeye = Glama's founder) expects a real **server** entry, not just a connector.

A maintainer claims a server in Glama's directory by adding a root `glama.json` and running the claim flow. This adds it.

## The file

```json
{
    "$schema": "https://glama.ai/mcp/schemas/server.json",
    "maintainers": ["rejifald"]
}
```

The [schema](https://glama.ai/mcp/schemas/server.json) supports **only** `maintainers` (required, array of GitHub usernames) — there is no field for a subdirectory, npm package, or Docker path, so this claims the **`rejifald/StitchAPI` repo as a whole** (it can't be scoped to `packages/docs-mcp`).

## After merge (manual, on glama.ai)

1. Merge this so `glama.json` is on the **default branch** (Glama reads it there).
2. On glama.ai, run **Claim ownership** for the StitchAPI server (or authenticate with GitHub, since the repo is under `rejifald`) — this associates the account and triggers a re-crawl.
3. Glama indexes the repo → a directory **server** entry appears → that should unblock #9027.

> Caveat: because it's a monorepo, Glama lists the repo (core + docs-mcp together), not a standalone docs-mcp server. If the maintainer wants a dedicated docs-mcp entry, that would need docs-mcp in its own repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)