### PR TITLE
refactor(core)!: drop the deprecated ThrottleOptions.scope alias (canonical pool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,12 +283,12 @@ const listUsers = stitch({
     baseUrl: 'https://demo.stitchapi.dev',
     path: '/users',
     retry: { attempts: 4, on: [429, 502, 503], respectRetryAfter: true },
-    throttle: { rate: '1/s', concurrency: 2, scope: 'host' },
+    throttle: { rate: '1/s', concurrency: 2, pool: 'host' },
     timeout: { total: '30s', perAttempt: '10s' },
 });
 ```
 
-`throttle` is proactive (keeps you under a limit before it bites; `scope: 'host'` shares a limiter across stitches), `retry` is reactive (backoff + `Retry-After`), and `timeout` aborts with a real `AbortSignal`. Three more knobs round it out: **`circuit`** fast-fails a dependency that's already down, **`idempotency`** injects a stable `Idempotency-Key` on writes, and **`acceptStatus`** treats a non-2xx (e.g. `404`) as a normal result instead of a throw. Full guide: [Resilience](https://stitchapi.dev/docs/guides/resilience/retry).
+`throttle` is proactive (keeps you under a limit before it bites; `pool: 'host'` shares a limiter across stitches), `retry` is reactive (backoff + `Retry-After`), and `timeout` aborts with a real `AbortSignal`. Three more knobs round it out: **`circuit`** fast-fails a dependency that's already down, **`idempotency`** injects a stable `Idempotency-Key` on writes, and **`acceptStatus`** treats a non-2xx (e.g. `404`) as a normal result instead of a throw. Full guide: [Resilience](https://stitchapi.dev/docs/guides/resilience/retry).
 
 ## Caching
 

--- a/apps/docs/content/blog/axios-alternatives.mdx
+++ b/apps/docs/content/blog/axios-alternatives.mdx
@@ -35,14 +35,14 @@ const listOrders = stitch({
     path: '/orders',
     output: z.object({ orders: z.array(Order) }),
     retry: { attempts: 4, on: [429, 502, 503], respectRetryAfter: true },
-    throttle: { rate: '1/s', concurrency: 2, scope: 'host' },
+    throttle: { rate: '1/s', concurrency: 2, pool: 'host' },
     timeout: { total: '30s', perAttempt: '10s' },
 });
 
 const { orders } = await listOrders(); // typed · validated · retried · throttled
 ```
 
-Everything that was an interceptor is now a field. `retry` backs off and honors `Retry-After`. `throttle` is **proactive** — it keeps you under the limit before the 429s arrive, and `scope: 'host'` shares one limiter across every stitch hitting that host, so it stays correct even as you add calls ([proactive throttling beats reacting to 429s](/blog/proactive-throttling-vs-reactive-429s)). `timeout` is layered: a ceiling for the whole call and a separate budget per attempt.
+Everything that was an interceptor is now a field. `retry` backs off and honors `Retry-After`. `throttle` is **proactive** — it keeps you under the limit before the 429s arrive, and `pool: 'host'` shares one limiter across every stitch hitting that host, so it stays correct even as you add calls ([proactive throttling beats reacting to 429s](/blog/proactive-throttling-vs-reactive-429s)). `timeout` is layered: a ceiling for the whole call and a separate budget per attempt.
 
 The `output` validator is the part axios never had. A stitch validates the **live** response on every call, so a shape mismatch is caught at the boundary as a typed error instead of surfacing as an `undefined` three layers downstream. Wrap the schema in `drift()` and each response is also diffed against its validated form, with every change leveled by severity — a renamed required field throws, a coercion the schema quietly absorbed surfaces as a `warn` on the event stream ([schema drift is a production bug](/blog/schema-drift-is-a-production-bug)). That's a class of failure an interceptor stack typically ships straight to production.
 

--- a/apps/docs/content/blog/call-any-llm-as-a-typed-function.mdx
+++ b/apps/docs/content/blog/call-any-llm-as-a-typed-function.mdx
@@ -169,7 +169,7 @@ const chat = llm({
         backoff: 'expo-jitter',
         respectRetryAfter: true,
     },
-    throttle: { rate: '5/s', concurrency: 2, scope: 'host' },
+    throttle: { rate: '5/s', concurrency: 2, pool: 'host' },
     timeout: { total: '60s' },
 });
 ```

--- a/apps/docs/content/blog/distributed-throttle-with-redis-kv.mdx
+++ b/apps/docs/content/blog/distributed-throttle-with-redis-kv.mdx
@@ -38,7 +38,7 @@ import { seam } from 'stitchapi';
 
 const api = seam({
     baseUrl: 'https://api.example.com',
-    throttle: { rate: '2/s', concurrency: 4, scope: 'host' },
+    throttle: { rate: '2/s', concurrency: 4, pool: 'host' },
     // The one line that makes it fleet-wide:
     store: redisStore(fromIoredis(new Redis(process.env.REDIS_URL))),
 });

--- a/apps/docs/content/blog/expose-a-stitch-as-an-ai-sdk-tool.mdx
+++ b/apps/docs/content/blog/expose-a-stitch-as-an-ai-sdk-tool.mdx
@@ -36,7 +36,7 @@ export const getOrder = stitch({
     auth: bearer(env('ORDERS_API_TOKEN')),
     // Resilience is declared once, here — not in the tool, not in the agent.
     retry: { attempts: 3, on: [429, 503], respectRetryAfter: true },
-    throttle: { rate: '10/s', concurrency: 4, scope: 'host' },
+    throttle: { rate: '10/s', concurrency: 4, pool: 'host' },
     timeout: { total: '5s' },
     cache: '30s',
 });
@@ -152,7 +152,7 @@ It cuts the other way too. The schema is also documentation the model can use: t
 
 This is the part that makes a stitch-as-tool different from a hand-rolled fetch tool. Everything declared on the stitch applies no matter who pulls the trigger — and a model is an unusually trigger-happy caller.
 
--   The `throttle` caps how fast the model can hammer the endpoint, even if it gets stuck in a retry-it-yourself loop. With `scope: 'host'`, that ceiling is shared across every stitch hitting the same host, so a chatty agent can't starve the rest of your app.
+-   The `throttle` caps how fast the model can hammer the endpoint, even if it gets stuck in a retry-it-yourself loop. With `pool: 'host'`, that ceiling is shared across every stitch hitting the same host, so a chatty agent can't starve the rest of your app.
 -   The `retry` absorbs a transient `503` without the model ever seeing it — and honors `Retry-After`, so you back off the way the upstream asked.
 -   The `cache` collapses a model that asks the same question twice in one loop into a single paid upstream call.
 -   The `timeout` bounds how long a single tool call can hang, so one slow dependency doesn't stall the whole generation.

--- a/apps/docs/content/blog/proactive-throttling-vs-reactive-429s.mdx
+++ b/apps/docs/content/blog/proactive-throttling-vs-reactive-429s.mdx
@@ -62,7 +62,7 @@ When a call has to wait its turn, it isn't silently stalled — the stitch emits
 
 A provider's rate limit is almost never per-endpoint. It's per account, per token, per host — and your code probably hits that one provider from several different stitches. If each stitch enforces its own budget, three stitches at `5/s` apiece can put `15/s` on a provider that only allows five, and you're back to meeting `429`s in production.
 
-`scope: 'host'` fixes this. It pools one limiter across every stitch that targets the same host, so the budget is shared the way the provider actually counts it.
+`pool: 'host'` fixes this. It pools one limiter across every stitch that targets the same host, so the budget is shared the way the provider actually counts it.
 
 ```ts twoslash
 import { seam } from 'stitchapi';
