### PR TITLE
refactor(sse)!: replace flat SSE frame options with symmetric `delta` / `error` envelopes

### DIFF
--- a/apps/docs/content/blog/stream-a-stitch-as-sse-in-next-app-router.mdx
+++ b/apps/docs/content/blog/stream-a-stitch-as-sse-in-next-app-router.mdx
@@ -58,7 +58,7 @@ export async function POST(request: Request) {
 
     try {
         return sseResponse(chat({ body: { prompt } }).stream(), {
-            data: (chunk) => String(chunk), // pull text out of each delta
+            delta: (chunk) => String(chunk), // pull text out of each delta
             signal: request.signal, // abort the stitch if the client leaves
         });
     } catch (err) {

--- a/apps/docs/content/docs/integrations/elysia.mdx
+++ b/apps/docs/content/docs/integrations/elysia.mdx
@@ -80,7 +80,7 @@ const app = new Elysia()
     .get('/chat', ({ stitch, query }) => {
         const chat = stitch.stitch({ kind: sseSurface, path: '/v1/messages' });
         return streamStitchSse(chat.stream({ body: { prompt: query.q } }), {
-            data: (chunk) => (chunk as { data: string }).data,
+            delta: (chunk) => (chunk as { data: string }).data,
         });
     });
 ```
@@ -88,9 +88,10 @@ const app = new Elysia()
 By default the terminal `error` frame carries a generic `data: error` token — the raw
 `event.message` is **not** echoed, since it can disclose internal network topology (a
 transport failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the
-upstream's status (`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream
-messages are known safe (`errorData: (e) => e.message`); `onError` still receives the real
-failure server-side for logging.
+upstream's status (`HTTP 401`) to the client. Pass `error` to opt in when the upstream
+messages are known safe (`error: (e) => e.message`); the object form `error: { observe }`
+still receives the real failure server-side for logging. Both `delta` and `error` also take
+a full object (`delta: { data, event, id }`, `error: { data, event, observe }`).
 
 <Callout type="warn">
     **Anti-pattern:** return the `streamStitchSse` `Response` as the handler's

--- a/apps/docs/content/docs/integrations/express.mdx
+++ b/apps/docs/content/docs/integrations/express.mdx
@@ -87,7 +87,7 @@ app.get('/chat', async (req, res) => {
         res,
         completion.stream({ body: { prompt: String(req.query.q ?? '') } }),
         {
-            data: (chunk) => (chunk as { data: string }).data,
+            delta: (chunk) => (chunk as { data: string }).data,
             req, // also tear down if the request socket signals disconnect
         },
     );

--- a/apps/docs/content/docs/integrations/fastify.mdx
+++ b/apps/docs/content/docs/integrations/fastify.mdx
@@ -102,7 +102,7 @@ const app = Fastify();
 
 app.get<{ Querystring: { q: string } }>('/chat', (req, reply) =>
     sendStitchSse(reply, chat.stream({ query: { q: req.query.q } }), {
-        data: (chunk) => (chunk as { data: string }).data, // pull text out
+        delta: (chunk) => (chunk as { data: string }).data, // pull text out
     }),
 );
 ```

--- a/apps/docs/content/docs/integrations/hono.mdx
+++ b/apps/docs/content/docs/integrations/hono.mdx
@@ -80,7 +80,7 @@ app.get('/chat', (c) => {
     return streamStitchSse(
         c,
         completion.stream({ body: { prompt: c.req.query('q') } }),
-        { data: (chunk) => (chunk as { data: string }).data },
+        { delta: (chunk) => (chunk as { data: string }).data },
     );
 });
 ```

--- a/apps/docs/content/docs/integrations/next.mdx
+++ b/apps/docs/content/docs/integrations/next.mdx
@@ -69,7 +69,7 @@ import { sseResponse } from '@stitchapi/next';
 export async function POST(request: Request) {
     const { prompt } = await request.json();
     return sseResponse(chat({ body: { prompt } }).stream(), {
-        data: (c) => String(c), // pull text out of each chunk
+        delta: (c) => String(c), // pull text out of each chunk
         signal: request.signal, // abort the upstream if the client leaves
     });
 }

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -279,6 +279,15 @@ error-options is `StitchErrorHandlerOptions` / `StitchErrorOptions` /
 result interface is `UseStitchResult` / `UseStitchReturn` / `InjectStitchResult` /
 `StitchStore`; `queryOptions` is still bare in vue/solid/svelte/angular.
 
+_Settled:_ the SSE frame options are **`delta`** and **`error`** on every SSE-capable
+host (`express` / `fastify` / `hono` / `next` / `elysia`) — symmetric envelopes, each a
+`{ data, event, … }` config that also accepts a **bare shaper function as shorthand for
+`{ data }`** (`delta: (c) => c.text`, `error: (e) => e.message`). `delta` carries
+`{ data, event, id }`; `error` carries `{ data, event, observe }` (`observe` sees the
+real server-side failure while the client still gets the generic `data: error` token).
+Do **not** reintroduce the flat `data` / `event` / `id` / `errorData` / `onError`
+spellings (nor the interim `payload` name).
+
 ### P17 · One canonical duration form
 
 Per **D3**, **ms is the single house time unit** and **no duration field carries the

--- a/packages/elysia/README.md
+++ b/packages/elysia/README.md
@@ -74,7 +74,7 @@ import { sseSurface } from 'stitchapi/sse';
 app.get('/chat', ({ stitch, query }) => {
     const chat = stitch.stitch({ kind: sseSurface, path: '/v1/messages' });
     return streamStitchSse(chat.stream({ body: { prompt: query.q } }), {
-        data: (chunk: any) => chunk.data, // pull text out of a structured chunk
+        delta: (chunk: any) => chunk.data, // pull text out of a structured chunk
     });
 });
 ```
@@ -88,9 +88,9 @@ forwarded.
 By default the `error` frame carries a generic `data: error` token, **not** the raw
 error message — echoing it can disclose internal network topology (a transport failure
 reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status
-(`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream messages are
-known safe (`errorData: (e) => e.message`); `onError` still receives the real failure
-server-side.
+(`HTTP 401`) to the client. Pass `error` to opt in when the upstream messages are
+known safe (`error: (e) => e.message`); the object form `error: { observe }` still
+receives the real failure server-side while the client gets the generic token.
 
 ## Error handling
 

--- a/packages/elysia/src/sse.ts
+++ b/packages/elysia/src/sse.ts
@@ -3,7 +3,7 @@
 // stitch's `.stream()` is an `AsyncIterable<StitchEvent>`; this forwards each `delta` chunk as one
 // SSE message, ends the stream cleanly on `done`, and turns an `error` event into a final
 // `event: error` message — a generic `data: error` by default, the raw message withheld (opt in via
-// `errorData`). When the client disconnects the `ReadableStream` is cancelled — the helper
+// `error`). When the client disconnects the `ReadableStream` is cancelled — the helper
 // calls the iterator's `return()` so the upstream stitch stream is torn down rather than left running.
 //
 // Web-standard: returns a plain `Response` whose body is a `ReadableStream` — no `node:*`, so it runs
@@ -18,18 +18,35 @@ export type StitchEventSource<T> =
 /** The terminal `error` event a stitch stream emits — carries `message`, `status`, `attempts`. */
 type StitchErrorEvent = Extract<StitchEvent, { type: 'error' }>;
 
-export interface StreamStitchSseOptions {
+/** Shape a `delta` chunk into the SSE frame `data`. */
+type DeltaShaper = (chunk: unknown) => string;
+/** Shape a terminal `error` event into the SSE frame `data`. */
+type ErrorShaper = (event: StitchErrorEvent) => string;
+
+// How each `delta` becomes a message. The bare {@link DeltaShaper} form (`delta: (c) => …`) is
+// shorthand for `{ data: (c) => … }`.
+interface DeltaFrameOptions {
     /**
      * Map a `delta` chunk to the SSE message `data` string. The default JSON-stringifies the chunk
      * (a string chunk is sent verbatim). Pull text out of a structured chunk with, e.g.,
-     * `data: (c) => c.choices[0].delta.content ?? ''`.
+     * `(c) => c.choices[0].delta.content ?? ''`.
      */
-    data?: (chunk: unknown) => string;
+    data?: DeltaShaper;
     /**
      * The SSE `event:` field for each delta message (default none). Set it to label the stream's
      * messages on the client (`event: 'token'`).
      */
     event?: string;
+    /**
+     * Provide an `id:` line per delta message (the SSE last-event id), e.g. for resumable streams.
+     * Receives the chunk and the zero-based frame index.
+     */
+    id?: (chunk: unknown, index: number) => string;
+}
+
+// How the terminal `error` becomes the final message. The bare {@link ErrorShaper} form
+// (`error: (e) => …`) is shorthand for `{ data: (e) => … }`.
+interface ErrorFrameOptions {
     /**
      * Shape the SSE `data` written for a terminal `error` event (or an uncaught throw mid-stream,
      * normalised to an error event). **Default: a generic token (`data: error`)** — the raw
@@ -38,17 +55,41 @@ export interface StreamStitchSseOptions {
      * the upstream's status (`HTTP 401`) to an untrusted client. Opt in with `(e) => e.message`
      * when the upstream messages are known safe, or return your own payload
      * (e.g. `() => JSON.stringify({ error: 'stream failed' })`). A multi-line return gets one
-     * `data:` line each (SSE spec); the `event: error` name is fixed.
+     * `data:` line each (SSE spec).
      */
-    errorData?: (event: StitchErrorEvent) => string;
+    data?: ErrorShaper;
+    /** The `event:` name of the terminal error message. Default `'error'`. */
+    event?: string;
     /**
-     * Called once, server-side, if the underlying stream errors (a stitch `error` event, or a
-     * throw) — use it to observe/log the real failure. It does **not** shape the client-facing
-     * frame: the SSE `data` sent to the client is controlled by `errorData` (a generic token by
-     * default), so the raw message reaches your logs here but not the client.
+     * Observe the real failure, server-side (a stitch `error` event, or a throw) — use it to
+     * log/trace. It does **not** shape the client-facing frame: the SSE `data` sent to the client
+     * is controlled by {@link ErrorFrameOptions.data} (a generic token by default), so the raw
+     * message reaches your logs here but not the client.
      */
-    onError?: (err: unknown) => void;
+    observe?: (err: unknown) => void;
 }
+
+export interface StreamStitchSseOptions {
+    /**
+     * How each `delta` becomes a message. Pass a **function** as shorthand for `{ data }`
+     * (`delta: (c) => c.text`), or the full `{ data, event, id }` object to set the SSE
+     * `event:` / `id:` lines too.
+     */
+    delta?: DeltaShaper | DeltaFrameOptions;
+    /**
+     * How the terminal error becomes the final message. Pass a **function** as shorthand for
+     * `{ data }` (`error: (e) => e.message`), or the full `{ data, event, observe }` object. By
+     * default the client gets a generic `data: error` token — the raw message is withheld to
+     * avoid disclosing internal topology.
+     */
+    error?: ErrorShaper | ErrorFrameOptions;
+}
+
+// Expand the function-shorthand form of each frame option to its full config object.
+const asDelta = (o: DeltaShaper | DeltaFrameOptions = {}): DeltaFrameOptions =>
+    typeof o === 'function' ? { data: o } : o;
+const asError = (o: ErrorShaper | ErrorFrameOptions = {}): ErrorFrameOptions =>
+    typeof o === 'function' ? { data: o } : o;
 
 function defaultData(chunk: unknown): string {
     return typeof chunk === 'string' ? chunk : JSON.stringify(chunk);
@@ -56,21 +97,22 @@ function defaultData(chunk: unknown): string {
 
 // One SSE frame string. A multi-line payload is split so every line gets its own `data:` prefix
 // (the SSE spec joins them with `\n`); the frame ends on a blank line.
-function frame(data: string, event?: string): string {
+function frame(data: string, event?: string, id?: string): string {
     const lines: string[] = [];
     if (event !== undefined) lines.push(`event: ${event}`);
+    if (id !== undefined) lines.push(`id: ${id}`);
     for (const line of data.split('\n')) lines.push(`data: ${line}`);
     return `${lines.join('\n')}\n\n`;
 }
 
 // The generic token written as an `error` message's `data` by default: the raw upstream message is
 // withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`)
-// never reaches the client. Override with `options.errorData`.
+// never reaches the client. Override with `error.data`.
 const DEFAULT_ERROR_DATA = 'error';
 
-// Normalise a thrown value into the terminal `error` event shape, so an `errorData` opt-in sees a
+// Normalise a thrown value into the terminal `error` event shape, so an `error.data` opt-in sees a
 // consistent argument whether the failure arrived as a surfaced `error` event or an unexpected
-// throw. `attempts`/`at` are best-effort placeholders — an `errorData` hook keys off `name`/`message`.
+// throw. `attempts`/`at` are best-effort placeholders — an `error.data` hook keys off `name`/`message`.
 function toErrorEvent(reason: unknown): StitchErrorEvent {
     const e = reason instanceof Error ? reason : new Error(String(reason));
     return {
@@ -92,14 +134,14 @@ function toErrorEvent(reason: unknown): StitchErrorEvent {
  * app.get('/chat', ({ stitch, query }) => {
  *   const completion = stitch.stitch({ kind: sseSurface, path: '/v1/messages' });
  *   return streamStitchSse(completion.stream({ body: { prompt: query.q } }), {
- *     data: (chunk: any) => chunk.data,
+ *     delta: (chunk: any) => chunk.data,
  *   });
  * });
  * ```
  *
  * Each `delta` becomes a `data:` message; a terminal `error` event (or a throw) becomes a final
  * `event: error` message and ends the stream — a generic `data: error` by default, the raw message
- * withheld to avoid disclosing internal topology (opt in via `errorData`); every control event
+ * withheld to avoid disclosing internal topology (opt in via `error`); every control event
  * (`start`/`progress`/`result`/`done`/…) is consumed but not forwarded. On client disconnect the
  * stream is cancelled and the upstream iterator is `return()`-ed so the stitch stream is aborted.
  */
@@ -107,9 +149,13 @@ export function streamStitchSse<T>(
     source: StitchEventSource<T>,
     options: StreamStitchSseOptions = {},
 ): Response {
-    const toData = options.data ?? defaultData;
+    const delta = asDelta(options.delta);
+    const error = asError(options.error);
+    const toData = delta.data ?? defaultData;
+    const errorEvent = error.event ?? 'error';
     const enc = new TextEncoder();
     const iterator = source[Symbol.asyncIterator]();
+    let index = 0;
 
     const body = new ReadableStream<Uint8Array>({
         async pull(controller) {
@@ -121,25 +167,29 @@ export function streamStitchSse<T>(
                         return;
                     }
                     if (event.type === 'delta') {
+                        const id = delta.id
+                            ? delta.id(event.chunk, index)
+                            : undefined;
+                        index += 1;
                         controller.enqueue(
                             enc.encode(
-                                frame(toData(event.chunk), options.event),
+                                frame(toData(event.chunk), delta.event, id),
                             ),
                         );
                         return; // one frame per pull → precise back-pressure
                     }
                     if (event.type === 'error') {
-                        // `onError` gets the real failure server-side; the client frame is a
-                        // generic token by default (never the raw `event.message`) — `errorData`
+                        // `error.observe` gets the real failure server-side; the client frame is a
+                        // generic token by default (never the raw `event.message`) — `error.data`
                         // opts in.
-                        options.onError?.(new Error(event.message));
+                        error.observe?.(new Error(event.message));
                         controller.enqueue(
                             enc.encode(
                                 frame(
-                                    options.errorData
-                                        ? options.errorData(event)
+                                    error.data
+                                        ? error.data(event)
                                         : DEFAULT_ERROR_DATA,
-                                    'error',
+                                    errorEvent,
                                 ),
                             ),
                         );
@@ -152,15 +202,15 @@ export function streamStitchSse<T>(
                 }
             } catch (err) {
                 // A throw (not a surfaced `error` event): still withhold the raw message by
-                // default — normalise it to an error event so `errorData` sees a consistent shape.
-                options.onError?.(err);
+                // default — normalise it to an error event so `error.data` sees a consistent shape.
+                error.observe?.(err);
                 controller.enqueue(
                     enc.encode(
                         frame(
-                            options.errorData
-                                ? options.errorData(toErrorEvent(err))
+                            error.data
+                                ? error.data(toErrorEvent(err))
                                 : DEFAULT_ERROR_DATA,
-                            'error',
+                            errorEvent,
                         ),
                     ),
                 );

--- a/packages/elysia/test/elysia.spec.ts
+++ b/packages/elysia/test/elysia.spec.ts
@@ -128,7 +128,7 @@ describe('streamStitchSse bridges a stitch stream to an SSE body', () => {
                 });
                 return streamStitchSse(events.stream(), {
                     // The sse surface parses each frame to `{ data: 'one' }`; pull the text back out.
-                    data: (chunk) => (chunk as { data: string }).data,
+                    delta: (chunk) => (chunk as { data: string }).data,
                 });
             });
 

--- a/packages/elysia/test/sse.spec.ts
+++ b/packages/elysia/test/sse.spec.ts
@@ -42,13 +42,13 @@ describe('streamStitchSse — delta mapping', () => {
         expect(body).toContain('data: {"a":1}');
     });
 
-    test('the event option labels each delta message', async () => {
+    test('the delta.event option labels each delta message', async () => {
         const res = streamStitchSse(
             gen([
                 { type: 'delta', chunk: 't1', at: 0 },
                 { type: 'done', ok: true, elapsed: 1, attempts: 1, at: 0 },
             ]),
-            { event: 'token' },
+            { delta: { event: 'token' } },
         );
 
         const body = await res.text();
@@ -56,17 +56,32 @@ describe('streamStitchSse — delta mapping', () => {
         expect(body).toContain('data: t1');
     });
 
-    test('a custom data mapper pulls text out of a structured chunk', async () => {
+    test('a delta function shorthand pulls text out of a structured chunk', async () => {
         const res = streamStitchSse(
             gen([
                 { type: 'delta', chunk: { text: 'pulled' }, at: 0 },
                 { type: 'done', ok: true, elapsed: 1, attempts: 1, at: 0 },
             ]),
-            { data: (chunk) => (chunk as { text: string }).text },
+            { delta: (chunk) => (chunk as { text: string }).text },
         );
 
         const body = await res.text();
         expect(body).toContain('data: pulled');
+    });
+
+    test('delta.id emits an id: line per message with the zero-based index', async () => {
+        const res = streamStitchSse(
+            gen([
+                { type: 'delta', chunk: 'a', at: 0 },
+                { type: 'delta', chunk: 'b', at: 0 },
+                { type: 'done', ok: true, elapsed: 1, attempts: 1, at: 0 },
+            ]),
+            { delta: { id: (chunk, index) => `${String(chunk)}-${index}` } },
+        );
+
+        const body = await res.text();
+        expect(body).toContain('id: a-0');
+        expect(body).toContain('id: b-1');
     });
 
     test('a multi-line chunk gets one data: prefix per line (SSE spec)', async () => {
@@ -114,7 +129,7 @@ describe('streamStitchSse — control events', () => {
 });
 
 describe('streamStitchSse — error paths', () => {
-    test('an error event writes an event: error frame, invokes onError, and stops forwarding', async () => {
+    test('an error event writes an event: error frame, invokes error.observe, and stops forwarding', async () => {
         let captured: unknown;
         const res = streamStitchSse(
             gen([
@@ -129,8 +144,10 @@ describe('streamStitchSse — error paths', () => {
                 { type: 'delta', chunk: 'never', at: 0 },
             ]),
             {
-                onError: (e) => {
-                    captured = e;
+                error: {
+                    observe: (e) => {
+                        captured = e;
+                    },
                 },
             },
         );
@@ -142,11 +159,11 @@ describe('streamStitchSse — error paths', () => {
         expect(body).not.toContain('upstream failed');
         expect(body).toContain('data: error');
         expect(body).not.toContain('never');
-        // onError still sees the real failure server-side
+        // error.observe still sees the real failure server-side
         expect((captured as Error).message).toBe('upstream failed');
     });
 
-    test('a throw mid-stream is caught: onError fires and a final event: error frame is written', async () => {
+    test('a throw mid-stream is caught: error.observe fires and a final event: error frame is written', async () => {
         let captured: unknown;
         async function* boom(): AsyncGenerator<StitchEvent, void> {
             yield { type: 'delta', chunk: 'a', at: 0 };
@@ -154,8 +171,10 @@ describe('streamStitchSse — error paths', () => {
         }
 
         const res = streamStitchSse(boom(), {
-            onError: (e) => {
-                captured = e;
+            error: {
+                observe: (e) => {
+                    captured = e;
+                },
             },
         });
 
@@ -165,7 +184,7 @@ describe('streamStitchSse — error paths', () => {
         // the raw throw message is withheld from the client by default
         expect(body).not.toContain('stream blew up');
         expect(body).toContain('data: error');
-        // onError still sees the real failure server-side
+        // error.observe still sees the real failure server-side
         expect((captured as Error).message).toBe('stream blew up');
     });
 });
@@ -195,7 +214,7 @@ describe('streamStitchSse — the error frame does not leak the raw message', ()
         expect(body).not.toContain('ENOTFOUND');
     });
 
-    test('errorData opts in to shaping the client-facing error payload', async () => {
+    test('error opts in to shaping the client-facing error payload', async () => {
         const res = streamStitchSse(
             gen([
                 {
@@ -206,20 +225,20 @@ describe('streamStitchSse — the error frame does not leak the raw message', ()
                     at: 0,
                 },
             ]),
-            { errorData: (e) => e.message },
+            { error: (e) => e.message },
         );
         const body = await res.text();
         expect(body).toContain('event: error');
         expect(body).toContain('data: upstream blew up');
     });
 
-    test('errorData shapes the throw path too', async () => {
+    test('error shapes the throw path too', async () => {
         async function* boom(): AsyncGenerator<StitchEvent, void> {
             yield { type: 'delta', chunk: 'a', at: 0 };
             throw new Error('stream blew up');
         }
         const res = streamStitchSse(boom(), {
-            errorData: (e) => JSON.stringify({ error: e.message }),
+            error: (e) => JSON.stringify({ error: e.message }),
         });
         const body = await res.text();
         expect(body).toContain('event: error');

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -74,7 +74,7 @@ app.get('/chat', (req, res) => {
         res,
         completion.stream({ body: { prompt: req.query.q } }),
         {
-            data: (chunk: any) => chunk.data, // pull the parsed payload out of each delta
+            delta: (chunk: any) => chunk.data, // pull the parsed payload out of each delta
             req, // also tear down if the request socket signals disconnect
         },
     );
@@ -87,14 +87,18 @@ response.
 By default the `error` frame carries a generic `data: error` token, **not** the raw
 error message — echoing it can disclose internal network topology (a transport
 failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's
-status (`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream
+status (`HTTP 401`) to the client. Pass `error` to opt in when the upstream
 messages are known safe to expose:
 
 ```ts
 streamStitchSse(res, completion.stream({ body: { prompt: req.query.q } }), {
-    errorData: (e) => e.message, // opt in to the raw upstream message
+    error: (e) => e.message, // opt in to the raw upstream message
 });
 ```
+
+Both `delta` and `error` also take the full object form — `delta: { data, event, id }`
+and `error: { data, event, observe }` — e.g. `error.observe` logs the real failure
+server-side while the client still gets the generic token.
 
 ## Errors: `stitchErrorHandler(options?)`
 

--- a/packages/express/src/sse.ts
+++ b/packages/express/src/sse.ts
@@ -15,13 +15,20 @@ export type StitchEventSource<T> =
 /** The terminal `error` event a stitch stream emits — carries `message`, `status`, `attempts`. */
 type StitchErrorEvent = Extract<StitchEvent, { type: 'error' }>;
 
-export interface StreamStitchSseOptions {
+/** Shape a `delta` chunk into the SSE frame `data`. */
+type DeltaShaper = (chunk: unknown) => string;
+/** Shape a terminal `error` event into the SSE frame `data`. */
+type ErrorShaper = (event: StitchErrorEvent) => string;
+
+// How each `delta` becomes a message frame. The bare {@link DeltaShaper} form (`delta: (c) => …`)
+// is shorthand for `{ data: (c) => … }`.
+interface DeltaFrameOptions {
     /**
      * Map a `delta` chunk to the SSE frame `data`. Default: the chunk itself (a string is sent
-     * as-is; anything else is `JSON.stringify`-ed). Use this to pull the text out of a structured
-     * chunk, e.g. `data: (c) => c.choices[0].delta.content`.
+     * as-is; anything else is `JSON.stringify`-ed). Pull the text out of a structured chunk with,
+     * e.g., `(c) => c.choices[0].delta.content`.
      */
-    data?: (chunk: unknown) => string;
+    data?: DeltaShaper;
     /**
      * Emit an `event:` line per delta frame (the SSE event name). Default: none (an unnamed
      * `message` event, which `EventSource.onmessage` receives).
@@ -32,16 +39,45 @@ export interface StreamStitchSseOptions {
      * Receives the chunk and the zero-based frame index.
      */
     id?: (chunk: unknown, index: number) => string;
+}
+
+// How the terminal `error` becomes the final frame. The bare {@link ErrorShaper} form
+// (`error: (e) => …`) is shorthand for `{ data: (e) => … }`.
+interface ErrorFrameOptions {
     /**
-     * Shape the SSE `data` written for a terminal `error` event. **Default: a generic token
+     * Shape the SSE `data` written for the terminal `error` event. **Default: a generic token
      * (`data: error`)** — the raw `event.message` is deliberately *not* echoed, because it can
      * disclose internal network topology (a transport failure reads like
      * `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to an
      * untrusted client. Opt in with `(e) => e.message` when the upstream messages are known safe,
      * or return your own payload (e.g. `() => JSON.stringify({ error: 'stream failed' })`). A
-     * multi-line return gets one `data:` line each (SSE spec); the `event: error` name is fixed.
+     * multi-line return gets one `data:` line each (SSE spec).
      */
-    errorData?: (event: StitchErrorEvent) => string;
+    data?: ErrorShaper;
+    /** The `event:` name of the terminal error frame. Default `'error'`. */
+    event?: string;
+    /**
+     * Observe the real, server-side failure — use it to log/trace. It does **not** shape the
+     * client frame: what the client receives is controlled by {@link ErrorFrameOptions.data} (a
+     * generic token by default), so the raw message reaches your logs here but never the client.
+     */
+    observe?: (err: unknown) => void;
+}
+
+export interface StreamStitchSseOptions {
+    /**
+     * How each `delta` becomes a message frame. Pass a **function** as shorthand for `{ data }`
+     * (`delta: (c) => c.text`), or the full `{ data, event, id }` object to set the SSE
+     * `event:` / `id:` lines too.
+     */
+    delta?: DeltaShaper | DeltaFrameOptions;
+    /**
+     * How the terminal error becomes the final frame. Pass a **function** as shorthand for
+     * `{ data }` (`error: (e) => e.message`), or the full `{ data, event, observe }` object. By
+     * default the client gets a generic `data: error` token — the raw message is withheld to
+     * avoid disclosing internal topology.
+     */
+    error?: ErrorShaper | ErrorFrameOptions;
     /**
      * The Express request, when available. Express normally fires `close` on the *response* on
      * disconnect, but passing `req` lets the helper also listen on the request socket for
@@ -50,33 +86,39 @@ export interface StreamStitchSseOptions {
     req?: Request;
 }
 
+// Expand the function-shorthand form of each frame option to its full config object.
+const asDelta = (o: DeltaShaper | DeltaFrameOptions = {}): DeltaFrameOptions =>
+    typeof o === 'function' ? { data: o } : o;
+const asError = (o: ErrorShaper | ErrorFrameOptions = {}): ErrorFrameOptions =>
+    typeof o === 'function' ? { data: o } : o;
+
 // One delta chunk → an SSE frame string. A multi-line payload is split so every line gets its own
 // `data:` prefix (the SSE spec joins them with `\n`); the frame ends on a blank line.
 function frame(
     chunk: unknown,
     index: number,
-    options: StreamStitchSseOptions,
+    delta: DeltaFrameOptions,
 ): string {
     const raw =
-        options.data?.(chunk) ??
+        delta.data?.(chunk) ??
         (typeof chunk === 'string' ? chunk : JSON.stringify(chunk));
     const lines: string[] = [];
-    if (options.event) lines.push(`event: ${options.event}`);
-    if (options.id) lines.push(`id: ${options.id(chunk, index)}`);
+    if (delta.event) lines.push(`event: ${delta.event}`);
+    if (delta.id) lines.push(`id: ${delta.id(chunk, index)}`);
     for (const dataLine of raw.split('\n')) lines.push(`data: ${dataLine}`);
     return `${lines.join('\n')}\n\n`;
 }
 
 // The generic token written as an `error` frame's `data` by default: the raw upstream message is
 // withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`)
-// never reaches the client. Override with `options.errorData`.
+// never reaches the client. Override with `error.data`.
 const DEFAULT_ERROR_DATA = 'error';
 
-// The terminal `error` frame: the fixed `event: error` name plus a (multi-line-safe) data payload —
-// every line of `data` gets its own `data:` prefix so a multi-line opt-in payload can't break the
-// SSE framing.
-function errorFrame(data: string): string {
-    const lines = ['event: error'];
+// The terminal `error` frame: the (configurable, default `error`) event name plus a
+// (multi-line-safe) data payload — every line of `data` gets its own `data:` prefix so a multi-line
+// opt-in payload can't break the SSE framing.
+function errorFrame(data: string, event: string): string {
+    const lines = [`event: ${event}`];
     for (const dataLine of data.split('\n')) lines.push(`data: ${dataLine}`);
     return `${lines.join('\n')}\n\n`;
 }
@@ -86,7 +128,7 @@ function errorFrame(data: string): string {
  * `.stream()` generator (or any `AsyncIterable<StitchEvent>`): each `delta` becomes one SSE frame, an
  * `error` event ends the stream with a named `event: error` frame (a generic `data: error` by
  * default — the raw message is withheld to avoid disclosing internal topology; opt in via
- * `errorData`), and stream end closes the response. The non-output events (`start` / `progress` /
+ * `error`), and stream end closes the response. The non-output events (`start` / `progress` /
  * `drift` / `result` / `done`) are control signals and are not forwarded to the client.
  *
  * Writes raw frames straight to the socket, so do **not** also `res.send()`/`res.json()` from the
@@ -97,7 +139,7 @@ function errorFrame(data: string): string {
  * ```ts
  * app.get('/chat', (req, res) =>
  *   streamStitchSse(res, chat.stream({ query: { q: req.query.q } }),
- *                   { data: (c: any) => c.text, req }),
+ *                   { delta: (c: any) => c.text, req }),
  * );
  * ```
  */
@@ -106,6 +148,8 @@ export async function streamStitchSse<T>(
     source: StitchEventSource<T>,
     options: StreamStitchSseOptions = {},
 ): Promise<void> {
+    const delta = asDelta(options.delta);
+    const error = asError(options.error);
     if (!res.headersSent) {
         res.writeHead(200, {
             'content-type': 'text/event-stream',
@@ -135,18 +179,19 @@ export async function streamStitchSse<T>(
             const { value: event, done } = await iterator.next();
             if (done) break;
             if (event.type === 'delta') {
-                res.write(frame(event.chunk, index, options));
+                res.write(frame(event.chunk, index, delta));
                 index += 1;
             } else if (event.type === 'error') {
                 // Surface the failure to the client as a named `error` SSE frame, then stop — but by
                 // default write a generic token, never the raw `event.message`, so an internal
                 // hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`) is not
-                // disclosed. Opt in to the real message via `options.errorData`.
+                // disclosed. Opt in to the real message via `error.data`; `error.observe` sees the
+                // real failure server-side.
+                error.observe?.(new Error(event.message));
                 res.write(
                     errorFrame(
-                        options.errorData
-                            ? options.errorData(event)
-                            : DEFAULT_ERROR_DATA,
+                        error.data ? error.data(event) : DEFAULT_ERROR_DATA,
+                        error.event ?? 'error',
                     ),
                 );
                 break;

--- a/packages/express/test/express.spec.ts
+++ b/packages/express/test/express.spec.ts
@@ -210,7 +210,7 @@ describe('streamStitchSse writes SSE frames to res', () => {
         expect(res.body()).not.toContain('ENOTFOUND');
     });
 
-    test('errorData opts in to the raw message on the error frame', async () => {
+    test('error (function shorthand) opts in to the raw message on the error frame', async () => {
         async function* events(): AsyncGenerator<StitchEvent<unknown>> {
             yield { type: 'delta', chunk: 'partial', at: 1 };
             yield {
@@ -223,12 +223,69 @@ describe('streamStitchSse writes SSE frames to res', () => {
         }
         const res = mockRes();
         await streamStitchSse(res as unknown as Response, events(), {
-            errorData: (e) => e.message,
+            error: (e) => e.message,
         });
 
         expect(res.body()).toBe(
             'data: partial\n\nevent: error\ndata: upstream blew up\n\n',
         );
+    });
+
+    test('error can be the full object: data + a custom event name + observe', async () => {
+        const observed: unknown[] = [];
+        async function* events(): AsyncGenerator<StitchEvent<unknown>> {
+            yield { type: 'delta', chunk: 'partial', at: 1 };
+            yield {
+                type: 'error',
+                name: 'StitchError',
+                message: 'upstream blew up',
+                attempts: 1,
+                at: 2,
+            };
+        }
+        const res = mockRes();
+        await streamStitchSse(res as unknown as Response, events(), {
+            error: {
+                data: (e) => e.message,
+                event: 'failure',
+                observe: (err) => observed.push(err),
+            },
+        });
+
+        // The custom event name is used and error.data shapes the payload.
+        expect(res.body()).toBe(
+            'data: partial\n\nevent: failure\ndata: upstream blew up\n\n',
+        );
+        // observe saw the real server-side failure.
+        expect(observed).toHaveLength(1);
+        expect((observed[0] as Error).message).toBe('upstream blew up');
+    });
+
+    test('error.observe sees the real failure even when the client gets the generic token', async () => {
+        const observed: unknown[] = [];
+        async function* events(): AsyncGenerator<StitchEvent<unknown>> {
+            yield { type: 'delta', chunk: 'partial', at: 1 };
+            yield {
+                type: 'error',
+                name: 'StitchError',
+                message: 'getaddrinfo ENOTFOUND payments.internal.corp',
+                status: 502,
+                attempts: 1,
+                at: 2,
+            };
+        }
+        const res = mockRes();
+        await streamStitchSse(res as unknown as Response, events(), {
+            error: { observe: (err) => observed.push(err) },
+        });
+
+        // Client still gets the generic token — the raw message is withheld.
+        expect(res.body()).toBe(
+            'data: partial\n\nevent: error\ndata: error\n\n',
+        );
+        expect(res.body()).not.toContain('payments.internal.corp');
+        // … but observe got the real failure server-side.
+        expect((observed[0] as Error).message).toContain('ENOTFOUND');
     });
 
     test('the data mapper + named event shape each delta frame', async () => {
@@ -238,8 +295,10 @@ describe('streamStitchSse writes SSE frames to res', () => {
         }
         const res = mockRes();
         await streamStitchSse(res as unknown as Response, events(), {
-            event: 'token',
-            data: (c) => (c as { text: string }).text,
+            delta: {
+                event: 'token',
+                data: (c) => (c as { text: string }).text,
+            },
         });
         expect(res.body()).toBe(
             'event: token\ndata: a\n\nevent: token\ndata: b\n\n',
@@ -257,14 +316,26 @@ describe('streamStitchSse writes SSE frames to res', () => {
         expect(res.body()).toBe('data: plain\n\ndata: {"a":1}\n\n');
     });
 
-    test('the id option emits an id: line per frame with the zero-based index', async () => {
+    test('delta as a function is shorthand for { data }', async () => {
+        async function* events(): AsyncGenerator<StitchEvent<unknown>> {
+            yield { type: 'delta', chunk: { text: 'a' }, at: 1 };
+            yield { type: 'delta', chunk: { text: 'b' }, at: 2 };
+        }
+        const res = mockRes();
+        await streamStitchSse(res as unknown as Response, events(), {
+            delta: (c) => (c as { text: string }).text,
+        });
+        expect(res.body()).toBe('data: a\n\ndata: b\n\n');
+    });
+
+    test('the delta.id option emits an id: line per frame with the zero-based index', async () => {
         async function* events(): AsyncGenerator<StitchEvent<unknown>> {
             yield { type: 'delta', chunk: 'a', at: 1 };
             yield { type: 'delta', chunk: 'b', at: 2 };
         }
         const res = mockRes();
         await streamStitchSse(res as unknown as Response, events(), {
-            id: (chunk, index) => `${String(chunk)}-${index}`,
+            delta: { id: (chunk, index) => `${String(chunk)}-${index}` },
         });
 
         expect(res.body()).toBe('id: a-0\ndata: a\n\nid: b-1\ndata: b\n\n');

--- a/packages/fastify/README.md
+++ b/packages/fastify/README.md
@@ -94,7 +94,7 @@ import { sendStitchSse } from '@stitchapi/fastify';
 
 app.get('/chat', (req, reply) =>
     sendStitchSse(reply, chat.stream({ query: { q: String(req.query.q) } }), {
-        data: (c) => c.text, // pull text out of a structured chunk
+        delta: (c) => c.text, // pull text out of a structured chunk
     }),
 );
 ```
@@ -106,14 +106,18 @@ aborts the upstream stitch generator rather than leaving it running.
 By default the `error` frame carries a generic `data: error` token, **not** the raw
 error message — echoing it can disclose internal network topology (a transport
 failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's
-status (`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream
+status (`HTTP 401`) to the client. Pass `error` to opt in when the upstream
 messages are known safe to expose:
 
 ```ts
 sendStitchSse(reply, chat.stream({ query: { q: String(req.query.q) } }), {
-    errorData: (e) => e.message, // opt in to the raw upstream message
+    error: (e) => e.message, // opt in to the raw upstream message
 });
 ```
+
+Both `delta` and `error` also take the full object form — `delta: { data, event, id }`
+and `error: { data, event, observe }` — e.g. `error.observe` logs the real failure
+server-side while the client still gets the generic token.
 
 ## Error handling
 

--- a/packages/fastify/src/sse.ts
+++ b/packages/fastify/src/sse.ts
@@ -10,13 +10,20 @@ import type { StitchEvent } from 'stitchapi';
 /** The terminal `error` event a stitch stream emits — carries `message`, `status`, `attempts`. */
 type StitchErrorEvent = Extract<StitchEvent, { type: 'error' }>;
 
-export interface SendStitchSseOptions {
+/** Shape a `delta` chunk into the SSE frame `data`. */
+type DeltaShaper = (chunk: unknown) => string;
+/** Shape a terminal `error` event into the SSE frame `data`. */
+type ErrorShaper = (event: StitchErrorEvent) => string;
+
+// How each `delta` becomes a message frame. The bare {@link DeltaShaper} form (`delta: (c) => …`)
+// is shorthand for `{ data: (c) => … }`.
+interface DeltaFrameOptions {
     /**
      * Map a `delta` chunk to the SSE frame `data`. Default: the chunk itself (a string is
-     * sent as-is; anything else is `JSON.stringify`-ed). Use this to pull the text out of a
-     * structured chunk, e.g. `data: (c) => c.choices[0].delta.content`.
+     * sent as-is; anything else is `JSON.stringify`-ed). Pull the text out of a structured
+     * chunk with, e.g., `(c) => c.choices[0].delta.content`.
      */
-    data?: (chunk: unknown) => string;
+    data?: DeltaShaper;
     /**
      * Emit an `event:` line per frame (the SSE event name). Default: none (an unnamed
      * `message` event, which `EventSource.onmessage` receives).
@@ -27,45 +34,80 @@ export interface SendStitchSseOptions {
      * Receives the chunk and the zero-based frame index.
      */
     id?: (chunk: unknown, index: number) => string;
+}
+
+// How the terminal `error` becomes the final frame. The bare {@link ErrorShaper} form
+// (`error: (e) => …`) is shorthand for `{ data: (e) => … }`.
+interface ErrorFrameOptions {
     /**
-     * Shape the SSE `data` written for a terminal `error` event. **Default: a generic token
+     * Shape the SSE `data` written for the terminal `error` event. **Default: a generic token
      * (`data: error`)** — the raw `event.message` is deliberately *not* echoed, because it can
      * disclose internal network topology (a transport failure reads like
      * `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to
      * an untrusted client. Opt in with `(e) => e.message` when the upstream messages are known
      * safe, or return your own payload (e.g. `() => JSON.stringify({ error: 'stream failed' })`).
-     * A multi-line return gets one `data:` line each (SSE spec); the `event: error` name is fixed.
+     * A multi-line return gets one `data:` line each (SSE spec).
      */
-    errorData?: (event: StitchErrorEvent) => string;
+    data?: ErrorShaper;
+    /** The `event:` name of the terminal error frame. Default `'error'`. */
+    event?: string;
+    /**
+     * Observe the real, server-side failure — use it to log/trace. It does **not** shape the
+     * client frame: what the client receives is controlled by {@link ErrorFrameOptions.data} (a
+     * generic token by default), so the raw message reaches your logs here but never the client.
+     */
+    observe?: (err: unknown) => void;
 }
+
+export interface SendStitchSseOptions {
+    /**
+     * How each `delta` becomes a message frame. Pass a **function** as shorthand for `{ data }`
+     * (`delta: (c) => c.text`), or the full `{ data, event, id }` object to set the SSE
+     * `event:` / `id:` lines too.
+     */
+    delta?: DeltaShaper | DeltaFrameOptions;
+    /**
+     * How the terminal error becomes the final frame. Pass a **function** as shorthand for
+     * `{ data }` (`error: (e) => e.message`), or the full `{ data, event, observe }` object. By
+     * default the client gets a generic `data: error` token — the raw message is withheld to
+     * avoid disclosing internal topology.
+     */
+    error?: ErrorShaper | ErrorFrameOptions;
+}
+
+// Expand the function-shorthand form of each frame option to its full config object.
+const asDelta = (o: DeltaShaper | DeltaFrameOptions = {}): DeltaFrameOptions =>
+    typeof o === 'function' ? { data: o } : o;
+const asError = (o: ErrorShaper | ErrorFrameOptions = {}): ErrorFrameOptions =>
+    typeof o === 'function' ? { data: o } : o;
 
 // One delta chunk → an SSE frame string. A multi-line payload is split so every line gets its
 // own `data:` prefix (the SSE spec joins them with `\n`); the frame ends on a blank line.
 function frame(
     chunk: unknown,
     index: number,
-    options: SendStitchSseOptions,
+    delta: DeltaFrameOptions,
 ): string {
     const raw =
-        options.data?.(chunk) ??
+        delta.data?.(chunk) ??
         (typeof chunk === 'string' ? chunk : JSON.stringify(chunk));
     const lines: string[] = [];
-    if (options.event) lines.push(`event: ${options.event}`);
-    if (options.id) lines.push(`id: ${options.id(chunk, index)}`);
+    if (delta.event) lines.push(`event: ${delta.event}`);
+    if (delta.id) lines.push(`id: ${delta.id(chunk, index)}`);
     for (const dataLine of raw.split('\n')) lines.push(`data: ${dataLine}`);
     return `${lines.join('\n')}\n\n`;
 }
 
 // The generic token written as an `error` frame's `data` by default: the raw upstream message is
 // withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`)
-// never reaches the client. Override with `options.errorData`.
+// never reaches the client. Override with `error.data`.
 const DEFAULT_ERROR_DATA = 'error';
 
-// The terminal `error` frame: the fixed `event: error` name plus a (multi-line-safe) data payload —
-// every line of `data` gets its own `data:` prefix so a multi-line opt-in payload can't break the
-// SSE framing.
-function errorFrame(data: string): string {
-    const lines = ['event: error'];
+// The terminal `error` frame: the (configurable, default `error`) event name plus a
+// (multi-line-safe) data payload — every line of `data` gets its own `data:` prefix so a multi-line
+// opt-in payload can't break the SSE framing.
+function errorFrame(data: string, event: string): string {
+    const lines = [`event: ${event}`];
     for (const dataLine of data.split('\n')) lines.push(`data: ${dataLine}`);
     return `${lines.join('\n')}\n\n`;
 }
@@ -75,7 +117,7 @@ function errorFrame(data: string): string {
  * stitch's `.stream()` generator (or any `AsyncIterable<StitchEvent>`): each `delta` becomes
  * one SSE frame, an `error` event ends the stream with a named `event: error` frame (a generic
  * `data: error` by default — the raw message is withheld to avoid disclosing internal topology;
- * opt in via `errorData`), and stream end closes the response. The non-output events (`start` /
+ * opt in via `error`), and stream end closes the response. The non-output events (`start` /
  * `progress` / `drift` / `result` / `done`) are control signals and are not forwarded to the client.
  *
  * Takes over the reply via `reply.hijack()` and writes raw frames, so do **not** also `send()`
@@ -86,7 +128,7 @@ function errorFrame(data: string): string {
  * ```ts
  * app.get('/chat', (req, reply) =>
  *   sendStitchSse(reply, chat.stream({ query: { q: req.query.q } }),
- *                 { data: (c: any) => c.text }),
+ *                 { delta: (c: any) => c.text }),
  * );
  * ```
  */
@@ -95,6 +137,8 @@ export async function sendStitchSse<T>(
     stream: AsyncIterable<StitchEvent<T>>,
     options: SendStitchSseOptions = {},
 ): Promise<void> {
+    const delta = asDelta(options.delta);
+    const error = asError(options.error);
     const res = reply.raw;
     // Take control of the reply: we own the socket from here, Fastify won't try to send.
     reply.hijack();
@@ -122,18 +166,19 @@ export async function sendStitchSse<T>(
             const { value: event, done } = await iterator.next();
             if (done) break;
             if (event.type === 'delta') {
-                res.write(frame(event.chunk, index, options));
+                res.write(frame(event.chunk, index, delta));
                 index += 1;
             } else if (event.type === 'error') {
                 // Surface the failure to the client as a named `error` SSE frame, then stop — but by
                 // default write a generic token, never the raw `event.message`, so an internal
                 // hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`) is not
-                // disclosed. Opt in to the real message via `options.errorData`.
+                // disclosed. Opt in to the real message via `error.data`; `error.observe` sees the
+                // real failure server-side.
+                error.observe?.(new Error(event.message));
                 res.write(
                     errorFrame(
-                        options.errorData
-                            ? options.errorData(event)
-                            : DEFAULT_ERROR_DATA,
+                        error.data ? error.data(event) : DEFAULT_ERROR_DATA,
+                        error.event ?? 'error',
                     ),
                 );
                 break;

--- a/packages/fastify/test/fastify.spec.ts
+++ b/packages/fastify/test/fastify.spec.ts
@@ -223,7 +223,7 @@ describe('stitchPlugin', () => {
         expect(res.body).not.toContain('ENOTFOUND');
     });
 
-    test('errorData opts in to the raw message on the error frame', async () => {
+    test('error (function shorthand) opts in to the raw message on the error frame', async () => {
         async function* events(): AsyncGenerator<StitchEvent<unknown>> {
             yield { type: 'delta', chunk: 'partial', at: 1 };
             yield {
@@ -248,7 +248,7 @@ describe('stitchPlugin', () => {
             logger: false,
         });
         app.get('/sse-err', (_request, reply) =>
-            sendStitchSse(reply, events(), { errorData: (e) => e.message }),
+            sendStitchSse(reply, events(), { error: (e) => e.message }),
         );
         await app.ready();
 
@@ -256,6 +256,47 @@ describe('stitchPlugin', () => {
         expect(res.body).toBe(
             'data: partial\n\nevent: error\ndata: upstream blew up\n\n',
         );
+    });
+
+    test('error.observe sees the real failure while the client gets the generic token', async () => {
+        const observed: unknown[] = [];
+        async function* events(): AsyncGenerator<StitchEvent<unknown>> {
+            yield { type: 'delta', chunk: 'partial', at: 1 };
+            yield {
+                type: 'error',
+                name: 'StitchError',
+                message: 'getaddrinfo ENOTFOUND payments.internal.corp',
+                status: 502,
+                attempts: 1,
+                at: 2,
+            };
+        }
+        const app = Fastify();
+        apps.push(app);
+        await app.register(stitchPlugin, {
+            seamConfig: {
+                baseUrl: 'https://api.test',
+                adapter: fakeAdapter(() => ({
+                    status: 200,
+                    headers: {},
+                    body: {},
+                })).adapter,
+            },
+            logger: false,
+        });
+        app.get('/sse-err', (_request, reply) =>
+            sendStitchSse(reply, events(), {
+                error: { observe: (err) => observed.push(err) },
+            }),
+        );
+        await app.ready();
+
+        const res = await app.inject({ method: 'GET', url: '/sse-err' });
+        // Client still gets the generic token — the raw message is withheld.
+        expect(res.body).toBe('data: partial\n\nevent: error\ndata: error\n\n');
+        expect(res.body).not.toContain('payments.internal.corp');
+        // … but observe got the real failure server-side.
+        expect((observed[0] as Error).message).toContain('ENOTFOUND');
     });
 
     test('the registered error handler maps a StitchError to 502 by default', async () => {

--- a/packages/hono/README.md
+++ b/packages/hono/README.md
@@ -64,7 +64,7 @@ app.get('/chat', (c) => {
         c,
         completion.stream({ body: { prompt: c.req.query('q') } }),
         {
-            data: (chunk: any) => chunk.data, // pull the parsed event payload out of each delta
+            delta: (chunk: any) => chunk.data, // pull the parsed event payload out of each delta
         },
     );
 });
@@ -73,16 +73,22 @@ app.get('/chat', (c) => {
 By default the `error` message carries a generic `data: error` token, **not** the
 raw error message — echoing it can disclose internal network topology (a transport
 failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's
-status (`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream
-messages are known safe; `onError` still receives the real failure server-side for
-logging:
+status (`HTTP 401`) to the client. Pass `error` to opt in when the upstream
+messages are known safe; `error.observe` still receives the real failure
+server-side for logging:
 
 ```ts
 return streamStitchSse(c, completion.stream({ body: { prompt: c.req.query('q') } }), {
-    errorData: (e) => e.message, // opt in to the raw upstream message
-    onError: (err) => c.get('log').error(err), // real failure, server-side only
+    error: {
+        data: (e) => e.message, // opt in to the raw upstream message
+        observe: (err) => c.get('log').error(err), // real failure, server-side only
+    },
 });
 ```
+
+Both `delta` and `error` also accept a bare function as shorthand for `{ data }` —
+`delta: (c) => c.text`, `error: (e) => e.message` — plus `delta.event` / `delta.id`
+and `error.event` for the SSE `event:` / `id:` lines.
 
 ## Errors: `stitchError(err)` / `stitchOnError(options?)`
 

--- a/packages/hono/src/sse.ts
+++ b/packages/hono/src/sse.ts
@@ -19,18 +19,35 @@ export type StitchEventSource<T> =
 /** The terminal `error` event a stitch stream emits — carries `message`, `status`, `attempts`. */
 type StitchErrorEvent = Extract<StitchEvent, { type: 'error' }>;
 
-export interface StreamStitchSseOptions {
+/** Shape a `delta` chunk into the SSE frame `data`. */
+type DeltaShaper = (chunk: unknown) => string;
+/** Shape a terminal `error` event into the SSE frame `data`. */
+type ErrorShaper = (event: StitchErrorEvent) => string;
+
+// How each `delta` becomes a message. The bare {@link DeltaShaper} form (`delta: (c) => …`) is
+// shorthand for `{ data: (c) => … }`.
+interface DeltaFrameOptions {
     /**
      * Map a `delta` chunk to the SSE message `data` string. The default JSON-stringifies the chunk
      * (a string chunk is sent verbatim). Pull text out of a structured chunk with, e.g.,
-     * `data: (c) => c.choices[0].delta.content ?? ''`.
+     * `(c) => c.choices[0].delta.content ?? ''`.
      */
-    data?: (chunk: unknown) => string;
+    data?: DeltaShaper;
     /**
      * The SSE `event:` field for each delta message (default none). Set it to label the stream's
      * messages on the client (`event: 'token'`).
      */
     event?: string;
+    /**
+     * Provide an `id:` line per delta message (the SSE last-event id), e.g. for resumable streams.
+     * Receives the chunk and the zero-based frame index.
+     */
+    id?: (chunk: unknown, index: number) => string;
+}
+
+// How the terminal `error` becomes the final message. The bare {@link ErrorShaper} form
+// (`error: (e) => …`) is shorthand for `{ data: (e) => … }`.
+interface ErrorFrameOptions {
     /**
      * Shape the SSE `data` written for a terminal `error` event (or an uncaught throw mid-stream,
      * normalised to an error event). **Default: a generic token (`data: error`)** — the raw
@@ -40,15 +57,39 @@ export interface StreamStitchSseOptions {
      * when the upstream messages are known safe, or return your own payload
      * (e.g. `() => JSON.stringify({ error: 'stream failed' })`).
      */
-    errorData?: (event: StitchErrorEvent) => string;
+    data?: ErrorShaper;
+    /** The `event:` name of the terminal error message. Default `'error'`. */
+    event?: string;
     /**
-     * Called once, server-side, if the underlying stream errors (a stitch `error` event, or a
-     * throw) — use it to observe/log the real failure. It does **not** shape the client-facing
-     * frame: the SSE `data` sent to the client is controlled by `errorData` (a generic token by
-     * default), so the raw message reaches your logs here but not the client.
+     * Observe the real failure, server-side (a stitch `error` event, or a throw) — use it to
+     * log/trace. It does **not** shape the client-facing frame: the SSE `data` sent to the client
+     * is controlled by {@link ErrorFrameOptions.data} (a generic token by default), so the raw
+     * message reaches your logs here but not the client.
      */
-    onError?: (err: unknown) => void;
+    observe?: (err: unknown) => void;
 }
+
+export interface StreamStitchSseOptions {
+    /**
+     * How each `delta` becomes a message. Pass a **function** as shorthand for `{ data }`
+     * (`delta: (c) => c.text`), or the full `{ data, event, id }` object to set the SSE
+     * `event:` / `id:` lines too.
+     */
+    delta?: DeltaShaper | DeltaFrameOptions;
+    /**
+     * How the terminal error becomes the final message. Pass a **function** as shorthand for
+     * `{ data }` (`error: (e) => e.message`), or the full `{ data, event, observe }` object. By
+     * default the client gets a generic `data: error` token — the raw message is withheld to
+     * avoid disclosing internal topology.
+     */
+    error?: ErrorShaper | ErrorFrameOptions;
+}
+
+// Expand the function-shorthand form of each frame option to its full config object.
+const asDelta = (o: DeltaShaper | DeltaFrameOptions = {}): DeltaFrameOptions =>
+    typeof o === 'function' ? { data: o } : o;
+const asError = (o: ErrorShaper | ErrorFrameOptions = {}): ErrorFrameOptions =>
+    typeof o === 'function' ? { data: o } : o;
 
 function defaultData(chunk: unknown): string {
     return typeof chunk === 'string' ? chunk : JSON.stringify(chunk);
@@ -56,12 +97,12 @@ function defaultData(chunk: unknown): string {
 
 // The generic token written as an `error` message's `data` by default: the raw upstream message is
 // withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`)
-// never reaches the client. Override with `options.errorData`.
+// never reaches the client. Override with `error.data`.
 const DEFAULT_ERROR_DATA = 'error';
 
-// Normalise a thrown value into the terminal `error` event shape, so an `errorData` opt-in sees a
+// Normalise a thrown value into the terminal `error` event shape, so an `error.data` opt-in sees a
 // consistent argument whether the failure arrived as a surfaced `error` event or an unexpected
-// throw. `attempts`/`at` are best-effort placeholders — an `errorData` hook keys off `name`/`message`.
+// throw. `attempts`/`at` are best-effort placeholders — an `error.data` hook keys off `name`/`message`.
 function toErrorEvent(err: unknown): StitchErrorEvent {
     const e = err instanceof Error ? err : new Error(String(err));
     return {
@@ -83,14 +124,14 @@ function toErrorEvent(err: unknown): StitchErrorEvent {
  * app.get('/chat', (c) => {
  *   const completion = c.get('stitch').stitch({ kind: sseSurface, path: '/v1/messages' });
  *   return streamStitchSse(c, completion.stream({ body: { prompt: c.req.query('q') } }), {
- *     data: (chunk: any) => chunk.data,
+ *     delta: (chunk: any) => chunk.data,
  *   });
  * });
  * ```
  *
  * Each `delta` becomes a `data:` message; a terminal `error` event (or a throw) becomes a final
  * `event: error` message and ends the stream — a generic `data: error` by default, the raw message
- * withheld to avoid disclosing internal topology (opt in via `errorData`); every control event
+ * withheld to avoid disclosing internal topology (opt in via `error`); every control event
  * (`start`/`progress`/`result`/`done`/…) is consumed but not forwarded. On client disconnect the
  * upstream iterator is `return()`-ed so the stitch stream is aborted.
  */
@@ -99,17 +140,19 @@ export function streamStitchSse<T>(
     source: StitchEventSource<T>,
     options: StreamStitchSseOptions = {},
 ): Response {
-    const toData = options.data ?? defaultData;
+    const delta = asDelta(options.delta);
+    const error = asError(options.error);
+    const toData = delta.data ?? defaultData;
+    const errorEvent = error.event ?? 'error';
     return streamSSE(c, async (stream: SSEStreamingApi) => {
         const iterator = source[Symbol.asyncIterator]();
+        let index = 0;
         // Write the terminal `error` message: a generic token by default so a raw message
-        // (`getaddrinfo ENOTFOUND …` / `HTTP 401`) is never disclosed; `errorData` opts in.
+        // (`getaddrinfo ENOTFOUND …` / `HTTP 401`) is never disclosed; `error.data` opts in.
         const writeErrorFrame = (event: StitchErrorEvent): Promise<void> =>
             stream.writeSSE({
-                event: 'error',
-                data: options.errorData
-                    ? options.errorData(event)
-                    : DEFAULT_ERROR_DATA,
+                event: errorEvent,
+                data: error.data ? error.data(event) : DEFAULT_ERROR_DATA,
             });
         // Client disconnect: stop pulling and tear down the upstream stitch stream.
         stream.onAbort(() => {
@@ -121,13 +164,14 @@ export function streamStitchSse<T>(
                 if (done) break;
                 if (event.type === 'delta') {
                     const message: SSEMessage = { data: toData(event.chunk) };
-                    if (options.event !== undefined)
-                        message.event = options.event;
+                    if (delta.event !== undefined) message.event = delta.event;
+                    if (delta.id) message.id = delta.id(event.chunk, index);
+                    index += 1;
                     await stream.writeSSE(message);
                 } else if (event.type === 'error') {
-                    // `onError` gets the real failure server-side; the client frame is shaped by
-                    // `errorData` (generic by default), never the raw `event.message`.
-                    options.onError?.(new Error(event.message));
+                    // `error.observe` gets the real failure server-side; the client frame is shaped
+                    // by `error.data` (generic by default), never the raw `event.message`.
+                    error.observe?.(new Error(event.message));
                     await writeErrorFrame(event);
                     return;
                 }
@@ -135,8 +179,8 @@ export function streamStitchSse<T>(
             }
         } catch (err) {
             // A throw (not a surfaced `error` event): still withhold the raw message by default —
-            // normalise it to an error event so an `errorData` opt-in sees a consistent shape.
-            options.onError?.(err);
+            // normalise it to an error event so an `error.data` opt-in sees a consistent shape.
+            error.observe?.(err);
             await writeErrorFrame(toErrorEvent(err));
         } finally {
             await iterator.return?.(undefined);

--- a/packages/hono/test/hono.spec.ts
+++ b/packages/hono/test/hono.spec.ts
@@ -126,7 +126,7 @@ describe('streamStitchSse bridges a stitch stream to an SSE body', () => {
             });
             return streamStitchSse(c, events.stream(), {
                 // The sse surface parses each frame to `{ data: 'one' }`; pull the text back out.
-                data: (chunk) => (chunk as { data: string }).data,
+                delta: (chunk) => (chunk as { data: string }).data,
             });
         });
 

--- a/packages/hono/test/sse.spec.ts
+++ b/packages/hono/test/sse.spec.ts
@@ -59,7 +59,7 @@ describe('streamStitchSse — delta mapping', () => {
                     { type: 'delta', chunk: 't2', at: 0 },
                     { type: 'done', ok: true, elapsed: 1, attempts: 1, at: 0 },
                 ]),
-                { event: 'token' },
+                { delta: { event: 'token' } },
             ),
         );
 
@@ -78,12 +78,35 @@ describe('streamStitchSse — delta mapping', () => {
                     { type: 'delta', chunk: { text: 'pulled' }, at: 0 },
                     { type: 'done', ok: true, elapsed: 1, attempts: 1, at: 0 },
                 ]),
-                { data: (chunk) => (chunk as { text: string }).text },
+                { delta: (chunk) => (chunk as { text: string }).text },
             ),
         );
 
         const body = await (await app.request('/x')).text();
         expect(body).toContain('data: pulled');
+    });
+
+    test('delta.id emits an id: line per message with the zero-based index', async () => {
+        const app = new Hono();
+        app.get('/x', (c) =>
+            streamStitchSse(
+                c,
+                gen([
+                    { type: 'delta', chunk: 'a', at: 0 },
+                    { type: 'delta', chunk: 'b', at: 0 },
+                    { type: 'done', ok: true, elapsed: 1, attempts: 1, at: 0 },
+                ]),
+                {
+                    delta: {
+                        id: (chunk, index) => `${String(chunk)}-${index}`,
+                    },
+                },
+            ),
+        );
+
+        const body = await (await app.request('/x')).text();
+        expect(body).toContain('id: a-0');
+        expect(body).toContain('id: b-1');
     });
 });
 
@@ -124,7 +147,7 @@ describe('streamStitchSse — control events', () => {
 });
 
 describe('streamStitchSse — error paths', () => {
-    test('by default an error event writes a generic event: error frame (raw message withheld), while onError still gets the real failure', async () => {
+    test('by default an error event writes a generic event: error frame (raw message withheld), while error.observe still gets the real failure', async () => {
         let captured: unknown;
         const app = new Hono();
         app.get('/x', (c) =>
@@ -146,8 +169,10 @@ describe('streamStitchSse — error paths', () => {
                     { type: 'delta', chunk: 'never', at: 0 },
                 ]),
                 {
-                    onError: (e) => {
-                        captured = e;
+                    error: {
+                        observe: (e) => {
+                            captured = e;
+                        },
                     },
                 },
             ),
@@ -161,14 +186,14 @@ describe('streamStitchSse — error paths', () => {
         expect(body).not.toContain('payments.internal.corp');
         expect(body).not.toContain('ENOTFOUND');
         expect(body).not.toContain('never');
-        // … but onError still observes the real failure server-side (for logging).
+        // … but error.observe still sees the real failure server-side (for logging).
         expect(captured).toBeInstanceOf(Error);
         expect((captured as Error).message).toBe(
             'getaddrinfo ENOTFOUND payments.internal.corp',
         );
     });
 
-    test('errorData opts in to the raw message on the error frame', async () => {
+    test('error (function shorthand) opts in to the raw message on the error frame', async () => {
         const app = new Hono();
         app.get('/x', (c) =>
             streamStitchSse(
@@ -183,7 +208,7 @@ describe('streamStitchSse — error paths', () => {
                         at: 0,
                     },
                 ]),
-                { errorData: (e) => e.message },
+                { error: (e) => e.message },
             ),
         );
 
@@ -192,7 +217,7 @@ describe('streamStitchSse — error paths', () => {
         expect(body).toContain('data: upstream failed');
     });
 
-    test('a throw mid-stream is caught: onError fires and a final generic event: error frame is written (raw message withheld)', async () => {
+    test('a throw mid-stream is caught: error.observe fires and a final generic event: error frame is written (raw message withheld)', async () => {
         let captured: unknown;
         async function* boom(): AsyncGenerator<StitchEvent, void> {
             yield { type: 'delta', chunk: 'a', at: 0 };
@@ -202,8 +227,10 @@ describe('streamStitchSse — error paths', () => {
         const app = new Hono();
         app.get('/x', (c) =>
             streamStitchSse(c, boom(), {
-                onError: (e) => {
-                    captured = e;
+                error: {
+                    observe: (e) => {
+                        captured = e;
+                    },
                 },
             }),
         );
@@ -214,13 +241,13 @@ describe('streamStitchSse — error paths', () => {
         expect(body).toContain('data: error');
         expect(body).not.toContain('payments.internal.corp');
         expect(body).not.toContain('ENOTFOUND');
-        // onError still sees the real thrown error server-side.
+        // error.observe still sees the real thrown error server-side.
         expect((captured as Error).message).toBe(
             'getaddrinfo ENOTFOUND payments.internal.corp',
         );
     });
 
-    test('errorData opts in on the throw path too (thrown error normalised to an error event)', async () => {
+    test('error opts in on the throw path too (thrown error normalised to an error event)', async () => {
         async function* boom(): AsyncGenerator<StitchEvent, void> {
             yield { type: 'delta', chunk: 'a', at: 0 };
             throw new Error('stream blew up');
@@ -228,7 +255,7 @@ describe('streamStitchSse — error paths', () => {
 
         const app = new Hono();
         app.get('/x', (c) =>
-            streamStitchSse(c, boom(), { errorData: (e) => e.message }),
+            streamStitchSse(c, boom(), { error: (e) => e.message }),
         );
 
         const body = await (await app.request('/x')).text();

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -59,7 +59,7 @@ import { sseResponse } from '@stitchapi/next';
 export async function POST(request: Request) {
     const { prompt } = await request.json();
     return sseResponse(chat({ body: { prompt } }).stream(), {
-        data: (c) => String(c), // pull text out of each chunk
+        delta: (c) => String(c), // pull text out of each chunk
         signal: request.signal, // abort the upstream if the client leaves
     });
 }
@@ -67,13 +67,15 @@ export async function POST(request: Request) {
 
 Pass `request.signal` so a client disconnect tears the stitch down rather than leaving it running.
 
-By default the `error` frame carries a generic `data: error` token, **not** the raw error message — echoing it can disclose internal network topology (a transport failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to the client. Pass `errorData` to opt in when the upstream messages are known safe to expose:
+By default the `error` frame carries a generic `data: error` token, **not** the raw error message — echoing it can disclose internal network topology (a transport failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to the client. Pass `error` to opt in when the upstream messages are known safe to expose:
 
 ```ts
 return sseResponse(chat({ body: { prompt } }).stream(), {
-    errorData: (e) => e.message, // opt in to the raw upstream message
+    error: (e) => e.message, // opt in to the raw upstream message
 });
 ```
+
+Both `delta` and `error` also take the full object form — `delta: { data, event, id }` and `error: { data, event, observe }` — e.g. `error.observe` logs the real failure server-side while the client still gets the generic token.
 
 ## License
 

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -30,28 +30,65 @@ export type StitchEventSource<T> =
 /** The terminal `error` event a stitch stream emits — carries `message`, `status`, `attempts`. */
 type StitchErrorEvent = Extract<StitchEvent, { type: 'error' }>;
 
-export interface SseResponseOptions {
+/** Shape a `delta` chunk into the SSE frame `data`. */
+type DeltaShaper = (chunk: unknown) => string;
+/** Shape a terminal `error` event into the SSE frame `data`. */
+type ErrorShaper = (event: StitchErrorEvent) => string;
+
+// How each `delta` becomes a frame. The bare {@link DeltaShaper} form (`delta: (c) => …`) is
+// shorthand for `{ data: (c) => … }`.
+interface DeltaFrameOptions {
     /**
      * Map a `delta` chunk to the SSE frame `data`. Default: the chunk itself (a
-     * string as-is; anything else `JSON.stringify`-ed). Use it to pull text out of a
-     * structured chunk, e.g. `data: (c) => c.choices[0].delta.content`.
+     * string as-is; anything else `JSON.stringify`-ed). Pull text out of a structured
+     * chunk with, e.g., `(c) => c.choices[0].delta.content`.
      */
-    data?: (chunk: unknown) => string;
+    data?: DeltaShaper;
     /** Emit an `event:` line per frame (the SSE event name). Default: unnamed. */
     event?: string;
     /** Provide an `id:` line per frame (the SSE last-event id), for resumable streams. */
     id?: (chunk: unknown, index: number) => string;
+}
+
+// How the terminal `error` becomes the final frame. The bare {@link ErrorShaper} form
+// (`error: (e) => …`) is shorthand for `{ data: (e) => … }`.
+interface ErrorFrameOptions {
     /**
-     * Shape the SSE `data` written for a terminal `error` event (or an uncaught throw
+     * Shape the SSE `data` written for the terminal `error` event (or an uncaught throw
      * mid-stream, normalised to an error event). **Default: a generic token (`data: error`)**
      * — the raw `event.message` is deliberately *not* echoed, because it can disclose internal
      * network topology (a transport failure reads like
      * `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to
      * an untrusted client. Opt in with `(e) => e.message` when the upstream messages are known
      * safe, or return your own payload (e.g. `() => JSON.stringify({ error: 'stream failed' })`).
-     * A multi-line return gets one `data:` line each (SSE spec); the `event: error` name is fixed.
+     * A multi-line return gets one `data:` line each (SSE spec).
      */
-    errorData?: (event: StitchErrorEvent) => string;
+    data?: ErrorShaper;
+    /** The `event:` name of the terminal error frame. Default `'error'`. */
+    event?: string;
+    /**
+     * Observe the real, server-side failure (a stitch `error` event, or a throw) — use it to
+     * log/trace. It does **not** shape the client frame: what the client receives is controlled
+     * by {@link ErrorFrameOptions.data} (a generic token by default), so the raw message reaches
+     * your logs here but never the client.
+     */
+    observe?: (err: unknown) => void;
+}
+
+export interface SseResponseOptions {
+    /**
+     * How each `delta` becomes a frame. Pass a **function** as shorthand for `{ data }`
+     * (`delta: (c) => c.text`), or the full `{ data, event, id }` object to set the SSE
+     * `event:` / `id:` lines too.
+     */
+    delta?: DeltaShaper | DeltaFrameOptions;
+    /**
+     * How the terminal error becomes the final frame. Pass a **function** as shorthand for
+     * `{ data }` (`error: (e) => e.message`), or the full `{ data, event, observe }` object. By
+     * default the client gets a generic `data: error` token — the raw message is withheld to
+     * avoid disclosing internal topology.
+     */
+    error?: ErrorShaper | ErrorFrameOptions;
     /** Extra response headers (merged over the SSE defaults). */
     headers?: Record<string, string>;
     /** Abort the upstream iterator when this fires — pass the route handler's
@@ -59,42 +96,48 @@ export interface SseResponseOptions {
     signal?: AbortSignal;
 }
 
+// Expand the function-shorthand form of each frame option to its full config object.
+const asDelta = (o: DeltaShaper | DeltaFrameOptions = {}): DeltaFrameOptions =>
+    typeof o === 'function' ? { data: o } : o;
+const asError = (o: ErrorShaper | ErrorFrameOptions = {}): ErrorFrameOptions =>
+    typeof o === 'function' ? { data: o } : o;
+
 // One delta chunk → an SSE frame. A multi-line payload is split so every line gets
 // its own `data:` prefix (the SSE spec joins them with `\n`); the frame ends blank.
 function frame(
     chunk: unknown,
     index: number,
-    options: SseResponseOptions,
+    delta: DeltaFrameOptions,
 ): string {
-    const payload = options.data
-        ? options.data(chunk)
+    const payload = delta.data
+        ? delta.data(chunk)
         : typeof chunk === 'string'
           ? chunk
           : JSON.stringify(chunk);
     let out = '';
-    if (options.event) out += `event: ${options.event}\n`;
-    if (options.id) out += `id: ${options.id(chunk, index)}\n`;
+    if (delta.event) out += `event: ${delta.event}\n`;
+    if (delta.id) out += `id: ${delta.id(chunk, index)}\n`;
     for (const line of payload.split('\n')) out += `data: ${line}\n`;
     return `${out}\n`;
 }
 
 // The generic token written as an `error` frame's `data` by default: the raw upstream message
 // is withheld so an internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status
-// (`HTTP 401`) never reaches the client. Override with `options.errorData`.
+// (`HTTP 401`) never reaches the client. Override with `error.data`.
 const DEFAULT_ERROR_DATA = 'error';
 
-// The terminal `error` frame: the fixed `event: error` name plus a (multi-line-safe) data
-// payload — every line of `data` gets its own `data:` prefix so a multi-line opt-in payload
-// can't break the SSE framing.
-function errorFrame(data: string): string {
-    let out = 'event: error\n';
+// The terminal `error` frame: the (configurable, default `error`) event name plus a
+// (multi-line-safe) data payload — every line of `data` gets its own `data:` prefix so a
+// multi-line opt-in payload can't break the SSE framing.
+function errorFrame(data: string, event: string): string {
+    let out = `event: ${event}\n`;
     for (const line of data.split('\n')) out += `data: ${line}\n`;
     return `${out}\n`;
 }
 
-// Normalise a thrown value into the terminal `error` event shape, so an `errorData` opt-in sees
+// Normalise a thrown value into the terminal `error` event shape, so an `error.data` opt-in sees
 // a consistent argument whether the failure arrived as a surfaced `error` event or an unexpected
-// throw. `attempts`/`at` are best-effort placeholders — an `errorData` hook keys off `name`/`message`.
+// throw. `attempts`/`at` are best-effort placeholders — an `error.data` hook keys off `name`/`message`.
 function toErrorEvent(reason: unknown): StitchErrorEvent {
     const e = reason instanceof Error ? reason : new Error(String(reason));
     return {
@@ -110,7 +153,7 @@ function toErrorEvent(reason: unknown): StitchErrorEvent {
  * Stream a stitch's events as a `text/event-stream` `Response`. Each `delta` becomes
  * one frame; an `error` event ends the stream with a named `event: error` frame (a generic
  * `data: error` by default — the raw message is withheld to avoid disclosing internal topology;
- * opt in via `errorData`); the terminal `result`/`done` closes it.
+ * opt in via `error`); the terminal `result`/`done` closes it.
  *
  * ```ts
  * // app/api/chat/route.ts
@@ -119,7 +162,7 @@ function toErrorEvent(reason: unknown): StitchErrorEvent {
  * export async function POST(request: Request) {
  *     const { prompt } = await request.json();
  *     return sseResponse(chat({ body: { prompt } }).stream(), {
- *         data: (c) => String(c),
+ *         delta: (c) => String(c),
  *         signal: request.signal, // abort the upstream if the client leaves
  *     });
  * }
@@ -129,6 +172,8 @@ export function sseResponse<T>(
     source: StitchEventSource<T>,
     options: SseResponseOptions = {},
 ): Response {
+    const delta = asDelta(options.delta);
+    const error = asError(options.error);
     const encoder = new TextEncoder();
     let index = 0;
     const stream = new ReadableStream<Uint8Array>({
@@ -138,21 +183,22 @@ export function sseResponse<T>(
                     if (options.signal?.aborted) break;
                     if (event.type === 'delta') {
                         controller.enqueue(
-                            encoder.encode(
-                                frame(event.chunk, index++, options),
-                            ),
+                            encoder.encode(frame(event.chunk, index++, delta)),
                         );
                     } else if (event.type === 'error') {
                         // Surface the failure as a named `error` frame, then stop — but by default
                         // write a generic token, never the raw `event.message`, so an internal
                         // hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`)
-                        // is not disclosed. Opt in to the real message via `options.errorData`.
+                        // is not disclosed. Opt in via `error.data`; `error.observe` sees the real
+                        // failure server-side.
+                        error.observe?.(new Error(event.message));
                         controller.enqueue(
                             encoder.encode(
                                 errorFrame(
-                                    options.errorData
-                                        ? options.errorData(event)
+                                    error.data
+                                        ? error.data(event)
                                         : DEFAULT_ERROR_DATA,
+                                    error.event ?? 'error',
                                 ),
                             ),
                         );
@@ -163,14 +209,16 @@ export function sseResponse<T>(
                 }
             } catch (reason) {
                 // A throw (not a surfaced `error` event): still withhold the raw message by
-                // default — normalise it to an error event so an `errorData` opt-in sees a
+                // default — normalise it to an error event so an `error.data` opt-in sees a
                 // consistent shape.
+                error.observe?.(reason);
                 controller.enqueue(
                     encoder.encode(
                         errorFrame(
-                            options.errorData
-                                ? options.errorData(toErrorEvent(reason))
+                            error.data
+                                ? error.data(toErrorEvent(reason))
                                 : DEFAULT_ERROR_DATA,
+                            error.event ?? 'error',
                         ),
                     ),
                 );

--- a/packages/next/test/next.spec.ts
+++ b/packages/next/test/next.spec.ts
@@ -55,9 +55,9 @@ describe('sseResponse', () => {
         expect(body).toBe('data: a\n\ndata: b\n\n');
     });
 
-    test('a `data` mapper pulls text out of a structured chunk', async () => {
+    test('a `delta` function shorthand pulls text out of a structured chunk', async () => {
         const res = sseResponse(events(delta({ text: 'hi' }), done), {
-            data: (c) => (c as { text: string }).text,
+            delta: (c) => (c as { text: string }).text,
         });
         expect(await res.text()).toBe('data: hi\n\n');
     });
@@ -83,7 +83,7 @@ describe('sseResponse', () => {
         expect(body).not.toContain('ENOTFOUND');
     });
 
-    test('errorData opts in to the raw message on the error frame', async () => {
+    test('error (function shorthand) opts in to the raw message on the error frame', async () => {
         const res = sseResponse(
             events(delta('a'), {
                 type: 'error',
@@ -92,7 +92,7 @@ describe('sseResponse', () => {
                 attempts: 1,
                 at: 0,
             }),
-            { errorData: (e) => e.message },
+            { error: (e) => e.message },
         );
         const body = await res.text();
         expect(body).toBe(
@@ -100,14 +100,16 @@ describe('sseResponse', () => {
         );
     });
 
-    test('the event option labels each frame', async () => {
-        const res = sseResponse(events(delta('a'), done), { event: 'token' });
+    test('the delta.event option labels each frame', async () => {
+        const res = sseResponse(events(delta('a'), done), {
+            delta: { event: 'token' },
+        });
         expect(await res.text()).toBe('event: token\ndata: a\n\n');
     });
 
-    test('the id option emits an id: line per frame with the zero-based index', async () => {
+    test('the delta.id option emits an id: line per frame with the zero-based index', async () => {
         const res = sseResponse(events(delta('a'), delta('b'), done), {
-            id: (chunk, i) => `${String(chunk)}-${i}`,
+            delta: { id: (chunk, i) => `${String(chunk)}-${i}` },
         });
         expect(await res.text()).toBe(
             'id: a-0\ndata: a\n\nid: b-1\ndata: b\n\n',
@@ -153,14 +155,51 @@ describe('sseResponse', () => {
         expect(body).not.toContain('ENOTFOUND');
     });
 
-    test('errorData opts in to the raw message on the throw path too', async () => {
+    test('error opts in to the raw message on the throw path too', async () => {
         async function* boom(): AsyncGenerator<StitchEvent, void> {
             yield delta('a');
             throw new Error('stream blew up');
         }
-        const res = sseResponse(boom(), { errorData: (e) => e.message });
+        const res = sseResponse(boom(), { error: (e) => e.message });
         const body = await res.text();
         expect(body).toBe('data: a\n\nevent: error\ndata: stream blew up\n\n');
+    });
+
+    test('error.observe sees the real failure even when the client gets the generic token', async () => {
+        const observed: unknown[] = [];
+        const res = sseResponse(
+            events(delta('a'), {
+                type: 'error',
+                name: 'StitchError',
+                message: 'getaddrinfo ENOTFOUND payments.internal.corp',
+                status: 502,
+                attempts: 1,
+                at: 0,
+            }),
+            { error: { observe: (err) => observed.push(err) } },
+        );
+        const body = await res.text();
+        // Client still gets the generic token — the raw message is withheld.
+        expect(body).toBe('data: a\n\nevent: error\ndata: error\n\n');
+        expect(body).not.toContain('payments.internal.corp');
+        // … but observe got the real failure server-side.
+        expect((observed[0] as Error).message).toContain('ENOTFOUND');
+    });
+
+    test('error can be the full object with a custom event name', async () => {
+        const res = sseResponse(
+            events(delta('a'), {
+                type: 'error',
+                name: 'StitchError',
+                message: 'upstream blew up',
+                attempts: 1,
+                at: 0,
+            }),
+            { error: { data: (e) => e.message, event: 'failure' } },
+        );
+        expect(await res.text()).toBe(
+            'data: a\n\nevent: failure\ndata: upstream blew up\n\n',
+        );
     });
 });
 


### PR DESCRIPTION
Replaces the flat, asymmetric SSE frame options with two **symmetric envelopes** — `delta` and `error` — each accepting a bare shaper function as shorthand for `{ data }`. Supersedes #478 (the `errorData` → `payload` rename) and stacks on #476, same as #478 did.

## Why

Every SSE host exposed the delta frame as `data` / `event` / `id` but the error frame as a single, prefixed `errorData` — a stutter beside `data`, and asymmetric. hono/elysia additionally carried a floating `onError`. #478 renamed `errorData` → `payload`, but `payload` is a fourth noun outside the `data` / `error` house vocabulary (CONTRACT.md D1: success payload = `data`, failure payload = `error`) and drops the "error" signal.

## What

```ts
// shorthand — a bare function is `{ data }`, so the happy path stays terse
streamStitchSse(res, s, { delta: (c) => c.text, error: (e) => e.message });

// full form
streamStitchSse(res, s, {
    delta: { data: (c) => c.text, event: 'token', id: (_, i) => String(i) },
    error: { data: (e) => e.message, event: 'failure', observe: (err) => log.error(err) },
});
```

- **`delta`**: `{ data, event, id }`. `id` is now wired on **hono/elysia** too (was express/fastify/next only) — the envelope is identical on every host.
- **`error`**: `{ data, event, observe }`. `observe` folds in hono/elysia's floating `onError` and is now available everywhere; the error frame's `event:` name is configurable (was hardcoded `error`). The client still gets a generic `data: error` token by default — the raw upstream/transport message is withheld to avoid topology disclosure (the behaviour #476 / #422 / #426 established).
- A bare function is shorthand for `{ data }` on both, matching the house pattern for polymorphic option values (`Secret`, `url`, durations).

## Hosts

`express` · `fastify` · `hono` · `next` · `elysia` — identical option shape across all five.

## Contract

`docs/CONTRACT.md` P16 now records `delta` / `error` as the settled cross-host shape and forbids the old `errorData` / `onError` / `payload` spellings.

## Verification

- `check:format`, `check:contract` (no new violations), `check:types` (38 packages), `check:lint`
- build + tests for all five hosts: express 21 · fastify 23 · hono 20 · next 20 · elysia 25
- docs twoslash typecheck (`fumadocs-mdx`) — green

## Supersedes #478

This replaces #478 in the stack (same base, `fix/elysia-sse-error-leak`). #478 will be closed with a pointer here once this is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
