### PR TITLE
refactor(nest)!: drop the bare nest bridge aliases (ecosystem-qualified, ADR 0012)

### DIFF
--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -138,10 +138,9 @@ seam and bind explicitly — `seam.as(job.data.tenantId)`.
 > [!NOTE]
 >
 > `nestLoggerSink` / `fromNestConfig` / `nestBorrowStore` / `NestConfigServiceLike` are
-> the ecosystem-qualified names introduced by
-> [ADR 0012](../../docs/adr/0012-integration-symbol-naming.md). The former bare names
-> (`loggerSink`, `fromConfig`, `borrowStore`, `ConfigServiceLike`) remain as
-> `@deprecated` aliases through the `1.0.0-rc` line and are removed at the 1.0 GA cut.
+> the ecosystem-qualified names required by
+> [ADR 0012](../../docs/adr/0012-integration-symbol-naming.md) — the former bare names
+> were removed at the 1.0 GA cut.
 
 ## Errors → HTTP — `StitchExceptionFilter`
 

--- a/packages/nest/src/bridges.ts
+++ b/packages/nest/src/bridges.ts
@@ -72,22 +72,6 @@ export function nestLoggerSink(
     });
 }
 
-/**
- * @deprecated Renamed to {@link nestLoggerSink}. The bare name collided with core's
- * generic `loggerSink` (you had to alias one at every shared import site), so the
- * cross-package logger-sink family is now ecosystem-qualified — see
- * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). This alias is kept
- * through the `1.0.0-rc` line and removed at the 1.0 GA cut.
- */
-export const loggerSink = nestLoggerSink;
-
-/**
- * @deprecated Renamed to {@link NestLoggerLike} (it was indistinguishable from core's
- * `LoggerLike`) — see [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md).
- * Kept through the `1.0.0-rc` line and removed at the 1.0 GA cut.
- */
-export type LoggerLike = NestLoggerLike;
-
 // Adapt a Nest `Logger` to core's `LoggerLike`. Core's level vocabulary is
 // error|warn|info|debug; Nest's is error|warn|log|debug|verbose. We route core `info` →
 // Nest `verbose` (the level `result` lands on) and guard `debug`/`verbose`, which a partial
@@ -210,28 +194,3 @@ export function nestBorrowStore(store: StitchStore): StitchStore {
         incr: (key, ttlMs) => store.incr(key, ttlMs),
     };
 }
-
-/**
- * @deprecated Renamed to {@link fromNestConfig} so the adapter's secret-source
- * constructor is ecosystem-qualified (a bare `fromConfig` would collide with any
- * other framework's config bridge) — see
- * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the
- * `1.0.0-rc` line and removed at the 1.0 GA cut.
- */
-export const fromConfig = fromNestConfig;
-
-/**
- * @deprecated Renamed to {@link nestBorrowStore} so the helper is ecosystem-qualified
- * (a bare `borrowStore` would collide with any other adapter's store wrapper) — see
- * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the
- * `1.0.0-rc` line and removed at the 1.0 GA cut.
- */
-export const borrowStore = nestBorrowStore;
-
-/**
- * @deprecated Renamed to {@link NestConfigServiceLike} so the duck-type is
- * ecosystem-qualified — see
- * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md). Kept through the
- * `1.0.0-rc` line and removed at the 1.0 GA cut.
- */
-export type ConfigServiceLike = NestConfigServiceLike;

