### PR TITLE
refactor(core)!: drop the `max`-prefixed cap-word aliases (P4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ const listAnnouncements = stitch({
         ttl: '1h',
         scope: 'app',
         vary: ['accept-language'],
-        maxEntries: 500,
+        entries: 500,
         version: 1, // pins the shape — cacheable without a fingerprinter
     },
 });

--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -45,7 +45,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "sse",
             type: "property",
             detail: "SseOptions",
-            info: "Resumable-SSE options (issue #71) — sibling to , but for the `sse` surface. **Off by default**: with no `sse.reconnect` the engine opens the live body once (today's behaviour). When enabled, a dropped stream reconnects, replaying the last `id:` as `Last-Event-ID` and honouring a server `retry:` (else `reconnect.backoff` / the `retry` policy), capped at `maxAttempts`. Plain JSON (the contract gate). Only the `sse` surface reads it.",
+            info: "Resumable-SSE options (issue #71) — sibling to , but for the `sse` surface. **Off by default**: with no `sse.reconnect` the engine opens the live body once (today's behaviour). When enabled, a dropped stream reconnects, replaying the last `id:` as `Last-Event-ID` and honouring a server `retry:` (else `reconnect.backoff` / the `retry` policy), capped at `reconnect.attempts`. Plain JSON (the contract gate). Only the `sse` surface reads it.",
         },
         {
             label: "responseType",

--- a/apps/docs/content/blog/typescript-pagination.mdx
+++ b/apps/docs/content/blog/typescript-pagination.mdx
@@ -64,7 +64,7 @@ const allUsers = stitch({
 const users = (await allUsers()) as unknown[]; // every page, one array
 ```
 
-`next(prevBody, pagesFetched)` reads the cursor off the previous page's raw body and returns the input for the next page, merged over the original call — set only what changes. Return `undefined` to stop. `items(value)` selects the array to aggregate from each page; it defaults to the value itself when that value is already an array. `max` caps the page count as a safety net (default `50`), so a `next` that never returns `undefined` can't spin forever.
+`next(prevBody, pagesFetched)` reads the cursor off the previous page's raw body and returns the input for the next page, merged over the original call — set only what changes. Return `undefined` to stop. `items(value)` selects the array to aggregate from each page; it defaults to the value itself when that value is already an array. `pages` caps the page count as a safety net (default `50`), so a `next` that never returns `undefined` can't spin forever.
 
 For an offset or page-number API, `next` uses the page count it's handed instead of a cursor:
 

--- a/apps/docs/content/docs/guides/data/pagination.mdx
+++ b/apps/docs/content/docs/guides/data/pagination.mdx
@@ -43,7 +43,7 @@ it defaults to the value itself when that value is already an array. The pick
 runs first, so pair `items` with [`pick`](/docs/guides/data/pick) when the
 array sits under an envelope, and use `items` to dig into a nested shape.
 
-`max` caps the page count as a safety net (default `50`) so a misbehaving
+`pages` caps the page count as a safety net (default `50`) so a misbehaving
 `next` can't loop forever.
 
 Auth, retry, and throttle apply per page, not once for the whole run: a

--- a/apps/docs/content/docs/recipes/paginate-into-one-array.mdx
+++ b/apps/docs/content/docs/recipes/paginate-into-one-array.mdx
@@ -41,7 +41,7 @@ const users = (await allUsers()) as unknown[];
 the [input](/docs/reference/config-types) for the next page, merged over the
 original call — set only what changes. Return `undefined` to stop. `items`
 selects the array to aggregate from each page (after [pick](/docs/guides/data/pick)).
-`max` caps the page count as a safety net (default `50`). Auth, retry, and
+`pages` caps the page count as a safety net (default `50`). Auth, retry, and
 throttle apply per page, not once for the whole run. Without an
 [`output` schema](/docs/guides/validation/validation) the aggregated result is
 typed `unknown[]`, hence the cast — add a schema to type the rows.

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -444,10 +444,6 @@ will apply under `@deprecated` aliases (P18). Severity = consumer blast radius.
 | Med  | `OAuth2Opts`, `CookieSessionOpts`                                  | `OAuth2Options`, `CookieSessionOptions`                        | P3     |
 | Med  | `McpServerInfo`, `SignV4Params`                                    | `…Options`                                                     | P3     |
 | Med  | `StitchQueryOptions` (a result)                                    | `StitchQueryResult`                                            | P3     |
-| Med  | `ReconnectOptions.maxAttempts`                                     | `attempts`                                                     | P4     |
-| Med  | `CacheConfig.maxEntries`                                           | `entries`                                                      | P4     |
-| Med  | `CircuitOptions.failureThreshold`                                  | `failures`                                                     | P4     |
-| Med  | `paginate.max`                                                     | `pages`                                                        | P4     |
 | Med  | `*Ms` duration inputs (`cooldownMs`, `backoffMs`, `ttlMs`, …)      | de-suffix + `number｜string`                                   | P17    |
 | Med  | `paginate` inline shape                                            | `PaginateOptions`                                              | P14    |
 | Med  | SSE helper `sendStitchSse`/`stitchSse`                             | `streamStitchSse`                                              | P16    |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -407,10 +407,10 @@ Throttle waits and retries emit `throttled` / `retry` events on the stream, so t
 
 Three more knobs round out the resilience set:
 
--   **`circuit`** fast-fails a dependency that is already down — after `failureThreshold` consecutive failures the breaker opens for `cooldownMs`, then allows a half-open trial. A repeatedly-failing dependency stops eating your latency budget (and throws `STITCH_CIRCUIT_OPEN` while open):
+-   **`circuit`** fast-fails a dependency that is already down — after `failures` consecutive failures the breaker opens for `cooldownMs`, then allows a half-open trial. A repeatedly-failing dependency stops eating your latency budget (and throws `STITCH_CIRCUIT_OPEN` while open):
 
     ```ts
-    circuit: { failureThreshold: 5, cooldownMs: 30_000 }
+    circuit: { failures: 5, cooldownMs: 30_000 }
     ```
 
 -   **`idempotency`** injects a stable `Idempotency-Key` header on writes, so a safe retry can't duplicate a side effect:
@@ -455,7 +455,7 @@ const listAnnouncements = stitch({
         ttl: '1h',
         scope: 'app', // public, unauthenticated data → share one entry across callers
         vary: ['accept-language'], // request headers that vary the response
-        maxEntries: 500, // in-process LRU cap (default 1000)
+        entries: 500, // in-process LRU cap (default 1000)
     },
 });
 ```
@@ -759,7 +759,7 @@ Because every surface is just a stitch underneath, `auth`, `retry`, `throttle`, 
 
 ## Pagination
 
-One logical call follows pages until `next` returns `undefined` (or the `max` safety cap, default 50, is hit), aggregating items into a single result. Each page is a full request — auth, retry, and throttle apply per page — and each page emits a `paginate` progress event:
+One logical call follows pages until `next` returns `undefined` (or the `pages` safety cap, default 50, is hit), aggregating items into a single result. Each page is a full request — auth, retry, and throttle apply per page — and each page emits a `paginate` progress event:
 
 ```ts
 const listOrders = stitch({

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -359,8 +359,7 @@ export function createCache(opts: CacheControllerOptions): CacheController {
     const methods = (config.methods ?? ['GET', 'HEAD']).map((m) =>
         m.toUpperCase(),
     );
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `maxEntries` is the @deprecated alias of `entries`, read for back-compat until the GA cut (CONTRACT.md P4)
-    const maxEntries = config.entries ?? config.maxEntries ?? 1000;
+    const maxEntries = config.entries ?? 1000;
     const explicitVary = config.vary?.length
         ? config.vary
               .map((n) => n.toLowerCase())

--- a/packages/core/src/config-summary.ts
+++ b/packages/core/src/config-summary.ts
@@ -40,8 +40,7 @@ export function pipelineStages(
         );
     if (kind !== 'http') stages.push(`${kind} interpret`);
     if (cfg.paginate) {
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- `max` is the @deprecated alias of `pages`, read for back-compat until the GA cut (CONTRACT.md P4)
-        const pages = cfg.paginate.pages ?? cfg.paginate.max ?? 50;
+        const pages = cfg.paginate.pages ?? 50;
         stages.push(opts.detailed ? `paginate (max ${pages})` : 'paginate');
     }
     // Post-response order matches the engine (engine.ts): transform → pick → validate. The body

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -875,8 +875,7 @@ async function* paginated(
     const { cfg } = rt;
     const name = nameOf(cfg);
     const pg = cfg.paginate!;
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `max` is the @deprecated alias of `pages`, read for back-compat until the GA cut (CONTRACT.md P4)
-    const max = pg.pages ?? pg.max ?? 50;
+    const max = pg.pages ?? 50;
     const acc: unknown[] = [];
     let pageInput = input;
     let page = 0;
@@ -1169,7 +1168,7 @@ async function* runFrom(
 // the cache), but resumable when the surface opts in: a surface that exposes the resume hooks
 // (`resumeToken`/`applyResume`) AND a stitch that set `sse.reconnect` (off by default — issue #71)
 // reconnect a dropped body, replaying the last resume token (sse → `Last-Event-ID`) and honouring a
-// server-sent backoff (sse → the `retry:` field), capped at `maxAttempts`. The engine stays
+// server-sent backoff (sse → the `retry:` field), capped at `reconnect.attempts`. The engine stays
 // surface-agnostic: it never branches on `kind.id === 'sse'`; it reads the resume token / server
 // backoff through the surface's generic hooks and the reconnect policy through one config accessor.
 // It charges the rate gate at every open (each reconnect is a fresh request) but takes NO concurrency
@@ -1439,8 +1438,7 @@ function resolveReconnect(cfg: ResolvedStitchConfig): {
     const backoff = parseDuration(r.backoff ?? r.backoffMs);
     return {
         enabled: true,
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- `maxAttempts` is the @deprecated alias of `attempts`, read for back-compat until the GA cut (CONTRACT.md P4)
-        maxAttempts: r.attempts ?? r.maxAttempts ?? 3,
+        maxAttempts: r.attempts ?? 3,
         backoff,
     };
 }

--- a/packages/core/src/resilience.ts
+++ b/packages/core/src/resilience.ts
@@ -284,8 +284,8 @@ interface CircuitRecord {
  * a success closes it, another failure re-opens it. State lives in the StitchStore, so a shared
  * store gives a breaker shared across workers (DESIGN.md §13).
  *
- * `failures` and `cooldown` are required by design (CONTRACT.md P15); this throws if neither they
- * nor their deprecated `failureThreshold`/`cooldownMs` aliases are set.
+ * `failures` and `cooldown` are required by design (CONTRACT.md P15); this throws if `failures` is
+ * not set, or if neither `cooldown` nor its deprecated `cooldownMs` alias is set.
  */
 export function createCircuit(
     opts: CircuitOptions,
@@ -297,8 +297,7 @@ export function createCircuit(
     onSuccess(): Promise<void>;
     onFailure(): Promise<boolean>;
 } {
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `failureThreshold` is the @deprecated alias of `failures` (CONTRACT.md P4)
-    const failureThreshold = opts.failures ?? opts.failureThreshold;
+    const failureThreshold = opts.failures;
     // eslint-disable-next-line @typescript-eslint/no-deprecated -- `cooldownMs` is the @deprecated alias of `cooldown` (CONTRACT.md P17)
     const cooldown = parseDuration(opts.cooldown ?? opts.cooldownMs);
     if (failureThreshold == null || cooldown == null)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -158,8 +158,6 @@ export interface ReconnectOptions {
      * ends/errors exactly as today. Default 3.
      */
     attempts?: number;
-    /** @deprecated Renamed to {@link ReconnectOptions.attempts} (CONTRACT.md P4). Read until the 1.0 GA cut. */
-    maxAttempts?: number;
     /**
      * Fallback reconnect backoff when the server has NOT sent a `retry:` field on the dropped
      * connection — `1000`, `'1s'`. When omitted, the stitch's `retry` (`RetryOptions` —
@@ -175,7 +173,7 @@ export interface ReconnectOptions {
  * default**: with no `sse.reconnect` block the engine opens the body exactly once (today's
  * behaviour, byte-identical). When enabled the engine tracks the last `id:` seen and replays it as
  * `Last-Event-ID` on each reconnect, honours a server-sent `retry:` as the backoff (falling back to
- * `reconnect.backoff` / the stitch's `retry` policy), and caps reconnects at `maxAttempts`.
+ * `reconnect.backoff` / the stitch's `retry` policy), and caps reconnects at `attempts`.
  *
  * `true` = enabled with sane defaults; the object form tunes the cap / fallback backoff. Plain JSON
  * (the contract gate). Only the `sse` surface acts on this; other surfaces ignore it.
@@ -318,13 +316,10 @@ export interface TimeoutOptions {
 export interface CircuitOptions {
     /**
      * Consecutive failures that trip the breaker OPEN. Required by design — a breaker with an
-     * invisible threshold fails silently (CONTRACT.md P15); `createCircuit` throws if neither
-     * `failures` nor the @deprecated `failureThreshold` is set. Optional at the type level only so
-     * the deprecated alias can stand in until the GA cut.
+     * invisible threshold fails silently (CONTRACT.md P15); `createCircuit` throws if `failures`
+     * is not set.
      */
     failures?: number;
-    /** @deprecated Renamed to {@link CircuitOptions.failures} (CONTRACT.md P4). Read until the 1.0 GA cut. */
-    failureThreshold?: number;
     /**
      * Fast-fail window after opening, before a half-open trial — `30_000`, `'30s'`. Required by
      * design (P15); `createCircuit` throws if neither `cooldown` nor the @deprecated `cooldownMs`
@@ -403,8 +398,6 @@ export interface CacheOptions {
     methods?: string[];
     /** In-process LRU cap on live entries (the store stays dumb). Default 1000. */
     entries?: number;
-    /** @deprecated Renamed to {@link CacheOptions.entries} (CONTRACT.md P4). Read until the 1.0 GA cut. */
-    maxEntries?: number;
     /**
      * Request coalescing mode. `'process'` (v1 default) collapses concurrent identical in-flight
      * callers in one process onto a single shared run; `false` disables it. `'cluster'` is
@@ -655,8 +648,6 @@ export interface PaginateOptions {
     items?: (value: unknown) => unknown[];
     /** Safety cap on pages. Default 50. */
     pages?: number;
-    /** @deprecated Renamed to `pages` (CONTRACT.md P4). Read until the 1.0 GA cut. */
-    max?: number;
 }
 export interface StitchConfig {
     /** Label used in events and traces; defaults to `path` or `'stitch'`. */
@@ -689,8 +680,8 @@ export interface StitchConfig {
      * surface. **Off by default**: with no `sse.reconnect` the engine opens the live body once
      * (today's behaviour). When enabled, a dropped stream reconnects, replaying the last `id:` as
      * `Last-Event-ID` and honouring a server `retry:` (else `reconnect.backoff` / the `retry`
-     * policy), capped at `maxAttempts`. Plain JSON (the contract gate). Only the `sse` surface
-     * reads it.
+     * policy), capped at `reconnect.attempts`. Plain JSON (the contract gate). Only the `sse`
+     * surface reads it.
      */
     sse?: SseOptions;
     /** How to read the response body. Default: auto by content-type. */

--- a/packages/core/test/circuit-breaker.spec.ts
+++ b/packages/core/test/circuit-breaker.spec.ts
@@ -94,7 +94,7 @@ test('a success resets the consecutive-failure count', async () => {
     expect(server.callCount('/svc')).toBe(5); // all 5 hit the server → breaker never opened
 });
 
-test('the @deprecated failureThreshold/cooldownMs aliases still trip the breaker (P4/P17)', async () => {
+test('the @deprecated cooldownMs alias still trips the breaker (P17)', async () => {
     server.route('GET', '/svc', {
         statuses: [500, 500, 200],
         body: { ok: true },
@@ -102,8 +102,8 @@ test('the @deprecated failureThreshold/cooldownMs aliases still trip the breaker
     const call = stitch({
         baseUrl: server.url,
         path: '/svc',
-        // Pre-rename spelling — must behave identically to `failures`/`cooldown` until the GA cut.
-        circuit: { failureThreshold: 2, cooldownMs: 300 },
+        // Pre-rename spelling — must behave identically to `cooldown` until the GA cut.
+        circuit: { failures: 2, cooldownMs: 300 },
     });
 
     for (let i = 0; i < 2; i++) await expect(call()).rejects.toBeDefined();


### PR DESCRIPTION
Extracts the **P4 cap-vocabulary** slice from #470 (the contract-freeze sweep). The bare-plural canonicals (`attempts`, `entries`, `failures`, `pages`) have been canonical since the P4 rename; the `max`-prefixed / `*Threshold` spellings lingered as `@deprecated` input aliases. Hard break (P19, pre-GA):

- `ReconnectOptions.maxAttempts` → `attempts`
- `CacheOptions.maxEntries` → `entries`
- `CircuitOptions.failureThreshold` → `failures`
- `paginate.max` → `pages`

Remove the alias members and the `?? *` runtime fallbacks. **Internal names are unchanged** — the normalized resilience-policy field `maxAttempts` and the local `const maxEntries`/`failureThreshold`/`max` vars stay; only the *public* surface loses the aliases. The `*Ms` circuit fields (`cooldownMs`/`halfOpenAfterMs`) are P17's slice and untouched here.

### Gates
`build` · full-workspace `check:types` · 1213 core tests · `check:contract` (baseline unchanged) · `check:lint` · `prettier` · all 9 yakir tethers (bundle unchanged at ~25 KB) — green (pre-push CI gate passed).

### BREAKING CHANGE
The `@deprecated` cap aliases `ReconnectOptions.maxAttempts`, `CacheOptions.maxEntries`, `CircuitOptions.failureThreshold`, and `paginate.max` are removed — use `attempts` / `entries` / `failures` / `pages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)