@@ -70,7 +70,7 @@ import { seam } from 'stitchapi';
 const api = seam({
     baseUrl: 'https://api.example.com',
     // One account-wide budget, shared by every member below.
-    throttle: { rate: '5/s', concurrency: 4, scope: 'host' },
+    throttle: { rate: '5/s', concurrency: 4, pool: 'host' },
 });
 
 const search = api.stitch({ path: '/search' });
@@ -78,7 +78,7 @@ const getItem = api.stitch({ path: '/items/{id}' });
 const listItems = api.stitch({ path: '/items' });
 ```
 
-Now `search`, `getItem`, and `listItems` draw from one `5/s` budget against `api.example.com`, no matter which one a given caller reaches for. This is exactly the case a `seam` is built for — a group of stitches sharing one base, one auth, and one runtime — but `scope: 'host'` pools the budget across separate stitches too, whenever they hit the same host. Host-scoped pooling works in-process with no extra setup.
+Now `search`, `getItem`, and `listItems` draw from one `5/s` budget against `api.example.com`, no matter which one a given caller reaches for. This is exactly the case a `seam` is built for — a group of stitches sharing one base, one auth, and one runtime — but `pool: 'host'` pools the budget across separate stitches too, whenever they hit the same host. Host-scoped pooling works in-process with no extra setup.
 
 ## Proactive and reactive, together
 
@@ -92,7 +92,7 @@ const search = stitch({
     baseUrl: 'https://api.example.com',
     path: '/search',
     // Proactive: stay under the limit so most 429s never happen.
-    throttle: { rate: '5/s', concurrency: 2, scope: 'host' },
+    throttle: { rate: '5/s', concurrency: 2, pool: 'host' },
     // Reactive: if one slips through anyway, back off and honor Retry-After.
     retry: { attempts: 3, on: [429, 503], respectRetryAfter: true },
 });
@@ -108,7 +108,7 @@ Flip on `throttle` — a single field on the same stitch — when:
 
 -   **Your volume brushes the limit.** You're making enough calls that `429`s start appearing in normal traffic, not just spikes. A declared rate gives you smooth pacing instead of a bounce-and-wait cycle.
 -   **You want to stop hammering a shared cap.** Multiple call sites share one account quota. The throttle keeps any one stitch from consuming the whole budget before others get a turn.
--   **Many stitches share one host budget.** Set `scope: 'host'` and the limiter counts across every stitch pointed at that origin — the right control when the ceiling is per-domain, not per-endpoint.
+-   **Many stitches share one host budget.** Set `pool: 'host'` and the limiter counts across every stitch pointed at that origin — the right control when the ceiling is per-domain, not per-endpoint.
 
 Two caveats stay real regardless of volume: you have to declare the actual limit (set it too high and `retry` is still doing the work; set it too low and you've throttled yourself for no reason), and the default limiter is per-process (multiple workers each keep their own count — span them with a shared store, covered in the [distributed throttle](/blog/distributed-throttle-with-redis-kv) write-up).
 
@@ -120,4 +120,4 @@ The reactive path is the floor you start from. `throttle` is the field you add w
 stitchapi
 ```
 
