### PR TITLE
refactor(core)!: rename registerSecretQueryKey→registerSecretKey, drop isSecretQueryKey alias

### DIFF
--- a/docs/adr/0018-inspect-raw-redaction.md
+++ b/docs/adr/0018-inspect-raw-redaction.md
@@ -17,6 +17,18 @@
 > work: "revisit with a `redact` option if an incident or demand justifies it."
 > This is that option.
 
+> [!IMPORTANT]
+>
+> **Amendment — the query-scoped compat alias was later removed.** This ADR
+> designed the `isSecretKey` promotion with the original query-scoped predicate
+> name kept as a backward-compatible alias, and the original query-scoped
+> registrar name unchanged. Both were pre-GA, no-alias renames: the registrar
+> is now **`registerSecretKey`**, and the alias predicate was deleted outright
+> (no replacement export — call `isSecretKey` directly). The prose below is
+> worded to avoid the removed spellings; where it says "the query-scoped
+> predicate/registrar" it means the pre-rename name of `isSecretKey` /
+> `registerSecretKey` respectively.
+
 ## Context
 
 0016 §5 makes `raw` the **unredacted** pre-validation body on a **non-enumerable**
@@ -60,8 +72,9 @@ stray-token case). Per-call keeps any blinding **local and visible**.
 
 Redaction reuses the curated trace-redaction denylist already in
 [`util.ts`](../../packages/core/src/util.ts) — the `SECRET_QUERY_KEYS` /
-`SECRET_QUERY_STEMS` predicate (`isSecretQueryKey`) plus any caller
-`registerSecretQueryKey` registrations — rather than inventing a parallel list
+`SECRET_QUERY_STEMS` predicate (originally under a query-scoped name, later
+`isSecretKey`) plus any caller registrations on the matching query-scoped
+registrar (later `registerSecretKey`) — rather than inventing a parallel list
 that would drift out of sync. A credential param name registered for URL
 scrubbing is then also caught when it echoes in a response body.
 
@@ -69,7 +82,8 @@ The denylist is **query-key-named** today; the body case needs the same matcher
 under a body-neutral name:
 
 -   Promote the predicate to **`isSecretKey(name)`** in `util.ts`, keeping
-    `isSecretQueryKey` as an alias (the URL scrubbers keep their name).
+    the original query-scoped name as a compat alias (the URL scrubbers keep
+    their name).
 -   Add **`redactSecretsDeep(value, extra?)`** in `util.ts`: walk a plain value,
     replace any object key matching `isSecretKey` (or the caller's `extra`
     name/path patterns via the existing `matchPath`) with the existing
