### PR TITLE
refactor(nest)!: fold the feature-seam config + seamToken into one `seam` envelope (P24)

### DIFF
--- a/apps/docs/content/docs/integrations/nestjs.mdx
+++ b/apps/docs/content/docs/integrations/nestjs.mdx
@@ -103,7 +103,8 @@ one store, one trace sink — plus the shared config (`baseUrl`, `auth`, `retry`
 `throttle`, …) every stitch inherits; `forRootAsync` resolves the same options
 from an injected factory. `forFeature({ stitches, seam })` registers injectable
 stitches and, optionally, a per-upstream seam built over the shared store and
-trace — omit `seam` to attach the stitches to the default one.
+trace — `seam: { config, token? }` (its `config` is the feature seam's
+`baseUrl`/`auth`/…); omit `seam` to attach the stitches to the default one.
 
 Two bridges connect the framework, and neither changes core:
 

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -541,6 +541,11 @@ cut; the lint skips the deprecated members so each rename ratchets the baseline 
     rich shape is assignable to the minimal one (a real stitch satisfies both), so it is **de-listed**.
     With this, **R5 is fully cleared** — the baseline is now 6, exactly R6's P20 backlog
     (multipart/stream/sse/throttle/hooks/input → `Scalar | AtLeastOne`).
+-   **P24 (nest seam)** `@stitchapi/nest`'s `StitchFeatureOptions` feature-seam facets (the `seam`
+    config slot + `seamToken`, sharing the "seam" prefix) fold into
+    `seam?: AtLeastOne<NestFeatureSeamOptions>` (`{ config?: AtLeastOne<SeamConfig>, token? }`).
+    `forFeature`/`forFeatureScoped` read `seam.config` / `seam.token`. Genuine breaking
+    flat→envelope, no alias.
 
 ## 7. Enforcement
 

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -69,8 +69,10 @@ export const GetUser = defineStitch((s) =>
     imports: [
         StitchModule.forFeature({
             seam: {
-                baseUrl: 'https://api.example.com',
-                auth: bearer(env('TOKEN')),
+                config: {
+                    baseUrl: 'https://api.example.com',
+                    auth: bearer(env('TOKEN')),
+                },
             },
             stitches: [GetUser],
         }),
@@ -102,8 +104,10 @@ the request-scoped `seam.as(principal)` handle and the request-scoped stitches f
     imports: [
         StitchModule.forFeatureScoped({
             seam: {
-                baseUrl: 'https://api.example.com',
-                auth: bearer(env('TOKEN')),
+                config: {
+                    baseUrl: 'https://api.example.com',
+                    auth: bearer(env('TOKEN')),
+                },
             },
             stitches: [GetUser],
             principal: (req) => req.user?.tenantId ?? 'anonymous',

--- a/packages/nest/src/index.ts
+++ b/packages/nest/src/index.ts
@@ -5,6 +5,7 @@ export {
     type StitchModuleAsyncOptions,
     type StitchFeatureOptions,
     type StitchScopedFeatureOptions,
+    type NestFeatureSeamOptions,
 } from './module';
 export {
     defineStitch,

--- a/packages/nest/src/module.ts
+++ b/packages/nest/src/module.ts
@@ -19,6 +19,7 @@ import {
 } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import {
+    type AtLeastOne,
     type Seam,
     type SeamConfig,
     type SeamOptions,
@@ -47,16 +48,29 @@ export interface StitchModuleAsyncOptions {
     isGlobal?: boolean;
 }
 
+/**
+ * The feature seam's build config and its DI exposure token — two facets of one capability
+ * folded into a single envelope (CONTRACT.md P24; `seam`/`seamToken` shared the "seam" prefix).
+ * Naming the envelope `seam` while it carries a `config` member is intentional: `config` is what
+ * carries the P1 clarity the original `seam` config slot was for, so nesting it here loses nothing.
+ */
+export interface NestFeatureSeamOptions {
+    /** The `SeamConfig` for this feature's own seam (its `baseUrl`/`auth`/…), built over the
+     *  shared store + trace. Omit to attach the stitches to the root/default seam. At least one
+     *  member is required — an empty `{}` is indistinguishable from omitting it (P20). */
+    config?: AtLeastOne<SeamConfig>;
+    /** Token to expose the feature seam under, for `.as(principal)` multi-tenant. */
+    token?: InjectionToken;
+}
+
 /** forFeature options — a feature's injectable stitches and, optionally, its own upstream seam. */
 export interface StitchFeatureOptions {
     // Any-input element: a feature registry is heterogeneous, so it must admit templated-path defs
     // whose call argument *requires* `params` (see `AnyStitchDef`). Per-def inference is unaffected.
     stitches: AnyStitchDef[];
-    /** This feature's own seam (its `baseUrl`/`auth`/…), built over the shared store + trace.
-     *  Omit to attach the stitches to the root/default seam. */
-    seam?: SeamConfig;
-    /** Token to expose the feature seam under, for `.as(principal)` multi-tenant. */
-    seamToken?: InjectionToken;
+    /** The feature's own seam config and/or its DI exposure token. At least one member is
+     *  required — an empty `{}` is indistinguishable from omitting it (P20). */
+    seam?: AtLeastOne<NestFeatureSeamOptions>;
 }
 
 /** forFeatureScoped options — {@link StitchFeatureOptions} plus a `principal` derived
@@ -183,11 +197,11 @@ export class StitchModule {
         const norm: StitchFeatureOptions = Array.isArray(opts)
             ? { stitches: opts }
             : opts;
-        const cfg = norm.seam;
+        const cfg = norm.seam?.config;
         // A feature seam gets its own token (or the caller's, for multi-tenant `.as()`);
         // with no feature seam, stitches bind to the root/default seam.
         const token: InjectionToken =
-            norm.seamToken ??
+            norm.seam?.token ??
             (cfg ? Symbol('stitch-feature-seam') : STITCH_SEAM);
         const providers: Provider[] = [];
         const exported: InjectionToken[] = [];
@@ -226,14 +240,14 @@ export class StitchModule {
      * singleton seam and bind explicitly instead: `seam.as(job.data.tenantId)`.
      */
     static forFeatureScoped(opts: StitchScopedFeatureOptions): DynamicModule {
-        const cfg = opts.seam;
+        const cfg = opts.seam?.config;
         // The singleton base seam each per-request handle derives from: a feature seam over
-        // shared infra (if `seam` given) or the root/default seam.
+        // shared infra (if `seam.config` given) or the root/default seam.
         const baseToken: InjectionToken = cfg
             ? Symbol('stitch-scoped-base-seam')
             : STITCH_SEAM;
         const principalToken: InjectionToken =
-            opts.seamToken ?? Symbol('stitch-principal-seam');
+            opts.seam?.token ?? Symbol('stitch-principal-seam');
         const providers: Provider[] = [];
         const exported: InjectionToken[] = [principalToken];
 

--- a/packages/nest/test/module.spec.ts
+++ b/packages/nest/test/module.spec.ts
@@ -84,8 +84,10 @@ describe('StitchModule.forFeature', () => {
         );
         const mod = StitchModule.forFeature({
             seam: {
-                baseUrl: 'https://feat.test',
-                adapter: recordingAdapter(calls),
+                config: {
+                    baseUrl: 'https://feat.test',
+                    adapter: recordingAdapter(calls),
+                },
             },
             stitches: [GetThing],
         });
@@ -139,8 +141,10 @@ describe('StitchModule.forFeature', () => {
         ];
         const providers = StitchModule.forFeature({
             seam: {
-                baseUrl: 'https://feat.test',
-                adapter: recordingAdapter(calls),
+                config: {
+                    baseUrl: 'https://feat.test',
+                    adapter: recordingAdapter(calls),
+                },
             },
             stitches: mixed,
         }).providers as FProv[];
@@ -170,11 +174,13 @@ describe('StitchModule.forFeatureScoped', () => {
         const GetThing = defineStitch((h) => h.stitch({ path: '/thing' }));
         const mod = StitchModule.forFeatureScoped({
             seam: {
-                baseUrl: 'https://feat.test',
-                adapter: recordingAdapter(calls),
+                config: {
+                    baseUrl: 'https://feat.test',
+                    adapter: recordingAdapter(calls),
+                },
+                token: TENANT,
             },
             stitches: [GetThing],
-            seamToken: TENANT,
             principal: (req: { tenantId: string }) => req.tenantId,
         });
         const providers = mod.providers as FProv[];
@@ -240,8 +246,10 @@ describe('defineStitch token', () => {
         const GetThing = defineStitch((h) => h.stitch({ path: '/thing' }));
         const providers = StitchModule.forFeature({
             seam: {
-                baseUrl: 'https://feat.test',
-                adapter: recordingAdapter(calls),
+                config: {
+                    baseUrl: 'https://feat.test',
+                    adapter: recordingAdapter(calls),
+                },
             },
             stitches: [GetThing],
         }).providers as FProv[];


### PR DESCRIPTION
## What

Carves the **nest feature-seam envelope** — the DI half of the P24 flat→envelope conversions — out of the contract-freeze sweep (#470). Genuine breaking flat→envelope, **no `@deprecated` alias**.

`@stitchapi/nest`'s `StitchFeatureOptions` carried two facets of one capability as sibling flat members sharing the "seam" prefix — the `seam` config slot (a `SeamConfig`) and `seamToken`. They fold into one envelope:

```ts
seam?: AtLeastOne<NestFeatureSeamOptions>; // { config?: AtLeastOne<SeamConfig>, token? }
```

`forFeature` / `forFeatureScoped` read `seam.config` / `seam.token`. The nested `config` is itself `AtLeastOne<SeamConfig>`, so the opaque `{}` is rejected (P20). `NestFeatureSeamOptions` is exported from the package entry.

## Scope

Extracts **only** the seam envelope from the audit's nest changes — the `logger`-bridge default-on rework (P8) and the `index.ts` alias/`streamStitchSse`/`StitchErrorOptions` export drops (separate waves) are deliberately left out.

## Why

`docs/CONTRACT.md` **P24**: a shared leading-word prefix across ≥2 flat members of a house contract is really one envelope. The nest feature seam's `config`+`token` are that.

## Independent of the stack

Needs only `AtLeastOne` (core, already on `main`) — lands straight off `main`.

## Gate

`build` · `check:types` (full workspace) · `test` (49 nest specs pass) · `check:contract` · `check:lint` · `prettier` · `build-docs` (twoslash). Full pre-push gate passed. No core-bundle change.

## Breaking

BREAKING CHANGE: `StitchModule.forFeature` / `forFeatureScoped` no longer accept a bare `seam: SeamConfig` or a `seamToken`. Nest the config under `seam.config` and the token under `seam.token`: `seam: { config: { baseUrl, auth, … }, token? }`. No deprecated alias — a hard break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)