### PR TITLE
refactor(core)!: drop the deprecated `key` derivation alias; rename cache.key()→cache.keyOf() (P6)

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -264,12 +264,12 @@ export const PLAYGROUND_INSTANCE_COMPLETIONS: Record<string, Completion[]> = {
             label: "invalidate",
             type: "method",
             detail: "(input?: StitchInput) => Promise<void>",
-            info: "Cache surface (ADR 0003). A no-op unless this stitch has a `cache` block. - `invalidate(input)` — **exact** eviction of the one entry that `input` would hit. - `cache.invalidate()` — **bulk** eviction of every entry this stitch produced (a per-stitch generation bump; prior entries become unreachable and TTL out). - `cache.key(input)` — the derived opaque key, for introspection.",
+            info: "Cache surface (ADR 0003). A no-op unless this stitch has a `cache` block. - `invalidate(input)` — **exact** eviction of the one entry that `input` would hit. - `cache.invalidate()` — **bulk** eviction of every entry this stitch produced (a per-stitch generation bump; prior entries become unreachable and TTL out). - `cache.keyOf(input)` — the derived opaque key, for introspection (CONTRACT.md P6).",
         },
         {
             label: "cache",
             type: "property",
-            detail: "{ invalidate(): Promise<void>; key(input?: StitchInput): Promise<string | undefined>; }",
+            detail: "{ invalidate(): Promise<void>; keyOf(input?: StitchInput): Promise<string | undefined>; }",
         },
         {
             label: "__config",

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -436,7 +436,6 @@ will apply under `@deprecated` aliases (P18). Severity = consumer blast radius.
 
 | Sev  | Current                                                            | Proposed                                                       | Rule   |
 | ---- | ------------------------------------------------------------------ | -------------------------------------------------------------- | ------ |
-| High | `IdempotencyOptions.key`, `CacheConfig.key` (fn)                   | `keyOf`                                                        | P6     |
 | High | `rateLimit` (separate top-level key) vs `throttle`                 | fold into one `throttle` envelope (`delegate` / `on` as modes) | P2/P14 |
 | High | `retry.on` + rate-limit `on` (`number[]`)                          | `number[] ｜ (status)=>boolean`                                | P7     |
 | High | `StitchStore`/`StitchLike`/`RequestSeam` cross-pkg clashes         | hoist or qualify                                               | P9     |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -417,7 +417,7 @@ Three more knobs round out the resilience set:
 
     ```ts
     idempotency: {
-        key: (input) => input.body.requestId;
+        keyOf: (input) => input.body.requestId;
     }
     ```
 

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -317,8 +317,8 @@ export interface CacheOp {
 export interface CacheController {
     /** Is `method` in the cacheable set (and so eligible for coalescing)? */
     cacheableMethod(method: string): boolean;
-    /** Derive the base key for a resolved request, or `undefined` when it is not hashable. */
-    key(d: RequestDescriptor, input: StitchInput): string | undefined;
+    /** Derive the base key for a resolved request, or `undefined` when it is not hashable (CONTRACT.md P6). */
+    keyOf(d: RequestDescriptor, input: StitchInput): string | undefined;
     /** Open a cache operation for `baseKey` (reads the live generation prefix once). */
     open(baseKey: string, d: RequestDescriptor): Promise<CacheOp>;
     /**
@@ -436,16 +436,15 @@ export function createCache(opts: CacheControllerOptions): CacheController {
             return methods.includes(method.toUpperCase());
         },
 
-        key(d, input) {
+        keyOf(d, input) {
             // Scope handling lives here: fold the bound principal in under 'principal' scope,
             // omit it under 'app'. The descriptor itself carries no principal (engine concern).
             const scoped: RequestDescriptor =
                 principalForScope !== undefined
                     ? { ...d, principal: principalForScope }
                     : d;
-            // eslint-disable-next-line @typescript-eslint/no-deprecated -- `key` is the @deprecated alias of `keyOf`, read as the back-compat fallback until the GA cut (CONTRACT.md P6)
-            const keyOf = config.keyOf ?? config.key;
-            const userKey = keyOf ? keyOf(input) : undefined;
+            const userKeyOf = config.keyOf;
+            const userKey = userKeyOf ? userKeyOf(input) : undefined;
             return deriveCacheKey(scoped, explicitVary, userKey);
         },
 

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -166,8 +166,7 @@ function applyIdempotency(
         )
     )
         return;
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `key` is the @deprecated alias of `keyOf`, read as the back-compat fallback until the GA cut (CONTRACT.md P6)
-    const keyOf = cfg.idempotency.keyOf ?? cfg.idempotency.key;
+    const keyOf = cfg.idempotency.keyOf;
     headers[header] = keyOf ? keyOf(input) : randomUUID();
 }
 
@@ -1519,7 +1518,7 @@ async function* runCached(
     }
 
     const d = describe(baseReq);
-    const key = ctl.key(d, input);
+    const key = ctl.keyOf(d, input);
     if (key === undefined) {
         yield cacheEvt('bypass: unhashable request');
         yield* runFrom(rt, baseReq, name, state, t0, run, budget);
@@ -1675,7 +1674,7 @@ export async function cacheInvalidateExact(
     }
     if (!ctl.cacheableMethod(baseReq.method)) return;
     const d = describe(baseReq);
-    const key = ctl.key(d, input);
+    const key = ctl.keyOf(d, input);
     if (key === undefined) return;
     await (await ctl.open(key, d)).delete();
 }
@@ -1688,7 +1687,7 @@ export async function cacheInvalidateBulk(rt: Runtime): Promise<void> {
     await ctl.invalidate();
 }
 
-/** The derived opaque key for `input`, for introspection. Backs `stitch.cache.key(input)`. */
+/** The derived opaque key for `input`, for introspection. Backs `stitch.cache.keyOf(input)`. */
 export async function cacheKeyOf(
     rt: Runtime,
     input: StitchInput = {},
@@ -1701,7 +1700,7 @@ export async function cacheKeyOf(
     } catch {
         return undefined;
     }
-    return ctl.key(describe(baseReq), input);
+    return ctl.keyOf(describe(baseReq), input);
 }
 
 export async function executeRaw(

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -231,10 +231,9 @@ function warnIdempotency(cfg: ResolvedStitchConfig): void {
         );
         return;
     }
-    // A derived key (either spelling — `keyOf`, or the @deprecated `key` alias) dedupes
-    // resubmissions on its own, so only the random default with no retry is the inert case.
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `key` is the back-compat alias of `keyOf` (CONTRACT.md P6)
-    if (idem.keyOf || idem.key || cfg.retry) return;
+    // A derived `keyOf` dedupes resubmissions on its own, so only the random default with no
+    // retry is the inert case.
+    if (idem.keyOf || cfg.retry) return;
     console.warn(
         `stitchapi: \`${name}\` has \`idempotency\` with a random key and no \`retry\`, so it ` +
             `only dedupes its own retries — add \`retry\`, or set \`idempotency.keyOf\`.`,
@@ -715,7 +714,7 @@ function attachCacheSurface(
     Object.defineProperty(target, 'cache', {
         value: {
             invalidate: () => cacheInvalidateBulk(rt),
-            key: (input?: StitchInput) => cacheKeyOf(rt, resolve(input)),
+            keyOf: (input?: StitchInput) => cacheKeyOf(rt, resolve(input)),
         },
     });
 }

--- a/packages/core/src/test-stub.ts
+++ b/packages/core/src/test-stub.ts
@@ -191,7 +191,7 @@ function assemble<TOut, TIn>(
     Object.defineProperty(stub, 'cache', {
         value: {
             invalidate: () => Promise.resolve(),
-            key: () => Promise.resolve(undefined),
+            keyOf: () => Promise.resolve(undefined),
         },
     });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -364,10 +364,8 @@ export interface CircuitOptions {
  */
 export interface IdempotencyOptions {
     header?: string; // header name (default 'Idempotency-Key')
-    /** Derive a stable key per logical call (default: a random uuid). Renamed from `key` (CONTRACT.md P6: `key` is a string, a derivation fn is `keyOf`). */
+    /** Derive a stable key per logical call (default: a random uuid). CONTRACT.md P6: `key` is a string; a derivation fn is `keyOf`. */
     keyOf?: (input: StitchInput) => string;
-    /** @deprecated Renamed to {@link IdempotencyOptions.keyOf} (CONTRACT.md P6). Read until the 1.0 GA cut. */
-    key?: (input: StitchInput) => string;
     /** false silences the "idempotency without retry" / "idempotency on a read" construction nudge. */
     warn?: boolean;
 }
@@ -444,10 +442,8 @@ export interface CacheOptions {
      * only for pure validators with no coercion/transform inside the schema).
      */
     onUnfingerprintable?: 'refuse' | 'revalidate';
-    /** Sugar: author the key seed from the input instead of deriving it from the request. Renamed from `key` (CONTRACT.md P6). */
+    /** Sugar: author the key seed from the input instead of deriving it from the request (CONTRACT.md P6). */
     keyOf?: (input: StitchInput) => string;
-    /** @deprecated Renamed to {@link CacheOptions.keyOf} (CONTRACT.md P6). Read until the 1.0 GA cut. */
-    key?: (input: StitchInput) => string;
 }
 
 // ---- Auth -----------------------------------------------------------------
@@ -1120,12 +1116,12 @@ export interface Stitch<TOut = unknown, TIn = StitchInput> {
      * - `invalidate(input)` — **exact** eviction of the one entry that `input` would hit.
      * - `cache.invalidate()` — **bulk** eviction of every entry this stitch produced (a
      *   per-stitch generation bump; prior entries become unreachable and TTL out).
-     * - `cache.key(input)` — the derived opaque key, for introspection.
+     * - `cache.keyOf(input)` — the derived opaque key, for introspection (CONTRACT.md P6).
      */
     invalidate(input?: StitchInput): Promise<void>;
     readonly cache: {
         invalidate(): Promise<void>;
-        key(input?: StitchInput): Promise<string | undefined>;
+        keyOf(input?: StitchInput): Promise<string | undefined>;
     };
     readonly __config: RedactedStitchConfig;
     readonly __stitch: true;

--- a/packages/core/test/cache-learned-vary.spec.ts
+++ b/packages/core/test/cache-learned-vary.spec.ts
@@ -19,7 +19,7 @@ describe('createCache learned Vary (response-driven)', () => {
         const store = memoryStore();
         const cache = createCache({ config: { ttl: 0 }, store, stitchId: 's' });
         const d = desc();
-        const baseKey = cache.key(d, {});
+        const baseKey = cache.keyOf(d, {});
         if (baseKey === undefined) throw new Error('expected a derived key');
         await (await cache.open(baseKey, d)).set('VALUE', 200, '*');
         expect(await (await cache.open(baseKey, d)).get()).toBeNull();
@@ -30,10 +30,10 @@ describe('createCache learned Vary (response-driven)', () => {
         const cache = createCache({ config: { ttl: 0 }, store, stitchId: 's' });
         const en = desc({ 'accept-language': 'en' });
         const de = desc({ 'accept-language': 'de' });
-        const baseKey = cache.key(en, {});
+        const baseKey = cache.keyOf(en, {});
         if (baseKey === undefined) throw new Error('expected a derived key');
         // Without an explicit vary allowlist, accept-language is NOT in the base key.
-        expect(cache.key(de, {})).toBe(baseKey);
+        expect(cache.keyOf(de, {})).toBe(baseKey);
 
         await (await cache.open(baseKey, en)).set('EN', 200, 'accept-language');
 

--- a/packages/core/test/cache.spec.ts
+++ b/packages/core/test/cache.spec.ts
@@ -265,7 +265,7 @@ describe('cache — invalidation', () => {
         expect(calls()).toBe(3);
     });
 
-    test('cache.key(input) exposes the derived opaque key', async () => {
+    test('cache.keyOf(input) exposes the derived opaque key', async () => {
         const { adapter } = counting();
         const s = stitch({
             url: URL,
@@ -273,9 +273,9 @@ describe('cache — invalidation', () => {
             trace: false,
             cache: { ttl: '60s', scope: 'app' },
         });
-        const k1 = await s.cache.key({ query: { id: 1 } });
-        const k2 = await s.cache.key({ query: { id: 1 } });
-        const k3 = await s.cache.key({ query: { id: 2 } });
+        const k1 = await s.cache.keyOf({ query: { id: 1 } });
+        const k2 = await s.cache.keyOf({ query: { id: 1 } });
+        const k3 = await s.cache.keyOf({ query: { id: 2 } });
         expect(k1).toMatch(/^[0-9a-f]{32}$/);
         expect(k1).toBe(k2);
         expect(k1).not.toBe(k3);

--- a/packages/core/test/idempotency.spec.ts
+++ b/packages/core/test/idempotency.spec.ts
@@ -69,26 +69,6 @@ test('uses a custom keyOf function derived from the input', async () => {
     expect(calls[1]!.headers['x-idempotency-key']).toBe('order-42'); // stable + deterministic
 });
 
-test('the @deprecated `key` alias still derives the same idempotency key (P6)', async () => {
-    server.route('POST', '/orders', { body: { ok: true } });
-    const create = stitch({
-        method: 'POST',
-        baseUrl: server.url,
-        path: '/orders',
-        idempotency: {
-            header: 'X-Idempotency-Key',
-            // The pre-rename spelling — must behave identically to `keyOf` until the GA cut.
-            key: (input) => `order-${(input.body as { id: number }).id}`,
-        },
-    });
-
-    await create({ body: { id: 7 } });
-
-    expect(server.calls('/orders')[0]!.headers['x-idempotency-key']).toBe(
-        'order-7',
-    );
-});
-
 test('separate logical calls get distinct generated keys', async () => {
     server.route('POST', '/c', { body: { ok: true } });
     const create = stitch({


### PR DESCRIPTION
Extracts the **P6 keyOf** slice from #470 (the contract-freeze sweep) into a standalone PR so it can land on its own.

`keyOf` has been canonical on `IdempotencyOptions` / `CacheOptions` since the P6 rename (#352); the `(input) => string` derivation form lingered as a `@deprecated` `key` alias that the engine read as `keyOf ?? key`. This is the hard break (P19):

- remove the `@deprecated key` member from both option types;
- drop the `?? key` back-compat fallbacks in `engine` / `cache` / `stitch` (and their `eslint-disable`s);
- rename the internal cache-controller method and the **public introspection method** `stitch.cache.key(input)` → `stitch.cache.keyOf(input)` (also a P6 derivation fn — a `key` must be a string).

### Scope
Core-only. A full-workspace typecheck confirms nothing outside core reads `idempotency.key` / `cache.key` (fn) or calls `stitch.cache.key(...)`. `CircuitOptions.key` and `StitchStore.get/set/incr(key)` are **string** keys and stay untouched. The alias-parity test is deleted and the §6 backlog row is cleared.

### Gates
`build` · `check:contract` (baseline unchanged) · full-workspace `check:types` + `check:types-d` · 1214 core tests · `check:lint` · `prettier` — all green (pre-push CI gate passed).

### BREAKING CHANGE
The `@deprecated` `key` function on `idempotency` / `cache` is removed — use `keyOf`. The cache introspection method `stitch.cache.key(input)` is renamed to `stitch.cache.keyOf(input)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)