### PR TITLE
refactor(core)!: rename the `otlpTrace` trace sink to `otlpSink`

### DIFF
--- a/apps/docs/content/docs/guides/observability/otlp.mdx
+++ b/apps/docs/content/docs/guides/observability/otlp.mdx
@@ -21,14 +21,14 @@ STITCH_EXPORT=otlp OTEL_EXPORTER_OTLP_ENDPOINT=https://api.example.com node app.
 ```
 
 To wire it yourself — to set headers, or to tee OTLP next to your own sink —
-build the sink with `otlpTrace()` and combine sinks with `multiplex`:
+build the sink with `otlpSink()` and combine sinks with `multiplex`:
 
 ```ts twoslash
-import { createTrace, multiplex, otlpTrace } from 'stitchapi';
+import { createTrace, multiplex, otlpSink } from 'stitchapi';
 
 const trace = multiplex(
     createTrace({ console: true }),
-    otlpTrace({
+    otlpSink({
         endpoint: 'https://api.example.com',
         headers: { authorization: 'Bearer token' },
     }),
@@ -40,7 +40,7 @@ const trace = multiplex(
 `STITCH_EXPORT=otlp` is the toggle (a comma list, e.g. `console,otlp`);
 `OTEL_EXPORTER_OTLP_ENDPOINT` sets the collector base URL.
 
-`otlpTrace(opts?)` returns a sink. `OtlpOptions` carries `endpoint` (OTLP/HTTP
+`otlpSink(opts?)` returns a sink. `OtlpOptions` carries `endpoint` (OTLP/HTTP
 base URL), `headers` (extra headers on the POST, e.g. auth), and `exporter` (a
 custom `SpanExporter` destination, defaulting to the built-in HTTP exporter).
 

--- a/apps/docs/content/docs/guides/observability/trace-sinks.mdx
+++ b/apps/docs/content/docs/guides/observability/trace-sinks.mdx
@@ -77,13 +77,13 @@ for await (const event of search({ query: { q: 'mango' } }).stream()) {
 
 The `trace` field accepts:
 
-| Value         | Effect                                                                 |
-| ------------- | ---------------------------------------------------------------------- |
-| _(unset)_     | Falls back to the env vars below — off unless one is set.              |
-| `'console'`   | The colored one-line-per-event stream to stderr.                       |
-| `fileSink(p)` | JSONL appended to `p` (defaults to `~/.stitch/runs/proto.jsonl`).      |
-| a `TraceSink` | Any custom sink — e.g. from `createTrace` / `multiplex` / `otlpTrace`. |
-| `false`       | Forces tracing off, even when `STITCH_TRACE_*` is set.                 |
+| Value         | Effect                                                                |
+| ------------- | --------------------------------------------------------------------- |
+| _(unset)_     | Falls back to the env vars below — off unless one is set.             |
+| `'console'`   | The colored one-line-per-event stream to stderr.                      |
+| `fileSink(p)` | JSONL appended to `p` (defaults to `~/.stitch/runs/proto.jsonl`).     |
+| a `TraceSink` | Any custom sink — e.g. from `createTrace` / `multiplex` / `otlpSink`. |
+| `false`       | Forces tracing off, even when `STITCH_TRACE_*` is set.                |
 
 When `trace` is unset, four env vars control the built-in sink:
 `STITCH_TRACE_CONSOLE=1` turns on the colored stderr stream;

--- a/apps/docs/content/docs/reference/helpers.mdx
+++ b/apps/docs/content/docs/reference/helpers.mdx
@@ -183,9 +183,9 @@ Fan one event stream out to several sinks — for example console/JSONL alongsid
 OTLP — flushing each in turn.
 
 ```ts twoslash
-import { createTrace, multiplex, otlpTrace } from 'stitchapi';
+import { createTrace, multiplex, otlpSink } from 'stitchapi';
 
-const sink = multiplex(createTrace(), otlpTrace());
+const sink = multiplex(createTrace(), otlpSink());
 ```
 
 ### loggerSink
@@ -206,16 +206,16 @@ import { loggerSink } from 'stitchapi';
 const sink = loggerSink(console, { levels: { result: 'debug' } });
 ```
 
-### otlpTrace
+### otlpSink
 
 An opt-in OpenTelemetry sink: it maps each stitch call's events to a single OTel
 `CLIENT` span and hands finished spans to a `SpanExporter`. With no exporter
 supplied it uses `otlpHttpExporter`. Configured by `OtlpOptions` (below).
 
 ```ts twoslash
-import { otlpTrace } from 'stitchapi';
+import { otlpSink } from 'stitchapi';
 
-const sink = otlpTrace({ endpoint: 'https://api.example.com:4318' });
+const sink = otlpSink({ endpoint: 'https://api.example.com:4318' });
 ```
 
 ### otlpHttpExporter

--- a/docs/sandbox/B1-SPIKE.md
+++ b/docs/sandbox/B1-SPIKE.md
@@ -24,14 +24,14 @@ Entry = [`packages/core/src/index.ts`](../../packages/core/src/index.ts). The ba
 **only** browser-safe + shimmable surfaces; it does **not** re-export `cli`/`serve`/`mcp`. Every
 Node-only import reachable from the barrel, with the surface that pulls it in:
 
-| Module           | Node built-in (import)                                            | Pulled in via barrel by                                                | Reachable from browser-safe surface? | Hot path?                                                                  |
-| ---------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------ | -------------------------------------------------------------------------- |
-| `engine.ts:38`   | `node:crypto` (`randomUUID`)                                      | `stitch`/`defineStitch`/`graphql` → `engine`                           | **YES**                              | **YES** — `applyIdempotency()` on writes                                   |
-| `stitch.ts:118`  | _(no import)_ `process.env` ×3 read at runtime                    | `stitch` → `getTrace()`                                                | **YES**                              | **YES** — runs on every `makeStitch()`                                     |
-| `trace.ts:5-6`   | `node:fs` (`appendFileSync`,`mkdirSync`), `node:path` (`dirname`) | `createTrace`/`multiplex`; also `stitch`→`getTrace()`                  | **YES**                              | Indirect — only if a JSONL `path` is set; default reads `process.env.HOME` |
-| `otlp.ts:7,249`  | `node:crypto` (`randomBytes`); `process.env`                      | `otlpTrace`/`otlpHttpExporter`; also `stitch`→`getTrace()` import-time | **YES**                              | No (export is lazy) but **imported** on the `stitch` path                  |
-| `auth.ts:15`     | `node:fs` (`existsSync`,`readFileSync`); `process.env`; `Buffer`  | `keychain`/`env`/`basic`/`cookieSession`/`oauth2`/`bearer`/`apiKey`    | **YES**                              | No — all call-time inside returned closures                                |
-| `drift.ts:11-12` | `node:fs` (4 fns), `node:path` (`dirname`)                        | `drift` (and `engine`→`drift` for snapshot mode)                       | **YES**                              | No — only when `drift({snapshotFile})` is used                             |
+| Module           | Node built-in (import)                                            | Pulled in via barrel by                                               | Reachable from browser-safe surface? | Hot path?                                                                  |
+| ---------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------ | -------------------------------------------------------------------------- |
+| `engine.ts:38`   | `node:crypto` (`randomUUID`)                                      | `stitch`/`defineStitch`/`graphql` → `engine`                          | **YES**                              | **YES** — `applyIdempotency()` on writes                                   |
+| `stitch.ts:118`  | _(no import)_ `process.env` ×3 read at runtime                    | `stitch` → `getTrace()`                                               | **YES**                              | **YES** — runs on every `makeStitch()`                                     |
+| `trace.ts:5-6`   | `node:fs` (`appendFileSync`,`mkdirSync`), `node:path` (`dirname`) | `createTrace`/`multiplex`; also `stitch`→`getTrace()`                 | **YES**                              | Indirect — only if a JSONL `path` is set; default reads `process.env.HOME` |
+| `otlp.ts:7,249`  | `node:crypto` (`randomBytes`); `process.env`                      | `otlpSink`/`otlpHttpExporter`; also `stitch`→`getTrace()` import-time | **YES**                              | No (export is lazy) but **imported** on the `stitch` path                  |
+| `auth.ts:15`     | `node:fs` (`existsSync`,`readFileSync`); `process.env`; `Buffer`  | `keychain`/`env`/`basic`/`cookieSession`/`oauth2`/`bearer`/`apiKey`   | **YES**                              | No — all call-time inside returned closures                                |
+| `drift.ts:11-12` | `node:fs` (4 fns), `node:path` (`dirname`)                        | `drift` (and `engine`→`drift` for snapshot mode)                      | **YES**                              | No — only when `drift({snapshotFile})` is used                             |
 
 **Browser-clean modules (no Node, confirmed):** `http-adapter.ts` (pure `fetch`/`FormData`/`Blob`),
 `util.ts`, `resilience.ts`, `store.ts`, `validator.ts`, `standard-schema.ts`, `types.ts`.
@@ -57,7 +57,7 @@ The design (SANDBOX §3, REQUIREMENTS §6) assumes the Tier-1 call path
    bundle even for a read-only `stitch()`.
 2. **`stitch.ts:118-127` `getTrace()`** reads `process.env.STITCH_TRACE_FILE` /
    `STITCH_TRACE_CONSOLE` / `STITCH_EXPORT` **on every `makeStitch()`**, and statically imports
-   `otlpTrace` (→`node:crypto`) and `createTrace`/`multiplex` (→`node:fs`). So constructing _any_
+   `otlpSink` (→`node:crypto`) and `createTrace`/`multiplex` (→`node:fs`). So constructing _any_
    stitch transitively loads three Node modules and reads `process.env` at runtime. `trace.ts`'s
    default path also dereferences `process.env.HOME`.
 
@@ -131,7 +131,7 @@ So: naive bundle fails predictably; **shim+define bundle succeeds and runs.**
 | `process.env` reads (`stitch.ts` getTrace, `trace.ts` HOME, `otlp.ts` endpoint) | **Trivial**          | Bundler `define:process={"env":{}}` (or inject a `process` stub global in the Worker).                                                                                           |
 | `createTrace` + `multiplex` (JSONL/fs)                                          | **Trivial**          | `node:fs` aliased to no-op writes; trace already surfaces via `StitchTraceEntry` (SANDBOX §5.7). `multiplex` is pure JS — keep as-is.                                            |
 | `cookieSession`                                                                 | **Moderate**         | In-memory cookie jar (the strategy logic is already pure JS in `auth.ts`; only the `node:fs` co-import in the module needs the fs stub). Browser jar reimpl per REQUIREMENTS §6. |
-| `otlpTrace` / `otlpHttpExporter`                                                | **Trivial-Moderate** | `randomBytes`→Web Crypto (trivial); real OTLP egress is blocked by CSP `connect-src` anyway — make the default exporter a no-op/sim-routed in browser.                           |
+| `otlpSink` / `otlpHttpExporter`                                                 | **Trivial-Moderate** | `randomBytes`→Web Crypto (trivial); real OTLP egress is blocked by CSP `connect-src` anyway — make the default exporter a no-op/sim-routed in browser.                           |
 | `cli` / `serve` / `mcp`                                                         | **Out-of-scope**     | Server tier only (REQUIREMENTS §7 Tier-3). Already not in the barrel — nothing to do for the browser build.                                                                      |
 
 No surface is harder than **Moderate**. The "Moderate" ones (`cookieSession`, real OTLP) are
@@ -145,7 +145,7 @@ behaviour reimpls, not build blockers — the build itself is unblocked by the t
 
 1. **New entry `stitch-browser.ts`** (in the docs/playground build, not `packages/core`): re-export
    the browser-safe surface from `packages/core/src/index.ts`, and re-export _shimmed_ versions of
-   `keychain`/`env`/`cookieSession`/`createTrace`/`otlpTrace` that emit a `RunNotice` (SANDBOX §5.7).
+   `keychain`/`env`/`cookieSession`/`createTrace`/`otlpSink` that emit a `RunNotice` (SANDBOX §5.7).
 2. **Bundler config** (esbuild/Vite, whatever R1's Worker build uses), three knobs, all proven above:
     - `alias`: `node:fs`/`node:path`/`node:crypto` → 3 tiny browser shim modules (fs no-op,
       path.dirname regex, crypto via Web Crypto). ~30 lines total.
@@ -174,7 +174,7 @@ Tier-1 examples need it. The risk is retired: the bundle builds and the call pat
 -   **R1:** `engine.ts` `randomUUID` is on the hot path (write idempotency). The Web Crypto shim covers
     it; just don't forget it when listing aliases.
 -   **D1 (dispatcher):** `NODE_ONLY_SURFACES` in [`contracts/dispatch.ts`](./contracts/dispatch.ts) is
-    accurate for _routing_, but note for the browser-shim path: `env`/`keychain`/`createTrace`/`otlpTrace`
+    accurate for _routing_, but note for the browser-shim path: `env`/`keychain`/`createTrace`/`otlpSink`
     load fine once aliased and run shimmed-with-notice; `cli`/`serve`/`mcp` genuinely cannot run in the
     browser (server-tier only). The scan list needs no change.
 -   **CSP (SANDBOX §7):** the OTLP default exporter does a real `fetch` to a collector. With

--- a/docs/sandbox/SANDBOX.md
+++ b/docs/sandbox/SANDBOX.md
@@ -73,7 +73,7 @@ Classification of the **develop** core exports ([`packages/core/src/index.ts`](.
 | `drift`, `graphql`                                               | `env` — reads `process.env`                               |
 | `bearer`, `apiKey`, `basic`, `oauth2` (token held in memory)     | `cookieSession` — persistent cookie jar                   |
 | `fetchAdapter` (global `fetch`, shimmed to the simulator)        | `createTrace` / `multiplex` — JSONL trace files (fs)      |
-| `toValidator`, `memoryStore`, resilience (retry/throttle — pure) | `otlpTrace` / `otlpHttpExporter` — real network egress    |
+| `toValidator`, `memoryStore`, resilience (retry/throttle — pure) | `otlpSink` / `otlpHttpExporter` — real network egress     |
 |                                                                  | `cli`, `serve`, `mcp` — process / stdio / server surfaces |
 
 **Detection** is a static scan of the (pre-transpile) source for references to the

--- a/docs/sandbox/contracts/surface.ts
+++ b/docs/sandbox/contracts/surface.ts
@@ -63,7 +63,7 @@ export const NODE_ONLY_SURFACES = [
     'cookieSession',
     'createTrace',
     'multiplex',
-    'otlpTrace',
+    'otlpSink',
     'otlpHttpExporter',
     'cli',
     'serve',

--- a/docs/sandbox/runtime/B1-README.md
+++ b/docs/sandbox/runtime/B1-README.md
@@ -31,7 +31,7 @@ docs/sandbox/runtime/
   shims/
     process.ts               ← `process` object injected into the snippet scope
     notices.ts               ← RunNotice collection channel (drainNotices)
-    otlp-browser.ts          ← no-op OTLP exporter (no egress) + shimmed otlpTrace
+    otlp-browser.ts          ← no-op OTLP exporter (no egress) + shimmed otlpSink
     node-surfaces.ts         ← keychain/env (demo values) + cookieSession (in-mem jar)
     server-tier-stubs.ts     ← cli/serve/mcp throwing stubs (server-tier only)
 ```
@@ -76,14 +76,14 @@ The Node built-ins (`node:crypto`/`fs`/`path`) and `process.env` are **no longer
 shimmed** — core handles them isomorphically (GAP-AUDIT §1.5). What remains are the
 Node-only **surfaces** the browser entry deliberately replaces with sandbox policy:
 
-| Surface                          | Shim                   | Behaviour                                                                                |
-| -------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------- |
-| `keychain(name)`                 | `node-surfaces.ts`     | documented **demo value** + `RunNotice{kind:'shim'}`                                     |
-| `env(name)`                      | `node-surfaces.ts`     | documented **demo value** + `RunNotice{kind:'shim'}`                                     |
-| `cookieSession`                  | `node-surfaces.ts`     | core's pure-JS strategy; **in-memory jar** (lives in the StitchStore) + notice           |
-| `createTrace`                    | `stitch-browser.ts`    | JSONL = no-op; **console forced off** (trace via StitchTraceEntry); notice if a file set |
-| `otlpTrace` / `otlpHttpExporter` | `otlp-browser.ts`      | **no-op exporter, zero network egress** + notice                                         |
-| `cli` / `serve` / `mcp`          | `server-tier-stubs.ts` | **throw** — server-tier only                                                             |
+| Surface                         | Shim                   | Behaviour                                                                                |
+| ------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------- |
+| `keychain(name)`                | `node-surfaces.ts`     | documented **demo value** + `RunNotice{kind:'shim'}`                                     |
+| `env(name)`                     | `node-surfaces.ts`     | documented **demo value** + `RunNotice{kind:'shim'}`                                     |
+| `cookieSession`                 | `node-surfaces.ts`     | core's pure-JS strategy; **in-memory jar** (lives in the StitchStore) + notice           |
+| `createTrace`                   | `stitch-browser.ts`    | JSONL = no-op; **console forced off** (trace via StitchTraceEntry); notice if a file set |
+| `otlpSink` / `otlpHttpExporter` | `otlp-browser.ts`      | **no-op exporter, zero network egress** + notice                                         |
+| `cli` / `serve` / `mcp`         | `server-tier-stubs.ts` | **throw** — server-tier only                                                             |
 
 ### Shim-notice channel
 
@@ -122,7 +122,7 @@ Lifted from B1-SPIKE §7, plus what this implementation adds:
    `crypto` into the snippet scope (whose `globalThis` is shadowed).
 3. **No-op OTLP.** Real OTLP egress is server-tier only. The browser build's default
    exporter is a no-op (`otlp-browser.ts`) — do **not** rely on CSP `connect-src`
-   alone (SANDBOX §7). `otlpTrace()`/`otlpHttpExporter()` are in `NODE_ONLY_SURFACES`,
+   alone (SANDBOX §7). `otlpSink()`/`otlpHttpExporter()` are in `NODE_ONLY_SURFACES`,
    so a snippet naming them routes to the server tier when it exists; pre-server it
    runs shimmed-with-notice.
 4. **Core's `createTrace` console path probes `process.stderr`.** In a Worker there is

--- a/docs/sandbox/runtime/shims/otlp-browser.ts
+++ b/docs/sandbox/runtime/shims/otlp-browser.ts
@@ -6,19 +6,19 @@
  * but the spike was explicit: don't rely on CSP alone (B1-SPIKE §7 / SANDBOX §7) —
  * make the browser build's default OTLP exporter a no-op.
  *
- * `otlpTrace()` and `otlpHttpExporter()` are NODE_ONLY_SURFACES, so a snippet that
+ * `otlpSink()` and `otlpHttpExporter()` are NODE_ONLY_SURFACES, so a snippet that
  * names them routes to the server tier when it exists; pre-server it runs shimmed.
  * The browser entry re-exports THESE in place of core's versions:
  *   - `otlpHttpExporter()` → a no-op SpanExporter (no network), + a shim notice.
- *   - `otlpTrace()`        → core's real otlpTrace, but defaulted to this no-op
+ *   - `otlpSink()`        → core's real otlpSink, but defaulted to this no-op
  *     exporter so no egress is ever attempted, + a shim notice.
  *
- * The `node:crypto` alias already covers `otlpTrace`'s `randomBytes` span ids, so
+ * The `node:crypto` alias already covers `otlpSink`'s `randomBytes` span ids, so
  * the trace mapping itself still works — it just exports nowhere.
  */
 import { emitShimNotice } from './notices';
 
-import { otlpTrace as coreOtlpTrace } from 'stitchapi';
+import { otlpSink as coreOtlpSink } from 'stitchapi';
 import type { OtelSpan, OtlpOptions, SpanExporter, TraceSink } from 'stitchapi';
 
 const OTLP_NOTICE =
@@ -42,10 +42,10 @@ export function otlpHttpExporter(
     return noopOtlpExporter();
 }
 
-/** Drop-in for core `otlpTrace` — builds spans, exports to the no-op exporter. */
-export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
-    emitShimNotice('otlpTrace', OTLP_NOTICE);
-    return coreOtlpTrace({
+/** Drop-in for core `otlpSink` — builds spans, exports to the no-op exporter. */
+export function otlpSink(opts: OtlpOptions = {}): TraceSink {
+    emitShimNotice('otlpSink', OTLP_NOTICE);
+    return coreOtlpSink({
         ...opts,
         exporter: opts.exporter ?? noopOtlpExporter(),
     });

--- a/docs/sandbox/runtime/stitch-browser.ts
+++ b/docs/sandbox/runtime/stitch-browser.ts
@@ -27,7 +27,7 @@ import type { TraceSink } from 'stitchapi';
  *     keychain, env            → ./shims/node-surfaces  (demo values)
  *     cookieSession            → ./shims/node-surfaces  (in-memory jar)
  *     createTrace              → shimmed below          (JSONL is a no-op)
- *     otlpTrace, otlpHttpExporter → ./shims/otlp-browser (no-op exporter, no egress)
+ *     otlpSink, otlpHttpExporter → ./shims/otlp-browser (no-op exporter, no egress)
  *   Server-tier only, THROWS here:
  *     cli, serve, mcp          → ./shims/server-tier-stubs
  */
@@ -69,7 +69,7 @@ export type * from 'stitchapi';
 /* ---- Node-only surfaces, shimmed (emit a RunNotice) ---------------------- */
 export { keychain, env, cookieSession } from './shims/node-surfaces';
 export {
-    otlpTrace,
+    otlpSink,
     otlpHttpExporter,
     noopOtlpExporter,
 } from './shims/otlp-browser';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,7 +36,7 @@ export {
     loggerSink,
 } from './trace';
 export type { LoggerLike, LoggerSinkOptions, LogLevel } from './trace';
-export { otlpTrace, otlpHttpExporter, toOtlpJson } from './otlp';
+export { otlpSink, otlpHttpExporter, toOtlpJson } from './otlp';
 export type {
     SpanExporter,
     OtelSpan,

--- a/packages/core/src/otlp.ts
+++ b/packages/core/src/otlp.ts
@@ -132,7 +132,7 @@ function buildChildSpans(run: OtelSpan): OtelSpan[] {
  * `traceId`/`spanId`/`parentSpanId` tree — falling back to the stitch name (a tolerant stack) only
  * when a sink is fed events by hand without ids (e.g. synthetic test events).
  */
-export function otlpTrace(opts: OtlpOptions = {}): TraceSink {
+export function otlpSink(opts: OtlpOptions = {}): TraceSink {
     const exporter =
         opts.exporter ??
         otlpHttpExporter(

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -16,7 +16,7 @@ import {
     makeRuntime,
 } from './engine';
 import type { InferOutput, InputOf, ResolveOutput } from './infer';
-import { otlpTrace } from './otlp';
+import { otlpSink } from './otlp';
 import { RateLimitError, createThrottle } from './resilience';
 import { createStoreThrottle, memoryStore } from './store';
 import { graphqlSurface } from './surface';
@@ -280,7 +280,7 @@ function getTrace(): TraceSink {
         }),
     );
     if (!exportsFromEnv(readEnv('STITCH_EXPORT')).includes('otlp')) return base;
-    return multiplex(base, otlpTrace());
+    return multiplex(base, otlpSink());
 }
 
 // A sink that drops every event — `trace: false` forces tracing off even when the

--- a/packages/core/test/gaps/resource-leaks.spec.ts
+++ b/packages/core/test/gaps/resource-leaks.spec.ts
@@ -2,7 +2,7 @@
 // `open` map, and prompt abort during retry/reconnect backoff + throttle waits. These are leak
 // regressions, not behaviour changes — each test asserts a bound or a prompt cancellation that the
 // pre-fix code violated (an ever-growing Map, or a backoff sleep that ignored the caller signal).
-import { otlpTrace, stitch } from '../../src';
+import { otlpSink, stitch } from '../../src';
 import { OPEN_SPANS } from '../../src/otlp';
 import { THROTTLE_STATES, createThrottle } from '../../src/resilience';
 import {
@@ -140,11 +140,11 @@ test('in-process throttle: a key with a queued waiter is not dropped early', asy
 });
 
 // ── 2. OTLP sink drains its `open` map after a completed run ─────────────────
-// otlpTrace stacks an in-flight span per run key; on `done` it popped the span but left the empty
+// otlpSink stacks an in-flight span per run key; on `done` it popped the span but left the empty
 // stack as a Map entry, leaking one entry per unique run id. The fix deletes the entry when the
 // stack empties.
 test('otlp sink: the internal open-span map is empty after a completed run', () => {
-    const sink = otlpTrace({
+    const sink = otlpSink({
         exporter: {
             export() {
                 /* drop spans — the test only inspects the internal map */

--- a/packages/core/test/no-credential-leak.spec.ts
+++ b/packages/core/test/no-credential-leak.spec.ts
@@ -10,7 +10,7 @@
 // into output MUST be registered as a case below. A future config-exporter — `stitch gen` /
 // client publishing (ADR 0013/0014) — that forgets to scrub will fail THIS test instead of baking
 // a password into a shared document. Add the surface here in the same PR that adds the surface.
-import { otlpTrace, stitch } from '../src';
+import { otlpSink, stitch } from '../src';
 import type { OtelSpan, SpanExporter, StitchEvent } from '../src';
 import { toOpenApi } from '../src/openapi';
 import type { StitchRegistry } from '../src/registry';
@@ -63,7 +63,7 @@ function otlpSpans(): OtelSpan[] {
             spans.push(...batch);
         },
     };
-    const sink = otlpTrace({ exporter });
+    const sink = otlpSink({ exporter });
     const name = 'getUser';
     sink.handle(startEvent(), { name });
     sink.handle(
@@ -110,7 +110,7 @@ const SURFACES: Surface[] = [
     },
     {
         // OTLP export — `url.full` / `server.address` on the exported CLIENT span.
-        name: 'otlpTrace → span url.full',
+        name: 'otlpSink → span url.full',
         serialize: () => JSON.stringify(otlpSpans()),
         emitsHost: true,
     },

--- a/packages/core/test/otlp-export.spec.ts
+++ b/packages/core/test/otlp-export.spec.ts
@@ -1,7 +1,7 @@
 // OTLP export: an opt-in trace sink maps the event stream to OpenTelemetry CLIENT spans (OTel
 // HTTP semconv attributes) and hands them to a SpanExporter. Tested with a STUB exporter that
 // captures spans in memory — no running collector, no network.
-import { otlpTrace, stitch } from '../src';
+import { otlpSink, stitch } from '../src';
 import type { OtelSpan, SpanExporter, StitchEvent } from '../src';
 import { exportsFromEnv, multiplex } from '../src/trace';
 import { scrubUrl } from '../src/util';
@@ -42,7 +42,7 @@ beforeEach(() => {
 
 test('maps a successful call to one CLIENT span with OTel HTTP semconv attributes', () => {
     const { exporter, spans } = stubExporter();
-    const sink = otlpTrace({ exporter });
+    const sink = otlpSink({ exporter });
     const name = 'getThing';
     const events: StitchEvent[] = [
         {
@@ -80,7 +80,7 @@ test('maps a successful call to one CLIENT span with OTel HTTP semconv attribute
 
 test('maps an error to an ERROR span with error.type and status_code', () => {
     const { exporter, spans } = stubExporter();
-    const sink = otlpTrace({ exporter });
+    const sink = otlpSink({ exporter });
     const name = 'createThing';
     const events: StitchEvent[] = [
         {
@@ -112,7 +112,7 @@ test('maps an error to an ERROR span with error.type and status_code', () => {
 
 test('end-to-end: a real stitch call exports one span to the stub exporter', async () => {
     const { exporter, spans } = stubExporter();
-    const sink = otlpTrace({ exporter });
+    const sink = otlpSink({ exporter });
     server.route('GET', '/ping', { body: { ok: true } });
     const ping = stitch({ name: 'ping', baseUrl: server.url, path: '/ping' });
 
@@ -149,7 +149,7 @@ test('STITCH_EXPORT parses to a list and multiplex fans out to every sink', () =
 // bodies), so it must be scrubbed before a span leaves for a collector.
 test('url.full strips userinfo and redacts secret query params before export', () => {
     const { exporter, spans } = stubExporter();
-    const sink = otlpTrace({ exporter });
+    const sink = otlpSink({ exporter });
     const name = 'fetchThing';
     const events: StitchEvent[] = [
         {

--- a/packages/core/test/otlp-json.spec.ts
+++ b/packages/core/test/otlp-json.spec.ts
@@ -1,5 +1,5 @@
 // Direct tests for toOtlpJson (src/otlp.ts) — the OTLP/JSON `ResourceSpans` serializer a collector
-// ingests on /v1/traces. otlp-export.spec.ts asserts the SPAN objects (OtelSpan) an otlpTrace sink
+// ingests on /v1/traces. otlp-export.spec.ts asserts the SPAN objects (OtelSpan) an otlpSink sink
 // produces; run-identity.spec.ts checks only that parentSpanId is serialized. The wire-shape itself
 // — the resource/scope envelope, attribute value TYPING (int vs double vs bool vs string), the
 // nanosecond timestamps, the status-code mapping, and event serialization — was unpinned. A drift

--- a/packages/core/test/public-api-surface.spec.ts
+++ b/packages/core/test/public-api-surface.spec.ts
@@ -28,7 +28,7 @@ const FUNCTIONS = [
     'fileSink',
     'multiplex',
     'loggerSink',
-    'otlpTrace',
+    'otlpSink',
     'otlpHttpExporter',
     'toOtlpJson',
     'memoryStore',

--- a/packages/core/test/run-identity.spec.ts
+++ b/packages/core/test/run-identity.spec.ts
@@ -3,13 +3,7 @@
 // The OTLP sink reads them to build a real span tree (shared traceId, parentSpanId) instead of
 // minting per-start and guessing by name; a child run inherits the parent's traceId and points
 // parentSpanId at the parent's spanId. Ids are engine-minted, never caller-supplied (ADR 0002 §2).
-import {
-    cookieSession,
-    multiplex,
-    otlpTrace,
-    stitch,
-    toOtlpJson,
-} from '../src';
+import { cookieSession, multiplex, otlpSink, stitch, toOtlpJson } from '../src';
 import type {
     OtelSpan,
     SpanExporter,
@@ -123,7 +117,7 @@ test('newRunContext: a root mints fresh ids; a child inherits traceId and sets p
 
 test('the OTLP sink builds a span tree from the ctx ids (traceId / spanId / parentSpanId)', () => {
     const { exporter, spans } = stubExporter();
-    const sink = otlpTrace({ exporter });
+    const sink = otlpSink({ exporter });
     const parent = newRunContext();
     const child = newRunContext(parent); // shares traceId, parentSpanId = parent.spanId
 
@@ -187,7 +181,7 @@ test('end-to-end: a real call feeds the OTLP sink the same ids it stamped on `st
         name: 'ping',
         baseUrl: server.url,
         path: '/ping',
-        trace: multiplex(cap, otlpTrace({ exporter })),
+        trace: multiplex(cap, otlpSink({ exporter })),
     });
 
     await ping();
@@ -200,7 +194,7 @@ test('end-to-end: a real call feeds the OTLP sink the same ids it stamped on `st
 
 test('a hand-fed OTLP sink (no ctx ids) still mints a valid span — back-compat', () => {
     const { exporter, spans } = stubExporter();
-    const sink = otlpTrace({ exporter });
+    const sink = otlpSink({ exporter });
     const name = 'legacy';
     sink.handle(
         {
@@ -277,7 +271,7 @@ test('OTLP: a retried call emits flat per-attempt child spans parented to the ru
         baseUrl: server.url,
         path: '/flaky',
         retry: { attempts: 3, on: [503], backoff: 'fixed', baseMs: 1 },
-        trace: otlpTrace({ exporter }),
+        trace: otlpSink({ exporter }),
     });
 
     await flaky();
@@ -307,7 +301,7 @@ test('OTLP: a paginated call emits flat per-page child spans parented to the run
             next: (_body, page) =>
                 page < 3 ? { query: { page: page + 1 } } : undefined,
         },
-        trace: otlpTrace({ exporter }),
+        trace: otlpSink({ exporter }),
     });
 
     await list();


### PR DESCRIPTION
Extracts the `otlpTrace`→`otlpSink` rename from #470 (the contract-freeze sweep) into a standalone PR. Hard break, no alias (P19, pre-GA).

`otlpSink` sits alongside the other trace sinks (`loggerSink`, …) and reads as one family; `otlpTrace` was the odd verb out. Pure rename of the exported factory — `otlpHttpExporter`, `toOtlpJson`, and `OtlpOptions` are untouched.

Footprint: core `otlp`/`index`/`stitch`, 6 core specs, 3 observability docs pages, and the `docs/sandbox` browser shim.

### Gates
`build` · full-workspace `check:types` · 1215 core tests · `check:contract` (baseline unchanged) · `check:lint` · `prettier` · docs twoslash build — all green (pre-push CI gate passed).

### BREAKING CHANGE
The `otlpTrace` export is renamed to `otlpSink`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)