### PR TITLE
refactor(core)!: drop the deprecated top-level `rateLimit` config (folded into throttle, P14)

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -135,7 +135,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "acceptStatus",
             type: "property",
             detail: "number[] | ((status: number) => boolean)",
-            info: "Statuses that are a NORMAL result rather than an error — a number list or a predicate. An accepted non-2xx flows through interpret → transform → pick → validate exactly like a 2xx (the response body becomes the result), instead of throwing a . Use this when an endpoint treats e.g. `404`/`400` as expected control flow (resource-gone → fall back to a broader call) so the happy path no longer runs through a `catch`. `retry.on` still wins while attempts remain: a status listed in BOTH is retried until attempts are exhausted, then accepted (returned) on the final attempt. Orthogonal to `rateLimit.delegate`, which surfaces a  on rate-limit statuses earlier.",
+            info: "Statuses that are a NORMAL result rather than an error — a number list or a predicate. An accepted non-2xx flows through interpret → transform → pick → validate exactly like a 2xx (the response body becomes the result), instead of throwing a . Use this when an endpoint treats e.g. `404`/`400` as expected control flow (resource-gone → fall back to a broader call) so the happy path no longer runs through a `catch`. `retry.on` still wins while attempts remain: a status listed in BOTH is retried until attempts are exhausted, then accepted (returned) on the final attempt. Orthogonal to `throttle.delegate`, which surfaces a  on rate-limit statuses earlier.",
         },
         {
             label: "throttle",
@@ -154,11 +154,6 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             type: "property",
             detail: "AtLeastOne<CircuitOptions>",
             info: "Circuit breaker that fast-fails a repeatedly failing dependency. `failures` + `cooldown` are required by design (P15), so the empty object is rejected (P20 — `AtLeastOne`).",
-        },
-        {
-            label: "rateLimit",
-            type: "property",
-            detail: "{ /** Surface rate-limit outcomes instead of retrying/throttling them. Default `false`. */ delegate?: boolean; /** Statuses treated as a rate-limit signal. Default `[429]`. */ on?: number[]; }",
         },
         {
             label: "idempotency",

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -434,19 +434,18 @@ bridge from JSON Schema, producing a `SchemaLike` those consumers treat identica
 Not normative. The rule is the law; these are the proposed target spellings the sweep
 will apply under `@deprecated` aliases (P18). Severity = consumer blast radius.
 
-| Sev  | Current                                                            | Proposed                                                       | Rule   |
-| ---- | ------------------------------------------------------------------ | -------------------------------------------------------------- | ------ |
-| High | `rateLimit` (separate top-level key) vs `throttle`                 | fold into one `throttle` envelope (`delegate` / `on` as modes) | P2/P14 |
-| High | `retry.on` + rate-limit `on` (`number[]`)                          | `number[] ｜ (status)=>boolean`                                | P7     |
-| High | `StitchStore`/`StitchLike`/`RequestSeam` cross-pkg clashes         | hoist or qualify                                               | P9     |
-| High | `queryOptions` bare in vue/solid/svelte/angular                    | `stitchQueryOptions`                                           | P16    |
-| Med  | `OAuth2Opts`, `CookieSessionOpts`                                  | `OAuth2Options`, `CookieSessionOptions`                        | P3     |
-| Med  | `StitchQueryOptions` (a result)                                    | `StitchQueryResult`                                            | P3     |
-| Med  | `paginate` inline shape                                            | `PaginateOptions`                                              | P14    |
-| Med  | SSE helper `sendStitchSse`/`stitchSse`                             | `streamStitchSse`                                              | P16    |
-| Med  | error-options `StitchErrorHandlerOptions`/`ToHttpExceptionOptions` | `StitchErrorOptions` (+ `body`)                                | P16    |
-| Low  | `RedisDriver.del`, `…quit`, sync `close`                           | `delete`, async `close`                                        | P18    |
-| Low  | `bodyKind` (from-curl)                                             | `bodyType`                                                     | P1     |
+| Sev  | Current                                                            | Proposed                                | Rule |
+| ---- | ------------------------------------------------------------------ | --------------------------------------- | ---- |
+| High | `retry.on` + rate-limit `on` (`number[]`)                          | `number[] ｜ (status)=>boolean`         | P7   |
+| High | `StitchStore`/`StitchLike`/`RequestSeam` cross-pkg clashes         | hoist or qualify                        | P9   |
+| High | `queryOptions` bare in vue/solid/svelte/angular                    | `stitchQueryOptions`                    | P16  |
+| Med  | `OAuth2Opts`, `CookieSessionOpts`                                  | `OAuth2Options`, `CookieSessionOptions` | P3   |
+| Med  | `StitchQueryOptions` (a result)                                    | `StitchQueryResult`                     | P3   |
+| Med  | `paginate` inline shape                                            | `PaginateOptions`                       | P14  |
+| Med  | SSE helper `sendStitchSse`/`stitchSse`                             | `streamStitchSse`                       | P16  |
+| Med  | error-options `StitchErrorHandlerOptions`/`ToHttpExceptionOptions` | `StitchErrorOptions` (+ `body`)         | P16  |
+| Low  | `RedisDriver.del`, `…quit`, sync `close`                           | `delete`, async `close`                 | P18  |
+| Low  | `bodyKind` (from-curl)                                             | `bodyType`                              | P1   |
 
 New shorthand/toggle slots to **add** (additive, non-breaking): `stream`, `multipart`,
 `sse`, `.inspect()` scalars (P12); `idempotency` boolean (P13-toggle);

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -602,16 +602,13 @@ async function* attemptLoop(
     const perAttemptMs = parseDuration(cfg.timeout?.perAttempt);
     const key = hostKey(baseReq, cfg);
     let refreshed = false;
-    // Delegate-backoff mode (issue #145): the host owns the gate. We bypass the internal throttle
-    // for the call (no acquire/release, so `throttle` is inert and no `throttled` event fires) and,
-    // on a response whose status matches `rlMatch` (default [429]), surface a RateLimitError instead
-    // of retrying. Everything else — auth, the success path, non-rate-limit failures — is unchanged.
-    // P14: `rateLimit` folded into `throttle` — read `throttle.delegate`/`throttle.on`, falling back
-    // to the @deprecated top-level `rateLimit` (read once here) until the GA cut.
-    // eslint-disable-next-line @typescript-eslint/no-deprecated -- `rateLimit` folded into `throttle` (P14); back-compat fallback until GA
-    const legacyRl = cfg.rateLimit;
-    const delegate = (cfg.throttle?.delegate ?? legacyRl?.delegate) === true;
-    const rlMatch = acceptsStatus(cfg.throttle?.on ?? legacyRl?.on ?? [429]);
+    // Delegate-backoff mode (issue #145, folded into `throttle` — P14): the host owns the gate. We
+    // bypass the internal throttle for the call (no acquire/release, so `throttle` is inert and no
+    // `throttled` event fires) and, on a response whose status matches `rlMatch` (default [429]),
+    // surface a RateLimitError instead of retrying. Everything else — auth, the success path,
+    // non-rate-limit failures — is unchanged.
+    const delegate = cfg.throttle?.delegate === true;
+    const rlMatch = acceptsStatus(cfg.throttle?.on ?? [429]);
     // acceptStatus (issue #155): statuses the caller declares NORMAL — an accepted non-2xx returns
     // `res` like a 2xx (flowing through interpret → transform → pick → validate) instead of
     // throwing. Checked at the `>= 400` site, i.e. AFTER the retry-on-status path, so `retry.on`

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,6 @@ export { systemClock } from './util';
 export { compact } from './compact';
 export type { Compact } from './compact';
 // The delegate-backoff error (issue #145): thrown on the awaited path and surfaced as an `error`
-// event when `rateLimit.delegate` is on, so a host's outer gate owns the rate-limit backoff.
+// event when `throttle.delegate` is on, so a host's outer gate owns the rate-limit backoff.
 export { RateLimitError } from './resilience';
 export * from './types';

--- a/packages/core/src/resilience.ts
+++ b/packages/core/src/resilience.ts
@@ -236,7 +236,7 @@ export class CircuitOpenError extends Error {
 
 /**
  * Thrown (and surfaced as an `error` event) when a stitch runs in **delegate-backoff** mode
- * (`rateLimit.delegate`) and the response carries a rate-limit status (default `429`). Instead of
+ * (`throttle.delegate`) and the response carries a rate-limit status (default `429`). Instead of
  * retrying internally or pacing on the built-in throttle, the engine surfaces the outcome so an
  * OUTER gate/circuit — owned by the host — decides the backoff (issue #145). Carries the structured
  * signal that gate needs: the `status`, the `retryAfter` parsed from `Retry-After` (delta-seconds

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -286,10 +286,10 @@ export interface ThrottleOptions {
      */
     pool?: 'stitch' | 'host';
     /**
-     * Delegate rate-limit handling to the host (folded in from the top-level `rateLimit`,
-     * CONTRACT.md P14). When `true`, a rate-limit response (status matched by `on`, default `[429]`)
-     * is **not** retried or throttled internally — self-pacing (`rate`/`concurrency`) is bypassed and
-     * the outcome surfaces as a {@link RateLimitError}. Use it when an OUTER gate owns the backoff.
+     * Delegate rate-limit handling to the host (CONTRACT.md P14). When `true`, a rate-limit
+     * response (status matched by `on`, default `[429]`) is **not** retried or throttled
+     * internally — self-pacing (`rate`/`concurrency`) is bypassed and the outcome surfaces as a
+     * {@link RateLimitError}. Use it when an OUTER gate owns the backoff.
      */
     delegate?: boolean;
     /** Statuses that count as a rate-limit signal under `delegate` — a list or a predicate. Default `[429]`. */
@@ -729,7 +729,7 @@ export interface StitchConfig {
      *
      * `retry.on` still wins while attempts remain: a status listed in BOTH is retried until attempts
      * are exhausted, then accepted (returned) on the final attempt. Orthogonal to
-     * `rateLimit.delegate`, which surfaces a {@link RateLimitError} on rate-limit statuses earlier.
+     * `throttle.delegate`, which surfaces a {@link RateLimitError} on rate-limit statuses earlier.
      */
     acceptStatus?: number[] | ((status: number) => boolean);
     /**
@@ -747,29 +747,6 @@ export interface StitchConfig {
      * required by design (P15), so the empty object is rejected (P20 — `AtLeastOne`).
      */
     circuit?: AtLeastOne<CircuitOptions>;
-    /**
-     * @deprecated Folded into `throttle` (CONTRACT.md P14): use `throttle.delegate` / `throttle.on`.
-     * Read until the 1.0 GA cut.
-     *
-     * Delegate backoff to the host (issue #145). When `delegate: true`, a rate-limit response
-     * (status in `on`, default `[429]`) is **not** retried internally and the built-in `throttle`
-     * is **bypassed** for the call — instead the outcome surfaces as a {@link RateLimitError}
-     * (carrying `status`, the `retryAfter` parsed from `Retry-After`, and the raw `response`) on
-     * the awaited path, and as an `error` event with `retryAfter` on `.stream()`. Use this when an
-     * OUTER gate/circuit owns the backoff (its own `Retry-After` hook, a DB-persisted budget) and
-     * StitchAPI's internal retry+throttle would double-count against it.
-     *
-     * ⚠️ In delegate mode the `throttle` config becomes **inert** for this stitch (the host owns the
-     * gate). A `circuit` block, if also set, still applies — the host may layer both. Non-rate-limit
-     * failures (5xx, etc.) behave exactly as today unless their status is listed in `on`. Validation,
-     * templating, transform/pick, and drift on the success path are unchanged.
-     */
-    rateLimit?: {
-        /** Surface rate-limit outcomes instead of retrying/throttling them. Default `false`. */
-        delegate?: boolean;
-        /** Statuses treated as a rate-limit signal. Default `[429]`. */
-        on?: number[];
-    };
     /**
      * Inject a stable Idempotency-Key header on writes so safe retries don't duplicate.
      * `true` enables it with defaults (header `Idempotency-Key`, a random uuid per call); the

--- a/packages/core/test/gaps/delegate-backoff.spec.ts
+++ b/packages/core/test/gaps/delegate-backoff.spec.ts
@@ -1,5 +1,5 @@
 // Pins issue #145: an opt-in delegate-backoff mode that SURFACES a rate-limit outcome (status in
-// `rateLimit.on`, default [429]) as a RateLimitError instead of retrying it internally, and bypasses
+// `throttle.on`, default [429]) as a RateLimitError instead of retrying it internally, and bypasses
 // the built-in throttle so an OUTER gate (owned by the host) — not StitchAPI — paces the backoff.
 import { RateLimitError, type StitchEvent, stitch } from '../../src';
 import { startMockServer } from '../support/mock-server';
@@ -262,24 +262,7 @@ test('.safe() surfaces the rate-limit status as a non-throwing StitchError', asy
     expect((out.error?.cause as RateLimitError).retryAfter).toBe(2000);
 });
 
-// ── I. back-compat + predicate widening (CONTRACT.md P14 / P7) ──
-test('the @deprecated top-level `rateLimit` still delegates identically (P14)', async () => {
-    server.route('GET', '/rl-legacy', {
-        statuses: [429],
-        retryAfterSeconds: 2,
-        body: { error: 'slow down' },
-    });
-    const call = stitch({
-        baseUrl: server.url,
-        path: '/rl-legacy',
-        // Pre-fold spelling — must behave exactly like `throttle: { delegate: true }` until GA.
-        rateLimit: { delegate: true },
-    });
-    const err = await rejectionOf(call());
-    expect(err).toBeInstanceOf(RateLimitError);
-    expect(err.status).toBe(429);
-});
-
+// ── I. predicate widening (CONTRACT.md P7) ──
 test('throttle.on accepts a predicate (P7): a 503 matched by the predicate delegates', async () => {
     server.route('GET', '/rl-pred', {
         statuses: [503],


### PR DESCRIPTION
Extracts the **rateLimit→throttle fold** (P14) from #470 (the contract-freeze sweep). The standalone top-level `rateLimit` config was folded into the one `throttle` envelope (its `delegate` / `on` modes); it lingered on `StitchConfig` as a `@deprecated` field the engine read once and merged. Hard break (P19, pre-GA):

- remove `StitchConfig.rateLimit` (types.ts) and the engine's fold block (engine.ts) — the engine reads only `throttle`;
- update the alias-parity test and three `rateLimit.delegate`→`throttle.delegate` comment refs;
- clear the §6 backlog row (the table re-pads to prettier's width — whitespace only; a `-w` diff shows the row removal as the sole content change).

`RateLimitError` (the thrown error class) is a different symbol and untouched.

### Gates
`build` · full-workspace `check:types` · 1207 core tests · `check:contract` (baseline unchanged) · `check:lint` · `prettier` · all 9 yakir tethers (bundle unchanged at ~24 KB) — green (pre-push CI gate passed).

### BREAKING CHANGE
The `@deprecated` top-level `rateLimit` config key is removed — use `throttle` (`throttle.delegate` / `throttle.on`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)