### PR TITLE
feat(docs): add a "Star on GitHub" nav button with a live count

### DIFF
--- a/apps/docs/app/(home)/components/github-star-button.tsx
+++ b/apps/docs/app/(home)/components/github-star-button.tsx
@@ -1,0 +1,85 @@
+import { GithubIcon } from './primitives';
+
+import { cn } from '@/lib/cn';
+import { appName, gitConfig } from '@/lib/shared';
+
+import { Star } from 'lucide-react';
+
+const repoUrl = `https://github.com/${gitConfig.user}/${gitConfig.repo}`;
+
+/**
+ * Live stargazer count, fetched server-side and cached for an hour (ISR).
+ * Returns `null` on any network/API failure so the button degrades to a plain
+ * "Star" CTA — the fetch must never block or break the render that hosts it.
+ */
+async function fetchStarCount(): Promise<number | null> {
+    try {
+        const res = await fetch(
+            `https://api.github.com/repos/${gitConfig.user}/${gitConfig.repo}`,
+            {
+                headers: { Accept: 'application/vnd.github+json' },
+                // Stars move slowly and the unauthenticated API is rate-limited
+                // (60 req/h/IP), so refresh at most hourly rather than per request.
+                next: { revalidate: 3600 },
+            },
+        );
+        if (!res.ok) return null;
+        const data = (await res.json()) as { stargazers_count?: unknown };
+        return typeof data.stargazers_count === 'number'
+            ? data.stargazers_count
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+/** Compact count: `938 → "938"`, `1234 → "1.2k"`, `12345 → "12k"`. */
+function formatCount(n: number): string {
+    if (n < 1000) return String(n);
+    const k = n / 1000;
+    return `${k >= 10 ? Math.round(k) : k.toFixed(1).replace(/\.0$/, '')}k`;
+}
+
+/**
+ * "Star on GitHub" call-to-action with a live stargazer count. An async server
+ * component: the count is resolved during render (cached hourly) so there is no
+ * client-side fetch, loading flash, or per-visitor API call. Pass `className`
+ * to place it — it is used both in the hero and in the persistent site nav.
+ */
+export async function GithubStarButton({ className }: { className?: string }) {
+    const count = await fetchStarCount();
+    const formatted = count === null ? null : formatCount(count);
+
+    return (
+        <a
+            href={repoUrl}
+            target="_blank"
+            rel="noreferrer"
+            aria-label={
+                count === null
+                    ? `Star ${appName} on GitHub`
+                    : `Star ${appName} on GitHub — ${count.toLocaleString('en-US')} stars`
+            }
+            className={cn(
+                'group inline-flex items-center gap-2 rounded-xl border border-fd-border bg-fd-card px-4 py-2.5 text-sm font-semibold text-fd-foreground transition-colors hover:bg-fd-accent',
+                className,
+            )}
+        >
+            <GithubIcon className="size-4" />
+            <span>Star</span>
+            <span
+                className={cn(
+                    'inline-flex items-center gap-1 text-fd-muted-foreground',
+                    formatted !== null &&
+                        'border-l border-fd-border pl-2 tabular-nums',
+                )}
+            >
+                <Star
+                    aria-hidden="true"
+                    className="size-3.5 fill-accent text-accent transition-transform group-hover:scale-110"
+                />
+                {formatted}
+            </span>
+        </a>
+    );
+}

--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -1,5 +1,6 @@
-import { gitConfig, npmUrl } from './shared';
+import { npmUrl } from './shared';
 
+import { GithubStarButton } from '@/app/(home)/components/github-star-button';
 import { NpmIcon } from '@/app/(home)/components/primitives';
 import { Logo } from '@/components/logo';
 
@@ -32,7 +33,14 @@ export function baseOptions(): BaseLayoutProps {
                 url: npmUrl,
                 external: true,
             },
+            // "Star on GitHub" CTA with a live count — supersedes the plain
+            // `githubUrl` icon (removed) so there is one GitHub affordance, and
+            // it rides the right ("secondary") side of the nav on every page.
+            {
+                type: 'custom',
+                secondary: true,
+                children: <GithubStarButton />,
+            },
         ],
-        githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
     };
 }


### PR DESCRIPTION
## What

Adds a **"Star on GitHub"** call-to-action to the site header, showing the live
stargazer count — `octocat · Star │ ⭐ N`.

A small, low-cost social-proof affordance for the star-growth push: it rides the
header on **every page** (top-right on the home layout, left sidebar on the docs
layout).

## How

- New `GithubStarButton` — an **async server component** that resolves the
  stargazer count during render via the GitHub REST API, cached hourly with ISR
  (`next: { revalidate: 3600 }`). No client-side fetch, no loading flash, and no
  per-visitor API call (the unauthenticated 60 req/h/IP limit is a non-issue).
- **Graceful fallback**: any network/API failure returns `null` and the button
  degrades to a plain "Star ⭐" with no number — the fetch can never block or
  break the render that hosts it.
- Wired into the shared nav (`lib/layout.shared.tsx`) as a `type: 'custom'`,
  `secondary: true` link, and the now-redundant plain `githubUrl` GitHub icon is
  removed so there is a single GitHub affordance.
- **On-brand & theme-aware**: the star uses the repo's amber `accent` token
  (`#b4690a` light / `#f6a823` dark), not a hardcoded color.
- **Accessible**: `aria-label="Star StitchAPI on GitHub — N stars"`,
  `target="_blank"`, `rel="noreferrer"`.

## Test plan

- `pnpm --filter @stitchapi/docs check:lint` — clean
- `pnpm --filter @stitchapi/docs check:types` — passes
- Manually verified in `next dev`:
  - Renders in the home header (top-right) and the docs sidebar; live count shown.
  - Correct `href` → `https://github.com/rejifald/StitchAPI`, `target=_blank`,
    `rel=noreferrer`, and aria-label.
  - Light and dark mode both correct (theme-aware amber).
  - No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
