### PR TITLE
refactor(hosts)!: drop the bare `RequestSeam`/`StitchHost` aliases — the per-request seam is ecosystem-qualified (P9)

### DIFF
--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -19,8 +19,6 @@
 export {
     stitch,
     type ElysiaRequestSeam,
-    // Deprecated alias (kept through 1.0.0-rc, removed at GA) — see ADR 0012.
-    type RequestSeam,
     type StitchPlugin,
     type StitchPluginOptions,
 } from './plugin';

--- a/packages/elysia/src/plugin.ts
+++ b/packages/elysia/src/plugin.ts
@@ -21,14 +21,6 @@ import type { PrincipalSeam, Seam } from 'stitchapi';
 export type ElysiaRequestSeam = PrincipalSeam | Seam;
 
 /**
- * @deprecated Renamed to {@link ElysiaRequestSeam} so the public type is ecosystem-qualified (a bare
- * `RequestSeam` would collide with any other host adapter's per-request seam type) — see
- * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the `1.0.0-rc`
- * line and removed at the 1.0 GA cut.
- */
-export type RequestSeam = ElysiaRequestSeam;
-
-/**
  * The Elysia instance {@link stitch} returns — a plugin you `.use()`. Its only public contract is
  * the global `derive` adding {@link StitchContext} (`{ stitch }`) to the context of the app that
  * mounts it; the other Singleton slots are empty. Narrowed to this so the published `.d.ts` stays a

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -18,8 +18,6 @@ export {
     stitch,
     currentStitch,
     type ExpressRequestSeam,
-    // Deprecated alias (kept through 1.0.0-rc, removed at GA) — see ADR 0012.
-    type RequestSeam,
     type StitchMiddlewareOptions,
 } from './middleware';
 

--- a/packages/express/src/middleware.ts
+++ b/packages/express/src/middleware.ts
@@ -18,14 +18,6 @@ import type { PrincipalSeam, Seam } from 'stitchapi';
  */
 export type ExpressRequestSeam = PrincipalSeam | Seam;
 
-/**
- * @deprecated Renamed to {@link ExpressRequestSeam} so the public type is ecosystem-qualified (a bare
- * `RequestSeam` would collide with any other host adapter's per-request seam type) — see
- * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the `1.0.0-rc`
- * line and removed at the 1.0 GA cut.
- */
-export type RequestSeam = ExpressRequestSeam;
-
 export interface StitchMiddlewareOptions {
     /**
      * The seam this middleware shares across requests. **Borrowed, not owned** — build it once at

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -5,8 +5,6 @@ export {
     type StitchPluginSeamOptions,
     type StitchPluginConfigOptions,
     type FastifyRequestSeam,
-    // Deprecated alias (kept through 1.0.0-rc, removed at GA) — see ADR 0012.
-    type StitchHost,
 } from './plugin';
 export { sendStitchSse, type SendStitchSseOptions } from './sse';
 export {

--- a/packages/fastify/src/plugin.ts
+++ b/packages/fastify/src/plugin.ts
@@ -25,14 +25,6 @@ import {
 // when a `principal` resolver is set, else the root seam (both create member stitches).
 export type FastifyRequestSeam = Seam | PrincipalSeam;
 
-/**
- * @deprecated Renamed to {@link FastifyRequestSeam} so the public type is ecosystem-qualified (a bare
- * `StitchHost` would collide with any other host adapter's per-request seam type) — see
- * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the `1.0.0-rc`
- * line and removed at the 1.0 GA cut.
- */
-export type StitchHost = FastifyRequestSeam;
-
 /** Common options shared by both `StitchPluginOptions` variants. */
 interface StitchPluginCommon {
     /**

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -19,8 +19,6 @@ export {
     type HonoRequestSeam,
     type StitchEnv,
     type StitchMiddlewareOptions,
-    // Deprecated alias (kept through 1.0.0-rc, removed at GA) — see ADR 0012.
-    type RequestSeam,
 } from './middleware';
 
 export {

--- a/packages/hono/src/middleware.ts
+++ b/packages/hono/src/middleware.ts
@@ -18,15 +18,6 @@ import type { PrincipalSeam, Seam } from 'stitchapi';
  */
 export type HonoRequestSeam = PrincipalSeam | Seam;
 
-/**
- * @deprecated Renamed to {@link HonoRequestSeam} so the public type is
- * ecosystem-qualified (a bare `RequestSeam` would collide with any other host
- * adapter's per-request seam type) — see
- * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the
- * `1.0.0-rc` line and removed at the 1.0 GA cut.
- */
-export type RequestSeam = HonoRequestSeam;
-
 /** The key the seam is stored under on `c.var` / via `c.set` / `c.get`. */
 export const STITCH_VAR = 'stitch' as const;
 

--- a/packages/nest/src/define-stitch.ts
+++ b/packages/nest/src/define-stitch.ts
@@ -8,14 +8,6 @@ import type { Seam, Stitch, StitchInput } from 'stitchapi';
 /** Both `Seam` and `PrincipalSeam` satisfy this — the host a stitch is built from. */
 export type NestRequestSeam = Pick<Seam, 'stitch' | 'graphql'>;
 
-/**
- * @deprecated Renamed to {@link NestRequestSeam} so the public type is ecosystem-qualified (a bare
- * `StitchHost` would collide with any other host adapter's per-request seam type) — see
- * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the `1.0.0-rc`
- * line and removed at the 1.0 GA cut.
- */
-export type StitchHost = NestRequestSeam;
-
 export interface StitchDef<TOut = unknown, TIn = StitchInput> {
     token: InjectionToken;
     build: (host: NestRequestSeam) => Stitch<TOut, TIn>;

--- a/packages/nest/src/index.ts
+++ b/packages/nest/src/index.ts
@@ -12,8 +12,6 @@ export {
     type StitchDef,
     type AnyStitchDef,
     type NestRequestSeam,
-    // Deprecated alias (kept through 1.0.0-rc, removed at GA) — see ADR 0012.
-    type StitchHost,
     type Injected,
 } from './define-stitch';
 export {


### PR DESCRIPTION
Extracts the **P9 seam-qualification** slice from #470 (the contract-freeze sweep). Each host adapter's per-request seam type already has its ecosystem-qualified canonical — `ExpressRequestSeam` / `ElysiaRequestSeam` / `FastifyRequestSeam` / `HonoRequestSeam` / `NestRequestSeam`. The bare `RequestSeam` (elysia/express/hono) and bare `StitchHost` (fastify/nest) lingered as `@deprecated` aliases that collided across packages. Hard break (P19, pre-GA): removed (10 files, all deletions).

Scope is exactly the two bare aliases — the qualified canonicals (38 refs) and the other in-flight per-package renames in these files (`StitchErrorOptions`, `streamStitchSse`, the nest logger/config bridges) are untouched, each its own slice.

### Gates
`build` (5 host packages) · full-workspace `check:types` · 139 host tests · `check:contract` (baseline unchanged) · `check:lint` · `prettier` · all 9 yakir tethers — green (pre-push CI gate passed).

### BREAKING CHANGE
The bare `RequestSeam` and `StitchHost` type aliases are removed from the host adapters — import the ecosystem-qualified name (`ExpressRequestSeam`, `NestRequestSeam`, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)