### PR TITLE
feat(core)!: reject `{}` at the last five config slots — Scalar|AtLeastOne (P20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <a href="https://www.npmjs.com/package/stitchapi"><img alt="npm version" src="https://img.shields.io/npm/v/stitchapi?color=2563EB&label=npm" /></a>
   <a href="https://www.npmjs.com/package/stitchapi?activeTab=dependencies"><img alt="Dependencies: 0" src="https://img.shields.io/badge/dependencies-0-brightgreen" /></a>
   <img alt="npm bundle size (minified + gzipped)" src="https://img.shields.io/bundlephobia/minzip/stitchapi" />
-  <img alt="Bundle: ~24 kB min+gzip" src="https://img.shields.io/badge/min%2Bgzip-~24%20kB-2563EB" />
+  <img alt="Bundle: ~25 kB min+gzip" src="https://img.shields.io/badge/min%2Bgzip-~25%20kB-2563EB" />
 </p>
 
 <!-- yakir:readme-badges -->
@@ -42,7 +42,7 @@
 </p>
 
 <p align="center">
-  <strong>Zero runtime dependencies · ~24&nbsp;kB min+gzip</strong> — a typical <code>import { stitch }</code> tree-shakes to ~20&nbsp;kB, and with no transitive tree there is nothing else to install or audit. The size is an <a href="packages/core/scripts/bundle-size.mjs">enforced budget in CI</a>, not an aspiration.
+  <strong>Zero runtime dependencies · ~25&nbsp;kB min+gzip</strong> — a typical <code>import { stitch }</code> tree-shakes to ~20&nbsp;kB, and with no transitive tree there is nothing else to install or audit. The size is an <a href="packages/core/scripts/bundle-size.mjs">enforced budget in CI</a>, not an aspiration.
 </p>
 
 <p align="center">
@@ -168,7 +168,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 -   **Pluggable state store** — throttle counters and sessions behind a 3-method store; swap in Redis/Postgres to go distributed.
 -   **Zero-infra observability** — tracing is **off by default**; opt in per stitch or via `STITCH_TRACE_*` env vars. No collector, no dashboard.
 -   **Four front doors, one definition** — in-process function, CLI (`stitch run`), HTTP (`stitch serve`), and MCP (`stitch mcp`).
--   **Zero runtime dependencies** — `"dependencies": {}`, built on global `fetch`, tree-shakeable; **~24 kB min+gzip** for the whole entry, **~20 kB** for a typical `import { stitch }`.
+-   **Zero runtime dependencies** — `"dependencies": {}`, built on global `fetch`, tree-shakeable; **~25 kB min+gzip** for the whole entry, **~20 kB** for a typical `import { stitch }`.
 
 ## Install
 

--- a/apps/docs/app/(home)/components/metrics.tsx
+++ b/apps/docs/app/(home)/components/metrics.tsx
@@ -5,7 +5,7 @@ const metrics = [
         body: 'Built on the platform’s global fetch — nothing to install, nothing to audit, nothing in your transitive tree.',
     },
     {
-        value: '~24 kB',
+        value: '~25 kB',
         unit: 'min + gzip',
         body: 'The whole stitchapi entry, tree-shaken — and it is an enforced budget in CI, not an aspiration.',
     },

--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -32,20 +32,20 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
         {
             label: "multipart",
             type: "property",
-            detail: "MultipartOptions",
-            info: "Multipart serialisation options (ADR 0005 Decision 6) — how nested objects/arrays become field names. Only meaningful with `bodyType: 'multipart'`. Default nesting `'bracket'`.",
+            detail: "MultipartNesting | AtLeastOne<MultipartOptions>",
+            info: "Multipart serialisation options (ADR 0005 Decision 6) — how nested objects/arrays become field names. Only meaningful with `bodyType: 'multipart'`. Default nesting `'bracket'`. A bare  string is shorthand for the object form — `multipart: 'dot'` ≡ `multipart: { nesting: 'dot' }` (CONTRACT.md P12); the opaque `multipart: {}` is rejected (P20).",
         },
         {
             label: "stream",
             type: "property",
-            detail: "StreamOptions",
-            info: "Streaming options (ADR 0005 Decision 5) — how a `stream` surface decodes the live body (`'bytes'` default / `'lines'` / `'ndjson'` / `'json'`). `'json'` is the structural, unframed streaming-JSON decoder (issue #111): one `delta` per complete value / top-level array element, tolerant of internal newlines and concatenated values. Only meaningful for the `stream` surface.",
+            detail: "StreamDecode | AtLeastOne<StreamOptions>",
+            info: "Streaming options (ADR 0005 Decision 5) — how a `stream` surface decodes the live body (`'bytes'` default / `'lines'` / `'ndjson'` / `'json'`). `'json'` is the structural, unframed streaming-JSON decoder (issue #111): one `delta` per complete value / top-level array element, tolerant of internal newlines and concatenated values. Only meaningful for the `stream` surface. A bare  string is shorthand for the object form — `stream: 'ndjson'` ≡ `stream: { decode: 'ndjson' }` (CONTRACT.md P12); the opaque `stream: {}` is rejected (P20).",
         },
         {
             label: "sse",
             type: "property",
-            detail: "SseOptions",
-            info: "Resumable-SSE options (issue #71) — sibling to , but for the `sse` surface. **Off by default**: with no `sse.reconnect` the engine opens the live body once (today's behaviour). When enabled, a dropped stream reconnects, replaying the last `id:` as `Last-Event-ID` and honouring a server `retry:` (else `reconnect.backoff` / the `retry` policy), capped at `reconnect.attempts`. Plain JSON (the contract gate). Only the `sse` surface reads it.",
+            detail: "boolean | AtLeastOne<SseOptions>",
+            info: "Resumable-SSE options (issue #71) — sibling to , but for the `sse` surface. **Off by default**: with no `sse` block the engine opens the live body once (today's behaviour). When enabled, a dropped stream reconnects, replaying the last `id:` as `Last-Event-ID` and honouring a server `retry:` (else `reconnect.backoff` / the `retry` policy), capped at `reconnect.attempts`. Plain JSON (the contract gate). Only the `sse` surface reads it. `true` is shorthand for `{ reconnect: true }` (CONTRACT.md P13); the object form must set at least one field (P20).",
         },
         {
             label: "responseType",
@@ -92,8 +92,8 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
         {
             label: "input",
             type: "property",
-            detail: "InputSchemas",
-            info: "Schemas validating params, query, body, headers, and (GraphQL) variables before the request.",
+            detail: "AtLeastOne<InputSchemas>",
+            info: "Schemas validating params, query, body, headers, and (GraphQL) variables before the request. At least one slot must be set — the opaque `input: {}` is rejected (CONTRACT.md P20).",
         },
         {
             label: "output",
@@ -182,8 +182,8 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
         {
             label: "hooks",
             type: "property",
-            detail: "Hooks",
-            info: "Request/response/error/retry lifecycle hooks.",
+            detail: "AtLeastOne<Hooks>",
+            info: "Request/response/error/retry lifecycle hooks. At least one — the opaque `hooks: {}` is rejected (CONTRACT.md P20).",
         },
         {
             label: "extends",

--- a/apps/docs/content/docs/concepts/principles.mdx
+++ b/apps/docs/content/docs/concepts/principles.mdx
@@ -105,7 +105,7 @@ behind its own import — so an app never ships bytes for a CLI it will not run.
 The same frugality the event stream practices with an agent's context, the
 package practices with your bundle.
 
-Concretely, the whole `stitch` entry is **~24 kB minified + gzipped**
+Concretely, the whole `stitch` entry is **~25 kB minified + gzipped**
 (≈61 kB raw), and because every surface beyond `http` is a separate subpath
 import, a typical `import { stitch }` tree-shakes to **~20 kB**. With zero
 runtime dependencies, that figure is the entire cost — not the tip of a

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -5,7 +5,7 @@ description: 'Install stitchapi and set up the zero-dependency runtime in Node o
 
 Install the package, import `stitch`, and turn your first endpoint into a typed,
 callable function. `stitchapi` has zero dependencies and runs anywhere `fetch`
-does — Node, the browser, and edge runtimes. The whole entry is **~24 kB
+does — Node, the browser, and edge runtimes. The whole entry is **~25 kB
 minified + gzipped** — and with no dependencies, there is no transitive tree
 behind it (a typical `import { stitch }` tree-shakes to ~20 kB).
 

--- a/apps/docs/content/docs/reference/surfaces.mdx
+++ b/apps/docs/content/docs/reference/surfaces.mdx
@@ -78,14 +78,16 @@ for await (const ev of ticks.stream()) {
 
 `stream` is the raw streaming sibling — it hands back the response body decoded
 per `stream.decode`: `'bytes'` (the default, lossless `Uint8Array` chunks),
-`'lines'` (UTF-8 lines), or `'ndjson'` (a parsed value per line).
+`'lines'` (UTF-8 lines), or `'ndjson'` (a parsed value per line). The bare
+decoder is shorthand for the object form — `stream: 'ndjson'` ≡
+`stream: { decode: 'ndjson' }` (the opaque `stream: {}` is rejected).
 
 ```ts
 import { stream } from 'stitchapi/stream';
 
 const logs = stream({
     url: 'https://api.example.com/logs',
-    stream: { decode: 'ndjson' },
+    stream: 'ndjson',
 });
 
 for await (const ev of logs.stream()) {

--- a/apps/docs/lib/source.ts
+++ b/apps/docs/lib/source.ts
@@ -25,7 +25,7 @@ Search these docs instead of loading the whole file: this site is also a hosted 
 - Capability, not credential: an agent invokes a stitch and gets structured, validated, traceable data; the secret stays behind the boundary.
 - One context-frugal **code-mode** tool (run_stitch + list_stitches + describe_stitch), not one tool per endpoint — adding APIs never floods the context window.
 - No server, no codegen, no config files — a URL and one example response is enough; only explicit composition (no ambient/global config a stitch silently inherits).
-- Zero-dependency core, ~24 kB min+gzip for the whole entry (~20 kB for a tree-shaken import { stitch }), validator-agnostic (bring your own Standard Schema / Zod), and it runs in the browser.
+- Zero-dependency core, ~25 kB min+gzip for the whole entry (~20 kB for a tree-shaken import { stitch }), validator-agnostic (bring your own Standard Schema / Zod), and it runs in the browser.
 - Composes with your data layer: a stitch is the queryFn for TanStack Query / SWR — it owns the call's resilience; your query layer owns view state.
 
 ## Quickstart

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -447,9 +447,8 @@ will apply under `@deprecated` aliases (P18). Severity = consumer blast radius.
 | Low  | `RedisDriver.del`, `…quit`, sync `close`                           | `delete`, async `close`                 | P18  |
 | Low  | `bodyKind` (from-curl)                                             | `bodyType`                              | P1   |
 
-New shorthand/toggle slots to **add** (additive, non-breaking): `stream`, `multipart`,
-`sse`, `.inspect()` scalars (P12); `idempotency` boolean (P13-toggle);
-`throttle` string (P14).
+New shorthand/toggle slots to **add** (additive, non-breaking): `.inspect()`
+scalars (P12); `idempotency` boolean (P13-toggle); `throttle` string (P14).
 
 **Shipped (migration in progress)** — all under `@deprecated` aliases read until the GA
 cut; the lint skips the deprecated members so each rename ratchets the baseline down:
@@ -541,6 +540,14 @@ cut; the lint skips the deprecated members so each rename ratchets the baseline 
     rich shape is assignable to the minimal one (a real stitch satisfies both), so it is **de-listed**.
     With this, **R5 is fully cleared** — the baseline is now 6, exactly R6's P20 backlog
     (multipart/stream/sse/throttle/hooks/input → `Scalar | AtLeastOne`).
+-   **P20/P12/P13 (empty-object rejection)** the five bare all-optional `StitchConfig` slots R6 flagged
+    now type their object form so `{}` is a **compile error**: `hooks?: AtLeastOne<Hooks>` and
+    `input?: AtLeastOne<InputSchemas>` (no scalar); `multipart?: MultipartNesting | AtLeastOne<MultipartOptions>`
+    and `stream?: StreamDecode | AtLeastOne<StreamOptions>` (P12 dominant-field scalar); and
+    `sse?: boolean | AtLeastOne<SseOptions>` (P13 toggle). `expandShorthand` folds each scalar into its
+    envelope at compose time (`multipart: 'dot'` → `{ nesting }`, `stream: 'ndjson'` → `{ decode }`,
+    `sse: true` → `{ reconnect: true }`; `sse: false` clears the slot), so the engine and `__config`
+    only ever see the object form. **R6 clears** — the baseline is now **0**.
 
 ## 7. Enforcement
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -120,7 +120,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 -   **CLI, HTTP & MCP surfaces** - the definition your code imports is also runnable from the shell (`stitch run <name>` streams JSONL events), served over HTTP (`stitch serve`), or exposed to agents over MCP (`stitch mcp`) — the same stitch behind every front door.
 -   **Typed URLs** - full [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) URI templates (`{id}`, `{+path}`, `{?q,sort}`, explode `*`, prefix `:n`), and a `qs`-style query builder that serializes nested objects (`a[b]=c`) and arrays — both dependency-free.
 -   **Pluggable transport** - `fetch` by default; drop in the shipped `axiosAdapter`, or any `Adapter` function, to route requests through axios or another HTTP client.
--   **Zero runtime dependencies** - `"dependencies": {}`; built on the platform's global `fetch`; tree-shakeable. The whole entry is **~24 kB min+gzip**; a typical `import { stitch }` trims to **~20 kB** — and with no transitive tree, that is the entire cost.
+-   **Zero runtime dependencies** - `"dependencies": {}`; built on the platform's global `fetch`; tree-shakeable. The whole entry is **~25 kB min+gzip**; a typical `import { stitch }` trims to **~20 kB** — and with no transitive tree, that is the entire cost.
 
 ## Documentation
 
@@ -162,7 +162,7 @@ const { stitch } = require("stitchapi");
 
 The runtime ships with zero dependencies. Schema validation is bring-your-own — pass a [Zod](https://zod.dev) schema or any [Standard Schema](https://standardschema.dev) validator ([Valibot](https://valibot.dev), [ArkType](https://arktype.io), …); none of them is bundled. The examples below use Zod for familiarity.
 
-**Bundle size.** The whole `stitchapi` entry is **~24 kB minified + gzipped** (~64 kB raw, ~20 kB brotli); because the package is side-effect-free and every surface beyond `http` lives behind its own subpath import, a typical `import { stitch }` tree-shakes to **~20 kB min+gzip**. With zero dependencies, that is the _whole_ cost — there is no transitive tree to install or audit.
+**Bundle size.** The whole `stitchapi` entry is **~25 kB minified + gzipped** (~64 kB raw, ~20 kB brotli); because the package is side-effect-free and every surface beyond `http` lives behind its own subpath import, a typical `import { stitch }` tree-shakes to **~20 kB min+gzip**. With zero dependencies, that is the _whole_ cost — there is no transitive tree to install or audit.
 
 ## Quick start
 
@@ -679,14 +679,14 @@ for await (const ev of events.stream()) {
 }
 ```
 
-`stream` is the raw sibling — `decode: 'bytes'` (default), `'lines'`, or `'ndjson'`:
+`stream` is the raw sibling — `decode: 'bytes'` (default), `'lines'`, or `'ndjson'`; the bare decoder is shorthand for the object (`stream: 'ndjson'` ≡ `stream: { decode: 'ndjson' }`):
 
 ```ts
 import { stream } from 'stitchapi/stream';
 
 const logs = stream({
     url: 'https://demo.stitchapi.dev/logs',
-    stream: { decode: 'ndjson' },
+    stream: 'ndjson',
 });
 
 for await (const ev of logs.stream()) {

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -146,7 +146,16 @@ function expandShorthand(cfg: Partial<StitchConfig>): void {
         cfg.timeout = { total: cfg.timeout };
     if (typeof cfg.cache === 'number' || typeof cfg.cache === 'string')
         cfg.cache = { ttl: cfg.cache };
+    // P12: the dominant-field scalar of `stream`/`multipart` folds into its envelope, so the opaque
+    // `{}` never reaches the slot (P20) and the engine only ever sees the object form.
+    if (typeof cfg.stream === 'string') cfg.stream = { decode: cfg.stream };
+    if (typeof cfg.multipart === 'string')
+        cfg.multipart = { nesting: cfg.multipart };
     if (typeof cfg.throttle === 'string') cfg.throttle = { rate: cfg.throttle };
+    // P13: `sse: true` enables reconnection with defaults; `false`/absent is off (the opaque
+    // `sse: {}` is a type error at the slot, so the all-defaults case arrives here as `true`).
+    if (cfg.sse === true) cfg.sse = { reconnect: true };
+    else if (cfg.sse === false) delete cfg.sse;
     // P20: `idempotency: true` enables it with defaults; `false`/absent is off. Normalize the
     // boolean toggle to the object form the engine reads (the opaque `idempotency: {}` is a type
     // error at the slot, so the all-defaults case arrives here as `true`).
@@ -197,16 +206,19 @@ export function compose(config: Fragment): ResolvedStitchConfig {
         // last to set it and set it off.
         if (idempotencyToggle === false) delete merged.idempotency;
     }
+    // The chained hooks / normalized input are the RESOLVED shapes (plain `Hooks`/`InputSchemas`),
+    // past the authoring-side `AtLeastOne` gate (P20) — write them through the resolved view.
+    const resolved = merged as ResolvedStitchConfig;
     const hooks = chainHooks(hookLayers);
-    if (hooks) merged.hooks = hooks;
+    if (hooks) resolved.hooks = hooks;
     if (store) merged.store = store;
     if (kind) merged.kind = kind;
     const output = normalizeOutput(merged.output);
     if (output !== undefined) merged.output = output;
     const input = normalizeInput(merged.input);
-    if (input !== undefined) merged.input = input;
-    // `expandShorthand` ran on every layer, so retry/timeout/cache are now their object form.
-    return merged as ResolvedStitchConfig;
+    if (input !== undefined) resolved.input = input;
+    // `expandShorthand` ran on every layer, so every scalar shorthand is now its envelope form.
+    return resolved;
 }
 
 // Construction-time nudges for `idempotency` misuse — hints with an out, never errors. Two cases,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -647,26 +647,32 @@ export interface StitchConfig {
     bodyType?: 'json' | 'form' | 'multipart';
     /**
      * Multipart serialisation options (ADR 0005 Decision 6) — how nested objects/arrays become
-     * field names. Only meaningful with `bodyType: 'multipart'`. Default nesting `'bracket'`.
+     * field names. Only meaningful with `bodyType: 'multipart'`. Default nesting `'bracket'`. A
+     * bare {@link MultipartNesting} string is shorthand for the object form —
+     * `multipart: 'dot'` ≡ `multipart: { nesting: 'dot' }` (CONTRACT.md P12); the opaque
+     * `multipart: {}` is rejected (P20).
      */
-    multipart?: MultipartOptions;
+    multipart?: MultipartNesting | AtLeastOne<MultipartOptions>;
     /**
      * Streaming options (ADR 0005 Decision 5) — how a `stream` surface decodes the live body
      * (`'bytes'` default / `'lines'` / `'ndjson'` / `'json'`). `'json'` is the structural,
      * unframed streaming-JSON decoder (issue #111): one `delta` per complete value / top-level
      * array element, tolerant of internal newlines and concatenated values. Only meaningful for
-     * the `stream` surface.
+     * the `stream` surface. A bare {@link StreamDecode} string is shorthand for the object form —
+     * `stream: 'ndjson'` ≡ `stream: { decode: 'ndjson' }` (CONTRACT.md P12); the opaque
+     * `stream: {}` is rejected (P20).
      */
-    stream?: StreamOptions;
+    stream?: StreamDecode | AtLeastOne<StreamOptions>;
     /**
      * Resumable-SSE options (issue #71) — sibling to {@link StitchConfig.stream}, but for the `sse`
-     * surface. **Off by default**: with no `sse.reconnect` the engine opens the live body once
+     * surface. **Off by default**: with no `sse` block the engine opens the live body once
      * (today's behaviour). When enabled, a dropped stream reconnects, replaying the last `id:` as
      * `Last-Event-ID` and honouring a server `retry:` (else `reconnect.backoff` / the `retry`
      * policy), capped at `reconnect.attempts`. Plain JSON (the contract gate). Only the `sse`
-     * surface reads it.
+     * surface reads it. `true` is shorthand for `{ reconnect: true }` (CONTRACT.md P13); the
+     * object form must set at least one field (P20).
      */
-    sse?: SseOptions;
+    sse?: boolean | AtLeastOne<SseOptions>;
     /** How to read the response body. Default: auto by content-type. */
     responseType?: ResponseType;
     /**
@@ -696,8 +702,11 @@ export interface StitchConfig {
      * (e.g. a multi-operation document) or pass `''` to suppress the field entirely.
      */
     operationName?: string;
-    /** Schemas validating params, query, body, headers, and (GraphQL) variables before the request. */
-    input?: InputSchemas;
+    /**
+     * Schemas validating params, query, body, headers, and (GraphQL) variables before the request.
+     * At least one slot must be set — the opaque `input: {}` is rejected (CONTRACT.md P20).
+     */
+    input?: AtLeastOne<InputSchemas>;
     /**
      * Response schema, or a {@link DriftSpec} for leveled drift detection. Accepts any
      * {@link SchemaLike} — a raw Zod schema, any Standard Schema (Valibot, ArkType), or a
@@ -776,8 +785,8 @@ export interface StitchConfig {
      * - `'repeat'`            — `ids=1&ids=2`
      */
     arrayFormat?: 'indices' | 'brackets' | 'repeat';
-    /** Request/response/error/retry lifecycle hooks. */
-    hooks?: Hooks;
+    /** Request/response/error/retry lifecycle hooks. At least one — the opaque `hooks: {}` is rejected (CONTRACT.md P20). */
+    hooks?: AtLeastOne<Hooks>;
     /** Fragments to deep-merge under this config — strings, partials, or other stitches. */
     extends?: (Partial<StitchConfig> | Stitch | string)[];
     /** Test seam / custom transport. */
@@ -804,19 +813,35 @@ export interface StitchConfig {
 
 /**
  * A {@link StitchConfig} after {@link compose} has run: every authoring shorthand is expanded, so
- * the resilience fields are always their object form (a scalar `retry` / `timeout` / `cache` /
- * `throttle` literal is normalised to `{ attempts }` / `{ total }` / `{ ttl }` / `{ rate }`). This
- * is the shape the engine and {@link redactConfig} read — never the loose authoring union.
+ * the fields are always their object form (a scalar `retry` / `timeout` / `cache` / `throttle` /
+ * `stream` / `multipart` literal is normalised to `{ attempts }` / `{ total }` / `{ ttl }` /
+ * `{ rate }` / `{ decode }` / `{ nesting }`, the `sse: true` toggle to `{ reconnect: true }`, and
+ * the `hooks` / `input` envelopes to their chained/normalized object). This is the shape the engine
+ * and {@link redactConfig} read — never the loose authoring union.
  */
 export type ResolvedStitchConfig = Omit<
     StitchConfig,
-    'retry' | 'timeout' | 'cache' | 'idempotency' | 'throttle'
+    | 'retry'
+    | 'timeout'
+    | 'cache'
+    | 'idempotency'
+    | 'throttle'
+    | 'stream'
+    | 'multipart'
+    | 'sse'
+    | 'hooks'
+    | 'input'
 > & {
     retry?: RetryOptions;
     timeout?: TimeoutOptions;
     cache?: CacheOptions;
     idempotency?: IdempotencyOptions;
     throttle?: ThrottleOptions;
+    stream?: StreamOptions;
+    multipart?: MultipartOptions;
+    sse?: SseOptions;
+    hooks?: Hooks;
+    input?: InputSchemas;
 };
 
 /**

--- a/packages/core/test/composition.spec.ts
+++ b/packages/core/test/composition.spec.ts
@@ -279,6 +279,23 @@ test('scalar shorthands (retry/timeout/cache/throttle) expand to option objects'
     expect(resolved.throttle).toEqual({ rate: '1/s' });
 });
 
+// 6a) P20/P12/P13: the stream/multipart dominant-field scalars and the `sse` toggle fold to their
+// envelope at compose time (the opaque `{}` is rejected at the slot, so all-defaults arrives as the
+// scalar). `sse: false` clears the slot.
+test('stream/multipart scalars and the sse toggle expand to option objects', () => {
+    const resolved = compose({
+        path: 'https://api.example.com/x',
+        stream: 'ndjson',
+        multipart: 'dot',
+        sse: true,
+    });
+    expect(resolved.stream).toEqual({ decode: 'ndjson' });
+    expect(resolved.multipart).toEqual({ nesting: 'dot' });
+    expect(resolved.sse).toEqual({ reconnect: true });
+
+    expect(compose({ path: '/x', sse: false }).sse).toBeUndefined();
+});
+
 // 6b) A scalar shorthand folds over an inherited object via extends, preserving the siblings the
 // scalar doesn't name (deep-merge runs AFTER each layer is normalized).
 test('a scalar shorthand merges over an inherited object, preserving siblings', () => {

--- a/packages/core/test/config-at-least-one.spec.ts
+++ b/packages/core/test/config-at-least-one.spec.ts
@@ -1,0 +1,59 @@
+// P20 (No empty-object config): the five `StitchConfig` slots that used to be a bare all-optional
+// `*Options` bag — `hooks`, `input`, `multipart`, `sse`, `stream` — now reject the opaque `{}` at
+// the slot. The all-defaults case is the scalar (`sse: true`, `stream: 'ndjson'`, `multipart: 'dot'`)
+// or a real ≥1-field object; the empty object is a COMPILE error. These `@ts-expect-error` assertions
+// are enforced by `check:types` (an unused directive would itself fail), not at runtime — the
+// closures are never invoked.
+import { stitch } from '../src';
+
+test('the opaque `{}` is rejected at each Scalar|AtLeastOne slot (P20)', () => {
+    const rejected = () => [
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
+            // @ts-expect-error — `hooks: {}` is rejected; set at least one lifecycle hook.
+            hooks: {},
+        }),
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
+            // @ts-expect-error — `input: {}` is rejected; set at least one input schema.
+            input: {},
+        }),
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
+            // @ts-expect-error — `multipart: {}` is rejected; use `'dot'` or set `nesting`.
+            multipart: {},
+        }),
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
+            // @ts-expect-error — `sse: {}` is rejected; use `true` or set `reconnect`.
+            sse: {},
+        }),
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
+            // @ts-expect-error — `stream: {}` is rejected; use `'ndjson'` or set `decode`.
+            stream: {},
+        }),
+    ];
+    // The assertions that matter are the @ts-expect-error directives above (checked by `check:types`).
+    expect(typeof rejected).toBe('function');
+});
+
+test('the scalar / ≥1-field forms are accepted at each slot (P12/P13/P20)', () => {
+    const accepted = () => [
+        stitch({ baseUrl: 'https://x', path: '/y', multipart: 'dot' }),
+        stitch({ baseUrl: 'https://x', path: '/y', stream: 'ndjson' }),
+        stitch({ baseUrl: 'https://x', path: '/y', sse: true }),
+        stitch({ baseUrl: 'https://x', path: '/y', sse: { reconnect: true } }),
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
+            hooks: { onRequest: () => undefined },
+        }),
+    ];
+    expect(typeof accepted).toBe('function');
+});

--- a/scripts/contract-violations.baseline.json
+++ b/scripts/contract-violations.baseline.json
@@ -1,46 +1,5 @@
 {
     "generatedBy": "scripts/check-contract.mjs --update",
-    "count": 5,
-    "violations": [
-        {
-            "rule": "R6",
-            "file": "packages/core/src/types.ts",
-            "symbol": "StitchConfig.hooks",
-            "detail": "all-optional Hooks accepts {} → Scalar|AtLeastOne<Hooks> (P20)",
-            "line": 670,
-            "key": "R6|packages/core/src/types.ts|StitchConfig.hooks"
-        },
-        {
-            "rule": "R6",
-            "file": "packages/core/src/types.ts",
-            "symbol": "StitchConfig.input",
-            "detail": "all-optional InputSchemas accepts {} → Scalar|AtLeastOne<InputSchemas> (P20)",
-            "line": 670,
-            "key": "R6|packages/core/src/types.ts|StitchConfig.input"
-        },
-        {
-            "rule": "R6",
-            "file": "packages/core/src/types.ts",
-            "symbol": "StitchConfig.multipart",
-            "detail": "all-optional MultipartOptions accepts {} → Scalar|AtLeastOne<MultipartOptions> (P20)",
-            "line": 670,
-            "key": "R6|packages/core/src/types.ts|StitchConfig.multipart"
-        },
-        {
-            "rule": "R6",
-            "file": "packages/core/src/types.ts",
-            "symbol": "StitchConfig.sse",
-            "detail": "all-optional SseOptions accepts {} → Scalar|AtLeastOne<SseOptions> (P20)",
-            "line": 670,
-            "key": "R6|packages/core/src/types.ts|StitchConfig.sse"
-        },
-        {
-            "rule": "R6",
-            "file": "packages/core/src/types.ts",
-            "symbol": "StitchConfig.stream",
-            "detail": "all-optional StreamOptions accepts {} → Scalar|AtLeastOne<StreamOptions> (P20)",
-            "line": 670,
-            "key": "R6|packages/core/src/types.ts|StitchConfig.stream"
-        }
-    ]
+    "count": 0,
+    "violations": []
 }


### PR DESCRIPTION
## What

Carves **P20 (No empty-object config)** out of the monolithic contract-freeze sweep (#470) as a standalone hard-break against `main`. Closes the last of R6's P20 backlog.

The five `StitchConfig` slots R6 flagged as bare all-optional `*Options` bags now type their object form so the opaque `{}` is a **compile error**:

| slot | before | after |
| --- | --- | --- |
| `hooks` | `Hooks` | `AtLeastOne<Hooks>` |
| `input` | `InputSchemas` | `AtLeastOne<InputSchemas>` |
| `multipart` | `MultipartOptions` | `MultipartNesting \| AtLeastOne<MultipartOptions>` |
| `stream` | `StreamOptions` | `StreamDecode \| AtLeastOne<StreamOptions>` |
| `sse` | `SseOptions` | `boolean \| AtLeastOne<SseOptions>` |

The all-defaults case is now the **scalar**, not the opaque `{}`: `sse: true`, `stream: 'ndjson'`, `multipart: 'dot'` (P12/P13). `expandShorthand` folds each into its envelope at compose time (`multipart: 'dot'` → `{ nesting }`, `stream: 'ndjson'` → `{ decode }`, `sse: true` → `{ reconnect: true }`, `sse: false` clears the slot), so the engine and `__config` still only ever see the resolved object form — `ResolvedStitchConfig` omits + re-declares these five, and `compose` writes chained `hooks` / normalized `input` through the resolved view.

## Why

`docs/CONTRACT.md` **P20**: the empty object `{}` must not be a valid value at a config slot — where `{}` would mean "enable with defaults", that case must be a scalar. This is the enforcement teeth behind P13 and refines P15.

## Notes

- `scripts/contract-violations.baseline.json` shrinks **5 → 0** (R6 fully cleared).
- Whole-entry bundle ticks **24 → 25 kB** min+gzip (advertised sizes updated across all 7 sites); `import { stitch }` stays 20 kB.
- Regenerated playground completions (all 5 slots' detail/info updated).
- Tests: `composition.spec` asserts the new scalar folds resolve correctly; new `config-at-least-one.spec` pins the `{}`-rejection at each slot with `@ts-expect-error` (enforced by `check:types`).

## Gate

`build` · `check:types` (full workspace + test tsconfig) · `test` (1210 pass) · `check:contract` (**0** known violations) · `check:lint` · `prettier --check` — all green. Full pre-push gate (yakir bundle-advertised-size + build-docs + exports) passed.

## Breaking

BREAKING CHANGE: `StitchConfig.hooks`, `input`, `multipart`, `sse`, and `stream` no longer accept the empty object `{}`. Enable-with-defaults is now the scalar — `sse: true`, `stream: 'ndjson'`, `multipart: 'dot'` — and `hooks`/`input` require at least one field set. Object forms with ≥1 field are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)