### PR TITLE
refactor(core)!: drop the deprecated `value` alias on SchemaFingerprint (canonical `token`)

### DIFF
--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -454,7 +454,6 @@ will apply under `@deprecated` aliases (P18). Severity = consumer blast radius.
 | Med  | SSE helper `sendStitchSse`/`stitchSse`                             | `streamStitchSse`                                              | P16    |
 | Med  | error-options `StitchErrorHandlerOptions`/`ToHttpExceptionOptions` | `StitchErrorOptions` (+ `body`)                                | P16    |
 | Low  | `RedisDriver.del`, `…quit`, sync `close`                           | `delete`, async `close`                                        | P18    |
-| Low  | `SchemaFingerprint.value`                                          | `token`                                                        | P5     |
 | Low  | `bodyKind` (from-curl)                                             | `bodyType`                                                     | P1     |
 | Low  | emitted `*Ms` (`waitedMs`, `retryAfterMs`, done `ms`)              | de-suffix (`waited`, `retryAfter`, `elapsed`); units → JSDoc   | P17    |
 

--- a/packages/core/src/fingerprint.ts
+++ b/packages/core/src/fingerprint.ts
@@ -56,8 +56,6 @@ export function hash(input: string): string {
  */
 export interface SchemaFingerprint {
     readonly token: string | null;
-    /** @deprecated Renamed to {@link SchemaFingerprint.token} (CONTRACT.md P5: `value` is the success payload, not a token). Read until the 1.0 GA cut. */
-    readonly value?: string | null;
     readonly strength: 'strong' | 'weak';
 }
 
@@ -227,10 +225,8 @@ export function resolveFingerprint(
         };
     }
 
