### PR TITLE
docs(readme): add Glama badge for the StitchAPI Docs MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@
 <!-- /yakir:readme-badges -->
 
 <p align="center">
+  <a href="https://glama.ai/mcp/servers/@rejifald/StitchAPI">
+    <img width="380" height="200" src="https://glama.ai/mcp/servers/@rejifald/StitchAPI/badge" alt="StitchAPI Docs — MCP server listed on Glama" />
+  </a>
+</p>
+
+<p align="center">
   <strong>Zero runtime dependencies · ~25&nbsp;kB min+gzip</strong> — a typical <code>import { stitch }</code> tree-shakes to ~20&nbsp;kB, and with no transitive tree there is nothing else to install or audit. The size is an <a href="packages/core/scripts/bundle-size.mjs">enforced budget in CI</a>, not an aspiration.
 </p>
 


### PR DESCRIPTION
Adds the Glama badge to the README, linking to the now-live directory listing: **[glama.ai/mcp/servers/@rejifald/StitchAPI](https://glama.ai/mcp/servers/@rejifald/StitchAPI)** ("StitchAPI Docs").

- Placed **after** the `<!-- /yakir:readme-badges -->` marker (outside the yakir-managed badges block), so it doesn't trip the `readme-badges` drift tether.
- Badge image verified live (`/badge` → HTTP 200, image/png).

Not touching the awesome-mcp-servers PR (#9027) yet — the Glama server still shows **non-installable** until a *Glama release* is published (Claim → Dockerfile build spec → Deploy → Make Release; `packages/docs-mcp/Dockerfile` is built for exactly that). Once it's installable, the badge + a PR nudge complete the promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)