@@ -112,8 +126,8 @@ on `wrapper.raw` and drops the unredacted body (otherwise redaction is pointless
     false confidence, and a name-based redactor can't catch the stray-token case
     anyway — so a default-on net protects least where it matters most.
 -   **A new, body-specific secret denylist.** Rejected: duplicates the curated
-    `isSecretKey` list, would drift, and caller `registerSecretQueryKey`
-    registrations wouldn't carry over.
+    `isSecretKey` list, would drift, and caller registrations on the
+    query-scoped registrar (later `registerSecretKey`) wouldn't carry over.
 -   **Value-shape (regex) redaction.** Rejected for v1: heuristic, false-positive
     prone, and still cannot guarantee catching the field manual inspection exists
     for. Could be a future additive `redact` mode if demand appears.
@@ -140,8 +154,8 @@ on `wrapper.raw` and drops the unredacted body (otherwise redaction is pointless
     `redact?: boolean | string[]`. Update the `Inspection.raw` JSDoc to mention
     the escape hatch.
 -   [`util.ts`](../../packages/core/src/util.ts) — rename the predicate to
-    `isSecretKey` (alias `isSecretQueryKey`); add `redactSecretsDeep(value, extra?)`
-    reusing it + `URL_REDACTED`.
+    `isSecretKey` (alias: the original query-scoped name); add
+    `redactSecretsDeep(value, extra?)` reusing it + `URL_REDACTED`.
 -   [`stitch.ts`](../../packages/core/src/stitch.ts) — the `.inspect()` consumer:
     after recovering `raw` (`RAW_BODY`) and computing `findings`, if `redact` is
     set, place `redactSecretsDeep(...)` on `wrapper.raw` instead of the raw body.

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -20,7 +20,7 @@ import {
     now,
     parseDuration,
     readEnv,
-    registerSecretQueryKey,
+    registerSecretKey,
 } from './util';
 
 export type Secret = string | (() => string);
@@ -200,7 +200,7 @@ export function apiKey(
         const name = opts.name ?? 'api_key';
         // Teach the trace scrubber this param name carries a secret, so the key never reaches a
         // sink in the clear — even when `name` is a vendor spelling the built-in stems don't catch.
-        registerSecretQueryKey(name);
+        registerSecretKey(name);
         return {
             name: 'apiKey',
             scheme: { type: 'apiKey', in: 'query', name },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,15 +47,10 @@ export type {
 // Trace-redaction escape hatch: widen the secret-key denylist so a host's custom credential
 // param name is scrubbed in every trace sink (start.url, OTLP url.full, input.query). `apiKey({ in:
 // 'query', name })` registers its name here automatically; this is the manual hook for a credential
-// the built-in set/stems don't catch. `isSecretKey` is the matching predicate (alias:
-// `isSecretQueryKey`), exposed so a host can audit which of its query params / body keys the
-// scrubbers already cover. `redactSecretsDeep` walks a plain value and replaces secret-named keys.
-export {
-    registerSecretQueryKey,
-    isSecretKey,
-    isSecretQueryKey,
-    redactSecretsDeep,
-} from './util';
+// the built-in set/stems don't catch. `isSecretKey` is the matching predicate, exposed so a host
+// can audit which of its query params / body keys the scrubbers already cover. `redactSecretsDeep`
+// walks a plain value and replaces secret-named keys.
+export { registerSecretKey, isSecretKey, redactSecretsDeep } from './util';
 export type { Issue, ValidationResult, Validator } from './validator';
 // Standalone validation, uniform with what `input`/`output` consume: `validate(schema, value)`
 // checks a value now; `compile(schema)` coerces once and returns a reusable checker. Both take any

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -4,7 +4,7 @@ import { compact } from './compact';
 import type { DriftLevel, StitchEvent, TraceContext, TraceSink } from './types';
 import {
     dirnameOf,
-    isSecretQueryKey,
+    isSecretKey,
     nodeFs,
     readEnv,
     redactSecretsDeep,
@@ -155,7 +155,7 @@ function redactSecretQuery(
 ): Record<string, unknown> {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(query))
-        out[k] = isSecretQueryKey(k) ? REDACTED : v;
+        out[k] = isSecretKey(k) ? REDACTED : v;
     return out;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -960,7 +960,7 @@ export interface InspectOptions {
      * undeclared field") is unimpaired. Set when you want to pipe `wrapper.raw` into a log or
      * support ticket and need the _known-secret_ fields removed first.
      *
-     * - `true` — apply the shared secret-key denylist (`isSecretKey` / `registerSecretQueryKey`
+     * - `true` — apply the shared secret-key denylist (`isSecretKey` / `registerSecretKey`
      *   registrations) to every object key in `raw`, depth-first. Returns a deep clone.
      * - `string[]` — additionally scrub the listed key-name/path patterns on top of the shared
      *   denylist (reuses the {@link matchPath} grammar: exact, `*` wildcard, or prefix).

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -492,7 +492,7 @@ const REGISTERED_SECRET_QUERY_KEYS = new Set<string>();
  * scrubbers redact it. Additive and process-wide (mirroring the built-in denylist): names can be
  * widened but never un-redacted. Idempotent — registering the same name twice is a no-op.
  */
-export function registerSecretQueryKey(name: string): void {
+export function registerSecretKey(name: string): void {
     REGISTERED_SECRET_QUERY_KEYS.add(name.toLowerCase());
 }
 
@@ -501,7 +501,7 @@ export function registerSecretQueryKey(name: string): void {
  * key in the same family — a `start` event's `input.query`) carries a secret value:
  * matched case-insensitively against the secret key set above, by containing one of
  * the secret stems, or because a caller registered it via
- * {@link registerSecretQueryKey} (e.g. `apiKey({ in: 'query', name })`).
+ * {@link registerSecretKey} (e.g. `apiKey({ in: 'query', name })`).
  */
 export function isSecretKey(key: string): boolean {
     const k = key.toLowerCase();
@@ -511,12 +511,6 @@ export function isSecretKey(key: string): boolean {
         SECRET_QUERY_STEMS.some((s) => k.includes(s))
     );
 }
-
-/**
- * Backward-compatible alias for {@link isSecretKey} — the URL scrubbers and any
- * external code that imported the original name keep working unchanged.
- */
-export const isSecretQueryKey: (key: string) => boolean = isSecretKey;
 
 /**
  * Deep-clone `value` and replace any object key that matches {@link isSecretKey}

--- a/packages/core/test/inspect-redact.spec.ts
+++ b/packages/core/test/inspect-redact.spec.ts
@@ -4,15 +4,9 @@
 //     key, extra patterns, input-immutability)
 //   - `.inspect({ redact: true })` redacts secret-named fields in `raw`; default off; findings
 //     are unaffected; `redact: string[]` adds extra patterns
-//   - `isSecretQueryKey` alias still works
 import { drift, stitch } from '../src';
 import type { Adapter } from '../src';
-import {
-    isSecretKey,
-    isSecretQueryKey,
-    redactSecretsDeep,
-    registerSecretQueryKey,
-} from '../src/util';
+import { isSecretKey, redactSecretsDeep, registerSecretKey } from '../src/util';
 
 import { z } from 'zod';
 
@@ -72,8 +66,8 @@ describe('redactSecretsDeep', () => {
         expect(result.users[0]?.['name']).toBe('bob');
     });
 
-    it('redacts a key registered via registerSecretQueryKey', () => {
-        registerSecretQueryKey('x_custom_cred');
+    it('redacts a key registered via registerSecretKey', () => {
+        registerSecretKey('x_custom_cred');
         const result = redactSecretsDeep({
             x_custom_cred: 'val',
             other: 1,
@@ -112,17 +106,13 @@ describe('redactSecretsDeep', () => {
     });
 });
 
-// ---- isSecretQueryKey alias -----------------------------------------------
+// ---- isSecretKey -----------------------------------------------------------
 
-describe('isSecretQueryKey alias', () => {
-    it('is the same function as isSecretKey', () => {
-        expect(isSecretQueryKey).toBe(isSecretKey);
-    });
-
-    it('still matches secret stems correctly', () => {
-        expect(isSecretQueryKey('api_key')).toBe(true);
-        expect(isSecretQueryKey('access_token')).toBe(true);
-        expect(isSecretQueryKey('page')).toBe(false);
+describe('isSecretKey', () => {
+    it('matches secret stems correctly', () => {
+        expect(isSecretKey('api_key')).toBe(true);
+        expect(isSecretKey('access_token')).toBe(true);
+        expect(isSecretKey('page')).toBe(false);
     });
 });
 


### PR DESCRIPTION
Extracts the secret-key-helper rename from #470 (the contract-freeze sweep) into a standalone PR.

The trace-redaction denylist now covers query params, body keys, and headers alike, so the `Query`-scoped spellings are leftovers. Hard break (P19, pre-GA):

- rename the exported registrar `registerSecretQueryKey` → **`registerSecretKey`**;
- remove the `isSecretQueryKey` export (it was a backward-compat alias of the canonical **`isSecretKey`**) and rewrite its two call sites (`trace.ts`) to `isSecretKey`.

The internal (non-exported) `REGISTERED_SECRET_QUERY_KEYS` set keeps its name — it's not public surface. ADR 0018 gets an amendment note rather than a history rewrite.

### Gates
`build` · full-workspace `check:types` · 1214 core tests · `check:contract` (baseline unchanged) · `check:lint` · `prettier` — all green (pre-push CI gate passed).

### BREAKING CHANGE
`registerSecretQueryKey` is renamed to `registerSecretKey`, and the `isSecretQueryKey` alias is removed — use `isSecretKey`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)