--- a/packages/nest/src/index.ts
+++ b/packages/nest/src/index.ts
@@ -21,12 +21,6 @@ export {
     type NestConfigServiceLike,
     type NestLoggerLike,
     type NestLoggerSinkOptions,
-    // Deprecated aliases (kept through 1.0.0-rc, removed at GA) — see ADR 0012.
-    loggerSink,
-    fromConfig,
-    borrowStore,
-    type LoggerLike,
-    type ConfigServiceLike,
 } from './bridges';
 export { STITCH_SEAM, STITCH_STORE, STITCH_TRACE } from './tokens';
 export {

--- a/packages/nest/test/bridges.spec.ts
+++ b/packages/nest/test/bridges.spec.ts
@@ -1,10 +1,10 @@
 // Unit tests for @stitchapi/nest's three bridges (`bridges.ts`), which no spec
-// touched: `loggerSink` (StitchEvent → Nest log level, delegating to core), the
-// `fromConfig` ConfigService-backed secret resolver, and `borrowStore` (a store
+// touched: `nestLoggerSink` (StitchEvent → Nest log level, delegating to core), the
+// `fromNestConfig` ConfigService-backed secret resolver, and `nestBorrowStore` (a store
 // wrapper that deliberately omits `close`). Pure — no Nest app, no network: we
 // drive recording doubles directly.
-import { borrowStore, fromConfig, loggerSink } from '../src';
-import type { ConfigServiceLike, LoggerLike } from '../src';
+import { fromNestConfig, nestBorrowStore, nestLoggerSink } from '../src';
+import type { NestConfigServiceLike, NestLoggerLike } from '../src';
 
 import type { StitchEvent, StitchStore, TraceContext } from 'stitchapi';
 import { describe, expect, test } from 'vitest';
@@ -16,7 +16,7 @@ type RecordedLevel = 'log' | 'warn' | 'error' | 'debug' | 'verbose';
 // A recording Nest-logger double. `partial` omits debug/verbose to prove the
 // sink guards those optional methods.
 function recorder(partial = false): {
-    logger: LoggerLike;
+    logger: NestLoggerLike;
     calls: Array<{ level: RecordedLevel; message: string }>;
 } {
     const calls: Array<{ level: RecordedLevel; message: string }> = [];
@@ -25,7 +25,7 @@ function recorder(partial = false): {
         (m: string): void => {
             calls.push({ level, message: m });
         };
-    const logger: LoggerLike = partial
+    const logger: NestLoggerLike = partial
         ? { log: push('log'), warn: push('warn'), error: push('error') }
         : {
               log: push('log'),
@@ -48,10 +48,10 @@ const startEvent = (url: string, input = {}): StitchEvent => ({
     at: 0,
 });
 
-describe('loggerSink — level mapping', () => {
+describe('nestLoggerSink — level mapping', () => {
     test('maps each event type to a Nest level (result → verbose, lifecycle → debug)', () => {
         const { logger, calls } = recorder();
-        const sink = loggerSink(logger);
+        const sink = nestLoggerSink(logger);
 
         const events: StitchEvent[] = [
             startEvent('https://api.test/u'),
@@ -90,7 +90,7 @@ describe('loggerSink — level mapping', () => {
 
     test('drift follows its finding level, pinning info-drift to debug', () => {
         const { logger, calls } = recorder();
-        const sink = loggerSink(logger);
+        const sink = nestLoggerSink(logger);
         const drift = (level: 'error' | 'warn' | 'info'): StitchEvent => ({
             type: 'drift',
             finding: { level, path: 'data.id', change: 'coerced' },
@@ -106,7 +106,7 @@ describe('loggerSink — level mapping', () => {
 
     test('delta chunks and info announcements are never logged', () => {
         const { logger, calls } = recorder();
-        const sink = loggerSink(logger);
+        const sink = nestLoggerSink(logger);
 
         sink.handle({ type: 'info', topic: 'auth', detail: 'x', at: 0 }, ctx);
         sink.handle({ type: 'delta', chunk: 'raw-data', at: 0 }, ctx);
@@ -116,7 +116,7 @@ describe('loggerSink — level mapping', () => {
 
     test('lifecycle:false drops start/result/done but keeps errors and retries', () => {
         const { logger, calls } = recorder();
-        const sink = loggerSink(logger, { lifecycle: false });
+        const sink = nestLoggerSink(logger, { lifecycle: false });
 
         sink.handle(startEvent('https://api.test/u'), ctx);
         sink.handle(
@@ -141,7 +141,7 @@ describe('loggerSink — level mapping', () => {
 
     test('a partial logger (no debug/verbose) does not throw — those events are skipped', () => {
         const { logger, calls } = recorder(true);
-        const sink = loggerSink(logger);
+        const sink = nestLoggerSink(logger);
 
         sink.handle(startEvent('https://api.test/u'), ctx); // debug → no-op
         sink.handle(
@@ -157,10 +157,10 @@ describe('loggerSink — level mapping', () => {
     });
 });
 
-describe('loggerSink — messages & security', () => {
+describe('nestLoggerSink — messages & security', () => {
     test('uses the trace-context name in the message', () => {
         const { logger, calls } = recorder();
-        const sink = loggerSink(logger);
+        const sink = nestLoggerSink(logger);
 
         sink.handle(
             { type: 'result', data: 1, status: 201, attempts: 2, at: 0 },
@@ -172,7 +172,7 @@ describe('loggerSink — messages & security', () => {
 
     test('strips the URL query and logs only metadata — never raw input/value/delta', () => {
         const { logger, calls } = recorder();
-        const sink = loggerSink(logger);
+        const sink = nestLoggerSink(logger);
 
         sink.handle(
             startEvent('https://api.test/login?api_key=SECRET', {
@@ -207,11 +207,11 @@ describe('loggerSink — messages & security', () => {
 // --- fromConfig ------------------------------------------------------------
 
 function fakeConfig(map: Record<string, string>): {
-    config: ConfigServiceLike;
+    config: NestConfigServiceLike;
     keys: string[];
 } {
     const keys: string[] = [];
-    const config: ConfigServiceLike = {
+    const config: NestConfigServiceLike = {
         getOrThrow<T = string>(key: string): T {
             keys.push(key);
             if (!(key in map)) {
@@ -223,10 +223,10 @@ function fakeConfig(map: Record<string, string>): {
     return { config, keys };
 }
 
-describe('fromConfig', () => {
+describe('fromNestConfig', () => {
     test('resolves lazily at call time, then returns the value', () => {
         const { config, keys } = fakeConfig({ API_TOKEN: 'tok' });
-        const thunk = fromConfig(config)('API_TOKEN');
+        const thunk = fromNestConfig(config)('API_TOKEN');
 
         // The thunk holds the key but has not touched the config yet — the secret
         // never lands on __config or in a trace.
@@ -237,20 +237,20 @@ describe('fromConfig', () => {
 
     test('propagates a missing-key error from getOrThrow', () => {
         const { config } = fakeConfig({});
-        const resolve = fromConfig(config)('MISSING');
+        const resolve = fromNestConfig(config)('MISSING');
         expect(() => resolve()).toThrow(/Configuration key "MISSING"/);
     });
 
     test('rejects an empty value so a blank credential can never ride along', () => {
         const { config } = fakeConfig({ BLANK: '' });
-        const resolve = fromConfig(config)('BLANK');
+        const resolve = fromNestConfig(config)('BLANK');
         expect(() => resolve()).toThrow(/missing secret BLANK/);
     });
 });
 
 // --- borrowStore -----------------------------------------------------------
 
-describe('borrowStore', () => {
+describe('nestBorrowStore', () => {
     test('delegates get/set/incr but omits close, so a seam cannot dispose the app store', async () => {
         const seen: string[] = [];
         let closed = false;
@@ -271,7 +271,7 @@ describe('borrowStore', () => {
             },
         };
 
-        const borrowed = borrowStore(store);
+        const borrowed = nestBorrowStore(store);
 
         // The borrowed wrapper exposes no close (ADR 0006 Decision 8).
         expect(borrowed.close).toBeUndefined();

--- a/packages/nest/test/module.spec.ts
+++ b/packages/nest/test/module.spec.ts
@@ -2,9 +2,6 @@
 // directly (no Nest DI container needed) and run the resulting stitches against a mock
 // adapter, asserting wire-level effects — the same style as core's tests.
 import {
-    // Deprecated aliases (ADR 0012) — exercised by the alias-guard test below.
-    type ConfigServiceLike,
-    type LoggerLike,
     type NestConfigServiceLike,
     type NestLoggerLike,
     STITCH_SEAM,
@@ -12,11 +9,8 @@ import {
     STITCH_TRACE,
     SeamRegistry,
     StitchModule,
-    borrowStore,
     defineStitch,
-    fromConfig,
     fromNestConfig,
-    loggerSink,
     nestBorrowStore,
     nestLoggerSink,
 } from '../src';
@@ -314,28 +308,6 @@ describe('bridges', () => {
         };
         return { rec, logger };
     };
-
-    it('keeps the pre-ADR-0012 names as deprecated aliases of the ecosystem-qualified ones', () => {
-        // Runtime: each deprecated function export is the very same function object.
-        expect(loggerSink).toBe(nestLoggerSink);
-        expect(fromConfig).toBe(fromNestConfig);
-        expect(borrowStore).toBe(nestBorrowStore);
-        // Type-level: the deprecated type aliases stay interchangeable with the canonical ones.
-        const loggerViaDeprecated: LoggerLike = {
-            log() {},
-            warn() {},
-            error() {},
-        };
-        const loggerViaCanonical: NestLoggerLike = loggerViaDeprecated;
-        expect(typeof loggerViaCanonical.log).toBe('function');
-        const cfgViaDeprecated: ConfigServiceLike = {
-            getOrThrow<T = string>(key: string): T {
-                return key as T;
-            },
-        };
-        const cfgViaCanonical: NestConfigServiceLike = cfgViaDeprecated;
-        expect(typeof cfgViaCanonical.getOrThrow).toBe('function');
-    });
 
     it('nestLoggerSink maps each event to the right level, payload-free, query redacted', () => {
         const { rec, logger } = recordingLogger();


### PR DESCRIPTION
Extracts the nest-bridge symbol qualification from #470 (the contract-freeze sweep). `@stitchapi/nest`'s helpers already carry their Nest-qualified canonicals — `nestLoggerSink` / `NestLoggerLike` / `fromNestConfig` / `nestBorrowStore` / `NestConfigServiceLike`; the bare `loggerSink` / `LoggerLike` / `fromConfig` / `borrowStore` / `ConfigServiceLike` lingered as `@deprecated` aliases that collided with core's own `loggerSink`/`LoggerLike`. Hard break (P19, pre-GA): removed (nest-only, mostly deletions).

Core's canonical `loggerSink`/`LoggerLike` are a different symbol and untouched; so is `NestRequestSeam` (a separate, already-landed slice). No §6 CONTRACT row existed for these (ADR-0012 symbol renames).

### Gates
`build` · full-workspace `check:types` · 49 nest tests · `check:contract` · `check:lint` · `prettier` · all 9 yakir tethers — green (pre-push CI gate passed).

### BREAKING CHANGE
The bare nest bridge aliases (`loggerSink`, `LoggerLike`, `fromConfig`, `borrowStore`, `ConfigServiceLike`) are removed — use the Nest-qualified names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)