### PR TITLE
refactor(core)!: rename CookieSessionOptions.scope → tenancy (P2)

### DIFF
--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -280,7 +280,7 @@ export interface OAuth2Options {
      * Token tenancy (ADR 0002 §3). Default **`'app'`**: one token serves every caller — the right
      * model for `client_credentials`, which authenticates the *application*, not a user. Set
      * `'principal'` to fold the seam-bound principal into the token's cache key (and **throw if no
-     * principal is bound**, mirroring {@link CookieSessionOptions.scope}); each tenant then caches its
+     * principal is bound**, mirroring {@link CookieSessionOptions.tenancy}); each tenant then caches its
      * own token and one tenant's 401/refresh never disturbs another's in-flight calls. Pair it with
      * per-tenant `clientId`/`clientSecret`/`scope` for full multi-tenant separation.
      */
@@ -330,7 +330,7 @@ export function oauth2(opts: OAuth2Options): AuthStrategy {
 
     // The vault key for THIS call. Default 'app' shares one token across all callers (correct for
     // client_credentials — the token authenticates the application, not a user). 'principal' folds
-    // the seam-bound principal in (fail-closed if none, mirroring cookieSession's scope), so each
+    // the seam-bound principal in (fail-closed if none, mirroring cookieSession's tenancy), so each
     // tenant caches its own token and one tenant's 401/refresh never disturbs another's.
     const keyFor = (ctx: AuthContext): string => {
         if (tenancy === 'app') return baseKey;
@@ -511,7 +511,7 @@ export interface CookieSessionOptions {
     refreshWhen?: (res: AdapterResponse) => boolean;
     /** Vault namespace — give two stitches the same `key` + a shared seam/store to share one session. */
     key?: string;
-    /** Optional TTL for the stored session — `60_000`, `'1m'`. With `scope: 'principal'`, set this — per-user sessions multiply. */
+    /** Optional TTL for the stored session — `60_000`, `'1m'`. With `tenancy: 'principal'`, set this — per-user sessions multiply. */
     ttl?: number | string;
     /** @deprecated Renamed to {@link CookieSessionOptions.ttl} (CONTRACT.md P17). Read until the 1.0 GA cut. */
     ttlMs?: number;
@@ -521,8 +521,12 @@ export interface CookieSessionOptions {
      * bound** — per-user auth can never silently run app-wide. `'app'` is the explicit opt-in to
      * sharing ONE session across all callers (the only safe choice for a standalone `stitch()`,
      * which never has a principal). Sessions always live in the {@link AuthContext.vault}.
+     *
+     * The two defaults deliberately diverge (CONTRACT.md P8): a cookie session belongs to a user,
+     * so it fails closed to `'principal'`, while {@link OAuth2Options.tenancy} defaults to `'app'`
+     * because a client-credentials token belongs to the application.
      */
-    scope?: 'principal' | 'app';
+    tenancy?: 'principal' | 'app';
     /**
      * Host-owned hook fired once per ACTUAL login attempt that failed to capture a cookie — NOT
      * per coalesced waiter (it runs inside the single-flight-guarded `doRefresh`). The host maps the
@@ -543,7 +547,7 @@ export interface CookieSessionOptions {
 export function cookieSession(opts: CookieSessionOptions): AuthStrategy {
     const refreshOn = opts.refreshOn ?? [401];
     const jarMode = opts.jar === true || opts.cookie === '*';
-    const scope = opts.scope ?? 'principal';
+    const tenancy = opts.tenancy ?? 'principal';
     const baseKey = (jarMode ? 'jar:' : 'cookie:') + (opts.key ?? opts.cookie);
     const flight = singleFlight<unknown>();
 
@@ -554,13 +558,13 @@ export function cookieSession(opts: CookieSessionOptions): AuthStrategy {
     const sessionFor = (
         ctx: AuthContext,
     ): { key: string; principal?: string } => {
-        if (scope === 'app') return { key: baseKey };
+        if (tenancy === 'app') return { key: baseKey };
         const principal = ctx.principal;
         if (principal == null || principal === '') {
             const e = new Error(
-                "cookieSession with scope 'principal' (the default) requires a bound principal: " +
+                "cookieSession with tenancy 'principal' (the default) requires a bound principal: " +
                     'create the stitch through a seam and call `seam.as(principalId)`, or set ' +
-                    "`scope: 'app'` to deliberately share one session across all callers.",
+                    "`tenancy: 'app'` to deliberately share one session across all callers.",
             );
             e.name = 'StitchAuthError';
             throw e;

--- a/packages/core/test/auth-trace.spec.ts
+++ b/packages/core/test/auth-trace.spec.ts
@@ -64,7 +64,7 @@ test('auth-wall: me() auto-logs-in and never asks the caller for a secret', asyn
         auth: cookieSession({
             login: signIn,
             cookie: 'sid',
-            scope: 'app',
+            tenancy: 'app',
             loginInput: () => ({
                 body: { user: env('DEMO_USER')(), pass: env('DEMO_PASS')() },
             }),
@@ -104,7 +104,7 @@ test('refresh on the 401 wall re-logs-in and retries the request', async () => {
             login: signIn,
             cookie: 'sid',
             refreshOn: [401],
-            scope: 'app',
+            tenancy: 'app',
         }),
     });
 

--- a/packages/core/test/body-encoding.spec.ts
+++ b/packages/core/test/body-encoding.spec.ts
@@ -118,7 +118,7 @@ describe('cookieSession content-aware refresh (soft wall)', () => {
             auth: cookieSession({
                 login,
                 cookie: 'SID',
-                scope: 'app',
+                tenancy: 'app',
                 // status is 200, so only a content predicate can catch this wall:
                 refreshWhen: (res) =>
                     typeof res.body === 'string' && /log in/i.test(res.body),

--- a/packages/core/test/cookie-jar.spec.ts
+++ b/packages/core/test/cookie-jar.spec.ts
@@ -2,7 +2,7 @@
 // Set-Cookie set from the login and replays every cookie on subsequent requests — not just
 // one named cookie. A login that sets two cookies should make both ride along next time.
 //
-// These standalone stitches share ONE session across all callers, so they pass `scope: 'app'`
+// These standalone stitches share ONE session across all callers, so they pass `tenancy: 'app'`
 // explicitly — the fail-closed default `'principal'` would throw (no seam binds a principal).
 import { cookieSession, env, stitch } from '../src';
 import { startMockServer } from './support/mock-server';
@@ -61,7 +61,7 @@ test('cookie: "*" captures and replays every cookie the login set', async () => 
             login: loginStitch(),
             cookie: '*',
             loginInput,
-            scope: 'app',
+            tenancy: 'app',
         }),
     });
 
@@ -94,7 +94,7 @@ test('jar: true is equivalent to cookie: "*"', async () => {
             cookie: 'session', // only seeds the store key in jar mode
             jar: true,
             loginInput,
-            scope: 'app',
+            tenancy: 'app',
         }),
     });
 
@@ -124,7 +124,7 @@ test('a single named cookie still replays only that one (regression)', async () 
             login: loginStitch(),
             cookie: 'sid',
             loginInput,
-            scope: 'app',
+            tenancy: 'app',
         }),
     });
 

--- a/packages/core/test/gaps/cookie-session-hooks.spec.ts
+++ b/packages/core/test/gaps/cookie-session-hooks.spec.ts
@@ -8,7 +8,7 @@
 // its own status. The hooks fire ONCE per actual login attempt (inside the single-flight-guarded
 // `doRefresh`), never per coalesced waiter, and a throwing hook never crashes the call.
 //
-// These standalone stitches share ONE session across all callers, so they pass `scope: 'app'`
+// These standalone stitches share ONE session across all callers, so they pass `tenancy: 'app'`
 // explicitly — the fail-closed default `'principal'` would throw (no seam binds a principal).
 import {
     type AuthFailureResult,
@@ -73,7 +73,7 @@ test('onRefresh fires with { ok: true, status: 200 } after a successful cold log
             login: loginStitch(server.url),
             cookie: 'sid',
             loginInput,
-            scope: 'app',
+            tenancy: 'app',
             onRefresh: (r) => {
                 refreshes.push(r);
             },
@@ -112,7 +112,7 @@ test('onRefresh fires ONCE (not per-waiter) under concurrent cold callers sharin
             login: loginStitch(server.url),
             cookie: 'sid',
             loginInput,
-            scope: 'app',
+            tenancy: 'app',
             onRefresh: () => {
                 refreshCount++;
             },
@@ -149,7 +149,7 @@ test("onAuthFailure fires category 'unauthenticated' when the login returns 401 
             login: loginStitch(server.url),
             cookie: 'sid',
             loginInput,
-            scope: 'app',
+            tenancy: 'app',
             onAuthFailure: (f) => {
                 failures.push(f);
             },
@@ -190,7 +190,7 @@ test("onAuthFailure fires category 'rate-limited' + retryAfter when the login re
             login: loginStitch(server.url),
             cookie: 'sid',
             loginInput,
-            scope: 'app',
+            tenancy: 'app',
             onAuthFailure: (f) => {
                 failures.push(f);
             },
@@ -231,7 +231,7 @@ test("onAuthFailure fires category 'network' + error when the login stitch throw
             login: loginStitch(deadUrl),
             cookie: 'sid',
             loginInput,
-            scope: 'app',
+            tenancy: 'app',
             onAuthFailure: (f) => {
                 failures.push(f);
             },
@@ -270,7 +270,7 @@ test('a throwing hook does not crash the stitch call', async () => {
             login: loginStitch(server.url),
             cookie: 'sid',
             loginInput,
-            scope: 'app',
+            tenancy: 'app',
             onRefresh: () => {
                 throw new Error('host bookkeeping blew up');
             },
@@ -300,7 +300,7 @@ test('hooks are absent → cookieSession behaves exactly as before (additive, no
             login: loginStitch(server.url),
             cookie: 'sid',
             loginInput,
-            scope: 'app',
+            tenancy: 'app',
         }),
     });
 

--- a/packages/core/test/integration-patterns.spec.ts
+++ b/packages/core/test/integration-patterns.spec.ts
@@ -127,7 +127,7 @@ describe('Session-cookie admin API (auto re-login on 403)', () => {
             auth: cookieSession({
                 login,
                 cookie: 'SID',
-                scope: 'app',
+                tenancy: 'app',
                 refreshOn: [403], // this integration uses 403, not 401
                 loginInput: () => ({
                     body: {
@@ -179,7 +179,7 @@ describe('HTML scrape provider — silent markup breakage becomes a loud drift e
             auth: cookieSession({
                 login,
                 cookie: 'session_id',
-                scope: 'app',
+                tenancy: 'app',
                 loginInput: () => ({
                     body: {
                         username: env('SCRAPE_USER')(),

--- a/packages/core/test/openapi.spec.ts
+++ b/packages/core/test/openapi.spec.ts
@@ -422,7 +422,7 @@ describe('toOpenApi security schemes', () => {
                 auth: cookieSession({
                     cookie: 'sid',
                     login: stitch('https://api.example.com/login'),
-                    scope: 'app',
+                    tenancy: 'app',
                 }),
             }),
         };

--- a/packages/core/test/run-identity.spec.ts
+++ b/packages/core/test/run-identity.spec.ts
@@ -247,7 +247,7 @@ test('cookieSession runs its login as a traced CHILD of the call that triggered 
         baseUrl: server.url,
         path: '/me',
         trace: sink,
-        auth: cookieSession({ login: signIn, cookie: 'sid', scope: 'app' }),
+        auth: cookieSession({ login: signIn, cookie: 'sid', tenancy: 'app' }),
     });
 
     await expect(me()).resolves.toEqual({ user: 'ada' });

--- a/packages/core/test/seam.spec.ts
+++ b/packages/core/test/seam.spec.ts
@@ -109,7 +109,7 @@ test('seam.as(principal) gives each principal its OWN session — no cross-princ
     expect((logins[1]!.body as { u: string }).u).toBe('B');
 });
 
-test('cookieSession fails closed: default scope throws when no principal is bound', async () => {
+test('cookieSession fails closed: default tenancy throws when no principal is bound', async () => {
     server.route('POST', '/login', {
         setCookie: { name: 'sid', value: 'OK' },
         body: { ok: true },
@@ -129,7 +129,7 @@ test('cookieSession fails closed: default scope throws when no principal is boun
     expect(server.callCount('/login')).toBe(0); // failed closed before any login
 });
 
-test("scope: 'app' is the explicit opt-in to ONE session shared across all callers", async () => {
+test("tenancy: 'app' is the explicit opt-in to ONE session shared across all callers", async () => {
     server.route('POST', '/login', {
         setCookie: { name: 'sid', value: 'OK' },
         body: { ok: true },
@@ -144,7 +144,7 @@ test("scope: 'app' is the explicit opt-in to ONE session shared across all calle
         auth: cookieSession({
             login: loginStitch(),
             cookie: 'sid',
-            scope: 'app',
+            tenancy: 'app',
             loginInput: (principal) => ({ body: { u: principal ?? 'app' } }),
         }),
     });

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -78,7 +78,7 @@ describe('Pluggable store — sessions', () => {
                 cookie: 'SID',
                 key: 'svc',
                 loginInput,
-                scope: 'app', // standalone shared session (no principal bound)
+                tenancy: 'app', // standalone shared session (no principal bound)
             }),
         });
         const b = stitch({
@@ -90,7 +90,7 @@ describe('Pluggable store — sessions', () => {
                 cookie: 'SID',
                 key: 'svc',
                 loginInput,
-                scope: 'app', // standalone shared session (no principal bound)
+                tenancy: 'app', // standalone shared session (no principal bound)
             }),
         });
 
@@ -129,7 +129,7 @@ describe('Pluggable store — sessions', () => {
                 cookie: 'SID',
                 key: 'svc',
                 loginInput,
-                scope: 'app', // standalone shared session (no principal bound)
+                tenancy: 'app', // standalone shared session (no principal bound)
             }),
         });
         const b = stitch({
@@ -140,7 +140,7 @@ describe('Pluggable store — sessions', () => {
                 cookie: 'SID',
                 key: 'svc',
                 loginInput,
-                scope: 'app', // standalone shared session (no principal bound)
+                tenancy: 'app', // standalone shared session (no principal bound)
             }),
         });
 


### PR DESCRIPTION
Extracts the cookieSession `scope`→`tenancy` rename from #470 (the contract-freeze sweep).

`OAuth2Options` already spells the token-ownership axis `tenancy`; cookieSession lagged on `scope`, so one word (`scope`) meant two concepts. This brings the session's ownership axis in line, freeing `scope` to mean exactly one thing. Hard break (P19, pre-GA).

Three different `scope`s exist in the surface — only cookieSession's tenancy axis is renamed:
- ✅ `CookieSessionOptions.scope: 'principal'|'app'` → **`tenancy`**
- ⬜ `CacheOptions.scope: 'principal'|'app'` — a different field, kept (33 refs untouched)
- ⬜ `OAuth2Options.scope` (OAuth scopes string) — kept

A P8 note is added to the JSDoc recording why the two `tenancy` defaults deliberately diverge (`'principal'` fail-closed for sessions vs `'app'` for client-credentials tokens).

### Gates
`build` · full-workspace `check:types` · 1215 core tests · `check:contract` (baseline unchanged) · `check:lint` · `prettier` — all green (pre-push CI gate passed).

### BREAKING CHANGE
`cookieSession({ scope })` is renamed to `cookieSession({ tenancy })`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)