### PR TITLE
refactor(core)!: rename the `unwrap` config key to `pick`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ import { z } from 'zod';
 const getUser = stitch({
     path: 'https://demo.stitchapi.dev/users/{id}',
     output: z.object({ id: z.number(), name: z.string() }),
-    unwrap: 'data',
+    pick: 'data',
 });
 
 const user = await getUser({ params: { id: 1 } }); // typed · validated
@@ -205,7 +205,7 @@ Reach for the full set of knobs only when you need them — they default off:
 const getUser = stitch({
     path: 'https://demo.stitchapi.dev/users/{id}',
     output: User, // a validator of your choice
-    unwrap: 'data',
+    pick: 'data',
     retry: 3, // ≡ { attempts: 3 }
     timeout: '5s', // ≡ { total: '5s' }
     cache: '1m', // ≡ { ttl: '1m' }
@@ -233,12 +233,12 @@ const api = seam({
 const listUsers = api.stitch({
     path: '/users',
     output: User.array(),
-    unwrap: 'data',
+    pick: 'data',
 });
 const getUser = api.stitch({
     path: '/users/{id}',
     output: User,
-    unwrap: 'data',
+    pick: 'data',
 });
 ```
 
@@ -261,7 +261,7 @@ import { z } from 'zod';
 
 const listOrders = stitch({
     path: 'https://demo.stitchapi.dev/users/{id}/orders',
-    unwrap: 'data',
+    pick: 'data',
     output: drift(
         z.array(z.object({ id: z.number(), total: z.number().optional() })),
         {
@@ -298,14 +298,14 @@ A read-through response cache with in-process request coalescing — **off by de
 const getUser = stitch({
     path: 'https://demo.stitchapi.dev/users/{id}',
     output: User,
-    unwrap: 'data',
+    pick: 'data',
     cache: '5m',
 });
 
 const listAnnouncements = stitch({
     path: 'https://demo.stitchapi.dev/announcements',
     output: z.array(z.object({ id: z.number(), title: z.string() })),
-    unwrap: 'data',
+    pick: 'data',
     cache: {
         ttl: '1h',
         scope: 'app',

--- a/apps/docs/AUTHORING.md
+++ b/apps/docs/AUTHORING.md
@@ -101,7 +101,7 @@ const signIn = stitch({
 
 const listUsers = stitch({
     path: 'https://demo.stitchapi.dev/users',
-    unwrap: 'data',
+    pick: 'data',
     auth: cookieSession({
         login: signIn,
         cookie: 'session_token',
@@ -360,11 +360,11 @@ stitch `unwrap`s it.)
 
 <!-- prettier-ignore -->
 ```ts
-const getUser    = api.stitch({ path: '/users/{id}', unwrap: 'data', output: User });
-const listUsers  = api.stitch({ path: '/users', unwrap: 'data', output: User.array() });
+const getUser    = api.stitch({ path: '/users/{id}', pick: 'data', output: User });
+const listUsers  = api.stitch({ path: '/users', pick: 'data', output: User.array() });
 const createUser = api.stitch({ method: 'POST', path: '/users', input: { body: User.omit({ id: true }) },
-                               unwrap: 'data', output: User });
-const listOrders = api.stitch({ path: '/users/{id}/orders', unwrap: 'data', output: Order.array() });
+                               pick: 'data', output: User });
+const listOrders = api.stitch({ path: '/users/{id}/orders', pick: 'data', output: Order.array() });
 ```
 
 | Stitch       | Endpoint                             | The canonical demo of                                                                                  |

--- a/apps/docs/app/(home)/demo/scene.tsx
+++ b/apps/docs/app/(home)/demo/scene.tsx
@@ -202,22 +202,22 @@ const user = await getUser({
         len: 4.8,
     },
     {
-        key: 'unwrap',
+        key: 'pick',
         label: 'Data shaping',
-        filename: 'unwrap.ts',
-        // Mirrors the README hero example: unwrap peels the transport
+        filename: 'pick.ts',
+        // Mirrors the README hero example: pick peels the transport
         // envelope before validation, so callers get the value itself.
         code: `const getUser = stitch({
   baseUrl: 'https://demo.stitchapi.dev',
   path: '/users/{id}',
   output: User,
-  unwrap: 'data', // peel the envelope
+  pick: 'data', // peel the envelope
 });
 
 const user = await getUser({
   params: { id: '42' },
 });`,
-        chip: `unwrap: 'data'`,
+        chip: `pick: 'data'`,
         chipMono: true,
         rows: [
             {
@@ -233,7 +233,7 @@ const user = await getUser({
                 icon: Scissors,
                 tone: 'brand',
                 text: 'envelope peeled before validation',
-                meta: "unwrap: 'data'",
+                meta: "pick: 'data'",
             },
             {
                 at: 2.5,
@@ -243,7 +243,7 @@ const user = await getUser({
                 meta: 'clean shape',
             },
         ],
-        doing: 'unwrapping',
+        doing: 'picking',
         done: 'just the data',
         doneAt: 3.4,
         len: 5.0,

--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -111,7 +111,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "transform",
             type: "property",
             detail: "(body: unknown) => unknown",
-            info: "Reshape the raw body before unwrap and validation (e.g. scrape HTML to structured data).",
+            info: "Reshape the raw body before `pick` and validation (e.g. scrape HTML to structured data).",
         },
         {
             label: "paginate",
@@ -135,7 +135,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "acceptStatus",
             type: "property",
             detail: "number[] | ((status: number) => boolean)",
-            info: "Statuses that are a NORMAL result rather than an error — a number list or a predicate. An accepted non-2xx flows through interpret → transform → unwrap → validate exactly like a 2xx (the response body becomes the result), instead of throwing a . Use this when an endpoint treats e.g. `404`/`400` as expected control flow (resource-gone → fall back to a broader call) so the happy path no longer runs through a `catch`. `retry.on` still wins while attempts remain: a status listed in BOTH is retried until attempts are exhausted, then accepted (returned) on the final attempt. Orthogonal to `rateLimit.delegate`, which surfaces a  on rate-limit statuses earlier.",
+            info: "Statuses that are a NORMAL result rather than an error — a number list or a predicate. An accepted non-2xx flows through interpret → transform → pick → validate exactly like a 2xx (the response body becomes the result), instead of throwing a . Use this when an endpoint treats e.g. `404`/`400` as expected control flow (resource-gone → fall back to a broader call) so the happy path no longer runs through a `catch`. `retry.on` still wins while attempts remain: a status listed in BOTH is retried until attempts are exhausted, then accepted (returned) on the final attempt. Orthogonal to `rateLimit.delegate`, which surfaces a  on rate-limit statuses earlier.",
         },
         {
             label: "throttle",
@@ -238,7 +238,7 @@ export const PLAYGROUND_INSTANCE_COMPLETIONS: Record<string, Completion[]> = {
             info: "Call without throwing: resolves to a `SafeResult` — `{ ok, data, error }`. The eager shortcut for `stitch(...).safe()`, mirroring `.stream()`.",
         },
         {
-            label: "pick",
+            label: "unwrap",
             type: "method",
             detail: "(...args: Args<TIn>) => Promise<TOut>",
             info: "Call and unwrap to the value, throwing a `StitchError` on failure. The named twin of `.safe()` (and an explicit spelling of the throwing bare call).",

--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -102,7 +102,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             info: "Response schema, or a  for leveled drift detection. Accepts any — a raw Zod schema, any Standard Schema (Valibot, ArkType), or a `(value) => boolean` predicate — directly; the stitch infers its result type from it (see `InferOutput`), so a hand-written generic is rarely needed.",
         },
         {
-            label: "unwrap",
+            label: "pick",
             type: "property",
             detail: "string",
             info: "Dot-path selecting the part of the response to return.",
@@ -238,7 +238,7 @@ export const PLAYGROUND_INSTANCE_COMPLETIONS: Record<string, Completion[]> = {
             info: "Call without throwing: resolves to a `SafeResult` — `{ ok, data, error }`. The eager shortcut for `stitch(...).safe()`, mirroring `.stream()`.",
         },
         {
-            label: "unwrap",
+            label: "pick",
             type: "method",
             detail: "(...args: Args<TIn>) => Promise<TOut>",
             info: "Call and unwrap to the value, throwing a `StitchError` on failure. The named twin of `.safe()` (and an explicit spelling of the throwing bare call).",

--- a/apps/docs/app/(home)/playground/playground-examples.ts
+++ b/apps/docs/app/(home)/playground/playground-examples.ts
@@ -47,22 +47,22 @@ const api = stitch({
 });
 
 // 2 - Derive endpoint clients with extends: each inherits everything above.
-//     unwrap pulls a value out of an envelope ({ data: ... } -> ...), and
+//     pick pulls a value out of an envelope ({ data: ... } -> ...), and
 //     output validates what you actually receive (pass a Zod / Standard
 //     Schema validator in real code; a plain predicate works too).
 const getUser = stitch({
   extends: [api],
   path: '/users/{id}',
-  unwrap: 'data',
+  pick: 'data',
   output: (u) => !!u && typeof u.id === 'number' && typeof u.email === 'string',
 });
 
 // 3 - .with(...) is partial application: bind input now, reuse the call later.
 const user = await getUser.with({ params: { id: 2 } })();
-console.log('1) validated + unwrapped user:');
+console.log('1) validated + picked user:');
 console.log(user);
 
-// 4 - transform reshapes the raw body before unwrap and validation run.
+// 4 - transform reshapes the raw body before pick and validation run.
 const listNames = stitch({
   extends: [api],
   path: '/users',
@@ -80,7 +80,7 @@ console.log('3) whoami:', me);
 //     succeeds; the retry policy + onRetry hook recover it. .stream() yields
 //     every lifecycle event (start -> progress -> result -> done) so you can
 //     watch the recovery happen instead of just awaiting a value.
-const flaky = stitch({ extends: [api], path: '/users', unwrap: 'data' });
+const flaky = stitch({ extends: [api], path: '/users', pick: 'data' });
 let recovered, attempts;
 for await (const event of flaky.stream({ query: { __flaky: 2 } })) {
   if (event.type === 'result') recovered = event.value;
@@ -115,7 +115,7 @@ import { z } from 'zod';
 const getUser = stitch({
   baseUrl: 'https://demo.stitchapi.dev',
   path: '/users/{id}',
-  unwrap: 'data', // pull the user out of the { data: ... } envelope
+  pick: 'data', // pull the user out of the { data: ... } envelope
   // Pass a Zod schema (or any Standard Schema) directly.
   input: { params: z.object({ id: z.number() }) }, // typed + validated BEFORE the request
   output: z.object({ id: z.number(), email: z.string() }), // typed + validated AFTER

--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -404,7 +404,7 @@ export const pages: Page[] = [
         path: 'guides/resilience/accept-status',
         title: 'Accept status',
         description:
-            'Declare statuses that are a normal result, not an error — an accepted non-2xx flows through transform/unwrap/validate instead of throwing.',
+            'Declare statuses that are a normal result, not an error — an accepted non-2xx flows through transform/pick/validate instead of throwing.',
         kind: 'guide',
     },
     {
@@ -445,8 +445,8 @@ export const pages: Page[] = [
 
     // ── Guides · Data shaping ───────────────────────────────────────────────
     {
-        path: 'guides/data/unwrap',
-        title: 'unwrap',
+        path: 'guides/data/pick',
+        title: 'pick',
         description: 'Pull just the part of the response you want by dot-path.',
         kind: 'guide',
     },
@@ -454,7 +454,7 @@ export const pages: Page[] = [
         path: 'guides/data/transform',
         title: 'transform',
         description:
-            'Reshape a response before unwrap and validation — for example, scrape HTML into structured data.',
+            'Reshape a response before pick and validation — for example, scrape HTML into structured data.',
         kind: 'guide',
     },
     {
@@ -481,7 +481,7 @@ export const pages: Page[] = [
         path: 'guides/data/graphql',
         title: 'GraphQL',
         description:
-            'Call a GraphQL endpoint with variables, unwrap data, and treat a 200 carrying errors as a failure.',
+            'Call a GraphQL endpoint with variables, pick data, and treat a 200 carrying errors as a failure.',
         kind: 'guide',
     },
 

--- a/apps/docs/content/blog/expose-a-stitch-as-an-ai-sdk-tool.mdx
+++ b/apps/docs/content/blog/expose-a-stitch-as-an-ai-sdk-tool.mdx
@@ -31,7 +31,7 @@ const Order = z.object({
 export const getOrder = stitch({
     path: 'https://internal.example.com/orders/{id}',
     output: Order,
-    unwrap: 'data',
+    pick: 'data',
     // The credential resolves at call time and never reaches the caller.
     auth: bearer(env('ORDERS_API_TOKEN')),
     // Resilience is declared once, here — not in the tool, not in the agent.

--- a/apps/docs/content/blog/migrate-from-axios-to-stitchapi.mdx
+++ b/apps/docs/content/blog/migrate-from-axios-to-stitchapi.mdx
@@ -88,7 +88,7 @@ const getUser = stitch({
         respectRetryAfter: true,
     },
     timeout: { total: '30s', perAttempt: '10s' },
-    unwrap: 'data', // the API wraps payloads in { data }
+    pick: 'data', // the API wraps payloads in { data }
     output: drift(User),
 });
 
@@ -106,7 +106,7 @@ const user = await getUser({ params: { id } }); // typed · validated · retried
 | retry interceptor with backoff              | re-issues on 429/502/503/504  | `retry: { attempts, on, backoff: 'expo-jitter', respectRetryAfter: true }` ([retry](/docs/guides/resilience/retry))               |
 | `baseURL`                                   | one host for many calls       | `baseUrl` on the stitch, or once on a `seam()` ([seam](/docs/guides/authoring/seam))                                              |
 | `validateStatus`                            | decide what status throws     | the engine never throws on a non-2xx by itself — you declare which statuses `retry`, and a `StitchError` carries the rest         |
-| `transformResponse` + `as User`             | reshape, then assert the type | `unwrap` plus an `output` schema (wrap in `drift()` to flag shape changes) ([drift](/docs/guides/validation/drift))               |
+| `transformResponse` + `as User`             | reshape, then assert the type | `pick` plus an `output` schema (wrap in `drift()` to flag shape changes) ([drift](/docs/guides/validation/drift))                 |
 
 The last row is the one axios never had. `output` validates the _live_ response on every call, so a mismatch is a typed error at the boundary, not an `undefined` downstream. Wrap it in `drift()` and each response is diffed against its validated form, every change leveled by severity — a renamed required field throws, a coercion the schema absorbed surfaces as a `warn` on the event stream.
 

--- a/apps/docs/content/blog/one-definition-four-front-doors.mdx
+++ b/apps/docs/content/blog/one-definition-four-front-doors.mdx
@@ -28,7 +28,7 @@ export const getUser = stitch({
     baseUrl: 'https://api.example.com',
     path: '/users/{id}',
     output: z.object({ id: z.number(), name: z.string() }),
-    unwrap: 'data',
+    pick: 'data',
     auth: bearer(env('API_TOKEN')),
     retry: { attempts: 3, on: [429, 503] },
     timeout: { total: '10s' },
@@ -39,7 +39,7 @@ Export your stitches by name from a module (the CLI and the servers default to `
 
 ## Door 1 — the in-process function: your app code
 
-The closest door. Import the stitch and call it like any async function; `await` returns the final unwrapped, validated value.
+The closest door. Import the stitch and call it like any async function; `await` returns the final picked, validated value.
 
 ```ts twoslash
 import { bearer, env, stitch } from 'stitchapi';
@@ -51,7 +51,7 @@ const getUser = stitch({
     baseUrl: 'https://api.example.com',
     path: '/users/{id}',
     output: z.object({ id: z.number(), name: z.string() }),
-    unwrap: 'data',
+    pick: 'data',
     auth: bearer(env('API_TOKEN')),
 });
 // ---cut---

--- a/apps/docs/content/blog/read-through-caching-and-coalescing.mdx
+++ b/apps/docs/content/blog/read-through-caching-and-coalescing.mdx
@@ -34,7 +34,7 @@ const User = z.object({ id: z.number(), name: z.string() });
 const getUser = stitch({
     path: 'https://api.example.com/users/{id}',
     output: User,
-    unwrap: 'data',
+    pick: 'data',
     cache: '5m', // ≡ { ttl: '5m' }
 });
 ```
@@ -76,7 +76,7 @@ import { z } from 'zod';
 const listAnnouncements = stitch({
     path: 'https://api.example.com/announcements',
     output: z.array(z.object({ id: z.number(), title: z.string() })),
-    unwrap: 'data',
+    pick: 'data',
     cache: {
         ttl: '1h',
         scope: 'app', // shared across principals — see below

--- a/apps/docs/content/blog/stitch-vs-codegen-api-clients.mdx
+++ b/apps/docs/content/blog/stitch-vs-codegen-api-clients.mdx
@@ -23,7 +23,7 @@ import { z } from 'zod';
 const getUser = stitch({
     path: 'https://api.example.com/users/{id}',
     output: z.object({ id: z.number(), name: z.string() }),
-    unwrap: 'data',
+    pick: 'data',
 });
 
 const user = await getUser({ params: { id: 1 } }); // typed · validated

--- a/apps/docs/content/blog/stop-writing-fetch-in-your-agents.mdx
+++ b/apps/docs/content/blog/stop-writing-fetch-in-your-agents.mdx
@@ -53,7 +53,7 @@ export const getOrders = stitch({
     path: 'https://api.example.com/users/{userId}/orders',
     auth: bearer(env('API_TOKEN')), // resolved at call time; the caller never sees it
     output: z.array(z.object({ id: z.number(), total: z.number() })),
-    unwrap: 'data',
+    pick: 'data',
     retry: { attempts: 3, on: [429, 503], respectRetryAfter: true },
     throttle: { rate: '10/s', concurrency: 4, scope: 'host' },
     timeout: { total: '10s' },

--- a/apps/docs/content/blog/test-api-code-without-the-network.mdx
+++ b/apps/docs/content/blog/test-api-code-without-the-network.mdx
@@ -75,7 +75,7 @@ test('validates the user', async () => {
 });
 ```
 
-The fixture is scoped to this stitch, not to a global. `mockAdapter` returns a real adapter — the same contract `fetchAdapter` satisfies — so the engine cannot tell it apart from a socket. That means `output: User` actually validates the canned body, `unwrap` actually unwraps it, and `paginate` actually walks your fixture pages. You are testing the stitch's behavior, not a fake of it.
+The fixture is scoped to this stitch, not to a global. `mockAdapter` returns a real adapter — the same contract `fetchAdapter` satisfies — so the engine cannot tell it apart from a socket. That means `output: User` actually validates the canned body, `pick` actually picks it, and `paginate` actually walks your fixture pages. You are testing the stitch's behavior, not a fake of it.
 
 A `MockRoute` is `{ method?, match?, respond }`. `match` is a URL substring, a `RegExp` against the full URL, or a predicate — first match wins. `respond` is a fixed `MockResponse` (status defaults to `200`), a function of the call, or — the useful one for resilience — an array consumed one per call, last entry repeating. That last form scripts a flaky endpoint, which is how you exercise the real retry path:
 

--- a/apps/docs/content/blog/typed-graphql-without-apollo.mdx
+++ b/apps/docs/content/blog/typed-graphql-without-apollo.mdx
@@ -39,7 +39,7 @@ The sharp edges are real. `res.ok` is `true` for a `200` that carries `{ "errors
 
 ## The same job as a stitch
 
-Declare the operation once. `graphql()` is a thin wrapper over `stitch()` that fixes `kind: 'graphql'`, `method: 'POST'`, and `unwrap: 'data'`:
+Declare the operation once. `graphql()` is a thin wrapper over `stitch()` that fixes `kind: 'graphql'`, `method: 'POST'`, and `pick: 'data'`:
 
 ```ts twoslash
 import { graphql } from 'stitchapi';
@@ -83,7 +83,7 @@ try {
 
 ## It is still a stitch
 
-`graphql()` returns the same object `stitch()` does, so every resilience and validation field applies. Add an `output` schema and the unwrapped `data` is validated before you touch it — the `as User` cast is gone, replaced by a runtime check the compiler can trust:
+`graphql()` returns the same object `stitch()` does, so every resilience and validation field applies. Add an `output` schema and the picked `data` is validated before you touch it — the `as User` cast is gone, replaced by a runtime check the compiler can trust:
 
 ```ts twoslash
 import { bearer, env, graphql } from 'stitchapi';
@@ -114,8 +114,8 @@ The secret resolves at call time from the environment, so the caller never holds
 | The POST + JSON envelope | You write `method`, `content-type`, `JSON.stringify({ query, variables })` every call | `graphql()` fixes them; you supply `path` + `query`                |
 | Variables                | Re-stringified per call site                                                          | Travel in `variables` at call time; one stitch, every argument set |
 | `200` with `errors`      | `res.ok` is `true` — failure slips through as `undefined`                             | A `StitchError` whose message is prefixed `GraphQL:`               |
-| Response shape           | `as User` — unchecked                                                                 | `output` schema validates the unwrapped `data` at runtime          |
-| Unwrapping `data`        | `json.data.user`, by hand                                                             | `unwrap: 'data'` by default; resolved value is `data`              |
+| Response shape           | `as User` — unchecked                                                                 | `output` schema validates the picked `data` at runtime             |
+| Picking `data`           | `json.data.user`, by hand                                                             | `pick: 'data'` by default; resolved value is `data`                |
 | Auth, retry, timeout     | More hand-written loops and headers                                                   | Config fields on the same declaration                              |
 
 The layer split is clean: the GraphQL document describes **what** you're asking for, and the stitch config describes **how** the call behaves — validation, auth, resilience — without a client object owning either. You keep writing GraphQL; you stop writing the POST around it.
@@ -153,7 +153,7 @@ stitchapi zod
 
 `graphql()` wraps `stitch()`, so install the core package, bring your own validator, and point a query at an endpoint.
 
--   [Guide: GraphQL](/docs/guides/data/graphql) — how `graphql()` posts the operation and unwraps `data`
+-   [Guide: GraphQL](/docs/guides/data/graphql) — how `graphql()` posts the operation and picks `data`
 -   [Error: STITCH_GRAPHQL](/docs/errors/stitch-graphql) — what a `200`-with-`errors` failure looks like
 -   [Validate an API response with Zod](/blog/validate-api-response-zod) — wiring an `output` schema
 -   [A type-safe API client without codegen](/blog/type-safe-api-client-without-codegen) — the same idea across REST and GraphQL

--- a/apps/docs/content/blog/typescript-pagination.mdx
+++ b/apps/docs/content/blog/typescript-pagination.mdx
@@ -119,7 +119,7 @@ const rows = (await mirror()) as unknown[];
 
 A `429` on page seven now recovers on its own through [retry](/docs/guides/resilience/retry), and [throttle](/docs/guides/resilience/throttle) keeps the whole run under five requests a second — applied **per page**, not once for the run. None of that touches the pagination logic; it's declared next to it. The two recipes go end to end: [loop a cursor API into one array](/docs/recipes/paginate-into-one-array) and [mirror a paginated API to NDJSON](/docs/recipes/mirror-a-paginated-api), the latter adding OAuth2 on the same declaration.
 
-One detail to get right: `next` reads the **raw body**, while `items` reads the value after [unwrap](/docs/guides/data/unwrap) runs. Reach for the cursor in `next` from where it actually lives in the response. And without an [`output` schema](/docs/guides/validation/validation) the aggregated rows arrive as `unknown[]` — hence the cast; add a schema and each row is typed and validated, and the cast goes away.
+One detail to get right: `next` reads the **raw body**, while `items` reads the value after [pick](/docs/guides/data/pick) runs. Reach for the cursor in `next` from where it actually lives in the response. And without an [`output` schema](/docs/guides/validation/validation) the aggregated rows arrive as `unknown[]` — hence the cast; add a schema and each row is typed and validated, and the cast goes away.
 
 ## Where the hand-rolled loop tops out
 
@@ -142,4 +142,4 @@ One caveat in the other direction: `paginate` aggregates every page into a singl
 stitchapi
 ```
 
-Give a stitch a `paginate` with a `next` and an `items`, and one `await` follows every page into a single array — with `retry` and `throttle` applied per page when you add them. The mechanics are in [Pagination](/docs/guides/data/pagination), the envelope handling in [Unwrap](/docs/guides/data/unwrap), and typed rows in [Validation](/docs/guides/validation/validation).
+Give a stitch a `paginate` with a `next` and an `items`, and one `await` follows every page into a single array — with `retry` and `throttle` applied per page when you add them. The mechanics are in [Pagination](/docs/guides/data/pagination), the envelope handling in [Pick](/docs/guides/data/pick), and typed rows in [Validation](/docs/guides/validation/validation).

--- a/apps/docs/content/docs/agents/run-stitch-tool.mdx
+++ b/apps/docs/content/docs/agents/run-stitch-tool.mdx
@@ -38,7 +38,7 @@ capability boundary. The agent never sees the credential.
 Before running a name, an agent can ask for its shape. `describe_stitch` takes
 `{ name }` and returns one text result — a JSON description built from the
 stitch's public `__config`: its endpoint and surface, which input slots it
-takes, whether the output is validated and where it unwraps, the auth **scheme**
+takes, whether the output is validated and what it picks, the auth **scheme**
 (never the token), which policies are on, the pipeline of steps a call runs
 through, and a Mermaid `diagram`.
 
@@ -59,7 +59,7 @@ returns one text result whose body is JSON like:
         "body": false,
         "headers": false
     },
-    "output": { "validated": true, "unwrap": "data" },
+    "output": { "validated": true, "pick": "data" },
     "auth": "bearer",
     "policies": {
         "retry": true,
@@ -72,7 +72,7 @@ returns one text result whose body is JSON like:
         "GET /widgets/{id}",
         "retry",
         "validate",
-        "unwrap: data",
+        "pick: data",
         "result"
     ],
     "diagram": "flowchart TD\n  subgraph ..."

--- a/apps/docs/content/docs/concepts/principles.mdx
+++ b/apps/docs/content/docs/concepts/principles.mdx
@@ -43,7 +43,7 @@ declaration _is_ the runtime; there is nothing to commit, diff, and regenerate.
 
 ### Composition over configuration
 
-Cross-cutting concerns — `baseUrl`, auth, `unwrap`, retry, throttle, timeout —
+Cross-cutting concerns — `baseUrl`, auth, `pick`, retry, throttle, timeout —
 are named, shareable values you compose, not a central config object far from the
 call site. Nothing is inherited implicitly: no config file, no ambient defaults,
 no global a stitch silently reads. Everything that shapes a call was composed into
@@ -63,7 +63,7 @@ const api = {
 };
 
 // Fold the shared fragment into each stitch; it inherits baseUrl + retry.
-const getUser = stitch({ extends: [api], path: '/users/{id}', unwrap: 'data' });
+const getUser = stitch({ extends: [api], path: '/users/{id}', pick: 'data' });
 ```
 
 ### One source of truth

--- a/apps/docs/content/docs/concepts/the-seam.mdx
+++ b/apps/docs/content/docs/concepts/the-seam.mdx
@@ -33,12 +33,12 @@ const api = seam({
 // share its store, throttle bucket, vault, and trace sink.
 const getUser = api.stitch({
     path: '/users/{id}',
-    unwrap: 'data',
+    pick: 'data',
     output: User,
 });
 const listUsers = api.stitch({
     path: '/users',
-    unwrap: 'data',
+    pick: 'data',
     output: User.array(),
 });
 ```

--- a/apps/docs/content/docs/errors/stitch-graphql.mdx
+++ b/apps/docs/content/docs/errors/stitch-graphql.mdx
@@ -7,7 +7,7 @@ description: 'A GraphQL 200 response carried an errors array and failed the call
 
 A stitch built with [`graphql()`](/docs/guides/data/graphql) throws a
 `StitchError` even though the HTTP status was `200`. The response body carried a
-non-empty top-level `errors` array, so the stitch refused to unwrap `data` and
+non-empty top-level `errors` array, so the stitch refused to pick `data` and
 surfaced the failure instead. The thrown error carries the GraphQL message(s),
 prefixed `GraphQL:` and joined with `; ` when there is more than one:
 
@@ -38,7 +38,7 @@ throws a `StitchError` today.)
 GraphQL-over-HTTP commonly answers with HTTP `200` even when the operation
 failed, reporting the failure in a top-level `errors` array rather than via the
 status line. A `graphql()` stitch treats a `200` that carries a non-empty
-`errors` array as a failure instead of silently unwrapping `data` — so a request
+`errors` array as a failure instead of silently picking `data` — so a request
 that "looked successful" at the transport layer still throws.
 
 The entries in `errors` come from the GraphQL server: a malformed query or
@@ -63,7 +63,7 @@ own description of what went wrong — and fix the cause:
 Remember that GraphQL signals failure in the response body, not through the HTTP
 status: a `200` is not proof of success. See the
 [GraphQL guide](/docs/guides/data/graphql) for how `graphql()` posts the
-operation and unwraps `data` on the success path.
+operation and picks `data` on the success path.
 
 <Callout type="info">
     Stuck, or debugging with an agent? Ask the [docs

--- a/apps/docs/content/docs/errors/stitch-validation.mdx
+++ b/apps/docs/content/docs/errors/stitch-validation.mdx
@@ -15,7 +15,7 @@ type mismatch on the response. Where it throws tells you which side failed:
     `params`, `query`, `body`, or `headers`.
 -   **Response, after the request.** When the response doesn't match `output`, the
     error is thrown after the response returns and has been transformed and
-    unwrapped — the request did go out, and the failure describes how the payload
+    picked — the request did go out, and the failure describes how the payload
     diverged from the contract.
 
 <Callout type="warn">

--- a/apps/docs/content/docs/guides/authoring/seam.mdx
+++ b/apps/docs/content/docs/guides/authoring/seam.mdx
@@ -30,12 +30,12 @@ const api = seam({
 // Members are stitches that belong to the seam.
 const getUser = api.stitch({
     path: '/users/{id}',
-    unwrap: 'data',
+    pick: 'data',
     output: User,
 });
 const listUsers = api.stitch({
     path: '/users',
-    unwrap: 'data',
+    pick: 'data',
     output: User.array(),
 });
 
@@ -57,7 +57,7 @@ const api = seam({ baseUrl: 'https://demo.stitchapi.dev' });
 
 // One handle per request — bind the caller's identity, then create members.
 const forTenant = api.as('tenant-42');
-const getUser = forTenant.stitch({ path: '/users/{id}', unwrap: 'data' });
+const getUser = forTenant.stitch({ path: '/users/{id}', pick: 'data' });
 ```
 
 <Callout type="warn">

--- a/apps/docs/content/docs/guides/data/graphql.mdx
+++ b/apps/docs/content/docs/guides/data/graphql.mdx
@@ -1,12 +1,12 @@
 ---
 title: 'GraphQL'
-description: 'Call a GraphQL endpoint with variables, unwrap data, and treat a 200 carrying errors as a failure.'
+description: 'Call a GraphQL endpoint with variables, pick data, and treat a 200 carrying errors as a failure.'
 prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `graphql()` when an API speaks GraphQL-over-HTTP and you want a stitch that
 POSTs a query, passes variables per call, and hands back the `data` payload
-already unwrapped — with a `200` that carries an `errors` array treated as a
+already picked — with a `200` that carries an `errors` array treated as a
 failure, not a success.
 
 ## Example
@@ -20,20 +20,20 @@ const getUser = graphql<{ user: { id: string; name: string } }>({
     query: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
 });
 
-// Variables travel in the input; the result is already unwrapped from `data`.
+// Variables travel in the input; the result is already picked from `data`.
 const data = await getUser({ variables: { id: '1' } });
 ```
 
 ## Options
 
 `graphql()` is a thin wrapper over `stitch()`: it fixes `kind: 'graphql'`,
-`method: 'POST'`, and `unwrap: 'data'` for you. You supply the GraphQL document
+`method: 'POST'`, and `pick: 'data'` for you. You supply the GraphQL document
 as `query`, plus a `baseUrl`/`path` pointing at the endpoint.
 
 Pass GraphQL variables through the input's `variables` field at call time —
 `getUser({ variables: { id: '1' } })` — so one stitch serves every set of
-arguments. Because `unwrap` defaults to `'data'`, the resolved value is the
-contents of the response's `data` object; override `unwrap` if you need a
+arguments. Because `pick` defaults to `'data'`, the resolved value is the
+contents of the response's `data` object; override `pick` if you need a
 different field or the raw envelope.
 
 <Callout type="warn">
@@ -55,7 +55,7 @@ For the full set of fields a stitch accepts, see
 ## See also
 
 <Cards>
-    <Card title="Unwrap" href="/docs/guides/data/unwrap" />
+    <Card title="pick" href="/docs/guides/data/pick" />
     <Card title="Validation" href="/docs/guides/validation/validation" />
     <Card title="STITCH_GRAPHQL" href="/docs/errors/stitch-graphql" />
     <Card title="Reference: Config types" href="/docs/reference/config-types" />

--- a/apps/docs/content/docs/guides/data/meta.json
+++ b/apps/docs/content/docs/guides/data/meta.json
@@ -1,7 +1,7 @@
 {
     "title": "Data shaping",
     "pages": [
-        "unwrap",
+        "pick",
         "transform",
         "pagination",
         "body-encoding",

--- a/apps/docs/content/docs/guides/data/pagination.mdx
+++ b/apps/docs/content/docs/guides/data/pagination.mdx
@@ -38,9 +38,9 @@ page count and returns the [`StitchInput`](/docs/reference/config-types) for the
 next page, merged over the original call — set only what changes, like a cursor
 or page number. Return `undefined` to stop.
 
-`items(value)` selects the array to aggregate from each page's unwrapped value;
-it defaults to the value itself when that value is already an array. The unwrap
-runs first, so pair `items` with [`unwrap`](/docs/guides/data/unwrap) when the
+`items(value)` selects the array to aggregate from each page's picked value;
+it defaults to the value itself when that value is already an array. The pick
+runs first, so pair `items` with [`pick`](/docs/guides/data/pick) when the
 array sits under an envelope, and use `items` to dig into a nested shape.
 
 `max` caps the page count as a safety net (default `50`) so a misbehaving
@@ -51,17 +51,17 @@ Auth, retry, and throttle apply per page, not once for the whole run: a
 and a [`retry`](/docs/guides/resilience/retry) recovers each page on its own.
 
 <Callout type="warn">
-    **Anti-pattern:** don't read the next-page cursor in `next` from the
-    unwrapped array, expecting it where `items` looks — `next` receives the raw
-    body and `items` receives the value after `unwrap` runs, so read the cursor
-    in `next` from where it lives in the raw response instead. See
-    [unwrap](/docs/guides/data/unwrap).
+    **Anti-pattern:** don't read the next-page cursor in `next` from the picked
+    array, expecting it where `items` looks — `next` receives the raw body and
+    `items` receives the value after `pick` runs, so read the cursor in `next`
+    from where it lives in the raw response instead. See
+    [pick](/docs/guides/data/pick).
 </Callout>
 
 ## See also
 
 <Cards>
-    <Card title="unwrap" href="/docs/guides/data/unwrap" />
+    <Card title="pick" href="/docs/guides/data/pick" />
     <Card title="throttle" href="/docs/guides/resilience/throttle" />
     <Card title="retry" href="/docs/guides/resilience/retry" />
     <Card title="Reference: Config types" href="/docs/reference/config-types" />

--- a/apps/docs/content/docs/guides/data/pick.mdx
+++ b/apps/docs/content/docs/guides/data/pick.mdx
@@ -1,10 +1,10 @@
 ---
-title: 'unwrap'
+title: 'pick'
 description: 'Pull just the part of the response you want by dot-path.'
 prerequisites: ['/docs/concepts/the-stitch']
 ---
 
-Use `unwrap` when an API wraps the value you want in an envelope and you want
+Use `pick` when an API wraps the value you want in an envelope and you want
 the stitch to hand back the inner field directly — give it a dot-path and the
 caller never sees the wrapper.
 
@@ -16,7 +16,7 @@ import { stitch } from 'stitchapi';
 const getUser = stitch<{ id: number; name: string }>({
     baseUrl: 'https://api.example.com',
     path: '/users/{id}',
-    unwrap: 'data.user',
+    pick: 'data.user',
 });
 
 // `user` is the inner { id, name } object, not the { data: { user } } envelope.
@@ -25,28 +25,28 @@ const user = await getUser({ params: { id: 1 } });
 
 ## Options
 
-`unwrap` takes a **dot-path** — each segment selects a nested key, so
+`pick` takes a **dot-path** — each segment selects a nested key, so
 `'data.user'` reaches into `{ data: { user: ... } }` and returns the inner
 object.
 
 It sits late in the pipeline: a response is reshaped by
-[`transform`](/docs/guides/data/transform) first, then `unwrap` selects the
+[`transform`](/docs/guides/data/transform) first, then `pick` selects the
 slice, and only then does [validation](/docs/guides/validation/validation) run —
-so a schema sees the unwrapped value, not the envelope. For paged calls, each
-page is unwrapped before its items are collected; see
+so a schema sees the picked value, not the envelope. For paged calls, each
+page is picked before its items are collected; see
 [Pagination](/docs/guides/data/pagination).
 
-Pair `unwrap` with the generic on `stitch<T>()` to type the result: the stitch
-returns `T` (the unwrapped value), not the envelope. See
+Pair `pick` with the generic on `stitch<T>()` to type the result: the stitch
+returns `T` (the picked value), not the envelope. See
 [Reference → Config types](/docs/reference/config-types) for the full config
 shape.
 
 <Callout type="warn">
     **Anti-pattern:** don't reach for the dot-path to reshape, rename, or merge
-    fields — `unwrap` only _selects_ one already-nested slice, so anything
-    beyond picking an existing branch belongs in a reshape step that runs first.
-    Do the restructuring in `transform` instead, then point `unwrap` at the
-    slice it produces. See [transform](/docs/guides/data/transform).
+    fields — `pick` only _selects_ one already-nested slice, so anything beyond
+    picking an existing branch belongs in a reshape step that runs first. Do the
+    restructuring in `transform` instead, then point `pick` at the slice it
+    produces. See [transform](/docs/guides/data/transform).
 </Callout>
 
 ## See also

--- a/apps/docs/content/docs/guides/data/transform.mdx
+++ b/apps/docs/content/docs/guides/data/transform.mdx
@@ -1,12 +1,12 @@
 ---
 title: 'transform'
-description: 'Reshape a response before unwrap and validation — for example, scrape HTML into structured data.'
+description: 'Reshape a response before pick and validation — for example, scrape HTML into structured data.'
 prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 Use `transform` when the raw response isn't yet the shape the rest of the
 pipeline expects — scrape HTML text into a structured object, or flatten an odd
-envelope — so a single function reshapes the body before unwrap and validation
+envelope — so a single function reshapes the body before pick and validation
 ever see it.
 
 ## Example
@@ -18,7 +18,7 @@ const listing = stitch({
     baseUrl: 'https://api.example.com',
     path: '/listings',
     // The body is `unknown` — narrow it, then reshape the raw envelope into a
-    // plain array before unwrap and validation run.
+    // plain array before pick and validation run.
     transform: (body) => (body as { results: unknown[] }).results,
 });
 ```
@@ -29,11 +29,11 @@ inner array, and everything downstream works against that array instead.
 ## Options
 
 `transform?: (body: unknown) => unknown` runs **first** in the response
-pipeline — before [`unwrap`](/docs/guides/data/unwrap) and before
+pipeline — before [`pick`](/docs/guides/data/pick) and before
 [validation](/docs/guides/validation/validation) (and
 [drift](/docs/guides/validation/drift)). That ordering is the point: reshape a
 raw body — scrape HTML text into a structured object, or flatten an odd
-envelope — into the shape unwrap and validation are written for, rather than
+envelope — into the shape pick and validation are written for, rather than
 bending them around the source's quirks.
 
 `body` is typed `unknown`, so narrow it before reading (a cast or a type guard)
@@ -44,15 +44,15 @@ and return any reshaped value. See
     **Anti-pattern:** don't reach for `transform` to pull the inner field out of
     an envelope — a cast like reading `.results` off the body is an opaque
     function whose output is unchecked, so a wrong narrowing slips past and only
-    surfaces later as drift. Name the path with `unwrap` instead, which is
+    surfaces later as drift. Name the path with `pick` instead, which is
     declarative, round-trips as JSON, and feeds validation and drift directly.
-    See [unwrap](/docs/guides/data/unwrap).
+    See [pick](/docs/guides/data/pick).
 </Callout>
 
 ## See also
 
 <Cards>
-    <Card title="unwrap" href="/docs/guides/data/unwrap" />
+    <Card title="pick" href="/docs/guides/data/pick" />
     <Card title="Validation" href="/docs/guides/validation/validation" />
     <Card title="Drift" href="/docs/guides/validation/drift" />
     <Card title="Reference: Config types" href="/docs/reference/config-types" />

--- a/apps/docs/content/docs/guides/resilience/accept-status.mdx
+++ b/apps/docs/content/docs/guides/resilience/accept-status.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Accept status'
-description: 'Declare statuses that are a normal result, not an error — an accepted non-2xx flows through transform/unwrap/validate instead of throwing.'
+description: 'Declare statuses that are a normal result, not an error — an accepted non-2xx flows through transform/pick/validate instead of throwing.'
 prerequisites: ['/docs/concepts/the-stitch']
 ---
 
@@ -11,7 +11,7 @@ ordinary control flow into exception handling.
 
 `acceptStatus` lets you declare which non-2xx statuses are a **normal result**. An
 accepted status no longer throws: its response body becomes the result and flows
-through the same pipeline a `2xx` does — `interpret` → `transform` → `unwrap` →
+through the same pipeline a `2xx` does — `interpret` → `transform` → `pick` →
 `output` validation — so the happy path stays on the happy path.
 
 ## Example

--- a/apps/docs/content/docs/guides/resilience/delegate-backoff.mdx
+++ b/apps/docs/content/docs/guides/resilience/delegate-backoff.mdx
@@ -85,7 +85,7 @@ for await (const ev of fetchPage.stream({ params: { id: '42' } })) {
 ## What still runs
 
 Delegate mode changes _only_ how a rate-limit status is handled. Everything else
-on a stitch is untouched: input validation, templating, `transform`, `unwrap`,
+on a stitch is untouched: input validation, templating, `transform`, `pick`,
 and [drift](/docs/guides/validation/drift) all still run on a successful response,
 and non-rate-limit failures (a `500`, a transport error) behave exactly as they
 do without the flag. A [`circuit`](/docs/guides/resilience/circuit-breaker)

--- a/apps/docs/content/docs/recipes/catch-a-selector-rename.mdx
+++ b/apps/docs/content/docs/recipes/catch-a-selector-rename.mdx
@@ -16,7 +16,7 @@ want that markup rename to surface the moment it happens, as a loud error on the
 
 ## Example
 
-The response pipeline is `transform → unwrap → validation`, so `transform`
+The response pipeline is `transform → pick → validation`, so `transform`
 reshapes the HTML into a structured object **before** drift ever runs — drift
 then validates the _parsed_ value, not the raw markup. Declare `score` as
 **required** in the schema: its loss is the breakage you want caught.
@@ -47,7 +47,7 @@ const catalog = stitch({
     baseUrl: 'https://api.example.com',
     path: '/catalog',
     transform: scrape, // HTML string -> { items: [...] }
-    unwrap: 'items',
+    pick: 'items',
     output: drift(
         // `score` is REQUIRED — its loss is the breakage we want caught.
         // A required field that goes missing throws (`STITCH_DRIFT`, `change: 'invalid'`).

--- a/apps/docs/content/docs/recipes/inspect-what-the-server-sent.mdx
+++ b/apps/docs/content/docs/recipes/inspect-what-the-server-sent.mdx
@@ -28,7 +28,7 @@ import { z } from 'zod';
 const getUser = stitch({
     baseUrl: 'https://demo.stitchapi.dev',
     path: '/users/{id}',
-    unwrap: 'data',
+    pick: 'data',
     output: drift(
         z.object({ id: z.number(), name: z.string(), role: z.string() }),
     ),

--- a/apps/docs/content/docs/recipes/mirror-a-paginated-api.mdx
+++ b/apps/docs/content/docs/recipes/mirror-a-paginated-api.mdx
@@ -79,8 +79,8 @@ schema and each row is typed and validated, and the cast goes away. Either way,
 serializing to NDJSON is one `.map()`.
 
 <Callout type="warn">
-    `next` reads the raw body; `items` reads the value after unwrap. Reach for
-    the cursor in `next` from where it actually lives in the response — see
+    `next` reads the raw body; `items` reads the value after pick. Reach for the
+    cursor in `next` from where it actually lives in the response — see
     [Pagination](/docs/guides/data/pagination).
 </Callout>
 

--- a/apps/docs/content/docs/recipes/paginate-into-one-array.mdx
+++ b/apps/docs/content/docs/recipes/paginate-into-one-array.mdx
@@ -40,7 +40,7 @@ const users = (await allUsers()) as unknown[];
 `next(prevBody)` reads the cursor off the previous page's raw body and returns
 the [input](/docs/reference/config-types) for the next page, merged over the
 original call — set only what changes. Return `undefined` to stop. `items`
-selects the array to aggregate from each page (after [unwrap](/docs/guides/data/unwrap)).
+selects the array to aggregate from each page (after [pick](/docs/guides/data/pick)).
 `max` caps the page count as a safety net (default `50`). Auth, retry, and
 throttle apply per page, not once for the whole run. Without an
 [`output` schema](/docs/guides/validation/validation) the aggregated result is
@@ -54,6 +54,6 @@ typed `unknown[]`, hence the cast — add a schema to type the rows.
         title="Mirror a paginated API to NDJSON"
         href="/docs/recipes/mirror-a-paginated-api"
     />
-    <Card title="Unwrap" href="/docs/guides/data/unwrap" />
+    <Card title="pick" href="/docs/guides/data/pick" />
     <Card title="Transform" href="/docs/guides/data/transform" />
 </Cards>

--- a/apps/docs/content/docs/reference/surfaces.mdx
+++ b/apps/docs/content/docs/reference/surfaces.mdx
@@ -19,13 +19,13 @@ Every non-`http` surface ships as its own **subpath import**, so
 `import { stitch }` from the root pulls in only the `http` engine — a surface's
 code (and its parser/decoder) loads only when you import it.
 
-| Surface    | Import               | Shapes                                     | `await` resolves to            |
-| ---------- | -------------------- | ------------------------------------------ | ------------------------------ |
-| `http`     | `stitch` (default)   | a JSON-over-HTTP call                      | the validated body             |
-| `graphql`  | `stitchapi/graphql`  | POST `{ query, variables }`, unwrap `data` | the `data` payload             |
-| `sse`      | `stitchapi/sse`      | a `text/event-stream` reader (over fetch)  | every parsed event, collected  |
-| `stream`   | `stitchapi/stream`   | a raw `ReadableStream` reader              | every decoded chunk, collected |
-| `download` | `stitchapi/download` | a buffered binary GET                      | `{ blob, filename }`           |
+| Surface    | Import               | Shapes                                    | `await` resolves to            |
+| ---------- | -------------------- | ----------------------------------------- | ------------------------------ |
+| `http`     | `stitch` (default)   | a JSON-over-HTTP call                     | the validated body             |
+| `graphql`  | `stitchapi/graphql`  | POST `{ query, variables }`, pick `data`  | the `data` payload             |
+| `sse`      | `stitchapi/sse`      | a `text/event-stream` reader (over fetch) | every parsed event, collected  |
+| `stream`   | `stitchapi/stream`   | a raw `ReadableStream` reader             | every decoded chunk, collected |
+| `download` | `stitchapi/download` | a buffered binary GET                     | `{ blob, filename }`           |
 
 ## http — the default
 
@@ -40,7 +40,7 @@ const getUser = stitch('https://api.example.com/users/{id}');
 
 ## graphql
 
-`graphql()` POSTs `{ query, variables }` and unwraps `data`; a `200` carrying
+`graphql()` POSTs `{ query, variables }` and picks `data`; a `200` carrying
 `errors[]` is treated as a failure, never silently passed.
 
 ```ts
@@ -120,7 +120,7 @@ const logs = stream({
 ```
 
 For `sse` the contract describes the event's `data` payload, not the
-`{ event, data, id, retry }` envelope. `transform` and `unwrap` reshape a whole
+`{ event, data, id, retry }` envelope. `transform` and `pick` reshape a whole
 buffered body and aren't applied to the delta path, and drift **snapshots** are
 a whole-body concept — not taken per-`delta`.
 

--- a/apps/docs/content/docs/surfaces/cli.mdx
+++ b/apps/docs/content/docs/surfaces/cli.mdx
@@ -89,7 +89,7 @@ there.
 **`stitch diagram [--module <path>] [--name <name>]`** prints a
 [Mermaid](https://mermaid.js.org) flowchart of each stitch's configured pipeline
 — throttle, request, retry, the request [surface](/docs/reference/surfaces),
-pagination, validation, transform, unwrap, and cache — read straight from the
+pagination, validation, transform, pick, and cache — read straight from the
 definition, with no run. Pass `--name` to diagram a single stitch by export name
 or configured `name`. Auth is redacted from a stitch's public config, so the
 credential never appears in the diagram.

--- a/apps/docs/content/docs/surfaces/function.mdx
+++ b/apps/docs/content/docs/surfaces/function.mdx
@@ -5,7 +5,7 @@ prerequisites: ['/docs/concepts/the-stitch']
 ---
 
 A stitch is a typed async function — no server, no transport. `await` it for the
-final unwrapped, validated value, or iterate its event stream for everything that
+final picked, validated value, or iterate its event stream for everything that
 happened on the way there. This is the closest of the four surfaces: the same
 definition you call here also runs from the CLI, over HTTP, and through MCP.
 
@@ -31,7 +31,7 @@ for await (const event of getUser.stream({ params: { id: 1 } })) {
 ## Options
 
 **Awaited vs streamed.** `await getUser(input)` resolves to the final value,
-already unwrapped and validated. `getUser.stream(input)` yields the typed
+already picked and validated. `getUser.stream(input)` yields the typed
 [event stream](/docs/concepts/event-stream) — `start → progress → drift →
 result → done` — so you can observe retries, throttling, and drift as they
 happen. Same call, two altitudes.

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -101,6 +101,17 @@ const config = {
     // The playground consumes the in-repo sandbox engine (@stitchapi/sandbox), a
     // workspace package that ships raw TS/TSX source — Next must transpile it.
     transpilePackages: ['@stitchapi/sandbox'],
+    // The config key `unwrap` was renamed to `pick`; the guide page moved with
+    // it. Permanent redirect keeps published links alive.
+    async redirects() {
+        return [
+            {
+                source: '/docs/guides/data/unwrap',
+                destination: '/docs/guides/data/pick',
+                permanent: true,
+            },
+        ];
+    },
     // CSP backstop for the sandbox Worker (egress confinement + worker-confined
     // eval). See lib/security-headers.mjs; proved by e2e/sandbox-egress.spec.ts.
     async headers() {

--- a/apps/docs/test/search-golden.json
+++ b/apps/docs/test/search-golden.json
@@ -68,8 +68,8 @@
         "expect": "guides/auth/oauth2"
     },
     {
-        "query": "unwrap the data field out of a JSON envelope response",
-        "expect": "guides/data/unwrap"
+        "query": "pick the data field out of a JSON envelope response",
+        "expect": "guides/data/pick"
     },
     {
         "query": "reshape or transform a response body before it returns",

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -25,7 +25,7 @@ A stitch is a typed, declarative, composable unit: `input → validated output`,
 
 1. **Progressive disclosure.** Zero-config to start; opt-in depth. `stitch('https://…')` just works. Every capability (validation, auth, retries, observability, streaming) has a sane default and reveals knobs only when you reach for them. _Simple to begin, opportunistic about what's possible._
 2. **Atomic stitches.** A stitch is fully self-contained. It can be exactly one endpoint and nothing else. **No global config is ever required.**
-3. **Composition over configuration.** Cross-cutting concerns (baseUrl, auth, unwrap, retry, throttle, timeout, hooks) are **named, shareable values** you compose — not a central config object far from the call site.
+3. **Composition over configuration.** Cross-cutting concerns (baseUrl, auth, pick, retry, throttle, timeout, hooks) are **named, shareable values** you compose — not a central config object far from the call site.
 4. **The stitch is the boundary.** Auth, validation, and observability live _at_ the stitch. Agents receive **capabilities, not credentials** — they call a stitch and get data without ever seeing the secret.
 5. **One definition, many surfaces.** The same stitch is callable as an in-process function, a CLI command, an HTTP endpoint, and an MCP/agent tool.
 6. **The event stream is the spine.** Streaming output, observability, and drift detection all read the _same_ event stream a stitch emits.
@@ -49,7 +49,7 @@ const listWebsites = stitch({
 
     input: { query: WebsiteQuery }, // schemas for params / query / body / headers
     output: Website.array(), // response contract → types + validation + drift
-    unwrap: 'data', // pluck the payload
+    pick: 'data', // pluck the payload
 
     auth: session, // a co-located auth strategy value (§5)
     retry: { attempts: 3, on: [429, 503] },
@@ -128,7 +128,7 @@ const listWebsites = stitch({
     extends: [base, session], // left→right precedence; own fields win last
     path: '/api/websites',
     output: Website.array(),
-    unwrap: 'data',
+    pick: 'data',
 });
 ```
 
@@ -153,7 +153,7 @@ A stitch is itself a composable value — inherit one and override the diff:
 
 ```ts
 const getWebsite = stitch({
-    extends: [listWebsites], // inherits base + auth + retry + unwrap
+    extends: [listWebsites], // inherits base + auth + retry + pick
     path: '/api/websites/{id}', // override
     output: Website, // override
 });
@@ -161,7 +161,7 @@ const getWebsite = stitch({
 
 ### Merge semantics **[proposed]**
 
--   **Scalars** (`path`, `method`, `baseUrl`, `url`, `unwrap`): replace. The endpoint is one slot: `url` and `baseUrl`/`path` are mutually exclusive, so the last fragment to set either spelling wins it whole — a child `url` clears an inherited `baseUrl`/`path`, and a child `baseUrl`/`path` clears an inherited `url`.
+-   **Scalars** (`path`, `method`, `baseUrl`, `url`, `pick`): replace. The endpoint is one slot: `url` and `baseUrl`/`path` are mutually exclusive, so the last fragment to set either spelling wins it whole — a child `url` clears an inherited `baseUrl`/`path`, and a child `baseUrl`/`path` clears an inherited `url`.
 -   **Objects** (`retry`, `throttle`, `timeout`, `input`, auth options): deep-merge field-wise.
 -   **`hooks`**: **chain**, don't replace — base `onRequest` runs, then child's; `onResponse` unwinds child→base (middleware order). This is what makes a base like "always log + add trace header" actually composable.
 -   **`output` / contracts**: replace (a child declares its own); compose explicitly with `schema.merge(...)` when you want to extend.
@@ -305,7 +305,7 @@ await user({ params: { id: 1 }, query: { expand: 'roles' } });
 const users = stitch({
     url: 'https://reqres.in/api/users',
     output: User.array(),
-    unwrap: 'data',
+    pick: 'data',
 });
 const list = await users(); // typed User[]; drift-checked
 ```
@@ -375,7 +375,7 @@ const listWebsites = stitch({
     extends: [api],
     path: '/api/websites',
     output: Website.array(),
-    unwrap: 'data',
+    pick: 'data',
     auth: cookieSession({
         login: signIn,
         cookie: 'session_token',

--- a/docs/sandbox/mcp/sandbox-stitches.ts
+++ b/docs/sandbox/mcp/sandbox-stitches.ts
@@ -17,22 +17,22 @@ export const sandboxRegistry: StitchRegistry = {
     /** GET /users/{id} — a single user (ids 1–3). `{ params: { id } }`. */
     getUser: stitch({
         path: 'https://demo.stitchapi.dev/users/{id}',
-        unwrap: 'data',
+        pick: 'data',
     }),
     /** GET /users — the fixed fixture (Alice, Bob, Carol). */
     listUsers: stitch({
         path: 'https://demo.stitchapi.dev/users',
-        unwrap: 'data',
+        pick: 'data',
     }),
     /** POST /users — create a user; echoes the body + an assigned id. */
     createUser: stitch({
         method: 'POST',
         path: 'https://demo.stitchapi.dev/users',
-        unwrap: 'data',
+        pick: 'data',
     }),
     /** GET /users/{id}/orders — a user's orders (ids 1–3). `{ params: { id } }`. */
     listOrders: stitch({
         path: 'https://demo.stitchapi.dev/users/{id}/orders',
-        unwrap: 'data',
+        pick: 'data',
     }),
 };

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -113,7 +113,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 -   **Declared resilience** - retry with backoff and `Retry-After`, proactive throttle (rate + concurrency, per stitch or per host), total / per-attempt timeouts with real aborts, a circuit breaker, and idempotency keys.
 -   **Read-through caching** - an opt-in response cache with in-process request coalescing, keyed by a derived, principal-scoped key — sound by construction (it refuses to cache a shape it can't fingerprint) and loaded lazily from `stitchapi/cache`.
 -   **Auth as a boundary** - `bearer`, `apiKey`, `basic`, `cookieSession` (auto-login and re-login), and `oauth2` client credentials; secrets resolve at call time via `env()` / `secretsFile()` and never reach the caller.
--   **Data shaping** - `unwrap` dot-paths, `transform` (e.g. scrape HTML into structure), auto-looping pagination, and `json` / `form` / `multipart` request bodies.
+-   **Data shaping** - `pick` dot-paths, `transform` (e.g. scrape HTML into structure), auto-looping pagination, and `json` / `form` / `multipart` request bodies.
 -   **Any request style** - `http` is the default; `graphql`, `sse`, `stream`, `download`, `llm`, `shell`, and `postmessage` are peer **surfaces**, each a subpath import (`stitchapi/sse`, …) on the same engine — so `import { stitch }` bundles `http` alone.
 -   **Pluggable state store** - throttle counters and sessions/tokens live behind a 3-method store; in-memory by default, a shared store makes throttling distributed and sessions shared across workers.
 -   **Zero-infra observability** - tracing is **off by default** (a stitch's only effect is its call); opt in per stitch with `trace: 'console'` / `fileSink(path)` / a `TraceSink`, or globally with `STITCH_TRACE_CONSOLE=1` / `STITCH_TRACE_FILE=<path>` / `STITCH_EXPORT=otlp`. `stitch trace` then summarizes runs, retries, drift, and latency percentiles.
@@ -212,7 +212,7 @@ const User = z.object({
 const getUser = stitch({
     path: 'https://demo.stitchapi.dev/users/{id}',
     output: User,
-    unwrap: 'data', // the demo sim wraps payloads in a { data } envelope
+    pick: 'data', // the demo sim wraps payloads in a { data } envelope
 });
 
 const user = await getUser({ params: { id: 1 } }); // typed User
@@ -222,7 +222,7 @@ One endpoint is one `stitch`. The moment a service has more than one — sharing
 
 ## The event stream
 
-A stitch does not return `Promise<bytes>`. It yields a typed event stream — `await` is sugar that consumes the stream and returns the final, unwrapped, validated `result` (or throws a `StitchError` carrying `.status`, plus `.body` (the parsed error payload) and `.url` (the final request URL) when the failure came from a response):
+A stitch does not return `Promise<bytes>`. It yields a typed event stream — `await` is sugar that consumes the stream and returns the final, picked, validated `result` (or throws a `StitchError` carrying `.status`, plus `.body` (the parsed error payload) and `.url` (the final request URL) when the failure came from a response):
 
 ```ts
 const users = await getUsers(); // sugar: consume the stream → the result value
@@ -285,12 +285,12 @@ const api = seam({
 const listUsers = api.stitch({
     path: '/users',
     output: User.array(),
-    unwrap: 'data',
+    pick: 'data',
 });
 const getUser = api.stitch({
     path: '/users/{id}',
     output: User,
-    unwrap: 'data',
+    pick: 'data',
 });
 ```
 
@@ -309,7 +309,7 @@ const listUsers = stitch({
     extends: [base],
     path: '/users',
     output: User.array(),
-    unwrap: 'data',
+    pick: 'data',
 });
 ```
 
@@ -317,13 +317,13 @@ A stitch is itself a composable value — extend one and override only the diff:
 
 ```ts
 const getOneUser = stitch({
-    extends: [listUsers], // inherits baseUrl + retry + unwrap
+    extends: [listUsers], // inherits baseUrl + retry + pick
     path: '/users/{id}',
     output: User,
 });
 ```
 
-Merge semantics: scalars (`path`, `method`, `baseUrl`, `unwrap`) replace; objects (`retry`, `throttle`, `timeout`, `input`) deep-merge; `hooks` chain across layers (`onRequest` runs base→child, the rest unwind child→base).
+Merge semantics: scalars (`path`, `method`, `baseUrl`, `pick`) replace; objects (`retry`, `throttle`, `timeout`, `input`) deep-merge; `hooks` chain across layers (`onRequest` runs base→child, the rest unwind child→base).
 
 `.with()` pre-binds part of the input and returns a new stitch that reuses the same runtime — so cookies, tokens, and throttle state persist across the bound and unbound forms:
 
@@ -350,7 +350,7 @@ import { z } from 'zod';
 
 const listOrders = stitch({
     path: 'https://demo.stitchapi.dev/users/{id}/orders',
-    unwrap: 'data',
+    pick: 'data',
     output: drift(
         z.array(z.object({ id: z.number(), total: z.number().optional() })),
         {
@@ -377,7 +377,7 @@ const createUser = stitch({
         }),
     },
     output: User, // { id, name, email, role }
-    unwrap: 'data',
+    pick: 'data',
 });
 ```
 
@@ -421,7 +421,7 @@ Three more knobs round out the resilience set:
     }
     ```
 
--   **`acceptStatus`** treats a non-2xx as a _normal_ result rather than a throw — for endpoints where, say, `404` is expected control flow. The body flows through `transform` → `unwrap` → validate exactly like a `2xx`:
+-   **`acceptStatus`** treats a non-2xx as a _normal_ result rather than a throw — for endpoints where, say, `404` is expected control flow. The body flows through `transform` → `pick` → validate exactly like a `2xx`:
 
     ```ts
     acceptStatus: [404]; // resource-gone → fall back, no try/catch on the happy path
@@ -439,7 +439,7 @@ A bare duration is the TTL shorthand:
 const getUser = stitch({
     path: 'https://demo.stitchapi.dev/users/{id}',
     output: User,
-    unwrap: 'data',
+    pick: 'data',
     cache: '5m', // ≡ { ttl: '5m' }
 });
 ```
@@ -450,7 +450,7 @@ Pass a config object for the full control surface:
 const listAnnouncements = stitch({
     path: 'https://demo.stitchapi.dev/announcements',
     output: z.array(z.object({ id: z.number(), title: z.string() })),
-    unwrap: 'data',
+    pick: 'data',
     cache: {
         ttl: '1h',
         scope: 'app', // public, unauthenticated data → share one entry across callers
@@ -510,7 +510,7 @@ const signIn = stitch({
 const listUsers = stitch({
     baseUrl: 'https://demo.stitchapi.dev',
     path: '/users',
-    unwrap: 'data',
+    pick: 'data',
     auth: cookieSession({
         login: signIn,
         cookie: 'session_token', // captured from Set-Cookie, replayed each call
@@ -637,22 +637,22 @@ A **surface** is the request _style_ a stitch speaks. `http` is the default — 
 
 Every non-`http` surface ships as its own **subpath import**, so `import { stitch }` from the root pulls in only the `http` engine; a surface's code loads only when you import it.
 
-| Surface       | Import                        | Shapes                                     | `await` resolves to            |
-| ------------- | ----------------------------- | ------------------------------------------ | ------------------------------ |
-| `http`        | `stitch` (default)            | a JSON-over-HTTP call                      | the validated body             |
-| `graphql`     | `stitchapi/graphql`           | POST `{ query, variables }`, unwrap `data` | the `data` payload             |
-| `sse`         | `stitchapi/sse`               | a `text/event-stream` reader (over fetch)  | every parsed event, collected  |
-| `stream`      | `stitchapi/stream`            | a raw `ReadableStream` reader              | every decoded chunk, collected |
-| `download`    | `stitchapi/download`          | a buffered binary GET                      | `{ blob, filename }`           |
-| `llm`         | `stitchapi/llm`               | a chat-completion via a provider contract  | the normalised `{ text, … }`   |
-| `shell`       | `@stitchapi/shell` (peer pkg) | a local command, args + stdin              | the command's stdout           |
-| `postmessage` | `stitchapi/postmessage`       | a typed iframe ↔ parent RPC / event call  | the typed RPC response         |
+| Surface       | Import                        | Shapes                                    | `await` resolves to            |
+| ------------- | ----------------------------- | ----------------------------------------- | ------------------------------ |
+| `http`        | `stitch` (default)            | a JSON-over-HTTP call                     | the validated body             |
+| `graphql`     | `stitchapi/graphql`           | POST `{ query, variables }`, pick `data`  | the `data` payload             |
+| `sse`         | `stitchapi/sse`               | a `text/event-stream` reader (over fetch) | every parsed event, collected  |
+| `stream`      | `stitchapi/stream`            | a raw `ReadableStream` reader             | every decoded chunk, collected |
+| `download`    | `stitchapi/download`          | a buffered binary GET                     | `{ blob, filename }`           |
+| `llm`         | `stitchapi/llm`               | a chat-completion via a provider contract | the normalised `{ text, … }`   |
+| `shell`       | `@stitchapi/shell` (peer pkg) | a local command, args + stdin             | the command's stdout           |
+| `postmessage` | `stitchapi/postmessage`       | a typed iframe ↔ parent RPC / event call | the typed RPC response         |
 
 (Distinct from the four _invocation_ surfaces — function, CLI, HTTP, MCP — which are how you _call_ a stitch. A request surface is how a stitch shapes its _request_.)
 
 ### GraphQL
 
-`graphql()` POSTs `{ query, variables }` and unwraps `data`. A `200` carrying `errors[]` is a failure — it will not silently pass:
+`graphql()` POSTs `{ query, variables }` and picks `data`. A `200` carrying `errors[]` is a failure — it will not silently pass:
 
 ```ts
 import { graphql } from 'stitchapi';
@@ -764,7 +764,7 @@ One logical call follows pages until `next` returns `undefined` (or the `max` sa
 ```ts
 const listOrders = stitch({
     path: 'https://demo.stitchapi.dev/users/{id}/orders',
-    unwrap: 'data',
+    pick: 'data',
     paginate: {
         // previous page's raw body + pages fetched so far → input for the
         // next page (merged over the original), or undefined to stop
@@ -776,17 +776,17 @@ const listOrders = stitch({
 const everything = await listOrders({ params: { id: 1 } }); // [...page1, ...page2, ...] as one array
 ```
 
-When the unwrapped page is not itself the array, pass `items` to pull the array out of each page.
+When the picked page is not itself the array, pass `items` to pull the array out of each page.
 
 ## Transform
 
-`transform` runs before `unwrap` and validation — turn an arbitrary payload (HTML, text, a legacy shape) into structured data, then let `unwrap` + `output` / `drift` treat it like any other contract:
+`transform` runs before `pick` and validation — turn an arbitrary payload (HTML, text, a legacy shape) into structured data, then let `pick` + `output` / `drift` treat it like any other contract:
 
 ```ts
 const listOrders = stitch({
     path: 'https://demo.stitchapi.dev/users/{id}/orders',
     transform: (html) => scrape(html), // your parser: HTML/text → { items: [...] }
-    unwrap: 'items',
+    pick: 'items',
     output: z.array(z.object({ id: z.number(), total: z.number() })),
 });
 ```

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -348,8 +348,8 @@ export interface CacheControllerOptions {
     output?: unknown;
     /** The stitch's `transform` closure — opaque, so it forces a version/trust decision (ADR 0004). */
     transform?: ((body: unknown) => unknown) | undefined;
-    /** The stitch's `unwrap` dot-path — serialisable, always folds soundly into the generation. */
-    unwrap?: string | undefined;
+    /** The stitch's `pick` dot-path — serialisable, always folds soundly into the generation. */
+    pick?: string | undefined;
 }
 
 export function createCache(opts: CacheControllerOptions): CacheController {
@@ -368,15 +368,15 @@ export function createCache(opts: CacheControllerOptions): CacheController {
         : undefined;
     // Fold the Standard Schema fingerprint (ADR 0004) ONCE, here at controller creation (which is
     // once per stitch — `ensureCache` memoises it). It resolves three things from the stitch's
-    // output/transform/unwrap + cache options: the GENERATION token (a changed output schema /
-    // unwrap / versioned transform yields a new token → a new bucket → old entries unreachable),
+    // output/transform/pick + cache options: the GENERATION token (a changed output schema /
+    // pick / versioned transform yields a new token → a new bucket → old entries unreachable),
     // the POLICY (fast / revalidate / refuse), and a human-readable REASON for traces. The token is
     // folded into the namespace ALONGSIDE the per-stitch generation counter (decision 8) — it does
     // not replace it: bulk-invalidate bumps the counter, a schema change bumps this token.
     const fp = resolveFingerprint({
         output: opts.output,
         transform: opts.transform,
-        unwrap: opts.unwrap,
+        pick: opts.pick,
         version: config.version,
         transformVersion: config.transformVersion,
         trustTransform: config.trustTransform,
@@ -461,7 +461,7 @@ export function createCache(opts: CacheControllerOptions): CacheController {
             const prefix = await genPrefix();
             // The stored key is prefixed with the frozen key-schema version (a derivation change is
             // a mass self-healing miss, never a stale-key hit — ADR 0003 follow-up) and the
-            // fingerprint generation token `fpTag` (an output-schema/unwrap/transform change moves
+            // fingerprint generation token `fpTag` (an output-schema/pick/transform change moves
             // the bucket — ADR 0004). For the 'revalidate' policy the token is empty and freshness
             // comes from re-validation on the hit path instead.
             const valueKey = (suffix = ''): string =>

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -478,7 +478,7 @@ by default (no side effects) — opt in with --trace or the STITCH_TRACE_* env v
 diagram:
   --name <name>   diagram only this stitch (by export name or configured name)
   Emits a Mermaid flowchart of each stitch's configured pipeline (throttle, request,
-  retry, surface, pagination, validation, transform, unwrap, cache). Auth is redacted
+  retry, surface, pagination, validation, transform, pick, cache). Auth is redacted
   from a stitch's public config, so it is not shown.
 
 export:

--- a/packages/core/src/config-summary.ts
+++ b/packages/core/src/config-summary.ts
@@ -44,10 +44,10 @@ export function pipelineStages(
         const pages = cfg.paginate.pages ?? cfg.paginate.max ?? 50;
         stages.push(opts.detailed ? `paginate (max ${pages})` : 'paginate');
     }
-    // Post-response order matches the engine (engine.ts): transform → unwrap → validate. The body
-    // is transformed, then the unwrap path is read, then the result is validated against `output`.
+    // Post-response order matches the engine (engine.ts): transform → pick → validate. The body
+    // is transformed, then the pick path is read, then the result is validated against `output`.
     if (cfg.transform) stages.push('transform');
-    if (cfg.unwrap) stages.push(`unwrap: ${cfg.unwrap}`);
+    if (cfg.pick) stages.push(`pick: ${cfg.pick}`);
     if (cfg.output) stages.push('validate');
     if (cfg.cache) stages.push('cache');
     stages.push('result');

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -628,7 +628,7 @@ async function* attemptLoop(
     const delegate = (cfg.throttle?.delegate ?? legacyRl?.delegate) === true;
     const rlMatch = acceptsStatus(cfg.throttle?.on ?? legacyRl?.on ?? [429]);
     // acceptStatus (issue #155): statuses the caller declares NORMAL — an accepted non-2xx returns
-    // `res` like a 2xx (flowing through interpret → transform → unwrap → validate) instead of
+    // `res` like a 2xx (flowing through interpret → transform → pick → validate) instead of
     // throwing. Checked at the `>= 400` site, i.e. AFTER the retry-on-status path, so `retry.on`
     // still wins while attempts remain (retried, then accepted on the final attempt).
     const accepts = acceptsStatus(cfg.acceptStatus);
@@ -910,7 +910,7 @@ async function* paginated(
 
         let value: unknown = outcome.value;
         if (cfg.transform) value = await cfg.transform(value);
-        if (cfg.unwrap) value = getPath(value, cfg.unwrap);
+        if (cfg.pick) value = getPath(value, cfg.pick);
         const items = pg.items
             ? pg.items(value)
             : Array.isArray(value)
@@ -970,10 +970,10 @@ async function ensureCache(rt: Runtime): Promise<CacheController | null> {
                 store: rt.store,
                 stitchId: m.cacheStitchId(cfg),
                 // The RAW output schema (not the Validator wrapper) so the fingerprinter can read its
-                // `~standard.vendor`; transform/unwrap are already raw on the config (ADR 0004 fold).
+                // `~standard.vendor`; transform/pick are already raw on the config (ADR 0004 fold).
                 output: outputSchemaSource(cfg),
                 transform: cfg.transform,
-                unwrap: cfg.unwrap,
+                pick: cfg.pick,
                 principal: rt.authCtx.principal,
             }),
         ),
@@ -1134,7 +1134,7 @@ async function* runFrom(
     }
 
     // The surface interprets the response (graphql's "200-with-`errors`-is-a-failure" lives in
-    // its interpret hook); with no hook the body is the value. Then transform → unwrap → validate.
+    // its interpret hook); with no hook the body is the value. Then transform → pick → validate.
     const outcome = interpretResponse(cfg, res);
     if (!outcome.ok) {
         yield surfaceErrEvt(outcome, name, state.attempts);
@@ -1143,7 +1143,7 @@ async function* runFrom(
     }
     let value: unknown = outcome.value;
     if (cfg.transform) value = await cfg.transform(value);
-    if (cfg.unwrap) value = getPath(value, cfg.unwrap);
+    if (cfg.pick) value = getPath(value, cfg.pick);
     // The pre-validation body — the left side of 0015's `diff(raw, validated)`, the coordinate space a
     // finding's `path` is anchored to. `.inspect()` (ADR 0016) surfaces it; otherwise it's discarded.
     const rawBody = value;
@@ -1180,7 +1180,7 @@ async function* runFrom(
 // slot (a rate-only acquire, never released), so a long-lived connection can never pin a seam's
 // concurrency budget (Decision 12). The await/`consume` path resolves to the COLLECTED array of
 // every emitted chunk ACROSS reconnects — the terminal `result` mirrors the whole delta spine (Stage
-// 5 sub-decision); `.stream()` yields the chunks incrementally and buffers nothing. transform/unwrap
+// 5 sub-decision); `.stream()` yields the chunks incrementally and buffers nothing. transform/pick
 // reshape a whole buffered body and are NOT applied here; the `output` contract, by contrast,
 // validates each chunk before its `delta` is emitted (per-`delta`, via the surface's `contractValue`
 // hook — ADR 0005 Addendum) and keeps firing across reconnects, snapshot-drift omitted.

--- a/packages/core/src/fingerprint.ts
+++ b/packages/core/src/fingerprint.ts
@@ -2,7 +2,7 @@
 //
 // The response cache (ADR 0003) stores the post-validation value and skips
 // re-validation on a hit, so a stored value is bound to the `output` schema
-// (plus `transform`/`unwrap`) it was validated against. Ship a changed schema and
+// (plus `transform`/`pick`) it was validated against. Ship a changed schema and
 // a hit would serve an old-shape value for the whole TTL. This module computes a
 // stable FINGERPRINT that folds into the cache GENERATION so a contract change
 // auto-invalidates.
@@ -134,8 +134,8 @@ export interface FingerprintInput {
     readonly output?: unknown;
     /** `config.transform` — opaque; cannot be soundly hashed (see ADR 0004 §6). */
     readonly transform?: ((body: unknown) => unknown) | undefined;
-    /** `config.unwrap` — a dot-path string; serialisable, so always sound. */
-    readonly unwrap?: string | undefined;
+    /** `config.pick` — a dot-path string; serialisable, so always sound. */
+    readonly pick?: string | undefined;
     /** Explicit `cache.version` — authoritative override; always wins. */
     readonly version?: string | number | undefined;
     /** A user tag making an opaque `transform` sound. */
@@ -181,12 +181,12 @@ function vendorOf(schema: unknown): string | undefined {
 export function resolveFingerprint(
     input: FingerprintInput,
 ): FingerprintResolution {
-    const unwrap = input.unwrap ?? '';
+    const pick = input.pick ?? '';
 
     // rung 1 — explicit cache.version is authoritative.
     if (input.version != null) {
         return {
-            generation: hash(`v|${input.version}|u|${unwrap}`),
+            generation: hash(`v|${input.version}|u|${pick}`),
             policy: 'fast',
             reason: 'explicit cache.version',
         };
@@ -234,7 +234,7 @@ export function resolveFingerprint(
     if (token != null) {
         return {
             generation: hash(
-                `s|${vendor}|${token}|${fp?.strength}|u|${unwrap}|${xTag}`,
+                `s|${vendor}|${token}|${fp?.strength}|u|${pick}|${xTag}`,
             ),
             policy: 'fast',
             reason: 'sound structural fingerprint',
@@ -242,10 +242,10 @@ export function resolveFingerprint(
     }
 
     // rung 4 — no output schema: the stored value is bound to no shape, so there
-    // is nothing to go stale. Cache fast; `unwrap`/transform tag still fold in.
+    // is nothing to go stale. Cache fast; `pick`/transform tag still fold in.
     if (input.output == null) {
         return {
-            generation: hash(`noschema|u|${unwrap}|${xTag}`),
+            generation: hash(`noschema|u|${pick}|${xTag}`),
             policy: 'fast',
             reason: 'no output schema',
         };

--- a/packages/core/src/graphql.ts
+++ b/packages/core/src/graphql.ts
@@ -2,7 +2,7 @@
 // monomorphic authoring helpers. `graphql(config)` stays the terse callable form; `graphql.stitch`
 // is its alias, `graphql.seam(...)` binds graphql members to a seam, and `graphql.surface` is the
 // Surface identity. The seam stays surface-agnostic — graphql members are created through the
-// seam's own `graphql()` method (in Stage 4 graphql's shaping/unwrap move behind the surface
+// seam's own `graphql()` method (in Stage 4 graphql's shaping/pick move behind the surface
 // hooks; today they ride the engine's id-keyed handling + this helper).
 import { seam as makeSeam } from './seam';
 import { graphql as graphqlStitch } from './stitch';

--- a/packages/core/src/mcp.ts
+++ b/packages/core/src/mcp.ts
@@ -79,7 +79,7 @@ const DESCRIBE_STITCH_TOOL = {
     name: 'describe_stitch',
     description:
         "Describe a named stitch's shape WITHOUT running it: its endpoint, surface, per-slot " +
-        'input presence, output (validated/unwrap), auth scheme (never the credential), the ' +
+        'input presence, output (validated/pick), auth scheme (never the credential), the ' +
         'configured policies (retry/throttle/cache/timeout), the request pipeline in engine ' +
         'order, and a Mermaid flowchart. Call this to learn a stitch before run_stitch.',
     inputSchema: {
@@ -214,7 +214,7 @@ export function createMcpServer(
             },
             output: {
                 validated: cfg.output !== undefined,
-                unwrap: cfg.unwrap ?? null,
+                pick: cfg.pick ?? null,
             },
             auth: authTagOf(cfg),
             policies: {

--- a/packages/core/src/seam.ts
+++ b/packages/core/src/seam.ts
@@ -101,7 +101,7 @@ function makeBuild(shared: SharedSeam, principal: string | undefined) {
         };
         if (isGql) {
             cfg.kind = graphqlSurface;
-            cfg.unwrap = own.unwrap ?? 'data';
+            cfg.pick = own.pick ?? 'data';
             // Default the endpoint to `/graphql` when the member gives neither `url` nor `path`
             // (method/body shaping is the surface's).
             if (own.url === undefined && own.path === undefined)

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -939,7 +939,7 @@ export function drift<S>(
     };
 }
 
-/** graphql(): a stitch preset for GraphQL-over-HTTP — POST { query, variables }, unwrap `data`. */
+/** graphql(): a stitch preset for GraphQL-over-HTTP — POST { query, variables }, picks `data`. */
 export function graphql<
     TExplicit = never,
     const C extends Partial<StitchConfig> & {
@@ -960,6 +960,6 @@ export function graphql<
         ...config,
         ...(endpointless ? { path: '/graphql' } : {}),
         kind: graphqlSurface,
-        unwrap: config.unwrap ?? 'data',
+        pick: config.pick ?? 'data',
     }) as unknown as Stitch<ResolveOutput<TExplicit, C>, InputOf<C>>;
 }

--- a/packages/core/src/surface.ts
+++ b/packages/core/src/surface.ts
@@ -107,7 +107,7 @@ export const httpSurface: Surface = { id: 'http' };
 /**
  * GraphQL-over-HTTP. Its behaviour lives entirely in these hooks (ADR 0005 Stage 4): `buildRequest`
  * packs `{ query, variables, operationName? }` as JSON and forces POST; `interpret` treats a 200
- * carrying `errors` as a failure. The `data` unwrap is a plain config key the `graphql(...)` helper
+ * carrying `errors` as a failure. The `data` pick is a plain config key the `graphql(...)` helper
  * / `seam.graphql()` set (the engine applies it after `interpret`), as is the `/graphql` default
  * path.
  *

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -419,7 +419,7 @@ export interface CacheOptions {
     /**
      * Opaque schema/version tag — the **authoritative** rung of the fingerprint ladder (ADR 0004):
      * setting it pins the contract and takes the **no-revalidate** fast path (you promise the
-     * `output`/`transform`/`unwrap` are unchanged for this tag). Leaving it unset hands off to the
+     * `output`/`transform`/`pick` are unchanged for this tag). Leaving it unset hands off to the
      * automatic fingerprint: a registered `@stitchapi/fingerprint-*` strategy makes `output`
      * changes self-invalidate on the fast path; an un-fingerprintable schema falls to
      * {@link CacheOptions.onUnfingerprintable} (default **refuse-to-cache**, fail-closed).
@@ -660,7 +660,7 @@ export interface PaginateOptions {
      * over the original) for the next page, or `undefined` to stop.
      */
     next: (prevBody: unknown, pagesFetched: number) => StitchInput | undefined;
-    /** Pull the array from each unwrapped page. Default: the value if it is an array. */
+    /** Pull the array from each picked page. Default: the value if it is an array. */
     items?: (value: unknown) => unknown[];
     /** Safety cap on pages. Default 50. */
     pages?: number;
@@ -743,8 +743,8 @@ export interface StitchConfig {
      */
     output?: SchemaLike | DriftSpec;
     /** Dot-path selecting the part of the response to return. */
-    unwrap?: string;
-    /** Reshape the raw body before unwrap and validation (e.g. scrape HTML to structured data). */
+    pick?: string;
+    /** Reshape the raw body before `pick` and validation (e.g. scrape HTML to structured data). */
     transform?: (body: unknown) => unknown;
     /** Auto-loop pages, aggregating items, with auth/retry/throttle applied to every page. */
     paginate?: PaginateOptions;
@@ -757,7 +757,7 @@ export interface StitchConfig {
     retry?: number | RetryOptions;
     /**
      * Statuses that are a NORMAL result rather than an error — a number list or a predicate.
-     * An accepted non-2xx flows through interpret → transform → unwrap → validate exactly like a
+     * An accepted non-2xx flows through interpret → transform → pick → validate exactly like a
      * 2xx (the response body becomes the result), instead of throwing a {@link StitchError}. Use
      * this when an endpoint treats e.g. `404`/`400` as expected control flow (resource-gone → fall
      * back to a broader call) so the happy path no longer runs through a `catch`.
@@ -794,7 +794,7 @@ export interface StitchConfig {
      * ⚠️ In delegate mode the `throttle` config becomes **inert** for this stitch (the host owns the
      * gate). A `circuit` block, if also set, still applies — the host may layer both. Non-rate-limit
      * failures (5xx, etc.) behave exactly as today unless their status is listed in `on`. Validation,
-     * templating, transform/unwrap, and drift on the success path are unchanged.
+     * templating, transform/pick, and drift on the success path are unchanged.
      */
     rateLimit?: {
         /** Surface rate-limit outcomes instead of retrying/throttling them. Default `false`. */
@@ -1205,7 +1205,7 @@ export interface StitchStore {
  * that are intrinsically **per-endpoint**: the address (`path` / `url` / `method` / `query`) and
  * the request/response shape (`name` / `input` / `output` / `kind`). Everything cross-cutting —
  * `baseUrl`, `headers`, `auth`, `retry`, `throttle`, `timeout`, `circuit`, `idempotency`,
- * `paginate`, `unwrap`, `transform`, `arrayFormat`, `hooks`, `trace`, `store`, `cache`, `adapter`
+ * `paginate`, `pick`, `transform`, `arrayFormat`, `hooks`, `trace`, `store`, `cache`, `adapter`
  * — belongs here, so the type itself answers "what belongs at the seam". Members set the endpoint
  * keys.
  */
@@ -1264,7 +1264,7 @@ export interface Seam {
     ): Stitch<ResolveOutput<TExplicit, C>, InputOf<C>>;
     /** Non-inferring fallback: a path string or a `string | Partial<StitchConfig>` value (see {@link StitchFn}). */
     stitch<T = unknown>(config: string | Partial<StitchConfig>): Stitch<T>;
-    /** GraphQL-over-HTTP member stitch (POST `{ query, variables }`, unwrap `data`). */
+    /** GraphQL-over-HTTP member stitch (POST `{ query, variables }`, picks `data`). */
     graphql<
         TExplicit = never,
         const C extends Partial<StitchConfig> & {

--- a/packages/core/test-d/stitch.test-d.ts
+++ b/packages/core/test-d/stitch.test-d.ts
@@ -31,7 +31,7 @@ expectType<unknown>(output(stitch({ path: '/ping' })));
 expectType<unknown>(output(stitch('/ping')));
 
 // 7) a raw Zod schema flows in WITHOUT `toValidator()` / `as Validator` (the old cast is gone).
-expectType<User>(output(stitch({ output: userSchema, unwrap: 'data' })));
+expectType<User>(output(stitch({ output: userSchema, pick: 'data' })));
 
 // 8) a non-schema `output` is rejected at compile time.
 expectError(stitch({ output: 123 }));

--- a/packages/core/test/HARNESS-API.md
+++ b/packages/core/test/HARNESS-API.md
@@ -27,8 +27,8 @@ import { z } from 'zod';
 
 -   `name`, `method` (default GET), `baseUrl` (string | `() => string`), `path` (may include `{param}` and `?predefined=query`)
 -   `input`: `{ params?, query?, body?, headers? }` — each a Zod/Standard-Schema validator
--   `output`: a schema **or** `drift(schema, opts)` — validated against the **unwrapped** value
--   `unwrap`: dot-path string (e.g. `'data'`)
+-   `output`: a schema **or** `drift(schema, opts)` — validated against the **picked** value
+-   `pick`: dot-path string (e.g. `'data'`)
 -   `auth`: an AuthStrategy (see below)
 -   `retry`: `{ attempts (total incl. first, default 1), on: number[] (default [429,502,503,504]), backoff: 'expo'|'expo-jitter'|'fixed', baseMs, maxMs, respectRetryAfter }`
 -   `throttle`: `{ rate: '2/s', concurrency: number, scope: 'stitch'|'host' }`

--- a/packages/core/test/cli.spec.ts
+++ b/packages/core/test/cli.spec.ts
@@ -197,7 +197,7 @@ describe('runStitch (arg → input → JSONL)', () => {
         const listWidgets = stitch({
             baseUrl: server.url,
             path: '/widgets',
-            unwrap: 'data',
+            pick: 'data',
             output: asValidator(
                 z.array(z.object({ id: z.number(), name: z.string() })),
             ),

--- a/packages/core/test/composition.spec.ts
+++ b/packages/core/test/composition.spec.ts
@@ -48,7 +48,7 @@ test('extends facade produces the correct result', async () => {
     const schema = asValidator(
         z.array(z.object({ id: z.number(), name: z.string() })),
     );
-    const base = { baseUrl: server.url, unwrap: 'data' };
+    const base = { baseUrl: server.url, pick: 'data' };
 
     const viaExtends = stitch({
         extends: [base],
@@ -71,7 +71,7 @@ test('a seam member is equivalent to the extends facade', async () => {
     const schema = asValidator(
         z.array(z.object({ id: z.number(), name: z.string() })),
     );
-    const base = { baseUrl: server.url, unwrap: 'data' };
+    const base = { baseUrl: server.url, pick: 'data' };
 
     const viaExtends = stitch({
         extends: [base],

--- a/packages/core/test/config-summary.spec.ts
+++ b/packages/core/test/config-summary.spec.ts
@@ -64,11 +64,11 @@ describe('pipelineStages', () => {
             retry: { attempts: 3 },
             paginate: { pages: 7 },
             transform: () => undefined,
-            unwrap: 'data',
+            pick: 'data',
             output: () => true,
             cache: '1m',
         });
-        // Post-response order is transform → unwrap → validate (engine.ts), bookended by call/result.
+        // Post-response order is transform → pick → validate (engine.ts), bookended by call/result.
         expect(pipelineStages(full, { detailed: true })).toEqual([
             'call',
             'throttle',
@@ -76,7 +76,7 @@ describe('pipelineStages', () => {
             'retry ×3',
             'paginate (max 7)',
             'transform',
-            'unwrap: data',
+            'pick: data',
             'validate',
             'cache',
             'result',

--- a/packages/core/test/diagram.spec.ts
+++ b/packages/core/test/diagram.spec.ts
@@ -21,7 +21,7 @@ const sampleRegistry = (): StitchRegistry => ({
         path: '/users/{id}',
         retry: { attempts: 3 },
         output: z.object({ id: z.number() }),
-        unwrap: 'data',
+        pick: 'data',
     }),
     ping: stitch('https://api.example.com/ping'),
 });
@@ -36,17 +36,17 @@ describe('toMermaid', () => {
 
     test('a stitch chains its configured pipeline stages in order', () => {
         const { diagram } = toMermaid(sampleRegistry());
-        // getUser: call -> request -> retry -> unwrap -> validate -> result (no throttle/cache).
+        // getUser: call -> request -> retry -> pick -> validate -> result (no throttle/cache).
         expect(diagram).toContain('(["call"]) -->');
         expect(diagram).toContain('GET https://api.example.com/users/{id}');
         expect(diagram).toContain('retry');
         expect(diagram).toContain('validate');
-        expect(diagram).toContain('unwrap: data');
+        expect(diagram).toContain('pick: data');
         expect(diagram).toContain('(["result"])');
     });
 
-    test('post-response stages render in engine order: transform -> unwrap -> validate', () => {
-        // The engine processes the response body transform → unwrap → validate (engine.ts), and the
+    test('post-response stages render in engine order: transform -> pick -> validate', () => {
+        // The engine processes the response body transform → pick → validate (engine.ts), and the
         // diagram's contract is "the configured request pipeline … in engine order". So the diagram
         // must place validate LAST of the three, not first.
         const { diagram } = toMermaid({
@@ -54,16 +54,16 @@ describe('toMermaid', () => {
                 baseUrl: 'https://api.example.com',
                 path: '/x',
                 transform: (b) => b,
-                unwrap: 'data',
+                pick: 'data',
                 output: z.object({ id: z.number() }),
             }),
         });
         const iTransform = diagram.indexOf('transform');
-        const iUnwrap = diagram.indexOf('unwrap: data');
+        const iPick = diagram.indexOf('pick: data');
         const iValidate = diagram.indexOf('validate');
         expect(iTransform).toBeGreaterThanOrEqual(0);
-        expect(iUnwrap).toBeGreaterThan(iTransform); // unwrap after transform
-        expect(iValidate).toBeGreaterThan(iUnwrap); // validate after unwrap
+        expect(iPick).toBeGreaterThan(iTransform); // pick after transform
+        expect(iValidate).toBeGreaterThan(iPick); // validate after pick
     });
 
     test('a bare stitch is just call -> request -> result', () => {

--- a/packages/core/test/fingerprint-resolve-edges.spec.ts
+++ b/packages/core/test/fingerprint-resolve-edges.spec.ts
@@ -1,6 +1,6 @@
 // Edge rungs of resolveFingerprint (src/fingerprint.ts) that fingerprint.spec.ts leaves open. That
 // suite walks the ladder thoroughly, but three precedence/folding details go unpinned:
-//   - the no-output (rung 4) generation FOLDS `unwrap` and a versioned `transform`, so two
+//   - the no-output (rung 4) generation FOLDS `pick` and a versioned `transform`, so two
 //     no-schema stitches that differ only in those get DISTINCT cache generations (the existing
 //     test only checks the policy is fast + the generation is non-empty);
 //   - an opaque transform with no output still REFUSES — the transform gate (rung 2) outranks the
@@ -23,10 +23,10 @@ beforeEach(() => {
     clearFingerprinters();
 });
 
-describe('resolveFingerprint: no-output (rung 4) folds unwrap + transform', () => {
-    it('distinct unwrap → distinct no-schema generation (still fast)', () => {
-        const a = resolveFingerprint({ unwrap: 'data' });
-        const b = resolveFingerprint({ unwrap: 'meta' });
+describe('resolveFingerprint: no-output (rung 4) folds pick + transform', () => {
+    it('distinct pick → distinct no-schema generation (still fast)', () => {
+        const a = resolveFingerprint({ pick: 'data' });
+        const b = resolveFingerprint({ pick: 'meta' });
         expect(a.policy).toBe('fast');
         expect(b.policy).toBe('fast');
         expect(a.generation).not.toBe(b.generation);

--- a/packages/core/test/fingerprint.spec.ts
+++ b/packages/core/test/fingerprint.spec.ts
@@ -127,10 +127,10 @@ describe('resolveFingerprint — the fallback ladder', () => {
         expect(r.policy).toBe('fast');
     });
 
-    it('rung 1: different version or unwrap → different generation', () => {
+    it('rung 1: different version or pick → different generation', () => {
         const a = resolveFingerprint({ version: 'v1' });
         const b = resolveFingerprint({ version: 'v2' });
-        const c = resolveFingerprint({ version: 'v1', unwrap: 'data' });
+        const c = resolveFingerprint({ version: 'v1', pick: 'data' });
         expect(a.generation).not.toBe(b.generation);
         expect(a.generation).not.toBe(c.generation);
     });
@@ -148,9 +148,9 @@ describe('resolveFingerprint — the fallback ladder', () => {
         expect(changed.generation).not.toBe(r1.generation); // sensitive
     });
 
-    it('rung 2: unwrap is folded into the generation', () => {
+    it('rung 2: pick is folded into the generation', () => {
         const a = resolveFingerprint({ output: userSchema() });
-        const b = resolveFingerprint({ output: userSchema(), unwrap: 'data' });
+        const b = resolveFingerprint({ output: userSchema(), pick: 'data' });
         expect(b.policy).toBe('fast');
         expect(b.generation).not.toBe(a.generation);
     });

--- a/packages/core/test/gaps/accept-status.spec.ts
+++ b/packages/core/test/gaps/accept-status.spec.ts
@@ -67,7 +67,7 @@ test('an accepted non-2xx still runs transform, unwrap, and output validation', 
         baseUrl: server.url,
         path: '/accepted-pipeline',
         acceptStatus: [404],
-        unwrap: 'data',
+        pick: 'data',
         transform: (body) => {
             const b = body as { data: { id: number; name: string } };
             return { data: { id: b.data.id, label: b.data.name } };

--- a/packages/core/test/gaps/delegate-backoff.spec.ts
+++ b/packages/core/test/gaps/delegate-backoff.spec.ts
@@ -213,11 +213,11 @@ test('throttle.on selects which statuses delegate (503 delegates, 429 retries)',
     expect(server.callCount('/retry-429')).toBe(3);
 });
 
-// ── G. the success path still runs transform → unwrap → drift under delegate mode ──
-// Delegate mode only intercepts rate-limit statuses; a 200 must validate/transform/unwrap exactly as
+// ── G. the success path still runs transform → pick → drift under delegate mode ──
+// Delegate mode only intercepts rate-limit statuses; a 200 must validate/transform/pick exactly as
 // it would without the flag — proving the mode is "validate + template + transform + drift, but
 // delegate backoff", not a bare pass-through.
-test('a success response still runs transform, unwrap, and output validation', async () => {
+test('a success response still runs transform, pick, and output validation', async () => {
     server.route('GET', '/ok', {
         statuses: [200],
         body: { data: { id: 7, name: 'widget' } },
@@ -226,9 +226,9 @@ test('a success response still runs transform, unwrap, and output validation', a
         baseUrl: server.url,
         path: '/ok',
         throttle: { delegate: true },
-        unwrap: 'data',
+        pick: 'data',
         transform: (body) => {
-            // raw body → reshape: rename `name` to `label`. Runs before unwrap.
+            // raw body → reshape: rename `name` to `label`. Runs before pick.
             const b = body as { data: { id: number; name: string } };
             return { data: { id: b.data.id, label: b.data.name } };
         },

--- a/packages/core/test/gaps/drift-on-transform-output.spec.ts
+++ b/packages/core/test/gaps/drift-on-transform-output.spec.ts
@@ -102,7 +102,7 @@ test('drift fires on the TRANSFORM output: a required scraped field renamed away
         baseUrl: server.url,
         path: '/catalog',
         transform: scrape, // HTML string -> { items: [...] }
-        unwrap: 'items',
+        pick: 'items',
         // `score` is REQUIRED — losing it is a hard contract violation, validated on the
         // STRUCTURED shape (`[].score` exists only on the parsed object, not the raw HTML).
         output: drift(schema),

--- a/packages/core/test/integration-patterns.spec.ts
+++ b/packages/core/test/integration-patterns.spec.ts
@@ -71,7 +71,7 @@ describe('GraphQL-over-HTTP API (ApiKey header, 1 req/s bucket, retry on 429/5xx
             path: '/graphql',
             auth: apiKey({ header: 'apikey', value: env('METADATA_API_KEY') }),
             retry: { attempts: 5, on: [429, 500, 502, 503], baseMs: 5 },
-            unwrap: 'data',
+            pick: 'data',
         });
 
         const out = await query({
@@ -189,7 +189,7 @@ describe('HTML scrape provider — silent markup breakage becomes a loud drift e
             }),
             throttle: { rate: '5/s' },
             transform: scrapeListings, // HTML -> { items: [...] }
-            unwrap: 'items',
+            pick: 'items',
             // `score` is REQUIRED — the schema is the contract, so a markup rename that drops it
             // is a loud validation error, not a silent gap. No snapshot, no baseline call.
             output: drift(

--- a/packages/core/test/mcp-e2e.spec.ts
+++ b/packages/core/test/mcp-e2e.spec.ts
@@ -66,7 +66,7 @@ interface FakeApi {
 
 // ---- the hermetic fake API (node:http, no external network) ---------------
 
-// GET /users/{id} → { data: { id, name } } (so a stitch's unwrap:'data' has something to peel);
+// GET /users/{id} → { data: { id, name } } (so a stitch's pick:'data' has something to peel);
 // GET /health → { ok: true }. Every response is `Connection: close` so no keep-alive socket
 // lingers in the child and wedges its exit — that is what makes the "no hang" assertion sound.
 function startFakeApi(): Promise<FakeApi> {
@@ -139,7 +139,7 @@ const userSchema = {
 export const getUser = stitch({
     baseUrl: ${JSON.stringify(baseUrl)},
     path: '/users/{id}',
-    unwrap: 'data',
+    pick: 'data',
     output: userSchema,
 });
 

--- a/packages/core/test/mcp.spec.ts
+++ b/packages/core/test/mcp.spec.ts
@@ -50,7 +50,7 @@ beforeEach(() => {
     const getWidget = stitch({
         baseUrl: api.url,
         path: '/widgets/{id}',
-        unwrap: 'data',
+        pick: 'data',
         auth: bearer('s3cr3t-token'),
         retry: { attempts: 3 },
         timeout: { perAttempt: 1000 },
@@ -192,7 +192,7 @@ test('tools/call describe_stitch teaches a stitch shape without running it', asy
         endpoint: string;
         surface: string;
         input: { params: boolean; query: boolean; body: boolean };
-        output: { validated: boolean; unwrap: string | null };
+        output: { validated: boolean; pick: string | null };
         auth: string | null;
         policies: Record<string, boolean>;
         pipeline: string[];
@@ -207,11 +207,11 @@ test('tools/call describe_stitch teaches a stitch shape without running it', asy
         query: false,
         body: false,
     });
-    expect(shape.output).toMatchObject({ validated: true, unwrap: 'data' });
-    // the pipeline lists stages in engine order: the engine unwraps THEN validates, so the
-    // 'unwrap' stage must precede 'validate' (not the reverse).
-    expect(shape.pipeline.indexOf('unwrap: data')).toBeGreaterThanOrEqual(0);
-    expect(shape.pipeline.indexOf('unwrap: data')).toBeLessThan(
+    expect(shape.output).toMatchObject({ validated: true, pick: 'data' });
+    // the pipeline lists stages in engine order: the engine picks THEN validates, so the
+    // 'pick' stage must precede 'validate' (not the reverse).
+    expect(shape.pipeline.indexOf('pick: data')).toBeGreaterThanOrEqual(0);
+    expect(shape.pipeline.indexOf('pick: data')).toBeLessThan(
         shape.pipeline.indexOf('validate'),
     );
     // a Mermaid flowchart string is included for the diagram view

--- a/packages/core/test/output-inference.spec.ts
+++ b/packages/core/test/output-inference.spec.ts
@@ -39,7 +39,7 @@ test('inferred element type flows through `unwrap`', async () => {
     const list = stitch({
         baseUrl: server.url,
         path: '/list',
-        unwrap: 'data',
+        pick: 'data',
         output: z.array(userSchema),
     });
     const users = await list();

--- a/packages/core/test/pagination.spec.ts
+++ b/packages/core/test/pagination.spec.ts
@@ -37,7 +37,7 @@ const listAll = () =>
     stitch<number[]>({
         baseUrl: server.url,
         path: '/list',
-        unwrap: 'data',
+        pick: 'data',
         paginate: {
             next: (body, fetched) =>
                 (body as { hasMore: boolean }).hasMore
@@ -88,7 +88,7 @@ test('paginated GraphQL advances its cursor through the variables slot', async (
         baseUrl: server.url,
         path: '/gql',
         query: 'query($after: String) { users(after: $after) { nodes pageInfo { endCursor hasNextPage } } }',
-        unwrap: 'data.users.nodes',
+        pick: 'data.users.nodes',
         paginate: {
             next: (body) => {
                 const pi = (
@@ -120,7 +120,7 @@ test('max caps the page loop (guards a runaway paginator)', async () => {
     const list = stitch({
         baseUrl: server.url,
         path: '/loop',
-        unwrap: 'data',
+        pick: 'data',
         paginate: { next: () => ({}), pages: 2 },
     });
     await list();

--- a/packages/core/test/seam-graphql.spec.ts
+++ b/packages/core/test/seam-graphql.spec.ts
@@ -1,7 +1,7 @@
 // seam.graphql() — the seam's GraphQL member builder (src/seam.ts, the makeBuild `isGql` branch).
 // seam.spec.ts covers regular `.stitch()` members (fragment inheritance, throttle pooling, principal
 // sessions, redaction, lifecycle) but NEVER exercises `.graphql()`. This pins the graphql member's
-// defaults — the graphql surface, a default POST /graphql endpoint, `unwrap: 'data'` — plus that it
+// defaults — the graphql surface, a default POST /graphql endpoint, `pick: 'data'` — plus that it
 // inherits the seam fragment, honours an explicit path, and is also buildable off a principal handle.
 import { seam } from '../src';
 import { startMockServer } from './support/mock-server';

--- a/packages/core/test/serve.spec.ts
+++ b/packages/core/test/serve.spec.ts
@@ -46,7 +46,7 @@ beforeAll(async () => {
     const getWidget = stitch({
         baseUrl: api.url,
         path: '/widgets/{id}',
-        unwrap: 'data',
+        pick: 'data',
         output: asValidator(z.object({ id: z.number() })),
     });
     const ping = stitch({ baseUrl: api.url, path: '/ping' });

--- a/packages/core/test/smoke.spec.ts
+++ b/packages/core/test/smoke.spec.ts
@@ -28,7 +28,7 @@ test('await sugar returns the unwrapped, validated result', async () => {
     const users = stitch({
         baseUrl: server.url,
         path: '/users',
-        unwrap: 'data',
+        pick: 'data',
         // raw Zod schema — inference removes the old `asValidator()` cast.
         output: z.array(z.object({ id: z.number(), name: z.string() })),
     });

--- a/packages/core/test/surface-graphql-hooks.spec.ts
+++ b/packages/core/test/surface-graphql-hooks.spec.ts
@@ -1,6 +1,6 @@
 // Direct tests for graphqlSurface's pure hooks (src/surface.ts). surface.spec.ts and
 // graphql-and-headers.spec.ts exercise the graphql surface through the ENGINE (observable POST,
-// unwrap data, 200-with-errors fails). The hooks' own branch contracts go unpinned:
+// pick data, 200-with-errors fails). The hooks' own branch contracts go unpinned:
 //   buildRequest — packs { query, variables } as a JSON POST over the base request; variables
 //                  precedence is input.variables → input.body → {}; query defaults to ''; a
 //                  configured method overrides POST and is upper-cased.

--- a/packages/core/test/surface.spec.ts
+++ b/packages/core/test/surface.spec.ts
@@ -74,7 +74,7 @@ describe('graphql surface helper (Decision 3/10)', () => {
             baseUrl: server.url,
             path: '/g',
             query: '{ me { id } }',
-            unwrap: 'data.me',
+            pick: 'data.me',
         });
         expect(await q()).toEqual({ id: 7 });
     });
@@ -85,7 +85,7 @@ describe('graphql surface helper (Decision 3/10)', () => {
         const ping = graphql.seam(api).stitch({
             path: '/api',
             query: '{ ping }',
-            unwrap: 'data.ping',
+            pick: 'data.ping',
         });
         expect(await ping()).toBe('pong');
     });
@@ -94,7 +94,7 @@ describe('graphql surface helper (Decision 3/10)', () => {
         server.route('POST', '/s', { body: { data: { v: 42 } } });
         const g = graphql.seam({ baseUrl: server.url });
         expect(g.seam.__seam).toBe(true);
-        const v = g.stitch({ path: '/s', query: '{ v }', unwrap: 'data.v' });
+        const v = g.stitch({ path: '/s', query: '{ v }', pick: 'data.v' });
         expect(await v()).toBe(42);
     });
 });

--- a/packages/eval-harness/README.md
+++ b/packages/eval-harness/README.md
@@ -26,7 +26,7 @@ Four seed tasks (plain data in `tasks/`):
 | --------------------------------- | ---------- | ---------------------------------------------------------------------------- |
 | `paginated-list-retries-validate` | pagination | `GET /paged/users` (cursor; flaky 429; validate each user)                   |
 | `oauth2-client-credentials`       | auth       | `POST /oauth/token` + `GET /auth/me` (bearer; credential held by the stitch) |
-| `wrap-graphql-endpoint`           | graphql    | `POST /graphql` (unwrap `data`; `errors[]` ⇒ failure)                        |
+| `wrap-graphql-endpoint`           | graphql    | `POST /graphql` (pick `data`; `errors[]` ⇒ failure)                          |
 | `stream-llm-completion`           | streaming  | `POST /v1/chat/completions` (SSE deltas, `[DONE]`-terminated)                |
 
 Each task is a `{ id, title, family, prompt, expectedShape, endpointHint }`

--- a/packages/eval-harness/runner/prebaked.ts
+++ b/packages/eval-harness/runner/prebaked.ts
@@ -88,7 +88,7 @@ export async function run(fetchImpl: typeof fetch): Promise<User> {
         adapter: fetchAdapter({ fetch: fetchImpl }),
         query: 'query { user { id name email } }',
         // The graphql surface unwraps 'data' and treats a non-empty errors[] as a failure.
-        unwrap: 'data.user',
+        pick: 'data.user',
         output: (v: unknown): v is User =>
             !!v && typeof v === 'object' &&
             typeof (v as any).id === 'number' &&


### PR DESCRIPTION
## Що це

Другий (і останній) зріз контракт-фризу [#470](https://github.com/rejifald/StitchAPI/pull/470), винесений окремо:
конфіг-ключ `unwrap` перейменовано на **`pick`**.

Разом із [#480](https://github.com/rejifald/StitchAPI/pull/480) (короткий запис `throttle`) це рівно ті дві зміни,
яких бракує статті для dou.ua ([#479](https://github.com/rejifald/StitchAPI/pull/479)), щоб писати її проти вже
опублікованого API. #470 має 325 файлів (+6071/−4262) — ревʼю цілого фризу зараз
нереальне; обидва зрізи вирізані так, щоб #470 перебазувався поверх.

> [!WARNING]
> **BREAKING.** `unwrap` зникає без аліаса — той самий hard-break підхід, що й у
> #470 (pre-GA, мало адоптерів, жодних `@deprecated` шимів).

## Що НЕ змінюється

**Метод `stitch.unwrap()` лишається `unwrap()`.** Це інша сутність, ніж конфіг-ключ,
і #470 його теж не чіпає. Перейменовано лише **ключ** і стадію пайплайну, названу
за ним. Наївний `s/unwrap/pick/` зламав би `.unwrap()`, `.safe()`-твін і купу
англомовної прози — тому кожне входження класифіковано окремо.

Англійське «unwraps data» у назвах тестів і коментарях лишено там, де його лишив
#470 — звірено пофайлово.

## Гайд переїхав

`guides/data/unwrap` → `guides/data/pick`, разом із `meta.json`. У
`next.config.mjs` доданий **permanent redirect** зі старого URL, щоб опубліковані
посилання не побилися. `check:docs-links` проходить: 110 маршрутів, усі
`/docs/...` резолвляться.

## Три місця, які пропустив сам #470

Цей PR лендить перейменування, тож вони полагоджені тут:

- **`docs/sandbox/mcp/sandbox-stitches.ts`** — 4 сайти, це **виконуваний** код
  пісочниці, не проза.
- **`apps/docs/AUTHORING.md`** — 5 сайтів у прикладах.
- Порівняльна таблиця в `blog/typed-graphql-without-apollo.mdx`.

## Свідомо НЕ чіпаю (два follow-up)

**1. ADR 0004.** `docs/adr/0004-standard-schema-fingerprint-for-cache-invalidation.md`
і далі пише `config.unwrap`. ADR фіксує рішення таким, яким його ухвалили; #470
його теж лишає.

**2. Демо-медіа README — застаріле.** `apps/docs/app/(home)/demo/scene.tsx`
показує ключ у кадрі (код, чип, імʼя файлу `unwrap.ts`), тож після цього PR
`docs/media/demo*.webp` / `demo*-clip.mp4` показуватимуть уже неіснуючий
`unwrap:`. Пуш зроблено з документованим `STITCH_MEDIA_STALE_OK=1` (не
`--no-verify` — решта гейтів відпрацювала), бо:

- гейт `media-fresh` живе **тільки в lefthook**, у CI його немає;
- #470 теж не перегенеровує `docs/media`;
- `pnpm gen:media` дає 6 бінарників, чия побайтова відтворюваність залежить від
  машини — це окрема зміна, не частина перейменування.

Полагодити варто одним `pnpm gen:media` разом із #470 (або одразу після).

## Як робилося

Не сліпим sed. Кожен рядок з `unwrap` прогнано через **оракул: сам #470** —
заміна приймалася, тільки якщо трансформований рядок буквально є у відповідному
файлі #470. Так рішення «поле чи метод чи англійська» ухвалював автор фризу, а не
здогадка. 199 рядків пройшли автоматично, 46 розібрано вручну проти #470.

## Верифікація

- `pnpm --filter stitchapi build` — 0
- `pnpm -r check:types` — 0
- `pnpm -r test` — **1764 passed, 1 skipped, 0 failed**
- `pnpm check:lint` — 0 · `pnpm check:format` — 0 · `pnpm check:contract` — 0
  (`no new violations`)
- `pnpm check:docs-links` — 0 (110 маршрутів)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
