### PR TITLE
refactor(core)!: rename StitchConfig.query → document (GraphQL document field)

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -78,16 +78,16 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             info: "Static default headers merged into every request.",
         },
         {
-            label: "query",
+            label: "document",
             type: "property",
             detail: "string",
-            info: "GraphQL query string (`kind: 'graphql'`).",
+            info: "GraphQL document string (`kind: 'graphql'`) — sent as the request body's `query` field.",
         },
         {
             label: "operationName",
             type: "property",
             detail: "string",
-            info: "GraphQL `operationName` sent alongside `query` + `variables` (`kind: 'graphql'`). Omit to derive it from the first named operation in `query`; set it explicitly to override (e.g. a multi-operation document) or pass `''` to suppress the field entirely.",
+            info: "GraphQL `operationName` sent alongside the document + `variables` (`kind: 'graphql'`). Omit to derive it from the first named operation in `document`; set it explicitly to override (e.g. a multi-operation document) or pass `''` to suppress the field entirely.",
         },
         {
             label: "input",

--- a/apps/docs/content/blog/typed-graphql-without-apollo.mdx
+++ b/apps/docs/content/blog/typed-graphql-without-apollo.mdx
@@ -24,7 +24,7 @@ async function getUser(id: string): Promise<User> {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
-            query: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
+            document: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
             variables: { id },
         }),
     });
@@ -47,14 +47,14 @@ import { graphql } from 'stitchapi';
 const getUser = graphql<{ user: { id: string; name: string } }>({
     baseUrl: 'https://api.example.com',
     path: '/graphql',
-    query: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
+    document: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
 });
 
 const data = await getUser({ variables: { id: '1' } });
 // data is already unwrapped from `data`: { user: { id, name } }
 ```
 
-Each field maps to glue you no longer write. `graphql()` sends the POST and the JSON body shape for you, so the `method`, the `content-type` header, and the `{ query, variables }` envelope vanish from your code. The arguments travel in the call input's `variables` field at call time, so one declared stitch serves every set of arguments — you do not interpolate values into the query string and mint a stitch per call. Because `unwrap` defaults to `'data'`, the resolved value is the contents of the response's `data` field; override `unwrap` to read a different field or the raw envelope.
+Each field maps to glue you no longer write. `graphql()` sends the POST and the JSON body shape for you, so the `method`, the `content-type` header, and the `{ query, variables }` envelope vanish from your code — the `document` you declare travels as the envelope's `query` field. The arguments travel in the call input's `variables` field at call time, so one declared stitch serves every set of arguments — you do not interpolate values into the document and mint a stitch per call. Because `unwrap` defaults to `'data'`, the resolved value is the contents of the response's `data` field; override `unwrap` to read a different field or the raw envelope.
 
 The footgun closes here. A GraphQL endpoint can return HTTP `200` while carrying a top-level `errors` array; the stitch treats that as a failure and surfaces it, rather than unwrapping a `data` that isn't there. A failed query rejects the awaitable with a `StitchError` whose message carries the GraphQL error text, prefixed `GraphQL:` (joined with `; ` when there is more than one):
 
@@ -64,7 +64,7 @@ import { StitchError, graphql } from 'stitchapi';
 const getUser = graphql<{ user: { name: string } }>({
     baseUrl: 'https://api.example.com',
     path: '/graphql',
-    query: `query GetUser($id: ID!) { user(id: $id) { name } }`,
+    document: `query GetUser($id: ID!) { user(id: $id) { name } }`,
 });
 
 try {
@@ -92,7 +92,7 @@ import { z } from 'zod';
 const getUser = graphql<{ user: { id: string; name: string } }>({
     baseUrl: 'https://api.example.com',
     path: '/graphql',
-    query: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
+    document: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
     output: z.object({
         user: z.object({ id: z.string(), name: z.string() }),
     }),
@@ -111,7 +111,7 @@ The secret resolves at call time from the environment, so the caller never holds
 
 | Axis                     | Hand-rolled `fetch`                                                                   | A `graphql()` stitch                                               |
 | ------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| The POST + JSON envelope | You write `method`, `content-type`, `JSON.stringify({ query, variables })` every call | `graphql()` fixes them; you supply `path` + `query`                |
+| The POST + JSON envelope | You write `method`, `content-type`, `JSON.stringify({ query, variables })` every call | `graphql()` fixes them; you supply `path` + `document`             |
 | Variables                | Re-stringified per call site                                                          | Travel in `variables` at call time; one stitch, every argument set |
 | `200` with `errors`      | `res.ok` is `true` — failure slips through as `undefined`                             | A `StitchError` whose message is prefixed `GraphQL:`               |
 | Response shape           | `as User` — unchecked                                                                 | `output` schema validates the picked `data` at runtime             |
@@ -134,12 +134,12 @@ const api = seam({
 
 const getUser = api.graphql({
     path: '/graphql',
-    query: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
+    document: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
 });
 
 const listOrders = api.graphql({
     path: '/graphql',
-    query: `query Orders($userId: ID!) { orders(userId: $userId) { id total } }`,
+    document: `query Orders($userId: ID!) { orders(userId: $userId) { id total } }`,
 });
 ```
 

