### PR TITLE
refactor(sse)!: rename the error-frame `errorData` option to `payload`

### DIFF
--- a/apps/docs/content/docs/integrations/elysia.mdx
+++ b/apps/docs/content/docs/integrations/elysia.mdx
@@ -88,8 +88,8 @@ const app = new Elysia()
 By default the terminal `error` frame carries a generic `data: error` token — the raw
 `event.message` is **not** echoed, since it can disclose internal network topology (a
 transport failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the
-upstream's status (`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream
-messages are known safe (`errorData: (e) => e.message`); `onError` still receives the real
+upstream's status (`HTTP 401`) to the client. Pass `payload` to opt in when the upstream
+messages are known safe (`payload: (e) => e.message`); `onError` still receives the real
 failure server-side for logging.
 
 <Callout type="warn">

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -279,6 +279,11 @@ error-options is `StitchErrorHandlerOptions` / `StitchErrorOptions` /
 result interface is `UseStitchResult` / `UseStitchReturn` / `InjectStitchResult` /
 `StitchStore`; `queryOptions` is still bare in vue/solid/svelte/angular.
 
+_Settled:_ the SSE error-frame shaping callback (default a generic `data: error`
+token; opt in to shape it, e.g. from `event.message`) is named `payload` on every
+SSE-capable host (`express` / `fastify` / `hono` / `next` / `elysia`) — do not
+reintroduce the earlier `errorData` name.
+
 ### P17 · One canonical duration form
 
 Per **D3**, **ms is the single house time unit** and **no duration field carries the

--- a/packages/elysia/README.md
+++ b/packages/elysia/README.md
@@ -88,8 +88,8 @@ forwarded.
 By default the `error` frame carries a generic `data: error` token, **not** the raw
 error message — echoing it can disclose internal network topology (a transport failure
 reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status
-(`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream messages are
-known safe (`errorData: (e) => e.message`); `onError` still receives the real failure
+(`HTTP 401`) to the client. Pass `payload` to opt in when the upstream messages are
+known safe (`payload: (e) => e.message`); `onError` still receives the real failure
 server-side.
 
 ## Error handling

--- a/packages/elysia/src/sse.ts
+++ b/packages/elysia/src/sse.ts
@@ -3,7 +3,7 @@
 // stitch's `.stream()` is an `AsyncIterable<StitchEvent>`; this forwards each `delta` chunk as one
 // SSE message, ends the stream cleanly on `done`, and turns an `error` event into a final
 // `event: error` message — a generic `data: error` by default, the raw message withheld (opt in via
-// `errorData`). When the client disconnects the `ReadableStream` is cancelled — the helper
+// `payload`). When the client disconnects the `ReadableStream` is cancelled — the helper
 // calls the iterator's `return()` so the upstream stitch stream is torn down rather than left running.
 //
 // Web-standard: returns a plain `Response` whose body is a `ReadableStream` — no `node:*`, so it runs
@@ -40,11 +40,11 @@ export interface StreamStitchSseOptions {
      * (e.g. `() => JSON.stringify({ error: 'stream failed' })`). A multi-line return gets one
      * `data:` line each (SSE spec); the `event: error` name is fixed.
      */
-    errorData?: (event: StitchErrorEvent) => string;
+    payload?: (event: StitchErrorEvent) => string;
     /**
      * Called once, server-side, if the underlying stream errors (a stitch `error` event, or a
      * throw) — use it to observe/log the real failure. It does **not** shape the client-facing
-     * frame: the SSE `data` sent to the client is controlled by `errorData` (a generic token by
+     * frame: the SSE `data` sent to the client is controlled by `payload` (a generic token by
      * default), so the raw message reaches your logs here but not the client.
      */
     onError?: (err: unknown) => void;
@@ -65,12 +65,12 @@ function frame(data: string, event?: string): string {
 
 // The generic token written as an `error` message's `data` by default: the raw upstream message is
 // withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`)
-// never reaches the client. Override with `options.errorData`.
-const DEFAULT_ERROR_DATA = 'error';
+// never reaches the client. Override with `options.payload`.
+const DEFAULT_PAYLOAD = 'error';
 
-// Normalise a thrown value into the terminal `error` event shape, so an `errorData` opt-in sees a
+// Normalise a thrown value into the terminal `error` event shape, so a `payload` opt-in sees a
 // consistent argument whether the failure arrived as a surfaced `error` event or an unexpected
-// throw. `attempts`/`at` are best-effort placeholders — an `errorData` hook keys off `name`/`message`.
+// throw. `attempts`/`at` are best-effort placeholders — a `payload` hook keys off `name`/`message`.
 function toErrorEvent(reason: unknown): StitchErrorEvent {
     const e = reason instanceof Error ? reason : new Error(String(reason));
     return {
@@ -99,7 +99,7 @@ function toErrorEvent(reason: unknown): StitchErrorEvent {
  *
  * Each `delta` becomes a `data:` message; a terminal `error` event (or a throw) becomes a final
  * `event: error` message and ends the stream — a generic `data: error` by default, the raw message
- * withheld to avoid disclosing internal topology (opt in via `errorData`); every control event
+ * withheld to avoid disclosing internal topology (opt in via `payload`); every control event
  * (`start`/`progress`/`result`/`done`/…) is consumed but not forwarded. On client disconnect the
  * stream is cancelled and the upstream iterator is `return()`-ed so the stitch stream is aborted.
  */
@@ -130,15 +130,15 @@ export function streamStitchSse<T>(
                     }
                     if (event.type === 'error') {
                         // `onError` gets the real failure server-side; the client frame is a
-                        // generic token by default (never the raw `event.message`) — `errorData`
+                        // generic token by default (never the raw `event.message`) — `payload`
                         // opts in.
                         options.onError?.(new Error(event.message));
                         controller.enqueue(
                             enc.encode(
                                 frame(
-                                    options.errorData
-                                        ? options.errorData(event)
-                                        : DEFAULT_ERROR_DATA,
+                                    options.payload
+                                        ? options.payload(event)
+                                        : DEFAULT_PAYLOAD,
                                     'error',
                                 ),
                             ),
@@ -152,14 +152,14 @@ export function streamStitchSse<T>(
                 }
             } catch (err) {
                 // A throw (not a surfaced `error` event): still withhold the raw message by
-                // default — normalise it to an error event so `errorData` sees a consistent shape.
+                // default — normalise it to an error event so `payload` sees a consistent shape.
                 options.onError?.(err);
                 controller.enqueue(
                     enc.encode(
                         frame(
-                            options.errorData
-                                ? options.errorData(toErrorEvent(err))
-                                : DEFAULT_ERROR_DATA,
+                            options.payload
+                                ? options.payload(toErrorEvent(err))
+                                : DEFAULT_PAYLOAD,
                             'error',
                         ),
                     ),

--- a/packages/elysia/test/sse.spec.ts
+++ b/packages/elysia/test/sse.spec.ts
@@ -195,7 +195,7 @@ describe('streamStitchSse — the error frame does not leak the raw message', ()
         expect(body).not.toContain('ENOTFOUND');
     });
 
-    test('errorData opts in to shaping the client-facing error payload', async () => {
+    test('payload opts in to shaping the client-facing error payload', async () => {
         const res = streamStitchSse(
             gen([
                 {
@@ -206,20 +206,20 @@ describe('streamStitchSse — the error frame does not leak the raw message', ()
                     at: 0,
                 },
             ]),
-            { errorData: (e) => e.message },
+            { payload: (e) => e.message },
         );
         const body = await res.text();
         expect(body).toContain('event: error');
         expect(body).toContain('data: upstream blew up');
     });
 
-    test('errorData shapes the throw path too', async () => {
+    test('payload shapes the throw path too', async () => {
         async function* boom(): AsyncGenerator<StitchEvent, void> {
             yield { type: 'delta', chunk: 'a', at: 0 };
             throw new Error('stream blew up');
         }
         const res = streamStitchSse(boom(), {
-            errorData: (e) => JSON.stringify({ error: e.message }),
+            payload: (e) => JSON.stringify({ error: e.message }),
         });
         const body = await res.text();
         expect(body).toContain('event: error');

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -87,12 +87,12 @@ response.
 By default the `error` frame carries a generic `data: error` token, **not** the raw
 error message — echoing it can disclose internal network topology (a transport
 failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's
-status (`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream
+status (`HTTP 401`) to the client. Pass `payload` to opt in when the upstream
 messages are known safe to expose:
 
 ```ts
 streamStitchSse(res, completion.stream({ body: { prompt: req.query.q } }), {
-    errorData: (e) => e.message, // opt in to the raw upstream message
+    payload: (e) => e.message, // opt in to the raw upstream message
 });
 ```
 

--- a/packages/express/src/sse.ts
+++ b/packages/express/src/sse.ts
@@ -41,7 +41,7 @@ export interface StreamStitchSseOptions {
      * or return your own payload (e.g. `() => JSON.stringify({ error: 'stream failed' })`). A
      * multi-line return gets one `data:` line each (SSE spec); the `event: error` name is fixed.
      */
-    errorData?: (event: StitchErrorEvent) => string;
+    payload?: (event: StitchErrorEvent) => string;
     /**
      * The Express request, when available. Express normally fires `close` on the *response* on
      * disconnect, but passing `req` lets the helper also listen on the request socket for
@@ -69,8 +69,8 @@ function frame(
 
 // The generic token written as an `error` frame's `data` by default: the raw upstream message is
 // withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`)
-// never reaches the client. Override with `options.errorData`.
-const DEFAULT_ERROR_DATA = 'error';
+// never reaches the client. Override with `options.payload`.
+const DEFAULT_PAYLOAD = 'error';
 
 // The terminal `error` frame: the fixed `event: error` name plus a (multi-line-safe) data payload —
 // every line of `data` gets its own `data:` prefix so a multi-line opt-in payload can't break the
@@ -86,7 +86,7 @@ function errorFrame(data: string): string {
  * `.stream()` generator (or any `AsyncIterable<StitchEvent>`): each `delta` becomes one SSE frame, an
  * `error` event ends the stream with a named `event: error` frame (a generic `data: error` by
  * default — the raw message is withheld to avoid disclosing internal topology; opt in via
- * `errorData`), and stream end closes the response. The non-output events (`start` / `progress` /
+ * `payload`), and stream end closes the response. The non-output events (`start` / `progress` /
  * `drift` / `result` / `done`) are control signals and are not forwarded to the client.
  *
  * Writes raw frames straight to the socket, so do **not** also `res.send()`/`res.json()` from the
@@ -141,12 +141,12 @@ export async function streamStitchSse<T>(
                 // Surface the failure to the client as a named `error` SSE frame, then stop — but by
                 // default write a generic token, never the raw `event.message`, so an internal
                 // hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`) is not
-                // disclosed. Opt in to the real message via `options.errorData`.
+                // disclosed. Opt in to the real message via `options.payload`.
                 res.write(
                     errorFrame(
-                        options.errorData
-                            ? options.errorData(event)
-                            : DEFAULT_ERROR_DATA,
+                        options.payload
+                            ? options.payload(event)
+                            : DEFAULT_PAYLOAD,
                     ),
                 );
                 break;

--- a/packages/express/test/express.spec.ts
+++ b/packages/express/test/express.spec.ts
@@ -210,7 +210,7 @@ describe('streamStitchSse writes SSE frames to res', () => {
         expect(res.body()).not.toContain('ENOTFOUND');
     });
 
-    test('errorData opts in to the raw message on the error frame', async () => {
+    test('payload opts in to the raw message on the error frame', async () => {
         async function* events(): AsyncGenerator<StitchEvent<unknown>> {
             yield { type: 'delta', chunk: 'partial', at: 1 };
             yield {
@@ -223,7 +223,7 @@ describe('streamStitchSse writes SSE frames to res', () => {
         }
         const res = mockRes();
         await streamStitchSse(res as unknown as Response, events(), {
-            errorData: (e) => e.message,
+            payload: (e) => e.message,
         });
 
         expect(res.body()).toBe(

--- a/packages/fastify/README.md
+++ b/packages/fastify/README.md
@@ -106,12 +106,12 @@ aborts the upstream stitch generator rather than leaving it running.
 By default the `error` frame carries a generic `data: error` token, **not** the raw
 error message — echoing it can disclose internal network topology (a transport
 failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's
-status (`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream
+status (`HTTP 401`) to the client. Pass `payload` to opt in when the upstream
 messages are known safe to expose:
 
 ```ts
 sendStitchSse(reply, chat.stream({ query: { q: String(req.query.q) } }), {
-    errorData: (e) => e.message, // opt in to the raw upstream message
+    payload: (e) => e.message, // opt in to the raw upstream message
 });
 ```
 

--- a/packages/fastify/src/sse.ts
+++ b/packages/fastify/src/sse.ts
@@ -36,7 +36,7 @@ export interface SendStitchSseOptions {
      * safe, or return your own payload (e.g. `() => JSON.stringify({ error: 'stream failed' })`).
      * A multi-line return gets one `data:` line each (SSE spec); the `event: error` name is fixed.
      */
-    errorData?: (event: StitchErrorEvent) => string;
+    payload?: (event: StitchErrorEvent) => string;
 }
 
 // One delta chunk → an SSE frame string. A multi-line payload is split so every line gets its
@@ -58,8 +58,8 @@ function frame(
 
 // The generic token written as an `error` frame's `data` by default: the raw upstream message is
 // withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`)
-// never reaches the client. Override with `options.errorData`.
-const DEFAULT_ERROR_DATA = 'error';
+// never reaches the client. Override with `options.payload`.
+const DEFAULT_PAYLOAD = 'error';
 
 // The terminal `error` frame: the fixed `event: error` name plus a (multi-line-safe) data payload —
 // every line of `data` gets its own `data:` prefix so a multi-line opt-in payload can't break the
@@ -75,7 +75,7 @@ function errorFrame(data: string): string {
  * stitch's `.stream()` generator (or any `AsyncIterable<StitchEvent>`): each `delta` becomes
  * one SSE frame, an `error` event ends the stream with a named `event: error` frame (a generic
  * `data: error` by default — the raw message is withheld to avoid disclosing internal topology;
- * opt in via `errorData`), and stream end closes the response. The non-output events (`start` /
+ * opt in via `payload`), and stream end closes the response. The non-output events (`start` /
  * `progress` / `drift` / `result` / `done`) are control signals and are not forwarded to the client.
  *
  * Takes over the reply via `reply.hijack()` and writes raw frames, so do **not** also `send()`
@@ -128,12 +128,12 @@ export async function sendStitchSse<T>(
                 // Surface the failure to the client as a named `error` SSE frame, then stop — but by
                 // default write a generic token, never the raw `event.message`, so an internal
                 // hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`) is not
-                // disclosed. Opt in to the real message via `options.errorData`.
+                // disclosed. Opt in to the real message via `options.payload`.
                 res.write(
                     errorFrame(
-                        options.errorData
-                            ? options.errorData(event)
-                            : DEFAULT_ERROR_DATA,
+                        options.payload
+                            ? options.payload(event)
+                            : DEFAULT_PAYLOAD,
                     ),
                 );
                 break;

--- a/packages/fastify/test/fastify.spec.ts
+++ b/packages/fastify/test/fastify.spec.ts
@@ -223,7 +223,7 @@ describe('stitchPlugin', () => {
         expect(res.body).not.toContain('ENOTFOUND');
     });
 
-    test('errorData opts in to the raw message on the error frame', async () => {
+    test('payload opts in to the raw message on the error frame', async () => {
         async function* events(): AsyncGenerator<StitchEvent<unknown>> {
             yield { type: 'delta', chunk: 'partial', at: 1 };
             yield {
@@ -248,7 +248,7 @@ describe('stitchPlugin', () => {
             logger: false,
         });
         app.get('/sse-err', (_request, reply) =>
-            sendStitchSse(reply, events(), { errorData: (e) => e.message }),
+            sendStitchSse(reply, events(), { payload: (e) => e.message }),
         );
         await app.ready();
 

--- a/packages/hono/README.md
+++ b/packages/hono/README.md
@@ -73,13 +73,13 @@ app.get('/chat', (c) => {
 By default the `error` message carries a generic `data: error` token, **not** the
 raw error message — echoing it can disclose internal network topology (a transport
 failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's
-status (`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream
+status (`HTTP 401`) to the client. Pass `payload` to opt in when the upstream
 messages are known safe; `onError` still receives the real failure server-side for
 logging:
 
 ```ts
 return streamStitchSse(c, completion.stream({ body: { prompt: c.req.query('q') } }), {
-    errorData: (e) => e.message, // opt in to the raw upstream message
+    payload: (e) => e.message, // opt in to the raw upstream message
     onError: (err) => c.get('log').error(err), // real failure, server-side only
 });
 ```

--- a/packages/hono/src/sse.ts
+++ b/packages/hono/src/sse.ts
@@ -40,11 +40,11 @@ export interface StreamStitchSseOptions {
      * when the upstream messages are known safe, or return your own payload
      * (e.g. `() => JSON.stringify({ error: 'stream failed' })`).
      */
-    errorData?: (event: StitchErrorEvent) => string;
+    payload?: (event: StitchErrorEvent) => string;
     /**
      * Called once, server-side, if the underlying stream errors (a stitch `error` event, or a
      * throw) — use it to observe/log the real failure. It does **not** shape the client-facing
-     * frame: the SSE `data` sent to the client is controlled by `errorData` (a generic token by
+     * frame: the SSE `data` sent to the client is controlled by `payload` (a generic token by
      * default), so the raw message reaches your logs here but not the client.
      */
     onError?: (err: unknown) => void;
@@ -56,12 +56,12 @@ function defaultData(chunk: unknown): string {
 
 // The generic token written as an `error` message's `data` by default: the raw upstream message is
 // withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`)
-// never reaches the client. Override with `options.errorData`.
-const DEFAULT_ERROR_DATA = 'error';
+// never reaches the client. Override with `options.payload`.
+const DEFAULT_PAYLOAD = 'error';
 
-// Normalise a thrown value into the terminal `error` event shape, so an `errorData` opt-in sees a
+// Normalise a thrown value into the terminal `error` event shape, so a `payload` opt-in sees a
 // consistent argument whether the failure arrived as a surfaced `error` event or an unexpected
-// throw. `attempts`/`at` are best-effort placeholders — an `errorData` hook keys off `name`/`message`.
+// throw. `attempts`/`at` are best-effort placeholders — a `payload` hook keys off `name`/`message`.
 function toErrorEvent(err: unknown): StitchErrorEvent {
     const e = err instanceof Error ? err : new Error(String(err));
     return {
@@ -90,7 +90,7 @@ function toErrorEvent(err: unknown): StitchErrorEvent {
  *
  * Each `delta` becomes a `data:` message; a terminal `error` event (or a throw) becomes a final
  * `event: error` message and ends the stream — a generic `data: error` by default, the raw message
- * withheld to avoid disclosing internal topology (opt in via `errorData`); every control event
+ * withheld to avoid disclosing internal topology (opt in via `payload`); every control event
  * (`start`/`progress`/`result`/`done`/…) is consumed but not forwarded. On client disconnect the
  * upstream iterator is `return()`-ed so the stitch stream is aborted.
  */
@@ -103,13 +103,13 @@ export function streamStitchSse<T>(
     return streamSSE(c, async (stream: SSEStreamingApi) => {
         const iterator = source[Symbol.asyncIterator]();
         // Write the terminal `error` message: a generic token by default so a raw message
-        // (`getaddrinfo ENOTFOUND …` / `HTTP 401`) is never disclosed; `errorData` opts in.
+        // (`getaddrinfo ENOTFOUND …` / `HTTP 401`) is never disclosed; `payload` opts in.
         const writeErrorFrame = (event: StitchErrorEvent): Promise<void> =>
             stream.writeSSE({
                 event: 'error',
-                data: options.errorData
-                    ? options.errorData(event)
-                    : DEFAULT_ERROR_DATA,
+                data: options.payload
+                    ? options.payload(event)
+                    : DEFAULT_PAYLOAD,
             });
         // Client disconnect: stop pulling and tear down the upstream stitch stream.
         stream.onAbort(() => {
@@ -126,7 +126,7 @@ export function streamStitchSse<T>(
                     await stream.writeSSE(message);
                 } else if (event.type === 'error') {
                     // `onError` gets the real failure server-side; the client frame is shaped by
-                    // `errorData` (generic by default), never the raw `event.message`.
+                    // `payload` (generic by default), never the raw `event.message`.
                     options.onError?.(new Error(event.message));
                     await writeErrorFrame(event);
                     return;
@@ -135,7 +135,7 @@ export function streamStitchSse<T>(
             }
         } catch (err) {
             // A throw (not a surfaced `error` event): still withhold the raw message by default —
-            // normalise it to an error event so an `errorData` opt-in sees a consistent shape.
+            // normalise it to an error event so a `payload` opt-in sees a consistent shape.
             options.onError?.(err);
             await writeErrorFrame(toErrorEvent(err));
         } finally {

--- a/packages/hono/test/sse.spec.ts
+++ b/packages/hono/test/sse.spec.ts
@@ -168,7 +168,7 @@ describe('streamStitchSse — error paths', () => {
         );
     });
 
-    test('errorData opts in to the raw message on the error frame', async () => {
+    test('payload opts in to the raw message on the error frame', async () => {
         const app = new Hono();
         app.get('/x', (c) =>
             streamStitchSse(
@@ -183,7 +183,7 @@ describe('streamStitchSse — error paths', () => {
                         at: 0,
                     },
                 ]),
-                { errorData: (e) => e.message },
+                { payload: (e) => e.message },
             ),
         );
 
@@ -220,7 +220,7 @@ describe('streamStitchSse — error paths', () => {
         );
     });
 
-    test('errorData opts in on the throw path too (thrown error normalised to an error event)', async () => {
+    test('payload opts in on the throw path too (thrown error normalised to an error event)', async () => {
         async function* boom(): AsyncGenerator<StitchEvent, void> {
             yield { type: 'delta', chunk: 'a', at: 0 };
             throw new Error('stream blew up');
@@ -228,7 +228,7 @@ describe('streamStitchSse — error paths', () => {
 
         const app = new Hono();
         app.get('/x', (c) =>
-            streamStitchSse(c, boom(), { errorData: (e) => e.message }),
+            streamStitchSse(c, boom(), { payload: (e) => e.message }),
         );
 
         const body = await (await app.request('/x')).text();

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -66,11 +66,11 @@ export async function POST(request: Request) {
 
 Pass `request.signal` so a client disconnect tears the stitch down rather than leaving it running.
 
-By default the `error` frame carries a generic `data: error` token, **not** the raw error message — echoing it can disclose internal network topology (a transport failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream messages are known safe to expose:
+By default the `error` frame carries a generic `data: error` token, **not** the raw error message — echoing it can disclose internal network topology (a transport failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to the client. Pass `payload` to opt in when the upstream messages are known safe to expose:
 
 ```ts
 return sseResponse(chat({ body: { prompt } }).stream(), {
-    errorData: (e) => e.message, // opt in to the raw upstream message
+    payload: (e) => e.message, // opt in to the raw upstream message
 });
 ```
 

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -50,7 +50,7 @@ export interface SseResponseOptions {
      * safe, or return your own payload (e.g. `() => JSON.stringify({ error: 'stream failed' })`).
      * A multi-line return gets one `data:` line each (SSE spec); the `event: error` name is fixed.
      */
-    errorData?: (event: StitchErrorEvent) => string;
+    payload?: (event: StitchErrorEvent) => string;
     /** Extra response headers (merged over the SSE defaults). */
     headers?: Record<string, string>;
     /** Abort the upstream iterator when this fires — pass the route handler's
@@ -79,8 +79,8 @@ function frame(
 
 // The generic token written as an `error` frame's `data` by default: the raw upstream message
 // is withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status
-// (`HTTP 401`) never reaches the client. Override with `options.errorData`.
-const DEFAULT_ERROR_DATA = 'error';
+// (`HTTP 401`) never reaches the client. Override with `options.payload`.
+const DEFAULT_PAYLOAD = 'error';
 
 // The terminal `error` frame: the fixed `event: error` name plus a (multi-line-safe) data
 // payload — every line of `data` gets its own `data:` prefix so a multi-line opt-in payload
@@ -91,9 +91,9 @@ function errorFrame(data: string): string {
     return `${out}\n`;
 }
 
-// Normalise a thrown value into the terminal `error` event shape, so an `errorData` opt-in sees
+// Normalise a thrown value into the terminal `error` event shape, so a `payload` opt-in sees
 // a consistent argument whether the failure arrived as a surfaced `error` event or an unexpected
-// throw. `attempts`/`at` are best-effort placeholders — an `errorData` hook keys off `name`/`message`.
+// throw. `attempts`/`at` are best-effort placeholders — a `payload` hook keys off `name`/`message`.
 function toErrorEvent(reason: unknown): StitchErrorEvent {
     const e = reason instanceof Error ? reason : new Error(String(reason));
     return {
@@ -109,7 +109,7 @@ function toErrorEvent(reason: unknown): StitchErrorEvent {
  * Stream a stitch's events as a `text/event-stream` `Response`. Each `delta` becomes
  * one frame; an `error` event ends the stream with a named `event: error` frame (a generic
  * `data: error` by default — the raw message is withheld to avoid disclosing internal topology;
- * opt in via `errorData`); the terminal `result`/`done` closes it.
+ * opt in via `payload`); the terminal `result`/`done` closes it.
  *
  * ```ts
  * // app/api/chat/route.ts
@@ -145,13 +145,13 @@ export function sseResponse<T>(
                         // Surface the failure as a named `error` frame, then stop — but by default
                         // write a generic token, never the raw `event.message`, so an internal
                         // hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`)
-                        // is not disclosed. Opt in to the real message via `options.errorData`.
+                        // is not disclosed. Opt in to the real message via `options.payload`.
                         controller.enqueue(
                             encoder.encode(
                                 errorFrame(
-                                    options.errorData
-                                        ? options.errorData(event)
-                                        : DEFAULT_ERROR_DATA,
+                                    options.payload
+                                        ? options.payload(event)
+                                        : DEFAULT_PAYLOAD,
                                 ),
                             ),
                         );
@@ -162,14 +162,14 @@ export function sseResponse<T>(
                 }
             } catch (reason) {
                 // A throw (not a surfaced `error` event): still withhold the raw message by
-                // default — normalise it to an error event so an `errorData` opt-in sees a
+                // default — normalise it to an error event so a `payload` opt-in sees a
                 // consistent shape.
                 controller.enqueue(
                     encoder.encode(
                         errorFrame(
-                            options.errorData
-                                ? options.errorData(toErrorEvent(reason))
-                                : DEFAULT_ERROR_DATA,
+                            options.payload
+                                ? options.payload(toErrorEvent(reason))
+                                : DEFAULT_PAYLOAD,
                         ),
                     ),
                 );

--- a/packages/next/test/next.spec.ts
+++ b/packages/next/test/next.spec.ts
@@ -83,7 +83,7 @@ describe('sseResponse', () => {
         expect(body).not.toContain('ENOTFOUND');
     });
 
-    test('errorData opts in to the raw message on the error frame', async () => {
+    test('payload opts in to the raw message on the error frame', async () => {
         const res = sseResponse(
             events(delta('a'), {
                 type: 'error',
@@ -92,7 +92,7 @@ describe('sseResponse', () => {
                 attempts: 1,
                 at: 0,
             }),
-            { errorData: (e) => e.message },
+            { payload: (e) => e.message },
         );
         const body = await res.text();
         expect(body).toBe(
@@ -153,12 +153,12 @@ describe('sseResponse', () => {
         expect(body).not.toContain('ENOTFOUND');
     });
 
-    test('errorData opts in to the raw message on the throw path too', async () => {
+    test('payload opts in to the raw message on the throw path too', async () => {
         async function* boom(): AsyncGenerator<StitchEvent, void> {
             yield delta('a');
             throw new Error('stream blew up');
         }
-        const res = sseResponse(boom(), { errorData: (e) => e.message });
+        const res = sseResponse(boom(), { payload: (e) => e.message });
         const body = await res.text();
         expect(body).toBe('data: a\n\nevent: error\ndata: stream blew up\n\n');
     });


### PR DESCRIPTION
## What

Every SSE-capable host — `express` / `fastify` / `hono` / `next` / `elysia` — exposed the
error-frame shaping callback as **`errorData`**. Beside the existing `data` delta option
that name is a stutter. Rename it (and the `DEFAULT_ERROR_DATA` constant → `DEFAULT_PAYLOAD`)
to **`payload`**: it names what goes *inside* the `frame()` envelope's `data:` line, pairing
cleanly with `data`.

```ts
// before
streamStitchSse(res, chat.stream(...), { errorData: (e) => e.message });
// after
streamStitchSse(res, chat.stream(...), { payload:  (e) => e.message });
```

No behavior change — same default (a generic `data: error` token, raw message withheld),
same opt-in semantics, same `onError` server-side hook. Identifier-only.

## ⚠️ Stacked on #476

Elysia's option is *introduced* by #476, not present on `main`. Basing this on `main` couldn't
rename elysia (nothing to rename there), so this branch **stacks on `fix/elysia-sse-error-leak`**
and this PR targets that branch — its diff is the rename alone (17 files). Elysia is thus **born
as `payload`** rather than shipping `errorData` and being renamed afterward. After #476 merges,
GitHub retargets this to `main` automatically.

## ⚠️ Breaking

Pre-GA rename of a published option across four already-shipped hosts (express/fastify/hono/next);
no deprecation alias, per current project policy. `docs/CONTRACT.md` P16 now records `payload` as
the settled cross-host name so it isn't reintroduced as `errorData`.

## Verification

`check:types` + tests green for all five packages — express 18, fastify 22, hono 19, next 18,
elysia 24. Full pre-push gate green (`contract`, `typecheck`, `typecheck-d`, `test`, `exports`,
`build-docs` twoslash, `yakir`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)