### PR TITLE
feat(core): accept `throttle: '1/s'` as shorthand for `{ rate: '1/s' }`

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -140,8 +140,8 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
         {
             label: "throttle",
             type: "property",
-            detail: "ThrottleOptions",
-            info: "Rate and concurrency limits.",
+            detail: "string | ThrottleOptions",
+            info: "Rate and concurrency limits. A bare rate string is shorthand for the rate — `throttle: '1/s'` ≡ `throttle: { rate: '1/s' }`.",
         },
         {
             label: "timeout",

--- a/apps/docs/content/docs/guides/resilience/throttle.mdx
+++ b/apps/docs/content/docs/guides/resilience/throttle.mdx
@@ -31,6 +31,22 @@ silently stalled.
 not a token bucket. `concurrency` caps simultaneous in-flight calls; either may
 be set on its own.
 
+When the rate is all you need, pass it directly — a bare string is shorthand for
+`rate`, exactly like `timeout: '5s'` is shorthand for `timeout: { total: '5s' }`:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const ping = stitch({
+    url: 'https://api.example.com/ping',
+    throttle: '1/s', // ≡ { rate: '1/s' }
+});
+```
+
+The shorthand expands at compose time, so `__config.throttle` always reads back
+as the object form, and a `throttle: '1/s'` layered over an inherited
+`{ rate: '5/s', concurrency: 2 }` replaces only the rate.
+
 `scope` decides what shares the budget: `'stitch'` (the default) gives each
 stitch its own budget, while `'host'` pools the budget across every stitch
 hitting the same host — use it when one API publishes a single account-wide

--- a/packages/core/src/seam.ts
+++ b/packages/core/src/seam.ts
@@ -37,6 +37,12 @@ import { systemClock } from './util';
 // Per-seam id so the shared bucket's store-counter key never collides across seams sharing a store.
 let seamCounter = 0;
 
+// The seam builds throttles from the RAW authoring config (before `compose` runs for the member),
+// so expand the rate-string shorthand here: `'2/s'` ≡ `{ rate: '2/s' }`.
+const throttleOptions = (
+    t: StitchConfig['throttle'],
+): ThrottleOptions | undefined => (typeof t === 'string' ? { rate: t } : t);
+
 /**
  * The seam's shared throttle bucket. Member stitches all acquire it under ONE seam-stable key, so
  * the budget (rate + in-process concurrency) pools across every stitch — "one shared bucket"
@@ -89,7 +95,11 @@ function makeBuild(shared: SharedSeam, principal: string | undefined) {
         // keys it per-stitch, so it limits just this stitch ON TOP OF the shared budget — it can
         // add a stricter gate but never replace or escape the seam's.
         const local = own.throttle
-            ? createStoreThrottle(own.throttle, shared.store, shared.clock)
+            ? createStoreThrottle(
+                  throttleOptions(own.throttle),
+                  shared.store,
+                  shared.clock,
+              )
             : undefined;
         const throttle = local
             ? chainThrottle([shared.throttle, local])
@@ -215,7 +225,12 @@ export function seam(options: SeamOptions = {}): Seam {
         clock,
         vault,
         trace,
-        throttle: seamBucket(fragment.throttle, store, seamId, clock),
+        throttle: seamBucket(
+            throttleOptions(fragment.throttle),
+            store,
+            seamId,
+            clock,
+        ),
         // `compact`'s `const` generic would freeze `[]` to `readonly []`; SharedSeam.stitches
         // is mutable, so pin the element type.
         stitches: [] as Stitch[],

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -146,6 +146,7 @@ function expandShorthand(cfg: Partial<StitchConfig>): void {
         cfg.timeout = { total: cfg.timeout };
     if (typeof cfg.cache === 'number' || typeof cfg.cache === 'string')
         cfg.cache = { ttl: cfg.cache };
+    if (typeof cfg.throttle === 'string') cfg.throttle = { rate: cfg.throttle };
     // P20: `idempotency: true` enables it with defaults; `false`/absent is off. Normalize the
     // boolean toggle to the object form the engine reads (the opaque `idempotency: {}` is a type
     // error at the slot, so the all-defaults case arrives here as `true`).

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -767,8 +767,11 @@ export interface StitchConfig {
      * `rateLimit.delegate`, which surfaces a {@link RateLimitError} on rate-limit statuses earlier.
      */
     acceptStatus?: number[] | ((status: number) => boolean);
-    /** Rate and concurrency limits. */
-    throttle?: ThrottleOptions;
+    /**
+     * Rate and concurrency limits. A bare rate string is shorthand for the rate —
+     * `throttle: '1/s'` ≡ `throttle: { rate: '1/s' }`.
+     */
+    throttle?: string | ThrottleOptions;
     /**
      * Total and per-attempt timeouts. A bare number (ms) or duration string is shorthand for the
      * total — `timeout: '5s'` ≡ `timeout: { total: '5s' }`.
@@ -859,18 +862,19 @@ export interface StitchConfig {
 
 /**
  * A {@link StitchConfig} after {@link compose} has run: every authoring shorthand is expanded, so
- * the resilience fields are always their object form (a scalar `retry` / `timeout` / `cache`
- * literal is normalised to `{ attempts }` / `{ total }` / `{ ttl }`). This is the shape the engine
- * and {@link redactConfig} read — never the loose authoring union.
+ * the resilience fields are always their object form (a scalar `retry` / `timeout` / `cache` /
+ * `throttle` literal is normalised to `{ attempts }` / `{ total }` / `{ ttl }` / `{ rate }`). This
+ * is the shape the engine and {@link redactConfig} read — never the loose authoring union.
  */
 export type ResolvedStitchConfig = Omit<
     StitchConfig,
-    'retry' | 'timeout' | 'cache' | 'idempotency'
+    'retry' | 'timeout' | 'cache' | 'idempotency' | 'throttle'
 > & {
     retry?: RetryOptions;
     timeout?: TimeoutOptions;
     cache?: CacheOptions;
     idempotency?: IdempotencyOptions;
+    throttle?: ThrottleOptions;
 };
 
 /**

--- a/packages/core/test/clock-seam.spec.ts
+++ b/packages/core/test/clock-seam.spec.ts
@@ -1,7 +1,7 @@
 // ADR 0010 — the injectable Clock. A `manualClock()` injected as `clock` makes retry backoff,
 // throttle pacing, and the per-attempt timeout deterministic with zero real waiting: `advance(ms)`
 // drives them. Verified against the REAL engine via the published mock adapter.
-import { stitch } from '../src';
+import { seam, stitch } from '../src';
 import { manualClock, mockAdapter } from '../src/testing';
 import type { Adapter } from '../src/types';
 
@@ -81,6 +81,32 @@ describe('manualClock drives throttle rate spacing (ADR 0010)', () => {
         expect(api.callCount()).toBe(1);
 
         await clock.advance(500); // release the second grant
+        await Promise.all([a, b]);
+        expect(api.callCount()).toBe(2);
+    });
+
+    // A seam builds its SHARED bucket from the raw authoring fragment, before `compose` normalizes
+    // any member — so the rate-string shorthand has to be expanded on that path too. Miss it and
+    // the bucket is built with an undefined rate: both members would fire at `advance(0)`.
+    test('a seam-level `throttle: "2/s"` shorthand paces two DIFFERENT members on one bucket', async () => {
+        const clock = manualClock();
+        const api = mockAdapter({ respond: { body: { ok: true } } });
+        const shared = seam({
+            baseUrl: 'https://api.test',
+            adapter: api,
+            throttle: '2/s', // ≡ { rate: '2/s' } — 500ms between grants
+            clock,
+        });
+        const x = shared.stitch('/x');
+        const y = shared.stitch('/y');
+
+        const a = x.safe();
+        const b = y.safe();
+
+        await clock.advance(0); // the seam pools one bucket, so the second member is paced
+        expect(api.callCount()).toBe(1);
+
+        await clock.advance(500);
         await Promise.all([a, b]);
         expect(api.callCount()).toBe(2);
     });

--- a/packages/core/test/composition.spec.ts
+++ b/packages/core/test/composition.spec.ts
@@ -265,16 +265,18 @@ test('.with() partial application sends bound query alongside call-time query', 
 });
 
 // 6) Scalar shorthands expand to their option objects at compose time.
-test('scalar shorthands (retry/timeout/cache) expand to option objects', () => {
+test('scalar shorthands (retry/timeout/cache/throttle) expand to option objects', () => {
     const resolved = compose({
         path: 'https://api.example.com/x',
         retry: 3,
         timeout: '5s',
         cache: '1m',
+        throttle: '1/s',
     });
     expect(resolved.retry).toEqual({ attempts: 3 });
     expect(resolved.timeout).toEqual({ total: '5s' });
     expect(resolved.cache).toEqual({ ttl: '1m' });
+    expect(resolved.throttle).toEqual({ rate: '1/s' });
 });
 
 // 6b) A scalar shorthand folds over an inherited object via extends, preserving the siblings the
@@ -283,15 +285,18 @@ test('a scalar shorthand merges over an inherited object, preserving siblings', 
     const base = {
         retry: { attempts: 2, on: [429, 503] },
         timeout: { total: '30s', perAttempt: '10s' },
+        throttle: { rate: '2/s', concurrency: 4 },
     };
     const resolved = compose({
         extends: [base],
         path: '/x',
         retry: 5,
         timeout: '5s',
+        throttle: '1/s',
     });
     expect(resolved.retry).toEqual({ attempts: 5, on: [429, 503] });
     expect(resolved.timeout).toEqual({ total: '5s', perAttempt: '10s' });
+    expect(resolved.throttle).toEqual({ rate: '1/s', concurrency: 4 });
 });
 
 // 6c) The shorthand survives end-to-end: a stitch's public __config shows the normalized objects.
@@ -300,7 +305,9 @@ test('a stitch built from shorthand exposes the normalized objects on __config',
         path: 'https://api.example.com/x',
         retry: 4,
         timeout: 2000,
+        throttle: '1/s',
     });
     expect(s.__config.retry).toEqual({ attempts: 4 });
     expect(s.__config.timeout).toEqual({ total: 2000 });
+    expect(s.__config.throttle).toEqual({ rate: '1/s' });
 });

--- a/scripts/contract-violations.baseline.json
+++ b/scripts/contract-violations.baseline.json
@@ -1,13 +1,13 @@
 {
     "generatedBy": "scripts/check-contract.mjs --update",
-    "count": 6,
+    "count": 5,
     "violations": [
         {
             "rule": "R6",
             "file": "packages/core/src/types.ts",
             "symbol": "StitchConfig.hooks",
             "detail": "all-optional Hooks accepts {} → Scalar|AtLeastOne<Hooks> (P20)",
-            "line": 602,
+            "line": 670,
             "key": "R6|packages/core/src/types.ts|StitchConfig.hooks"
         },
         {
@@ -15,7 +15,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "StitchConfig.input",
             "detail": "all-optional InputSchemas accepts {} → Scalar|AtLeastOne<InputSchemas> (P20)",
-            "line": 602,
+            "line": 670,
             "key": "R6|packages/core/src/types.ts|StitchConfig.input"
         },
         {
@@ -23,7 +23,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "StitchConfig.multipart",
             "detail": "all-optional MultipartOptions accepts {} → Scalar|AtLeastOne<MultipartOptions> (P20)",
-            "line": 602,
+            "line": 670,
             "key": "R6|packages/core/src/types.ts|StitchConfig.multipart"
         },
         {
@@ -31,7 +31,7 @@
             "file": "packages/core/src/types.ts",
             "symbol": "StitchConfig.sse",
             "detail": "all-optional SseOptions accepts {} → Scalar|AtLeastOne<SseOptions> (P20)",
-            "line": 602,
+            "line": 670,
             "key": "R6|packages/core/src/types.ts|StitchConfig.sse"
         },
         {
@@ -39,16 +39,8 @@
             "file": "packages/core/src/types.ts",
             "symbol": "StitchConfig.stream",
             "detail": "all-optional StreamOptions accepts {} → Scalar|AtLeastOne<StreamOptions> (P20)",
-            "line": 602,
+            "line": 670,
             "key": "R6|packages/core/src/types.ts|StitchConfig.stream"
-        },
-        {
-            "rule": "R6",
-            "file": "packages/core/src/types.ts",
-            "symbol": "StitchConfig.throttle",
-            "detail": "all-optional ThrottleOptions accepts {} → Scalar|AtLeastOne<ThrottleOptions> (P20)",
-            "line": 602,
-            "key": "R6|packages/core/src/types.ts|StitchConfig.throttle"
         }
     ]
 }


### PR DESCRIPTION
## Що це

Зріз контракт-фризу [#470](https://github.com/rejifald/StitchAPI/pull/470), винесений окремо: `throttle` приймає
короткий рядок рейту — `throttle: '1/s'` ≡ `throttle: { rate: '1/s' }`.

Це **1 з 2** змін, яких статтю для dou.ua ([#479](https://github.com/rejifald/StitchAPI/pull/479)) бракує, щоб її
можна було писати проти вже опублікованого API. Друга — перейменування
`unwrap:` → `pick:` — піде окремим PR. #470 має 325 файлів (+6071/−4262), тож
ревʼю цілого фризу зараз нереальне; ці два зрізи вирізані так, щоб #470
перебазувався поверх без конфліктів.

## Зміна

`throttle` стає в один ряд з `retry` / `timeout` / `cache`: короткий запис
розкривається в `expandShorthand`, тому двигун і `__config` бачать **тільки**
обʼєктну форму.

- `StitchConfig.throttle?: string | ThrottleOptions` — суто **адитивно**,
  обʼєктна форма недоторкана, `throttle: 7` і далі помилка типу.
- `ResolvedStitchConfig` звужує `throttle` назад до `ThrottleOptions` — рівно як
  уже робить для інших трьох.

Свідомо **без** `AtLeastOne<ThrottleOptions>`, який стоїть у #470: то окремий
пункт контракту (P20, заборона `{}`) і ще один злам. Тут його немає, тож цей PR
не ламає нічого.

## Seam: окремий шлях розкриття

Seam будує свій **спільний** бакет із сирого authoring-фрагмента, ще до того як
`compose` нормалізує будь-якого члена. Тому голий рядок дійшов би до
`createStoreThrottle` нерозкритим і бакет мовчки не пейсив би нічого — жодної
помилки, просто зникле обмеження.

Це не гіпотеза: новий тест у `clock-seam.spec.ts` падає з
`expected 2 to be 1`, якщо прибрати розкриття (перевірено мутацією).

## Верифікація

- `packages/core`: `tsc --noEmit` = 0; повний сет — **1213 passed, 2 skipped**
  (128 файлів).
- `prettier --check` чисто на всіх змінених файлах.
- Новий clock-тест детермінований (`manualClock`, без wall-clock) — 3 прогони
  поспіль зелені. Першу версію тесту я писав на реальному таймінгу; вона
  виявилась флакі (14/288/14 мс), тому переписана на фейковий годинник.
- Сніпет із доків перевірено проти **зібраних** `.d.mts`, включно з негативним
  контролем: `throttle: 7` лишається помилкою типу.

## Контракт-гейт

`check:contract` каже, що зміна **закриває** забейслайнену violation
`R6 | StitchConfig.throttle`, тож бейслайн зменшується 6 → 5.

⚠️ `--update` заодно оновив полям решти пʼятьох `line` 602 → 670. Цей дрифт
**уже був на main** (там `StitchConfig` на рядку 670, а бейслайн казав 602) — не
внесений цим PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
