### PR TITLE
refactor(auth)!: fold refreshOn/refreshSkew/refreshWhen into one `refresh` envelope (P24)

### DIFF
--- a/apps/docs/AUTHORING.md
+++ b/apps/docs/AUTHORING.md
@@ -108,7 +108,7 @@ const listUsers = stitch({
         loginInput: () => ({
             body: { email: env('APP_USER')(), password: env('APP_PASS')() },
         }),
-        refreshOn: 401,
+        refresh: 401,
     }),
 });
 ```
@@ -117,8 +117,9 @@ const listUsers = stitch({
 
 {/* Only the options that matter here, with defaults. Link to Reference for the
 exhaustive table — never paste a full type table into a guide (rule 6). */}
-`refreshOn` re-runs the login on a status code; `refreshWhen` re-runs it on a
-content predicate (for soft 200 walls). See
+`refresh` re-runs the login: a bare `StatusMatch` (`refresh: 401`) matches a
+status code, and `refresh: { when }` takes a content predicate (for soft 200
+walls). See
 [Reference → Auth strategies](/docs/reference/auth-strategies) for every field.
 
 <Callout type="warn">

--- a/apps/docs/content/blog/auth-as-a-capability-not-a-credential.mdx
+++ b/apps/docs/content/blog/auth-as-a-capability-not-a-credential.mdx
@@ -101,7 +101,7 @@ const me = stitch({
         loginInput: () => ({
             body: { user: env('USER')(), pass: env('PASS')() },
         }),
-        refreshOn: [401], // re-login and retry on expiry
+        refresh: [401], // re-login and retry on expiry
     }),
 });
 

--- a/apps/docs/content/docs/errors/stitch-auth-wall.mdx
+++ b/apps/docs/content/docs/errors/stitch-auth-wall.mdx
@@ -7,7 +7,7 @@ description: 'Authentication failed, or a soft 200 login wall was hit and could 
 
 A call that depends on a session fails after the runtime has tried to
 re-authenticate. With [`cookieSession`](/docs/guides/auth/cookie-session) the
-login is re-run on the configured `refreshOn` status (default `401`) and the
+login is re-run on the configured `refresh` status (default `401`) and the
 request retried once; when that retry still can't get through, the stitch
 surfaces the failure instead of looping. The downstream response keeps coming
 back unauthenticated — most often a `401`, sometimes a `200` whose body is
@@ -21,7 +21,7 @@ Two distinct triggers land here:
     rotated form fields, or a login endpoint that now sets a different cookie than
     the one you capture — so `cookieSession` replays a cookie the API rejects.
 -   **A soft 200 wall.** The API answers an unauthenticated request with `200` and
-    an HTML login page rather than a `401`. `refreshOn` only matches status codes,
+    an HTML login page rather than a `401`. `refresh.on` only matches status codes,
     so the wall slips past it and the body is treated as a successful response.
 
 ## How to fix
@@ -31,7 +31,7 @@ Confirm the credentials resolve at call time (see
 captures the cookie the API actually checks — `'*'` captures the whole jar when
 you're unsure which one matters.
 
-For a soft 200 wall, add `refreshWhen` so a login page served with `200`
+For a soft 200 wall, add `refresh.when` so a login page served with `200`
 triggers a re-login instead of passing as data:
 
 ```ts twoslash
@@ -54,8 +54,10 @@ const me = stitch({
             body: { user: env('USER')(), pass: env('PASS')() },
         }),
         // A 200 that is really the login page is a soft wall — re-login on it.
-        refreshWhen: (res) =>
-            typeof res.body === 'string' && res.body.includes('id="login"'),
+        refresh: {
+            when: (res) =>
+                typeof res.body === 'string' && res.body.includes('id="login"'),
+        },
     }),
 });
 ```

--- a/apps/docs/content/docs/guides/auth/cookie-session.mdx
+++ b/apps/docs/content/docs/guides/auth/cookie-session.mdx
@@ -31,7 +31,7 @@ const me = stitch({
         loginInput: () => ({
             body: { user: env('USER')(), pass: env('PASS')() },
         }),
-        refreshOn: [401],
+        refresh: [401],
     }),
 });
 ```
