### PR TITLE
fix(docs-mcp): install git in Dockerfile builder stage for lefthook prepare

### DIFF
--- a/packages/docs-mcp/Dockerfile
+++ b/packages/docs-mcp/Dockerfile
@@ -19,6 +19,15 @@ WORKDIR /repo
 
 RUN corepack enable
 
+# git is required by the root workspace's `prepare` script (`lefthook install`),
+# which `pnpm install` below triggers — node:24-slim doesn't ship it. The build
+# context intentionally omits .git (see COPY list below), so `lefthook install`
+# has nothing to find; a throwaway `git init` gives it a repo to point hooks at.
+# Both are discarded with this stage — nothing here reaches the runtime image.
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/* \
+    && git init -q
+
 # Workspace manifests first for layer caching.
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY packages ./packages


### PR DESCRIPTION
## Why

Testing `packages/docs-mcp/Dockerfile` locally (the spec Glama's Docker build step is meant to use — see #469) surfaced a real build failure: `docker build -f packages/docs-mcp/Dockerfile -t mcp-server .` failed with `exec: "git": executable file not found in $PATH`.

## Root cause

`pnpm install --frozen-lockfile` in the builder stage triggers the root workspace's `prepare` script (`lefthook install`), which shells out to `git`. `node:24-slim` doesn't ship `git`, and the build context intentionally omits `.git` (it's not in the COPY list, and shouldn't be — no reason to ship repo history into a build context). So even after installing `git`, `lefthook install` still failed with `fatal: not a git repository`.

## Fix

Install `git` and run a throwaway `git init` in the builder stage, right after `corepack enable`. Both are discarded along with the rest of that stage — nothing here reaches the runtime image.

## Test plan

- [x] `docker build -f packages/docs-mcp/Dockerfile -t mcp-server .` succeeds end-to-end (full pnpm workspace install + apps/docs bundle pipeline + tsup build)
- [x] `docker run -i --rm -e MCP_PROXY_DEBUG=true mcp-server` piped a real `initialize` → `tools/list` → `tools/call search_docs` sequence over stdio and got back correct, on-topic hybrid-search results (Throttle, Retry & backoff, RateLimitError docs), confirming the embedding model and search index work at runtime inside the container — not just that the image builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)