### PR TITLE
feat(core): declarative auth descriptors — ADR 0020

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -122,8 +122,8 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
         {
             label: "auth",
             type: "property",
-            detail: "AuthStrategy",
-            info: "Auth strategy — the stitch holds the credential; the caller never sees it.",
+            detail: "AuthConfig",
+            info: "Auth — the stitch holds the credential; the caller never sees it. Accepts a live (a `bearer()`/`apiKey()`/`basic()`/`oauth2()`/`cookieSession()` factory result, or a BYO strategy) **or** a declarative  (`{ strategy: 'apiKey', … }`) — the same shape the config already serialises to on `__config.authScheme` (ADR 0020). Both forms are first-class; a descriptor is normalised to its strategy at construction.",
         },
         {
             label: "retry",

--- a/apps/docs/content/blog/scaffold-a-stitch-from-curl.mdx
+++ b/apps/docs/content/blog/scaffold-a-stitch-from-curl.mdx
@@ -53,12 +53,12 @@ stitch from-curl 'curl https://api.acme.dev/v1/orders/4821 \
 ```
 
 ```ts twoslash
-import { bearer, env, stitch } from 'stitchapi';
+import { env, stitch } from 'stitchapi';
 
 export const getOrders = stitch({
     baseUrl: 'https://api.acme.dev',
     path: '/v1/orders/{orderId}',
-    auth: bearer(env('API_TOKEN')),
+    auth: { strategy: 'bearer', token: env('API_TOKEN') },
 });
 
 // add an output schema to validate + type the response (rerun with --zod)
@@ -69,15 +69,15 @@ await getOrders({
 });
 ```
 
-The literal `sk_live_a1b2c3d4e5f6` is gone. The recognised `Authorization: Bearer` header became `auth: bearer(env('API_TOKEN'))` — a capability that resolves the secret from the environment at call time, not a string baked into the file. Only headers the curl actually carried are emitted, so there is no fabricated `Accept` or `User-Agent` cluttering the output. This is the difference between a generated declaration you can commit and a curl you have to scrub by hand before anyone sees it.
+The literal `sk_live_a1b2c3d4e5f6` is gone. The recognised `Authorization: Bearer` header became `auth: { strategy: 'bearer', token: env('API_TOKEN') }` — a declarative descriptor (ADR 0020) that resolves the secret from the environment at call time, not a string baked into the file. It is pure config data, so the ejected client imports only `stitch` and `env`, no strategy factory. Only headers the curl actually carried are emitted, so there is no fabricated `Accept` or `User-Agent` cluttering the output. This is the difference between a generated declaration you can commit and a curl you have to scrub by hand before anyone sees it.
 
 The CLI recognises three credential shapes, each from the header (or query param) it actually appears in — `from-curl` reads the request it was given, not flags it was not:
 
--   **`Authorization: Bearer <token>`** → `auth: bearer(env('API_TOKEN'))`
--   **`Authorization: Basic <base64>`** → `auth: basic({ user: env('API_USER'), pass: env('API_PASSWORD') })`
--   **An `X-API-Key` header or an API-key query param** → `auth: apiKey({ value: env('API_KEY') })` for a header, or `auth: apiKey({ in: 'query', name: 'api_key', value: env('API_KEY') })` for a query param
+-   **`Authorization: Bearer <token>`** → `auth: { strategy: 'bearer', token: env('API_TOKEN') }`
+-   **`Authorization: Basic <base64>`** → `auth: { strategy: 'basic', user: env('API_USER'), pass: env('API_PASSWORD') }`
+-   **An `X-API-Key` header or an API-key query param** → `auth: { strategy: 'apiKey', value: env('API_KEY') }` for a header, or `auth: { strategy: 'apiKey', in: 'query', name: 'api_key', value: env('API_KEY') }` for a query param
 
-In every case the value is an `env(...)` placeholder, not the captured secret — `basic` and `apiKey` each take a single options object, so the generated call is the real API you would have written. (curl's `-u user:password` flag is a different story: `from-curl` does not parse it and warns it as an unknown flag. Basic auth is recognised from an `Authorization: Basic …` header, the form a browser's **Copy as cURL** actually emits.)
+In every case the value is an `env(...)` placeholder, not the captured secret — each `auth` is a plain descriptor object, so the generated config is data you can commit as-is, with no strategy import to wire up. (curl's `-u user:password` flag is a different story: `from-curl` does not parse it and warns it as an unknown flag. Basic auth is recognised from an `Authorization: Basic …` header, the form a browser's **Copy as cURL** actually emits.)
 
 ## Type the response when you want it
 
@@ -95,13 +95,13 @@ stitch from-curl 'curl https://api.acme.dev/v1/orders/4821' \
 What you get back is an ordinary stitch declaration, not a frozen artifact. The same fields you would reach for on any stitch are one edit away:
 
 ```ts twoslash
-import { bearer, env, stitch } from 'stitchapi';
+import { env, stitch } from 'stitchapi';
 
 // ---cut---
 export const getOrder = stitch({
     baseUrl: 'https://api.acme.dev',
     path: '/v1/orders/{orderId}',
-    auth: bearer(env('API_TOKEN')),
+    auth: { strategy: 'bearer', token: env('API_TOKEN') },
     retry: 3,
     timeout: '5s',
 });

--- a/apps/docs/content/docs/agents/author-from-one-example.mdx
+++ b/apps/docs/content/docs/agents/author-from-one-example.mdx
@@ -37,8 +37,9 @@ await getUsers({ params: { userId: 1 } });
 The origin becomes `baseUrl`, the rest becomes `path`, and id-like segments
 (`/users/1`) are lifted into `{param}` slots — each lift is announced on stderr so
 you can revert a false positive. A recognised credential is **never** emitted: an
-`Authorization: Bearer …` header becomes `auth: bearer(env('API_TOKEN'))`, an
-`x-api-key` header becomes `auth: apiKey({ value: env('API_KEY') })`, and the
+`Authorization: Bearer …` header becomes `auth: { strategy: 'bearer', token: env('API_TOKEN') }`, an
+`x-api-key` header becomes `auth: { strategy: 'apiKey', value: env('API_KEY') }` (a declarative
+descriptor — pure data, no strategy import), and the
 captured token stays in your shell, out of committed code. Read a single HAR entry
 instead with `--from-har request.har`.
 

--- a/apps/docs/content/docs/guides/auth/api-key.mdx
+++ b/apps/docs/content/docs/guides/auth/api-key.mdx
@@ -30,13 +30,15 @@ the capability boundary.
 [`env('API_KEY')`](/docs/guides/auth/secret-resolvers) so the secret is read at
 call time and never committed.
 
-`in` chooses where the key goes: `'header'` (the default) or `'query'`.
+`in` chooses where the key goes: `'header'` (the default), `'query'`, or
+`'cookie'`.
 
-`header` overrides the header name (default `x-api-key`, lowercased) when
-`in: 'header'`: pass `apiKey({ header: 'X-My-Key', value: env('API_KEY') })` to
-send the key under a custom header. The name goes on the wire **lowercased**
-(`x-my-key`) — case-insensitive per HTTP, but worth knowing if a fixture asserts
-the original casing. See [Migration notes](/docs/getting-started/migration-notes).
+`name` is the parameter name in every location — it defaults to `x-api-key`
+(header), `api_key` (query), or `session` (cookie). In header mode the name goes
+on the wire **lowercased** (`x-my-key`) — case-insensitive per HTTP, but worth
+knowing if a fixture asserts the original casing. The pre-symmetric `header`
+alias still names the header (`apiKey({ header: 'X-My-Key', value })`); prefer
+`name`. See [Migration notes](/docs/getting-started/migration-notes).
 
 ## In a query parameter
 
@@ -68,6 +70,26 @@ Every call appends `&api_key=<resolved>` to the URL. `name` is the parameter nam
     `input.query`) it is redacted to `REDACTED`, exactly like
     `api_key`/`access_token`. None of that protects the upstream server's logs.
 </Callout>
+
+## As a descriptor
+
+`auth` also takes a declarative descriptor (ADR 0020) — the same key placement
+without importing `apiKey`. Here the key rides in a cookie:
+
+```ts twoslash
+import { env, stitch } from 'stitchapi';
+
+const search = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/search',
+    auth: {
+        strategy: 'apiKey',
+        in: 'cookie',
+        name: 'sid',
+        value: env('API_KEY'),
+    },
+});
+```
 
 See [Reference → Auth strategies](/docs/reference/auth-strategies) for every
 field.

--- a/apps/docs/content/docs/guides/auth/basic.mdx
+++ b/apps/docs/content/docs/guides/auth/basic.mdx
@@ -25,6 +25,21 @@ Each call to `report()` resolves `API_USER` and `API_PASS`, encodes them, and
 attaches the header — behind the capability boundary, so the credential is never
 passed in by the caller.
 
+## As a descriptor
+
+`auth` also accepts a declarative descriptor (ADR 0020) — the same strategy
+without importing `basic`:
+
+```ts twoslash
+import { env, stitch } from 'stitchapi';
+
+const report = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/report',
+    auth: { strategy: 'basic', user: env('API_USER'), pass: env('API_PASS') },
+});
+```
+
 ## Options
 
 `user` and `pass` each take a string or a resolver. Prefer a resolver like

--- a/apps/docs/content/docs/guides/auth/bearer.mdx
+++ b/apps/docs/content/docs/guides/auth/bearer.mdx
@@ -24,6 +24,25 @@ const me = stitch({
 The token is read each time `me()` runs, so a rotated secret takes effect on the
 next call with no rewiring.
 
+## As a descriptor
+
+`auth` also accepts a declarative descriptor (ADR 0020) — the same strategy
+without importing `bearer`:
+
+```ts twoslash
+import { env, stitch } from 'stitchapi';
+
+const me = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/me',
+    auth: { strategy: 'bearer', token: env('API_TOKEN') },
+});
+```
+
+The factory form stays first-class and is terser (`bearer(env('API_TOKEN'))`);
+the descriptor earns its keep when you'd rather write pure config data — for
+example in a generated client, where it needs no strategy import.
+
 ## Options
 
 `bearer` accepts either a literal string or a resolver thunk (`() => string`).

--- a/apps/docs/content/docs/guides/auth/cookie-session.mdx
+++ b/apps/docs/content/docs/guides/auth/cookie-session.mdx
@@ -40,6 +40,37 @@ The first call to `me()` runs `login` once, captures its cookies, and replays
 them; a `401` afterward re-runs the login and retries, all behind the
 capability boundary.
 
+## As a descriptor
+
+`auth` also accepts a declarative descriptor (ADR 0020) — the `login` stitch and
+every option ride on it beside `strategy: 'cookieSession'`, with no
+`cookieSession` import:
+
+```ts twoslash
+import { env, stitch } from 'stitchapi';
+
+const login = stitch({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/login',
+    bodyType: 'form',
+});
+
+const me = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/me',
+    auth: {
+        strategy: 'cookieSession',
+        login,
+        cookie: '*',
+        loginInput: () => ({
+            body: { user: env('USER')(), pass: env('PASS')() },
+        }),
+        refreshOn: [401],
+    },
+});
+```
+
 ## Options
 
 Point `login` at the stitch that authenticates, and pass `loginInput` to supply

--- a/apps/docs/content/docs/guides/auth/oauth2.mdx
+++ b/apps/docs/content/docs/guides/auth/oauth2.mdx
@@ -31,6 +31,27 @@ token in the stitch store (TTL from `expires_in`), and attaches it as
 `Authorization: Bearer …`; later calls reuse the cached token until it nears
 expiry, all behind the capability boundary.
 
+## As a descriptor
+
+`auth` also accepts a declarative descriptor (ADR 0020) — every `oauth2` option
+rides on the descriptor beside `strategy: 'oauth2'`, with no `oauth2` import:
+
+```ts twoslash
+import { env, stitch } from 'stitchapi';
+
+const orders = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/orders',
+    auth: {
+        strategy: 'oauth2',
+        tokenUrl: 'https://api.example.com/oauth/token',
+        clientId: env('CLIENT_ID'),
+        clientSecret: env('CLIENT_SECRET'),
+        scope: 'orders.read',
+    },
+});
+```
+
 ## Options
 
 `tokenUrl` is the `client_credentials` token endpoint. Pass `clientId` and

--- a/apps/docs/content/docs/reference/auth-strategies.mdx
+++ b/apps/docs/content/docs/reference/auth-strategies.mdx
@@ -17,9 +17,11 @@ import { bearer } from 'stitchapi';
 
 ## apiKey
 
-Sends a secret in a header (`x-api-key` by default), or — with `in: 'query'` — as
-a URL query parameter (`api_key` by default), resolved and URL-encoded at call
-time.
+Sends a secret in a **header** (`x-api-key` by default), a URL **query** parameter
+(`api_key` by default), or a **cookie** (`session` by default) — picked with
+`in: 'header' | 'query' | 'cookie'`. `name` is the parameter name in every
+location (the legacy `header` alias still names the header); the value is resolved
+at call time, and URL-encoded for a query key.
 
 ```ts twoslash
 import { apiKey } from 'stitchapi';