@@ -48,10 +48,11 @@ its credentials, resolved at call time with [`env()`](/docs/guides/auth/secret-r
 `cookie` selects what to keep: a single cookie name, or `'*'` (equivalently
 `jar: true`) to capture and replay the whole Set-Cookie jar.
 
-`refreshOn` re-runs the login on a matched status — a `StatusMatch`: a number, a
-list, or a predicate (default `[401]`, and `refreshOn: 401` ≡ `refreshOn: [401]`);
-`refreshWhen` re-runs it on a content predicate, for soft 200 walls where a login
-page is served with a `200`. Give two stitches the same `key` plus a shared `store` to
+`refresh` is one envelope (CONTRACT.md P24). A bare `StatusMatch` — a number, a
+list, or a predicate — is shorthand for `refresh: { on }`: the status(es) that
+re-run the login (default `[401]`, and `refresh: 401` ≡ `refresh: { on: [401] }`).
+Reach `refresh.when` — a content predicate for soft 200 walls where a login page
+is served with a `200` — through the envelope form: `refresh: { when: (res) => … }`. Give two stitches the same `key` plus a shared `store` to
 share one session. See
 [Reference → Auth strategies](/docs/reference/auth-strategies) for every field.
 
@@ -70,7 +71,7 @@ never crashes the call.
     clear or extend a cooldown.
 -   `onAuthFailure(info)` runs when an attempt captured no cookie, with a
     `category` you map to your own status:
-    `'unauthenticated'` (a `refreshOn` status, e.g. `401` — bad/expired creds),
+    `'unauthenticated'` (a `refresh` status, e.g. `401` — bad/expired creds),
     `'rate-limited'` (`429`, with `retryAfter` parsed from `Retry-After`),
     `'network'` (the login threw before any response — with the thrown `error`),
     or `'unknown'`. `info.phase` is `'apply'` for a cold session or `'refresh'`
@@ -134,14 +135,14 @@ const me = stitch({
 
 The hooks are purely additive: omit them and `cookieSession` behaves exactly as
 before. They observe and record — they never change _whether_ the stitch logs in
-or retries (that stays governed by `refreshOn`/`refreshWhen`). Your external loop
+or retries (that stays governed by `refresh`). Your external loop
 reads the durable state and decides when to call the stitch again.
 
 <Callout type="warn">
-    **Anti-pattern:** don't lean on `refreshOn` status codes alone to catch an
+    **Anti-pattern:** don't lean on `refresh.on` status codes alone to catch an
     expired session — a soft 200 wall, where the login page comes back with
     status `200`, slips straight past it and your stitch reads the login HTML as
-    data; add a `refreshWhen` content predicate so the session re-logs in on
+    data; add a `refresh.when` content predicate so the session re-logs in on
     that body too. See [STITCH_AUTH_WALL](/docs/errors/stitch-auth-wall).
 </Callout>
 

--- a/apps/docs/content/docs/guides/auth/oauth2.mdx
+++ b/apps/docs/content/docs/guides/auth/oauth2.mdx
@@ -38,11 +38,13 @@ expiry, all behind the capability boundary.
 `env('CLIENT_ID')` — so the credentials are read at call time and never
 committed. `scope` is an optional space-delimited scope string.
 
-The token is cached and auto-refreshed: `refreshSkew` (default `30_000`)
-refreshes it that many milliseconds before expiry, so it is never used
-mid-flight, and `refreshOn` (default `[401]`) is the `StatusMatch` — a status, a
-list, or a predicate — that means the token was rejected and forces a fresh fetch
-plus retry (`refreshOn: 419` ≡ `refreshOn: [419]`).
+The token is cached and auto-refreshed through one `refresh` envelope
+(CONTRACT.md P24). A bare `StatusMatch` — a status, a list, or a predicate — is
+shorthand for `refresh: { on }`: the status(es) that mean the token was rejected
+and force a fresh fetch plus retry (default `[401]`, and `refresh: 419` ≡
+`refresh: { on: [419] }`). Reach `refresh.skew` — how many milliseconds before
+expiry to refresh so the token is never used mid-flight (default `30_000`) —
+through the envelope form: `refresh: { skew: '1m' }`.
 
 Give two stitches the same `key` plus a shared `store` and one token serves them
 all — across stitches and across workers, surviving restarts. See

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -544,6 +544,14 @@ cut; the lint skips the deprecated members so each rename ratchets the baseline 
     rich shape is assignable to the minimal one (a real stitch satisfies both), so it is **de-listed**.
     With this, **R5 is fully cleared** — the baseline is now 6, exactly R6's P20 backlog
     (multipart/stream/sse/throttle/hooks/input → `Scalar | AtLeastOne`).
+-   **P24 (refresh envelope)** the auth strategies' `refresh`-prefixed flat members fold into one
+    envelope (genuine breaking flat→envelope, no alias): `OAuth2Options.refreshOn`/`refreshSkew` →
+    `refresh?: StatusMatch | AtLeastOne<OAuth2RefreshOptions>` (`{ on, skew }`), and
+    `CookieSessionOptions.refreshOn`/`refreshWhen` → `refresh?: StatusMatch | AtLeastOne<CookieSessionRefreshOptions>`
+    (`{ on, when }`). A bare `StatusMatch` is the P12 dominant-field shorthand for `{ on }`
+    (`refresh: 401` ≡ `refresh: { on: [401] }`); a shared `normalizeRefresh` collapses the union to
+    the envelope once at construction, and every internal read goes through `refresh.on` (via the
+    shared `acceptsStatus` matcher) / `refresh.skew` / `refresh.when`.
 
 ## 7. Enforcement
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -117,7 +117,7 @@ const session = cookieSession({
     login: signIn, // ← another stitch
     cookie: 'session_token',
     secret: keychain('app'),
-    refreshOn: [401],
+    refresh: [401],
 });
 ```
 
@@ -380,7 +380,7 @@ const listWebsites = stitch({
         login: signIn,
         cookie: 'session_token',
         secret: secretsFile('app'),
-        refreshOn: [401],
+        refresh: [401],
     }),
 });
 await listWebsites(); // logs in, manages cookie, retries wall, returns Website[]

--- a/docs/FEATURE-LENSES.md
+++ b/docs/FEATURE-LENSES.md
@@ -55,7 +55,7 @@ existing or proposed — passes through all three before it ships.
 -   Secret resolvers — `env()` and `secretsFile()`, resolved at **call time**
 -   The caller gets a capability, not a credential — the stitch holds the secret; an agent
     invoking it never sees the token
--   Session handling — cookie capture + replay, TTL, refresh on `refreshOn` / `refreshWhen`,
+-   Session handling — cookie capture + replay, TTL, refresh on `refresh` (`refresh.on` / `refresh.when`),
     sessions shareable across stitches via a `key` + shared store
 
 ### Performance & scale

--- a/docs/SEO-EDITORIAL-ROADMAP.md
+++ b/docs/SEO-EDITORIAL-ROADMAP.md
@@ -113,7 +113,7 @@ above: rank for the generic problem, teach it honestly, then show the one-line s
 
 | Topic (working title)                                       | Pillar | Target query                                          | Maps to (feature)                                                             |
 | ----------------------------------------------------------- | ------ | ----------------------------------------------------- | ----------------------------------------------------------------------------- |
-| Session auth that logs itself back in                       | 1      | "refresh token on 401", "session auth fetch"          | `cookieSession` (`refreshOn`/`refreshWhen`/`loginInput`) + `oauth2`           |
+| Session auth that logs itself back in                       | 1      | "refresh token on 401", "session auth fetch"          | `cookieSession` (`refresh`/`loginInput`) + `oauth2`                           |
 | Multi-tenant API calls from one definition                  | 4      | "multi-tenant api client"                             | `seam.as(principal)` + `oauth2` `tenancy`, per-tenant credentials             |
 | Tap into every request with hooks (interceptor alternative) | 1      | "fetch interceptor alternative", "http middleware ts" | request/response/error/retry `hooks`                                          |
 | Use any validator (Standard Schema)                         | 3      | "valibot api validation", "standard schema"           | validator-agnostic core; Zod/Valibot/ArkType/Effect/Typebox via `toValidator` |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -477,7 +477,7 @@ const getUser = stitch({
 });
 ```
 
-**OAuth2 client credentials** — `oauth2()` POSTs the token endpoint (form-encoded `client_credentials` grant), caches the access token in the [store](#pluggable-state-store) with the TTL from `expires_in`, refreshes it `refreshSkew` (default 30s) before expiry, and attaches it as `Authorization: Bearer …`. A rejected token (status in `refreshOn`, default `[401]`) forces a fresh fetch and an uncounted re-run of the attempt:
+**OAuth2 client credentials** — `oauth2()` POSTs the token endpoint (form-encoded `client_credentials` grant), caches the access token in the [store](#pluggable-state-store) with the TTL from `expires_in`, refreshes it `refresh.skew` (default 30s) before expiry, and attaches it as `Authorization: Bearer …`. A rejected token (status matched by `refresh`, default `[401]`) forces a fresh fetch and an uncounted re-run of the attempt:
 
 ```ts
 import { env, oauth2, stitch } from 'stitchapi';
@@ -520,7 +520,7 @@ const listUsers = stitch({
                 password: secretsFile('APP_PASS')(),
             },
         }),
-        refreshOn: [401], // the wall → re-login, then retry (default)
+        refresh: [401], // the wall → re-login, then retry (default)
     }),
 });
 
@@ -535,8 +535,9 @@ A `200` that is really a login page is a soft wall — catch it with a content p
 auth: cookieSession({
     login: signIn,
     cookie: 'session_token',
-    refreshWhen: (res) =>
-        typeof res.body === 'string' && /log in/i.test(res.body),
+    refresh: {
+        when: (res) => typeof res.body === 'string' && /log in/i.test(res.body),
+    },
 });
 ```
 

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -7,6 +7,7 @@ import { acceptsStatus, parseRetryAfter } from './resilience';
 import type {
     Adapter,
     AdapterResponse,
+    AtLeastOne,
     AuthContext,
     AuthStrategy,
     RunContext,
@@ -238,6 +239,21 @@ export function basic(opts: { user: Secret; pass: Secret }): AuthStrategy {
     };
 }
 
+/**
+ * Envelope for {@link OAuth2Options.refresh} (CONTRACT.md P24: `refreshOn` + `refreshSkew` shared
+ * the `refresh` prefix, so they fold into one envelope; a bare {@link StatusMatch} is the P12
+ * dominant-field shorthand for `{ on }`).
+ */
+export interface OAuth2RefreshOptions {
+    /**
+     * Status(es) — or a predicate — that mean the token was rejected and should force a refresh
+     * (CONTRACT.md P7: `401` ≡ `[401]`). Default `[401]`.
+     */
+    on?: StatusMatch;
+    /** Refresh this long BEFORE the token's expiry, so it is never used mid-flight — `30_000`, `'30s'`. Default 30s. */
+    skew?: number | string;
+}
+
 export interface OAuth2Options {
     /** The `client_credentials` token endpoint (POST, form-encoded). */
     tokenUrl: string;
@@ -269,10 +285,14 @@ export interface OAuth2Options {
      * cannot override the `Authorization` header that `clientAuth: 'basic'` sets.
      */
     headers?: Record<string, string>;
-    /** Status(es) — a number, list, or predicate — that mean the token was rejected and should force a refresh (CONTRACT.md P7: `401` ≡ `[401]`). Default [401]. */
-    refreshOn?: StatusMatch;
-    /** Refresh this long BEFORE the token's expiry, so it is never used mid-flight — `30_000`, `'30s'`. Default 30s. */
-    refreshSkew?: number | string;
+    /**
+     * When to force a fresh token (CONTRACT.md P24 envelope). A bare {@link StatusMatch} — a
+     * number, a list, or a predicate — is shorthand for `{ on }` (P12): the status(es) that mean
+     * the token was rejected (CONTRACT.md P7: `401` ≡ `[401]`). Default `[401]`. Reach `skew` —
+     * how long BEFORE the token's expiry to refresh it, so it is never used mid-flight (`30_000`,
+     * `'30s'`; default 30s) — through the envelope form: `refresh: { skew: '1m' }`.
+     */
+    refresh?: StatusMatch | AtLeastOne<OAuth2RefreshOptions>;
     /** Store namespace — give two stitches the same `key` + a shared `store` to share one token. Default: `tokenUrl`. */
     key?: string;
     /**
@@ -311,14 +331,36 @@ function singleFlight<T>(): (key: string, run: () => Promise<T>) => Promise<T> {
 }
 
 /**
+ * Normalize a `refresh` slot (CONTRACT.md P24) to its envelope form, ONCE, at strategy
+ * construction — every internal read then goes through the normalized object, never the raw
+ * union. A bare {@link StatusMatch} (number, list, or predicate) is the P12 dominant-field
+ * shorthand for `{ on: <value> }`; an object is already the envelope (possibly `undefined`,
+ * meaning "use the caller's defaults").
+ */
+function normalizeRefresh<T extends { on?: StatusMatch }>(
+    refresh: StatusMatch | AtLeastOne<T> | undefined,
+): Partial<T> {
+    if (refresh === undefined) return {};
+    if (
+        typeof refresh === 'number' ||
+        typeof refresh === 'function' ||
+        Array.isArray(refresh)
+    )
+        return { on: refresh } as Partial<T>;
+    return refresh;
+}
+
+/**
  * OAuth2 `client_credentials`: POST the token endpoint, cache the access token in the
- * StitchStore (TTL from `expires_in`), refresh it `refreshSkew` before expiry, and attach
+ * StitchStore (TTL from `expires_in`), refresh it `refresh.skew` before expiry, and attach
  * it as `Authorization: Bearer …`. A SHARED store makes one token serve many stitches/workers
- * and survive restarts; a rejected token (status in `refreshOn`) forces a fresh fetch + retry.
+ * and survive restarts; a rejected token (status matched by `refresh`/`refresh.on`) forces a
+ * fresh fetch + retry.
  */
 export function oauth2(opts: OAuth2Options): AuthStrategy {
-    const matchRefresh = acceptsStatus(opts.refreshOn ?? [401]);
-    const skew = parseDuration(opts.refreshSkew) ?? 30_000;
+    const refreshOpts = normalizeRefresh<OAuth2RefreshOptions>(opts.refresh);
+    const refreshMatch = acceptsStatus(refreshOpts.on ?? [401]);
+    const skew = parseDuration(refreshOpts.skew) ?? 30_000;
     const baseKey = 'oauth2:' + (opts.key ?? opts.tokenUrl);
     const tenancy = opts.tenancy ?? 'app';
     const adapter = opts.adapter ?? fetchAdapter();
@@ -441,7 +483,7 @@ export function oauth2(opts: OAuth2Options): AuthStrategy {
             req.headers['authorization'] = `Bearer ${await tokenFor(ctx)}`;
         },
         shouldRefresh(res) {
-            return matchRefresh(res.status);
+            return refreshMatch(res.status);
         },
         async refresh(ctx) {
             // Force a fresh token, ignoring the cache — but simultaneous 401s
@@ -468,7 +510,7 @@ export interface AuthFailureResult {
     /** The thrown value when the login stitch itself threw (network/transport failure). */
     error?: unknown;
     /**
-     * - `'unauthenticated'` — login responded with a `refreshOn` status (e.g. 401) and set no cookie (bad/expired creds);
+     * - `'unauthenticated'` — login responded with a status matched by `refresh` (e.g. 401) and set no cookie (bad/expired creds);
      * - `'rate-limited'` — login responded `429` (back off, then retry; see `retryAfter`);
      * - `'network'` — the login stitch threw before any response (DNS/connection/transport);
      * - `'unknown'` — login responded but captured no cookie for some other reason.
@@ -482,6 +524,22 @@ export interface RefreshResult {
     ok: boolean;
     /** The login response status when the login responded (absent when it threw). */
     status?: number;
+}
+
+/**
+ * Envelope for {@link CookieSessionOptions.refresh} (CONTRACT.md P24: `refreshOn` + `refreshWhen`
+ * shared the `refresh` prefix, so they fold into one envelope; a bare {@link StatusMatch} — incl.
+ * a bare function, which is the STATUS predicate — is the P12 dominant-field shorthand for
+ * `{ on }`; reaching `when` requires the envelope form).
+ */
+export interface CookieSessionRefreshOptions {
+    /**
+     * Status(es) — or a predicate — that mean "the wall" and should trigger a re-login
+     * (CONTRACT.md P7: `401` ≡ `[401]`). Default `[401]`.
+     */
+    on?: StatusMatch;
+    /** Inspect the response (status + body) for a soft wall — e.g. a 200 that is actually a login page. */
+    when?: (res: AdapterResponse) => boolean;
 }
 
 export interface CookieSessionOptions {
@@ -500,10 +558,15 @@ export interface CookieSessionOptions {
      * identity to that user's credentials — credentials still never originate from the caller.
      */
     loginInput?: (principal?: string) => StitchInput;
-    /** Status(es) — a number, list, or predicate — that mean "the wall" and should trigger a re-login (CONTRACT.md P7: `401` ≡ `[401]`). Default [401]. */
-    refreshOn?: StatusMatch;
-    /** Inspect the response (status + body) for a soft wall — e.g. a 200 that is actually a login page. */
-    refreshWhen?: (res: AdapterResponse) => boolean;
+    /**
+     * When to trigger a re-login (CONTRACT.md P24 envelope). A bare function is the P12
+     * dominant-field shorthand for `{ on: <fn> }` — a {@link StatusMatch} predicate over the
+     * response STATUS; likewise a bare number/list is `{ on: <value> }`: status(es) that mean
+     * "the wall" (CONTRACT.md P7: `401` ≡ `[401]`). Default `[401]`. Reach `when` — inspecting the
+     * full response (status + body) for a SOFT wall, e.g. a 200 that is actually a login page —
+     * only through the envelope form: `refresh: { when: (res) => … }`.
+     */
+    refresh?: StatusMatch | AtLeastOne<CookieSessionRefreshOptions>;
     /** Vault namespace — give two stitches the same `key` + a shared seam/store to share one session. */
     key?: string;
     /** Optional TTL for the stored session — `60_000`, `'1m'`. With `tenancy: 'principal'`, set this — per-user sessions multiply. */
@@ -538,7 +601,10 @@ export interface CookieSessionOptions {
 }
 
 export function cookieSession(opts: CookieSessionOptions): AuthStrategy {
-    const matchRefresh = acceptsStatus(opts.refreshOn ?? [401]);
+    const refreshOpts = normalizeRefresh<CookieSessionRefreshOptions>(
+        opts.refresh,
+    );
+    const refreshMatch = acceptsStatus(refreshOpts.on ?? [401]);
     const jarMode = opts.jar === true || opts.cookie === '*';
     const tenancy = opts.tenancy ?? 'principal';
     const baseKey = (jarMode ? 'jar:' : 'cookie:') + (opts.key ?? opts.cookie);
@@ -586,8 +652,8 @@ export function cookieSession(opts: CookieSessionOptions): AuthStrategy {
     };
 
     // Categorise a login response that captured no cookie, given its status + headers. A 429 means
-    // rate-limited (back off per `Retry-After`); a `refreshOn` status (e.g. 401) means the creds were
-    // rejected; anything else — including a soft 200 wall that set no cookie — is `unknown`.
+    // rate-limited (back off per `Retry-After`); a status matched by `refresh` (e.g. 401) means the
+    // creds were rejected; anything else — including a soft 200 wall that set no cookie — is `unknown`.
     const classify = (
         phase: 'apply' | 'refresh',
         status: number,
@@ -603,7 +669,7 @@ export function cookieSession(opts: CookieSessionOptions): AuthStrategy {
                 retryAfter: parseRetryAfter(headers['retry-after']),
             });
         }
-        if (matchRefresh(status))
+        if (refreshMatch(status))
             return { phase, status, category: 'unauthenticated' };
         return { phase, status, category: 'unknown' };
     };
@@ -743,7 +809,7 @@ export function cookieSession(opts: CookieSessionOptions): AuthStrategy {
             }
         },
         shouldRefresh(res) {
-            return matchRefresh(res.status) || !!opts.refreshWhen?.(res);
+            return refreshMatch(res.status) || !!refreshOpts.when?.(res);
         },
         async refresh(ctx) {
             const { key, principal } = sessionFor(ctx);

--- a/packages/core/src/resilience.ts
+++ b/packages/core/src/resilience.ts
@@ -18,7 +18,7 @@ export class TimeoutError extends Error {}
 /**
  * Normalize a status-match field (a bare number, a number list, a predicate, or unset) into a
  * single predicate — the shared CONTRACT.md P7 matcher every status-match slot runs through
- * (`retry.on`, `throttle.on`, `acceptStatus`, the auth strategies' `refreshOn`, …). Unset →
+ * (`retry.on`, `throttle.on`, `acceptStatus`, the auth strategies' `refresh`/`refresh.on`, …). Unset →
  * accept nothing.
  */
 export function acceptsStatus(

--- a/packages/core/test/HARNESS-API.md
+++ b/packages/core/test/HARNESS-API.md
@@ -76,7 +76,7 @@ Drift is schema-anchored — no snapshot (ADR 0015). Each call validates the unw
 
 ## Auth
 
-`bearer(secret)`, `apiKey({ header?, value })`, `basic({ user, pass })`, `cookieSession({ login: <stitch>, cookie: 'sid', loginInput?: () => StitchInput, refreshOn?: [401] })`. Secrets: `env('VAR')` / `secretsFile('name')` return `() => string` resolved at call time. `cookieSession` auto-logs-in when no cookie is stored, replays the captured cookie, and re-logs-in when a response status is in `refreshOn`.
+`bearer(secret)`, `apiKey({ header?, value })`, `basic({ user, pass })`, `cookieSession({ login: <stitch>, cookie: 'sid', loginInput?: () => StitchInput, refresh?: [401] })`. Secrets: `env('VAR')` / `secretsFile('name')` return `() => string` resolved at call time. `cookieSession` auto-logs-in when no cookie is stored, replays the captured cookie, and re-logs-in when a response status is matched by `refresh`.
 
 ## Mock server
 

--- a/packages/core/test/auth-trace.spec.ts
+++ b/packages/core/test/auth-trace.spec.ts
@@ -103,7 +103,7 @@ test('refresh on the 401 wall re-logs-in and retries the request', async () => {
         auth: cookieSession({
             login: signIn,
             cookie: 'sid',
-            refreshOn: [401],
+            refresh: [401],
             tenancy: 'app',
         }),
     });

--- a/packages/core/test/body-encoding.spec.ts
+++ b/packages/core/test/body-encoding.spec.ts
@@ -120,8 +120,11 @@ describe('cookieSession content-aware refresh (soft wall)', () => {
                 cookie: 'SID',
                 tenancy: 'app',
                 // status is 200, so only a content predicate can catch this wall:
-                refreshWhen: (res) =>
-                    typeof res.body === 'string' && /log in/i.test(res.body),
+                refresh: {
+                    when: (res) =>
+                        typeof res.body === 'string' &&
+                        /log in/i.test(res.body),
+                },
                 loginInput: () => ({
                     body: { u: env('SOFT_USER')(), p: env('SOFT_PASS')() },
                 }),

--- a/packages/core/test/gaps/cookie-session-hooks.spec.ts
+++ b/packages/core/test/gaps/cookie-session-hooks.spec.ts
@@ -129,7 +129,7 @@ test('onRefresh fires ONCE (not per-waiter) under concurrent cold callers sharin
 
 test("onAuthFailure fires category 'unauthenticated' when the login returns 401 and sets no cookie", async () => {
     // No setCookie + a 401 status: the login responded but captured nothing, and 401 is a
-    // `refreshOn` status → the host hears "the creds were rejected".
+    // `refresh` (`refresh.on`) status → the host hears "the creds were rejected".
     server.route('POST', '/login', {
         statuses: [401],
         body: { error: 'bad creds' },

--- a/packages/core/test/integration-patterns.spec.ts
+++ b/packages/core/test/integration-patterns.spec.ts
@@ -128,7 +128,7 @@ describe('Session-cookie admin API (auto re-login on 403)', () => {
                 login,
                 cookie: 'SID',
                 tenancy: 'app',
-                refreshOn: [403], // this integration uses 403, not 401
+                refresh: [403], // this integration uses 403, not 401
                 loginInput: () => ({
                     body: {
                         username: env('CLIENT_USER')(),

--- a/packages/core/test/oauth2.spec.ts
+++ b/packages/core/test/oauth2.spec.ts
@@ -105,7 +105,7 @@ test('refreshes the token after it expires', async () => {
     });
 
     // skew 0 so the token stays usable until its real expiry, isolating the expiry path.
-    const data = protectedStitch('/data', { refreshSkew: 0 });
+    const data = protectedStitch('/data', { refresh: { skew: 0 } });
     await data();
     await sleep(1100); // let the cached token (and its store TTL) expire
     await data();
@@ -116,7 +116,7 @@ test('refreshes the token after it expires', async () => {
     expect(calls[1]!.headers['authorization']).toBe('Bearer T2'); // the refreshed token
 }, 10000);
 
-test('refreshes proactively BEFORE expiry using refreshSkew', async () => {
+test('refreshes proactively BEFORE expiry using refresh.skew', async () => {
     server.route('POST', '/token', {
         body: (i: number) => ({
             access_token: i === 0 ? 'T1' : 'T2',
@@ -130,7 +130,7 @@ test('refreshes proactively BEFORE expiry using refreshSkew', async () => {
     });
 
     // With a 1.5s skew the token is treated as stale ~0.5s in, well before the 2s expiry.
-    const data = protectedStitch('/data', { refreshSkew: 1500 });
+    const data = protectedStitch('/data', { refresh: { skew: 1500 } });
     await data();
     await sleep(600);
     await data();
@@ -163,7 +163,7 @@ test('re-fetches the token when the resource server rejects it (401)', async () 
     expect(calls[1]!.headers['authorization']).toBe('Bearer FRESH');
 });
 
-test('refreshOn accepts a bare status number (P7): a 419 wall forces one refresh', async () => {
+test('refresh accepts a bare status number (P24/P12): a 419 wall forces one refresh', async () => {
     server.route('POST', '/token', {
         body: (i: number) => ({
             access_token: i === 0 ? 'STALE' : 'FRESH',
@@ -171,18 +171,42 @@ test('refreshOn accepts a bare status number (P7): a 419 wall forces one refresh
             expires_in: 3600,
         }),
     });
-    // The resource rejects the stale token with 419 (not the default 401). `refreshOn: 419` — a bare
-    // `StatusMatch` number (CONTRACT.md P7, `419` ≡ `[419]`) — classifies it as the wall, so the
-    // strategy forces exactly one refresh and the retry succeeds.
+    // The resource rejects the stale token with 419 (not the default 401). `refresh: 419` — a bare
+    // `StatusMatch` number, the P12 dominant-field shorthand for `{ on: 419 }` (CONTRACT.md P24;
+    // `419` ≡ `[419]` per P7) — classifies it as the wall, so the strategy forces exactly one
+    // refresh and the retry succeeds.
     server.route('GET', '/data', {
         statuses: [419, 200],
         body: { ok: true },
     });
 
-    const data = protectedStitch('/data', { refreshOn: 419 });
+    const data = protectedStitch('/data', { refresh: 419 });
     await expect(data()).resolves.toEqual({ ok: true });
 
     expect(server.callCount('/token')).toBe(2); // initial fetch + forced refresh on the 419 wall
+    const calls = server.calls('/data');
+    expect(calls[0]!.headers['authorization']).toBe('Bearer STALE');
+    expect(calls[1]!.headers['authorization']).toBe('Bearer FRESH');
+});
+
+test('the refresh envelope carries both `on` and `skew` (P24)', async () => {
+    server.route('POST', '/token', {
+        body: (i: number) => ({
+            access_token: i === 0 ? 'STALE' : 'FRESH',
+            token_type: 'Bearer',
+            expires_in: 3600,
+        }),
+    });
+    // Both facets folded into one envelope: `on: 419` classifies the wall (default is 401), and
+    // `skew: 0` keeps the token usable until real expiry so ONLY the 419 forces the refresh.
+    server.route('GET', '/data', { statuses: [419, 200], body: { ok: true } });
+
+    const data = protectedStitch('/data', {
+        refresh: { on: 419, skew: 0 },
+    });
+    await expect(data()).resolves.toEqual({ ok: true });
+
+    expect(server.callCount('/token')).toBe(2); // initial + the forced 419 refresh
     const calls = server.calls('/data');
     expect(calls[0]!.headers['authorization']).toBe('Bearer STALE');
     expect(calls[1]!.headers['authorization']).toBe('Bearer FRESH');

--- a/packages/core/test/status-match.spec.ts
+++ b/packages/core/test/status-match.spec.ts
@@ -1,6 +1,6 @@
 // Unit tests for the shared `acceptsStatus` matcher (src/resilience.ts) — the CONTRACT.md P7
 // normalizer every status-classification slot runs through (`retry.on`, `throttle.on`,
-// `acceptStatus`, the auth strategies' `refreshOn`). It collapses the four `StatusMatch` spellings
+// `acceptStatus`, the auth strategies' `refresh`). It collapses the four `StatusMatch` spellings
 // (a bare number, a number list, a predicate, or unset) into one `(status) => boolean` predicate,
 // so `on: 429` ≡ `on: [429]` at every reader.
 import type { StatusMatch } from '../src';


### PR DESCRIPTION
## What

Carves the **P24 refresh envelope** — the auth half of the P24 flat→envelope conversions — out of the contract-freeze sweep (#470). Genuine breaking flat→envelope, **no `@deprecated` alias**.

The auth strategies' `refresh`-prefixed flat members fold into one envelope each:

- `OAuth2Options.refreshOn` + `refreshSkew` → `refresh?: StatusMatch | AtLeastOne<OAuth2RefreshOptions>` (`{ on, skew }`)
- `CookieSessionOptions.refreshOn` + `refreshWhen` → `refresh?: StatusMatch | AtLeastOne<CookieSessionRefreshOptions>` (`{ on, when }`)

A bare `StatusMatch` is the P12 dominant-field shorthand for `{ on }` — `refresh: 401` ≡ `refresh: { on: [401] }`. For `cookieSession` a bare **function** is the STATUS predicate, so reaching the response-body `when` predicate requires the envelope form (`refresh: { when: (res) => … }`). A shared `normalizeRefresh` collapses the union to the envelope **once** at strategy construction; every internal read then goes through `refresh.on` (via the shared `acceptsStatus` matcher) / `refresh.skew` / `refresh.when`.

## ⚠️ Stacked on #506

The refresh envelope's `on` is the exported **`StatusMatch`** from **#506 (P7)** — so this PR targets `refactor/status-match-p7`, not `main`. Merge #506 first; GitHub will retarget this to `main` automatically.

## Why

`docs/CONTRACT.md` **P24** (introduced with the sweep, enforced by lint R8 in the finale): a shared leading-word prefix across ≥2 flat members of a house contract is really one envelope. `refreshOn`/`refreshSkew`/`refreshWhen` are the auth instance of that.

## Migration (this PR does it)

Every consumer moves to the envelope: 5 auth specs (`oauth2`, `auth-trace`, `body-encoding`, `integration-patterns`, `cookie-session-hooks`), the auth guides + error page + blog, `packages/core/README`, DESIGN/AUTHORING/harness docs. New oauth2 test pins the combined `{ on, skew }` envelope.

## Gate

`build` · `check:types` · `test` (1218 pass) · `check:contract` · `check:lint` · `prettier` · **`build-docs` (twoslash) locally green**. Full pre-push gate passed. Bundle unchanged at **25 kB / 20 kB** (inherited from the P7 base). No baseline or completions change (refresh is an auth option, not a stitch config field).

## Breaking

BREAKING CHANGE: `oauth2()` no longer accepts `refreshOn` / `refreshSkew`, and `cookieSession()` no longer accepts `refreshOn` / `refreshWhen`. Use the `refresh` envelope: `refresh: 401` (or `[401]`) for the status match; `refresh: { on, skew }` (oauth2) / `refresh: { on, when }` (cookieSession) for the full form. No deprecated alias — a hard break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)