--- a/apps/docs/content/docs/errors/stitch-graphql.mdx
+++ b/apps/docs/content/docs/errors/stitch-graphql.mdx
@@ -17,7 +17,7 @@ import { StitchError, graphql } from 'stitchapi';
 const user = graphql({
     baseUrl: 'https://api.example.com',
     path: '/graphql',
-    query: `query ($id: ID!) { user(id: $id) { name } }`,
+    document: `query ($id: ID!) { user(id: $id) { name } }`,
 });
 
 try {

--- a/apps/docs/content/docs/guides/data/graphql.mdx
+++ b/apps/docs/content/docs/guides/data/graphql.mdx
@@ -17,7 +17,7 @@ import { graphql } from 'stitchapi';
 const getUser = graphql<{ user: { id: string; name: string } }>({
     baseUrl: 'https://api.example.com',
     path: '/graphql',
-    query: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
+    document: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
 });
 
 // Variables travel in the input; the result is already picked from `data`.
@@ -28,7 +28,7 @@ const data = await getUser({ variables: { id: '1' } });
 
 `graphql()` is a thin wrapper over `stitch()`: it fixes `kind: 'graphql'`,
 `method: 'POST'`, and `pick: 'data'` for you. You supply the GraphQL document
-as `query`, plus a `baseUrl`/`path` pointing at the endpoint.
+as `document`, plus a `baseUrl`/`path` pointing at the endpoint.
 
 Pass GraphQL variables through the input's `variables` field at call time —
 `getUser({ variables: { id: '1' } })` — so one stitch serves every set of

--- a/apps/docs/content/docs/reference/stitch.mdx
+++ b/apps/docs/content/docs/reference/stitch.mdx
@@ -22,14 +22,14 @@ const user = stitch<{ id: string }>({
 ## graphql()
 
 `graphql<T>(config)` is a thin wrapper over `stitch()` for GraphQL-over-HTTP: it POSTs
-`{ query, variables }` and unwraps `data`. The config must carry a `query`.
+`{ query, variables }` and picks `data`. The config must carry a `document`.
 
 ```ts twoslash
 import { graphql } from 'stitchapi';
 
 const viewer = graphql<{ viewer: { id: string } }>({
     path: 'https://api.example.com/graphql',
-    query: 'query { viewer { id } }',
+    document: 'query { viewer { id } }',
 });
 ```
 

--- a/apps/docs/content/docs/reference/surfaces.mdx
+++ b/apps/docs/content/docs/reference/surfaces.mdx
@@ -48,7 +48,7 @@ import { graphql } from 'stitchapi/graphql';
 
 const getThing = graphql({
     baseUrl: 'https://api.example.com',
-    query: 'query ($id: ID) { thing(id: $id) { name } }',
+    document: 'query ($id: ID) { thing(id: $id) { name } }',
 });
 
 const thing = await getThing({ variables: { id: 1 } });

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -73,8 +73,7 @@ A public field or symbol **MUST** be the shortest unambiguous token for its conc
 value-space across the entire surface.
 
 _Current violations:_ `key` is a `string` namespace in `CircuitOptions` but a
-`(input) => string` in `IdempotencyOptions` / `CacheConfig`; `query` is a GraphQL
-document string in `StitchConfig` but URL params in `StitchInput` / `InputSchemas`;
+`(input) => string` in `IdempotencyOptions` / `CacheConfig`;
 `on` is retry-trigger statuses **and** rate-limit-signal statuses; `bodyKind`
 (`from-curl`) vs `bodyType` (everywhere else) for one `'json'|'form'` concept.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -659,7 +659,7 @@ import { graphql } from 'stitchapi';
 
 const getUser = graphql({
     baseUrl: 'https://demo.stitchapi.dev',
-    query: 'query ($id: ID) { user(id: $id) { name } }',
+    document: 'query ($id: ID) { user(id: $id) { name } }',
 });
 
 const user = await getUser({ variables: { id: 1 } });

--- a/packages/core/src/seam.ts
+++ b/packages/core/src/seam.ts
@@ -156,7 +156,7 @@ function principalHandle(shared: SharedSeam, principal: string): PrincipalSeam {
         // of that return under an unresolved `C` — so `graphql` needs the `as`. Sound — runtime is
         // identical; only the static call-arg richness is restored.
         stitch: (config: string | Partial<StitchConfig>) => build(config),
-        graphql: ((config: Partial<StitchConfig> & { query: string }) =>
+        graphql: ((config: Partial<StitchConfig> & { document: string }) =>
             build(config, true)) as PrincipalSeam['graphql'],
         as: (p) => principalHandle(shared, p),
         get __config() {
@@ -175,7 +175,7 @@ function rootHandle(shared: SharedSeam): Seam {
         // restore its rich `InputOf<C>` return after #76 widened `InputOf`; `stitch` satisfies its
         // loose fallback overload as-is.
         stitch: (config: string | Partial<StitchConfig>) => build(config),
-        graphql: ((config: Partial<StitchConfig> & { query: string }) =>
+        graphql: ((config: Partial<StitchConfig> & { document: string }) =>
             build(config, true)) as Seam['graphql'],
         as: (p) => principalHandle(shared, p),
         // Bulk cache invalidation over the seam's shared store (ADR 0003 §8). No argument bumps

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -944,9 +944,9 @@ export function drift<S>(
 export function graphql<
     TExplicit = never,
     const C extends Partial<StitchConfig> & {
-        query: string;
+        document: string;
     } = Partial<StitchConfig> & {
-        query: string;
+        document: string;
     },
 >(config: C): Stitch<ResolveOutput<TExplicit, C>, InputOf<C>> {
     // Default the endpoint to `/graphql` only when neither `url` nor `path` is given (preserves the

--- a/packages/core/src/surface.ts
+++ b/packages/core/src/surface.ts
@@ -106,9 +106,10 @@ export const httpSurface: Surface = { id: 'http' };
 
 /**
  * GraphQL-over-HTTP. Its behaviour lives entirely in these hooks (ADR 0005 Stage 4): `buildRequest`
- * packs `{ query, variables, operationName? }` as JSON and forces POST; `interpret` treats a 200
- * carrying `errors` as a failure. The `data` pick is a plain config key the `graphql(...)` helper
- * / `seam.graphql()` set (the engine applies it after `interpret`), as is the `/graphql` default
+ * packs the `document` as the wire body's `query` field (`{ query, variables, operationName? }`,
+ * the GraphQL-over-HTTP protocol shape) as JSON and forces POST; `interpret` treats a 200 carrying
+ * `errors` as a failure. The `data` pick is a plain config key the `graphql(...)` helper /
+ * `seam.graphql()` set (the engine applies it after `interpret`), as is the `/graphql` default
  * path.
  *
  * `operationName` is derived the way graphql clients (e.g. graphql-request) do: the name token of
@@ -120,16 +121,18 @@ export const httpSurface: Surface = { id: 'http' };
 export const graphqlSurface: Surface = {
     id: 'graphql',
     buildRequest: (cfg, input, base) => {
-        const query = cfg.query ?? '';
+        const document = cfg.document ?? '';
         const operationName =
             cfg.operationName ??
-            /\b(?:query|mutation|subscription)\s+(\w+)/.exec(query)?.[1];
+            /\b(?:query|mutation|subscription)\s+(\w+)/.exec(document)?.[1];
         return {
             ...base,
             method: (cfg.method ?? 'POST').toUpperCase(),
             bodyType: 'json',
             body: {
-                query,
+                // `query` is the GraphQL-over-HTTP wire field for the document — protocol shape,
+                // not the config spelling.
+                query: document,
                 variables: input.variables ?? input.body ?? {},
                 // Only carry the key when a name is known — anonymous documents omit it, matching
                 // graphql-request and keeping the body clean. `cfg.operationName: ''` suppresses it.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -723,12 +723,12 @@ export interface StitchConfig {
     path?: string;
     /** Static default headers merged into every request. */
     headers?: Record<string, string>;
-    /** GraphQL query string (`kind: 'graphql'`). */
-    query?: string;
+    /** GraphQL document string (`kind: 'graphql'`) — sent as the request body's `query` field. */
+    document?: string;
     /**
-     * GraphQL `operationName` sent alongside `query` + `variables` (`kind: 'graphql'`). Omit to
-     * derive it from the first named operation in `query`; set it explicitly to override (e.g. a
-     * multi-operation document) or pass `''` to suppress the field entirely.
+     * GraphQL `operationName` sent alongside the document + `variables` (`kind: 'graphql'`). Omit
+     * to derive it from the first named operation in `document`; set it explicitly to override
+     * (e.g. a multi-operation document) or pass `''` to suppress the field entirely.
      */
     operationName?: string;
     /** Schemas validating params, query, body, headers, and (GraphQL) variables before the request. */
@@ -1206,16 +1206,23 @@ export interface StitchStore {
 // ---- Seam (a primitive stitches belong to) --------------------------------
 /**
  * The config a seam shares with every member as a fragment — {@link StitchConfig} minus the keys
- * that are intrinsically **per-endpoint**: the address (`path` / `url` / `method` / `query`) and
- * the request/response shape (`name` / `input` / `output` / `kind`). Everything cross-cutting —
- * `baseUrl`, `headers`, `auth`, `retry`, `throttle`, `timeout`, `circuit`, `idempotency`,
+ * that are intrinsically **per-endpoint**: the address (`path` / `url` / `method` / `document`)
+ * and the request/response shape (`name` / `input` / `output` / `kind`). Everything cross-cutting
+ * — `baseUrl`, `headers`, `auth`, `retry`, `throttle`, `timeout`, `circuit`, `idempotency`,
  * `paginate`, `pick`, `transform`, `arrayFormat`, `hooks`, `trace`, `store`, `cache`, `adapter`
  * — belongs here, so the type itself answers "what belongs at the seam". Members set the endpoint
  * keys.
  */
 export type SeamConfig = Omit<
     StitchConfig,
-    'path' | 'url' | 'method' | 'query' | 'name' | 'input' | 'output' | 'kind'
+    | 'path'
+    | 'url'
+    | 'method'
+    | 'document'
+    | 'name'
+    | 'input'
+    | 'output'
+    | 'kind'
 >;
 
 /**
@@ -1272,9 +1279,9 @@ export interface Seam {
     graphql<
         TExplicit = never,
         const C extends Partial<StitchConfig> & {
-            query: string;
+            document: string;
         } = Partial<StitchConfig> & {
-            query: string;
+            document: string;
         },
     >(
         config: C,

--- a/packages/core/test-d/graphql-variables.test-d.ts
+++ b/packages/core/test-d/graphql-variables.test-d.ts
@@ -11,7 +11,7 @@ import { z } from 'zod';
 
 // 1) a declared `input.variables` schema types the call arg's `variables` and makes it required.
 const getThing = graphql({
-    query: 'query($id: ID!) { thing(id: $id) { name } }',
+    document: 'query($id: ID!) { thing(id: $id) { name } }',
     input: { variables: z.object({ id: z.string() }) },
 });
 expectType<{ id: string }>(
@@ -25,7 +25,7 @@ expectError(getThing({ variables: { id: 1 } })); // `id` is a string, not a numb
 //    (so a no-arg call stays legal, asserted via `{}` below), yet a present `variables` is still
 //    type-checked: a bad shape is rejected.
 const maybeVars = graphql({
-    query: 'query { ok }',
+    document: 'query { ok }',
     input: { variables: z.object({ region: z.string() }).optional() },
 });
 expectAssignable<CallArg<typeof maybeVars>>({}); // optional slot → empty arg is valid
@@ -34,14 +34,14 @@ expectError(maybeVars({ variables: { region: 1 } })); // region must be a string
 
 // 3) a graphql stitch with NO variables schema keeps `variables` optional + a loose passthrough —
 //    the pre-#75 behaviour, preserved now that `variables` is an InputSchemas slot. Any shape goes.
-const loose = graphql({ query: 'query { ok }' });
+const loose = graphql({ document: 'query { ok }' });
 expectAssignable<CallArg<typeof loose>>({ variables: { anything: 1 } });
 expectAssignable<CallArg<typeof loose>>({}); // and the arg stays fully optional
 
 // 4) `seam.graphql(...)` infers `variables` identically (it routes through the same `InputOf<C>`).
 const api = seam({ baseUrl: 'https://api.example.com' });
 const memberTyped = api.graphql({
-    query: 'query($id: ID!) { thing(id: $id) { name } }',
+    document: 'query($id: ID!) { thing(id: $id) { name } }',
     input: { variables: z.object({ id: z.string() }) },
 });
 expectType<{ id: string }>(
@@ -51,5 +51,5 @@ expectError(memberTyped()); // required on a seam member too
 expectError(memberTyped({ variables: { id: 1 } })); // wrong type on a seam member too
 
 // a schema-less seam graphql member also keeps the loose passthrough.
-const memberLoose = api.graphql({ query: 'query { ok }' });
+const memberLoose = api.graphql({ document: 'query { ok }' });
 expectAssignable<CallArg<typeof memberLoose>>({ variables: { anything: 1 } });

--- a/packages/core/test-d/input-inference.test-d.ts
+++ b/packages/core/test-d/input-inference.test-d.ts
@@ -86,7 +86,7 @@ expectType<{ id: string }>(
     null as unknown as CallArg<typeof asMember>['params'],
 );
 const gqlTyped = api.graphql({
-    query: 'query { ok }',
+    document: 'query { ok }',
     input: { params: z.object({ region: z.string() }) },
 });
 expectType<{ region: string }>(
@@ -95,7 +95,7 @@ expectType<{ region: string }>(
 // A graphql stitch with NO `input.variables` schema keeps `variables` as a loose untyped
 // passthrough. (Issue #75 makes a DECLARED `input.variables` schema type them — covered in
 // graphql-variables.test-d.ts; this case pins the schema-less behaviour stays unchanged.)
-const gqlLoose = api.graphql({ query: 'query { ok }', output: userSchema });
+const gqlLoose = api.graphql({ document: 'query { ok }', output: userSchema });
 expectAssignable<CallArg<typeof gqlLoose>>({ variables: { region: 'eu' } });
 
 // 7) a non-schema `input` slot value is rejected at compile time.

--- a/packages/core/test-d/overloads.test-d.ts
+++ b/packages/core/test-d/overloads.test-d.ts
@@ -26,10 +26,10 @@ expectType<unknown>(output(makeApi('/x')));
 const api = seam({ baseUrl: 'x' });
 expectType<unknown>(output(api.stitch(either)));
 
-// 4) graphql is a single overload, so a union of query-configs already resolves (no fallback needed).
+// 4) graphql is a single overload, so a union of document-configs already resolves (no fallback needed).
 declare const gqlEither:
-    | (Partial<StitchConfig> & { query: string })
-    | (Partial<StitchConfig> & { query: string; method: string });
+    | (Partial<StitchConfig> & { document: string })
+    | (Partial<StitchConfig> & { document: string; method: string });
 expectType<unknown>(output(api.graphql(gqlEither)));
 
 // 5) REGRESSION GUARD: the fallback overload must NOT shadow inference for concrete literals.

--- a/packages/core/test-d/path-vars.test-d.ts
+++ b/packages/core/test-d/path-vars.test-d.ts
@@ -128,7 +128,7 @@ expectType<{ org: string | number }>(
 );
 expectError(asMember());
 const gqlMember = api.graphql({
-    query: 'query { ok }',
+    document: 'query { ok }',
     path: '/gql/{region}',
 });
 expectType<{ region: string | number }>(

--- a/packages/core/test-d/seam.test-d.ts
+++ b/packages/core/test-d/seam.test-d.ts
@@ -27,6 +27,9 @@ expectType<User>(
 // graphql member infers from `output`
 expectType<User>(
     output(
-        api.graphql({ query: 'query { u { id name } }', output: userSchema }),
+        api.graphql({
+            document: 'query { u { id name } }',
+            output: userSchema,
+        }),
     ),
 );

--- a/packages/core/test/cache.spec.ts
+++ b/packages/core/test/cache.spec.ts
@@ -591,7 +591,7 @@ describe('cache — GraphQL opt-in', () => {
         });
         const q = graphql({
             url: 'https://api.test/graphql',
-            query: '{ me { id } }',
+            document: '{ me { id } }',
             adapter,
             trace: false,
             cache: { ttl: '60s', scope: 'app', methods: ['POST'] },
@@ -607,7 +607,7 @@ describe('cache — GraphQL opt-in', () => {
         });
         const q = graphql({
             url: 'https://api.test/graphql',
-            query: '{ me { id } }',
+            document: '{ me { id } }',
             adapter,
             trace: false,
             cache: { ttl: '60s', scope: 'app' }, // default methods GET/HEAD → POST excluded

--- a/packages/core/test/gaps/graphql-paginated-errors.spec.ts
+++ b/packages/core/test/gaps/graphql-paginated-errors.spec.ts
@@ -75,7 +75,8 @@ test('paginated GraphQL rejects when a page body carries errors[]', async () => 
 
     const query = graphql({
         baseUrl: server.url,
-        query: 'query($after: String) { users(after: $after) { nodes { id name } pageInfo { endCursor hasNextPage } } }',
+        document:
+            'query($after: String) { users(after: $after) { nodes { id name } pageInfo { endCursor hasNextPage } } }',
         ...paginateConfig,
     });
 

--- a/packages/core/test/graphql-and-headers.spec.ts
+++ b/packages/core/test/graphql-and-headers.spec.ts
@@ -37,7 +37,7 @@ describe('GraphQL kind', () => {
 
         const query = graphql({
             baseUrl: server.url,
-            query: 'query($id: ID) { thing(id: $id) { name } }',
+            document: 'query($id: ID) { thing(id: $id) { name } }',
             auth: apiKey({ header: 'apikey', value: env('GQL_KEY') }),
         });
 
@@ -56,7 +56,7 @@ describe('GraphQL kind', () => {
         server.route('POST', '/graphql', { body: { data: { ok: true } } });
         const query = graphql({
             baseUrl: server.url,
-            query: 'query($id: ID) { thing(id: $id) { name } }',
+            document: 'query($id: ID) { thing(id: $id) { name } }',
         });
 
         // Partial application must preserve EVERY StitchInput field. `variables` is the primary
@@ -74,7 +74,7 @@ describe('GraphQL kind', () => {
         server.route('POST', '/graphql', {
             body: { errors: [{ message: 'field "thing" not found' }] },
         });
-        const query = graphql({ baseUrl: server.url, query: '{ thing }' });
+        const query = graphql({ baseUrl: server.url, document: '{ thing }' });
         await expect(query()).rejects.toThrow(/thing.*not found/);
     });
 });
@@ -86,7 +86,7 @@ describe('GraphQL input.variables validation', () => {
         server.route('POST', '/graphql', { body: { data: { ok: true } } });
         const query = graphql({
             baseUrl: server.url,
-            query: 'query($id: ID!) { thing(id: $id) { name } }',
+            document: 'query($id: ID!) { thing(id: $id) { name } }',
             input: { variables: z.object({ id: z.string() }) },
         });
 
@@ -104,7 +104,7 @@ describe('GraphQL input.variables validation', () => {
         });
         const query = graphql({
             baseUrl: server.url,
-            query: 'query($id: ID!) { thing(id: $id) { name } }',
+            document: 'query($id: ID!) { thing(id: $id) { name } }',
             input: { variables: z.object({ id: z.string() }) },
         });
 
@@ -120,7 +120,7 @@ describe('GraphQL input.variables validation', () => {
         server.route('POST', '/graphql', { body: { data: { ok: true } } });
         const query = graphql({
             baseUrl: server.url,
-            query: 'query($id: ID) { thing(id: $id) { name } }',
+            document: 'query($id: ID) { thing(id: $id) { name } }',
         });
 
         // No `input.variables` → no validation; any variables flow straight through.

--- a/packages/core/test/idempotency.spec.ts
+++ b/packages/core/test/idempotency.spec.ts
@@ -177,7 +177,7 @@ test('the nudge is a hint with an out — silenced, and never fired for the case
         // even though `method` is unset here.
         graphql({
             baseUrl: server.url,
-            query: '{ me { id } }',
+            document: '{ me { id } }',
             idempotency: true,
         });
         expect(warn).not.toHaveBeenCalled();

--- a/packages/core/test/pagination.spec.ts
+++ b/packages/core/test/pagination.spec.ts
@@ -87,7 +87,8 @@ test('paginated GraphQL advances its cursor through the variables slot', async (
     const listUsers = graphql({
         baseUrl: server.url,
         path: '/gql',
-        query: 'query($after: String) { users(after: $after) { nodes pageInfo { endCursor hasNextPage } } }',
+        document:
+            'query($after: String) { users(after: $after) { nodes pageInfo { endCursor hasNextPage } } }',
         pick: 'data.users.nodes',
         paginate: {
             next: (body) => {

--- a/packages/core/test/seam-graphql.spec.ts
+++ b/packages/core/test/seam-graphql.spec.ts
@@ -31,7 +31,7 @@ describe('seam.graphql() member', () => {
         server.route('POST', '/graphql', { body: { data: { thing: 42 } } });
         const api = seam({ baseUrl: server.url, headers: { 'x-seam': 'yes' } });
 
-        const q = api.graphql({ query: '{ thing }' });
+        const q = api.graphql({ document: '{ thing }' });
 
         // kind round-trips as the graphql surface id.
         const json = JSON.parse(JSON.stringify(q.__config)) as {
@@ -52,7 +52,7 @@ describe('seam.graphql() member', () => {
         server.route('POST', '/gql', { body: { data: { ok: true } } });
         const api = seam({ baseUrl: server.url });
 
-        const q = api.graphql({ query: '{ ok }', path: '/gql' });
+        const q = api.graphql({ document: '{ ok }', path: '/gql' });
         await expect(q()).resolves.toEqual({ ok: true });
         expect(server.callCount('/gql')).toBe(1);
         expect(server.callCount('/graphql')).toBe(0);
@@ -62,7 +62,7 @@ describe('seam.graphql() member', () => {
         server.route('POST', '/graphql', { body: { data: { who: 'me' } } });
         const api = seam({ baseUrl: server.url });
 
-        const scoped = api.as('user-1').graphql({ query: '{ who }' });
+        const scoped = api.as('user-1').graphql({ document: '{ who }' });
         await expect(scoped()).resolves.toEqual({ who: 'me' });
         expect(server.callCount('/graphql')).toBe(1);
     });

--- a/packages/core/test/surface-graphql-hooks.spec.ts
+++ b/packages/core/test/surface-graphql-hooks.spec.ts
@@ -16,7 +16,7 @@ import type {
 } from '../src/types';
 
 const cfg = (
-    o: { query?: string; method?: string; operationName?: string } = {},
+    o: { document?: string; method?: string; operationName?: string } = {},
 ): ResolvedStitchConfig => o;
 
 const base: AdapterRequest = {
@@ -40,7 +40,7 @@ const res = (body: unknown, status = 200): AdapterResponse => ({
 
 describe('graphqlSurface.buildRequest', () => {
     test('packs { query, variables } as a JSON POST, preserving the base request', () => {
-        const req = build(cfg({ query: '{ thing }' }), {
+        const req = build(cfg({ document: '{ thing }' }), {
             variables: { id: 1 },
         });
         expect(req.method).toBe('POST');
@@ -51,16 +51,16 @@ describe('graphqlSurface.buildRequest', () => {
     });
 
     test('variables fall back to input.body, then to {}', () => {
-        const fromBody = build(cfg({ query: 'q' }), { body: { a: 1 } });
+        const fromBody = build(cfg({ document: 'q' }), { body: { a: 1 } });
         expect((fromBody.body as { variables: unknown }).variables).toEqual({
             a: 1,
         });
-        const none = build(cfg({ query: 'q' }), {});
+        const none = build(cfg({ document: 'q' }), {});
         expect((none.body as { variables: unknown }).variables).toEqual({});
     });
 
     test('input.variables wins over input.body', () => {
-        const req = build(cfg({ query: 'q' }), {
+        const req = build(cfg({ document: 'q' }), {
             variables: { v: 1 },
             body: { b: 2 },
         });
@@ -75,14 +75,14 @@ describe('graphqlSurface.buildRequest', () => {
     });
 
     test('honours and upper-cases a configured method', () => {
-        const req = build(cfg({ query: 'q', method: 'put' }), {});
+        const req = build(cfg({ document: 'q', method: 'put' }), {});
         expect(req.method).toBe('PUT');
     });
 
     test('derives operationName from the first named operation in the query', () => {
         const req = build(
             cfg({
-                query: 'query findScene($id: ID!) { scene(id: $id) { id } }',
+                document: 'query findScene($id: ID!) { scene(id: $id) { id } }',
             }),
             { variables: { id: 's1' } },
         );
@@ -97,7 +97,9 @@ describe('graphqlSurface.buildRequest', () => {
         expect(
             (
                 build(
-                    cfg({ query: 'mutation Login($p: P!) { login(p: $p) }' }),
+                    cfg({
+                        document: 'mutation Login($p: P!) { login(p: $p) }',
+                    }),
                     {},
                 ).body as {
                     operationName?: string;
@@ -106,7 +108,7 @@ describe('graphqlSurface.buildRequest', () => {
         ).toBe('Login');
         expect(
             (
-                build(cfg({ query: 'subscription OnTick { tick }' }), {})
+                build(cfg({ document: 'subscription OnTick { tick }' }), {})
                     .body as {
                     operationName?: string;
                 }
@@ -115,11 +117,11 @@ describe('graphqlSurface.buildRequest', () => {
     });
 
     test('omits operationName for an anonymous document (shorthand or unnamed query)', () => {
-        for (const query of [
+        for (const document of [
             '{ thing }',
             'query($id: ID) { thing(id: $id) }',
         ]) {
-            const body = build(cfg({ query }), {}).body as Record<
+            const body = build(cfg({ document }), {}).body as Record<
                 string,
                 unknown
             >;
@@ -129,7 +131,10 @@ describe('graphqlSurface.buildRequest', () => {
 
     test('an explicit cfg.operationName overrides the derived name', () => {
         const body = build(
-            cfg({ query: 'query A { a } query B { b }', operationName: 'B' }),
+            cfg({
+                document: 'query A { a } query B { b }',
+                operationName: 'B',
+            }),
             {},
         ).body as { operationName?: string };
         expect(body.operationName).toBe('B');
@@ -137,7 +142,7 @@ describe('graphqlSurface.buildRequest', () => {
 
     test('cfg.operationName of "" suppresses the field even for a named query', () => {
         const body = build(
-            cfg({ query: 'query Named { x }', operationName: '' }),
+            cfg({ document: 'query Named { x }', operationName: '' }),
             {},
         ).body as Record<string, unknown>;
         expect('operationName' in body).toBe(false);
@@ -146,7 +151,7 @@ describe('graphqlSurface.buildRequest', () => {
     test('does not mistake a field or type named like a keyword for the operation', () => {
         // `queryStatus` field + `query` keyword: only the real operation `Dash` is picked up.
         const body = build(
-            cfg({ query: 'query Dash { queryStatus mutationCount }' }),
+            cfg({ document: 'query Dash { queryStatus mutationCount }' }),
             {},
         ).body as { operationName?: string };
         expect(body.operationName).toBe('Dash');

--- a/packages/core/test/surface.spec.ts
+++ b/packages/core/test/surface.spec.ts
@@ -26,7 +26,7 @@ describe('Surface model (ADR 0005 Decisions 1-2, 11)', () => {
     });
 
     test('kind round-trips through __config as the id STRING, never the live object', () => {
-        const g = graphql({ baseUrl: 'https://x.test', query: '{ a }' });
+        const g = graphql({ baseUrl: 'https://x.test', document: '{ a }' });
         const json = JSON.parse(JSON.stringify(g.__config)) as {
             kind?: unknown;
         };
@@ -52,7 +52,7 @@ describe('generic stitch({ kind }) accepts a Surface (Decision 3)', () => {
             kind: graphqlSurface,
             baseUrl: server.url,
             path: '/gql',
-            query: '{ ok }',
+            document: '{ ok }',
         });
 
         await q({ variables: { x: 1 } });
@@ -73,7 +73,7 @@ describe('graphql surface helper (Decision 3/10)', () => {
         const q = graphql.stitch({
             baseUrl: server.url,
             path: '/g',
-            query: '{ me { id } }',
+            document: '{ me { id } }',
             pick: 'data.me',
         });
         expect(await q()).toEqual({ id: 7 });
@@ -84,7 +84,7 @@ describe('graphql surface helper (Decision 3/10)', () => {
         const api = seam({ baseUrl: server.url });
         const ping = graphql.seam(api).stitch({
             path: '/api',
-            query: '{ ping }',
+            document: '{ ping }',
             pick: 'data.ping',
         });
         expect(await ping()).toBe('pong');
@@ -94,7 +94,7 @@ describe('graphql surface helper (Decision 3/10)', () => {
         server.route('POST', '/s', { body: { data: { v: 42 } } });
         const g = graphql.seam({ baseUrl: server.url });
         expect(g.seam.__seam).toBe(true);
-        const v = g.stitch({ path: '/s', query: '{ v }', pick: 'data.v' });
+        const v = g.stitch({ path: '/s', document: '{ v }', pick: 'data.v' });
         expect(await v()).toBe(42);
     });
 });

--- a/packages/eval-harness/runner/prebaked.ts
+++ b/packages/eval-harness/runner/prebaked.ts
@@ -86,7 +86,7 @@ export async function run(fetchImpl: typeof fetch): Promise<User> {
         baseUrl: '${SNIPPET_BASE}',
         path: '/graphql',
         adapter: fetchAdapter({ fetch: fetchImpl }),
-        query: 'query { user { id name email } }',
+        document: 'query { user { id name email } }',
         // The graphql surface unwraps 'data' and treats a non-empty errors[] as a failure.
         pick: 'data.user',
         output: (v: unknown): v is User =>


### PR DESCRIPTION
## What

Extracts the **`query` → `document`** rename from #470 (the contract-freeze sweep) into a standalone, independently-mergeable PR.

Per `docs/CONTRACT.md` **P1**, `query` denoted two concepts on the surface:
- a **GraphQL document string** on `StitchConfig` (`kind: 'graphql'`), and
- **URL params** on `StitchInput` / `InputSchemas`.

This renames the GraphQL authoring field to **`document`**, freeing `query` to mean URL params everywhere. It's the single, self-contained slice of #470's ~20-rename sweep.

> **The GraphQL-over-HTTP wire body is unchanged.** The document is still sent as the `query` field of `{ query, variables, operationName? }` — that's the protocol shape, not the config spelling. The `graphqlSurface` maps `cfg.document` → body `query`.

## Scope

| Area | Change |
| --- | --- |
| `packages/core/src` | `types.ts` (`StitchConfig.document`, `Seam.graphql`, `SeamConfig` omit), `surface.ts` (`graphqlSurface`), `stitch.ts` + `seam.ts` (`graphql()` constraints) |
| Tests | 8 graphql `.spec.ts` + 5 `test-d/` type-tests |
| eval-harness | `runner/prebaked.ts` snippet |
| Docs | 5 MDX (`reference/`, `guides/`, `errors/`, blog), `core/README.md`, regenerated `playground-completions.generated.ts` (`gen:completions`), and the `CONTRACT.md` P1 note |

**26 files, +106/−87.** Every changed line is a `query`↔`document` change or its immediate comment/reflow — no other #470 rename (`value→data`, `unwrap→pick`, `scope→pool`, `key→keyOf`, …) leaks in.

## Deliberately out of scope

- **No contract-baseline change.** `scripts/check-contract.mjs` is a rule-based ratchet (R1–R6: suffixes, `Ms`, `key`-fn, `scope`, watch-list, all-optional bags); the `query` double-meaning isn't an encoded rule and has no baseline entry, so nothing to shrink. Ratchet stays green (5 known, 0 new).
- **`docs/proposals/type-inference-end-to-end.md` left as-is.** It's a frozen "mostly shipped" design snapshot, not site-rendered/twoslash/link-checked — and **#470 itself didn't touch it**, so this matches the source PR's scope.

## Verification — all gates green

`check:types` · `check:lint` · `check:format` (pre-commit) · `check:types-d` (tsd) · `test` (1213 passed) · `check:exports` · **`build-docs`** (full twoslash docs build) (pre-push) · `check:contract` · `check:docs-links`.

## Relation to #470

Independent of #470. Once this lands, #470 should be rebased to drop its `query`→`document` slice (the rest of its sweep is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)