### PR TITLE
chore(mcp): dogfood the docs MCP in this repo (.mcp.json + CLAUDE.md rule)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+    "mcpServers": {
+        "stitchapi-docs": {
+            "command": "npx",
+            "args": ["-y", "@stitchapi/docs-mcp"]
+        }
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,29 @@ If you ever land in a worktree without deps (e.g. the hook was disabled), run th
 same command by hand. Don't symlink `node_modules` into the worktree — pnpm would
 write through the symlink into the primary checkout's store. A real `pnpm install`
 is the correct fix.
+
+## Using the StitchAPI docs MCP
+
+This repo ships the `stitchapi-docs` MCP server preconfigured in
+[`.mcp.json`](.mcp.json) — the local, offline
+[`@stitchapi/docs-mcp`](https://www.npmjs.com/package/@stitchapi/docs-mcp)
+package, which answers from a docs bundle on your machine (no per-query network;
+a one-time embedding-model download on first use). For any question about
+StitchAPI's own public API, configuration, errors, or runtime behavior, use it
+before answering:
+
+-   Call `search_docs` with a natural-language query first, and read the excerpts
+    and deep links it returns.
+-   Call `get_doc` to read a full page when an excerpt is not enough.
+-   Prefer these tools over prior knowledge. StitchAPI moves faster than model
+    training data, so the published docs are the source of truth — when they
+    disagree with memory, follow the docs.
+
+Two caveats specific to working **inside this repo**:
+
+-   The bundle tracks the last published release, so for docs you are actively
+    editing under `apps/docs/content`, read the working tree — it is ahead of the
+    bundle.
+-   Want the latest unreleased docs over the local bundle instead? Swap the
+    `.mcp.json` entry to the hosted server (`https://stitchapi.dev/api/mcp`,
+    transport `http`).


### PR DESCRIPTION
## What

Makes the StitchAPI repo **dogfood its own docs MCP**. Until now nothing here pointed agents at `stitchapi-docs` — no `.mcp.json`, no rule — even though we just shipped and documented the server.

- **`.mcp.json`** (new) — registers `stitchapi-docs` as the local, offline [`@stitchapi/docs-mcp`](https://www.npmjs.com/package/@stitchapi/docs-mcp) package (`npx -y @stitchapi/docs-mcp`), so any Claude Code session in this repo has `search_docs`/`get_doc` with no per-query network.
- **`CLAUDE.md`** — a "Using the StitchAPI docs MCP" section: `search_docs` first, `get_doc` for full pages, prefer the docs over stale training data.

## Why the local package (not the hosted URL)

Consistent with the local-first stance in the docs: the bundle answers from disk, and no query leaves the machine (aside from a one-time embedding-model download on first use). Two in-repo caveats are called out in the rule:

- For docs you're **actively editing** under `apps/docs/content`, read the working tree — it's ahead of the published bundle.
- Want the latest unreleased docs instead? Swap the `.mcp.json` entry to the hosted server (`https://stitchapi.dev/api/mcp`, transport `http`).

## Scope

The library repo isn't a stitch *consumer*, so it gets the docs-**lookup** rule — not the `stitch init` "declare a stitch instead of fetch" consumer rule. Other clients (Cursor, VS Code) can add their own config per [the docs](https://stitchapi.dev/docs/agents/search-over-mcp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