@@ -49,6 +51,53 @@ Performs the `client_credentials` grant, caches the access token, refreshes it
 before expiry, and attaches it as `Authorization: Bearer …`.
 
 <AutoTypeTable path="../../packages/core/src/auth.ts" name="OAuth2Options" />
+
+## Declarative descriptors
+
+Every strategy above also has a **declarative form** (ADR 0020): `auth` accepts an
+`AuthDescriptor` — a flat object tagged with `strategy` — as an alternative to the
+factory result. It resolves to the exact same strategy at construction, so the
+wire behaviour is identical; it just needs no factory import, which keeps
+generated / ejected clients pure data. `AuthConfig`, the type of
+`StitchConfig.auth`, is `AuthStrategy | AuthDescriptor`.
+
+```ts twoslash
+import { env, stitch } from 'stitchapi';
+
+const gh = stitch({
+    url: 'https://api.github.com/user',
+    // ↓ no `bearer` import — the descriptor is pure data
+    auth: { strategy: 'bearer', token: env('GH_TOKEN') },
+});
+```
+
+The five shapes, one per strategy:
+
+```ts twoslash
+import { env } from 'stitchapi';
+import type { AuthDescriptor, Stitch } from 'stitchapi';
+
+declare const login: Stitch;
+
+const forms: AuthDescriptor[] = [
+    { strategy: 'bearer', token: env('TOKEN') },
+    { strategy: 'apiKey', in: 'cookie', name: 'sid', value: env('KEY') },
+    { strategy: 'basic', user: env('USER'), pass: env('PASS') },
+    {
+        strategy: 'oauth2',
+        tokenUrl: 'https://id.example.com/token',
+        clientId: env('CLIENT_ID'),
+        clientSecret: env('CLIENT_SECRET'),
+    },
+    { strategy: 'cookieSession', login, cookie: 'sid' },
+];
+```
+
+Detection is unambiguous: an object with an `apply` function is a live strategy
+(and wins even if it also carries a `strategy` key); an object with `strategy` is
+a descriptor; anything else throws at construction. The factory form stays
+first-class — it is required for a custom / BYO `apply` a closed union can't
+express, and stays terser for `bearer`.
 
 ## env
 

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -78,6 +78,13 @@ document string in `StitchConfig` but URL params in `StitchInput` / `InputSchema
 `on` is retry-trigger statuses **and** rate-limit-signal statuses; `bodyKind`
 (`from-curl`) vs `bodyType` (everywhere else) for one `'json'|'form'` concept.
 
+_Settled (ADR 0020):_ the declarative `AuthDescriptor` discriminant is
+**`strategy`** — its value-space is exactly the five strategy names, mirroring the
+`AuthStrategy` it resolves to. Deliberately **not `type`** (would collide with
+`SecurityScheme.type`'s value-space — a reader seeing intake `type: 'bearer'` and
+scheme `type: 'http'` is misled), not `name` (taken by `apiKey`'s `name`), and not
+`kind` (the surface selector, ADR 0005).
+
 ### P2 · Don't reuse one word for genuinely different concepts — rename one
 
 When two fields legitimately mean **different** things, they **MUST NOT** share a
@@ -106,6 +113,8 @@ _Violations:_ `CacheConfig`, `OAuth2Opts`, `CookieSessionOpts`, `McpServerInfo`,
 _Carve-out:_ `StitchConfig`/`SeamConfig`/`RedactedStitchConfig` keep `*Config` as the
 one well-known top-level authoring type family (the thing you literally call
 `stitch(config)` with); the ban targets the **sibling capability bags**.
+`AuthConfig` (ADR 0020) joins the carve-out: it is the config-slot **union** typing
+`StitchConfig.auth` (`AuthStrategy | AuthDescriptor`), not a `*Options` bag.
 
 ### P4 · One cap vocabulary
 

--- a/packages/core/scripts/bundle-size.mjs
+++ b/packages/core/scripts/bundle-size.mjs
@@ -120,16 +120,29 @@ const KB = 1024;
 // / ~0.28 KB gzip. The step restores the same tight ~0.2 KB headroom the gate is meant to hold. The
 // cost buys closing a HIGH credential-exfiltration hole — a deliberate trade the maintainer signs off
 // on by merging (see PR body for the exact before/after/Δ).
+// Budgets raised for declarative auth descriptors — ADR 0020 (24.80→25.30 / 20.00→20.25; measured
+// 25.07 / 20.04). `auth` now accepts an `AuthDescriptor` (`{ strategy: 'oauth2', … }`) beside the
+// factory result. The RESOLUTION machinery — the five strategy factories `fromDescriptor` dispatches
+// to — is deliberately kept OFF core: `auth.ts` installs the resolver into a core seam
+// (`auth-registry.ts`) only when a secret resolver (`env`/`secretsFile`/`secretFrom`) runs, which a
+// real descriptor's credential always does. So `import { stitch }` with no auth still tree-shakes the
+// factories away entirely (that path did NOT gain the ~2.4 KB the factories weigh). What DOES lift
+// both scenarios is the small, unavoidable bits on the core config-intake path, which can't move to a
+// subpath: (1) `normalizeAuth` — the descriptor-vs-strategy detection + resolver routing + two
+// actionable construction errors — runs in `compose` for every stitch (~0.24 KB on `import
+// { stitch }`); and (2) `fromDescriptor` + the new `apiKey` `in: 'cookie'` branch, which sit on the
+// whole entry. The step restores the same tight ~0.2 KB headroom the gate is meant to hold; the PR
+// body carries the exact before/after/Δ.
 const SCENARIOS = [
     {
         name: 'stitchapi — whole entry',
         code: `export * from './index.mjs';`,
-        budget: 24.8 * KB,
+        budget: 25.3 * KB,
     },
     {
         name: 'import { stitch }',
         code: `export { stitch } from './index.mjs';`,
-        budget: 20.0 * KB,
+        budget: 20.25 * KB,
     },
 ];
 

