### PR TITLE
refactor(store)!: whole-word store verbs — incr→increment, del→delete; increment ttl optional (P18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,35 @@ npm release are grouped under the in-development version that introduced them.
 
 ## [Unreleased]
 
+### Changed
+
+-   **BREAKING — the store contract speaks whole words: `incr` is now `increment`, and
+    `RedisDriver.del` is now `delete`.** `StitchStore` — the interface every store
+    implements — renames its atomic counter to `increment(key, ttl?)`, and
+    `@stitchapi/redis`'s `RedisDriver` follows for both verbs. The house contracts are
+    the vocabulary a consumer implements against, not bytes on a socket, so they use
+    whole words (CONTRACT.md P18); the Redis **commands** are untouched — the Lua still
+    calls `INCR`, and the `IoredisLike`/`NodeRedisLike`/`UpstashLike` mirrors still
+    expose `del`, because a mirror keeps its SDK's spelling. Shipped **without
+    `@deprecated` aliases** — CONTRACT.md P19 scopes the alias obligation to the GA
+    channel, and this lands on `rc`. (They could not have carried one anyway: on an
+    interface the consumer implements and core calls, an alias means typing both
+    spellings optional forever and letting a store satisfy the type while implementing
+    neither verb.)
+
+    _Migration:_ rename the method on any custom store or driver — `incr` → `increment`,
+    and on a `RedisDriver`, `del` → `delete`. The bundled stores (`memoryStore`,
+    `@stitchapi/redis`, `@stitchapi/deno-kv`, `@stitchapi/cloudflare-kv`,
+    `@stitchapi/react-native`, `@stitchapi/expo`) are already updated, so you only act
+    if you hand-rolled one. TypeScript names every site.
+
+-   **BREAKING — `ttl` is now optional on `increment`.** `StitchStore.increment(key, ttl?)`
+    and `RedisDriver.increment(key, ttl?)` match `set`: an absent `ttl` means **no
+    window**, so the counter accumulates and never expires. Previously `ttl` was
+    required on the counter but optional on `set` — the same parameter with two
+    optionalities. Widening, so existing call sites are unaffected; an implementor whose
+    signature typed `ttl` as required should relax it and handle the absent case.
+
 ## [1.0.0-rc.6] — 2026-07-23
 
 ### Changed

--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -529,7 +529,7 @@ export const pages: Page[] = [
         path: 'guides/state/pluggable-store',
         title: 'The pluggable store',
         description:
-            'Swap the in-memory store for a shared one to back throttle and sessions with get/set/incr + TTL.',
+            'Swap the in-memory store for a shared one to back throttle and sessions with get/set/increment + TTL.',
         kind: 'guide',
     },
     {

--- a/apps/docs/content/blog/distributed-throttle-with-redis-kv.mdx
+++ b/apps/docs/content/blog/distributed-throttle-with-redis-kv.mdx
@@ -73,7 +73,7 @@ The drivers aren't interchangeable, and the line that separates them is one oper
 
 That single requirement decides the fit:
 
-| Driver                     | Best for                            | Atomic `incr` → distributed throttle                |
+| Driver                     | Best for                            | Atomic `increment` → distributed throttle           |
 | -------------------------- | ----------------------------------- | --------------------------------------------------- |
 | `@stitchapi/redis`         | Node servers; edge via Upstash HTTP | Yes — a single Lua `INCR` + `PEXPIRE`               |
 | `@stitchapi/deno-kv`       | Deno Deploy, Node, or Bun           | Yes — an atomic compare-and-set loop                |
@@ -81,13 +81,13 @@ That single requirement decides the fit:
 
 For a fleet of **servers**, reach for Redis: it has a real atomic `INCR`, so the counters increment exactly once and the limiter paces evenly across the fleet. Deno KV gives the same guarantee through a compare-and-set loop, and on Deno Deploy the same handle is replicated globally — a natural fit at the edge.
 
-**Workers KV is the honest exception.** It's last-write-wins `get`/`put` with no atomic increment, so a throttle counter on it would undercount under concurrency and silently break the cap. Rather than pretend, `cloudflareKvStore(...).incr(...)` throws a documented error. KV stays the right backend for the read-heavy halves — **cache and shared sessions** — which is usually exactly what an edge handler needs. For a distributed _throttle_ at the edge, pair KV with a Cloudflare Durable Object (the single-writer counter an atomic increment requires) or run the Redis driver over Upstash's HTTP API.
+**Workers KV is the honest exception.** It's last-write-wins `get`/`put` with no atomic increment, so a throttle counter on it would undercount under concurrency and silently break the cap. Rather than pretend, `cloudflareKvStore(...).increment(...)` throws a documented error. KV stays the right backend for the read-heavy halves — **cache and shared sessions** — which is usually exactly what an edge handler needs. For a distributed _throttle_ at the edge, pair KV with a Cloudflare Durable Object (the single-writer counter an atomic increment requires) or run the Redis driver over Upstash's HTTP API.
 
 <Callout type="info">
     The deciding question isn't "server or edge" — it's "do I need a shared
     *throttle*, or just shared cache and sessions?" Cache and sessions work on
-    any of the three; a distributed throttle needs atomic `incr`, which is what
-    splits Workers KV off from the other two.
+    any of the three; a distributed throttle needs atomic `increment`, which is
+    what splits Workers KV off from the other two.
 </Callout>
 
 ## Start in-memory — reach for a shared store when you scale out
@@ -100,7 +100,7 @@ Reach for a shared store the moment any of these are true:
 -   **You autoscale.** Ephemeral instances spin up with no memory of what the others have already sent. The store is the one line that turns N independent limiters back into one.
 -   **The upstream enforces per-account, not per-IP.** One account, many servers — the limit applies across all of them, so the counter has to live somewhere they all reach.
 
-A few trade-offs to account for when you cross that line: the store adds a network hop on every throttle check (latency on the hot path), and under contention the cap is "close to N/s across the fleet" rather than exact — keep a little headroom below the upstream's real ceiling. Workers KV is looser still (eventually-consistent reads, 60-second TTL floor), which is why `incr` throws there. And namespace staging vs. production with `keyPrefix` — one store, no collision.
+A few trade-offs to account for when you cross that line: the store adds a network hop on every throttle check (latency on the hot path), and under contention the cap is "close to N/s across the fleet" rather than exact — keep a little headroom below the upstream's real ceiling. Workers KV is looser still (eventually-consistent reads, 60-second TTL floor), which is why `increment` throws there. And namespace staging vs. production with `keyPrefix` — one store, no collision.
 
 It's a config change, not a rewrite. The call sites don't move.
 
@@ -112,7 +112,7 @@ stitchapi
 
 Then attach a driver and your throttle and sessions go fleet-wide without touching a call site:
 
--   [Distributed stores](/docs/integrations/stores) — the Redis, Workers KV, and Deno KV drivers, with the atomic-`incr` trade-off in full.
+-   [Distributed stores](/docs/integrations/stores) — the Redis, Workers KV, and Deno KV drivers, with the atomic-`increment` trade-off in full.
 -   [Pluggable store](/docs/guides/state/pluggable-store) — the `StitchStore` interface the drivers implement.
 -   [Distributed throttle](/docs/guides/state/distributed-throttle) and [Shared sessions](/docs/guides/state/shared-sessions) — the exact pacing and session-sharing semantics.
 

--- a/apps/docs/content/docs/guides/state/pluggable-store.mdx
+++ b/apps/docs/content/docs/guides/state/pluggable-store.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'The pluggable store'
-description: 'Swap the in-memory store for a shared one to back throttle and sessions with get/set/incr + TTL.'
+description: 'Swap the in-memory store for a shared one to back throttle and sessions with get/set/increment + TTL.'
 prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
@@ -24,7 +24,7 @@ const sharedStore: StitchStore = {
     async set(key, value, ttl) {
         /* write, honoring ttl */
     },
-    async incr(key, ttl) {
+    async increment(key, ttl) {
         /* atomic counter with a TTL window */
         return 1;
     },
@@ -47,7 +47,7 @@ const getUser = stitch({
 
 A store is the `StitchStore` contract — three async methods: `get(key)` returns
 the value or `undefined`, `set(key, value, ttl?)` writes with an optional
-expiry, and `incr(key, ttl)` is an atomic counter scoped to a TTL window. The
+expiry, and `increment(key, ttl)` is an atomic counter scoped to a TTL window. The
 runtime holds two kinds of state behind this interface: throttle counters (the
 even-spaced rate counter) and auth session/token state (captured cookies and
 refreshed tokens).

--- a/apps/docs/content/docs/integrations/expo.mdx
+++ b/apps/docs/content/docs/integrations/expo.mdx
@@ -92,7 +92,7 @@ useReconnectRefetch(q, { netInfo: NetInfo });
 ## The secure store
 
 `expoSecureStore(SecureStore, options?)` reuses the AsyncStorage store's logic
-(JSON envelope, TTL, serialized atomic `incr`) over SecureStore's `*Async` methods,
+(JSON envelope, TTL, serialized atomic `increment`) over SecureStore's `*Async` methods,
 hex-encoding engine keys into SecureStore's restricted key charset. Keep individual
 values under SecureStore's ~2 KB limit — auth tokens fit comfortably. For non-secret
 throttle counters, pair it with the re-exported `asyncStorageStore`.

--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -142,7 +142,7 @@ into a shared backend — fleet-wide, with no call-site change.
     <Card
         title="Distributed stores"
         href="/docs/integrations/stores"
-        description="Redis (+ Upstash edge), Cloudflare Workers KV, and Deno KV drivers — with the atomic-incr trade-off that decides which fits."
+        description="Redis (+ Upstash edge), Cloudflare Workers KV, and Deno KV drivers — with the atomic-increment trade-off that decides which fits."
     />
 </Cards>
 

--- a/apps/docs/content/docs/integrations/react-native.mdx
+++ b/apps/docs/content/docs/integrations/react-native.mdx
@@ -118,7 +118,7 @@ outside React.
 
 `asyncStorageStore(storage, options?)` accepts any client matching
 `{ getItem, setItem, removeItem }`. Values ride in a JSON envelope with an absolute
-expiry (AsyncStorage has no native TTL), and `incr` is serialized so concurrent
+expiry (AsyncStorage has no native TTL), and `increment` is serialized so concurrent
 increments stay atomic — the throttle counter behaves exactly as it does on Redis.
 It is proven against the same `verifyStoreContract` kit every
 [`StitchStore`](/docs/guides/state/pluggable-store) passes.

--- a/apps/docs/content/docs/integrations/stores.mdx
+++ b/apps/docs/content/docs/integrations/stores.mdx
@@ -1,6 +1,6 @@
 ---
 title: Distributed stores
-description: Attach a Redis, Cloudflare Workers KV, or Deno KV StitchStore so a stitch's throttle, sessions, and cache become fleet-wide — same call site, no backend in core. Includes the atomic-incr trade-off that decides which store fits.
+description: Attach a Redis, Cloudflare Workers KV, or Deno KV StitchStore so a stitch's throttle, sessions, and cache become fleet-wide — same call site, no backend in core. Includes the atomic-increment trade-off that decides which store fits.
 prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
@@ -19,11 +19,11 @@ the same `verifyStoreContract` from `stitchapi/testing`.
 
 ## Which store?
 
-The deciding axis is **atomic `incr`**: a distributed _throttle_ needs it (rate
+The deciding axis is **atomic `increment`**: a distributed _throttle_ needs it (rate
 counters must increment exactly once under concurrency), while shared _cache_ and
 _sessions_ need only `get` / `set`.
 
-| Package                    | Runtime                                        | Atomic `incr` → distributed throttle      | Shared cache & sessions | TTL unit    |
+| Package                    | Runtime                                        | Atomic `increment` → distributed throttle | Shared cache & sessions | TTL unit    |
 | -------------------------- | ---------------------------------------------- | ----------------------------------------- | ----------------------- | ----------- |
 | `@stitchapi/redis`         | Node (TCP) **and** edge (Upstash HTTP)         | ✅ Lua `INCR` + `PEXPIRE`                 | ✅                      | ms          |
 | `@stitchapi/deno-kv`       | Deno / Deno Deploy · Node & Bun via `@deno/kv` | ✅ atomic compare-and-set                 | ✅                      | ms          |
@@ -66,7 +66,7 @@ import { Redis } from '@upstash/redis';
 const store = redisStore(fromUpstash(Redis.fromEnv()));
 ```
 
-`incr` must be **atomic** and set the key's TTL only when it _creates_ the counter
+`increment` must be **atomic** and set the key's TTL only when it _creates_ the counter
 — the bundled adapters do this in a single Lua `EVAL` (`INCR`, then `PEXPIRE` only
 when the value is `1`), so a rate window can't slide forever and a crash can't
 strand an immortal counter. With a shared store the rate limiter is
@@ -105,11 +105,11 @@ export default {
     **Workers KV has no atomic increment.** It is last-write-wins `get` / `put`
     / `delete` only, so a throttle counter built on it would undercount under
     concurrency and silently break rate limiting. Rather than do that,
-    `cloudflareKvStore(...).incr(...)` **throws** a documented error. For a
+    `cloudflareKvStore(...).increment(...)` **throws** a documented error. For a
     distributed throttle, back it with a [Durable
     Object](https://developers.cloudflare.com/durable-objects/) — the
-    single-writer, strongly-consistent counter an atomic `incr` requires. KV
-    remains the right backend for cache and sessions, the common edge need.
+    single-writer, strongly-consistent counter an atomic `increment` requires.
+    KV remains the right backend for cache and sessions, the common edge need.
 </Callout>
 
 KV's `expirationTtl` is in **seconds** with a **60-second minimum**; the store
@@ -146,7 +146,7 @@ import { seam } from 'stitchapi';
 const api = seam({ store: denoKvStore(await openKv(process.env.DENO_KV_URL)) });
 ```
 
-Deno KV has no native `INCR`, so `incr` is an **atomic compare-and-set loop**
+Deno KV has no native `INCR`, so `increment` is an **atomic compare-and-set loop**
 (read value + `versionstamp`, then `atomic().check(...).set(...).commit()`,
 retrying if another isolate raced) — N concurrent increments net exactly +N. The
 TTL (`expireIn`, already in milliseconds) is set only on the increment that

--- a/apps/docs/content/docs/recipes/one-rate-limit-across-workers.mdx
+++ b/apps/docs/content/docs/recipes/one-rate-limit-across-workers.mdx
@@ -41,7 +41,7 @@ budget by origin, so every stitch hitting the host pools into it; workers share
 only when they point at the same store and resolve to the same key. (Concurrency
 stays in-process; only the rate limit is distributed.) A
 [`StitchStore`](/docs/guides/state/pluggable-store) is three async methods —
-`get` / `set` / `incr` with TTL — backed by anything; the same store also gives
+`get` / `set` / `increment` with TTL — backed by anything; the same store also gives
 you [shared auth sessions](/docs/guides/state/shared-sessions).
 
 ## See also

--- a/apps/docs/content/docs/reference/conformance-kits.mdx
+++ b/apps/docs/content/docs/reference/conformance-kits.mdx
@@ -52,13 +52,13 @@ test('myStore implements the StitchStore contract', async () => {
 ## verifyStoreContract
 
 `verifyStoreContract(makeStore, opts?)` verifies a [pluggable
-store](/docs/guides/state/pluggable-store) — the `get`/`set`/`incr` + TTL
+store](/docs/guides/state/pluggable-store) — the `get`/`set`/`increment` + TTL
 surface the engine uses for throttle counters and auth/session state:
 
 -   `set`/`get` round-trips a value; a missing key resolves to `undefined`;
     a second `set` overwrites; writes are isolated by key.
 -   A `set` with `ttl` expires; a `set` without `ttl` does not.
--   `incr` initializes a missing key to 1, increments an existing counter,
+-   `increment` initializes a missing key to 1, increments an existing counter,
     restarts at 1 once its TTL window lapses, and is atomic within a process:
     20 concurrent calls must return 1..20 exactly.
 
@@ -170,7 +170,7 @@ fails with every broken rule named:
 ```
 Error: StitchAPI store contract: 2 violation(s), 8 rule(s) passed
   - set: a ttlMs entry expires: value survived its 250ms TTL: got "soon-gone"
-  - incr: 20 concurrent calls net exactly +20: sorted results of 20 concurrent incrs ...
+  - increment: 20 concurrent calls net exactly +20: sorted results of 20 concurrent increments ...
 ```
 
 Passing the kit is the compatibility claim: a store that passes can back

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -145,7 +145,7 @@ function **MUST** be named **`keyOf`** (a `(input) => string`) and **MUST NOT** 
 called `key`.
 
 _Violations:_ `IdempotencyOptions.key`, `CacheConfig.key` (both `(input) => string`)
-→ `keyOf`. `CircuitOptions.key` and `StitchStore.get/set/incr(key)` are correct as-is.
+→ `keyOf`. `CircuitOptions.key` and `StitchStore.get/set/increment(key)` are correct as-is.
 
 ### P7 · Status-classification parity
 
@@ -319,16 +319,49 @@ at the adapter edge and is named with its true unit (`expirationSeconds`,
 A duck-type that mirrors a foreign SDK **MUST** keep that SDK's spelling (so it
 structurally matches). StitchAPI's **own normalized** contracts (`StitchStore`,
 `RedisDriver`) **MUST** use one house vocabulary: `ttl` (ms — the house unit, no suffix
-per P17; convert foreign units at the edge), `delete` (not `del`),
+per P17; convert foreign units at the edge), **whole words — never a wire
+abbreviation** (`delete` not `del`, `increment` not `incr`),
 `close(): Promise<void>` (async, per P11), with one optionality per parameter (`ttl`
-MUST NOT be optional on `set` but required on `incr`).
+MUST NOT be optional on `set` but required on `increment`).
 
-### P19 · No pre-GA hard break
+_Why whole words:_ the house verbs are the vocabulary a **consumer** implements against,
+not the bytes a server parses. `DEL`/`INCR` are terse because they cross a socket
+millions of times a second; a TypeScript method name is read, not transmitted. The rule
+is all-or-nothing by construction — a contract that spells `delete` but keeps `incr`
+teaches neither convention, and the reader has to memorize which verbs got the
+abbreviation. The Redis **command** names stay verbatim wherever the code speaks Redis
+(the Lua `INCR`, the `IoredisLike`/`NodeRedisLike`/`UpstashLike` mirrors' `del`) — that
+is the first half of this rule doing its job, not an exception to the second.
 
-Every rename, narrowing, or removal mandated here **MUST** ship a `@deprecated`
-re-export/field alias pinned by an identity test, removed at the **1.0 GA cut**
-(extending ADR 0012's precedent from symbols to fields). Widening
-(`number → number | string`, P17) is non-breaking and needs no alias.
+### P19 · The alias obligation is scoped to the GA channel
+
+The `@deprecated`-alias requirement binds the **general-availability** channel. On a
+pre-release channel (`rc`, `beta`, `canary` — anything published under a prerelease tag),
+a rename, narrowing, or removal mandated here **MAY** ship as a **hard break**: no alias,
+declared under **BREAKING CHANGE** with a one-line migration in `CHANGELOG.md`. Once
+**1.0 GA** ships, the obligation is in force — every such change **MUST** carry a
+`@deprecated` re-export/field alias pinned by an identity test (extending ADR 0012's
+precedent from symbols to fields), retired only on the next major. Widening
+(`number → number | string`, P17) is non-breaking and needs no alias in either channel.
+
+_Why the channel, not the change:_ a prerelease is the window the semver contract sets
+aside for exactly this. Paying alias tax during it buys back-compat for a population that
+has accepted breakage by installing an `rc`, and the aliases accumulate into a second
+vocabulary the GA cut then has to delete — every one a field a reader must learn is dead.
+The clean surface at 1.0 is worth more than continuity between two release candidates.
+
+_Aliases already shipped stay._ Relaxing the rule forward does not retroactively demand
+their removal: the `*Ms` duration aliases, `keyOf`, `StatusMatch`, and the rest listed in
+[§6](#6-migration-backlog) remain, pinned by their identity tests, until the GA cut
+removes them together. Removing one now would itself be a break, for no gain.
+
+_Corollary — some contracts cannot alias at all._ Where the consumer **implements** an
+interface and core **calls** it (`StitchStore`, `RedisDriver`, `Adapter`, `TraceSink`,
+`AuthStrategy`), there is no `new ?? old` to read: an "alias" means typing **both**
+spellings optional forever and dispatching on whichever is present, which erases the
+contract the rename exists to state and lets an implementation satisfy the type while
+providing neither. For these, a rename is a hard break in **any** channel — post-GA it is
+a major-version change, not an aliasable one.
 
 ### P20 · No empty-object config; enable-with-defaults is a scalar
 
@@ -432,7 +465,9 @@ bridge from JSON Schema, producing a `SchemaLike` those consumers treat identica
 ## 6. Migration backlog (proposed renames — confirm during sweep)
 
 Not normative. The rule is the law; these are the proposed target spellings the sweep
-will apply under `@deprecated` aliases (P18). Severity = consumer blast radius.
+will apply. While the line is pre-GA, each may land as a hard break or under a
+`@deprecated` alias — [P19](#p19--the-alias-obligation-is-scoped-to-the-ga-channel) scopes
+the obligation to the GA channel. Severity = consumer blast radius.
 
 | Sev  | Current                                                            | Proposed                                | Rule |
 | ---- | ------------------------------------------------------------------ | --------------------------------------- | ---- |
@@ -444,7 +479,8 @@ will apply under `@deprecated` aliases (P18). Severity = consumer blast radius.
 | Med  | `paginate` inline shape                                            | `PaginateOptions`                       | P14  |
 | Med  | SSE helper `sendStitchSse`/`stitchSse`                             | `streamStitchSse`                       | P16  |
 | Med  | error-options `StitchErrorHandlerOptions`/`ToHttpExceptionOptions` | `StitchErrorOptions` (+ `body`)         | P16  |
-| Low  | `RedisDriver.del`, `…quit`, sync `close`                           | `delete`, async `close`                 | P18  |
+| Low  | `RedisDriver…quit`, sync `close`                                   | async `close`                           | P18  |
+| Low  | `deno-kv maxIncrRetries`                                           | `incrementRetries`                      | P4   |
 | Low  | `bodyKind` (from-curl)                                             | `bodyType`                              | P1   |
 
 New shorthand/toggle slots to **add** (additive, non-breaking): `stream`, `multipart`,
@@ -476,7 +512,7 @@ cut; the lint skips the deprecated members so each rename ratchets the baseline 
     `ReconnectOptions.backoffMs`→`backoff`; `OAuth2Options.refreshSkewMs`→`refreshSkew`;
     `CookieSessionOptions.ttlMs`→`ttl`. Each keeps a `@deprecated` `*Ms` alias (runtime prefers
     `new ?? old`). House store contracts use the bare `ttl` param (ms, no suffix): `StitchStore` /
-    `RedisDriver` `set`/`incr` and the redis/deno-kv/cloudflare-kv drivers; `verifyStoreContract`'s
+    `RedisDriver` `set`/`increment` and the redis/deno-kv/cloudflare-kv drivers; `verifyStoreContract`'s
     knob is `ttl` (deprecated `ttlMs` alias).
 -   **P17 (circuit) + P4** `CircuitOptions` overhaul: `failureThreshold`→`failures` (P4),
     `cooldownMs`→`cooldown`, `halfOpenAfterMs`→`halfOpenAfter` (P17, widened to `number | string`).
@@ -541,6 +577,19 @@ cut; the lint skips the deprecated members so each rename ratchets the baseline 
     rich shape is assignable to the minimal one (a real stitch satisfies both), so it is **de-listed**.
     With this, **R5 is fully cleared** — the baseline is now 6, exactly R6's P20 backlog
     (multipart/stream/sse/throttle/hooks/input → `Scalar | AtLeastOne`).
+-   **P18 (store verbs) + P17 (`ttl`)** the house store contracts speak whole words:
+    `RedisDriver.del`→`delete` and `StitchStore`/`RedisDriver` `incr`→**`increment`**, across
+    core `memoryStore`/`vaultView`, `@stitchapi/redis` (all three adapters), `@stitchapi/deno-kv`,
+    `@stitchapi/cloudflare-kv`, `@stitchapi/react-native` (and `@stitchapi/expo`, which reuses it),
+    the `nestBorrowStore` bridge, and `verifyStoreContract`. `ttl` (ms) is now optional on
+    **both** verbs — absent means no expiry / no window — so the parameter's optionality no
+    longer differs between `set` and `increment`. The upstream mirrors (`IoredisLike`,
+    `NodeRedisLike`, `UpstashLike`) keep `del`, and the Lua keeps `INCR`, per P18's first half.
+    **No `@deprecated` aliases** — a deliberate hard break on the `rc` channel, where
+    [P19](#p19--the-alias-obligation-is-scoped-to-the-ga-channel) does not impose one; and
+    both are consumer-implemented contracts, which could not have carried an alias in any
+    case. (`deno-kv`'s `maxIncrRetries` is untouched here; it is a P4 `max`-prefix
+    violation and renames in that slice.)
 
 ## 7. Enforcement
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -486,8 +486,8 @@ The two gaps both audits flagged _critical_ — distributed rate limiting and pe
 ```ts
 interface StitchStore {
     get(key: string): Promise<unknown | undefined>;
-    set(key: string, value: unknown, ttlMs?: number): Promise<void>;
-    incr(key: string, ttlMs: number): Promise<number>; // atomic — for rate windows
+    set(key: string, value: unknown, ttl?: number): Promise<void>;
+    increment(key: string, ttl?: number): Promise<number>; // atomic — for rate windows
 }
 
 const api = seam({

--- a/docs/FEATURE-LENSES.md
+++ b/docs/FEATURE-LENSES.md
@@ -63,7 +63,7 @@ existing or proposed — passes through all three before it ships.
 -   Proactive throttle — `rate` (e.g. `"2/s"`) spacing **+** `concurrency` cap (FIFO),
     scoped per-stitch or per-`host` — [`src/resilience.ts`](../src/resilience.ts)
 -   Streaming delivers early instead of blocking for the whole body
--   Pluggable state store (`get` / `set` / `incr` + TTL) turns throttle **distributed** and
+-   Pluggable state store (`get` / `set` / `increment` + TTL) turns throttle **distributed** and
     sessions **persistent / shared across workers** — [`src/store.ts`](../src/store.ts)
 -   Zero runtime dependencies, tree-shakeable
 

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -103,7 +103,7 @@ teardown order + GC. Dropped along the way: request dedup, abandoned-request can
 -   **Tags:** caching, performance, resilience, multi-tenant, agents, runtime
 -   **Gates:** browser-first — sync browser-safe body hash, no `node:*`; uncacheable (stream)
     calls warn-and-pass-through, never crash. · bundle-frugal — subpath export, off until a
-    `cache` block exists; reuses the `StitchStore` `get/set/incr` contract, grows no new backend.
+    `cache` block exists; reuses the `StitchStore` `get/set/increment` contract, grows no new backend.
     · declarative — `cache: { ttl, scope, vary?, methods?, maxEntries? }` round-trips as JSON;
     `key()` is sugar over the derived default.
 
@@ -117,13 +117,13 @@ caller never authors (and never mis-authors) one. This also revives the **reques
 **Sketch** — Opaque **derived** key (method + URL + canonicalised body/GraphQL variables + vary
 headers + principal), **exact-match only** (no hierarchy). Cache only **validated** responses;
 hits skip re-validation. **Principal-scoped, fail-closed**; `scope: 'app'` opts into sharing.
-**Coalescing** is full cross-process via an `incr`-based lease lock — retries serialised, failures
+**Coalescing** is full cross-process via an `increment`-based lease lock — retries serialised, failures
 not shared, aborts ref-counted. Placement is **outermost** (a hit short-circuits
 throttle/circuit/network). **Invalidation**: exact = `set(key, undefined)` delete; bulk =
 generation-counter bump (no enumeration). LRU/max-entries live in the **cache layer**. Works on a
 bare `stitch()`; the seam just provisions the shared store. Subpath export, off by default.
 
-**Backed by / builds on** — `StitchStore` `get/set/incr` + TTL, ADR 0002 principal-keying, the
+**Backed by / builds on** — `StitchStore` `get/set/increment` + TTL, ADR 0002 principal-keying, the
 shared-store-makes-it-distributed pattern (throttle/circuit), the trace event stream, output
 validation + drift. Net-new runtime dependency count stays zero.
 
@@ -131,7 +131,7 @@ validation + drift. Net-new runtime dependency count stays zero.
 deploy); pick a sync browser-safe body hash + collision stance (oversized/stream bodies
 warn-and-skip); the cross-process lock protocol (lease TTL, poll backoff, leader-finished-without-
 cache signal); GraphQL query-vs-mutation opt-in classification; conformance-kit addendum for
-`incr`-as-lock correctness; `__config`/trace redaction of cached values + lock keys (extends ADR
+`increment`-as-lock correctness; `__config`/trace redaction of cached values + lock keys (extends ADR
 0002 §6). Dropped: hierarchy, SWR/background refresh, mutation-driven cross-stitch invalidation
 (= app-level cache policy, out of scope — see ADR 0003 §12).
 
@@ -216,9 +216,9 @@ demonstrable, but it's Node/TCP. The edge story (Workers / Deno / Vercel + `@sti
 HTTP/Web-API-native store so distributed throttle + shared sessions/cache work where there is no TCP
 socket. "Edge caching is eating Redis's lunch" — Upstash (HTTP Redis), Cloudflare Workers KV, Deno KV.
 
-**Sketch** — Thin `StitchStore` implementations (`get`/`set`/`incr`/`close?`) over each driver, same
-shape as `@stitchapi/redis`: `upstashStore(redis)` (Redis-command-compatible — `incr` is atomic),
-`cloudflareKvStore(KVNamespace)` (CF-KV has **no atomic `incr`** → rate-limiting needs Durable Objects;
+**Sketch** — Thin `StitchStore` implementations (`get`/`set`/`increment`/`close?`) over each driver, same
+shape as `@stitchapi/redis`: `upstashStore(redis)` (Redis-command-compatible — `increment` is atomic),
+`cloudflareKvStore(KVNamespace)` (CF-KV has **no atomic `increment`** → rate-limiting needs Durable Objects;
 document the gap or expose a DO-backed variant), `denoKvStore(kv)` (atomic ops available). Each ships
 against the `stitchapi/testing` store conformance kit.
 
@@ -226,7 +226,7 @@ against the `stitchapi/testing` store conformance kit.
 (driver-adapter + conformance pattern), and `@stitchapi/hono` (the edge backend they pair with).
 
 **Open questions** — `@stitchapi/redis` already takes any Redis-shaped driver — does Upstash just need
-a `fromUpstash` adapter there, or a dedicated package? How to expose the CF-KV `incr` gap without a
+a `fromUpstash` adapter there, or a dedicated package? How to expose the CF-KV `increment` gap without a
 footgun? **Postgres-as-KV is explicitly rejected** — KV-on-RDBMS is an anti-pattern and Redis already
 covers the `StitchStore` contract; it is not the storage gap worth filling.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -135,7 +135,7 @@ The entire core library (`stitchapi`, currently `1.0.0-rc.1`), verified against
 -   [x] **ADR 0004 Standard-Schema fingerprint** (PR #81) — **folded into cache
         generation** (PR #85), so a sound vendor fingerprint skips revalidation.
 -   [x] **`@stitchapi/redis`** — the package exists ([`packages/redis/`](../packages/redis/)):
-        a Redis-backed `StitchStore` (`get`/`set`/`incr`/`close`) with
+        a Redis-backed `StitchStore` (`get`/`set`/`increment`/`close`) with
         `fromIoredis` + `fromNodeRedis` driver adapters, passing
         `verifyStoreContract` against a hermetic in-repo Redis engine. Makes "two
         workers share one login + rate budget" work out of the box. Versioned

--- a/docs/adr/0003-derived-key-response-cache-and-coalescing.md
+++ b/docs/adr/0003-derived-key-response-cache-and-coalescing.md
@@ -4,6 +4,8 @@
 -   **Date:** 2026-06-14
 -   **Tags:** caching, performance, resilience, runtime, multi-tenant, agents
 
+> **Amendment — the store contract's counter verb is `increment`.** This ADR was written when `StitchStore`'s atomic counter was spelled `incr`; the house contracts now use whole words, so it is **`increment`** (`get`/`set`/`increment`/`close?`) per [CONTRACT.md P18](../CONTRACT.md#p18--adapter-mirrors-keep-upstream-spelling-house-contracts-use-house-vocabulary). Read `incr` as `increment` throughout the text below — the Redis **command** `INCR` is unchanged. The decision itself (reuse the store contract, grow no new vendor surface) is unaffected.
+
 ## Context
 
 The request that started this: "we're missing a cache — two calls with the same key and

--- a/docs/adr/0006-nestjs-integration.md
+++ b/docs/adr/0006-nestjs-integration.md
@@ -8,6 +8,8 @@
 >
 > The integration is a thin **adapter package**, exactly the class [ADR 0001](./0001-package-naming-and-distribution.md) Decision 2 already anticipated ("framework adapters (e.g. React)… `@stitchapi/<name>`"). It contributes _DI wiring + two bridge helpers + a Logger sink_ over primitives core already exposes — no new capability, so it cannot regress the **contract-not-dependency** gate ([`two-gates`](../DESIGN.md)).
 
+> **Amendment — the store contract's counter verb is `increment`.** The `StitchStore` shape quoted below as `get`/`set`/`incr`/`close?` (and the `nestBorrowStore` sample that delegates it) now spells the atomic counter **`increment`**, per [CONTRACT.md P18](../CONTRACT.md#p18--adapter-mirrors-keep-upstream-spelling-house-contracts-use-house-vocabulary). Read `incr` as `increment` throughout; the bridge's behaviour (delegate `get`/`set`/`increment`, never `close`) is unchanged.
+
 ## Context
 
 A stitch is a plain function: `stitch(config)` returns a callable that runs an HTTP/GraphQL/streaming call ([`stitch.ts`](../../packages/core/src/stitch.ts)). That works in any runtime, but it is **unwired** in a NestJS backend — there is no module to import, no provider to inject, no lifecycle hook, and no idiomatic path from Nest's `ConfigService`/`Logger`/request scope into a stitch. Today a Nest user hand-rolls all of that, and gets three things subtly wrong:

--- a/packages/cloudflare-kv/README.md
+++ b/packages/cloudflare-kv/README.md
@@ -49,9 +49,9 @@ is the overwhelmingly common edge need.
 KV's `expirationTtl` is in **seconds** and has a **60-second minimum**. The store
 reconciles this with the StitchStore contract's millisecond TTLs for you:
 
--   `ttlMs` → `Math.max(60, Math.ceil(ttlMs / 1000))` seconds.
+-   `ttl` (ms) → `Math.max(60, Math.ceil(ttl / 1000))` seconds.
 -   So a value asked to live for 5s lives for 60s (harmless for caches/sessions).
--   No `ttlMs` → no expiry.
+-   No `ttl` → no expiry (`ttl` is optional on both `set` and `incr`).
 
 `set(key, undefined)` deletes the key (the cache's delete, ADR 0003 §8). The store
 owns no connection, so there is no `close()`.

--- a/packages/cloudflare-kv/README.md
+++ b/packages/cloudflare-kv/README.md
@@ -30,17 +30,17 @@ types** — it runs on a small structural `KVNamespaceLike` surface that a real
 `KVNamespace` binding satisfies as-is, so there's no `@cloudflare/workers-types`
 dependency and a test double is a drop-in.
 
-## `incr` is unsupported on Workers KV — use a Durable Object
+## `increment` is unsupported on Workers KV — use a Durable Object
 
 > **Workers KV has no atomic increment.** It is last-write-wins `get`/`put`/
 > `delete` only, so a distributed throttle counter built on it would **undercount
 > under concurrency and silently break rate limiting**. Rather than do that,
-> `cloudflareKvStore(...).incr(...)` **throws** a clear, documented error.
+> `cloudflareKvStore(...).increment(...)` **throws** a clear, documented error.
 
 If you need a **distributed throttle**, back it with a
 **[Durable Object](https://developers.cloudflare.com/durable-objects/)**-based
 `StitchStore` instead: a Durable Object gives you the single-writer,
-strongly-consistent counter that an atomic `incr` requires. KV remains the right
+strongly-consistent counter that an atomic `increment` requires. KV remains the right
 backend for the rest — **cache and shared sessions/tokens** (`get`/`set`), which
 is the overwhelmingly common edge need.
 
@@ -51,7 +51,7 @@ reconciles this with the StitchStore contract's millisecond TTLs for you:
 
 -   `ttl` (ms) → `Math.max(60, Math.ceil(ttl / 1000))` seconds.
 -   So a value asked to live for 5s lives for 60s (harmless for caches/sessions).
--   No `ttl` → no expiry (`ttl` is optional on both `set` and `incr`).
+-   No `ttl` → no expiry (`ttl` is optional on both `set` and `increment`).
 
 `set(key, undefined)` deletes the key (the cache's delete, ADR 0003 §8). The store
 owns no connection, so there is no `close()`.

--- a/packages/cloudflare-kv/package.json
+++ b/packages/cloudflare-kv/package.json
@@ -2,7 +2,7 @@
     "name": "@stitchapi/cloudflare-kv",
     "version": "1.0.0-rc.6",
     "type": "commonjs",
-    "description": "Cloudflare Workers KV-backed StitchStore for StitchAPI — edge cache + shared sessions/tokens. Bring your own KV namespace binding. (incr → use a Durable Object store.)",
+    "description": "Cloudflare Workers KV-backed StitchStore for StitchAPI — edge cache + shared sessions/tokens. Bring your own KV namespace binding. (increment → use a Durable Object store.)",
     "main": "lib/index.js",
     "module": "lib/index.mjs",
     "types": "lib/index.d.ts",

--- a/packages/cloudflare-kv/src/index.ts
+++ b/packages/cloudflare-kv/src/index.ts
@@ -12,10 +12,10 @@
 // custom proxy is a drop-in. The package is Web-API only (no `node:*`), so it runs
 // in a Worker, in Pages Functions, and in any other edge runtime.
 //
-// !! THE atomic-incr GAP !! Workers KV has NO atomic increment — only
+// !! THE atomic-increment GAP !! Workers KV has NO atomic increment — only
 // last-write-wins `get`/`put`/`delete`. Distributed throttle counters need an
 // atomic read-modify-write, which KV cannot provide, so {@link cloudflareKvStore}'s
-// `incr` THROWS (see below). Use a Durable Object-backed store for distributed
+// `increment` THROWS (see below). Use a Durable Object-backed store for distributed
 // throttle; KV remains correct for cache + shared sessions/tokens, which is the
 // overwhelmingly common edge need.
 import type { StitchStore } from 'stitchapi';
@@ -58,11 +58,11 @@ export interface KVNamespaceLike {
 // 5s simply lives for 60s, which is harmless for caches and sessions.
 const KV_MIN_TTL_SECONDS = 60;
 
-// Surfaced when `incr` is called: Workers KV has no atomic counter, so honoring it
+// Surfaced when `increment` is called: Workers KV has no atomic counter, so honoring it
 // would silently undercount under concurrency and break rate limiting. Failing
 // loud (and pointing at the fix) is the only safe behavior.
-const INCR_UNSUPPORTED =
-    'incr() is not supported on Cloudflare Workers KV: KV has no atomic ' +
+const INCREMENT_UNSUPPORTED =
+    'increment() is not supported on Cloudflare Workers KV: KV has no atomic ' +
     'read-modify-write, so a distributed counter would undercount under ' +
     'concurrency and silently break rate limiting. Back the throttle with a ' +
     'Durable Object-based StitchStore instead; KV remains correct for cache ' +
@@ -102,7 +102,7 @@ export interface CloudflareKvStoreOptions {
  * second-resolution `expirationTtl` and floored to KV's 60s minimum. `set(key,
  * undefined)` deletes the key (the cache's delete, ADR 0003 §8).
  *
- * **`incr` is unsupported and throws.** Workers KV offers no atomic increment, so
+ * **`increment` is unsupported and throws.** Workers KV offers no atomic increment, so
  * a distributed throttle counter cannot be implemented correctly on it — see the
  * module header. Use a Durable Object-backed store for distributed throttle; KV is
  * the right backend for the read-heavy halves (cache + shared sessions/tokens).
@@ -146,9 +146,9 @@ export function cloudflareKvStore(
             );
             await kv.put(k(key), body, { expirationTtl });
         },
-        incr() {
-            // Fail loud, not silent: see INCR_UNSUPPORTED.
-            return Promise.reject(new Error(INCR_UNSUPPORTED));
+        increment() {
+            // Fail loud, not silent: see INCREMENT_UNSUPPORTED.
+            return Promise.reject(new Error(INCREMENT_UNSUPPORTED));
         },
     };
 }

--- a/packages/cloudflare-kv/test/store.spec.ts
+++ b/packages/cloudflare-kv/test/store.spec.ts
@@ -1,11 +1,11 @@
 // Behaviour proof for @stitchapi/cloudflare-kv.
 //
 // We deliberately do NOT run `verifyStoreContract` from `stitchapi/testing`: that
-// kit asserts the atomic-incr rule ("20 concurrent incrs net +20"), and Workers KV
-// has no atomic counter, so `incr` throws by design (see src/index.ts). The
+// kit asserts the atomic-increment rule ("20 concurrent increments net +20"), and Workers KV
+// has no atomic counter, so `increment` throws by design (see src/index.ts). The
 // contract would fail — correctly — so instead we prove the half KV *does* support
 // (get/set/delete/TTL) against a faithful in-memory KVNamespace, and assert that
-// `incr` rejects with the documented Durable-Object pointer.
+// `increment` rejects with the documented Durable-Object pointer.
 import { cloudflareKvStore } from '../src';
 import type { KVNamespaceLike } from '../src';
 
@@ -172,20 +172,22 @@ describe('@stitchapi/cloudflare-kv keyPrefix', () => {
     });
 });
 
-// --- the atomic-incr gap ---------------------------------------------------
+// --- the atomic-increment gap ---------------------------------------------------
 
-describe('@stitchapi/cloudflare-kv incr is unsupported', () => {
-    test('incr rejects with a documented Durable-Object pointer', async () => {
+describe('@stitchapi/cloudflare-kv increment is unsupported', () => {
+    test('increment rejects with a documented Durable-Object pointer', async () => {
         const store = cloudflareKvStore(new FakeKvNamespace());
-        await expect(store.incr('rate', 1_000)).rejects.toThrow(
+        await expect(store.increment('rate', 1_000)).rejects.toThrow(
             /Durable Object/i,
         );
-        await expect(store.incr('rate', 1_000)).rejects.toThrow(
+        await expect(store.increment('rate', 1_000)).rejects.toThrow(
             /not supported on Cloudflare Workers KV/i,
         );
-        // `ttl` is optional on `incr` (StitchStore contract) — the no-window
+        // `ttl` is optional on `increment` (StitchStore contract) — the no-window
         // call shape must typecheck, and still fails loud on KV.
-        await expect(store.incr('rate')).rejects.toThrow(/Durable Object/i);
+        await expect(store.increment('rate')).rejects.toThrow(
+            /Durable Object/i,
+        );
     });
 
     test('cloudflareKvStore has no close() (it owns no connection)', () => {

--- a/packages/cloudflare-kv/test/store.spec.ts
+++ b/packages/cloudflare-kv/test/store.spec.ts
@@ -183,6 +183,9 @@ describe('@stitchapi/cloudflare-kv incr is unsupported', () => {
         await expect(store.incr('rate', 1_000)).rejects.toThrow(
             /not supported on Cloudflare Workers KV/i,
         );
+        // `ttl` is optional on `incr` (StitchStore contract) — the no-window
+        // call shape must typecheck, and still fails loud on KV.
+        await expect(store.incr('rate')).rejects.toThrow(/Durable Object/i);
     });
 
     test('cloudflareKvStore has no close() (it owns no connection)', () => {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -551,7 +551,7 @@ Throttle counters and session/token state live behind one small seam — a `stor
 export interface StitchStore {
     get(key: string): Promise<unknown | undefined>;
     set(key: string, value: unknown, ttl?: number): Promise<void>;
-    incr(key: string, ttl: number): Promise<number>; // atomic — rate windows
+    increment(key: string, ttl: number): Promise<number>; // atomic — rate windows
 }
 ```
 

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -5,7 +5,7 @@
 //
 // Browser-first: no `node:*`, no WebCrypto (`crypto.subtle.digest` is async and a JS crypto
 // hash is bundle weight). The key is a 128-bit SYNCHRONOUS non-cryptographic digest. It reuses
-// the `StitchStore` get/set/incr contract — no new vendor surface — exactly like throttle and
+// the `StitchStore` get/set/increment contract — no new vendor surface — exactly like throttle and
 // the circuit breaker, so a shared store makes the cache distributed for free.
 import { resolveFingerprint } from './fingerprint';
 import type { CachePolicy } from './fingerprint';
@@ -280,7 +280,7 @@ export async function bumpCacheGeneration(
     store: StitchStore,
     stitchId?: string,
 ): Promise<void> {
-    await store.incr(
+    await store.increment(
         stitchId ? stitchGenKey(stitchId) : cacheGenKey,
         GEN_TTL_MS,
     );

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -50,7 +50,8 @@ export function memoryStore(): StitchStore {
             sweepExpired();
             data.set(key, {
                 value: n,
-                expires: live(e) ? e!.expires : now() + ttl,
+                // Absent `ttl` = no window: the counter never expires (0 marks "live forever").
+                expires: live(e) ? e!.expires : ttl ? now() + ttl : 0,
             });
             return n;
         },

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -9,13 +9,13 @@ import type {
 } from './types';
 import { now, parseRate, systemClock } from './util';
 
-/** Default store: in-memory, single process, with TTL + atomic incr. */
+/** Default store: in-memory, single process, with TTL + atomic increment. */
 export function memoryStore(): StitchStore {
     const data = new Map<string, { value: unknown; expires: number }>();
     const live = (e?: { expires: number }) =>
         !!e && (e.expires === 0 || e.expires > now());
     // Opportunistic, bounded sweep of expired entries. The store evicts a key lazily on a `get`/
-    // `incr` of THAT key, so a throttle that mints a new per-window `rl:` key each window would
+    // `increment` of THAT key, so a throttle that mints a new per-window `rl:` key each window would
     // otherwise accumulate dead keys forever (no key is ever read again). On a write we scan up to
     // `SWEEP_BUDGET` entries and drop any that have expired — never touching a live key, so
     // observable behaviour is unchanged; it just keeps the Map from growing without bound.
@@ -44,7 +44,7 @@ export function memoryStore(): StitchStore {
             sweepExpired();
             data.set(key, { value, expires: ttl ? now() + ttl : 0 });
         },
-        async incr(key, ttl) {
+        async increment(key, ttl) {
             const e = data.get(key);
             const n = (live(e) ? (e!.value as number) : 0) + 1;
             sweepExpired();
@@ -72,7 +72,7 @@ export function vaultView(store: StitchStore, prefix = 'vault:'): StitchStore {
     const view: StitchStore = {
         get: (key) => store.get(prefix + key),
         set: (key, value, ttl) => store.set(prefix + key, value, ttl),
-        incr: (key, ttl) => store.incr(prefix + key, ttl),
+        increment: (key, ttl) => store.increment(prefix + key, ttl),
     };
     // Delegate lifecycle to the backend (bind keeps `this` for stores that need it).
     if (store.close) view.close = store.close.bind(store);
@@ -173,7 +173,7 @@ export function createStoreThrottle(
         }
         if (rate) {
             // Even-spaced pacing over the shared counter (mirrors createThrottle's `spacing`):
-            // the atomic incr hands each caller a unique slot N in the window, and slot N is
+            // the atomic increment hands each caller a unique slot N in the window, and slot N is
             // scheduled at windowStart + (N-1)·spacing. Slot count+1 lands exactly at the next
             // windowStart, so grants stay one `spacing` apart across the boundary — no fixed-window
             // burst. No re-check loop: each caller owns a distinct, non-colliding slot.
@@ -187,7 +187,7 @@ export function createStoreThrottle(
             if (s.lastWindow !== undefined && s.lastWindow < windowStart)
                 await store.set(`rl:${key}:${s.lastWindow}`, undefined);
             s.lastWindow = windowStart;
-            const n = await store.incr(
+            const n = await store.increment(
                 `rl:${key}:${windowStart}`,
                 rate.per + 100,
             );

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -157,7 +157,7 @@ function asJsonObject(body: unknown, label: string): Record<string, unknown> {
  *   a second `set` overwrites; writes are isolated by key.
  * - `set(key, value, ttl)` expires the value after `ttl` ms; a `set` without
  *   `ttl` does not expire.
- * - `incr(key, ttl)` initializes a missing key to 1, increments an existing
+ * - `increment(key, ttl)` initializes a missing key to 1, increments an existing
  *    counter, is ATOMIC within a process (20 concurrent calls return
  *    1..20 exactly), and restarts at 1 once its TTL window lapses.
  *
@@ -269,30 +269,30 @@ export async function verifyStoreContract(
             },
         ],
         [
-            'incr: initializes a missing key to 1',
+            'increment: initializes a missing key to 1',
             async () => {
-                const first = await store.incr(k('init'), 5_000);
+                const first = await store.increment(k('init'), 5_000);
                 if (first !== 1) {
                     throw new Error(`expected 1, got ${show(first)}`);
                 }
             },
         ],
         [
-            'incr: increments an existing counter',
+            'increment: increments an existing counter',
             async () => {
-                await store.incr(k('seq'), 5_000);
-                const second = await store.incr(k('seq'), 5_000);
+                await store.increment(k('seq'), 5_000);
+                const second = await store.increment(k('seq'), 5_000);
                 if (second !== 2) {
                     throw new Error(`expected 2, got ${show(second)}`);
                 }
             },
         ],
         [
-            'incr: 20 concurrent calls net exactly +20',
+            'increment: 20 concurrent calls net exactly +20',
             async () => {
                 const results = await Promise.all(
                     Array.from({ length: 20 }, () =>
-                        store.incr(k('atomic'), 5_000),
+                        store.increment(k('atomic'), 5_000),
                     ),
                 );
                 const sorted = [...results].sort((a, b) => a - b);
@@ -300,16 +300,16 @@ export async function verifyStoreContract(
                 expectDeepEqual(
                     sorted,
                     wanted,
-                    'sorted results of 20 concurrent incrs (non-atomic stores collide)',
+                    'sorted results of 20 concurrent increments (non-atomic stores collide)',
                 );
             },
         ],
         [
-            'incr: the counter expires after its ttl',
+            'increment: the counter expires after its ttl',
             async () => {
-                await store.incr(k('window'), ttlMs);
+                await store.increment(k('window'), ttlMs);
                 await sleep(ttlMs + 50);
-                const restarted = await store.incr(k('window'), ttlMs);
+                const restarted = await store.increment(k('window'), ttlMs);
                 if (restarted !== 1) {
                     throw new Error(
                         `expected a fresh window to restart at 1, got ${show(restarted)}`,
@@ -323,24 +323,24 @@ export async function verifyStoreContract(
                 await store.set(k('iso-a'), 'a');
                 await store.set(k('iso-b'), 'b');
                 // Counters live under their own keys, never a shared one:
-                // iso-n's first incr lands at 1, an incr on a different
-                // key (iso-m) must not advance it, so iso-n's next incr is 2.
-                const isoN = await store.incr(k('iso-n'), 5_000);
+                // iso-n's first increment lands at 1, an increment on a different
+                // key (iso-m) must not advance it, so iso-n's next increment is 2.
+                const isoN = await store.increment(k('iso-n'), 5_000);
                 if (isoN !== 1) {
                     throw new Error(
                         `expected iso-n to start at 1, got ${show(isoN)}`,
                     );
                 }
-                const isoM = await store.incr(k('iso-m'), 5_000);
+                const isoM = await store.increment(k('iso-m'), 5_000);
                 if (isoM !== 1) {
                     throw new Error(
                         `expected iso-m to start at 1, got ${show(isoM)}`,
                     );
                 }
-                const isoNAgain = await store.incr(k('iso-n'), 5_000);
+                const isoNAgain = await store.increment(k('iso-n'), 5_000);
                 if (isoNAgain !== 2) {
                     throw new Error(
-                        `incr on iso-m leaked into iso-n: expected 2, got ${show(isoNAgain)}`,
+                        `increment on iso-m leaked into iso-n: expected 2, got ${show(isoNAgain)}`,
                     );
                 }
                 expectDeepEqual(await store.get(k('iso-a')), 'a', 'iso-a');

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1137,7 +1137,7 @@ export interface StitchStore {
     /** Set a value. `ttl` (ms) is optional on both verbs — absent means no expiry. */
     set(key: string, value: unknown, ttl?: number): Promise<void>;
     /** Atomically increment a counter. Absent `ttl` means no window — the counter never expires. */
-    incr(key: string, ttl?: number): Promise<number>;
+    increment(key: string, ttl?: number): Promise<number>;
     /**
      * Release any resources (connections, timers) the store holds. Optional — the in-memory
      * default clears its map. A seam's `close()` calls this as the last lifecycle step.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1134,8 +1134,10 @@ export interface TraceSink {
 // sessions persistent/shared across workers — see DESIGN.md §13.
 export interface StitchStore {
     get(key: string): Promise<unknown>;
+    /** Set a value. `ttl` (ms) is optional on both verbs — absent means no expiry. */
     set(key: string, value: unknown, ttl?: number): Promise<void>;
-    incr(key: string, ttl: number): Promise<number>;
+    /** Atomically increment a counter. Absent `ttl` means no window — the counter never expires. */
+    incr(key: string, ttl?: number): Promise<number>;
     /**
      * Release any resources (connections, timers) the store holds. Optional — the in-memory
      * default clears its map. A seam's `close()` calls this as the last lifecycle step.

--- a/packages/core/test/cache-internals.spec.ts
+++ b/packages/core/test/cache-internals.spec.ts
@@ -268,7 +268,7 @@ describe('generation helpers', () => {
         expect(cacheStitchId({})).toBe('stitch');
     });
 
-    test('bumpCacheGeneration incr-s the cache-wide and per-stitch counters', async () => {
+    test('bumpCacheGeneration increments the cache-wide and per-stitch counters', async () => {
         const store = memoryStore();
         await bumpCacheGeneration(store);
         await bumpCacheGeneration(store);

--- a/packages/core/test/conformance-kit.spec.ts
+++ b/packages/core/test/conformance-kit.spec.ts
@@ -92,7 +92,7 @@ function mountFixture(): Promise<FixtureHost> {
 // ---------------------------------------------------------------------------
 
 // Deliberately broken store: set() ignores ttl (entries never expire) and
-// incr() awaits between read and write (concurrent calls collide).
+// increment() awaits between read and write (concurrent calls collide).
 function brokenStore(): StitchStore {
     const data = new Map<string, unknown>();
     return {
@@ -102,7 +102,7 @@ function brokenStore(): StitchStore {
         async set(key, value) {
             data.set(key, value);
         },
-        async incr(key) {
+        async increment(key) {
             const base = (data.get(key) as number | undefined) ?? 0;
             await new Promise((resolve) => setTimeout(resolve, 1));
             data.set(key, base + 1);
@@ -118,7 +118,7 @@ describe('verifyStoreContract', () => {
         expect(report.violations).toEqual([]);
         expect(report.ok).toBe(true);
         expect(report.passed).toContain(
-            'incr: 20 concurrent calls net exactly +20',
+            'increment: 20 concurrent calls net exactly +20',
         );
         expect(() => {
             assertConformance(report);
@@ -130,14 +130,20 @@ describe('verifyStoreContract', () => {
         expect(report.ok).toBe(false);
         const failed = report.violations.map((v) => v.rule);
         expect(failed).toContain('set: a ttl entry expires');
-        expect(failed).toContain('incr: the counter expires after its ttl');
-        expect(failed).toContain('incr: 20 concurrent calls net exactly +20');
+        expect(failed).toContain(
+            'increment: the counter expires after its ttl',
+        );
+        expect(failed).toContain(
+            'increment: 20 concurrent calls net exactly +20',
+        );
         // Independent rules: violations do not mask the healthy behaviors.
         expect(report.passed).toContain('set/get: round-trips a value');
         expect(report.passed).toContain(
             'get: a missing key resolves to undefined',
         );
-        expect(report.passed).toContain('incr: increments an existing counter');
+        expect(report.passed).toContain(
+            'increment: increments an existing counter',
+        );
     });
 });
 

--- a/packages/core/test/gaps/resource-leaks.spec.ts
+++ b/packages/core/test/gaps/resource-leaks.spec.ts
@@ -49,10 +49,10 @@ test('store throttle: old rate-window keys do not accumulate over many windows',
             }
             return inner.set(k, v, ttl);
         },
-        async incr(k: string, ttl: number): Promise<number> {
+        async increment(k: string, ttl: number): Promise<number> {
             liveKeys.add(k);
             seen.add(k);
-            return inner.incr(k, ttl);
+            return inner.increment(k, ttl);
         },
     };
 
@@ -73,7 +73,7 @@ test('store throttle: old rate-window keys do not accumulate over many windows',
 });
 
 // ── 1a'. memoryStore sweeps expired entries on write (no unbounded growth) ───
-// The default store evicts a key lazily only on a get/incr of THAT key. Many short-TTL keys that
+// The default store evicts a key lazily only on a get/increment of THAT key. Many short-TTL keys that
 // are never read again must still be reclaimed: a write triggers a bounded opportunistic sweep.
 test('memoryStore sweeps expired keys on write so it stays bounded', async () => {
     const store = memoryStore();

--- a/packages/core/test/principal.spec.ts
+++ b/packages/core/test/principal.spec.ts
@@ -42,7 +42,7 @@ function spyStore(): { store: StitchStore; closed: () => boolean } {
         store: {
             get: (k) => base.get(k),
             set: (k, v, ttl) => base.set(k, v, ttl),
-            incr: (k, ttl) => base.incr(k, ttl),
+            increment: (k, ttl) => base.increment(k, ttl),
             close: async () => {
                 didClose = true;
                 await base.close?.();

--- a/packages/core/test/seam.spec.ts
+++ b/packages/core/test/seam.spec.ts
@@ -211,7 +211,7 @@ test('close() flushes the sink and closes the shared store', async () => {
     const spyStore: StitchStore = {
         get: (k) => base.get(k),
         set: (k, v, ttl) => base.set(k, v, ttl),
-        incr: (k, ttl) => base.incr(k, ttl),
+        increment: (k, ttl) => base.increment(k, ttl),
         close: async () => {
             closed = true;
             await base.close?.();

--- a/packages/core/test/stitch-helpers.spec.ts
+++ b/packages/core/test/stitch-helpers.spec.ts
@@ -40,7 +40,7 @@ describe('redactConfig', () => {
                 store: {
                     get: () => undefined,
                     set: () => undefined,
-                    incr: () => 1,
+                    increment: () => 1,
                 },
                 adapter: () => Promise.resolve({}),
                 clock: systemClock,

--- a/packages/core/test/store-units.spec.ts
+++ b/packages/core/test/store-units.spec.ts
@@ -2,7 +2,7 @@
 // throttle + sessions through real stitches (integration), but three building blocks are only ever
 // exercised indirectly:
 //   memoryStore   — the bare key/value contract (get-missing, set/get, set(undefined) deletes,
-//                   incr atomicity, close clears);
+//                   increment atomicity, close clears);
 //   vaultView     — the namespaced lens that prefixes every key and delegates close to the backend;
 //   chainThrottle — composing gates: acquire each in order (summing waited), release in REVERSE,
 //                   threading acquire options to every gate.
@@ -25,11 +25,11 @@ describe('memoryStore (key/value contract)', () => {
         expect(await s.get('k')).toBeUndefined();
     });
 
-    test('incr starts at 1 and increments the same key atomically', async () => {
+    test('increment starts at 1 and increments the same key atomically', async () => {
         const s = memoryStore();
-        expect(await s.incr('c', 1000)).toBe(1);
-        expect(await s.incr('c', 1000)).toBe(2);
-        expect(await s.incr('c', 1000)).toBe(3);
+        expect(await s.increment('c', 1000)).toBe(1);
+        expect(await s.increment('c', 1000)).toBe(2);
+        expect(await s.increment('c', 1000)).toBe(3);
     });
 
     test('close() clears all state', async () => {
@@ -48,7 +48,7 @@ describe('vaultView (namespaced lens)', () => {
         expect(await backend.get('vault:token')).toBe('abc'); // stored under the prefix
         expect(await backend.get('token')).toBeUndefined(); // not under the bare key
         expect(await vault.get('token')).toBe('abc'); // read back through the lens
-        await vault.incr('count', 1000);
+        await vault.increment('count', 1000);
         expect(await backend.get('vault:count')).toBe(1);
     });
 
@@ -64,7 +64,7 @@ describe('vaultView (namespaced lens)', () => {
         const backend: StitchStore = {
             get: async () => undefined,
             set: async () => undefined,
-            incr: async () => 1,
+            increment: async () => 1,
             close: async () => {
                 closed = true;
             },
@@ -77,7 +77,7 @@ describe('vaultView (namespaced lens)', () => {
         const backend: StitchStore = {
             get: async () => undefined,
             set: async () => undefined,
-            incr: async () => 1,
+            increment: async () => 1,
         };
         expect('close' in vaultView(backend)).toBe(false);
     });

--- a/packages/deno-kv/README.md
+++ b/packages/deno-kv/README.md
@@ -66,8 +66,11 @@ deadline. That keeps the window's expiry alive across every write instead of a
 later increment silently wiping it and leaking the key forever. (`get` unwraps this
 envelope back to the plain count, so nothing downstream sees the internal shape.)
 The TTL unit is **milliseconds** — the same unit as the contract's `ttl`, and Deno
-KV's own `expireIn` unit, so there's no conversion at the seam. `maxIncrRetries`
-(default `100`) bounds the loop under pathological contention.
+KV's own `expireIn` unit, so there's no conversion at the seam. An `incr` without
+a `ttl` (or with `ttl <= 0`) has **no window**: the counter accumulates forever
+and the key never expires — the same "absent `ttl` = no expiry" rule `set`
+follows. `maxIncrRetries` (default `100`) bounds the loop under pathological
+contention.
 
 The store owns no connection: `store.close()` delegates to the handle, so you
 decide when KV shuts down.

--- a/packages/deno-kv/README.md
+++ b/packages/deno-kv/README.md
@@ -49,12 +49,12 @@ Anything that satisfies `DenoKvLike` (a test double, a proxy) is a drop-in.
 
 ## Atomic counters
 
-Deno KV has no `INCR`, so `incr` is implemented as an **atomic compare-and-set
+Deno KV has no `INCR`, so `increment` is implemented as an **atomic compare-and-set
 loop**: read the current value + its `versionstamp`, then
 `atomic().check({ key, versionstamp }).set(key, next, { expireIn }).commit()`. If
 another isolate raced us, the versionstamp moved, the commit returns `ok: false`,
 and the loop re-reads and retries — so N concurrent increments net **exactly +N**
-(proven by the store contract's "20 concurrent incrs net +20" rule).
+(proven by the store contract's "20 concurrent increments net +20" rule).
 
 The counter is a **fixed window** (matching the Redis adapter): the first increment
 pins an absolute deadline `now + ttl`, and every increment inside that window keeps
@@ -66,7 +66,7 @@ deadline. That keeps the window's expiry alive across every write instead of a
 later increment silently wiping it and leaking the key forever. (`get` unwraps this
 envelope back to the plain count, so nothing downstream sees the internal shape.)
 The TTL unit is **milliseconds** — the same unit as the contract's `ttl`, and Deno
-KV's own `expireIn` unit, so there's no conversion at the seam. An `incr` without
+KV's own `expireIn` unit, so there's no conversion at the seam. An `increment` without
 a `ttl` (or with `ttl <= 0`) has **no window**: the counter accumulates forever
 and the key never expires — the same "absent `ttl` = no expiry" rule `set`
 follows. `maxIncrRetries` (default `100`) bounds the loop under pathological

--- a/packages/deno-kv/package.json
+++ b/packages/deno-kv/package.json
@@ -2,7 +2,7 @@
     "name": "@stitchapi/deno-kv",
     "version": "1.0.0-rc.6",
     "type": "commonjs",
-    "description": "Deno KV-backed StitchStore for StitchAPI — distributed throttle + shared sessions/tokens with atomic incr. Bring your own Deno.Kv handle.",
+    "description": "Deno KV-backed StitchStore for StitchAPI — distributed throttle + shared sessions/tokens with atomic increment. Bring your own Deno.Kv handle.",
     "main": "lib/index.js",
     "module": "lib/index.mjs",
     "types": "lib/index.d.ts",

--- a/packages/deno-kv/src/index.ts
+++ b/packages/deno-kv/src/index.ts
@@ -86,11 +86,13 @@ export interface DenoKvLike {
 
 /**
  * What `incr` stores under a counter key: the running count `n` plus the window's
- * absolute `deadline` (epoch ms). We keep the deadline in the VALUE — rather than
- * relying on the key's `expireIn` alone — because Deno KV's `set` replaces the
- * whole entry (clearing any prior expiry) and `get` never exposes the remaining
- * TTL. Storing the deadline lets each `incr` re-derive the correct `expireIn` on
- * every write, so a fixed window's expiry survives later increments intact.
+ * absolute `deadline` (epoch ms; `0` = no window — the counter never expires,
+ * mirroring `memoryStore`'s "0 marks live forever"). We keep the deadline in the
+ * VALUE — rather than relying on the key's `expireIn` alone — because Deno KV's
+ * `set` replaces the whole entry (clearing any prior expiry) and `get` never
+ * exposes the remaining TTL. Storing the deadline lets each `incr` re-derive the
+ * correct `expireIn` on every write, so a fixed window's expiry survives later
+ * increments intact.
  */
 interface CounterWindow {
     n: number;
@@ -212,15 +214,27 @@ export function denoKvStore(
                 const prev = asWindow(entry.value);
                 // A window past its deadline (or an absent / legacy bare-number
                 // value) starts a fresh window at 1; an old bare counter thus
-                // self-heals into the envelope on its next incr.
-                const live = prev != null && prev.deadline > now;
-                const deadline = live ? prev.deadline : now + ttl;
+                // self-heals into the envelope on its next incr. A `deadline` of
+                // 0 marks a windowless counter — live forever.
+                const live =
+                    prev != null &&
+                    (prev.deadline === 0 || prev.deadline > now);
+                // Absent (or non-positive) `ttl` = no window: the counter never
+                // expires — `deadline: 0`, the same "live forever" marker
+                // `memoryStore` uses. A live counter keeps its original
+                // deadline, windowed or not, regardless of this call's `ttl`.
+                const windowed = ttl != null && ttl > 0;
+                const deadline = live
+                    ? prev.deadline
+                    : windowed
+                      ? now + ttl
+                      : 0;
                 const n = (live ? prev.n : 0) + 1;
                 // Deno KV rejects `expireIn` of 0/negative; keep it ≥ 1 while the
-                // deadline is in the future. `ttl <= 0` means "no window" — write
-                // without an expiry (matching `set`'s no-TTL path).
+                // deadline is in the future. A windowless counter (deadline 0)
+                // writes without an expiry (matching `set`'s no-TTL path).
                 const options =
-                    ttl > 0
+                    deadline > 0
                         ? { expireIn: Math.max(1, deadline - now) }
                         : undefined;
                 const res = await kv

--- a/packages/deno-kv/src/index.ts
+++ b/packages/deno-kv/src/index.ts
@@ -85,12 +85,12 @@ export interface DenoKvLike {
 // ---------------------------------------------------------------------------
 
 /**
- * What `incr` stores under a counter key: the running count `n` plus the window's
+ * What `increment` stores under a counter key: the running count `n` plus the window's
  * absolute `deadline` (epoch ms; `0` = no window — the counter never expires,
  * mirroring `memoryStore`'s "0 marks live forever"). We keep the deadline in the
  * VALUE — rather than relying on the key's `expireIn` alone — because Deno KV's
  * `set` replaces the whole entry (clearing any prior expiry) and `get` never
- * exposes the remaining TTL. Storing the deadline lets each `incr` re-derive the
+ * exposes the remaining TTL. Storing the deadline lets each `increment` re-derive the
  * correct `expireIn` on every write, so a fixed window's expiry survives later
  * increments intact.
  */
@@ -122,7 +122,7 @@ export interface DenoKvStoreOptions {
      */
     keyPrefix?: string;
     /**
-     * How many times {@link StitchStore.incr} retries a lost compare-and-set race
+     * How many times {@link StitchStore.increment} retries a lost compare-and-set race
      * before giving up. Each retry re-reads the current value, so the loop only
      * spins under genuine contention. With N callers racing one counter, the
      * unluckiest needs up to N−1 retries (each round exactly one commit wins, so
@@ -146,7 +146,7 @@ export interface DenoKvStoreOptions {
  * Values round-trip through a JSON envelope so the store never wrestles with Deno
  * KV's structured-clone edge cases (BigInt, undefined-vs-null) — it persists the
  * exact bytes the contract handed it. The throttle's counter uses an atomic
- * compare-and-set loop (see {@link StitchStore.incr}). The store owns no
+ * compare-and-set loop (see {@link StitchStore.increment}). The store owns no
  * connection — `close()` delegates to the handle, so the caller decides when KV
  * shuts down.
  */
@@ -165,7 +165,7 @@ export function denoKvStore(
         async get(key) {
             const { value } = await kv.get(k(key));
             if (value == null) return undefined;
-            // A counter written by `incr` is a `{ n, deadline }` envelope; the
+            // A counter written by `increment` is a `{ n, deadline }` envelope; the
             // contract's cross-reads of a counter (e.g. core's cache-generation
             // number) expect the plain count, so unwrap it back to `n`. A legacy
             // bare-number counter from before this envelope is returned as-is.
@@ -191,12 +191,12 @@ export function denoKvStore(
                 ttl != null && ttl > 0 ? { expireIn: ttl } : undefined;
             await kv.set(k(key), JSON.stringify(value), options);
         },
-        async incr(key, ttl) {
+        async increment(key, ttl) {
             // Atomic FIXED-window counter via compare-and-set. Read the current
             // value + its versionstamp, then commit the next state guarded by a
             // `check` on that versionstamp: if another isolate raced us, the
             // versionstamp moved, the commit returns `ok: false`, and we re-read
-            // and retry — so N concurrent incrs net exactly +N (the contract).
+            // and retry — so N concurrent increments net exactly +N (the contract).
             //
             // The window is a `{ n, deadline }` envelope, NOT a bare number,
             // because Deno KV's `set` replaces the whole entry — including its
@@ -214,7 +214,7 @@ export function denoKvStore(
                 const prev = asWindow(entry.value);
                 // A window past its deadline (or an absent / legacy bare-number
                 // value) starts a fresh window at 1; an old bare counter thus
-                // self-heals into the envelope on its next incr. A `deadline` of
+                // self-heals into the envelope on its next increment. A `deadline` of
                 // 0 marks a windowless counter — live forever.
                 const live =
                     prev != null &&
@@ -245,7 +245,7 @@ export function denoKvStore(
                 if (res.ok) return n;
             }
             throw new Error(
-                `@stitchapi/deno-kv: incr(${key}) lost ${maxRetries + 1} compare-and-set races`,
+                `@stitchapi/deno-kv: increment(${key}) lost ${maxRetries + 1} compare-and-set races`,
             );
         },
     };

--- a/packages/deno-kv/test/conformance.spec.ts
+++ b/packages/deno-kv/test/conformance.spec.ts
@@ -5,7 +5,7 @@
 // expiry + a monotonic versionstamp + an atomic builder that fails the commit
 // when a checked versionstamp is stale). Single-threaded JS makes the engine's
 // read-modify-write atomic, exactly as Deno KV's real `atomic().commit()` does
-// against its storage — so the contract's "20 concurrent incrs net +20" rule
+// against its storage — so the contract's "20 concurrent increments net +20" rule
 // holds here and on real Deno KV alike, including the compare-and-set RETRY path
 // (the fake genuinely fails losing commits, so the store must re-read and retry).
 import { denoKvStore } from '../src';

--- a/packages/deno-kv/test/store-behaviour.spec.ts
+++ b/packages/deno-kv/test/store-behaviour.spec.ts
@@ -1,8 +1,8 @@
 // Targeted behaviour tests for @stitchapi/deno-kv that the conformance proof
 // (`conformance.spec.ts`) does not pin down: the FIXED-window TTL rule (the
-// counter's window has an absolute deadline pinned at creation — later incrs in
+// counter's window has an absolute deadline pinned at creation — later increments in
 // the same window neither extend nor clear it, and a fresh window restarts at 1),
-// the NO-window rule (an incr without a ttl — or with ttl <= 0 — never expires),
+// the NO-window rule (an increment without a ttl — or with ttl <= 0 — never expires),
 // the compare-and-set retry EXHAUSTION error, the array-key shape (flat vs
 // prefixed), the cache-delete (`set(k, undefined)`), and `close()` delegation.
 // Driven by two fakes: a recording KV that captures every write's `expireIn`, and
@@ -110,7 +110,7 @@ function recordingKv(opts: { failAtomic?: boolean } = {}): Recording {
 //     This is the trap: on real Deno KV a bare `set` REPLACES the entry, so it
 //     also clears any expiry the entry had — unlike Redis INCR, which keeps it.
 //   • a key read at/after `expiresAt` comes back as `{ value: null,
-//     versionstamp: null }` (absent), so the next incr sees a fresh window.
+//     versionstamp: null }` (absent), so the next increment sees a fresh window.
 //   • `atomic().check(versionstamp).set(...).commit()` is real optimistic CAS.
 // Virtual time is driven by vitest's fake timers (`vi.setSystemTime`), so the
 // tests never sleep.
@@ -202,58 +202,58 @@ function expiryKv(): DenoKvLike {
     };
 }
 
-describe('denoKvStore — incr TTL window', () => {
+describe('denoKvStore — increment TTL window', () => {
     afterEach(() => {
         vi.useRealTimers();
     });
 
-    test('a fixed window RESETS: after the ttl elapses the next incr restarts at 1', async () => {
+    test('a fixed window RESETS: after the ttl elapses the next increment restarts at 1', async () => {
         vi.useFakeTimers();
         vi.setSystemTime(0);
         const store = denoKvStore(expiryKv());
         const ttl = 200;
 
-        // Two incrs inside one window — the counter must not be permanent.
-        expect(await store.incr('rate', ttl)).toBe(1);
-        expect(await store.incr('rate', ttl)).toBe(2);
+        // Two increments inside one window — the counter must not be permanent.
+        expect(await store.increment('rate', ttl)).toBe(1);
+        expect(await store.increment('rate', ttl)).toBe(2);
 
-        // Advance past the window's absolute deadline (pinned at the FIRST incr).
+        // Advance past the window's absolute deadline (pinned at the FIRST increment).
         vi.setSystemTime(ttl + 1);
 
         // The window expired, so the counter starts over. Under the TTL-clearing
-        // bug the 2nd incr wiped the expiry, the key never expired, and this
+        // bug the 2nd increment wiped the expiry, the key never expired, and this
         // returned 3 (an ever-growing permanent counter — the rate limit never
         // reset). It must be 1.
-        expect(await store.incr('rate', ttl)).toBe(1);
+        expect(await store.increment('rate', ttl)).toBe(1);
     });
 
-    test('within one window incrs accumulate (1, 2, 3) without any early reset', async () => {
+    test('within one window increments accumulate (1, 2, 3) without any early reset', async () => {
         vi.useFakeTimers();
         vi.setSystemTime(0);
         const store = denoKvStore(expiryKv());
         const ttl = 1000;
 
-        expect(await store.incr('rate', ttl)).toBe(1);
+        expect(await store.increment('rate', ttl)).toBe(1);
         // Time advances but stays INSIDE the window — no reset, no extension.
         vi.setSystemTime(400);
-        expect(await store.incr('rate', ttl)).toBe(2);
+        expect(await store.increment('rate', ttl)).toBe(2);
         vi.setSystemTime(900);
-        expect(await store.incr('rate', ttl)).toBe(3);
+        expect(await store.increment('rate', ttl)).toBe(3);
     });
 
-    test('the window deadline is FIXED, not sliding: later incrs never push it out', async () => {
+    test('the window deadline is FIXED, not sliding: later increments never push it out', async () => {
         vi.useFakeTimers();
         vi.setSystemTime(0);
         const store = denoKvStore(expiryKv());
         const ttl = 200;
 
-        expect(await store.incr('rate', ttl)).toBe(1); // deadline pinned at 200
+        expect(await store.increment('rate', ttl)).toBe(1); // deadline pinned at 200
         vi.setSystemTime(150);
-        expect(await store.incr('rate', ttl)).toBe(2); // must NOT reset to t=350
+        expect(await store.increment('rate', ttl)).toBe(2); // must NOT reset to t=350
         // Cross the ORIGINAL deadline. A sliding window would still be alive here
         // (150 + 200 = 350); a fixed window has already expired at 200.
         vi.setSystemTime(210);
-        expect(await store.incr('rate', ttl)).toBe(1);
+        expect(await store.increment('rate', ttl)).toBe(1);
     });
 
     test('every commit carries a positive expireIn so the window can always expire', async () => {
@@ -263,9 +263,9 @@ describe('denoKvStore — incr TTL window', () => {
         const rec = recordingKv();
         const store = denoKvStore(rec.kv);
 
-        expect(await store.incr('rate', 1000)).toBe(1);
-        expect(await store.incr('rate', 1000)).toBe(2);
-        expect(await store.incr('rate', 1000)).toBe(3);
+        expect(await store.increment('rate', 1000)).toBe(1);
+        expect(await store.increment('rate', 1000)).toBe(2);
+        expect(await store.increment('rate', 1000)).toBe(3);
 
         // No `undefined` — the entry never loses its expiry on a later write.
         for (const s of rec.atomicSets) {
@@ -278,27 +278,27 @@ describe('denoKvStore — incr TTL window', () => {
     test('a legacy bare-number counter (pre-upgrade value) self-heals into a fresh window', async () => {
         // On a deploy transition an old value could be a bare number with no
         // window envelope. The store must treat it as a fresh window rather than
-        // crash or read NaN — incr returns 1 and the value is now well-formed.
+        // crash or read NaN — increment returns 1 and the value is now well-formed.
         vi.useFakeTimers();
         vi.setSystemTime(0);
         const kv = expiryKv();
         await kv.set(['legacy'], 7); // an old bare counter, no deadline
         const store = denoKvStore(kv);
 
-        expect(await store.incr('legacy', 200)).toBe(1);
-        expect(await store.incr('legacy', 200)).toBe(2);
+        expect(await store.increment('legacy', 200)).toBe(1);
+        expect(await store.increment('legacy', 200)).toBe(2);
     });
 
     test('throws after exhausting maxIncrRetries lost compare-and-set races', async () => {
         const rec = recordingKv({ failAtomic: true });
         const store = denoKvStore(rec.kv, { maxIncrRetries: 3 });
-        await expect(store.incr('x', 1000)).rejects.toThrow(
+        await expect(store.increment('x', 1000)).rejects.toThrow(
             /lost 4 compare-and-set races/,
         );
     });
 });
 
-describe('denoKvStore — incr without a window', () => {
+describe('denoKvStore — increment without a window', () => {
     afterEach(() => {
         vi.useRealTimers();
     });
@@ -308,11 +308,11 @@ describe('denoKvStore — incr without a window', () => {
         vi.setSystemTime(0);
         const store = denoKvStore(expiryKv());
 
-        expect(await store.incr('count')).toBe(1);
+        expect(await store.increment('count')).toBe(1);
         // Arbitrarily far in the future — a windowless counter never resets.
         vi.setSystemTime(1_000_000_000);
-        expect(await store.incr('count')).toBe(2);
-        expect(await store.incr('count')).toBe(3);
+        expect(await store.increment('count')).toBe(2);
+        expect(await store.increment('count')).toBe(3);
         // `get` unwraps the envelope to the plain count, windowed or not.
         expect(await store.get('count')).toBe(3);
     });
@@ -321,9 +321,9 @@ describe('denoKvStore — incr without a window', () => {
         const rec = recordingKv();
         const store = denoKvStore(rec.kv);
 
-        expect(await store.incr('count')).toBe(1);
-        expect(await store.incr('count', 0)).toBe(2);
-        expect(await store.incr('count', -5)).toBe(3);
+        expect(await store.increment('count')).toBe(1);
+        expect(await store.increment('count', 0)).toBe(2);
+        expect(await store.increment('count', -5)).toBe(3);
 
         // A windowless counter is written WITHOUT an expiry, matching `set`'s
         // no-TTL path — the key must never silently gain a window.
@@ -331,17 +331,17 @@ describe('denoKvStore — incr without a window', () => {
         for (const s of rec.atomicSets) expect(s.expireIn).toBeUndefined();
     });
 
-    test('a live windowless counter keeps counting even when a later incr passes a ttl', async () => {
+    test('a live windowless counter keeps counting even when a later increment passes a ttl', async () => {
         // Mirrors memoryStore: a LIVE counter keeps its original (absent) window;
         // a later ttl neither expires it nor resets the count.
         vi.useFakeTimers();
         vi.setSystemTime(0);
         const store = denoKvStore(expiryKv());
 
-        expect(await store.incr('count')).toBe(1); // windowless
-        expect(await store.incr('count', 200)).toBe(2); // ttl ignored — still live
+        expect(await store.increment('count')).toBe(1); // windowless
+        expect(await store.increment('count', 200)).toBe(2); // ttl ignored — still live
         vi.setSystemTime(500); // past the ttl that was ignored
-        expect(await store.incr('count')).toBe(3);
+        expect(await store.increment('count')).toBe(3);
     });
 });
 

--- a/packages/deno-kv/test/store-behaviour.spec.ts
+++ b/packages/deno-kv/test/store-behaviour.spec.ts
@@ -2,6 +2,7 @@
 // (`conformance.spec.ts`) does not pin down: the FIXED-window TTL rule (the
 // counter's window has an absolute deadline pinned at creation — later incrs in
 // the same window neither extend nor clear it, and a fresh window restarts at 1),
+// the NO-window rule (an incr without a ttl — or with ttl <= 0 — never expires),
 // the compare-and-set retry EXHAUSTION error, the array-key shape (flat vs
 // prefixed), the cache-delete (`set(k, undefined)`), and `close()` delegation.
 // Driven by two fakes: a recording KV that captures every write's `expireIn`, and
@@ -294,6 +295,53 @@ describe('denoKvStore — incr TTL window', () => {
         await expect(store.incr('x', 1000)).rejects.toThrow(
             /lost 4 compare-and-set races/,
         );
+    });
+});
+
+describe('denoKvStore — incr without a window', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    test('absent ttl = no window: the counter accumulates and never expires', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        const store = denoKvStore(expiryKv());
+
+        expect(await store.incr('count')).toBe(1);
+        // Arbitrarily far in the future — a windowless counter never resets.
+        vi.setSystemTime(1_000_000_000);
+        expect(await store.incr('count')).toBe(2);
+        expect(await store.incr('count')).toBe(3);
+        // `get` unwraps the envelope to the plain count, windowed or not.
+        expect(await store.get('count')).toBe(3);
+    });
+
+    test('ttl <= 0 unifies with absent: no window, and no commit carries an expireIn', async () => {
+        const rec = recordingKv();
+        const store = denoKvStore(rec.kv);
+
+        expect(await store.incr('count')).toBe(1);
+        expect(await store.incr('count', 0)).toBe(2);
+        expect(await store.incr('count', -5)).toBe(3);
+
+        // A windowless counter is written WITHOUT an expiry, matching `set`'s
+        // no-TTL path — the key must never silently gain a window.
+        expect(rec.atomicSets).toHaveLength(3);
+        for (const s of rec.atomicSets) expect(s.expireIn).toBeUndefined();
+    });
+
+    test('a live windowless counter keeps counting even when a later incr passes a ttl', async () => {
+        // Mirrors memoryStore: a LIVE counter keeps its original (absent) window;
+        // a later ttl neither expires it nor resets the count.
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        const store = denoKvStore(expiryKv());
+
+        expect(await store.incr('count')).toBe(1); // windowless
+        expect(await store.incr('count', 200)).toBe(2); // ttl ignored — still live
+        vi.setSystemTime(500); // past the ttl that was ignored
+        expect(await store.incr('count')).toBe(3);
     });
 });
 

--- a/packages/deno-kv/tsup.config.ts
+++ b/packages/deno-kv/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup';
 
 // Single dual-format entry; `stitchapi` is the only peer dep, externalised by
 // tsup. The Deno KV surface is a structural interface (no runtime client), so
-// the bundle is just the store + the atomic-incr logic.
+// the bundle is just the store + the atomic-increment logic.
 export default defineConfig({
     entry: ['src/index.ts'],
     format: ['cjs', 'esm'],

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -72,7 +72,7 @@ useReconnectRefetch(q, { netInfo: NetInfo });
 
 ## The secure store
 
-`expoSecureStore(SecureStore, options?)` reuses the AsyncStorage store's logic (JSON envelope, TTL, serialized atomic `incr`) over SecureStore's `*Async` methods. Engine keys are hex-encoded into SecureStore's restricted key charset (`[A-Za-z0-9._-]`). Keep individual values under SecureStore's ~2 KB limit — auth tokens fit comfortably. For non-secret throttle counters, pair it with the re-exported `asyncStorageStore`.
+`expoSecureStore(SecureStore, options?)` reuses the AsyncStorage store's logic (JSON envelope, TTL, serialized atomic `increment`) over SecureStore's `*Async` methods. Engine keys are hex-encoded into SecureStore's restricted key charset (`[A-Za-z0-9._-]`). Keep individual values under SecureStore's ~2 KB limit — auth tokens fit comfortably. For non-secret throttle counters, pair it with the re-exported `asyncStorageStore`.
 
 ## License
 

--- a/packages/expo/src/store.ts
+++ b/packages/expo/src/store.ts
@@ -3,7 +3,7 @@
 // jars are stored encrypted at rest rather than in plaintext AsyncStorage.
 //
 // It REUSES @stitchapi/react-native's `asyncStorageStore` for all the store logic
-// (JSON envelope, TTL, serialized atomic incr); only two things differ from
+// (JSON envelope, TTL, serialized atomic increment); only two things differ from
 // AsyncStorage and live here: the `*Async` method names, and SecureStore's
 // restricted key charset (keys allow only `[A-Za-z0-9._-]`), which we satisfy by
 // hex-encoding every engine key.

--- a/packages/nest/src/bridges.ts
+++ b/packages/nest/src/bridges.ts
@@ -183,14 +183,14 @@ export function fromNestConfig(
 }
 
 /**
- * Wrap a store the package does **not** own: `get`/`set`/`incr` delegate, but `close` is
+ * Wrap a store the package does **not** own: `get`/`set`/`increment` delegate, but `close` is
  * omitted, so a seam's `close()` never tears down a store the app passed in (ADR 0006
  * Decision 8). The app — not the package — disposes a store it provides.
  */
 export function nestBorrowStore(store: StitchStore): StitchStore {
     return {
         get: (key) => store.get(key),
-        set: (key, value, ttlMs) => store.set(key, value, ttlMs),
-        incr: (key, ttlMs) => store.incr(key, ttlMs),
+        set: (key, value, ttl) => store.set(key, value, ttl),
+        increment: (key, ttl) => store.increment(key, ttl),
     };
 }

--- a/packages/nest/test/bridges.spec.ts
+++ b/packages/nest/test/bridges.spec.ts
@@ -251,7 +251,7 @@ describe('fromNestConfig', () => {
 // --- borrowStore -----------------------------------------------------------
 
 describe('nestBorrowStore', () => {
-    test('delegates get/set/incr but omits close, so a seam cannot dispose the app store', async () => {
+    test('delegates get/set/increment but omits close, so a seam cannot dispose the app store', async () => {
         const seen: string[] = [];
         let closed = false;
         const store: StitchStore = {
@@ -262,8 +262,8 @@ describe('nestBorrowStore', () => {
             set: async (k, v, ttl) => {
                 seen.push(`set:${k}=${String(v)}@${String(ttl)}`);
             },
-            incr: async (k, ttl) => {
-                seen.push(`incr:${k}@${ttl}`);
+            increment: async (k, ttl) => {
+                seen.push(`increment:${k}@${ttl}`);
                 return 7;
             },
             close: async () => {
@@ -278,9 +278,9 @@ describe('nestBorrowStore', () => {
 
         expect(await borrowed.get('a')).toBe('v');
         await borrowed.set('b', 'x', 1000);
-        expect(await borrowed.incr('c', 2000)).toBe(7);
+        expect(await borrowed.increment('c', 2000)).toBe(7);
 
-        expect(seen).toEqual(['get:a', 'set:b=x@1000', 'incr:c@2000']);
+        expect(seen).toEqual(['get:a', 'set:b=x@1000', 'increment:c@2000']);
         expect(closed).toBe(false);
     });
 });

--- a/packages/nest/test/module.spec.ts
+++ b/packages/nest/test/module.spec.ts
@@ -264,7 +264,7 @@ describe('defineStitch token', () => {
 });
 
 describe('bridges', () => {
-    it('nestBorrowStore delegates get/set/incr but omits close', async () => {
+    it('nestBorrowStore delegates get/set/increment but omits close', async () => {
         const calls: string[] = [];
         const backing: StitchStore = {
             get: async () => {
@@ -274,8 +274,8 @@ describe('bridges', () => {
             set: async () => {
                 calls.push('set');
             },
-            incr: async () => {
-                calls.push('incr');
+            increment: async () => {
+                calls.push('increment');
                 return 2;
             },
             close: async () => {
@@ -286,8 +286,8 @@ describe('bridges', () => {
         expect(borrowed.close).toBeUndefined();
         expect(await borrowed.get('k')).toBe(1);
         await borrowed.set('k', 'v');
-        expect(await borrowed.incr('k', 1)).toBe(2);
-        expect(calls).toEqual(['get', 'set', 'incr']); // close is never delegated
+        expect(await borrowed.increment('k', 1)).toBe(2);
+        expect(calls).toEqual(['get', 'set', 'increment']); // close is never delegated
     });
 
     // A NestLoggerLike that records messages per level.

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -88,7 +88,7 @@ Both subscriptions are also available as plain functions — `onAppActive(appSta
 
 ## The persistent store
 
-`asyncStorageStore(storage, options?)` accepts any client matching `{ getItem, setItem, removeItem }` (the community AsyncStorage module, an MMKV shim, a test double). Values ride in a JSON envelope with an absolute expiry (AsyncStorage has no native TTL); `incr` is serialized so concurrent increments stay atomic — the throttle counter behaves exactly as it does on Redis. Pass `keyPrefix` to namespace, `now` to inject a clock in tests.
+`asyncStorageStore(storage, options?)` accepts any client matching `{ getItem, setItem, removeItem }` (the community AsyncStorage module, an MMKV shim, a test double). Values ride in a JSON envelope with an absolute expiry (AsyncStorage has no native TTL); `increment` is serialized so concurrent increments stay atomic — the throttle counter behaves exactly as it does on Redis. Pass `keyPrefix` to namespace, `now` to inject a clock in tests.
 
 ## License
 

--- a/packages/react-native/src/store.ts
+++ b/packages/react-native/src/store.ts
@@ -103,7 +103,7 @@ export function asyncStorageStore(
         async get(key) {
             return (await readEnvelope(key))?.v;
         },
-        async set(key, value, ttlMs) {
+        async set(key, value, ttl) {
             // `set(key, undefined)` is the cache's delete (ADR 0003 §8).
             if (value === undefined) {
                 await storage.removeItem(k(key));
@@ -111,19 +111,23 @@ export function asyncStorageStore(
             }
             await write(
                 key,
-                ttlMs === undefined
-                    ? { v: value }
-                    : { v: value, e: now() + ttlMs },
+                ttl === undefined ? { v: value } : { v: value, e: now() + ttl },
             );
         },
-        incr(key, ttlMs) {
+        incr(key, ttl) {
             return serialize(async () => {
                 const env = await readEnvelope(key);
                 const current = typeof env?.v === 'number' ? env.v : 0;
                 const next = current + 1;
                 // Set the expiry only when CREATING the counter, never extending it,
                 // so a busy window still resets once it lapses (matches redisStore).
-                const expiry = env === undefined ? now() + ttlMs : env.e;
+                // An absent `ttl` means no window — the counter never expires.
+                const expiry =
+                    env === undefined
+                        ? ttl === undefined
+                            ? undefined
+                            : now() + ttl
+                        : env.e;
                 await write(
                     key,
                     expiry === undefined ? { v: next } : { v: next, e: expiry },

--- a/packages/react-native/src/store.ts
+++ b/packages/react-native/src/store.ts
@@ -55,7 +55,7 @@ interface Envelope {
  * const api = seam({ store: asyncStorageStore(AsyncStorage) });
  * ```
  *
- * `incr` is serialized through an in-process queue so concurrent increments stay
+ * `increment` is serialized through an in-process queue so concurrent increments stay
  * atomic (RN is single-threaded, and a device-local store has one writer) — the
  * throttle counter behaves exactly as it does on Redis.
  */
@@ -86,7 +86,7 @@ export function asyncStorageStore(
     const write = (key: string, env: Envelope): Promise<void> =>
         storage.setItem(k(key), JSON.stringify(env));
 
-    // Serialize read-modify-write increments so 20 concurrent `incr` calls return
+    // Serialize read-modify-write increments so 20 concurrent `increment` calls return
     // 1..20 exactly (the store contract's atomicity rule). AsyncStorage has no
     // atomic INCR, but a single-threaded JS queue gives the same guarantee.
     let tail: Promise<unknown> = Promise.resolve();
@@ -114,7 +114,7 @@ export function asyncStorageStore(
                 ttl === undefined ? { v: value } : { v: value, e: now() + ttl },
             );
         },
-        incr(key, ttl) {
+        increment(key, ttl) {
             return serialize(async () => {
                 const env = await readEnvelope(key);
                 const current = typeof env?.v === 'number' ? env.v : 0;

--- a/packages/react-native/test/store.spec.ts
+++ b/packages/react-native/test/store.spec.ts
@@ -51,6 +51,14 @@ describe('asyncStorageStore', () => {
         expect(await store.get('k')).toBe('v');
     });
 
+    test('incr without a ttl never expires (no window)', async () => {
+        let t = 0;
+        const store = asyncStorageStore(fakeAsyncStorage(), { now: () => t });
+        expect(await store.incr('c')).toBe(1);
+        t = 10_000_000;
+        expect(await store.incr('c')).toBe(2);
+    });
+
     test('incr resets to 1 once its TTL window lapses', async () => {
         let t = 0;
         const store = asyncStorageStore(fakeAsyncStorage(), { now: () => t });

--- a/packages/react-native/test/store.spec.ts
+++ b/packages/react-native/test/store.spec.ts
@@ -1,5 +1,5 @@
 // asyncStorageStore conformance + the AsyncStorage-specific behaviours (TTL via a
-// JSON envelope, serialized atomic incr) the generic contract can't express
+// JSON envelope, serialized atomic increment) the generic contract can't express
 // deterministically.
 import { asyncStorageStore } from '../src/store';
 import type { AsyncStorageLike } from '../src/store';
@@ -7,7 +7,7 @@ import type { AsyncStorageLike } from '../src/store';
 import { assertConformance, verifyStoreContract } from 'stitchapi/testing';
 import { describe, expect, test } from 'vitest';
 
-// A Map-backed AsyncStorage double with async resolution, so concurrent `incr`
+// A Map-backed AsyncStorage double with async resolution, so concurrent `increment`
 // calls genuinely interleave at await points — exercising the store's serializer.
 function fakeAsyncStorage(): AsyncStorageLike {
     const map = new Map<string, string>();
@@ -51,27 +51,27 @@ describe('asyncStorageStore', () => {
         expect(await store.get('k')).toBe('v');
     });
 
-    test('incr without a ttl never expires (no window)', async () => {
+    test('increment without a ttl never expires (no window)', async () => {
         let t = 0;
         const store = asyncStorageStore(fakeAsyncStorage(), { now: () => t });
-        expect(await store.incr('c')).toBe(1);
+        expect(await store.increment('c')).toBe(1);
         t = 10_000_000;
-        expect(await store.incr('c')).toBe(2);
+        expect(await store.increment('c')).toBe(2);
     });
 
-    test('incr resets to 1 once its TTL window lapses', async () => {
+    test('increment resets to 1 once its TTL window lapses', async () => {
         let t = 0;
         const store = asyncStorageStore(fakeAsyncStorage(), { now: () => t });
-        expect(await store.incr('c', 100)).toBe(1);
-        expect(await store.incr('c', 100)).toBe(2);
+        expect(await store.increment('c', 100)).toBe(1);
+        expect(await store.increment('c', 100)).toBe(2);
         t = 200; // window lapsed
-        expect(await store.incr('c', 100)).toBe(1);
+        expect(await store.increment('c', 100)).toBe(1);
     });
 
-    test('concurrent incr stays atomic', async () => {
+    test('concurrent increment stays atomic', async () => {
         const store = asyncStorageStore(fakeAsyncStorage());
         const results = await Promise.all(
-            Array.from({ length: 20 }, () => store.incr('n', 60_000)),
+            Array.from({ length: 20 }, () => store.increment('n', 60_000)),
         );
         expect(results.sort((a, b) => a - b)).toEqual(
             Array.from({ length: 20 }, (_, i) => i + 1),

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -67,12 +67,12 @@ const store = redisStore({
     get: (k) => myClient.get(k),
     set: (k, v, ttl) => myClient.set(k, v, ttl),
     delete: (k) => myClient.del(k),
-    incr: (k, ttl) => myClient.incrWithWindow(k, ttl), // atomic INCR + first-time PEXPIRE
+    increment: (k, ttl) => myClient.incrWithWindow(k, ttl), // atomic INCR + first-time PEXPIRE
 });
 ```
 
-`ttl` (ms) is optional on both `set` and `incr` — absent means no expiry / no
-window. When a `ttl` is given, `incr` must be **atomic** and set it **only when
+`ttl` (ms) is optional on both `set` and `increment` — absent means no expiry / no
+window. When a `ttl` is given, `increment` must be **atomic** and set it **only when
 it creates the counter** — `fromIoredis` / `fromNodeRedis` do this with a single
 Lua `EVAL` (`INCR`, then `PEXPIRE` only when the value is `1`), so a window
 can't slide forever and a crash can't strand an immortal counter.

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -65,16 +65,17 @@ import { redisStore } from '@stitchapi/redis';
 
 const store = redisStore({
     get: (k) => myClient.get(k),
-    set: (k, v, ttlMs) => myClient.set(k, v, ttlMs),
-    del: (k) => myClient.del(k),
-    incr: (k, ttlMs) => myClient.incrWithTtl(k, ttlMs), // atomic INCR + first-time PEXPIRE
+    set: (k, v, ttl) => myClient.set(k, v, ttl),
+    delete: (k) => myClient.del(k),
+    incr: (k, ttl) => myClient.incrWithWindow(k, ttl), // atomic INCR + first-time PEXPIRE
 });
 ```
 
-`incr` must be **atomic** and set the key's TTL **only when it creates the
-counter** — `fromIoredis` / `fromNodeRedis` do this with a single Lua `EVAL`
-(`INCR`, then `PEXPIRE` only when the value is `1`), so a window can't slide
-forever and a crash can't strand an immortal counter.
+`ttl` (ms) is optional on both `set` and `incr` — absent means no expiry / no
+window. When a `ttl` is given, `incr` must be **atomic** and set it **only when
+it creates the counter** — `fromIoredis` / `fromNodeRedis` do this with a single
+Lua `EVAL` (`INCR`, then `PEXPIRE` only when the value is `1`), so a window
+can't slide forever and a crash can't strand an immortal counter.
 
 The store owns no connection: `store.close()` delegates to the driver, so you
 decide when the client shuts down.

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -33,7 +33,7 @@ import type { StitchStore } from 'stitchapi';
  * primitives only. `redisStore` layers the JSON envelope and key prefixing on
  * top; a driver only moves opaque strings and one atomic counter.
  *
- * `incr(key, ttl)` MUST be atomic and, when `ttl` is given, set the key's
+ * `increment(key, ttl)` MUST be atomic and, when `ttl` is given, set the key's
  * expiry **only when it creates the counter** (the first increment), never
  * extending it afterwards — otherwise a busy rate window would slide forever
  * and never reset. An absent `ttl` means **no window**: a plain atomic `INCR`,
@@ -52,7 +52,7 @@ export interface RedisDriver {
      * first-time `PEXPIRE key ttl` is bound to the creating increment; absent
      * `ttl` = no expiry.
      */
-    incr(key: string, ttl?: number): Promise<number>;
+    increment(key: string, ttl?: number): Promise<number>;
     /** Release the connection (optional — `redisStore().close()` delegates here). */
     close?(): Promise<void>;
 }
@@ -153,7 +153,7 @@ export function fromIoredis(client: IoredisLike): RedisDriver {
         async delete(key) {
             await client.del(key);
         },
-        async incr(key, ttl) {
+        async increment(key, ttl) {
             // ioredis: eval(script, numKeys, ...keysThenArgs). 0 = no window.
             return Number(await client.eval(INCR_SCRIPT, 1, key, ttl ?? 0));
         },
@@ -186,7 +186,7 @@ export function fromNodeRedis(client: NodeRedisLike): RedisDriver {
         async delete(key) {
             await client.del(key);
         },
-        async incr(key, ttl) {
+        async increment(key, ttl) {
             // node-redis: eval(script, { keys, arguments }); ARGV are strings.
             // '0' = no window.
             return Number(
@@ -240,7 +240,7 @@ export function fromUpstash(client: UpstashLike): RedisDriver {
         async delete(key) {
             await client.del(key);
         },
-        async incr(key, ttl) {
+        async increment(key, ttl) {
             // Upstash: eval(script, keys[], args[]); ARGV are strings. '0' = no window.
             return Number(
                 await client.eval(INCR_SCRIPT, [key], [String(ttl ?? 0)]),
@@ -276,7 +276,7 @@ export interface RedisStoreOptions {
  * ```
  *
  * Values round-trip through a JSON envelope; the throttle's atomic counters use
- * the driver's native `incr`. The store owns no connection — `close()` delegates
+ * the driver's native `increment`. The store owns no connection — `close()` delegates
  * to the driver, so the caller decides when the client shuts down.
  */
 export function redisStore(
@@ -305,8 +305,8 @@ export function redisStore(
             }
             await driver.set(k(key), JSON.stringify(value), ttl);
         },
-        incr(key, ttl) {
-            return driver.incr(k(key), ttl);
+        increment(key, ttl) {
+            return driver.increment(k(key), ttl);
         },
     };
     if (driver.close) {

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -33,11 +33,12 @@ import type { StitchStore } from 'stitchapi';
  * primitives only. `redisStore` layers the JSON envelope and key prefixing on
  * top; a driver only moves opaque strings and one atomic counter.
  *
- * `incr(key, ttl)` MUST be atomic and set the key's expiry **only when it
- * creates the counter** (the first increment), never extending it afterwards —
- * otherwise a busy rate window would slide forever and never reset. {@link
- * fromIoredis} / {@link fromNodeRedis} guarantee this with a Lua `EVAL`; a custom
- * driver must do the same.
+ * `incr(key, ttl)` MUST be atomic and, when `ttl` is given, set the key's
+ * expiry **only when it creates the counter** (the first increment), never
+ * extending it afterwards — otherwise a busy rate window would slide forever
+ * and never reset. An absent `ttl` means **no window**: a plain atomic `INCR`,
+ * the counter never expires. {@link fromIoredis} / {@link fromNodeRedis}
+ * guarantee this with a Lua `EVAL`; a custom driver must do the same.
  */
 export interface RedisDriver {
     /** `GET key` — the raw stored string, or `null` when absent. */
@@ -45,20 +46,27 @@ export interface RedisDriver {
     /** `SET key value` (no TTL) or `SET key value PX ttl` when `ttl` is set. */
     set(key: string, value: string, ttl?: number): Promise<void>;
     /** `DEL key`. */
-    del(key: string): Promise<void>;
-    /** Atomic `INCR key` + first-time `PEXPIRE key ttl`; resolves to the new count. */
-    incr(key: string, ttl: number): Promise<number>;
+    delete(key: string): Promise<void>;
+    /**
+     * Atomic `INCR key`; resolves to the new count. When `ttl` (ms) is set, a
+     * first-time `PEXPIRE key ttl` is bound to the creating increment; absent
+     * `ttl` = no expiry.
+     */
+    incr(key: string, ttl?: number): Promise<number>;
     /** Release the connection (optional — `redisStore().close()` delegates here). */
     close?(): Promise<void>;
 }
 
-// Atomic counter-with-window. INCR is atomic on its own; the EXPIRE is bound to
-// it in one server-side script so the TTL is set exactly once — on the increment
-// that creates the window (`v == 1`) — and a crash can never leave an immortal
-// counter. Redis caches the script body after the first EVAL, so re-sending it is
-// cheap; EVALSHA would shave the bytes but isn't worth the dialect surface here.
-const INCR_WITH_TTL = `local v = redis.call('INCR', KEYS[1])
-if v == 1 then redis.call('PEXPIRE', KEYS[1], ARGV[1]) end
+// Atomic counter-with-optional-window. INCR is atomic on its own; the EXPIRE is
+// bound to it in one server-side script so the TTL is set exactly once — on the
+// increment that creates the window (`v == 1`) — and a crash can never leave an
+// immortal counter. ARGV[1] = 0 encodes an absent `ttl` (a deliberate no-window
+// counter: plain INCR, no expiry — the adapters send `ttl ?? 0`). Redis caches
+// the script body after the first EVAL, so re-sending it is cheap; EVALSHA would
+// shave the bytes but isn't worth the dialect surface here.
+const INCR_SCRIPT = `local v = redis.call('INCR', KEYS[1])
+local ttl = tonumber(ARGV[1]) or 0
+if v == 1 and ttl > 0 then redis.call('PEXPIRE', KEYS[1], ttl) end
 return v`;
 
 // ---------------------------------------------------------------------------
@@ -142,12 +150,12 @@ export function fromIoredis(client: IoredisLike): RedisDriver {
             if (ttl == null) await client.set(key, value);
             else await client.set(key, value, 'PX', ttl);
         },
-        async del(key) {
+        async delete(key) {
             await client.del(key);
         },
         async incr(key, ttl) {
-            // ioredis: eval(script, numKeys, ...keysThenArgs).
-            return Number(await client.eval(INCR_WITH_TTL, 1, key, ttl));
+            // ioredis: eval(script, numKeys, ...keysThenArgs). 0 = no window.
+            return Number(await client.eval(INCR_SCRIPT, 1, key, ttl ?? 0));
         },
         async close() {
             await client.quit?.();
@@ -175,15 +183,16 @@ export function fromNodeRedis(client: NodeRedisLike): RedisDriver {
             if (ttl == null) await client.set(key, value);
             else await client.set(key, value, { PX: ttl });
         },
-        async del(key) {
+        async delete(key) {
             await client.del(key);
         },
         async incr(key, ttl) {
             // node-redis: eval(script, { keys, arguments }); ARGV are strings.
+            // '0' = no window.
             return Number(
-                await client.eval(INCR_WITH_TTL, {
+                await client.eval(INCR_SCRIPT, {
                     keys: [key],
-                    arguments: [String(ttl)],
+                    arguments: [String(ttl ?? 0)],
                 }),
             );
         },
@@ -228,13 +237,13 @@ export function fromUpstash(client: UpstashLike): RedisDriver {
             if (ttl == null) await client.set(key, value);
             else await client.set(key, value, { px: ttl });
         },
-        async del(key) {
+        async delete(key) {
             await client.del(key);
         },
         async incr(key, ttl) {
-            // Upstash: eval(script, keys[], args[]); ARGV are strings.
+            // Upstash: eval(script, keys[], args[]); ARGV are strings. '0' = no window.
             return Number(
-                await client.eval(INCR_WITH_TTL, [key], [String(ttl)]),
+                await client.eval(INCR_SCRIPT, [key], [String(ttl ?? 0)]),
             );
         },
     };
@@ -291,7 +300,7 @@ export function redisStore(
         async set(key, value, ttl) {
             // `set(key, undefined)` is the cache's delete (ADR 0003 §8) — drop the key.
             if (value === undefined) {
-                await driver.del(k(key));
+                await driver.delete(k(key));
                 return;
             }
             await driver.set(k(key), JSON.stringify(value), ttl);

--- a/packages/redis/test/conformance.spec.ts
+++ b/packages/redis/test/conformance.spec.ts
@@ -7,7 +7,7 @@
 // an ioredis-shaped, a node-redis-shaped and an Upstash-shaped facade, so each
 // adapter's dialect translation is exercised without a server. Single-threaded JS
 // makes the engine atomic, which is exactly what the real `EVAL` guarantees — so
-// the contract's "20 concurrent incrs net +20" rule holds here, on real Redis,
+// the contract's "20 concurrent increments net +20" rule holds here, on real Redis,
 // and on Upstash's edge HTTP Redis alike.
 //
 // Set REDIS_URL to additionally run the SAME verifier against a live Redis via a
@@ -190,14 +190,14 @@ describe('@stitchapi/redis store contract', () => {
     });
 });
 
-// --- no-window incr (absent ttl) -------------------------------------------
+// --- no-window increment (absent ttl) -------------------------------------------
 //
-// `StitchStore.incr(key)` without a ttl means "no window": the counter never
+// `StitchStore.increment(key)` without a ttl means "no window": the counter never
 // expires. The adapters encode the absent ttl as ARGV[1] = 0 and the script
 // skips the PEXPIRE; the fake engine mirrors that (0 → no expiry), so this
 // pins each dialect's translation of the sentinel end to end.
 
-describe('incr without a ttl never expires (no window)', () => {
+describe('increment without a ttl never expires (no window)', () => {
     const stores = [
         [
             'fromIoredis',
@@ -221,11 +221,11 @@ describe('incr without a ttl never expires (no window)', () => {
     test.each(stores)('%s', async (_name, makeStore) => {
         const store = makeStore();
         // A windowed counter alongside proves the wait outlives a real window.
-        await store.incr('windowed', 40);
-        expect(await store.incr('unwindowed')).toBe(1);
+        await store.increment('windowed', 40);
+        expect(await store.increment('unwindowed')).toBe(1);
         await new Promise((resolve) => setTimeout(resolve, 90));
-        expect(await store.incr('windowed', 40)).toBe(1); // window expired → restart
-        expect(await store.incr('unwindowed')).toBe(2); // no window → still counting
+        expect(await store.increment('windowed', 40)).toBe(1); // window expired → restart
+        expect(await store.increment('unwindowed')).toBe(2); // no window → still counting
     });
 });
 
@@ -254,7 +254,7 @@ describe.skipIf(!REDIS_URL)('against a real Redis (REDIS_URL)', () => {
         }
     });
 
-    test('incr without a ttl never expires (the real Lua skips PEXPIRE on 0)', async () => {
+    test('increment without a ttl never expires (the real Lua skips PEXPIRE on 0)', async () => {
         const mod = (await import('ioredis')) as unknown as {
             default: new (url: string) => IoredisLike & {
                 quit(): Promise<unknown>;
@@ -264,9 +264,9 @@ describe.skipIf(!REDIS_URL)('against a real Redis (REDIS_URL)', () => {
         const store = redisStore(fromIoredis(client));
         const key = `stitch-conformance:no-window-${Date.now().toString(36)}`;
         try {
-            await store.incr(key);
+            await store.increment(key);
             await new Promise((resolve) => setTimeout(resolve, 90));
-            expect(await store.incr(key)).toBe(2); // no window → still counting
+            expect(await store.increment(key)).toBe(2); // no window → still counting
         } finally {
             await store.set(key, undefined); // drop the immortal counter
             await client.quit();

--- a/packages/redis/test/conformance.spec.ts
+++ b/packages/redis/test/conformance.spec.ts
@@ -16,7 +16,7 @@ import { fromIoredis, fromNodeRedis, fromUpstash, redisStore } from '../src';
 import type { IoredisLike, NodeRedisLike, UpstashLike } from '../src';
 
 import { assertConformance, verifyStoreContract } from 'stitchapi/testing';
-import { describe, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 // --- a faithful in-memory Redis engine ------------------------------------
 
@@ -57,10 +57,15 @@ class FakeRedisEngine {
 
     // The INCR + first-time-PEXPIRE script, run atomically (no await between read
     // and write — the JS event loop can't interleave it, just as Redis can't).
-    incrWithTtl(key: string, ttlMs: number): number {
+    // Mirrors the Lua exactly: ARGV[1] = 0 means no window — the counter is
+    // created without an expiry (the adapters send `ttl ?? 0`).
+    incrScript(key: string, ttlMs: number): number {
         const e = this.live(key);
         if (!e) {
-            this.data.set(key, { value: '1', expiresAt: Date.now() + ttlMs });
+            this.data.set(key, {
+                value: '1',
+                expiresAt: ttlMs > 0 ? Date.now() + ttlMs : Infinity,
+            });
             return 1;
         }
         const v = Number(e.value) + 1;
@@ -91,7 +96,7 @@ function ioredisFacade(engine: FakeRedisEngine): IoredisLike {
         },
         async eval(_script, _numKeys, ...args) {
             const [key, ttlMs] = args;
-            return engine.incrWithTtl(String(key), Number(ttlMs));
+            return engine.incrScript(String(key), Number(ttlMs));
         },
         async quit() {
             return 'OK';
@@ -115,7 +120,7 @@ function nodeRedisFacade(engine: FakeRedisEngine): NodeRedisLike {
         async eval(_script, options) {
             const key = options.keys[0] ?? '';
             const ttlMs = Number(options.arguments[0]);
-            return engine.incrWithTtl(key, ttlMs);
+            return engine.incrScript(key, ttlMs);
         },
         async quit() {
             return 'OK';
@@ -150,7 +155,7 @@ function upstashFacade(engine: FakeRedisEngine): UpstashLike {
         async eval(_script, keys, args) {
             const key = keys[0] ?? '';
             const ttlMs = Number(args[0]);
-            return engine.incrWithTtl(key, ttlMs);
+            return engine.incrScript(key, ttlMs);
         },
     };
 }
@@ -185,6 +190,45 @@ describe('@stitchapi/redis store contract', () => {
     });
 });
 
+// --- no-window incr (absent ttl) -------------------------------------------
+//
+// `StitchStore.incr(key)` without a ttl means "no window": the counter never
+// expires. The adapters encode the absent ttl as ARGV[1] = 0 and the script
+// skips the PEXPIRE; the fake engine mirrors that (0 → no expiry), so this
+// pins each dialect's translation of the sentinel end to end.
+
+describe('incr without a ttl never expires (no window)', () => {
+    const stores = [
+        [
+            'fromIoredis',
+            (): ReturnType<typeof redisStore> =>
+                redisStore(fromIoredis(ioredisFacade(new FakeRedisEngine()))),
+        ],
+        [
+            'fromNodeRedis',
+            (): ReturnType<typeof redisStore> =>
+                redisStore(
+                    fromNodeRedis(nodeRedisFacade(new FakeRedisEngine())),
+                ),
+        ],
+        [
+            'fromUpstash',
+            (): ReturnType<typeof redisStore> =>
+                redisStore(fromUpstash(upstashFacade(new FakeRedisEngine()))),
+        ],
+    ] as const;
+
+    test.each(stores)('%s', async (_name, makeStore) => {
+        const store = makeStore();
+        // A windowed counter alongside proves the wait outlives a real window.
+        await store.incr('windowed', 40);
+        expect(await store.incr('unwindowed')).toBe(1);
+        await new Promise((resolve) => setTimeout(resolve, 90));
+        expect(await store.incr('windowed', 40)).toBe(1); // window expired → restart
+        expect(await store.incr('unwindowed')).toBe(2); // no window → still counting
+    });
+});
+
 // --- opt-in: against a real Redis -----------------------------------------
 
 const REDIS_URL = process.env['REDIS_URL'];
@@ -206,6 +250,25 @@ describe.skipIf(!REDIS_URL)('against a real Redis (REDIS_URL)', () => {
                 ),
             );
         } finally {
+            await client.quit();
+        }
+    });
+
+    test('incr without a ttl never expires (the real Lua skips PEXPIRE on 0)', async () => {
+        const mod = (await import('ioredis')) as unknown as {
+            default: new (url: string) => IoredisLike & {
+                quit(): Promise<unknown>;
+            };
+        };
+        const client = new mod.default(REDIS_URL as string);
+        const store = redisStore(fromIoredis(client));
+        const key = `stitch-conformance:no-window-${Date.now().toString(36)}`;
+        try {
+            await store.incr(key);
+            await new Promise((resolve) => setTimeout(resolve, 90));
+            expect(await store.incr(key)).toBe(2); // no window → still counting
+        } finally {
+            await store.set(key, undefined); // drop the immortal counter
             await client.quit();
         }
     });

--- a/packages/redis/test/store.spec.ts
+++ b/packages/redis/test/store.spec.ts
@@ -19,16 +19,16 @@ function recordingDriver(over: { close?: () => Promise<void> } = {}): {
             calls.push(['get', key]);
             return data.get(key) ?? null;
         },
-        async set(key, value, ttlMs) {
-            calls.push(['set', key, value, ttlMs]);
+        async set(key, value, ttl) {
+            calls.push(['set', key, value, ttl]);
             data.set(key, value);
         },
-        async del(key) {
-            calls.push(['del', key]);
+        async delete(key) {
+            calls.push(['delete', key]);
             data.delete(key);
         },
-        async incr(key, ttlMs) {
-            calls.push(['incr', key, ttlMs]);
+        async incr(key, ttl) {
+            calls.push(['incr', key, ttl]);
             return 1;
         },
         ...(over.close ? { close: over.close } : {}),
@@ -57,6 +57,19 @@ describe('redisStore — key mapping', () => {
         await redisStore(driver).set('k', 'v');
         expect(calls[0]).toEqual(['set', 'k', JSON.stringify('v'), undefined]);
     });
+
+    test('an absent ttl passes through as absent on set and incr (no expiry / no window)', async () => {
+        const { driver, calls } = recordingDriver();
+        const store = redisStore(driver);
+
+        await store.set('k', 'v');
+        await store.incr('c');
+
+        expect(calls).toEqual([
+            ['set', 'k', JSON.stringify('v'), undefined],
+            ['incr', 'c', undefined],
+        ]);
+    });
 });
 
 describe('redisStore — values & delete', () => {
@@ -71,7 +84,7 @@ describe('redisStore — values & delete', () => {
     test('set(key, undefined) deletes the prefixed key (cache delete) and writes nothing', async () => {
         const { driver, calls } = recordingDriver();
         await redisStore(driver, { keyPrefix: 'app:' }).set('k', undefined);
-        expect(calls).toEqual([['del', 'app:k']]);
+        expect(calls).toEqual([['delete', 'app:k']]);
     });
 });
 

--- a/packages/redis/test/store.spec.ts
+++ b/packages/redis/test/store.spec.ts
@@ -27,8 +27,8 @@ function recordingDriver(over: { close?: () => Promise<void> } = {}): {
             calls.push(['delete', key]);
             data.delete(key);
         },
-        async incr(key, ttl) {
-            calls.push(['incr', key, ttl]);
+        async increment(key, ttl) {
+            calls.push(['increment', key, ttl]);
             return 1;
         },
         ...(over.close ? { close: over.close } : {}),
@@ -37,18 +37,18 @@ function recordingDriver(over: { close?: () => Promise<void> } = {}): {
 }
 
 describe('redisStore — key mapping', () => {
-    test('applies keyPrefix to every key on get / set / incr', async () => {
+    test('applies keyPrefix to every key on get / set / increment', async () => {
         const { driver, calls } = recordingDriver();
         const store = redisStore(driver, { keyPrefix: 'app:' });
 
         await store.set('k', 'v', 1000);
         await store.get('k');
-        await store.incr('c', 2000);
+        await store.increment('c', 2000);
 
         expect(calls).toEqual([
             ['set', 'app:k', JSON.stringify('v'), 1000],
             ['get', 'app:k'],
-            ['incr', 'app:c', 2000],
+            ['increment', 'app:c', 2000],
         ]);
     });
 
@@ -58,16 +58,16 @@ describe('redisStore — key mapping', () => {
         expect(calls[0]).toEqual(['set', 'k', JSON.stringify('v'), undefined]);
     });
 
-    test('an absent ttl passes through as absent on set and incr (no expiry / no window)', async () => {
+    test('an absent ttl passes through as absent on set and increment (no expiry / no window)', async () => {
         const { driver, calls } = recordingDriver();
         const store = redisStore(driver);
 
         await store.set('k', 'v');
-        await store.incr('c');
+        await store.increment('c');
 
         expect(calls).toEqual([
             ['set', 'k', JSON.stringify('v'), undefined],
-            ['incr', 'c', undefined],
+            ['increment', 'c', undefined],
         ]);
     });
 });

--- a/packages/redis/test/upstash-roundtrip.spec.ts
+++ b/packages/redis/test/upstash-roundtrip.spec.ts
@@ -75,7 +75,7 @@ describe('fromUpstash — JSON-parseable string values round-trip', () => {
     });
 
     test('a bare INCR counter (Upstash returns a number) round-trips', async () => {
-        // A counter is written by `incr`, not `set`, so the stored value is the
+        // A counter is written by `increment`, not `set`, so the stored value is the
         // bare string "1"; Upstash's auto-deserialize turns that reply into the
         // number 1. `fromUpstash.get` must re-serialize it to "1" so
         // `redisStore.get` reads back the number 1, not `undefined`/a throw.


### PR DESCRIPTION
Extracts the **store-contract** slice from #470 (the contract-freeze sweep) so every KV store speaks one contract.

- **`incr` → `increment`** on `StitchStore` and `RedisDriver`. This is the other half of `del`→`delete`: P18 rejects `del` because it is a wire abbreviation, and `incr` is the same thing — shipping one without the other left the house contract reading `get`/`set`/`delete`/`incr`, which teaches neither convention. Applied to core `memoryStore`/`vaultView`, `@stitchapi/redis` (all three adapters), `@stitchapi/deno-kv`, `@stitchapi/cloudflare-kv`, `@stitchapi/react-native` (and `@stitchapi/expo`, which reuses it), the `nestBorrowStore` bridge, and `verifyStoreContract`.
- **`del` → `delete`** on the driver contract — only `@stitchapi/redis`'s `RedisDriver` was still on `del`; deno-kv / cloudflare-kv / react-native were already on `delete` and are untouched.
- **`StitchStore.increment(key, ttl)` → `increment(key, ttl?)`** — an absent ttl means "no window, never expires." Applied to core `memoryStore`, `@stitchapi/redis` (all three adapters), `@stitchapi/deno-kv`, and `@stitchapi/react-native`. `@stitchapi/cloudflare-kv` needs no change (Workers KV has no atomic increment — its `increment` already throws).

The Redis **commands** are deliberately untouched: the Lua still calls `INCR`, and the `IoredisLike` / `NodeRedisLike` / `UpstashLike` mirrors still expose `del`. That is P18's first half doing its job — a duck-type that mirrors a foreign SDK keeps that SDK's spelling — not an exception to the second.

### Contract changes

- **P18** now states the rule that was previously only implied by a single example: house contracts use **whole words, never a wire abbreviation**, with both `delete`/`del` and `increment`/`incr` given, plus the why (`DEL`/`INCR` are terse because they cross a socket; a TypeScript method name is read, not transmitted) and the explicit note that the Redis command names stay verbatim wherever the code speaks Redis. Without this, the rule reads as half-applied and the next reader can't tell which verbs were meant to keep the abbreviation.
- **P19 is rescoped from the change to the channel.** It was "no pre-GA hard break — every rename MUST ship a `@deprecated` alias"; it is now "the alias obligation is scoped to the GA channel." On a prerelease tag (`rc`/`beta`/`canary`) a mandated rename MAY land as a hard break, declared under BREAKING CHANGE with a one-line `CHANGELOG.md` migration; once 1.0 GA ships the obligation is in force. Rationale: a prerelease is the window semver sets aside for exactly this, and alias tax paid during it buys back-compat for a population that accepted breakage by installing an `rc` — while accumulating a second vocabulary the GA cut then has to delete.
  - **Aliases already shipped stay** — the `*Ms` durations, `keyOf`, `StatusMatch` and the rest keep their identity tests until the GA cut removes them together. Relaxing the rule forward does not retroactively demand their removal; pulling one now would itself be a break, for no gain.
  - **Corollary:** contracts the consumer *implements* (`StitchStore`, `RedisDriver`, `Adapter`, `TraceSink`, `AuthStrategy`) cannot alias in *any* channel — there is no `new ?? old` to read, so an "alias" means typing both spellings optional forever and letting an implementation satisfy the type while providing neither verb. Post-GA that makes such a rename a major-version change, not an aliasable one.
- The §6 backlog row for `RedisDriver.del` moves out of "proposed" into the shipped list (the remaining `…quit` / sync `close` work stays listed), and `deno-kv maxIncrRetries` is listed with its target spelling.

`maxIncrRetries` itself is **not** renamed here — it is a P4 `max`-prefix violation and belongs to that slice, same as the scope split the original PR describes.

### No deprecated aliases

Both renames ship as hard breaks: core is at `1.0.0-rc.6`, a prerelease tag, so P19 as rescoped above imposes no alias — and as consumer-implemented contracts they could not have carried one anyway. Recorded in `CHANGELOG.md` under `[Unreleased]` with the one-line migration. Blast radius is bounded: an implementor renames a method and the compiler names every site. The bundled stores are all updated, so this only bites a hand-rolled `StitchStore` or `RedisDriver`.

ADRs 0003 and 0006 quote the old spelling in their decision text; both get an amendment note in the established ADR 0007 style (read `incr` as `increment`) rather than a rewrite, since neither decision is affected.

### Gates

`build` · full-workspace `check:types` (34 packages + docs, 0 errors) · `check:types-d` · tests (core 1207, redis 21, deno-kv 15, cloudflare-kv 11, react-native 23, expo 5, nest 49, docs 59) · `check:contract` (no new violations, 5 baselined) · `check:exports` · `check:docs-links` (110 routes) · `check:lint` · `check:media-fresh` · `check:format` · all 9 yakir tethers (0 drift) · `@stitchapi/docs` build (437/437 pages) — green. Every `lefthook` pre-push job was run individually.

The docs build is the load-bearing one here: `guides/state/pluggable-store` has a bare ```ts twoslash fence that annotates an object literal as `StitchStore`, so it is typechecked against the real built interface — a missed rename on either side fails the build rather than shipping stale docs.

### BREAKING CHANGE

`StitchStore.incr` is renamed to `increment`, and `@stitchapi/redis`'s `RedisDriver` renames both `incr`→`increment` and `del`→`delete`. `increment`'s `ttl` parameter is now optional (widening; existing call sites unaffected). No `@deprecated` aliases: P19 (rescoped here) scopes that obligation to the GA channel, and this lands on `rc` — and a consumer-implemented contract could not carry one in any case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
