### PR TITLE
fix(next)!: stitchErrorResponse returns Response | undefined so it composes

### DIFF
--- a/apps/docs/content/docs/integrations/next.mdx
+++ b/apps/docs/content/docs/integrations/next.mdx
@@ -31,7 +31,7 @@ A non-streaming endpoint is the stitch plus the error helper — no per-route
 // app/api/users/[id]/route.ts
 import { getUser } from '@/lib/api';
 
-import { isStitchError, stitchErrorResponse } from '@stitchapi/next';
+import { stitchErrorResponse } from '@stitchapi/next';
 
 export async function GET(
     _req: Request,
@@ -41,15 +41,18 @@ export async function GET(
     try {
         return Response.json(await getUser({ params: { id } }));
     } catch (err) {
-        if (isStitchError(err)) return stitchErrorResponse(err);
+        const mapped = stitchErrorResponse(err);
+        if (mapped) return mapped;
         throw err;
     }
 }
 ```
 
-`stitchErrorResponse` maps a `StitchError` to `502` by default — the safe choice that
-never leaks the upstream's `401`/`404` semantics. Pass `{ status: (e) => e.status ?? 502 }`
-to propagate the upstream status instead.
+`stitchErrorResponse` returns a `Response` for a `StitchError` and `undefined` for
+anything else — map the stitch failure, rethrow the rest, no `instanceof` dance. It maps
+to `502` by default — the safe choice that never leaks the upstream's `401`/`404`
+semantics. Pass `{ status: (e) => e.status ?? 502 }` to propagate the upstream status
+instead.
 
 ## Streaming with SSE
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -7,7 +7,7 @@
 Next App Router route handlers are Web-standard — they take a `Request` and return a `Response` — so a stitch already runs in one directly: define a `seam` once and call it in the handler. What's worth a helper is the two bits you'd otherwise hand-roll on the Web platform:
 
 -   **`sseResponse(stitch.stream())`** — turn a streaming stitch into a `text/event-stream` `Response`.
--   **`stitchErrorResponse(err)`** — map a thrown `StitchError` to a `Response` with a safe status.
+-   **`stitchErrorResponse(err)`** — map a thrown `StitchError` to a `Response` with a safe status, or `undefined` for anything else so you can rethrow it.
 
 Built on Web standards only (`Response`, `ReadableStream`, `TextEncoder`) — **no `next` import** — so the same helpers also work in Remix, SvelteKit endpoints, Bun, Deno, and Workers.
 
@@ -27,7 +27,7 @@ A non-streaming endpoint is just the stitch plus the error helper:
 // app/api/users/[id]/route.ts
 import { getUser } from '@/lib/api';
 
-import { isStitchError, stitchErrorResponse } from '@stitchapi/next';
+import { stitchErrorResponse } from '@stitchapi/next';
 
 export async function GET(
     _req: Request,
@@ -37,13 +37,14 @@ export async function GET(
     try {
         return Response.json(await getUser({ params: { id } }));
     } catch (err) {
-        if (isStitchError(err)) return stitchErrorResponse(err);
-        throw err;
+        const mapped = stitchErrorResponse(err);
+        if (mapped) return mapped; // a Stitch failure → safe JSON Response
+        throw err; // anything else falls through untouched
     }
 }
 ```
 
-`stitchErrorResponse` maps a `StitchError` to `502` by default (never leaking the upstream's status); pass `{ status: (e) => e.status ?? 502 }` to propagate it. The body is a generic, status-tied message (`{ error: 'Bad Gateway' }`) — the raw `err.message` is withheld, since it can leak an internal hostname (`getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`). Opt in with `{ body: (e) => ({ error: e.message }) }` when the upstream messages are safe to expose.
+`stitchErrorResponse` maps a `StitchError` to `502` by default (never leaking the upstream's status) and returns `undefined` for any other error, so the map-or-rethrow composition stays one branch; pass `{ status: (e) => e.status ?? 502 }` to propagate the upstream status. The body is a generic, status-tied message (`{ error: 'Bad Gateway' }`) — the raw `err.message` is withheld, since it can leak an internal hostname (`getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`). Opt in with `{ body: (e) => ({ error: e.message }) }` when the upstream messages are safe to expose.
 
 ## Streaming with SSE
 

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -9,7 +9,8 @@
 //   `Response` (the Web-standard twin of `@stitchapi/express`'s `streamStitchSse`,
 //   which targets a Node `ServerResponse`).
 // - `stitchErrorResponse(err)` — map a thrown `StitchError` to a `Response` with a
-//   safe status (default 502), so a route handler needs no bespoke error shaping.
+//   safe status (default 502), or `undefined` for anything else so the caller can
+//   rethrow it untouched.
 //
 // Built on Web standards (`Response`, `ReadableStream`, `TextEncoder`) only — no
 // `next` import — so the same helpers work in Next route handlers, Remix, SvelteKit
@@ -229,13 +230,16 @@ export interface ErrorResponseOptions {
 }
 
 /**
- * Map a thrown error to a JSON `Response`. Use it in a route handler's `catch`:
+ * Map a thrown `StitchError` to a JSON `Response`, or `undefined` when `err` is not a Stitch
+ * error — so the caller can rethrow / fall through with `?? throw err`. Use it in a route
+ * handler's `catch`:
  *
  * ```ts
  * try {
  *     return Response.json(await getUser({ params: { id } }));
  * } catch (err) {
- *     if (isStitchError(err)) return stitchErrorResponse(err);
+ *     const mapped = stitchErrorResponse(err);
+ *     if (mapped) return mapped; // undefined → not a StitchError
  *     throw err;
  * }
  * ```
@@ -248,16 +252,14 @@ export interface ErrorResponseOptions {
 export function stitchErrorResponse(
     err: unknown,
     options: ErrorResponseOptions = {},
-): Response {
-    const e: StitchErrorLike =
-        err instanceof Error ? err : new Error(String(err));
-    const fallback = isStitchError(err) ? 502 : 500;
+): Response | undefined {
+    if (!isStitchError(err)) return undefined;
     const status =
         typeof options.status === 'function'
-            ? options.status(e)
-            : (options.status ?? fallback);
+            ? options.status(err)
+            : (options.status ?? 502);
     const body = options.body
-        ? options.body(e, status)
+        ? options.body(err, status)
         : { error: STATUS_TEXT[status] ?? 'Error' };
     return Response.json(body, { status });
 }

--- a/packages/next/test/next.spec.ts
+++ b/packages/next/test/next.spec.ts
@@ -167,8 +167,18 @@ describe('sseResponse', () => {
 // --- stitchErrorResponse ---------------------------------------------------
 
 describe('stitchErrorResponse', () => {
+    // The helper now returns `Response | undefined` (undefined ⇒ not a StitchError, so the
+    // caller can rethrow). The cases below all pass a StitchError, so a Response is
+    // guaranteed — narrow it once here.
+    const mustRespond = (res: Response | undefined): Response => {
+        if (!res) throw new Error('expected a Response');
+        return res;
+    };
+
     test('a StitchError maps to 502 by default with a generic JSON body', async () => {
-        const res = stitchErrorResponse(stitchError('upstream down', 503));
+        const res = mustRespond(
+            stitchErrorResponse(stitchError('upstream down', 503)),
+        );
         expect(res.status).toBe(502);
         expect(res.headers.get('content-type')).toContain('application/json');
         // the raw message is withheld by default (see the leak-regression block below)
@@ -176,15 +186,17 @@ describe('stitchErrorResponse', () => {
     });
 
     test('status can propagate the upstream status', async () => {
-        const res = stitchErrorResponse(stitchError('rate limited', 429), {
-            status: (e) => e.status ?? 502,
-        });
+        const res = mustRespond(
+            stitchErrorResponse(stitchError('rate limited', 429), {
+                status: (e) => e.status ?? 502,
+            }),
+        );
         expect(res.status).toBe(429);
     });
 
-    test('a non-StitchError defaults to 500', async () => {
-        const res = stitchErrorResponse(new Error('oops'));
-        expect(res.status).toBe(500);
+    test('a non-StitchError returns undefined so the caller can rethrow', () => {
+        expect(stitchErrorResponse(new Error('oops'))).toBeUndefined();
+        expect(stitchErrorResponse('not even an error')).toBeUndefined();
     });
 
     // Regression: the default body must not echo the raw upstream/transport message,
@@ -192,8 +204,10 @@ describe('stitchErrorResponse', () => {
     // failed to reach) or the upstream's status semantics to an untrusted client.
     describe('does not leak the raw error message by default', () => {
         test('a transport failure with an internal hostname is not disclosed', async () => {
-            const res = stitchErrorResponse(
-                stitchError('getaddrinfo ENOTFOUND payments.internal.corp'),
+            const res = mustRespond(
+                stitchErrorResponse(
+                    stitchError('getaddrinfo ENOTFOUND payments.internal.corp'),
+                ),
             );
             expect(res.status).toBe(502);
             const body = await res.text();
@@ -202,15 +216,19 @@ describe('stitchErrorResponse', () => {
         });
 
         test("an upstream 401 does not surface as 'HTTP 401' in the body", async () => {
-            const res = stitchErrorResponse(stitchError('HTTP 401', 401));
+            const res = mustRespond(
+                stitchErrorResponse(stitchError('HTTP 401', 401)),
+            );
             expect(res.status).toBe(502);
             expect(await res.text()).not.toContain('HTTP 401');
         });
 
         test('the `body` opt-in can still include the raw message', async () => {
-            const res = stitchErrorResponse(
-                stitchError('getaddrinfo ENOTFOUND payments.internal.corp'),
-                { body: (e) => ({ error: e.message }) },
+            const res = mustRespond(
+                stitchErrorResponse(
+                    stitchError('getaddrinfo ENOTFOUND payments.internal.corp'),
+                    { body: (e) => ({ error: e.message }) },
+                ),
             );
             expect(await res.text()).toContain('payments.internal.corp');
         });


### PR DESCRIPTION
## What

`@stitchapi/next`'s `stitchErrorResponse(err)` mapped **any** thrown value to a `Response`
(a `StitchError` → `502`, everything else → `500`). That made "I handled it" and "not my
error" indistinguishable at the call site: to rethrow a non-stitch error you had to
pre-guard with `isStitchError`, and the internal `500` branch **silently swallowed
unrelated bugs** into an HTTP response.

It now returns **`undefined`** for a non-`StitchError`, so map-or-rethrow collapses to one
branch:

```ts
} catch (err) {
    const mapped = stitchErrorResponse(err);
    if (mapped) return mapped; // a Stitch failure → safe JSON Response
    throw err;                 // anything else falls through untouched
}
```

This is the contract **`@stitchapi/elysia`'s `stitchErrorResponse` already ships on `main`**
(`stitchErrorResponse(err) ?? new Response(...)`); this aligns `@stitchapi/next` with it.

## ⚠️ Breaking

`stitchErrorResponse(nonStitchError)` was a `500` `Response`; it is now `undefined`. Pre-GA,
no deprecation. Callers that relied on the catch-all 500 should pass an explicit fallback
(`stitchErrorResponse(err) ?? Response.json(…, { status: 500 })`).

## Changed

- `src/index.ts` — guard `if (!isStitchError(err)) return undefined;`, return type
  `Response | undefined`, drop the now-dead non-stitch `500` branch.
- `test/next.spec.ts` — flip the non-stitch case to `toBeUndefined()`; narrow the
  StitchError cases through a small `mustRespond` helper.
- `README.md` + `integrations/next.mdx` — composition pattern; drop the now-redundant
  `isStitchError` pre-guard from the snippet.

## Context

Carved out of the #470 contract-freeze sweep so this contract change lands and is reviewed
on its own. (In #470 it also picks up an `ErrorResponseOptions`→`StitchErrorOptions` rename
and a `BAD_GATEWAY` const — omitted here to keep the diff to the behavior change.)

## Verification

`pnpm --filter @stitchapi/next test` (18 pass) + `check:types` clean; full pre-push suite
green (incl. `build-docs` twoslash-compiling the updated `next.mdx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
