### PR TITLE
chore(release): 1.0.0-rc.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ npm release are grouped under the in-development version that introduced them.
 
 ## [Unreleased]
 
+## [1.0.0-rc.6] — 2026-07-23
+
+### Changed
+
+-   **BREAKING — the `unwrap` config key is renamed to `pick`.** The response-shaping
+    key that pulls a nested payload out of an envelope (`{ data: … }` → the value it
+    wraps) is now spelled `pick`, the verb the guides already used for it, leaving
+    `unwrap` to mean only the throwing call twin (`stitch.unwrap()`). Rename
+    `unwrap: '<path>'` to `pick: '<path>'` in every stitch config — there is no
+    deprecated alias. (#481)
+
+-   **BREAKING — `@stitchapi/next`'s `stitchErrorResponse` now returns
+    `Response | undefined`.** It returns `undefined` for anything that is not a
+    `StitchError` (previously it always produced a `Response`), so it composes inside
+    a `catch` that must also rethrow non-stitch failures untouched:
+
+    ```ts
+    const mapped = stitchErrorResponse(err); // default status 502
+    if (mapped) return mapped; // undefined → not a StitchError
+    throw err;
+    ```
+
+    Callers that assumed a non-null `Response` must handle the `undefined` branch. (#475)
+
+### Added
+
+-   **`throttle` string shorthand.** `throttle: '1/s'` is now accepted as shorthand for
+    `throttle: { rate: '1/s' }`, matching the ergonomics of the other rate-shaped
+    options. The object form is unchanged and is still required when you also set a
+    `pool` (or any other throttle field). (#480)
+
 ## [1.0.0-rc.5] — 2026-07-08
 
 ### Changed
@@ -276,7 +307,8 @@ causality push:
 -   **Playground:** the browser Worker runner, handler registration, incremental
     streaming, and the trace → Mermaid DAG wiring.
 
-[Unreleased]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.5...HEAD
+[Unreleased]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.6...HEAD
+[1.0.0-rc.6]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.5...v1.0.0-rc.6
 [1.0.0-rc.5]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.4...v1.0.0-rc.5
 [1.0.0-rc.4]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.3...v1.0.0-rc.4
 [1.0.0-rc.3]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.2...v1.0.0-rc.3

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 
 > [!NOTE]
 >
-> **StitchAPI is at `1.0.0-rc.5`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is welcome.
+> **StitchAPI is at `1.0.0-rc.6`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is welcome.
 
 ---
 

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/angular",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Angular bindings for StitchAPI — injectStitch/injectStitchStream expose a stitch's lifecycle as both signals and an RxJS observable over @stitchapi/query-core. Streaming-first: re-render as `delta` chunks arrive. Plus an optional TanStack Query queryOptions helper.",
     "main": "lib/index.js",

--- a/packages/aws-sigv4/package.json
+++ b/packages/aws-sigv4/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/aws-sigv4",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "AWS Signature V4 request signing for StitchAPI — an AuthStrategy that signs each request with SigV4 (Web Crypto, edge-safe), for AWS APIs, S3-compatible stores, and any SigV4-protected endpoint.",
     "main": "lib/index.js",

--- a/packages/cloudflare-kv/package.json
+++ b/packages/cloudflare-kv/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/cloudflare-kv",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Cloudflare Workers KV-backed StitchStore for StitchAPI — edge cache + shared sessions/tokens. Bring your own KV namespace binding. (incr → use a Durable Object store.)",
     "main": "lib/index.js",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,7 +4,7 @@
 
 > [!NOTE]
 >
-> **StitchAPI is at `1.0.0-rc.5`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is welcome.
+> **StitchAPI is at `1.0.0-rc.6`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is welcome.
 
 **Turn any REST, GraphQL, SSE, or LLM API into a typed, resilient function.** Its one primitive — a **stitch** — takes a single endpoint and hands you back a callable: declare the endpoint's contract once (input, output, auth, resilience) and call it like a local function. No server, no codegen, no config files — only explicit composition. The same definition your code calls, the CLI runs and an AI agent can invoke without ever touching a credential.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "stitchapi",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Turn any API into a typed, resilient function. A declarative stitch takes one endpoint — HTTP, GraphQL, SSE, LLM, even a shell command — and hands back a callable with auth, retries, validation, and drift built in. No server, no codegen, no config files. Callable from code, the CLI, or an AI agent over MCP — agents get a capability, not your credentials. Zero deps.",
     "main": "lib/index.js",

--- a/packages/deno-kv/package.json
+++ b/packages/deno-kv/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/deno-kv",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Deno KV-backed StitchStore for StitchAPI — distributed throttle + shared sessions/tokens with atomic incr. Bring your own Deno.Kv handle.",
     "main": "lib/index.js",

--- a/packages/docs-mcp/package.json
+++ b/packages/docs-mcp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@stitchapi/docs-mcp",
     "mcpName": "dev.stitchapi/docs",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "StitchAPI documentation search, running locally over MCP stdio. Bundled docs, no network calls per query — the offline/air-gapped counterpart to the hosted stitchapi.dev/api/mcp server.",
     "bin": {

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/elysia",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Elysia plugin for StitchAPI — put a request-scoped seam on the context, stream a stitch's SSE output, and map Stitch errors to HTTP. Web-standard (Fetch-only, no node:*).",
     "main": "lib/index.js",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/expo",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Expo bindings for StitchAPI — expoFetchAdapter (streaming over expo/fetch, no polyfills), an expo-secure-store-backed StitchStore for encrypted tokens, and the re-exported useStitch/useStitchStream hooks, AsyncStorage store, and AppState/NetInfo refetch helpers from @stitchapi/react-native.",
     "main": "lib/index.js",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/express",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Express middleware for StitchAPI — attach a request-scoped seam to req, stream a stitch's SSE output, and map Stitch errors to HTTP. Express 4 & 5.",
     "main": "lib/index.js",

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fastify",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Fastify plugin for StitchAPI — decorate the app/request with a seam, request-scoped principal (AsyncLocalStorage), and SSE + error + Pino-logger bridges.",
     "main": "lib/index.js",

--- a/packages/fingerprint-arktype/package.json
+++ b/packages/fingerprint-arktype/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-arktype",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for ArkType — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-effect/package.json
+++ b/packages/fingerprint-effect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-effect",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for Effect Schema — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-typebox/package.json
+++ b/packages/fingerprint-typebox/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-typebox",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for TypeBox — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-valibot/package.json
+++ b/packages/fingerprint-valibot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-valibot",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for Valibot — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-zod/package.json
+++ b/packages/fingerprint-zod/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-zod",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for Zod — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/hono",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Hono middleware + helpers for StitchAPI — put a seam on the request context, stream a stitch's SSE output, and map Stitch errors to HTTP. Edge/multi-runtime (Fetch-only, no node:*).",
     "main": "lib/index.js",

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/json-schema",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Turn a runtime-discovered JSON Schema into a Standard Schema validator StitchAPI accepts — validate against schemas you only obtain at runtime, without codegen.",
     "main": "lib/index.js",

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/nest",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "First-class NestJS integration for StitchAPI — StitchModule.forRoot/forFeature/forFeatureScoped, injectable stitches, Logger + ConfigService bridges, an exception filter and an SSE bridge (ADR 0006).",
     "main": "lib/index.js",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/next",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Next.js helpers for StitchAPI — stream a stitch as an SSE Response and map a StitchError to a Response, for App Router route handlers (and any Web-standard fetch handler).",
     "main": "lib/index.js",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/openapi",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Eject selected operations from an OpenAPI document into ready-to-own StitchAPI source — a build-time code generator, separate from the zero-dep runtime.",
     "main": "lib/index.js",

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/pino",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Pino TraceSink for StitchAPI — bridge the stitch event stream to a Pino logger as structured, metadata-only log records.",
     "main": "lib/index.js",

--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/query-core",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Framework-agnostic reactive query store for StitchAPI — a subscribe/getSnapshot store wrapping a stitch call (unary + streaming deltas). The shared core behind @stitchapi/react and future Vue/Svelte/Solid bindings.",
     "main": "lib/index.js",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/react-native",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "React Native bindings for StitchAPI — a streaming-capable XHR transport adapter (the streaming `fetch` bare RN lacks), an AsyncStorage-backed StitchStore for persistent sessions/tokens, AppState/NetInfo refetch helpers, and the re-exported useStitch/useStitchStream hooks.",
     "main": "lib/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/react",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "React bindings for StitchAPI — tearing-free useStitch/useStitchStream hooks over useSyncExternalStore, plus an optional TanStack Query queryOptions helper. Streaming-first: re-render as `delta` chunks arrive.",
     "main": "lib/index.js",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/redis",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Redis-backed StitchStore for StitchAPI — distributed throttle + shared sessions/tokens. Bring your own ioredis, node-redis, or Upstash (edge HTTP Redis) client.",
     "main": "lib/index.js",

--- a/packages/rtk-query/package.json
+++ b/packages/rtk-query/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/rtk-query",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "RTK Query bindings for StitchAPI — stitchQueryFn turns a stitch into an RTK Query endpoint queryFn (error-normalized), and stitchStreamUpdater folds a streaming stitch into the cache via onCacheEntryAdded.",
     "main": "lib/index.js",

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/sentry",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "A Sentry TraceSink for StitchAPI — maps the stitch event stream to Sentry breadcrumbs, and captures error events with the call's context. Metadata-only, safe on a secret-bearing seam.",
     "main": "lib/index.js",

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/shell",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Run a static local command as a StitchAPI surface — Node-only, injection-proof by construction (static binary + argv array + no shell). ADR 0008.",
     "main": "lib/index.js",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/solid",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Solid bindings for StitchAPI — createStitch/createStitchStream primitives that reconcile a Solid store from the query-core reactive store. Streaming-first: re-render as `delta` chunks arrive. Plus an optional TanStack Query queryOptions helper.",
     "main": "lib/index.js",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/svelte",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Svelte bindings for StitchAPI — stitchStore/stitchStreamStore Svelte stores over @stitchapi/query-core (unary + streaming deltas), plus an optional TanStack-shaped queryOptions helper. Works on Svelte 4 and 5.",
     "main": "lib/index.js",

--- a/packages/swr/package.json
+++ b/packages/swr/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/swr",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "SWR bindings for StitchAPI — useStitchSWR runs a stitch as an SWR fetcher, so SWR owns caching and revalidation while the stitch stays typed, validated, and traced.",
     "main": "lib/index.js",

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/vercel-ai",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Vercel AI SDK adapter for StitchAPI — expose a stitch as a tool() the model can call. It runs the typed, validated, traced stitch as the tool's execute; the model gets validated data, never the credential.",
     "main": "lib/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/vue",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "type": "commonjs",
     "description": "Vue 3 bindings for StitchAPI — reactive useStitch/useStitchStream composables over @stitchapi/query-core, plus an optional TanStack Query queryOptions helper. Streaming-first: re-render as `delta` chunks arrive.",
     "main": "lib/index.js",

--- a/yakir.lock
+++ b/yakir.lock
@@ -2,147 +2,147 @@
   "version": 1,
   "tethers": {
     "release-version": {
-      "baseline": "1.0.0-rc.5",
+      "baseline": "1.0.0-rc.6",
       "sites": {
         "packages/angular/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/aws-sigv4/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/cloudflare-kv/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/core/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/deno-kv/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/docs-mcp/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/elysia/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/expo/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/express/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/fastify/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/fingerprint-arktype/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/fingerprint-effect/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/fingerprint-typebox/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/fingerprint-valibot/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/fingerprint-zod/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/hono/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/json-schema/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/nest/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/next/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/openapi/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/pino/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/query-core/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/react-native/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/react/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/redis/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/rtk-query/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/sentry/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/shell/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/solid/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/svelte/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/swr/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/vercel-ai/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/vue/package.json#/version": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "README.md#pattern:StitchAPI is at `([^`]+)`": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         },
         "packages/core/README.md#pattern:StitchAPI is at `([^`]+)`": {
-          "value": "1.0.0-rc.5",
-          "fp": "sha256:e011e3d256fdde4051a12a38f6631312bd6c5742cee80cb002fb65c10c01e6dc"
+          "value": "1.0.0-rc.6",
+          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
         }
       },
       "accepted": null


### PR DESCRIPTION
Lockstep version bump of all **33 publishable packages** `1.0.0-rc.5 → 1.0.0-rc.6`, with the README version banners propagated by the yakir `release-version` tether and the baseline advanced.

## Why now

`main` has accumulated three notable changes since rc.5 that were never released — most importantly the **`unwrap` → `pick`** config-key rename (#481), which is a breaking change with no alias. Cutting rc.6 gets `pick` (and the throttle shorthand) onto npm under the `rc` tag so downstream content and docs can target the real published API instead of drifting ahead of it.

## What's in rc.6 (see CHANGELOG)

- **BREAKING** — `unwrap` config key renamed to `pick` (#481). No deprecated alias.
- **BREAKING** — `@stitchapi/next`'s `stitchErrorResponse` returns `Response | undefined` so it composes (#475).
- **Added** — `throttle: '1/s'` string shorthand for `{ rate: '1/s' }` (#480).

## Verification

- `pnpm check:release --changelog` ✓ (peer-range coherence, public access, CHANGELOG entry present, 47 install specs target `rc`; the only note is the expected "prerelease → publish with `--tag rc`").
- yakir token drift gate ✓ — all sites agree on `1.0.0-rc.6`.
- Full pre-push gate ✓ — format, typecheck, typecheck-d, **test**, exports, build-docs, yakir.

## Publishing (after merge)

Publish is OIDC trusted-publishing fired by **creating a GitHub Release** (`npm-publish.yml`). Per `docs/RELEASING.md`:

```sh
git tag v1.0.0-rc.6 && git push origin v1.0.0-rc.6
gh release create v1.0.0-rc.6 --title v1.0.0-rc.6 --notes "See CHANGELOG.md" --prerelease
```

The derived dist-tag is `rc` (a prerelease never takes `latest`), so `npm install stitchapi` keeps resolving the last stable `0.7.0`; `stitchapi@rc` gets rc.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)