--- a/packages/core/src/auth-registry.ts
+++ b/packages/core/src/auth-registry.ts
@@ -1,0 +1,60 @@
+// The auth-descriptor resolver seam (ADR 0020, P21 extension seam).
+//
+// Core must resolve a declarative `auth` DESCRIPTOR (`{ strategy: 'oauth2', … }`) to a live
+// {@link AuthStrategy} at construction — but it MUST NOT statically import the strategy factories
+// (`bearer`/`apiKey`/`basic`/`oauth2`/`cookieSession`). Those live in `./auth`, and a static import
+// would drag the whole auth module — the heavy `oauth2`/`cookieSession` machinery included — into the
+// lean `import { stitch }` bundle for EVERY consumer, even ones that never touch auth.
+//
+// Instead this holds a resolver slot the auth module installs (`installAuthDescriptorResolver`) —
+// NOT as a module-load side effect (esbuild would keep that, dragging the factories back into the
+// lean bundle), but the first time a SECRET RESOLVER (`env`/`secretsFile`/`secretFrom`) runs. A real
+// descriptor resolves its credential through one of those EAGERLY (`token: env('T')` runs while the
+// descriptor literal is built, before `stitch()`), so the resolver is armed precisely when a
+// descriptor is in play. A bare `import { stitch }` that never touches auth arms nothing, so the auth
+// module — factories included — tree-shakes away; only this tiny slot + detection remain.
+//
+// Type-only imports (erased) — no runtime dependency on the factory-bearing module, so this stays a
+// runtime leaf and the `stitch` → `auth-registry` edge never reaches `./auth`.
+import type { AuthConfig, AuthDescriptor } from './auth';
+import type { AuthStrategy } from './types';
+
+let resolveDescriptor: ((d: AuthDescriptor) => AuthStrategy) | undefined;
+
+/**
+ * Install the descriptor→strategy resolver. `./auth` calls this the first time a secret resolver
+ * runs; idempotent (last writer wins). Kept out of the public surface — an internal seam, not an API.
+ */
+export function installAuthDescriptorResolver(
+    fn: (d: AuthDescriptor) => AuthStrategy,
+): void {
+    resolveDescriptor = fn;
+}
+
+/**
+ * Resolve {@link StitchConfig.auth} intake to a live {@link AuthStrategy} (ADR 0020). Detection is
+ * unambiguous for every real input (Q6): a value carrying an `apply` function IS a strategy — a
+ * factory result or a BYO strategy, and `apply` **wins** even for the hand-spliced `{ strategy, apply
+ * }` corner; otherwise a value carrying a `strategy` key is a descriptor, routed to the installed
+ * resolver; a value with neither throws. Idempotent: a normalized strategy flowing back in as a
+ * fragment (`__rawConfig.auth`) has `apply`, so it passes straight through — no resolver needed.
+ */
+export function normalizeAuth(auth: AuthConfig): AuthStrategy {
+    if (typeof (auth as AuthStrategy).apply === 'function')
+        return auth as AuthStrategy;
+    if ('strategy' in auth) {
+        if (!resolveDescriptor)
+            // The resolver arms when a secret resolver (`env`/`secretsFile`/`secretFrom`) runs, which
+            // a descriptor's credential normally does. Only a descriptor with a LITERAL secret and no
+            // other auth import lands here — steer the author to the one-line fix.
+            throw new Error(
+                "declarative `auth` needs the resolver loaded: give the credential an env('X') " +
+                    "value (or import any strategy from 'stitchapi'), or pass a factory result.",
+            );
+        return resolveDescriptor(auth);
+    }
+    throw new Error(
+        '`auth` needs `apply` (a strategy) or `strategy` (a descriptor). Pass a factory result, ' +
+            "or e.g. { strategy: 'bearer', token: env('TOKEN') }.",
+    );
+}

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -1,6 +1,7 @@
 // Auth strategies + secret resolvers. The key idea: the stitch holds the credential,
 // resolved at call time — the caller (an agent) never sees it. `cookieSession` performs
 // a login (another stitch) and manages the cookie jar, refreshing on a 401 wall.
+import { installAuthDescriptorResolver } from './auth-registry';
 import { compact } from './compact';
 import { fetchAdapter } from './http-adapter';
 import { parseRetryAfter } from './resilience';