-Declare a `throttle` on a stitch, pair it with `retry` as a backstop, and the next time you brush a provider's rate limit you'll pace under it instead of bouncing off it. The full field list and `scope` semantics are in the [Throttle guide](/docs/guides/resilience/throttle); the reactive side is in [Retry & backoff](/docs/guides/resilience/retry).
+Declare a `throttle` on a stitch, pair it with `retry` as a backstop, and the next time you brush a provider's rate limit you'll pace under it instead of bouncing off it. The full field list and `pool` semantics are in the [Throttle guide](/docs/guides/resilience/throttle); the reactive side is in [Retry & backoff](/docs/guides/resilience/retry).

--- a/apps/docs/content/blog/rate-limit-api-calls-typescript.mdx
+++ b/apps/docs/content/blog/rate-limit-api-calls-typescript.mdx
@@ -55,7 +55,7 @@ import { stitch } from 'stitchapi';
 const search = stitch({
     baseUrl: 'https://api.example.com',
     path: '/search',
-    throttle: { rate: '5/s', concurrency: 2, scope: 'host' },
+    throttle: { rate: '5/s', concurrency: 2, pool: 'host' },
 });
 
 const results = await search({ query: { q: 'shoes' } }); // paced and bounded
@@ -63,11 +63,11 @@ const results = await search({ query: { q: 'shoes' } }); // paced and bounded
 
 `rate` is a string like `'5/s'` — a minimum spacing between successive calls, not a token bucket that lets a burst through. `concurrency` caps simultaneous in-flight calls; set either on its own or both together. When a call has to wait its turn it isn't a silent stall — the stitch emits a `progress` event with phase `throttled`, so a queued call shows up on the event stream instead of looking like a hang.
 
-`scope` is the answer to the multiple-call-sites problem. The default `'stitch'` gives each stitch its own budget; `'host'` pools one budget across every stitch hitting the same host — which is how a provider actually counts, since a rate limit is per account or per host, almost never per endpoint. Set `scope: 'host'` and three stitches against `api.example.com` draw from one `5/s` budget no matter which one a caller reaches for. Host-scoped pooling works in-process with no extra setup.
+`pool` is the answer to the multiple-call-sites problem. The default `'stitch'` gives each stitch its own budget; `'host'` pools one budget across every stitch hitting the same host — which is how a provider actually counts, since a rate limit is per account or per host, almost never per endpoint. Set `pool: 'host'` and three stitches against `api.example.com` draw from one `5/s` budget no matter which one a caller reaches for. Host-scoped pooling works in-process with no extra setup.
 
 ## Multiple processes: the distributed story
 
-`scope: 'host'` shares a budget across stitches in one process; it does nothing across processes, because the counters live in memory. Run more than one instance against the same upstream budget and you're back to N times your cap. The fix isn't a different limiter — it's a different place to keep the counters. Attach a shared `store` to move them off-box, so every instance pointed at the same store draws from one budget:
+`pool: 'host'` shares a budget across stitches in one process; it does nothing across processes, because the counters live in memory. Run more than one instance against the same upstream budget and you're back to N times your cap. The fix isn't a different limiter — it's a different place to keep the counters. Attach a shared `store` to move them off-box, so every instance pointed at the same store draws from one budget:
 
 ```ts twoslash
 // @noErrors
@@ -77,7 +77,7 @@ import { seam } from 'stitchapi';
 
 const api = seam({
     baseUrl: 'https://api.example.com',
-    throttle: { rate: '5/s', concurrency: 4, scope: 'host' },
+    throttle: { rate: '5/s', concurrency: 4, pool: 'host' },
     store: redisStore(fromIoredis(new Redis(process.env.REDIS_URL))),
 });
 ```
@@ -91,7 +91,7 @@ The `setTimeout` version above is the honest floor. A handful of calls well unde
 Reach for `throttle` when you hit the first trigger:
 
 -   **You start brushing the cap.** Reactive `429` handling works until volume approaches the ceiling; proactive pacing keeps you under it. That's the moment a declared rate is worth more than a caught error.
--   **The budget is shared across call sites or processes.** A second endpoint that draws from the same provider quota, or a second worker process, means the in-memory counter is silently undercounting. `scope: 'host'` and a `store` close that gap — the counter that moves is the one the upstream sees.
+-   **The budget is shared across call sites or processes.** A second endpoint that draws from the same provider quota, or a second worker process, means the in-memory counter is silently undercounting. `pool: 'host'` and a `store` close that gap — the counter that moves is the one the upstream sees.
 -   **You pair pacing with retry or auth.** A `throttle` alongside `retry` on the same stitch is one declaration; threading both through a hand-rolled limiter wrapping `fetch` is two separate maintenance surfaces.
 
 The line is whether the shared budget has grown past a single variable. While it hasn't, the limiter is fine. When it has — crossing that line is a field on the declaration, not a rewrite. The same call gains `throttle` applied by the engine rather than by convention.
