### PR TITLE
refactor(auth)!: apiKey — symmetric name+in triad (header/query/cookie)

### DIFF
--- a/apps/docs/content/blog/call-any-llm-as-a-typed-function.mdx
+++ b/apps/docs/content/blog/call-any-llm-as-a-typed-function.mdx
@@ -45,7 +45,7 @@ import { anthropic, llm } from 'stitchapi/llm';
 const chat = llm({
     provider: anthropic,
     model: 'claude-opus-4-8',
-    auth: apiKey({ header: 'x-api-key', value: env('ANTHROPIC_API_KEY') }),
+    auth: apiKey({ name: 'x-api-key', value: env('ANTHROPIC_API_KEY') }),
 });
 
 const { text } = await chat({
@@ -85,7 +85,7 @@ const { text } = await chat({
 });
 ```
 
-`openai` authenticates with `bearer(env('OPENAI_API_KEY'))`; `anthropic` authenticates with `apiKey({ header: 'x-api-key', value: env('ANTHROPIC_API_KEY') })`. The provider absorbs the wire difference — different URL, different header, different body and response shapes — and `result.text` is the same on both sides. The code that sends messages and reads the completion does not move.
+`openai` authenticates with `bearer(env('OPENAI_API_KEY'))`; `anthropic` authenticates with `apiKey({ name: 'x-api-key', value: env('ANTHROPIC_API_KEY') })`. The provider absorbs the wire difference — different URL, different header, different body and response shapes — and `result.text` is the same on both sides. The code that sends messages and reads the completion does not move.
 
 When you need a provider that does not ship first-party, you implement the same contract the built-ins do. An `LlmProvider` declares its `id`, its full completions `url`, optional non-secret `headers`, an optional `defaultModel`, a `buildBody` that maps a normalised `LlmRequest` to that vendor's wire body, and a `parse` that lifts the response back into an `LlmResult`:
 
@@ -136,7 +136,7 @@ const fast = llm({
 const deep = llm({
     provider: anthropic,
     model: 'claude-opus-4-8',
-    auth: apiKey({ header: 'x-api-key', value: env('ANTHROPIC_API_KEY') }),
+    auth: apiKey({ name: 'x-api-key', value: env('ANTHROPIC_API_KEY') }),
 });
 
 async function summarize(input: string, hard: boolean) {
@@ -162,7 +162,7 @@ import { anthropic, llm } from 'stitchapi/llm';
 const chat = llm({
     provider: anthropic,
     model: 'claude-opus-4-8',
-    auth: apiKey({ header: 'x-api-key', value: env('ANTHROPIC_API_KEY') }),
+    auth: apiKey({ name: 'x-api-key', value: env('ANTHROPIC_API_KEY') }),
     retry: {
         attempts: 3,
         on: [429, 529],

--- a/apps/docs/content/docs/getting-started/migration-notes.mdx
+++ b/apps/docs/content/docs/getting-started/migration-notes.mdx
@@ -20,7 +20,7 @@ server exposing items behind an API key.
 
 ## Header names go on the wire lowercase
 
-You configure `apiKey({ header: 'X-Catalog-Token', ... })` and your fixture
+You configure `apiKey({ name: 'X-Catalog-Token', ... })` and your fixture
 asserts the request carried a header literally named `X-Catalog-Token`.
 
 A stitch lowercases the header name: it sends `x-catalog-token`. The default
@@ -33,7 +33,7 @@ import { apiKey, env, stitch } from 'stitchapi';
 const getItem = stitch({
     baseUrl: 'https://api.example.com',
     path: '/items/{id}',
-    auth: apiKey({ header: 'X-Catalog-Token', value: env('CATALOG_TOKEN') }),
+    auth: apiKey({ name: 'X-Catalog-Token', value: env('CATALOG_TOKEN') }),
 });
 // On the wire, the request header is `x-catalog-token`, not `X-Catalog-Token`.
 ```

--- a/apps/docs/content/docs/guides/auth/api-key.mdx
+++ b/apps/docs/content/docs/guides/auth/api-key.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'apiKey'
-description: 'Send an API key as a header or query parameter, resolved at call time.'
+description: 'Send an API key as a header, query parameter, or cookie, resolved at call time.'
 prerequisites:
     ['/docs/concepts/the-stitch', '/docs/concepts/capability-not-credential']
 ---
@@ -30,13 +30,16 @@ the capability boundary.
 [`env('API_KEY')`](/docs/guides/auth/secret-resolvers) so the secret is read at
 call time and never committed.
 
-`in` chooses where the key goes: `'header'` (the default) or `'query'`.
+`in` chooses where the key goes: `'header'` (the default), `'query'`, or
+`'cookie'`.
 
-`header` overrides the header name (default `x-api-key`, lowercased) when
-`in: 'header'`: pass `apiKey({ header: 'X-My-Key', value: env('API_KEY') })` to
-send the key under a custom header. The name goes on the wire **lowercased**
-(`x-my-key`) — case-insensitive per HTTP, but worth knowing if a fixture asserts
-the original casing. See [Migration notes](/docs/getting-started/migration-notes).
+`name` labels the key in every arm — the header name, the query-parameter name,
+or the cookie name. It defaults to `X-API-Key` for a header and `api_key` for a
+query parameter or cookie. For a custom header, pass
+`apiKey({ name: 'X-My-Key', value: env('API_KEY') })`. A header name goes on the
+wire **lowercased** (`x-my-key`) — case-insensitive per HTTP, but worth knowing
+if a fixture asserts the original casing. See
+[Migration notes](/docs/getting-started/migration-notes).
 
 ## In a query parameter
 
@@ -68,6 +71,25 @@ Every call appends `&api_key=<resolved>` to the URL. `name` is the parameter nam
     `input.query`) it is redacted to `REDACTED`, exactly like
     `api_key`/`access_token`. None of that protects the upstream server's logs.
 </Callout>
+
+## In a cookie
+
+Some APIs read the key from a cookie. Set `in: 'cookie'`; the key is appended to
+the `Cookie` header as `name=<resolved>` at call time, merged with any cookie the
+request already carries:
+
+```ts twoslash
+import { apiKey, env, stitch } from 'stitchapi';
+
+const search = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/search',
+    auth: apiKey({ in: 'cookie', name: 'api_key', value: env('API_KEY') }),
+});
+```
+
+The `Cookie` header is on StitchAPI's trace denylist, so the key is redacted from
+sinks exactly like a header key — no separate scrubber registration is needed.
 
 See [Reference → Auth strategies](/docs/reference/auth-strategies) for every
 field.

--- a/apps/docs/content/docs/reference/auth-strategies.mdx
+++ b/apps/docs/content/docs/reference/auth-strategies.mdx
@@ -17,9 +17,9 @@ import { bearer } from 'stitchapi';
 
 ## apiKey
 
-Sends a secret in a header (`x-api-key` by default), or — with `in: 'query'` — as
-a URL query parameter (`api_key` by default), resolved and URL-encoded at call
-time.
+Sends a secret in a header (`X-API-Key` by default), a query parameter
+(`in: 'query'`, `api_key` by default, URL-encoded), or a cookie (`in: 'cookie'`).
+`name` labels the key in every arm, resolved at call time.
 
 ```ts twoslash
 import { apiKey } from 'stitchapi';

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -452,6 +452,13 @@ field is gone. The **wire** side still follows its own standard — W3C Trace Co
 [ADR 0017 Decision 7](adr/0017-outbound-trace-context-propagation.md) and the
 `concepts/run-identity` page.
 
+_Also:_ `apiKey`'s options mirror OpenAPI's `apiKey` security scheme: the key is labelled with
+**`name`** and located with **`in: 'header' | 'query' | 'cookie'`** — the same two fields in every
+arm. So `stitch gen openapi` (import) and `stitch export --openapi` (export) are identity mappings
+with no translation seam, and the three locations are symmetric
+([P16](#p16--cross-surface--cross-package-parity)). The pre-GA sweep removed the header-only
+`header` alias: **`name` is the only spelling — `apiKey({ header })` is forbidden.**
+
 ### P23 · One schema intake; foreign formats enter through one adapter
 
 Every place that consumes a validation schema — a stitch's `input`/`output`, and the

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -177,27 +177,72 @@ export function bearer(token: Secret | OptionalSecret): AuthStrategy {
 }
 
 /**
- * API-key auth, in a request **header** (the default) or a **query param**. The key is a
- * {@link Secret} resolved at call time — the caller (an agent) never sees it.
+ * Options for {@link apiKey}. `in` selects where the key goes and `name` labels it there — the same
+ * two fields for every location (they no longer diverge by arm), so the shape maps 1:1 onto
+ * OpenAPI's `apiKey` security scheme (`{ name, in }`, CONTRACT.md P22).
  *
- * - `in: 'header'` (default): writes `header` (default `'x-api-key'`, lower-cased) — byte-for-byte
- *   the original behaviour, so existing stitches are unaffected.
- * - `in: 'query'`: appends `name=<resolved>` (default `'api_key'`) to the request URL,
- *   URL-encoded. The strategy runs in the attempt loop on the fully-built `req` (after
- *   templating/query-building), so it safely appends onto whatever query the URL already carries.
+ * Local (non-exported) — like {@link OAuth2Options}/{@link CookieSessionOptions}, the builder's
+ * param type is not part of the package's public export surface (P16: none of the auth option
+ * types are). It is inlined into `apiKey`'s emitted `.d.ts`.
+ */
+interface ApiKeyOptions {
+    /** Where the key is sent. Default `'header'`. */
+    in?: 'header' | 'query' | 'cookie';
+    /**
+     * Name of the header, query parameter, or cookie the key is sent as. Default `'X-API-Key'` for
+     * a header (sent lower-cased), `'api_key'` for a query parameter or cookie.
+     */
+    name?: string;
+    /** The key itself — a {@link Secret} resolved at call time; the caller never sees it. */
+    value: Secret;
+}
+
+/**
+ * Set `name=value` on a request `Cookie` header, REPLACING any existing pair with the same name
+ * (a duplicate cookie name is ambiguous — RFC 6265 §5.4 — and re-applying the strategy on a retry
+ * must stay idempotent) while keeping the other pairs in place. Cookie names are case-sensitive, so
+ * the match is exact.
+ */
+function setCookiePair(
+    existing: string | undefined,
+    name: string,
+    value: string,
+): string {
+    const parts = (existing ?? '')
+        .split(';')
+        .map((p) => p.trim())
+        .filter(Boolean);
+    const idx = parts.findIndex((p) => {
+        const eq = p.indexOf('=');
+        return (eq < 0 ? p : p.slice(0, eq)).trim() === name;
+    });
+    const pair = `${name}=${value}`;
+    if (idx >= 0) parts[idx] = pair;
+    else parts.push(pair);
+    return parts.join('; ');
+}
+
+/**
+ * API-key auth, sent in a request **header** (the default), a **query param**, or a **cookie**.
+ * `in` selects the location and `name` labels it in every arm (matching OpenAPI's `{ name, in }`).
+ * The key is a {@link Secret} resolved at call time — the caller (an agent) never sees it.
+ *
+ * - `in: 'header'` (default): writes the `name` header (default `'X-API-Key'`, lower-cased on the wire).
+ * - `in: 'query'`: appends `name=<resolved>` (default `'api_key'`) to the request URL, URL-encoded.
+ *   The strategy runs in the attempt loop on the fully-built `req` (after templating/query-building),
+ *   so it safely appends onto whatever query the URL already carries.
+ * - `in: 'cookie'`: appends `name=<resolved>` (default `'api_key'`) to the `Cookie` header, merging
+ *   with any cookie the request already carries.
  *
  * SECURITY: a key in the URL leaks wherever URLs go — server access logs, proxies, the browser
- * history, a `Referer` header. Prefer `in: 'header'` when the API accepts it. The key stays out of
- * StitchAPI's own traces two ways: the strategy mutates only the request the transport sends (the
- * `start` event carries the pre-auth URL, so the key never lands there), and the configured query
- * `name` is registered with the URL-credential scrubber, so if it does surface in a sink (an OTLP
- * `url.full`, the structured `input.query`) it is REDACTED, like `api_key`/`access_token`/… are.
+ * history, a `Referer` header. Prefer `in: 'header'` (or `'cookie'`) when the API accepts it. The
+ * key stays out of StitchAPI's own traces: the strategy mutates only the request the transport
+ * sends (the `start` event carries the pre-auth request, so the key never lands there); the `header`
+ * and `cookie` arms write header names already on the trace denylist (`cookie` / `x-api-key`); and
+ * the `query` arm registers its `name` with the URL-credential scrubber, so if the key surfaces in a
+ * sink (an OTLP `url.full`, the structured `input.query`) it is REDACTED, like `api_key`/… are.
  */
-export function apiKey(
-    opts:
-        | { in?: 'header'; header?: string; value: Secret }
-        | { in: 'query'; name?: string; value: Secret },
-): AuthStrategy {
+export function apiKey(opts: ApiKeyOptions): AuthStrategy {
     if (opts.in === 'query') {
         const name = opts.name ?? 'api_key';
         // Teach the trace scrubber this param name carries a secret, so the key never reaches a
@@ -217,7 +262,26 @@ export function apiKey(
             },
         };
     }
-    const headerName = opts.header ?? 'X-API-Key';
+    if (opts.in === 'cookie') {
+        const name = opts.name ?? 'api_key';
+        return {
+            name: 'apiKey',
+            scheme: { type: 'apiKey', in: 'cookie', name },
+            apply(req) {
+                // Send the key as a cookie: set `name=value` on the Cookie header, replacing any
+                // same-named cookie the request already carries (never a duplicate; idempotent on
+                // retry) and keeping the rest. The value is sent verbatim — a cookie is read
+                // byte-for-byte, unlike a percent-decoded query param. The `cookie` header is on
+                // the trace denylist, so the key is redacted from sinks like the header arm.
+                req.headers['cookie'] = setCookiePair(
+                    req.headers['cookie'],
+                    name,
+                    resolve(opts.value),
+                );
+            },
+        };
+    }
+    const headerName = opts.name ?? 'X-API-Key';
     const header = headerName.toLowerCase();
     return {
         name: 'apiKey',

--- a/packages/core/src/from-curl.ts
+++ b/packages/core/src/from-curl.ts
@@ -941,7 +941,7 @@ function renderAuth(auth: AuthEmit): string {
             return auth.queryName
                 ? `apiKey({ in: 'query', name: '${auth.queryName}', value: env('${auth.envName}') })`
                 : auth.header && auth.header.toLowerCase() !== 'x-api-key'
-                  ? `apiKey({ header: '${auth.header}', value: env('${auth.envName}') })`
+                  ? `apiKey({ name: '${auth.header}', value: env('${auth.envName}') })`
                   : `apiKey({ value: env('${auth.envName}') })`;
         case 'basic':
             return `basic({ user: env('${auth.userEnv}'), pass: env('${auth.passEnv}') })`;

--- a/packages/core/test/HARNESS-API.md
+++ b/packages/core/test/HARNESS-API.md
@@ -76,7 +76,7 @@ Drift is schema-anchored — no snapshot (ADR 0015). Each call validates the unw
 
 ## Auth
 
-`bearer(secret)`, `apiKey({ in?, name?, value })`, `basic({ user, pass })`, `cookieSession({ login: <stitch>, cookie: 'sid', loginInput?: () => StitchInput, refresh?: [401] })`. Secrets: `env('VAR')` / `secretsFile('name')` return `() => string` resolved at call time. `cookieSession` auto-logs-in when no cookie is stored, replays the captured cookie, and re-logs-in when a response status is matched by `refresh`.
+`bearer(secret)`, `apiKey({ name?, in?, value })` (`in: 'header' | 'query' | 'cookie'`, default `header`), `basic({ user, pass })`, `cookieSession({ login: <stitch>, cookie: 'sid', loginInput?: () => StitchInput, refresh?: [401] })`. Secrets: `env('VAR')` / `secretsFile('name')` return `() => string` resolved at call time. `cookieSession` auto-logs-in when no cookie is stored, replays the captured cookie, and re-logs-in when a response status is matched by `refresh`.
 
 ## Mock server
 

--- a/packages/core/test/apikey-location.spec.ts
+++ b/packages/core/test/apikey-location.spec.ts
@@ -1,0 +1,95 @@
+// apiKey's location model (CONTRACT.md P16/P22): ONE builder with three symmetric arms — `name`
+// labels the key in every arm and `in` selects where it goes: header (default) / query / cookie.
+// The cookie arm makes `in: 'cookie'` a first-class location (matching OpenAPI's three `in` values),
+// so an OpenAPI `apiKey` cookie scheme maps to a real strategy instead of a not-auto-mapped warning.
+import { apiKey, stitch } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+describe('apiKey — location model (header / query / cookie)', () => {
+    test("in: 'header' (default) writes the named header, lower-cased on the wire", async () => {
+        server.route('GET', '/thing', { body: { ok: true } });
+        const s = stitch({
+            baseUrl: server.url,
+            path: '/thing',
+            auth: apiKey({ name: 'X-My-Key', value: 'tok' }),
+        });
+        await s();
+        expect(server.calls('/thing')[0]?.headers['x-my-key']).toBe('tok');
+    });
+
+    test('header name defaults to x-api-key', async () => {
+        server.route('GET', '/thing', { body: { ok: true } });
+        const s = stitch({
+            baseUrl: server.url,
+            path: '/thing',
+            auth: apiKey({ value: 'tok' }),
+        });
+        await s();
+        expect(server.calls('/thing')[0]?.headers['x-api-key']).toBe('tok');
+    });
+
+    test("in: 'query' appends the named param to the URL", async () => {
+        server.route('GET', '/thing', { body: { ok: true } });
+        const s = stitch({
+            baseUrl: server.url,
+            path: '/thing',
+            auth: apiKey({ in: 'query', name: 'access_token', value: 'tok' }),
+        });
+        await s();
+        expect(server.calls('/thing')[0]?.query['access_token']).toBe('tok');
+    });
+
+    test("in: 'cookie' sends the key as a cookie", async () => {
+        server.route('GET', '/thing', { body: { ok: true } });
+        const s = stitch({
+            baseUrl: server.url,
+            path: '/thing',
+            auth: apiKey({ in: 'cookie', name: 'sid', value: 'tok' }),
+        });
+        await s();
+        const call = server.calls('/thing')[0];
+        expect(call?.headers['cookie']).toBe('sid=tok');
+        expect(call?.cookies['sid']).toBe('tok');
+    });
+
+    test("in: 'cookie' merges with a cookie the request already carries", async () => {
+        server.route('GET', '/thing', { body: { ok: true } });
+        const s = stitch({
+            baseUrl: server.url,
+            path: '/thing',
+            headers: { cookie: 'theme=dark' },
+            auth: apiKey({ in: 'cookie', name: 'sid', value: 'tok' }),
+        });
+        await s();
+        const call = server.calls('/thing')[0];
+        expect(call?.headers['cookie']).toBe('theme=dark; sid=tok');
+        expect(call?.cookies).toMatchObject({ theme: 'dark', sid: 'tok' });
+    });
+
+    test("in: 'cookie' replaces a same-named cookie instead of duplicating it", async () => {
+        server.route('GET', '/thing', { body: { ok: true } });
+        const s = stitch({
+            baseUrl: server.url,
+            path: '/thing',
+            headers: { cookie: 'sid=stale; theme=dark' },
+            auth: apiKey({ in: 'cookie', name: 'sid', value: 'fresh' }),
+        });
+        await s();
+        const call = server.calls('/thing')[0];
+        // exactly one `sid` — replaced in place, not appended — and the other cookie preserved
+        expect(call?.headers['cookie']).toBe('sid=fresh; theme=dark');
+        expect(call?.cookies['sid']).toBe('fresh');
+    });
+});

--- a/packages/core/test/graphql-and-headers.spec.ts
+++ b/packages/core/test/graphql-and-headers.spec.ts
@@ -38,7 +38,7 @@ describe('GraphQL kind', () => {
         const query = graphql({
             baseUrl: server.url,
             document: 'query($id: ID) { thing(id: $id) { name } }',
-            auth: apiKey({ header: 'apikey', value: env('GQL_KEY') }),
+            auth: apiKey({ name: 'apikey', value: env('GQL_KEY') }),
         });
 
         const out = await query({ variables: { id: 1 } });

--- a/packages/core/test/integration-patterns.spec.ts
+++ b/packages/core/test/integration-patterns.spec.ts
@@ -69,7 +69,7 @@ describe('GraphQL-over-HTTP API (ApiKey header, 1 req/s bucket, retry on 429/5xx
             method: 'POST',
             baseUrl: server.url,
             path: '/graphql',
-            auth: apiKey({ header: 'apikey', value: env('METADATA_API_KEY') }),
+            auth: apiKey({ name: 'apikey', value: env('METADATA_API_KEY') }),
             retry: {
                 attempts: 5,
                 on: [429, 500, 502, 503],
@@ -94,7 +94,7 @@ describe('GraphQL-over-HTTP API (ApiKey header, 1 req/s bucket, retry on 429/5xx
             method: 'POST',
             baseUrl: server.url,
             path: '/graphql',
-            auth: apiKey({ header: 'apikey', value: () => 'sk' }),
+            auth: apiKey({ name: 'apikey', value: () => 'sk' }),
             throttle: { rate: '1/s' },
         });
         const start = Date.now();
@@ -249,7 +249,7 @@ describe('Diverse co-located auth (three providers, three header formats)', () =
             baseUrl: server.url,
             path: '/system',
             auth: apiKey({
-                header: 'authorization',
+                name: 'authorization',
                 value: () => `MediaToken token="${env('MEDIA_A_TOKEN')()}"`,
             }),
         });
@@ -257,7 +257,7 @@ describe('Diverse co-located auth (three providers, three header formats)', () =
             baseUrl: server.url,
             path: '/node',
             auth: apiKey({
-                header: 'x-media-token',
+                name: 'x-media-token',
                 value: env('MEDIA_B_TOKEN'),
             }),
             hooks: {

--- a/packages/core/test/openapi.spec.ts
+++ b/packages/core/test/openapi.spec.ts
@@ -348,7 +348,7 @@ describe('toOpenApi security schemes', () => {
             createThing: stitch({
                 method: 'POST',
                 url: 'https://api.example.com/things',
-                auth: apiKey({ header: 'X-My-Key', value: 'zzz-apikey-cred' }),
+                auth: apiKey({ name: 'X-My-Key', value: 'zzz-apikey-cred' }),
             }),
             grant: stitch({
                 url: 'https://api.example.com/grant',
@@ -442,11 +442,11 @@ describe('toOpenApi security schemes', () => {
         const registry: StitchRegistry = {
             a: stitch({
                 url: 'https://api.example.com/a',
-                auth: apiKey({ header: 'X-Key-A', value: 'k' }),
+                auth: apiKey({ name: 'X-Key-A', value: 'k' }),
             }),
             b: stitch({
                 url: 'https://api.example.com/b',
-                auth: apiKey({ header: 'X-Key-B', value: 'k' }),
+                auth: apiKey({ name: 'X-Key-B', value: 'k' }),
             }),
         };
         const { document } = toOpenApi(registry);

--- a/packages/openapi/src/gen-openapi.ts
+++ b/packages/openapi/src/gen-openapi.ts
@@ -100,9 +100,12 @@ export interface GenOptions {
     validator?: 'types-only' | 'valibot' | 'zod';
     /** ADR 0013 Q3: default `dir`. `single` is not implemented in v1. */
     layout?: 'dir' | 'flat';
-    /** Filters (ADR 0013 Decision 2). `all` overrides the others. */
-    only?: string[]; // operationIds (or derived names)
-    tags?: string[];
+    /**
+     * Filters (ADR 0013 Decision 2). `all` overrides the others. The list-shaped filters take a
+     * bare value too — `tags: 'pets'` ≡ `tags: ['pets']` (CONTRACT.md P7).
+     */
+    only?: string | string[]; // operationIds (or derived names)
+    tags?: string | string[];
     grep?: string; // substring match on the path
     all?: boolean;
 }
@@ -660,19 +663,21 @@ export function planGen(doc: OpenApiDoc, opts: GenOptions = {}): GenResult {
 
 // ---- selection ------------------------------------------------------------
 
+// P7 widening: `tags`/`only` accept a bare string or a list — normalize once here.
+function toList(v: string | string[] | undefined): string[] {
+    return v === undefined ? [] : Array.isArray(v) ? v : [v];
+}
+
 function matches(o: SelectedOp, opts: GenOptions): boolean {
     if (opts.all) return true;
+    const tags = toList(opts.tags);
+    const only = toList(opts.only);
     const hasFilter =
-        (opts.tags?.length ?? 0) > 0 ||
-        (opts.only?.length ?? 0) > 0 ||
-        (opts.grep?.length ?? 0) > 0;
+        tags.length > 0 || only.length > 0 || (opts.grep?.length ?? 0) > 0;
     if (!hasFilter) return false; // selective by default: require an explicit selector
-    if (opts.tags?.length && o.tag && opts.tags.includes(o.tag)) return true;
-    if (opts.only?.length) {
-        if (opts.only.includes(o.name)) return true;
-        if (o.op.operationId && opts.only.includes(o.op.operationId))
-            return true;
-    }
+    if (o.tag && tags.includes(o.tag)) return true;
+    if (only.includes(o.name)) return true;
+    if (o.op.operationId && only.includes(o.op.operationId)) return true;
     if (opts.grep && o.path.includes(opts.grep)) return true;
     return false;
 }
@@ -920,21 +925,27 @@ function deriveAuth(
         scheme.type === 'apiKey' &&
         (scheme.in === 'header' ||
             scheme.in === 'query' ||
+            scheme.in === 'cookie' ||
             scheme.in === undefined)
     ) {
-        // Core's `apiKey()` only has header (default) and query arms — `name` locates the key in
-        // both. Header is the default, so `in: 'header'` is never emitted; a query scheme gets the
-        // `in: 'query'` discriminant. An `in: 'cookie'` scheme has no arm, so it must NOT land here
-        // (it would silently become a header key) — it falls through to the not-auto-mapped warning.
-        const where = scheme.in === 'query' ? `in: 'query', ` : '';
-        const nm = scheme.name ? `name: ${JSON.stringify(scheme.name)}, ` : '';
+        // Core's `apiKey()` models all three OpenAPI locations, discriminated on `in`, with `name`
+        // labelling the key in every arm. Header is the default arm, so `in: 'header'` is never
+        // emitted; `query`/`cookie` carry their `in` discriminant. Any other `in` has no core arm
+        // and falls through to the not-auto-mapped warning instead of silently becoming a header key.
+        const where =
+            scheme.in === 'query' || scheme.in === 'cookie'
+                ? `in: ${q(scheme.in)}, `
+                : '';
+        const nm = scheme.name ? `name: ${q(scheme.name)}, ` : '';
         return {
             expr: `apiKey({ ${where}${nm}value: env('API_KEY') })`,
             imports: ['apiKey', 'env'],
         };
     }
     warnings.push(
-        `security scheme "${schemeName}" (type ${scheme.type ?? '?'}) not auto-mapped — set client.ts auth manually`,
+        `security scheme "${schemeName}" (type ${scheme.type ?? '?'}${
+            scheme.type === 'apiKey' ? `, in ${scheme.in ?? '?'}` : ''
+        }) not auto-mapped — set client.ts auth manually`,
     );
     return { imports: [] };
 }

--- a/packages/openapi/test/gen-openapi.spec.ts
+++ b/packages/openapi/test/gen-openapi.spec.ts
@@ -143,6 +143,21 @@ describe('planGen — selection', () => {
         const r = planGen(doc, { all: true });
         expect(r.selected).toHaveLength(4);
     });
+
+    // P7 widening: the list-shaped filters take a bare value too — `tags: 'users'` ≡ `tags: ['users']`.
+    test('P7: a bare-string tag ≡ a single-element list', () => {
+        const bare = planGen(doc, { tags: 'users' });
+        const list = planGen(doc, { tags: ['users'] });
+        expect(bare.selected.map((s) => s.name).sort()).toEqual(
+            list.selected.map((s) => s.name).sort(),
+        );
+        expect(bare.selected).toHaveLength(3);
+    });
+
+    test('P7: a bare-string only ≡ a single-element list', () => {
+        const r = planGen(doc, { only: 'getUser' });
+        expect(r.selected.map((s) => s.name)).toEqual(['getUser']);
+    });
 });
 
 describe('planGen — ownership (fan-in over the transitive closure)', () => {
@@ -202,17 +217,10 @@ describe('planGen — naming, typing, auth, notice', () => {
         expect(c).not.toMatch(/\bscope\b/);
     });
 
-    test('types-only emits the validation-off notice', () => {
-        const r = planGen(doc, { all: true });
-        expect(r.notices.join('\n')).toMatch(
-            /runtime validation \+ drift are OFF/,
-        );
-    });
-
-    // apiKey auth. Core's `apiKey()` only models a header (default) or query key; a `cookie` apiKey
-    // has no arm. The generator must emit the header/query forms but let `cookie` fall through to
-    // the not-auto-mapped warning — never silently emit it as a header key.
-    const apiKeyDoc = (loc: 'header' | 'query' | 'cookie'): OpenApiDoc => ({
+    // apiKey auth (CONTRACT.md P16/P22). Core's `apiKey()` models all three OpenAPI locations —
+    // header (default), query, and cookie — each naming the key with `name`. The generator emits the
+    // matching arm; `name`/`in` are single-quoted literals (`q()`), matching the emitted-source style.
+    const apiKeyDoc = (loc: string): OpenApiDoc => ({
         openapi: '3.0.0',
         info: { title: 'T', version: '1' },
         servers: [{ url: 'https://api.example.com' }],
@@ -229,24 +237,44 @@ describe('planGen — naming, typing, auth, notice', () => {
         const r = planGen(apiKeyDoc('header'), { all: true });
         const c = file(r, 'client.ts') ?? '';
         expect(c).toMatch(
-            /auth: apiKey\(\{ name: "X-API-Key", value: env\('API_KEY'\) \}\)/,
+            /auth: apiKey\(\{ name: 'X-API-Key', value: env\('API_KEY'\) \}\)/,
         );
-        expect(c).not.toMatch(/in: 'query'/);
+        expect(c).not.toMatch(/apiKey\(\{ in:/);
         expect(r.warnings.join('\n')).not.toMatch(/not auto-mapped/);
     });
 
     test("apiKey in query → `in: 'query'` discriminant emitted", () => {
         const r = planGen(apiKeyDoc('query'), { all: true });
         expect(file(r, 'client.ts') ?? '').toMatch(
-            /auth: apiKey\(\{ in: 'query', name: "X-API-Key", value: env\('API_KEY'\) \}\)/,
+            /auth: apiKey\(\{ in: 'query', name: 'X-API-Key', value: env\('API_KEY'\) \}\)/,
         );
     });
 
-    test('apiKey in cookie → not auto-mapped, no silent header key', () => {
+    // Supersedes #474's "cookie → not auto-mapped" behavior: core's cookie arm makes the cookie
+    // location first-class, so the generator MAPS it instead of dropping to a warning.
+    test("apiKey in cookie → `in: 'cookie'` discriminant emitted (first-class, not a warning)", () => {
         const r = planGen(apiKeyDoc('cookie'), { all: true });
-        // Must NOT emit an apiKey() call at all — cookie has no core arm.
+        const c = file(r, 'client.ts') ?? '';
+        expect(c).toMatch(
+            /auth: apiKey\(\{ in: 'cookie', name: 'X-API-Key', value: env\('API_KEY'\) \}\)/,
+        );
+        expect(r.warnings.join('\n')).not.toMatch(/not auto-mapped/);
+    });
+
+    test('apiKey with an `in` core has no arm for → not auto-mapped, no silent header key', () => {
+        const r = planGen(apiKeyDoc('matrix'), { all: true });
+        // Must NOT emit an apiKey() call at all — an unmodelled location has no core arm.
         expect(file(r, 'client.ts') ?? '').not.toMatch(/apiKey\(/);
-        expect(r.warnings.join('\n')).toMatch(/not auto-mapped/);
+        const warn = r.warnings.join('\n');
+        expect(warn).toMatch(/not auto-mapped/);
+        expect(warn).toMatch(/in matrix/); // the warning names the offending location
+    });
+
+    test('types-only emits the validation-off notice', () => {
+        const r = planGen(doc, { all: true });
+        expect(r.notices.join('\n')).toMatch(
+            /runtime validation \+ drift are OFF/,
+        );
     });
 });
 

--- a/yakir.lock
+++ b/yakir.lock
@@ -148,35 +148,35 @@
       "accepted": null
     },
     "bundle-advertised-size": {
-      "baseline": "19, 24",
+      "baseline": "20, 25",
       "sites": {
         "command:node packages/core/scripts/bundle-size.mjs --json#regex:\"kb\"\\s*:\\s*(\\d+):all": {
-          "value": "19, 24",
-          "fp": "sha256:94eb0530a98af45bfd198e4fda97eecd20de9db344236ba391f59943ddf05a33"
+          "value": "20, 25",
+          "fp": "sha256:9f8c571518b30cb8ac607774cb140b3562f8bbcde0335c509a04930449fe327c"
         },
         "README.md#pattern:~(?:\\s|&nbsp;|%20)*(\\d+)(?:\\s|&nbsp;|%20)*kB:all": {
-          "value": "19, 24",
-          "fp": "sha256:94eb0530a98af45bfd198e4fda97eecd20de9db344236ba391f59943ddf05a33"
+          "value": "20, 25",
+          "fp": "sha256:9f8c571518b30cb8ac607774cb140b3562f8bbcde0335c509a04930449fe327c"
         },
         "packages/core/README.md#pattern:~(?:\\s|&nbsp;|%20)*(\\d+)(?:\\s|&nbsp;|%20)*kB:all": {
-          "value": "19, 24",
-          "fp": "sha256:94eb0530a98af45bfd198e4fda97eecd20de9db344236ba391f59943ddf05a33"
+          "value": "20, 25",
+          "fp": "sha256:9f8c571518b30cb8ac607774cb140b3562f8bbcde0335c509a04930449fe327c"
         },
         "apps/docs/content/docs/getting-started/installation.mdx#pattern:~(?:\\s|&nbsp;|%20)*(\\d+)(?:\\s|&nbsp;|%20)*kB:all": {
-          "value": "19, 24",
-          "fp": "sha256:94eb0530a98af45bfd198e4fda97eecd20de9db344236ba391f59943ddf05a33"
+          "value": "20, 25",
+          "fp": "sha256:9f8c571518b30cb8ac607774cb140b3562f8bbcde0335c509a04930449fe327c"
         },
         "apps/docs/content/docs/concepts/principles.mdx#pattern:~(?:\\s|&nbsp;|%20)*(\\d+)(?:\\s|&nbsp;|%20)*kB:all": {
-          "value": "19, 24",
-          "fp": "sha256:94eb0530a98af45bfd198e4fda97eecd20de9db344236ba391f59943ddf05a33"
+          "value": "20, 25",
+          "fp": "sha256:9f8c571518b30cb8ac607774cb140b3562f8bbcde0335c509a04930449fe327c"
         },
         "apps/docs/app/(home)/components/metrics.tsx#pattern:~(?:\\s|&nbsp;|%20)*(\\d+)(?:\\s|&nbsp;|%20)*kB:all": {
-          "value": "19, 24",
-          "fp": "sha256:94eb0530a98af45bfd198e4fda97eecd20de9db344236ba391f59943ddf05a33"
+          "value": "20, 25",
+          "fp": "sha256:9f8c571518b30cb8ac607774cb140b3562f8bbcde0335c509a04930449fe327c"
         },
         "apps/docs/lib/source.ts#pattern:~(?:\\s|&nbsp;|%20)*(\\d+)(?:\\s|&nbsp;|%20)*kB:all": {
-          "value": "19, 24",
-          "fp": "sha256:94eb0530a98af45bfd198e4fda97eecd20de9db344236ba391f59943ddf05a33"
+          "value": "20, 25",
+          "fp": "sha256:9f8c571518b30cb8ac607774cb140b3562f8bbcde0335c509a04930449fe327c"
         }
       },
       "accepted": null


### PR DESCRIPTION
Replaces `apiKey()`'s asymmetric two-arm options with one **symmetric `name` + `in` triad** — `in: 'header' | 'query' | 'cookie'`, the key named with `name` in every arm — matching OpenAPI's own `{ name, in }`. Completes #474's cookie gap at the source (a cookie scheme now *maps* instead of *warns*) and carves the `only`/`tags` P7 widening out of #470.

Study #484 (the SSE `delta`/`error` envelopes) as the parallel: like #484, this replaces a stopgap shape with the symmetric one and *adds the missing arm* rather than institutionalizing the gap.

## Why

`apiKey()` named the key `header` in the header arm but `name` in the query arm — asymmetric for one concept (CONTRACT.md P16), and diverging from the standard it round-trips to (P22): OpenAPI's `apiKey` scheme is `{ name, in }`, the query arm already used `name`, and the builder's own emitted `scheme` is `{ in, name }`.

It was also a **live footgun**. `apiKey({ name: 'X-Custom' })` type-checks — `name` is a non-excess property because the query-arm sibling declares it — but at runtime the header arm ignored `name` and sent the default `x-api-key`. The openapi generator walked straight into this: `deriveAuth` emits `name:` for header schemes, correct today only because the one test happened to use the default name. And `apiKey` couldn't model a cookie at all, so #474 could only *warn* on a cookie scheme.

## What

```ts
// header (default) — `name` sets the header (X-API-Key by default)
apiKey({ name: 'X-API-Key', value: env('API_KEY') });
// query — appended to the URL, URL-encoded (api_key by default)
apiKey({ in: 'query', name: 'api_key', value: env('API_KEY') });
// cookie — NEW; appended onto the Cookie header (api_key by default)
apiKey({ in: 'cookie', name: 'session', value: env('API_KEY') });
```

- **core**: one symmetric `{ name?, in: 'header' | 'query' | 'cookie' }` options type — all three locations share the same `name` + `value` shape, so it's a single interface, not a discriminated union. The **cookie arm** *upserts* `name=value` on the `Cookie` header: it replaces a same-named cookie (never a duplicate — RFC 6265 §5.4 leaves those ambiguous), stays idempotent on retry, and preserves any other cookies. `Cookie` is on the trace denylist (`SECRET_HEADERS` in `trace.ts`), so the key is redacted exactly like the header arm — no scrubber registration needed. `header` is **removed, no alias** (maintainer-sanctioned pre-GA hard break, CONTRACT D5/P19). `ApiKeyOptions` stays **local/non-exported** — no auth option type is on the public surface (P16).
- **openapi `deriveAuth`**: maps `in: 'cookie'` → `apiKey({ in: 'cookie', name, value })` (**supersedes #474**'s warn-only fall-through); an unmodelled `in` still falls through to the now location-aware not-auto-mapped warning; emitted `name`/`in` literals are single-quoted via `q()`.
- **openapi selection**: `only`/`tags` accept a bare string — `tags: 'pets'` ≡ `tags: ['pets']` (**P7 widening**, carved from #470).
- **from-curl**: its generated `apiKey(...)` source uses `name:` too.

## Contract

`docs/CONTRACT.md` gains a P22/P16 note: `apiKey` labels the key with `name` and locates it with `in: 'header' | 'query' | 'cookie'` (identity mapping with OpenAPI, symmetric across arms); the `header` spelling is forbidden.

## Rebased onto main (2026-07-31)

Two slices this PR originally carried have since landed on `main` independently and are **no longer in the diff**:

- the `scope`→`pool` emitted throttle comment (main already emits `pool:`; its test is kept);
- the advertised `~24 kB` → `~25 kB` copy edits (main already reads `~25`/`~20`).

What remains of that second commit is the **yakir `bundle-advertised-size` re-baseline**: the tether still read `19, 24` against a live `20, 25` — pre-existing drift on `main`, fixed here.

The rebase also **removed #474's warn-only cookie test** from `gen-openapi.spec.ts`, which this PR supersedes; its `apiKeyDoc` fixture is replaced by the mapping-test block below.

## Verification (local, post-rebase)

- `check:format`, `check:contract` (baseline 0), `check:lint`, `check:types-d` (tsd), `pnpm -r check:types` (all 38 packages + docs twoslash), core `check:exports` (attw, all subpaths green)
- core tests **1250 pass** (incl. new `apikey-location.spec.ts` covering header/query/cookie + cookie-merge); openapi tests **25 pass** (incl. header/query/cookie mapping, unmodelled-`in` fall-through, P7 bare-string widening)
- full lefthook pre-push gate: typecheck / typecheck-d / test / exports / **build-docs** / **yakir** — all green

**`check:size` passes with 0.02 KB of headroom.** The cookie arm lifts the whole entry 24.99 → **25.08 KB** gzip against a 25.10 KB budget; `import { stitch }` is unchanged at 20.14 KB (the arm tree-shakes away), and the rounded advertised figure stays `~25`/`~20`. That headroom is deliberately *not* bought with a budget bump — [ADR 0021](docs/adr/0021-auth-strategies-move-to-a-subpath.md) moves the whole auth surface behind a `stitchapi/auth` subpath, which drops the entry to ~22.7 KB and restores ~2.4 KB of headroom. The gate's own guidance prefers exactly that over a bump.

## Supersedes / carves out

- **Supersedes #474** — a cookie apiKey scheme now maps to `apiKey({ in: 'cookie', … })` instead of the not-auto-mapped warning #474 added. #474 can be closed with a pointer here.
- **Carves out of #470** — the apiKey `header`→`name` symmetry (extended here with the cookie arm) and the `only`/`tags` P7 widening. #470 keeps its other sweeps (basic P15, oauth2 P24, …) and can drop these slices on rebase.

## Related

The declarative-auth-descriptors design (#486 / ADR 0020) that this apiKey shape was meant to enable has since been **withdrawn** — see ADR 0021. This PR stands on its own and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
