### PR TITLE
refactor(core)!: drop the deprecated `*Config`/`*Info`/`*Params` type aliases (P3)

### DIFF
--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -440,9 +440,7 @@ will apply under `@deprecated` aliases (P18). Severity = consumer blast radius.
 | High | `retry.on` + rate-limit `on` (`number[]`)                          | `number[] ｜ (status)=>boolean`                                | P7     |
 | High | `StitchStore`/`StitchLike`/`RequestSeam` cross-pkg clashes         | hoist or qualify                                               | P9     |
 | High | `queryOptions` bare in vue/solid/svelte/angular                    | `stitchQueryOptions`                                           | P16    |
-| Med  | `CacheConfig` →                                                    | `CacheOptions`                                                 | P3     |
 | Med  | `OAuth2Opts`, `CookieSessionOpts`                                  | `OAuth2Options`, `CookieSessionOptions`                        | P3     |
-| Med  | `McpServerInfo`, `SignV4Params`                                    | `…Options`                                                     | P3     |
 | Med  | `StitchQueryOptions` (a result)                                    | `StitchQueryResult`                                            | P3     |
 | Med  | `ReconnectOptions.maxAttempts`                                     | `attempts`                                                     | P4     |
 | Med  | `CacheConfig.maxEntries`                                           | `entries`                                                      | P4     |

--- a/packages/aws-sigv4/src/index.ts
+++ b/packages/aws-sigv4/src/index.ts
@@ -384,7 +384,3 @@ export function awsSigV4(opts: AwsSigV4Options): AuthStrategy {
         },
     };
 }
-
-// CONTRACT.md P3 — deprecated alias, removed at the 1.0 GA cut.
-/** @deprecated Renamed to {@link SignV4Options} (CONTRACT.md P3). Imported name kept until the 1.0 GA cut. */
-export type SignV4Params = SignV4Options;

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -796,7 +796,3 @@ function serializeJar(jar: Record<string, string> | undefined): string {
         .map(([k, v]) => `${k}=${v}`)
         .join('; ');
 }
-
-// CONTRACT.md P3 — deprecated alias, removed at the 1.0 GA cut.
-/** @deprecated Renamed to {@link AuthFailureResult} (CONTRACT.md P3). Imported name kept until the 1.0 GA cut. */
-export type AuthFailureInfo = AuthFailureResult;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,9 +15,6 @@ export {
     secretFrom,
 } from './auth';
 export type { SecretSource, AuthFailureResult, RefreshResult } from './auth';
-// CONTRACT.md P3 — deprecated alias re-export, removed at GA.
-// eslint-disable-next-line @typescript-eslint/no-deprecated -- intentional back-compat re-export of the @deprecated `AuthFailureInfo` (now `AuthFailureResult`) until the GA cut
-export type { AuthFailureInfo } from './auth';
 export { fetchAdapter } from './http-adapter';
 export type { FetchAdapterOptions } from './http-adapter';
 export { axiosAdapter } from './axios-adapter';

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -259,7 +259,3 @@ export const openai: LlmProvider = {
         return result;
     },
 };
-
-// CONTRACT.md P3 — deprecated alias, removed at the 1.0 GA cut.
-/** @deprecated Renamed to {@link LlmOptions} (CONTRACT.md P3). Imported name kept until the 1.0 GA cut. */
-export type LlmConfig = LlmOptions;

--- a/packages/core/src/mcp.ts
+++ b/packages/core/src/mcp.ts
@@ -327,7 +327,3 @@ export function serveStdio(
     input.on('data', onData);
     return { server, close: () => input.off('data', onData) };
 }
-
-// CONTRACT.md P3 — deprecated alias, removed at the 1.0 GA cut.
-/** @deprecated Renamed to {@link McpServerOptions} (CONTRACT.md P3). Imported name kept until the 1.0 GA cut. */
-export type McpServerInfo = McpServerOptions;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1298,7 +1298,3 @@ export interface Seam {
     readonly __config: RedactedStitchConfig;
     readonly __seam: true;
 }
-
-// CONTRACT.md P3 — deprecated alias, removed at the 1.0 GA cut.
-/** @deprecated Renamed to {@link CacheOptions} (CONTRACT.md P3). Imported name kept until the 1.0 GA cut. */
-export type CacheConfig = CacheOptions;


### PR DESCRIPTION
Extracts the **P3 suffix-rename** slice from #470 (the contract-freeze sweep). The `*Options`/`*Result` canonicals have been the real types since the P3 rename; the old suffixes lingered as dangling `@deprecated` type aliases. Hard break (P19, pre-GA) — **type-only, zero runtime, no bundle change**:

- `CacheConfig` → `CacheOptions` (core types)
- `LlmConfig` → `LlmOptions` (`stitchapi/llm`)
- `McpServerInfo` → `McpServerOptions` (`stitchapi/mcp`)
- `SignV4Params` → `SignV4Options` (`@stitchapi/aws-sigv4`)
- `AuthFailureInfo` → `AuthFailureResult` (core, incl. its `index.ts` re-export)

A full-workspace typecheck confirms nothing imports the old names. The two §6 backlog rows are cleared; `OAuth2Opts`/`CookieSessionOpts` (a separate, already-landed rename) and the query-family `StitchQueryOptions` row are intentionally left for their own slices.

### Gates
`build` · full-workspace `check:types` · `check:contract` (baseline unchanged) · `check:lint` · `prettier` · all 9 yakir tethers — green (pre-push CI gate passed).

### BREAKING CHANGE
The `@deprecated` type aliases `CacheConfig`, `LlmConfig`, `McpServerInfo`, `SignV4Params`, and `AuthFailureInfo` are removed — use `CacheOptions` / `LlmOptions` / `McpServerOptions` / `SignV4Options` / `AuthFailureResult`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)