@@ -104,4 +104,4 @@ If you're weighing this against the interceptor stack you'd otherwise hand-write
 stitchapi
 ```
 
-Declare a `throttle` on a stitch, set `scope: 'host'` to share the budget the way the provider counts, and pace under the limit instead of bouncing off it. The full field list and `scope` semantics are in the [Throttle guide](/docs/guides/resilience/throttle).
+Declare a `throttle` on a stitch, set `pool: 'host'` to share the budget the way the provider counts, and pace under the limit instead of bouncing off it. The full field list and `pool` semantics are in the [Throttle guide](/docs/guides/resilience/throttle).

--- a/apps/docs/content/blog/stitch-vs-codegen-api-clients.mdx
+++ b/apps/docs/content/blog/stitch-vs-codegen-api-clients.mdx
@@ -74,12 +74,12 @@ const listUsers = stitch({
     baseUrl: 'https://api.example.com',
     path: '/users',
     retry: { attempts: 4, on: [429, 502, 503], respectRetryAfter: true },
-    throttle: { rate: '1/s', concurrency: 2, scope: 'host' },
+    throttle: { rate: '1/s', concurrency: 2, pool: 'host' },
     timeout: { total: '30s', perAttempt: '10s' },
 });
 ```
 
-`throttle` is proactive — it keeps you under a limit before the 429s arrive, and `scope: 'host'` shares one limiter across stitches hitting the same host. Auth is a boundary too: `bearer`, `apiKey`, `basic`, `cookieSession` (with auto-login and re-login), and `oauth2` live on the stitch, secrets resolve at call time, and the caller gets data without ever holding the credential. Observability rides the same event stream every call already emits — off by default, opt in per stitch or via `STITCH_TRACE_*` env vars, with bridges to Pino logs or Sentry breadcrumbs.
+`throttle` is proactive — it keeps you under a limit before the 429s arrive, and `pool: 'host'` shares one limiter across stitches hitting the same host. Auth is a boundary too: `bearer`, `apiKey`, `basic`, `cookieSession` (with auto-login and re-login), and `oauth2` live on the stitch, secrets resolve at call time, and the caller gets data without ever holding the credential. Observability rides the same event stream every call already emits — off by default, opt in per stitch or via `STITCH_TRACE_*` env vars, with bridges to Pino logs or Sentry breadcrumbs.
 
 The honest framing: you _can_ build all of this around a generated client, and plenty of teams have. The difference is whether it's declared once on a primitive or assembled and maintained per project. If your integration is a single well-behaved internal service that never rate-limits you and never flakes, the resilience layer mostly sits dormant, and a generated client's leaner output can be the better fit there.
 

--- a/apps/docs/content/blog/stop-writing-fetch-in-your-agents.mdx
+++ b/apps/docs/content/blog/stop-writing-fetch-in-your-agents.mdx
@@ -55,7 +55,7 @@ export const getOrders = stitch({
     output: z.array(z.object({ id: z.number(), total: z.number() })),
     pick: 'data',
     retry: { attempts: 3, on: [429, 503], respectRetryAfter: true },
-    throttle: { rate: '10/s', concurrency: 4, scope: 'host' },
+    throttle: { rate: '10/s', concurrency: 4, pool: 'host' },
     timeout: { total: '10s' },
 });
 ```

--- a/apps/docs/content/blog/typescript-pagination.mdx
+++ b/apps/docs/content/blog/typescript-pagination.mdx
@@ -103,7 +103,7 @@ const mirror = stitch({
         backoff: 'expo-jitter',
         respectRetryAfter: true,
     },
-    throttle: { rate: '5/s', concurrency: 2, scope: 'host' },
+    throttle: { rate: '5/s', concurrency: 2, pool: 'host' },
     paginate: {
         next: (prevBody) => {
             const cursor = (prevBody as { nextCursor?: string }).nextCursor;

--- a/apps/docs/content/docs/guides/resilience/throttle.mdx
+++ b/apps/docs/content/docs/guides/resilience/throttle.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Throttle'
-description: 'Space requests by rate and cap concurrency, scoped per stitch or per host.'
+description: 'Space requests by rate and cap concurrency, pooled per stitch or per host.'
 prerequisites: ['/docs/concepts/the-stitch']
 ---
 
@@ -16,7 +16,7 @@ import { stitch } from 'stitchapi';
 const search = stitch({
     baseUrl: 'https://api.example.com',
     path: '/search',
-    throttle: { rate: '5/s', concurrency: 2, scope: 'host' },
+    throttle: { rate: '5/s', concurrency: 2, pool: 'host' },
 });
 ```
 
@@ -47,10 +47,10 @@ The shorthand expands at compose time, so `__config.throttle` always reads back
 as the object form, and a `throttle: '1/s'` layered over an inherited
 `{ rate: '5/s', concurrency: 2 }` replaces only the rate.
 
-`scope` decides what shares the budget: `'stitch'` (the default) gives each
+`pool` decides what shares the budget: `'stitch'` (the default) gives each
 stitch its own budget, while `'host'` pools the budget across every stitch
 hitting the same host — use it when one API publishes a single account-wide
-limit. Host-scoped pooling works in-process out of the box: separate stitches in
+limit. Host pooling works in-process out of the box: separate stitches in
 the same process draw from one budget per host with no extra configuration.
 Giving those stitches a shared
 [store](/docs/guides/state/pluggable-store) extends that single-process budget
@@ -58,7 +58,7 @@ into a [distributed one](/docs/guides/state/distributed-throttle) that spans
 workers.
 
 <Callout type="warn">
-    **Anti-pattern:** don't rely on a host-scoped throttle to honor an
+    **Anti-pattern:** don't rely on a host-pooled throttle to honor an
     account-wide limit once you run more than one process — the budget lives in
     memory and is process-local, so each of N workers keeps its own count and
     together they hit `api.example.com` at up to N times the rate you declared;