@@ -62,6 +63,7 @@ function base64(s: string): string {
  * use {@link optionalEnv}.
  */
 export function env(name: string): () => string {
+    armDescriptorResolver(); // a descriptor resolves its credential through here (ADR 0020 seam)
     return () => {
         const v = readEnv(name);
         if (v == null || v === '')
@@ -86,6 +88,7 @@ export type SecretSource =
  * `bearer(secretFrom(configService, 'GITHUB_TOKEN'))`.
  */
 export function secretFrom(source: SecretSource, name: string): () => string {
+    armDescriptorResolver(); // ADR 0020 seam — see env()
     return () => {
         const v =
             typeof source === 'function' ? source(name) : source.get(name);
@@ -107,6 +110,7 @@ export function secretFrom(source: SecretSource, name: string): () => string {
  * so `bearer` simply attaches nothing.
  */
 export function optionalEnv(name: string): OptionalSecret {
+    armDescriptorResolver(); // ADR 0020 seam — see env()
     // An exported-but-empty var (`MY_TOKEN=`) counts as absent — never send `Bearer ` with no token.
     const read = (): string | undefined => {
         const v = readEnv(name);
@@ -127,6 +131,7 @@ export function optionalEnv(name: string): OptionalSecret {
  * permissions (`chmod 600 ~/.stitch/secrets.json`) and never commit it.
  */
 export function secretsFile(name: string): () => string {
+    armDescriptorResolver(); // ADR 0020 seam — see env()
     return () => {
         try {
             // No node:fs (browser): skip the file, fall through to the env var.
@@ -175,14 +180,42 @@ export function bearer(token: Secret | OptionalSecret): AuthStrategy {
 }
 
 /**
- * API-key auth, in a request **header** (the default) or a **query param**. The key is a
- * {@link Secret} resolved at call time — the caller (an agent) never sees it.
+ * Options for {@link apiKey}. Symmetric across the three locations: `in` selects where the key
+ * rides, `name` is the parameter name (with a per-location default), `value` is the secret. Kept
+ * LOCAL — deliberately NOT a public export (ADR 0020 Q9) — so the option shape can evolve without a
+ * surface-area promise; the public declarative form is the `apiKey` arm of {@link AuthDescriptor}.
+ */
+interface ApiKeyOptions {
+    /** Where the key rides: a request `header` (default), a `query` param, or a `cookie`. */
+    in?: 'header' | 'query' | 'cookie';
+    /**
+     * The parameter name. Per-location default when omitted: `X-API-Key` (header), `api_key`
+     * (query), `session` (cookie).
+     */
+    name?: string;
+    /**
+     * Back-compat alias for {@link ApiKeyOptions.name} in header mode (the pre-symmetric spelling,
+     * before `name` covered all three locations). `name` wins when both are set. Prefer `name`.
+     */
+    header?: string;
+    /** The API key — a {@link Secret} resolved at call time, so the caller (an agent) never sees it. */
+    value: Secret;
+}
+
+/**
+ * API-key auth, carried in a request **header** (the default), a **query param**, or a **cookie**.
+ * The key is a {@link Secret} resolved at call time — the caller (an agent) never sees it. `name`
+ * is the parameter name across all three locations (ADR 0020's symmetric shape); `header` is a
+ * back-compat alias for `name` in header mode.
  *
- * - `in: 'header'` (default): writes `header` (default `'x-api-key'`, lower-cased) — byte-for-byte
+ * - `in: 'header'` (default): writes `name` (default `'X-API-Key'`, lower-cased) — byte-for-byte
  *   the original behaviour, so existing stitches are unaffected.
- * - `in: 'query'`: appends `name=<resolved>` (default `'api_key'`) to the request URL,
- *   URL-encoded. The strategy runs in the attempt loop on the fully-built `req` (after
- *   templating/query-building), so it safely appends onto whatever query the URL already carries.
+ * - `in: 'query'`: appends `name=<resolved>` (default `'api_key'`) to the request URL, URL-encoded.
+ *   The strategy runs in the attempt loop on the fully-built `req` (after templating/query-building),
+ *   so it safely appends onto whatever query the URL already carries.
+ * - `in: 'cookie'`: appends `name=<resolved>` (default `'session'`) onto the request's `Cookie`
+ *   header. The whole `Cookie` header is in the trace secret-header denylist, so the key is redacted
+ *   in every sink.
  *
  * SECURITY: a key in the URL leaks wherever URLs go — server access logs, proxies, the browser
  * history, a `Referer` header. Prefer `in: 'header'` when the API accepts it. The key stays out of
@@ -191,12 +224,9 @@ export function bearer(token: Secret | OptionalSecret): AuthStrategy {
  * `name` is registered with the URL-credential scrubber, so if it does surface in a sink (an OTLP
  * `url.full`, the structured `input.query`) it is REDACTED, like `api_key`/`access_token`/… are.
  */
-export function apiKey(
-    opts:
-        | { in?: 'header'; header?: string; value: Secret }
-        | { in: 'query'; name?: string; value: Secret },
-): AuthStrategy {
-    if (opts.in === 'query') {
+export function apiKey(opts: ApiKeyOptions): AuthStrategy {
+    const where = opts.in ?? 'header';
+    if (where === 'query') {
         const name = opts.name ?? 'api_key';
         // Teach the trace scrubber this param name carries a secret, so the key never reaches a
         // sink in the clear — even when `name` is a vendor spelling the built-in stems don't catch.
@@ -215,7 +245,24 @@ export function apiKey(
             },
         };
     }
-    const headerName = opts.header ?? 'X-API-Key';
+    if (where === 'cookie') {
+        // A key carried as a cookie: append `name=value` onto the request's Cookie header (mirroring
+        // how `cookieSession` replays its jar). The whole header is redacted in every trace sink —
+        // `cookie` is in the secret-header denylist — so the key never surfaces.
+        const name = opts.name ?? 'session';
+        return {
+            name: 'apiKey',
+            scheme: { type: 'apiKey', in: 'cookie', name },
+            apply(req) {
+                const pair = `${name}=${resolve(opts.value)}`;
+                req.headers['cookie'] = [req.headers['cookie'], pair]
+                    .filter(Boolean)
+                    .join('; ');
+            },
+        };
+    }
+    // header (default). `name` is the symmetric spelling; `header` is the back-compat alias.
+    const headerName = opts.name ?? opts.header ?? 'X-API-Key';
     const header = headerName.toLowerCase();
     return {
         name: 'apiKey',
@@ -761,6 +808,102 @@ export function cookieSession(opts: CookieSessionOptions): AuthStrategy {
             await flight(key, () => doRefresh(ctx, key, principal, 'refresh'));
         },
     };
+}
+
+// ---- declarative descriptors (ADR 0020) -----------------------------------
+
+/**
+ * A declarative, JSON-shaped intake for {@link StitchConfig.auth}: a flat discriminated union on
+ * `strategy` (the strategy name) that resolves, at `stitch()`/`seam()` construction, to the exact
+ * {@link AuthStrategy} the matching factory builds (ADR 0020). It is a **second intake form**
+ * alongside the factories, not a replacement — both are first-class and permanent; the factory form
+ * stays required for custom / BYO strategies (an arbitrary `apply`) a closed union can't express.
+ *
+ * Live leaves (a {@link Secret} thunk, an {@link Adapter}, the `cookieSession` login stitch) are
+ * allowed on the descriptor exactly as `StitchConfig` already allows url thunks / `transform` /
+ * `keyOf`; {@link normalizeAuth} captures them into the strategy closure **before** `__config` is
+ * built, so a descriptor's secret leaves never touch the strict-JSON config (the redaction outcome
+ * is byte-identical to a factory call).
+ *
+ * @example
+ * // no import of the strategy factory — pure data
+ * auth: { strategy: 'apiKey', in: 'cookie', name: 'sid', value: env('API_KEY') }
+ */
+export type AuthDescriptor =
+    | { strategy: 'bearer'; token: Secret }
+    | {
+          strategy: 'apiKey';
+          in?: 'header' | 'query' | 'cookie';
+          name?: string;
+          value: Secret;
+      }
+    | { strategy: 'basic'; user: Secret; pass: Secret }
+    | ({ strategy: 'oauth2' } & OAuth2Options)
+    | ({ strategy: 'cookieSession' } & CookieSessionOptions);
+
+/**
+ * What {@link StitchConfig.auth} accepts (ADR 0020): a live {@link AuthStrategy} — a factory result
+ * or a BYO strategy with a custom `apply` — **or** a declarative {@link AuthDescriptor}. Both are
+ * exported public types because this is the type of the public `auth` field (ADR 0020 Q9).
+ */
+export type AuthConfig = AuthStrategy | AuthDescriptor;
+
+// On ADR 0020 Q1's belt-and-suspenders "add `value`/`token`/`clientSecret` to the trace secret
+// stems": `token` and `secret` (which catches `clientSecret`) are ALREADY stems (util.ts), and
+// `value` is deliberately NOT added — the shared stem set also drives `redactSecretsDeep` over the
+// request body on every `start` frame, so a `value` stem would redact legitimate body fields for no
+// gain: a descriptor is `config.auth`, never request-body data, and `redactConfig` strips `auth`
+// wholesale from `__config` regardless of ordering — the real guarantee, which needs no new stem.
+
+// Map a {@link AuthDescriptor} to the strategy its matching factory builds. The factories are the
+// single source of wire behaviour; the descriptor is sugar that resolves to them (ADR 0020). This
+// references all five factories, so it MUST stay in this (auth) module — never core — or the lean
+// `import { stitch }` bundle would carry every strategy. Core reaches it only through the resolver
+// seam below (`installAuthDescriptorResolver`), which runs when this module loads.
+function fromDescriptor(d: AuthDescriptor): AuthStrategy {
+    switch (d.strategy) {
+        case 'bearer':
+            return bearer(d.token);
+        case 'apiKey': {
+            // Build the option object by hand (not a spread) so `exactOptionalPropertyTypes` is
+            // satisfied — an absent `in`/`name` stays absent rather than becoming `undefined`.
+            const opts: ApiKeyOptions = { value: d.value };
+            if (d.in !== undefined) opts.in = d.in;
+            if (d.name !== undefined) opts.name = d.name;
+            return apiKey(opts);
+        }
+        case 'basic':
+            return basic({ user: d.user, pass: d.pass });
+        // The oauth2 / cookieSession descriptors ARE their options plus a `strategy` tag; the extra
+        // tag is inert (the factories read named fields, never spread), so pass the value straight
+        // through rather than reconstructing the (large) options object.
+        case 'oauth2':
+            return oauth2(d);
+        case 'cookieSession':
+            return cookieSession(d);
+        default: {
+            // Exhaustiveness backstop: only reachable via an unchecked cast (the union forbids it).
+            const bad: never = d;
+            throw new Error(
+                `unknown auth strategy ${JSON.stringify((bad as { strategy?: unknown }).strategy)}. ` +
+                    'Expected one of bearer, apiKey, basic, oauth2, cookieSession.',
+            );
+        }
+    }
+}
+
+// Arm core's descriptor-resolver seam (ADR 0020) — but NOT as a module-top-level side effect, which
+// esbuild would keep, dragging `fromDescriptor` → every factory into the lean `import { stitch }`
+// bundle for all consumers. Instead the SECRET RESOLVERS (env/optionalEnv/secretsFile/secretFrom)
+// call this on first use: a real descriptor resolves its credential through one of them EAGERLY
+// (`token: env('T')` runs while the descriptor literal is built, before `stitch()`), so the resolver
+// is present exactly when a descriptor is. A bare `import { stitch }` that never touches auth calls
+// none of them, so this whole module — factories included — tree-shakes away. Idempotent + cheap.
+let descriptorsArmed = false;
+function armDescriptorResolver(): void {
+    if (descriptorsArmed) return;
+    descriptorsArmed = true;
+    installAuthDescriptorResolver(fromDescriptor);
 }
 
 /**

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -501,9 +501,10 @@ from-curl:
   --name <export>        export name for the emitted const (default: derived from the path)
   Deterministically turns ONE example into a ready-to-paste \`export const … = stitch({…})\` plus a
   matching call. URL origin → baseUrl, the rest → path with id-like segments lifted into {param}
-  slots (each lift is warned). A captured credential is NEVER emitted — recognised auth becomes
-  \`bearer(env('API_TOKEN'))\` / \`apiKey({ value: env('API_KEY') })\` / \`basic({ … })\`. Without --zod
-  no output schema is emitted, just a comment to add one.
+  slots (each lift is warned). A captured credential is NEVER emitted — recognised auth becomes a
+  declarative descriptor \`{ strategy: 'bearer', token: env('API_TOKEN') }\` / \`{ strategy: 'apiKey',
+  value: env('API_KEY') }\` / \`{ strategy: 'basic', … }\` (no strategy import). Without --zod no
+  output schema is emitted, just a comment to add one.
 
 init (alias: rules):
   --format <ids>|all   comma-list of conventions to write (default: all). ids:

--- a/packages/core/src/from-curl.ts
+++ b/packages/core/src/from-curl.ts
@@ -932,31 +932,30 @@ function renderBody(raw: string, bodyType: 'json' | 'form'): string {
     return `{\n${inner},\n    }`;
 }
 
-// Render the `auth:` value for a recognised strategy. The credential is ALWAYS an env() placeholder.
+// Render the `auth:` value for a recognised strategy as a declarative descriptor (ADR 0020 Q8) —
+// pure data, so the ejected client needs NO strategy-factory import. The credential is ALWAYS an
+// env() placeholder.
 function renderAuth(auth: AuthEmit): string {
     switch (auth.kind) {
         case 'bearer':
-            return `bearer(env('${auth.envName}'))`;
+            return `{ strategy: 'bearer', token: env('${auth.envName}') }`;
         case 'apiKey':
             return auth.queryName
-                ? `apiKey({ in: 'query', name: '${auth.queryName}', value: env('${auth.envName}') })`
+                ? `{ strategy: 'apiKey', in: 'query', name: '${auth.queryName}', value: env('${auth.envName}') }`
                 : auth.header && auth.header.toLowerCase() !== 'x-api-key'
-                  ? `apiKey({ header: '${auth.header}', value: env('${auth.envName}') })`
-                  : `apiKey({ value: env('${auth.envName}') })`;
+                  ? `{ strategy: 'apiKey', name: '${auth.header}', value: env('${auth.envName}') }`
+                  : `{ strategy: 'apiKey', value: env('${auth.envName}') }`;
         case 'basic':
-            return `basic({ user: env('${auth.userEnv}'), pass: env('${auth.passEnv}') })`;
+            return `{ strategy: 'basic', user: env('${auth.userEnv}'), pass: env('${auth.passEnv}') }`;
     }
 }
 
-// The import line: only the symbols the emitted code actually uses (stitch always; an auth helper
-// when present; env when auth is present; z is imported separately under --zod).
+// The import line: only the symbols the emitted code actually uses. `stitch` always; `env` when auth
+// is present (for the secret placeholder). The declarative descriptor form (ADR 0020 Q8) means NO
+// strategy factory (bearer/apiKey/basic) is imported — the ejected client's `auth:` is pure data.
+// `z` is imported separately under --zod.
 function buildImport(auth: AuthEmit | undefined): string {
     const named = ['stitch'];
-    if (auth) {
-        if (auth.kind === 'bearer') named.push('bearer');
-        else if (auth.kind === 'apiKey') named.push('apiKey');
-        else named.push('basic');
-        named.push('env');
-    }
+    if (auth) named.push('env');
     return `import { ${named.join(', ')} } from 'stitchapi';`;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,16 @@ export {
     secretsFile,
     secretFrom,
 } from './auth';
-export type { SecretSource, AuthFailureResult, RefreshResult } from './auth';
+export type {
+    SecretSource,
+    AuthFailureResult,
+    RefreshResult,
+    // ADR 0020 — the declarative `auth` intake union + the `AuthStrategy | AuthDescriptor` alias
+    // that is the type of the public `StitchConfig.auth` field (Q9). Option types (ApiKeyOptions,
+    // …) stay local, deliberately not exported.
+    AuthDescriptor,
+    AuthConfig,
+} from './auth';
 // CONTRACT.md P3 — deprecated alias re-export, removed at GA.
 // eslint-disable-next-line @typescript-eslint/no-deprecated -- intentional back-compat re-export of the @deprecated `AuthFailureInfo` (now `AuthFailureResult`) until the GA cut
 export type { AuthFailureInfo } from './auth';

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -1,6 +1,9 @@
 // The authoring surface: stitch() + the extends composition facade +
 // `.with()` partial application, all resolving to one canonical config. For a shared surface —
 // shared runtime + a trusted principal boundary — reach for `seam` (see seam.ts).
+// From the resolver seam, NOT `./auth` — so the strategy factories never enter the lean
+// `import { stitch }` bundle (ADR 0020 bundle gate). The auth module installs the resolver on load.
+import { normalizeAuth } from './auth-registry';
 import { compact } from './compact';
 import {
     ERROR_SOURCE,
@@ -161,18 +164,24 @@ export function compose(config: Fragment): ResolvedStitchConfig {
     const hookLayers: Hooks[] = [];
     let store: StitchStore | undefined;
     let kind: StitchConfig['kind'];
+    let auth: StitchConfig['auth'];
     for (const layer of layers) {
         if (layer.hooks) hookLayers.push(layer.hooks);
         if (layer.store) store = layer.store;
         // The surface is an atomic value (last-writer-wins), never deep-merged — merging two
         // Surface objects would corrupt their hooks/identity (ADR 0005 Decision 2).
         if (layer.kind) kind = layer.kind;
-        // hooks/store/kind are accumulated above; strip them so deepMerge only folds the rest
+        // Auth is an atomic slot too (ADR 0020 Q7): last-writer-wins, never deep-merged. deepMerge
+        // would blend two strategies (or a strategy and a descriptor) field-by-field — a latent bug
+        // — and a descriptor and the strategy it resolves to have different shapes entirely.
+        if (layer.auth) auth = layer.auth;
+        // hooks/store/kind/auth are accumulated above; strip them so deepMerge only folds the rest
         // (exactOptionalPropertyTypes forbids spreading them back in as `undefined`).
         const rest = { ...layer };
         delete rest.hooks;
         delete rest.store;
         delete rest.kind;
+        delete rest.auth;
         // Capture the raw `idempotency` toggle BEFORE `expandShorthand` normalizes it away — a
         // child `idempotency: false` must clear an inherited object (see the reconcile below), but
         // `expandShorthand` deletes `false` from this layer, so `deepMerge` would never see it and
@@ -201,6 +210,10 @@ export function compose(config: Fragment): ResolvedStitchConfig {
     if (hooks) merged.hooks = hooks;
     if (store) merged.store = store;
     if (kind) merged.kind = kind;
+    // Normalise the winning auth ONCE, after `extends` has resolved and before `__config` is built:
+    // a declarative descriptor becomes its live strategy here (ADR 0020), so redaction and the
+    // engine always see an `AuthStrategy`, and a descriptor's secret leaves never reach __config.
+    if (auth) merged.auth = normalizeAuth(auth);
     const output = normalizeOutput(merged.output);
     if (output !== undefined) merged.output = output;
     const input = normalizeInput(merged.input);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,6 @@
 // Shared vocabulary for the prototype. Leaf modules (resilience, trace, http-adapter,
 // auth, mock-server) and the engine all code against these types.
+import type { AuthConfig } from './auth';
 import type {
     Args,
     InputOf,
@@ -748,8 +749,14 @@ export interface StitchConfig {
     transform?: (body: unknown) => unknown;
     /** Auto-loop pages, aggregating items, with auth/retry/throttle applied to every page. */
     paginate?: PaginateOptions;
-    /** Auth strategy — the stitch holds the credential; the caller never sees it. */
-    auth?: AuthStrategy;
+    /**
+     * Auth — the stitch holds the credential; the caller never sees it. Accepts a live
+     * {@link AuthStrategy} (a `bearer()`/`apiKey()`/`basic()`/`oauth2()`/`cookieSession()` factory
+     * result, or a BYO strategy) **or** a declarative {@link AuthDescriptor} (`{ strategy: 'apiKey',
+     * … }`) — the same shape the config already serialises to on `__config.authScheme` (ADR 0020).
+     * Both forms are first-class; a descriptor is normalised to its strategy at construction.
+     */
+    auth?: AuthConfig;
     /**
      * Retry-and-backoff policy. A bare number is shorthand for the attempt count —
      * `retry: 3` ≡ `retry: { attempts: 3 }`.
@@ -868,13 +875,19 @@ export interface StitchConfig {
  */
 export type ResolvedStitchConfig = Omit<
     StitchConfig,
-    'retry' | 'timeout' | 'cache' | 'idempotency' | 'throttle'
+    'retry' | 'timeout' | 'cache' | 'idempotency' | 'throttle' | 'auth'
 > & {
     retry?: RetryOptions;
     timeout?: TimeoutOptions;
     cache?: CacheOptions;
     idempotency?: IdempotencyOptions;
     throttle?: ThrottleOptions;
+    /**
+     * Always a live {@link AuthStrategy} here: {@link normalizeAuth} resolves a declarative
+     * {@link AuthDescriptor} intake to its strategy during {@link compose}, before this shape is
+     * read by the engine and {@link redactConfig}.
+     */
+    auth?: AuthStrategy;
 };
 
 /**

--- a/packages/core/test/HARNESS-API.md
+++ b/packages/core/test/HARNESS-API.md
@@ -76,7 +76,9 @@ Drift is schema-anchored — no snapshot (ADR 0015). Each call validates the unw
 
 ## Auth
 
-`bearer(secret)`, `apiKey({ header?, value })`, `basic({ user, pass })`, `cookieSession({ login: <stitch>, cookie: 'sid', loginInput?: () => StitchInput, refreshOn?: [401] })`. Secrets: `env('VAR')` / `secretsFile('name')` return `() => string` resolved at call time. `cookieSession` auto-logs-in when no cookie is stored, replays the captured cookie, and re-logs-in when a response status is in `refreshOn`.
+`bearer(secret)`, `apiKey({ in?: 'header' | 'query' | 'cookie', name?, value })` (symmetric — `name` defaults to `X-API-Key`/`api_key`/`session` per location; legacy `header?` alias still works), `basic({ user, pass })`, `cookieSession({ login: <stitch>, cookie: 'sid', loginInput?: () => StitchInput, refreshOn?: [401] })`. Secrets: `env('VAR')` / `secretsFile('name')` return `() => string` resolved at call time. `cookieSession` auto-logs-in when no cookie is stored, replays the captured cookie, and re-logs-in when a response status is in `refreshOn`.
+
+`auth` also accepts a **declarative descriptor** (ADR 0020) — the same shape without importing the factory: `{ strategy: 'bearer', token }`, `{ strategy: 'apiKey', in?, name?, value }`, `{ strategy: 'basic', user, pass }`, `{ strategy: 'oauth2', …OAuth2Options }`, `{ strategy: 'cookieSession', …CookieSessionOptions }`. Detection: an object with `apply` is a live strategy (wins); else an object with `strategy` is a descriptor; else construction throws.
 
 ## Mock server
 

--- a/packages/core/test/auth-descriptor-unarmed.spec.ts
+++ b/packages/core/test/auth-descriptor-unarmed.spec.ts
@@ -1,0 +1,19 @@
+// ADR 0020 edge case. The strategy factories are kept OUT of the lean `import { stitch }` bundle by
+// arming the descriptor resolver only when a secret resolver (`env`/`secretsFile`/`secretFrom`) runs
+// — which a real descriptor's credential (`token: env('…')`) always does. A descriptor that resolves
+// NO secret through them (a literal-string secret) AND whose module imports no other auth symbol can
+// therefore reach `stitch()` with the resolver unarmed; it MUST fail loudly at construction with an
+// actionable fix, never silently.
+//
+// This lives in its own file so vitest's per-file module isolation guarantees an UNARMED resolver:
+// nothing here (and no earlier test in this registry) has called a secret resolver.
+import { stitch } from '../src';
+
+test('a literal-secret descriptor with no auth import throws a helpful construction error', () => {
+    expect(() =>
+        stitch({
+            url: 'https://api.example.com/me',
+            auth: { strategy: 'bearer', token: 'sk-literal' },
+        }),
+    ).toThrow(/declarative .auth. needs the resolver loaded/i);
+});

--- a/packages/core/test/auth-descriptor.spec.ts
+++ b/packages/core/test/auth-descriptor.spec.ts
@@ -1,0 +1,409 @@
+// ADR 0020 — `auth` accepts a declarative `AuthDescriptor` beside the strategy factories. These
+// pin the two guarantees the ADR turns on: a descriptor produces byte-identical WIRE behaviour to
+// the factory it sugars (all five strategies), and the intake-detection (Q6), atomic-`extends` slot
+// (Q7), and `__config` redaction rules all hold. The apiKey factory's new symmetric `{ in, name,
+// value }` shape (incl. `in: 'cookie'`) is exercised here too.
+import {
+    apiKey,
+    basic,
+    bearer,
+    cookieSession,
+    env,
+    oauth2,
+    stitch,
+} from '../src';
+import type { AuthConfig } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+    // Arm the ADR 0020 descriptor resolver. In real code a descriptor's credential is an `env()`
+    // thunk, and calling `env()` arms the resolver (the seam that keeps the strategy factories OUT of
+    // the lean `import { stitch }` bundle). These parity tests use literal secrets for clarity, so
+    // trigger the same arming once here — exactly what a real `token: env('…')` descriptor does.
+    void env('STITCH_ADR20_ARM');
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+// Drive the factory form then the descriptor form against ONE route and hand back the two recorded
+// requests, so each parity test can assert they carry byte-identical credentials.
+async function twoRequests(
+    path: string,
+    factory: AuthConfig,
+    descriptor: AuthConfig,
+) {
+    server.route('GET', path, { body: { ok: true } });
+    await stitch({ baseUrl: server.url, path, auth: factory })();
+    await stitch({ baseUrl: server.url, path, auth: descriptor })();
+    const calls = server.calls(path);
+    return { factory: calls[0]!, descriptor: calls[1]! };
+}
+
+describe('ADR 0020 — declarative auth descriptors', () => {
+    // ── descriptor → identical wire behaviour as its factory ────────────────
+    describe('a descriptor produces the same request as its factory', () => {
+        test('bearer', async () => {
+            const { factory, descriptor } = await twoRequests(
+                '/d-bearer',
+                bearer('tok-123'),
+                { strategy: 'bearer', token: 'tok-123' },
+            );
+            expect(descriptor.headers['authorization']).toBe('Bearer tok-123');
+            expect(descriptor.headers['authorization']).toBe(
+                factory.headers['authorization'],
+            );
+        });
+
+        test('apiKey — header (default location + default name)', async () => {
+            const { factory, descriptor } = await twoRequests(
+                '/d-ak-h',
+                apiKey({ value: 'sk-1' }),
+                { strategy: 'apiKey', value: 'sk-1' },
+            );
+            expect(descriptor.headers['x-api-key']).toBe('sk-1');
+            expect(descriptor.headers['x-api-key']).toBe(
+                factory.headers['x-api-key'],
+            );
+        });
+
+        test('apiKey — header with a custom name', async () => {
+            const { factory, descriptor } = await twoRequests(
+                '/d-ak-hn',
+                apiKey({ name: 'X-Custom-Key', value: 'sk-2' }),
+                {
+                    strategy: 'apiKey',
+                    in: 'header',
+                    name: 'X-Custom-Key',
+                    value: 'sk-2',
+                },
+            );
+            expect(descriptor.headers['x-custom-key']).toBe('sk-2');
+            expect(descriptor.headers['x-custom-key']).toBe(
+                factory.headers['x-custom-key'],
+            );
+        });
+
+        test('apiKey — query param', async () => {
+            const { factory, descriptor } = await twoRequests(
+                '/d-ak-q',
+                apiKey({ in: 'query', name: 'access_token', value: 'sk-3' }),
+                {
+                    strategy: 'apiKey',
+                    in: 'query',
+                    name: 'access_token',
+                    value: 'sk-3',
+                },
+            );
+            expect(descriptor.query['access_token']).toBe('sk-3');
+            expect(descriptor.query['access_token']).toBe(
+                factory.query['access_token'],
+            );
+        });
+
+        test('apiKey — cookie', async () => {
+            const { factory, descriptor } = await twoRequests(
+                '/d-ak-c',
+                apiKey({ in: 'cookie', name: 'sid', value: 'sk-4' }),
+                {
+                    strategy: 'apiKey',
+                    in: 'cookie',
+                    name: 'sid',
+                    value: 'sk-4',
+                },
+            );
+            expect(descriptor.cookies['sid']).toBe('sk-4');
+            expect(descriptor.cookies['sid']).toBe(factory.cookies['sid']);
+        });
+
+        test('basic', async () => {
+            const { factory, descriptor } = await twoRequests(
+                '/d-basic',
+                basic({ user: 'ada', pass: 'pw' }),
+                { strategy: 'basic', user: 'ada', pass: 'pw' },
+            );
+            // base64('ada:pw') — the exact same Basic credential either way.
+            expect(descriptor.headers['authorization']).toMatch(/^Basic /);
+            expect(descriptor.headers['authorization']).toBe(
+                factory.headers['authorization'],
+            );
+        });
+
+        test('oauth2 — fetches and attaches the same Bearer token', async () => {
+            server.route('POST', '/token', {
+                body: {
+                    access_token: 'T1',
+                    token_type: 'Bearer',
+                    expires_in: 3600,
+                },
+            });
+            // `requireHeader` gates the route: the call only resolves if `Bearer T1` was sent.
+            server.route('GET', '/o-data', {
+                requireHeader: { name: 'authorization', value: 'Bearer T1' },
+                body: { ok: true },
+            });
+            const opts = {
+                tokenUrl: `${server.url}/token`,
+                clientId: 'cid',
+                clientSecret: 'csecret',
+            };
+            const viaFactory = stitch({
+                baseUrl: server.url,
+                path: '/o-data',
+                auth: oauth2(opts),
+            });
+            const viaDescriptor = stitch({
+                baseUrl: server.url,
+                path: '/o-data',
+                auth: { strategy: 'oauth2', ...opts },
+            });
+            await expect(viaFactory()).resolves.toEqual({ ok: true });
+            await expect(viaDescriptor()).resolves.toEqual({ ok: true });
+            // Both passed the `Bearer T1` gate; each standalone stitch fetched its own token.
+            expect(server.callCount('/o-data')).toBe(2);
+        });
+
+        test('cookieSession — captures and replays the same session cookie', async () => {
+            server.route('POST', '/login', {
+                setCookie: { name: 'sid', value: 'GOOD' },
+                body: { ok: true },
+            });
+            server.route('GET', '/cs-data', {
+                requireCookie: { name: 'sid' },
+                body: { user: 'ada' },
+            });
+            const login = stitch({
+                method: 'POST',
+                baseUrl: server.url,
+                path: '/login',
+            });
+            const opts = { login, cookie: 'sid', scope: 'app' as const };
+            const viaFactory = stitch({
+                baseUrl: server.url,
+                path: '/cs-data',
+                auth: cookieSession(opts),
+            });
+            const viaDescriptor = stitch({
+                baseUrl: server.url,
+                path: '/cs-data',
+                auth: { strategy: 'cookieSession', ...opts },
+            });
+            await expect(viaFactory()).resolves.toEqual({ user: 'ada' });
+            await expect(viaDescriptor()).resolves.toEqual({ user: 'ada' });
+            const calls = server.calls('/cs-data');
+            expect(calls[0]?.cookies['sid']).toBe('GOOD');
+            expect(calls[1]?.cookies['sid']).toBe('GOOD');
+        });
+    });
+
+    // ── detection: strategy vs descriptor vs neither (Q6) ───────────────────
+    describe('intake detection (Q6)', () => {
+        test('an object carrying BOTH `apply` and `strategy` is a strategy — apply wins', async () => {
+            server.route('GET', '/both', { body: { ok: true } });
+            // A hand-spliced object: a real `apply` that sets a sentinel header, plus a misleading
+            // `strategy`/`token`. Detection must RUN `apply`, not resolve the bearer descriptor.
+            // Structurally a valid strategy (it has `apply`) that also carries a `strategy` tag.
+            // Its inferred type is assignable to `AuthConfig` as-is (a variable skips the literal's
+            // excess-property check), so no cast is needed — and detection must still pick `apply`.
+            const spliced = {
+                strategy: 'bearer',
+                token: 'should-be-ignored',
+                apply(req: { headers: Record<string, string> }) {
+                    req.headers['x-sentinel'] = 'from-apply';
+                },
+            };
+            await stitch({
+                baseUrl: server.url,
+                path: '/both',
+                auth: spliced,
+            })();
+            const c = server.calls('/both')[0];
+            expect(c?.headers['x-sentinel']).toBe('from-apply');
+            // The descriptor's bearer token was NOT applied.
+            expect(c?.headers['authorization']).toBeUndefined();
+        });
+
+        test('auth with neither `apply` nor `strategy` throws at construction', () => {
+            expect(() =>
+                stitch({
+                    baseUrl: server.url,
+                    path: '/x',
+                    auth: {} as unknown as AuthConfig,
+                }),
+            ).toThrow(/needs .apply. \(a strategy\) or .strategy./i);
+        });
+
+        test('an unknown `strategy` id throws at construction', () => {
+            expect(() =>
+                stitch({
+                    baseUrl: server.url,
+                    path: '/x',
+                    auth: {
+                        strategy: 'magic',
+                        token: 'x',
+                    } as unknown as AuthConfig,
+                }),
+            ).toThrow(/unknown auth strategy/i);
+        });
+    });
+
+    // ── extends: auth is an atomic last-writer-wins slot, never deep-merged (Q7) ──
+    describe('extends — auth is an atomic slot (Q7)', () => {
+        test('a child descriptor replaces an inherited strategy wholesale (no blend)', async () => {
+            server.route('GET', '/ext1', { body: { ok: true } });
+            await stitch({
+                extends: [{ auth: bearer('BASE') }],
+                baseUrl: server.url,
+                path: '/ext1',
+                auth: { strategy: 'apiKey', name: 'X-Key', value: 'sk-child' },
+            })();
+            const c = server.calls('/ext1')[0];
+            // Child wins entirely: the apiKey header is set, the inherited bearer is GONE.
+            expect(c?.headers['x-key']).toBe('sk-child');
+            expect(c?.headers['authorization']).toBeUndefined();
+        });
+
+        test('a child strategy replaces an inherited descriptor wholesale', async () => {
+            server.route('GET', '/ext2', { body: { ok: true } });
+            await stitch({
+                extends: [
+                    {
+                        auth: {
+                            strategy: 'apiKey',
+                            name: 'X-Base',
+                            value: 'sk-base',
+                        },
+                    },
+                ],
+                baseUrl: server.url,
+                path: '/ext2',
+                auth: bearer('CHILD'),
+            })();
+            const c = server.calls('/ext2')[0];
+            expect(c?.headers['authorization']).toBe('Bearer CHILD');
+            expect(c?.headers['x-base']).toBeUndefined();
+        });
+
+        test('two descriptors — last writer wins, fields never blend', async () => {
+            server.route('GET', '/ext3', { body: { ok: true } });
+            await stitch({
+                extends: [
+                    {
+                        auth: {
+                            strategy: 'apiKey',
+                            name: 'X-Base',
+                            value: 'sk-base',
+                        },
+                    },
+                ],
+                baseUrl: server.url,
+                path: '/ext3',
+                auth: {
+                    strategy: 'apiKey',
+                    in: 'query',
+                    name: 'child_key',
+                    value: 'sk-child',
+                },
+            })();
+            const c = server.calls('/ext3')[0];
+            // Only the child's query key; the base header name did NOT survive a field-merge.
+            expect(c?.query['child_key']).toBe('sk-child');
+            expect(c?.headers['x-base']).toBeUndefined();
+            expect(c?.query['x-base']).toBeUndefined();
+        });
+    });
+
+    // ── __config projection + redaction ─────────────────────────────────────
+    describe('__config projection + redaction', () => {
+        test('a descriptor surfaces the same authScheme as the factory, with no live auth', () => {
+            const viaFactory = stitch({
+                path: '/x',
+                auth: apiKey({ in: 'cookie', name: 'sid', value: 'sk' }),
+            });
+            const viaDescriptor = stitch({
+                path: '/x',
+                auth: {
+                    strategy: 'apiKey',
+                    in: 'cookie',
+                    name: 'sid',
+                    value: 'sk',
+                },
+            });
+            expect(viaDescriptor.__config.authScheme).toEqual({
+                type: 'apiKey',
+                in: 'cookie',
+                name: 'sid',
+            });
+            expect(viaDescriptor.__config.authScheme).toEqual(
+                viaFactory.__config.authScheme,
+            );
+            // The live, secret-bearing auth is stripped from the public config either way.
+            expect(
+                (viaDescriptor.__config as { auth?: unknown }).auth,
+            ).toBeUndefined();
+        });
+
+        test('a descriptor never lands its secret (or the raw shell) on __config', () => {
+            const s = stitch({
+                path: '/x',
+                auth: { strategy: 'bearer', token: 'super-secret-token' },
+            });
+            const json = JSON.stringify(s.__config);
+            expect(json).not.toContain('super-secret-token');
+            expect(json).not.toContain('strategy');
+        });
+    });
+
+    // ── apiKey factory — symmetric { in, name, value } shape (ADR 0020 / #485) ──
+    describe('apiKey factory — symmetric shape', () => {
+        test('`name` sets the header name (symmetric with query/cookie)', async () => {
+            server.route('GET', '/sym-h', { body: { ok: true } });
+            await stitch({
+                baseUrl: server.url,
+                path: '/sym-h',
+                auth: apiKey({ name: 'X-Sym', value: 'v' }),
+            })();
+            expect(server.calls('/sym-h')[0]?.headers['x-sym']).toBe('v');
+        });
+
+        test('the legacy `header` alias still names the header (back-compat)', async () => {
+            server.route('GET', '/sym-legacy', { body: { ok: true } });
+            await stitch({
+                baseUrl: server.url,
+                path: '/sym-legacy',
+                auth: apiKey({ header: 'X-Legacy', value: 'v' }),
+            })();
+            expect(server.calls('/sym-legacy')[0]?.headers['x-legacy']).toBe(
+                'v',
+            );
+        });
+
+        test('`name` wins when both `name` and `header` are given', async () => {
+            server.route('GET', '/sym-both', { body: { ok: true } });
+            await stitch({
+                baseUrl: server.url,
+                path: '/sym-both',
+                auth: apiKey({ name: 'X-Win', header: 'X-Lose', value: 'v' }),
+            })();
+            const c = server.calls('/sym-both')[0];
+            expect(c?.headers['x-win']).toBe('v');
+            expect(c?.headers['x-lose']).toBeUndefined();
+        });
+
+        test('in: cookie attaches name=value on the Cookie header (default name `session`)', async () => {
+            server.route('GET', '/sym-c', { body: { ok: true } });
+            await stitch({
+                baseUrl: server.url,
+                path: '/sym-c',
+                auth: apiKey({ in: 'cookie', value: 'v' }),
+            })();
+            expect(server.calls('/sym-c')[0]?.cookies['session']).toBe('v');
+        });
+    });
+});

--- a/packages/core/test/from-curl-edges.spec.ts
+++ b/packages/core/test/from-curl-edges.spec.ts
@@ -10,7 +10,7 @@
 import { parseCurl, parseHar, toStitchSource } from '../src/from-curl';
 
 describe('toStitchSource — auth recognition (untested strategies)', () => {
-    it('maps Basic auth to basic(env(...)) and never emits the credential', () => {
+    it('maps Basic auth to a basic descriptor and never emits the credential', () => {
         const cred = 'dXNlcjpzdXBlci1zZWNyZXQ='; // base64 user:super-secret
         const { source } = toStitchSource(
             parseCurl(
@@ -18,15 +18,14 @@ describe('toStitchSource — auth recognition (untested strategies)', () => {
             ),
         );
         expect(source).not.toContain(cred);
+        // ADR 0020: declarative descriptor, no strategy import (only `stitch` + `env`).
         expect(source).toContain(
-            "basic({ user: env('API_USER'), pass: env('API_PASSWORD') })",
+            "{ strategy: 'basic', user: env('API_USER'), pass: env('API_PASSWORD') }",
         );
-        expect(source).toContain(
-            "import { stitch, basic, env } from 'stitchapi'",
-        );
+        expect(source).toContain("import { stitch, env } from 'stitchapi'");
     });
 
-    it('maps an ?api_key= query param to apiKey({ in: query }) and strips the secret', () => {
+    it('maps an ?api_key= query param to an apiKey query descriptor and strips the secret', () => {
         const { source } = toStitchSource(
             parseCurl(
                 'curl "https://api.example.com/data?api_key=secret-123&page=2"',
@@ -34,11 +33,9 @@ describe('toStitchSource — auth recognition (untested strategies)', () => {
         );
         expect(source).not.toContain('secret-123');
         expect(source).toContain(
-            "apiKey({ in: 'query', name: 'api_key', value: env('API_KEY') })",
+            "{ strategy: 'apiKey', in: 'query', name: 'api_key', value: env('API_KEY') }",
         );
-        expect(source).toContain(
-            "import { stitch, apiKey, env } from 'stitchapi'",
-        );
+        expect(source).toContain("import { stitch, env } from 'stitchapi'");
         // the non-auth query param survives; the auth one is removed from the call query.
         expect(source).toContain('page: 2');
         expect(source).not.toMatch(/query:\s*{[^}]*api_key/);
@@ -52,7 +49,7 @@ describe('toStitchSource — auth recognition (untested strategies)', () => {
         );
         expect(source).not.toContain('tok-xyz');
         expect(source).toContain(
-            "apiKey({ in: 'query', name: 'access_token', value: env('API_KEY') })",
+            "{ strategy: 'apiKey', in: 'query', name: 'access_token', value: env('API_KEY') }",
         );
     });
 });

--- a/packages/core/test/from-curl.spec.ts
+++ b/packages/core/test/from-curl.spec.ts
@@ -91,7 +91,7 @@ describe('toStitchSource', () => {
         );
     });
 
-    test('a Bearer token never appears in the source; bearer(env(...)) does', () => {
+    test('a Bearer token never appears in the source; a bearer descriptor does', () => {
         const secret = 'sk-super-secret-token-zzz';
         const { source } = toStitchSource(
             parseCurl(
@@ -99,11 +99,13 @@ describe('toStitchSource', () => {
             ),
         );
         expect(source).not.toContain(secret);
-        expect(source).toContain("bearer(env('API_TOKEN'))");
-        // The import line carries exactly the symbols used.
+        // ADR 0020: auth is emitted as a declarative descriptor — pure data, no strategy import.
         expect(source).toContain(
-            "import { stitch, bearer, env } from 'stitchapi'",
+            "{ strategy: 'bearer', token: env('API_TOKEN') }",
         );
+        // The import line carries exactly the symbols used — `stitch` + `env`, NOT the `bearer`
+        // factory (the descriptor form imports no strategy).
+        expect(source).toContain("import { stitch, env } from 'stitchapi'");
         // The Authorization header is consumed by auth, not echoed into static headers.
         expect(source).not.toMatch(/headers:\s*{[^}]*authorization/i);
     });
@@ -144,7 +146,7 @@ describe('toStitchSource', () => {
         expect(source).toContain('limit: 10');
     });
 
-    test('an x-api-key header → apiKey({ value: env(API_KEY) }), secret stripped', () => {
+    test('an x-api-key header → an apiKey descriptor, secret stripped', () => {
         const key = 'apikey-zzz-1234567890';
         const { source } = toStitchSource(
             parseCurl(
@@ -152,10 +154,11 @@ describe('toStitchSource', () => {
             ),
         );
         expect(source).not.toContain(key);
-        expect(source).toContain("apiKey({ value: env('API_KEY') })");
+        // ADR 0020: a declarative descriptor, no `apiKey` factory import.
         expect(source).toContain(
-            "import { stitch, apiKey, env } from 'stitchapi'",
+            "{ strategy: 'apiKey', value: env('API_KEY') }",
         );
+        expect(source).toContain("import { stitch, env } from 'stitchapi'");
     });
 
     test('--zod emits an output schema inferred from a sample response', () => {
@@ -214,7 +217,9 @@ describe('parseHar', () => {
     test('toStitchSource on the HAR request strips the Bearer secret', () => {
         const { source } = toStitchSource(parseHar(har));
         expect(source).not.toContain('har-tok');
-        expect(source).toContain("bearer(env('API_TOKEN'))");
+        expect(source).toContain(
+            "{ strategy: 'bearer', token: env('API_TOKEN') }",
+        );
         expect(source).toContain("bodyType: 'json'");
     });
 

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -170,6 +170,9 @@ const SUFFIX_CARVEOUT = new Set([
     'ResolvedStitchConfig',
     'RedactedStitchConfig',
     'SeamConfig',
+    // ADR 0020: the config-slot UNION type of `StitchConfig.auth` (`AuthStrategy | AuthDescriptor`),
+    // not a consumer-input `*Options` envelope — same `*Config` family as StitchConfig above.
+    'AuthConfig',
     'OpenApiInfo', // mirrors the OpenAPI spec's InfoObject (P18: keep the upstream spelling)
 ]);
 const isLike = (n) => /Like/.test(n);


### PR DESCRIPTION
Implements [ADR 0020](docs/adr/0020-declarative-auth-descriptors.md) — `auth` accepts a declarative `AuthDescriptor` alongside the strategy factories — across all three proposed rollout steps, as three commits.

## What changed

**1 · Core (`feat(core): declarative auth descriptors`)**
- `StitchConfig.auth` now accepts **`AuthStrategy | AuthDescriptor`** (exported as `AuthConfig`). A descriptor is a flat discriminated union on `strategy`: `{ strategy: 'apiKey', in: 'cookie', name: 'sid', value: env('KEY') }` resolves to exactly what `apiKey({ … })` builds — same wire behaviour, no factory import. Both forms are first-class and permanent.
- **Detection (Q6):** `apply` fn ⇒ live strategy (wins even alongside `strategy`); else `strategy` key ⇒ descriptor; else throw at construction.
- **Atomic `extends` slot (Q7):** `auth` stops flowing through `deepMerge` (which would blend two strategies field-by-field — a latent bug) and becomes last-writer-wins like `store`/`kind`; the winner is normalized once, after `extends` resolves and before `__config` is built, so a descriptor's secret leaves never reach the strict-JSON `__config`.
- **Folded in #485's symmetric `apiKey`:** the ADR builds on `apiKey({ in: 'header'|'query'|'cookie', name, value })`, but #485 wasn't merged — so this extends the factory to that shape (incl. `in: 'cookie'`), keeping the legacy `header` alias working. **If #485 lands separately, the two need reconciling.**

**2 · Docs (`docs(auth): …`)** — a descriptor variant beside the factory snippet in every auth guide, a "Declarative descriptors" section in the reference, and the symmetric/cookie `apiKey` shape documented. All `ts twoslash` blocks type-check against the real exports.

**3 · from-curl (`feat(core): from-curl scaffolds auth as a declarative descriptor`)** — `stitch from-curl` emits `auth: { strategy: '…', … }` (pure data; imports only `stitch` + `env`, no strategy factory). `export --openapi` already emits descriptor-shaped JSON, and no OpenAPI→source `gen` command exists yet, so from-curl is the only source emitter to switch.

## Bundle (the load-bearing design decision)

Naively importing the resolver into `stitch.ts` dragged **all five factories** (incl. heavy `oauth2`/`cookieSession`) into the lean `import { stitch }` path — for *every* consumer, even no-auth ones. Fix: a **resolver seam** (`packages/core/src/auth-registry.ts`) holding the detection + a resolver slot; `auth.ts` keeps `fromDescriptor` (which references the factories) and **arms the seam from the secret resolvers** (`env`/`secretsFile`/`secretFrom`) — which a real descriptor's credential runs eagerly — *not* as a module-load side effect (esbuild would keep that and re-bloat the path). A bare `import { stitch }` with no auth therefore tree-shakes the factories away; only the small on-core-path detection seam remains. A literal-secret descriptor with no auth import throws a clear construction error (pinned by `auth-descriptor-unarmed.spec.ts`).

Budget bumped in `bundle-size.mjs` — the factories' weight does **not** hit `import { stitch }`:

| scenario | before (main) | after | Δ | old budget → new |
| --- | --- | --- | --- | --- |
| `import { stitch }` | 19.82 KB | **20.04 KB** | +0.22 KB | 20.00 → 20.25 |
| whole entry | 24.62 KB | **25.07 KB** | +0.45 KB | 24.80 → 25.30 |

(A naive in-core resolver would have been **+2.45 KB / 22.27 KB** on `import { stitch }` — 2.27 KB over. The seam avoids that.) Advertised sizes stay ~25/~20 KB, so the yakir advertised-size tether is unaffected. `AuthConfig` joins the P3 `*Config` carve-out (it's the config-slot union, not an options bag).

## Deliberate deviation from the ADR

ADR Q1's belt-and-suspenders "add `value`/`token`/`clientSecret` to the trace secret stems" — **not done for `value`.** `token`/`secret` (→`clientSecret`) are already stems; but the shared stem set also drives `redactSecretsDeep` over request bodies on every `start` frame, so a `value` stem would redact legitimate body fields for no gain — a descriptor is `config.auth`, never body data, and `redactConfig` strips `auth` wholesale regardless. Reasoned in a code comment near `AuthConfig`.

## Validation

Local: full core suite (**1236 passing**), `check:types` + `check:types-d` (tsd), eslint, prettier, `check:contract`, `check:exports`, `check:size` (within budget), and `fumadocs-mdx` twoslash over every edited doc block. `build:typed-deps` builds all 7 integration packages against the new `AuthConfig` (non-breaking, monorepo-wide). The full pre-push/CI gate (whole-tree `pnpm test` + `build-docs`) runs here.

> Note: this branch's worktree had two pre-existing, unrelated environmental gaps — a stale `packages/core/lib/` (fixed by a rebuild) and a missing `twoslash` devDep (fixed by `pnpm install`); neither is caused by these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)