-    // rung 3 — sound structural fingerprint → fast path. Prefer `token`; fall back to the
-    // @deprecated `value` so an external fingerprinter still on the old spelling keeps working.
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- back-compat fallback for the renamed `value` alias (CONTRACT.md P5)
-    const token = fp?.token ?? fp?.value;
+    // rung 3 — sound structural fingerprint → fast path.
+    const token = fp?.token;
     if (token != null) {
         return {
             generation: hash(

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -818,13 +818,12 @@ function callFingerprint(
         throw new Error(`${label}: fingerprint() must be synchronous`);
     }
     const r = result as
-        | { token?: unknown; value?: unknown; strength?: unknown }
+        | { token?: unknown; strength?: unknown }
         | null
         | undefined;
-    // Accept the canonical `token` or the @deprecated `value` alias (CONTRACT.md P5), and normalize
-    // so downstream rules read `.token` regardless of which spelling the fingerprinter produced. A
-    // presence check (not `??`) preserves the `null` ABSTAIN sentinel — `null ?? value` would drop it.
-    const token = r?.token !== undefined ? r.token : r?.value;
+    // `null` is the ABSTAIN sentinel, so the shape check below is a presence check on `token`
+    // (missing/`undefined` fails, `null` passes) rather than a truthiness one.
+    const token = r?.token;
     if (
         !r ||
         (token !== null && typeof token !== 'string') ||
@@ -834,7 +833,7 @@ function callFingerprint(
             `${label}: expected { token: string|null, strength: 'strong'|'weak' }, got ${show(result)}`,
         );
     }
-    return { token, value: token, strength: r.strength };
+    return { token, strength: r.strength };
 }
 
 /**

--- a/packages/fingerprint-arktype/README.md
+++ b/packages/fingerprint-arktype/README.md
@@ -8,7 +8,7 @@ Stable [Standard Schema](https://standardschema.dev) fingerprint strategy for
 It reads ArkType's canonical `t.json` representation and hashes a canonicalised
 form into an opaque, synchronous token. The token changes iff the schema's
 validation/shape semantics change. It is an **allowlist**: it abstains (returns
-`value: null`, so the cache falls back to re-validate-on-hit) on anything it can't
+`token: null`, so the cache falls back to re-validate-on-hit) on anything it can't
 soundly capture — morphs (`.pipe`) and narrows (`.narrow`), which ArkType emits as
 opaque, non-deterministic `$ark.fn<n>` references, and property defaults.
 

--- a/packages/fingerprint-arktype/src/index.ts
+++ b/packages/fingerprint-arktype/src/index.ts
@@ -3,7 +3,7 @@
 // ArkType exposes a canonical JSON representation of every type on `t.json`. It
 // already normalises the parts that matter for structural identity — object keys
 // are emitted in a stable order and union branches are pre-sorted — so the bulk
-// of the work is reading that surface, then ABSTAINING (returning `value: null`)
+// of the work is reading that surface, then ABSTAINING (returning `token: null`)
 // the moment it contains something that can't be soundly captured:
 //
 //   - morphs (`.pipe`) surface as `morphs: ["$ark.fn10"]` and narrows (`.narrow`)
@@ -120,10 +120,10 @@ export const arktypeFingerprinter: SchemaFingerprinter = {
             // `afp1` tags the descriptor format: bump it to force a one-time,
             // safe re-fingerprint if the descriptor scheme ever changes.
             const token = hash(`afp1|${describe(schema)}`);
-            return { token, value: token, strength: 'strong' };
+            return { token, strength: 'strong' };
         } catch {
             // ABSTAIN sentinel or any unexpected introspection failure → abstain.
-            return { token: null, value: null, strength: 'strong' };
+            return { token: null, strength: 'strong' };
         }
     },
 };

--- a/packages/fingerprint-effect/README.md
+++ b/packages/fingerprint-effect/README.md
@@ -7,7 +7,7 @@ Stable [Standard Schema](https://standardschema.dev) fingerprint strategy for
 
 It walks Effect's `.ast` into a canonical structural descriptor hashed into an
 opaque, synchronous token. The token changes iff the schema's validation/shape
-semantics change. It is an **allowlist**: it abstains (returns `value: null`, so
+semantics change. It is an **allowlist**: it abstains (returns `token: null`, so
 the cache falls back to re-validate-on-hit) on anything it can't soundly capture —
 `Transformation`, `Refinement`, `Suspend`, and `Declaration` AST nodes.
 

--- a/packages/fingerprint-effect/src/index.ts
+++ b/packages/fingerprint-effect/src/index.ts
@@ -8,7 +8,7 @@
 //
 // The walker is an ALLOWLIST: it only emits a fingerprint for AST nodes whose
 // validation/shape semantics it fully captures, and ABSTAINS (returns
-// `value: null`) on anything else — `Transformation` (`.transform`/applied
+// `token: null`) on anything else — `Transformation` (`.transform`/applied
 // defaults), `Refinement` (an opaque predicate), `Suspend` (lazy/recursive),
 // `Declaration`, or any unknown `_tag`. Abstain is sound: the cache falls back to
 // re-validate-on-hit rather than trust a token that might collide across
@@ -155,10 +155,10 @@ export const effectFingerprinter: SchemaFingerprinter = {
             // `efp1` tags the descriptor format: bump it to force a one-time,
             // safe re-fingerprint if the descriptor scheme ever changes.
             const token = hash(`efp1|${describeAst(ast)}`);
-            return { token, value: token, strength: 'strong' };
+            return { token, strength: 'strong' };
         } catch {
             // ABSTAIN sentinel or any unexpected introspection failure → abstain.
-            return { token: null, value: null, strength: 'strong' };
+            return { token: null, strength: 'strong' };
         }
     },
 };

--- a/packages/fingerprint-typebox/README.md
+++ b/packages/fingerprint-typebox/README.md
@@ -8,7 +8,7 @@ Stable [Standard Schema](https://standardschema.dev) fingerprint strategy for
 A TypeBox schema _is_ a JSON Schema object, so this strategy canonical-hashes it
 (recursively sorted keys; the `required` set sorted) into an opaque, synchronous
 token. The token changes iff the schema's validation/shape semantics change. It is
-an **allowlist**: it abstains (returns `value: null`, so the cache falls back to
+an **allowlist**: it abstains (returns `token: null`, so the cache falls back to
 re-validate-on-hit) on anything it can't soundly capture — a `Type.Transform`
 codec (detected via its symbol, recursively, since it is invisible to
 `JSON.stringify`) and opaque kinds (`Function`/`Constructor`/`Unsafe`/…).

--- a/packages/fingerprint-typebox/src/index.ts
+++ b/packages/fingerprint-typebox/src/index.ts
@@ -11,7 +11,7 @@
 // opaque parts of a schema are INVISIBLE to a naive stringify: a
 // `Type.Transform(Type.String())...` serialises to exactly `{ type: 'string' }`,
 // indistinguishable from a plain string. We therefore walk every nested node and
-// ABSTAIN (return `value: null`) the moment we hit a part we cannot soundly
+// ABSTAIN (return `token: null`) the moment we hit a part we cannot soundly
 // capture: a transform codec (detected by `Symbol(TypeBox.Transform)`), an opaque
 // Kind (`Function`/`Constructor`/`Unsafe`/`Undefined`/`Void`), or a node that
 // carries no JSON-Schema discriminator at all (`Any`/`Unknown`/`Unsafe`, which all
@@ -149,10 +149,10 @@ export const typeboxFingerprinter: SchemaFingerprinter = {
             // `tbfp1` tags the descriptor format: bump it to force a one-time,
             // safe re-fingerprint if the descriptor scheme ever changes.
             const token = hash(`tbfp1|${describeRoot(schema)}`);
-            return { token, value: token, strength: 'strong' };
+            return { token, strength: 'strong' };
         } catch {
             // ABSTAIN sentinel or any unexpected introspection failure → abstain.
-            return { token: null, value: null, strength: 'strong' };
+            return { token: null, strength: 'strong' };
         }
     },
 };

--- a/packages/fingerprint-valibot/README.md
+++ b/packages/fingerprint-valibot/README.md
@@ -8,7 +8,7 @@ Stable [Standard Schema](https://standardschema.dev) fingerprint strategy for
 It walks Valibot's plain-object representation — `.type`, `.entries`, and the
 `.pipe` action chain — into a canonical structural descriptor hashed into an
 opaque, synchronous token. The token changes iff the schema's validation/shape
-semantics change. It is an **allowlist**: it abstains (returns `value: null`, so
+semantics change. It is an **allowlist**: it abstains (returns `token: null`, so
 the cache falls back to re-validate-on-hit) on anything it can't soundly capture —
 `transformation` actions, `check`/`custom`/`raw_*` actions, function-valued
 requirements, and injected defaults.

--- a/packages/fingerprint-valibot/src/index.ts
+++ b/packages/fingerprint-valibot/src/index.ts
@@ -7,7 +7,7 @@
 // `[baseSchema, ...actions]`, each action a `{ kind, type, requirement }` record.
 //
 // The walker is an ALLOWLIST: it only emits a fingerprint for constructs whose
-// validation/shape semantics it fully captures, and ABSTAINS (`value: null`) on
+// validation/shape semantics it fully captures, and ABSTAINS (`token: null`) on
 // anything else — opaque `check`/`custom`/`transform`/`brand` pipe actions, any
 // action whose `requirement` is a function (hidden, unserialisable logic), an
 // injected `default`, or any unknown node. Abstain is sound: the cache falls
@@ -245,10 +245,10 @@ export const valibotFingerprinter: SchemaFingerprinter = {
             // `vfp1` tags the descriptor format: bump it to force a one-time,
             // safe re-fingerprint if the descriptor scheme ever changes.
             const token = hash(`vfp1|${describe(schema)}`);
-            return { token, value: token, strength: 'strong' };
+            return { token, strength: 'strong' };
         } catch {
             // ABSTAIN sentinel or any unexpected introspection failure → abstain.
-            return { token: null, value: null, strength: 'strong' };
+            return { token: null, strength: 'strong' };
         }
     },
 };

--- a/packages/fingerprint-valibot/test/conformance.spec.ts
+++ b/packages/fingerprint-valibot/test/conformance.spec.ts
@@ -217,6 +217,6 @@ describe('@stitchapi/fingerprint-valibot', () => {
             ) as never,
         );
         expect(base.token).not.toBeNull();
-        expect(checked.value).toBeNull();
+        expect(checked.token).toBeNull();
     });
 });

--- a/packages/fingerprint-zod/README.md
+++ b/packages/fingerprint-zod/README.md
@@ -8,7 +8,7 @@ Stable [Standard Schema](https://standardschema.dev) fingerprint strategy for
 It walks Zod's internal representation — `_def`/`typeName` on Zod 3, `_zod.def`/
 `type` on Zod 4 — into a canonical structural descriptor hashed into an opaque,
 synchronous token. The token changes iff the schema's validation/shape semantics
-change. It is an **allowlist**: it abstains (returns `value: null`, so the cache
+change. It is an **allowlist**: it abstains (returns `token: null`, so the cache
 falls back to re-validate-on-hit) on anything it can't soundly capture — opaque
 `.refine`/`.transform`/`.default`/custom checks.
 

--- a/packages/fingerprint-zod/src/index.ts
+++ b/packages/fingerprint-zod/src/index.ts
@@ -4,7 +4,7 @@
 // `type` on Zod 4 — building a canonical structural descriptor that is hashed
 // into an opaque token. The walker is an ALLOWLIST: it only emits a fingerprint
 // for constructs whose validation/shape semantics it fully captures, and ABSTAINS
-// (returns `value: null`) on anything else — opaque `.refine`/`.transform`/
+// (returns `token: null`) on anything else — opaque `.refine`/`.transform`/
 // `.default`/custom checks, unrepresentable literals, or any unknown node. Abstain
 // is sound: the cache falls back to re-validate-on-hit rather than trust a token
 // that might collide across semantically-different schemas.
@@ -298,10 +298,10 @@ export const zodFingerprinter: SchemaFingerprinter = {
             // `zfp1` tags the descriptor format: bump it to force a one-time,
             // safe re-fingerprint if the descriptor scheme ever changes.
             const token = hash(`zfp1|${describe(schema)}`);
-            return { token, value: token, strength: 'strong' };
+            return { token, strength: 'strong' };
         } catch {
             // ABSTAIN sentinel or any unexpected introspection failure → abstain.
-            return { token: null, value: null, strength: 'strong' };
+            return { token: null, strength: 'strong' };
         }
     },
 };


### PR DESCRIPTION
Extracts the `SchemaFingerprint` value→token slice from #470 (the contract-freeze sweep).

`token` has been canonical since the P5 rename (`value` is the success-payload word, not a schema-identity token); `value` lingered as a co-emitted `@deprecated` alias — on the core `SchemaFingerprint` interface **and** in every first-party fingerprint adapter (zod / valibot / arktype / typebox / effect), which returned `{ token, value: token }` / `{ token: null, value: null }`. Hard break (P19, pre-GA):

- remove the interface member and read only `token` (`fp.token ?? fp.value` → `fp.token`);
- drop the `value` co-emission from all five adapters (+ their README abstain notes);
- clear the §6 backlog row.

Standard-Schema `{ value, issues }` and the result-envelope `.value` are a different `value` and stay untouched.

### Gates
`build` · full-workspace `check:types` · 1215 core tests + all five adapter suites · `check:contract` (baseline unchanged) · `check:lint` · `prettier` — all green (pre-push CI gate passed).

### BREAKING CHANGE
The `@deprecated` `value` field on `SchemaFingerprint`, and its co-emission by the fingerprint adapters, is removed — use `token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)