--- a/apps/docs/content/docs/guides/state/distributed-throttle.mdx
+++ b/apps/docs/content/docs/guides/state/distributed-throttle.mdx
@@ -6,7 +6,7 @@ prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 
 Share one rate limit across every worker or server by pointing the throttle at a
 shared `store`. By default a stitch keeps its throttle counters in the in-memory
-store, so the rate budget is per process: with `scope: 'host'` every stitch in
+store, so the rate budget is per process: with `pool: 'host'` every stitch in
 that process already pools into one budget per host (see
 [Throttle](/docs/guides/resilience/throttle)), but the in-memory store keeps that
 pooling within a single process — each worker gets its own. Point the throttle at
@@ -24,7 +24,7 @@ declare const sharedStore: StitchStore;
 const search = stitch({
     baseUrl: 'https://api.example.com',
     path: '/search',
-    throttle: { rate: '10/s', scope: 'host' },
+    throttle: { rate: '10/s', pool: 'host' },
     store: sharedStore, // the budget now spans all workers using this store
 });
 ```
@@ -32,7 +32,7 @@ const search = stitch({
 ## Options
 
 `throttle` sets the limits — `rate` (e.g. `'10/s'`), `concurrency`, and
-`scope` — while `store` decides where the counters live. The default in-memory
+`pool` — while `store` decides where the counters live. The default in-memory
 store is single-process, so each worker enforces `10/s` on its own and the fleet
 runs at `10/s × workers`. A shared store holds the rate counter every worker
 increments, so the whole fleet shares one `10/s` budget — and grants are
@@ -48,10 +48,10 @@ boundary bursts. (Concurrency stays in-process; only the rate limit is distribut
     The budget itself still holds.
 </Callout>
 
-`scope` decides what shares a budget: `'stitch'` (the default) gives each stitch
+`pool` decides what shares a budget: `'stitch'` (the default) gives each stitch
 its own counter keyed by name, while `'host'` keys by origin so every stitch
 hitting `api.example.com` draws from one budget. Workers share a budget only when
-they point at the same store and resolve to the same key — same scope, same
+they point at the same store and resolve to the same key — same pool, same
 stitch name or host.
 
 <Callout type="info">

--- a/apps/docs/content/docs/recipes/mirror-a-paginated-api.mdx
+++ b/apps/docs/content/docs/recipes/mirror-a-paginated-api.mdx
@@ -33,7 +33,7 @@ const mirror = stitch({
         backoff: 'expo-jitter',
         respectRetryAfter: true,
     },
-    throttle: { rate: '5/s', concurrency: 2, scope: 'host' },
+    throttle: { rate: '5/s', concurrency: 2, pool: 'host' },
     paginate: {
         next: (prevBody) => {
             const cursor = (prevBody as { nextCursor?: string }).nextCursor;

--- a/apps/docs/content/docs/recipes/one-rate-limit-across-workers.mdx
+++ b/apps/docs/content/docs/recipes/one-rate-limit-across-workers.mdx
@@ -24,7 +24,7 @@ declare const sharedStore: StitchStore;
 const search = stitch({
     baseUrl: 'https://api.example.com',
     path: '/search',
-    throttle: { rate: '10/s', scope: 'host' },
+    throttle: { rate: '10/s', pool: 'host' },
     store: sharedStore, // the budget now spans all workers using this store
 });
 
@@ -36,7 +36,7 @@ const hits = await search({ query: { q: 'mango' } });
 By default throttle counters live in the in-memory store, so each worker enforces
 the limit alone and the fleet runs at `10/s × workers`. Point `store` at one
 shared backend and the rate counter becomes a single fixed-window count every
-worker increments — one `10/s` budget across the fleet. `scope: 'host'` keys the
+worker increments — one `10/s` budget across the fleet. `pool: 'host'` keys the
 budget by origin, so every stitch hitting the host pools into it; workers share
 only when they point at the same store and resolve to the same key. (Concurrency
 stays in-process; only the rate limit is distributed.) A

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -439,7 +439,6 @@ will apply under `@deprecated` aliases (P18). Severity = consumer blast radius.
 | ---- | --------------------------------------------------------------------- | -------------------------------------------------------------- | ------ |
 | High | `SafeResult.data` ↔ `Inspection.value` ↔ `StitchEvent.result.value` | `data` everywhere                                              | P5     |
 | High | `IdempotencyOptions.key`, `CacheConfig.key` (fn)                      | `keyOf`                                                        | P6     |
-| High | `ThrottleOptions.scope` (`'stitch'｜'host'`)                          | `pool`                                                         | P2     |
 | High | `rateLimit` (separate top-level key) vs `throttle`                    | fold into one `throttle` envelope (`delegate` / `on` as modes) | P2/P14 |
 | High | `retry.on` + rate-limit `on` (`number[]`)                             | `number[] ｜ (status)=>boolean`                                | P7     |
 | High | `StitchStore`/`StitchLike`/`RequestSeam` cross-pkg clashes            | hoist or qualify                                               | P9     |
@@ -468,7 +467,6 @@ New shorthand/toggle slots to **add** (additive, non-breaking): `stream`, `multi
 **Shipped (migration in progress)** — all under `@deprecated` aliases read until the GA
 cut; the lint skips the deprecated members so each rename ratchets the baseline down:
 
