### PR TITLE
refactor(sentry)!: fold captureErrors/captureDrift into one `capture` envelope (P24)

### DIFF
--- a/apps/docs/content/docs/integrations/sentry.mdx
+++ b/apps/docs/content/docs/integrations/sentry.mdx
@@ -46,16 +46,16 @@ The same sink works on a single stitch — `stitch({ trace: sentrySink(Sentry) }
 
 ## What it sends
 
-| Event                          | Sentry                                                               |
-| ------------------------------ | -------------------------------------------------------------------- |
-| `error`                        | `captureMessage` (level `error`) + an error breadcrumb               |
-| `progress` (`retry`/`circuit`) | breadcrumb, level `warning`                                          |
-| `progress` (throttle/paginate) | breadcrumb, level `debug`                                            |
-| `drift`                        | breadcrumb (level follows the finding); captured with `captureDrift` |
-| `start` / `result` / `done`    | breadcrumb only when `lifecycle: true` (off by default)              |
-| `delta` / `info`               | **never sent** (raw response data / strategy announcements)          |
+| Event                          | Sentry                                                                |
+| ------------------------------ | --------------------------------------------------------------------- |
+| `error`                        | `captureMessage` (level `error`) + an error breadcrumb                |
+| `progress` (`retry`/`circuit`) | breadcrumb, level `warning`                                           |
+| `progress` (throttle/paginate) | breadcrumb, level `debug`                                             |
+| `drift`                        | breadcrumb (level follows the finding); captured with `capture.drift` |
+| `start` / `result` / `done`    | breadcrumb only when `lifecycle: true` (off by default)               |
+| `delta` / `info`               | **never sent** (raw response data / strategy announcements)           |
 
-Options: `{ lifecycle?, captureErrors?, captureDrift? }`.
+Options: `{ lifecycle?, capture? }` — `capture` is `boolean | { errors?, drift? }`: `true`/omitted captures errors (not drift), `false` disables both, or set `errors`/`drift` independently.
 
 <Callout type="warn">
     **Metadata only, by design.** A custom `TraceSink` receives the **raw**

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -541,6 +541,10 @@ cut; the lint skips the deprecated members so each rename ratchets the baseline 
     rich shape is assignable to the minimal one (a real stitch satisfies both), so it is **de-listed**.
     With this, **R5 is fully cleared** — the baseline is now 6, exactly R6's P20 backlog
     (multipart/stream/sse/throttle/hooks/input → `Scalar | AtLeastOne`).
+-   **P24 (Sentry capture)** `@stitchapi/sentry`'s `SentrySinkOptions.captureErrors`+`captureDrift`
+    (shared `capture` prefix) fold into `capture?: boolean | AtLeastOne<SentryCaptureOptions>` —
+    `capture: true`/omitted keeps the defaults (errors on, drift off), `false` disables both, and the
+    `{ errors, drift }` envelope sets them independently. Genuine breaking flat→envelope, no alias.
 
 ## 7. Enforcement
 

--- a/packages/sentry/README.md
+++ b/packages/sentry/README.md
@@ -33,16 +33,16 @@ The same sink works on a single stitch — `stitch({ trace: sentrySink(Sentry) }
 
 ## What it sends
 
-| Event                          | Sentry                                                               |
-| ------------------------------ | -------------------------------------------------------------------- |
-| `error`                        | `captureMessage` (level `error`) + an error breadcrumb               |
-| `progress` (`retry`/`circuit`) | breadcrumb, level `warning`                                          |
-| `progress` (throttle/paginate) | breadcrumb, level `debug`                                            |
-| `drift`                        | breadcrumb (level follows the finding); captured with `captureDrift` |
-| `start` / `result` / `done`    | breadcrumb only when `lifecycle: true` (off by default)              |
-| `delta` / `info`               | **never sent** (raw response data / strategy announcements)          |
+| Event                          | Sentry                                                                |
+| ------------------------------ | --------------------------------------------------------------------- |
+| `error`                        | `captureMessage` (level `error`) + an error breadcrumb                |
+| `progress` (`retry`/`circuit`) | breadcrumb, level `warning`                                           |
+| `progress` (throttle/paginate) | breadcrumb, level `debug`                                             |
+| `drift`                        | breadcrumb (level follows the finding); captured with `capture.drift` |
+| `start` / `result` / `done`    | breadcrumb only when `lifecycle: true` (off by default)               |
+| `delta` / `info`               | **never sent** (raw response data / strategy announcements)           |
 
-Options: `{ lifecycle?, captureErrors?, captureDrift? }`.
+Options: `{ lifecycle?, capture? }` — `capture` is `boolean | { errors?, drift? }`: `true`/omitted captures errors (not drift), `false` disables both, or set `errors`/`drift` independently.
 
 ## Safe on a secret-bearing seam
 

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -18,7 +18,12 @@
 // `event.input` (its headers carry the live `authorization`/`cookie`), `event.data`,
 // or a `delta` chunk. Both the URL userinfo (`user:pass@`) and the query string are
 // dropped — either can carry a credential (`?api_key=…`).
-import type { StitchEvent, TraceContext, TraceSink } from 'stitchapi';
+import type {
+    AtLeastOne,
+    StitchEvent,
+    TraceContext,
+    TraceSink,
+} from 'stitchapi';
 import { compact } from 'stitchapi';
 
 // ---------------------------------------------------------------------------
@@ -64,16 +69,26 @@ export interface SentrySinkOptions {
      */
     lifecycle?: boolean;
     /**
-     * Capture `error` events as Sentry issues via `captureMessage`. Default `true`.
-     * Set `false` to only leave breadcrumbs (e.g. when your framework already reports
-     * the error to Sentry and you just want the stitch trail).
+     * Capture Sentry issues via `captureMessage`: `errors` for every `error` event
+     * (default `true`) and `drift` for an **error-level** `drift` finding (a breaking
+     * API change; default `false`). `capture: false` disables both — only breadcrumbs
+     * are left (e.g. when your framework already reports the error to Sentry and you
+     * just want the stitch trail). `capture: true` (or omitting the option) resolves
+     * both sub-fields to the defaults above. Pass a {@link SentryCaptureOptions}
+     * envelope to set them independently.
      */
-    captureErrors?: boolean;
+    capture?: boolean | AtLeastOne<SentryCaptureOptions>;
+}
+
+/** Envelope for {@link SentrySinkOptions.capture} (CONTRACT.md P24). */
+export interface SentryCaptureOptions {
+    /** Capture `error` events as Sentry issues via `captureMessage`. Default `true`. */
+    errors?: boolean;
     /**
      * Also capture an **error-level** `drift` finding (a breaking API change) as its
      * own Sentry issue, not just a breadcrumb. Default `false`.
      */
-    captureDrift?: boolean;
+    drift?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -99,6 +114,17 @@ function redactUrl(url: string): string {
     }
     const q = url.indexOf('?');
     return q === -1 ? url : `${url.slice(0, q)}?…`;
+}
+
+/** Resolve {@link SentrySinkOptions.capture} to its two booleans (P24 envelope). */
+function resolveCapture(
+    capture: boolean | AtLeastOne<SentryCaptureOptions> | undefined,
+): { errors: boolean; drift: boolean } {
+    if (capture === false) return { errors: false, drift: false };
+    if (capture === true || capture === undefined) {
+        return { errors: true, drift: false };
+    }
+    return { errors: capture.errors ?? true, drift: capture.drift ?? false };
 }
 
 const DRIFT_TO_SENTRY: Record<string, SentryLevel> = {
@@ -214,8 +240,9 @@ export function sentrySink(
     options: SentrySinkOptions = {},
 ): TraceSink {
     const lifecycle = options.lifecycle ?? false;
-    const captureErrors = options.captureErrors ?? true;
-    const captureDrift = options.captureDrift ?? false;
+    const { errors: captureErrors, drift: captureDrift } = resolveCapture(
+        options.capture,
+    );
 
     return {
         handle(event: StitchEvent, ctx: TraceContext): void {

--- a/packages/sentry/test/sentry.spec.ts
+++ b/packages/sentry/test/sentry.spec.ts
@@ -110,7 +110,7 @@ describe('sentrySink', () => {
         expect(on.breadcrumbs).toHaveLength(1);
     });
 
-    test('error-level drift is breadcrumbed; captured only with captureDrift', () => {
+    test('error-level drift is breadcrumbed; captured only with capture.drift', () => {
         const a = mockSentry();
         sentrySink(a.sentry).handle(ev.driftError, ctx);
         expect(a.breadcrumbs).toHaveLength(1);
@@ -121,13 +121,19 @@ describe('sentrySink', () => {
         expect(a.captures).toHaveLength(0);
 
         const b = mockSentry();
-        sentrySink(b.sentry, { captureDrift: true }).handle(ev.driftError, ctx);
+        sentrySink(b.sentry, { capture: { drift: true } }).handle(
+            ev.driftError,
+            ctx,
+        );
         expect(b.captures).toHaveLength(1);
     });
 
-    test('captureErrors:false still breadcrumbs the error but does not capture it as an issue', () => {
+    test('capture.errors:false still breadcrumbs the error but does not capture it as an issue', () => {
         const { sentry, breadcrumbs, captures } = mockSentry();
-        sentrySink(sentry, { captureErrors: false }).handle(ev.error, ctx);
+        sentrySink(sentry, { capture: { errors: false } }).handle(
+            ev.error,
+            ctx,
+        );
 
         // The error trail is preserved, but the framework owns the issue.
         expect(captures).toHaveLength(0);
@@ -135,7 +141,7 @@ describe('sentrySink', () => {
         expect(breadcrumbs[0]!.level).toBe('error');
     });
 
-    test('captureDrift only captures an error-level finding — a warn-level drift is breadcrumbed only', () => {
+    test('capture.drift only captures an error-level finding — a warn-level drift is breadcrumbed only', () => {
         const driftWarn: StitchEvent = {
             type: 'drift',
             finding: {
@@ -146,15 +152,25 @@ describe('sentrySink', () => {
             at: 0,
         };
         const { sentry, breadcrumbs, captures } = mockSentry();
-        sentrySink(sentry, { captureDrift: true }).handle(driftWarn, ctx);
+        sentrySink(sentry, { capture: { drift: true } }).handle(driftWarn, ctx);
 
-        // captureDrift is gated on an error-level finding; a warn drift only crumbs.
+        // capture.drift is gated on an error-level finding; a warn drift only crumbs.
         expect(captures).toHaveLength(0);
         expect(breadcrumbs).toHaveLength(1);
         expect(breadcrumbs[0]).toMatchObject({
             category: 'stitch.drift',
             level: 'warning',
         });
+    });
+
+    test('capture:false disables both errors and drift — only breadcrumbs (P24 toggle)', () => {
+        const { sentry, breadcrumbs, captures } = mockSentry();
+        const sink = sentrySink(sentry, { capture: false });
+        sink.handle(ev.error, ctx);
+        sink.handle(ev.driftError, ctx);
+        // Both the error and the error-level drift are trailed but never captured as issues.
+        expect(captures).toHaveLength(0);
+        expect(breadcrumbs).toHaveLength(2);
     });
 
     test('delta and info events are never sent (raw data / announcements)', () => {


### PR DESCRIPTION
## What

Carves the **Sentry `capture` envelope** — the sink half of the P24 flat→envelope conversions — out of the contract-freeze sweep (#470). Genuine breaking flat→envelope, **no `@deprecated` alias**.

`SentrySinkOptions.captureErrors` + `captureDrift` share the `capture` prefix, so they fold into one envelope:

```ts
capture?: boolean | AtLeastOne<SentryCaptureOptions>; // { errors?, drift? }
```

- `capture: true` (or omitting it) → the defaults: capture errors, not drift.
- `capture: false` → disable both; only breadcrumbs are left.
- `capture: { errors, drift }` → set each independently (`{ drift: true }` ≡ the old `captureDrift: true`).

A shared `resolveCapture` collapses the union to the two booleans the sink reads.

## Why

`docs/CONTRACT.md` **P24**: a shared leading-word prefix across ≥2 flat members of a house contract is really one envelope. `captureErrors`/`captureDrift` are the Sentry instance.

## Independent of the stack

Needs only `AtLeastOne` (core, already on `main`) — no dependency on #506/#508, so this lands straight off `main`.

## Gate

`build` · `check:types` (full workspace) · `test` (10 sentry specs pass, incl. a new `capture: false` toggle test) · `check:contract` · `check:lint` · `prettier` · `build-docs` (twoslash). Full pre-push gate passed. No core-bundle change (sink-only).

## Breaking

BREAKING CHANGE: `sentrySink()` no longer accepts `captureErrors` / `captureDrift`. Use `capture`: `capture: false` to disable both, or `capture: { errors, drift }` to set them independently. No deprecated alias — a hard break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)