--   **P2** `ThrottleOptions.scope`→`pool`; runtime prefers `pool ?? scope`.
 -   **P6** `IdempotencyOptions.key`/`CacheOptions.key`→`keyOf`; runtime prefers `keyOf ?? key`.
 -   **P3** suffix renames (type-only, zero runtime): `CacheConfig`→`CacheOptions`,
     `OAuth2Opts`→`OAuth2Options`, `CookieSessionOpts`→`CookieSessionOptions`,

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -203,11 +203,11 @@ This is a concrete cookie wall (`GET /api/websites` needs a `session_token` cook
 
 ```ts
 retry:    { attempts: 3, backoff: 'expo+jitter', on: [429, 503], respectRetryAfter: true },
-throttle: { rate: '1/s', concurrency: 2, scope: 'host' },   // proactive limiter
+throttle: { rate: '1/s', concurrency: 2, pool: 'host' },   // proactive limiter
 timeout:  { total: '30s', perAttempt: '10s' },
 ```
 
--   **`throttle`** is _proactive_ — a token-bucket/concurrency cap to stay _under_ a vendor's limit (replaces the hand-rolled 1/s buckets and per-request delays integrations write by hand). `scope: 'host'` shares one limiter across all stitches hitting the same host.
+-   **`throttle`** is _proactive_ — a token-bucket/concurrency cap to stay _under_ a vendor's limit (replaces the hand-rolled 1/s buckets and per-request delays integrations write by hand). `pool: 'host'` shares one limiter across all stitches hitting the same host.
 -   **`retry`** is _reactive_ — backoff+jitter, honoring `Retry-After`.
 -   All emit events (`retry`, `throttled`) onto the stream → visible in the trace for free.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -392,12 +392,12 @@ const listUsers = stitch({
     baseUrl: 'https://demo.stitchapi.dev',
     path: '/users',
     retry: { attempts: 4, on: [429, 502, 503], respectRetryAfter: true },
-    throttle: { rate: '1/s', concurrency: 2, scope: 'host' },
+    throttle: { rate: '1/s', concurrency: 2, pool: 'host' },
     timeout: { total: '30s', perAttempt: '10s' },
 });
 ```
 
--   **`throttle` is proactive** - a rate (`'1/s'`) and a concurrency cap that keep you under a vendor's limit before it bites; `scope: 'host'` shares one limiter across every stitch hitting the same host.
+-   **`throttle` is proactive** - a rate (`'1/s'`) and a concurrency cap that keep you under a vendor's limit before it bites; `pool: 'host'` shares one limiter across every stitch hitting the same host.
 -   **`retry` is reactive** - `attempts` is the total including the first; retried statuses default to `[429, 502, 503, 504]`; backoff is `'expo'` / `'expo-jitter'` / `'fixed'` with `baseMs` / `maxMs` clamps; `respectRetryAfter` honors the `Retry-After` header (delta-seconds or HTTP-date).
 -   **`timeout` aborts** - `total` and/or `perAttempt`, as milliseconds or `'30s'`-style strings, enforced with a real `AbortSignal` instead of a request left hanging.
 

--- a/packages/core/scripts/bundle-size.mjs
+++ b/packages/core/scripts/bundle-size.mjs
@@ -70,7 +70,7 @@ const KB = 1024;
 // (#369/#370), and variadic argument lists (#371) — core-entry surface, so it lifts
 // the whole entry more than `import { stitch }`, which tree-shakes it away. (2) The
 // meta-contract sweep (#352, P3–P20) renamed/de-suffixed public fields and co-emits
-// the old names as @deprecated runtime aliases (throttle.scope→pool, key→keyOf;
+// the old names as @deprecated runtime aliases (key→keyOf;
 // value→data on result envelopes; *Ms duration de-suffixing) — shared code on
 // stitch's own path. Together they reach ~23.13 / ~18.61 KB gzip (+~0.39 / +~0.27
 // since #362). Neither wave can move to a subpath — composition and the renamed

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -256,8 +256,7 @@ const cloneReq = (r: AdapterRequest): AdapterRequest => ({
     headers: { ...r.headers },
 });
 const hostKey = (req: AdapterRequest, cfg: ResolvedStitchConfig): string => {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `scope` is the @deprecated alias of `pool`, read as the back-compat fallback until the GA cut (CONTRACT.md P2)
-    if ((cfg.throttle?.pool ?? cfg.throttle?.scope) === 'host') {
+    if (cfg.throttle?.pool === 'host') {
         try {
             return new URL(req.url).host;
         } catch {

--- a/packages/core/src/resilience.ts
+++ b/packages/core/src/resilience.ts
@@ -83,8 +83,7 @@ export function createThrottle(
     const limit = opts?.concurrency;
     const rate = opts?.rate ? parseRate(opts.rate) : undefined;
     const spacing = rate ? rate.per / rate.count : 0; // ms between grants
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `scope` is the @deprecated alias of `pool`, read as the back-compat fallback until the GA cut (CONTRACT.md P2)
-    const hostPooled = (opts?.pool ?? opts?.scope) === 'host';
+    const hostPooled = opts?.pool === 'host';
     const states = hostPooled ? hostStates : new Map<string, KeyState>();
 
     const stateFor = (key: string): KeyState => {

--- a/packages/core/src/seam.ts
+++ b/packages/core/src/seam.ts
@@ -55,8 +55,7 @@ function seamBucket(
     clock: Clock,
 ): Throttle {
     const inner = createStoreThrottle(opts, store, clock);
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `scope` is the @deprecated alias of `pool`, read as the back-compat fallback until the GA cut (CONTRACT.md P2)
-    if ((opts?.pool ?? opts?.scope) === 'host') return inner; // host key already pools across the seam
+    if (opts?.pool === 'host') return inner; // host key already pools across the seam
     const key = `seam:${seamId}`;
     return {
         // Re-key every acquire onto the one seam-stable key, forwarding the acquire options (e.g.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -290,12 +290,9 @@ export interface ThrottleOptions {
     concurrency?: number;
     /**
      * Where the limiter's counter is pooled: `'stitch'` (default) keeps a per-stitch
-     * budget; `'host'` shares one budget across every stitch hitting the same host. Renamed
-     * from `scope` (CONTRACT.md P2) so `scope` only ever means principal/app tenancy.
+     * budget; `'host'` shares one budget across every stitch hitting the same host.
      */
     pool?: 'stitch' | 'host';
-    /** @deprecated Renamed to {@link ThrottleOptions.pool} (CONTRACT.md P2). Read until the 1.0 GA cut. */
-    scope?: 'stitch' | 'host';
     /**
      * Delegate rate-limit handling to the host (folded in from the top-level `rateLimit`,
      * CONTRACT.md P14). When `true`, a rate-limit response (status matched by `on`, default `[429]`)

--- a/packages/core/test/HARNESS-API.md
+++ b/packages/core/test/HARNESS-API.md
@@ -31,7 +31,7 @@ import { z } from 'zod';
 -   `pick`: dot-path string (e.g. `'data'`)
 -   `auth`: an AuthStrategy (see below)
 -   `retry`: `{ attempts (total incl. first, default 1), on: number[] (default [429,502,503,504]), backoff: 'expo'|'expo-jitter'|'fixed', baseMs, maxMs, respectRetryAfter }`
--   `throttle`: `{ rate: '2/s', concurrency: number, scope: 'stitch'|'host' }`
+-   `throttle`: `{ rate: '2/s', concurrency: number, pool: 'stitch'|'host' }`
 -   `timeout`: `{ total: number|string, perAttempt: number|string }` (ms or '30s')
 -   `hooks`: `{ onRequest, onResponse, onError, onRetry }` — `(ctx) => void|Promise<void>`, `ctx = { name, attempt, req?, res?, error? }`
 -   `extends`: `Array<fragment | stitch>`

--- a/packages/core/test/gaps/throttle-host-pooling.spec.ts
+++ b/packages/core/test/gaps/throttle-host-pooling.spec.ts
@@ -1,4 +1,4 @@
-// Pins docs/GAP-AUDIT.md §1.4: throttle scope:'host' must pool the budget across stitch instances in-process, as throttle.mdx documents
+// Pins docs/GAP-AUDIT.md §1.4: throttle pool:'host' must pool the budget across stitch instances in-process, as throttle.mdx documents
 import { stitch } from '../../src';
 import { startMockServer } from '../support/mock-server';
 import type { MockServer } from '../support/mock-server';
@@ -22,7 +22,7 @@ beforeEach(() => {
     server.reset();
 });
 
-describe('GAP-AUDIT §1.4 — throttle scope:"host" pools across instances', () => {
+describe('GAP-AUDIT §1.4 — throttle pool:"host" pools across instances', () => {
     test('two separate stitches (no shared store) hitting the same host share one 2/s budget', async () => {
         // Record the server-side arrival time of each request.
         const hits: number[] = [];
@@ -37,9 +37,6 @@ describe('GAP-AUDIT §1.4 — throttle scope:"host" pools across instances', () 
         // declaring host pooling against the same origin. throttle.mdx says
         // 'host' "pools the budget across every stitch hitting the same host",
         // so the 2/s budget (500ms spacing) must apply across BOTH instances.
-        // `a` uses the canonical `pool` (CONTRACT.md P2); `b` uses the
-        // `@deprecated` `scope` alias — they MUST pool together, proving the
-        // alias is byte-equivalent to the new field.
         const a = stitch({
             baseUrl: server.url,
             path: '/pooled',
@@ -48,7 +45,7 @@ describe('GAP-AUDIT §1.4 — throttle scope:"host" pools across instances', () 
         const b = stitch({
             baseUrl: server.url,
             path: '/pooled',
-            throttle: { rate: '2/s', scope: 'host' },
+            throttle: { rate: '2/s', pool: 'host' },
         });
 
         await Promise.all([a(), b()]);

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -158,13 +158,13 @@ describe('Pluggable store — throttle', () => {
             baseUrl: server.url,
             path: '/x',
             store,
-            throttle: { rate: '1/s', scope: 'host' },
+            throttle: { rate: '1/s', pool: 'host' },
         });
         const s2 = stitch({
             baseUrl: server.url,
             path: '/x',
             store,
-            throttle: { rate: '1/s', scope: 'host' },
+            throttle: { rate: '1/s', pool: 'host' },
         });
 
         const [w1, w2] = await Promise.all([
@@ -174,7 +174,7 @@ describe('Pluggable store — throttle', () => {
         expect(w1 + w2).toBe(1); // 1/s shared → exactly one of two concurrent calls is paced
     });
 
-    test('scope:"host" pools the rate budget in-process WITHOUT a shared store', async () => {
+    test('pool:"host" pools the rate budget in-process WITHOUT a shared store', async () => {
         // throttle.mdx: "'host' pools the budget across every stitch hitting the same host."
         // Host-scoped state lives in a module-level registry (resilience.ts), so two separate
         // stitches with no shared store still draw from one 1/s budget — one of two concurrent
@@ -183,12 +183,12 @@ describe('Pluggable store — throttle', () => {
         const s1 = stitch({
             baseUrl: server.url,
             path: '/y',
-            throttle: { rate: '1/s', scope: 'host' },
+            throttle: { rate: '1/s', pool: 'host' },
         });
         const s2 = stitch({
             baseUrl: server.url,
             path: '/y',
-            throttle: { rate: '1/s', scope: 'host' },
+            throttle: { rate: '1/s', pool: 'host' },
         });
 
         const [w1, w2] = await Promise.all([
@@ -198,8 +198,8 @@ describe('Pluggable store — throttle', () => {
         expect(w1 + w2).toBe(1); // pooled 1/s → exactly one of two concurrent calls is paced
     });
 
-    test('scope:"stitch" (default) keeps separate budgets per instance', async () => {
-        // The default scope is per-stitch: each instance keeps its own closure-local budget,
+    test('pool:"stitch" (default) keeps separate budgets per instance', async () => {
+        // The default pool is per-stitch: each instance keeps its own closure-local budget,
         // so two separate stitches (no shared store) on distinct names never pace each other.
         server.route('GET', '/z', { body: { ok: true } });
         const s1 = stitch({

--- a/packages/openapi/src/gen-openapi.ts
+++ b/packages/openapi/src/gen-openapi.ts
@@ -757,7 +757,7 @@ function emitClient(baseUrl: string | undefined, auth: DerivedAuth): GenFile {
     if (auth.expr) lines.push(`    auth: ${auth.expr},`);
     lines.push('    // TODO: tune shared resilience, e.g.');
     lines.push('    // retry: { attempts: 3, on: [429, 502, 503] },');
-    lines.push("    // throttle: { rate: '10/s', scope: 'host' },");
+    lines.push("    // throttle: { rate: '10/s', pool: 'host' },");
     lines.push('});');
     return { path: 'client.ts', contents: `${lines.join('\n')}\n` };
 }

--- a/packages/openapi/test/gen-openapi.spec.ts
+++ b/packages/openapi/test/gen-openapi.spec.ts
@@ -195,6 +195,13 @@ describe('planGen — naming, typing, auth, notice', () => {
         expect(c).toMatch(/import \{ seam, bearer, env \}/);
     });
 
+    test('emitted throttle TODO uses the canonical `pool` (ThrottleOptions.scope is gone)', () => {
+        const r = planGen(doc, { all: true });
+        const c = file(r, 'client.ts') as string;
+        expect(c).toMatch(/pool: 'host'/);
+        expect(c).not.toMatch(/\bscope\b/);
+    });
+
     test('types-only emits the validation-off notice', () => {
         const r = planGen(doc, { all: true });
         expect(r.notices.join('\n')).toMatch(


### PR DESCRIPTION
## What

Extracts the **throttle `scope`→`pool`** slice from #470 (the contract-freeze sweep) into a standalone, independently-mergeable PR.

`pool` has been the canonical `ThrottleOptions` field since the P2 rename; `scope` lingered as a `@deprecated` back-compat alias with `pool ?? scope` fallback reads. This is the **hard break** (P19): the alias is removed.

## Changes

- **Remove** the `@deprecated ThrottleOptions.scope` field (`types.ts`) and trim its `pool` JSDoc.
- **Drop the three `?? scope` fallback reads** — `seam.ts`, `resilience.ts`, `engine.ts` now read `pool` only (and lose their `eslint-disable no-deprecated`).
- **Convert** the remaining deprecated `scope: 'host'|'stitch'` throttle examples across tests + docs to `pool`. The alias-parity test in `throttle-host-pooling.spec.ts` collapses to the canonical spelling.
- **Regression test**: a new `gen-openapi` case pins that the emitted throttle TODO uses `pool`, not `scope`.
- **CONTRACT.md**: drop the two backlog/"migration-in-progress" entries that asserted the `scope` alias still exists (the P6/`*Ms`/`rateLimit` aliases they sit beside are untouched — not part of this slice).

## Not in scope

> **Tenancy `scope` is a different axis and is untouched.** `cache` / `cookieSession` / `oauth2` `scope` (`'principal'|'app'`) is the tenancy concept P2 frees the word for — this PR does not rename it to `tenancy` (that's a separate #470 slice). The `'host'|'stitch'` value space cleanly disambiguates the two.

- **No contract-baseline change** — `check-contract`'s R4 (`scope: 'stitch'|'host'`) skips `@deprecated` fields, so the alias was never a baselined violation. Ratchet stays green (5 known, 0 new).
- **Historical records left as-is** (matching #470's own scope): `docs/GAP-AUDIT.md`, `docs/adr/0002-*` still reference the old spelling as a point-in-time record; #470 didn't touch them either.
- **Bundle budget unchanged** — removing the alias only shrinks the core; the whole-sweep budget bump in #470 is a P0/shorthand artifact, not this slice.

## Verification — all gates green

`check:types` · `check:lint` · `check:format` (pre-commit) · `check:types-d` (tsd) · `test` (core 1213 + openapi 19 incl. the new case) · `check:exports` · **`build-docs`** (full twoslash) (pre-push) · `check:contract`.

## Relation to #470 / #489

Independent off `main`, and disjoint from #489 (query→document). After both land, #470 rebases to drop these two slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)