### PR TITLE
refactor(deno-kv)!: maxIncrRetries → retry envelope (P4 + P12/P20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,40 @@ npm release are grouped under the in-development version that introduced them.
 
 ## [Unreleased]
 
+### Added
+
+-   **`parseDuration` is now exported from `stitchapi`.** The one shared duration parser
+    (`5_000`, `'5s'`, `'1m'` → ms) that CONTRACT.md P17 requires every consumer-authored
+    duration to go through. It was already the parser core used internally; exporting it
+    lets a peer package accept `number | string` without mirroring the grammar and drifting
+    from it. Additive — nothing else changes.
+
 ### Changed
+
+-   **BREAKING — `@stitchapi/deno-kv`'s `maxIncrRetries` becomes `retry`.** The
+    compare-and-set budget for `increment` is now `retry?: number | AtLeastOne<DenoKvRetryOptions>`,
+    speaking core's `retry` vocabulary rather than a second private spelling. A bare number
+    is the attempts shorthand; the envelope adds a backoff curve the loop never had:
+
+    ```ts
+    denoKvStore(kv, { retry: 20 }); // ≡ { attempts: 20 }
+    denoKvStore(kv, { retry: { attempts: 20, backoff: 'expo-jitter' } });
+    ```
+
+    Two things to know when migrating, beyond the rename:
+
+    -   **`attempts` counts total attempts, not retries.** `maxIncrRetries: 3` allowed four
+        reads (the first plus three retries); `retry: 3` allows three. Add one to preserve the
+        old budget exactly. The default moves from `100` retries to `100` attempts — one fewer
+        read in the worst case, which no realistic contention notices.
+    -   **`{}` is a compile error.** The object form is `AtLeastOne<DenoKvRetryOptions>` per
+        P20, so `retry: {}` (which reads as a no-op but would silently mean "defaults") is
+        rejected; write `retry: 100` for the all-defaults case.
+
+    `backoff` is **off by default**, preserving today's behaviour — the loop re-reads
+    immediately on a lost race. Set `'expo'`, `'expo-jitter'` or `'fixed'` (with `baseDelay`
+    5ms, `maxDelay` 250ms) when many isolates contend on one key. No `@deprecated` alias:
+    P19 scopes that obligation to the GA channel and this lands on `rc`.
 
 -   **BREAKING — the store contract speaks whole words: `incr` is now `increment`, and
     `RedisDriver.del` is now `delete`.** `StitchStore` — the interface every store

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -116,7 +116,7 @@ current index.
 
 _Violations:_ `ReconnectOptions.maxAttempts` (→ `attempts`), `CacheConfig.maxEntries`
 (→ `entries`), `CircuitOptions.failureThreshold` (→ `failures`), `paginate.max`
-(→ `pages`), `deno-kv maxIncrRetries`.
+(→ `pages`). (`deno-kv maxIncrRetries` → `retry.attempts` — **fixed**, see [§6](#6-migration-backlog).)
 
 ---
 
@@ -479,7 +479,6 @@ the obligation to the GA channel. Severity = consumer blast radius.
 | Med  | SSE helper `sendStitchSse`/`stitchSse`                             | `streamStitchSse`                       | P16  |
 | Med  | error-options `StitchErrorHandlerOptions`/`ToHttpExceptionOptions` | `StitchErrorOptions` (+ `body`)         | P16  |
 | Low  | `RedisDriver…quit`, sync `close`                                   | async `close`                           | P18  |
-| Low  | `deno-kv maxIncrRetries`                                           | `incrementRetries`                      | P4   |
 | Low  | `bodyKind` (from-curl)                                             | `bodyType`                              | P1   |
 
 New shorthand/toggle slots to **add** (additive, non-breaking): `.inspect()`
@@ -592,6 +591,16 @@ cut; the lint skips the deprecated members so each rename ratchets the baseline 
     both are consumer-implemented contracts, which could not have carried an alias in any
     case. (`deno-kv`'s `maxIncrRetries` is untouched here; it is a P4 `max`-prefix
     violation and renames in that slice.)
+-   **P4 + P12/P14/P20 (`deno-kv` CAS retries)** `maxIncrRetries` — the last `max`-prefixed
+    count cap — becomes `retry?: number | AtLeastOne<DenoKvRetryOptions>`, reusing core's
+    `retry` vocabulary for the same concept instead of a second private spelling:
+    `attempts` (P4 bare noun, total incl. the first), plus `backoff`/`baseDelay`/`maxDelay`
+    for a curve the loop never had. A bare number is the P12 dominant-field shorthand
+    (`retry: 20` ≡ `{ attempts: 20 }`), and the object form is `AtLeastOne`, so `{}` is a
+    compile error (P20). No `on`: a CAS loop retries exactly one condition. Durations parse
+    through core's `parseDuration`, now **exported** so a peer package satisfies P17's "one
+    shared parser" instead of mirroring the grammar. Backoff stays **off by default** — the
+    hot re-read is today's behaviour and flipping it is a separate call.
 -   **P24 (refresh envelope)** the auth strategies' `refresh`-prefixed flat members fold into one
     envelope (genuine breaking flat→envelope, no alias): `OAuth2Options.refreshOn`/`refreshSkew` →
     `refresh?: StatusMatch | AtLeastOne<OAuth2RefreshOptions>` (`{ on, skew }`), and

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,6 +61,10 @@ export { memoryStore } from './store';
 // The default Clock (ADR 0010) — wall-clock + global timers. Inject a custom `Clock` (or a
 // `manualClock()` from `stitchapi/testing`) via a stitch/seam `clock` to control time.
 export { systemClock } from './util';
+// The one shared duration parser (CONTRACT.md P17): `5_000`, `'5s'`, `'1m'` → ms.
+// Exported so a peer package that takes a consumer-authored duration parses it the
+// same way core does, instead of mirroring the grammar and drifting from it.
+export { parseDuration } from './util';
 // `compact({ ...obj, key: value })` — a shallow copy with `undefined`-valued keys removed, typed so
 // undefined-admitting keys come back optional. Pairs with `exactOptionalPropertyTypes`: it omits an
 // absent optional without the `...(key !== undefined ? { key } : {})` spread dance.

--- a/packages/deno-kv/README.md
+++ b/packages/deno-kv/README.md
@@ -69,8 +69,27 @@ The TTL unit is **milliseconds** — the same unit as the contract's `ttl`, and 
 KV's own `expireIn` unit, so there's no conversion at the seam. An `increment` without
 a `ttl` (or with `ttl <= 0`) has **no window**: the counter accumulates forever
 and the key never expires — the same "absent `ttl` = no expiry" rule `set`
-follows. `maxIncrRetries` (default `100`) bounds the loop under pathological
-contention.
+follows.
+
+### Tuning the compare-and-set loop
+
+`retry` bounds that loop. A bare number is the attempts shorthand; the envelope adds
+a backoff curve, using the same words as core's `retry`:
+
+```ts
+denoKvStore(kv, { retry: 20 }); // ≡ { attempts: 20 }
+denoKvStore(kv, { retry: { attempts: 20, backoff: 'expo-jitter' } });
+```
+
+`attempts` (default `100`) is the **total** including the first, so it is a budget,
+not a retry count. There is no `on`: the loop retries exactly one condition — another
+isolate committed first — so there is nothing to match against.
+
+`backoff` is **off by default**: the loop re-reads immediately, which is the tightest
+path to a win when contention is brief. Set a curve (`'expo'`, `'expo-jitter'`,
+`'fixed'`, with `baseDelay` 5ms and `maxDelay` 250ms) when many isolates hammer one
+key and the hot spin costs more KV reads than it saves — `'expo-jitter'` is the one to
+reach for there, since full jitter stops a thundering herd re-colliding in lockstep.
 
 The store owns no connection: `store.close()` delegates to the handle, so you
 decide when KV shuts down.

--- a/packages/deno-kv/src/index.ts
+++ b/packages/deno-kv/src/index.ts
@@ -16,7 +16,8 @@
 //
 // Compliance with the store contract is proven against `verifyStoreContract` from
 // `stitchapi/testing` (see test/conformance.spec.ts).
-import type { StitchStore } from 'stitchapi';
+import { parseDuration } from 'stitchapi';
+import type { AtLeastOne, StitchStore } from 'stitchapi';
 
 // ---------------------------------------------------------------------------
 // the Deno KV surface
@@ -108,9 +109,55 @@ function asWindow(value: unknown): CounterWindow | null {
         : null;
 }
 
+// Delay before retry #n (1-based) under a backoff curve, clamped to `max`. Mirrors
+// core's `RetryOptions` curves: `fixed` holds `base`, `expo` doubles it, and
+// `expo-jitter` picks uniformly in `[0, expo]` (full jitter) so a thundering herd of
+// isolates doesn't re-collide in lockstep on the same tick.
+function backoffDelay(
+    curve: 'expo' | 'expo-jitter' | 'fixed',
+    n: number,
+    base: number,
+    max: number,
+): number {
+    if (curve === 'fixed') return Math.min(base, max);
+    const expo = Math.min(base * 2 ** (n - 1), max);
+    return curve === 'expo' ? expo : Math.random() * expo;
+}
+
+const sleep = (ms: number): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
 // ---------------------------------------------------------------------------
 // the store
 // ---------------------------------------------------------------------------
+
+/**
+ * How {@link StitchStore.increment} rides out a lost compare-and-set race. The
+ * subset of core's `RetryOptions` that means anything to a CAS loop: there is no
+ * `on`, because the loop retries exactly one condition — another isolate committed
+ * first — and nothing else.
+ */
+export interface DenoKvRetryOptions {
+    /**
+     * Total attempts including the first (default `100`). Each attempt re-reads the
+     * current value, so the loop only spins under genuine contention. With N callers
+     * racing one counter, the unluckiest needs up to N−1 retries (each round exactly
+     * one commit wins, so contention drains one caller at a time); the default
+     * comfortably covers any realistic per-key concurrency on a single window.
+     */
+    attempts?: number;
+    /**
+     * Delay curve between attempts. Omitted (the default) means **no delay** — the
+     * loop re-reads immediately, which is the tightest path to a win when contention
+     * is brief. Set a curve when many isolates hammer one key and the hot spin costs
+     * more KV reads than it saves.
+     */
+    backoff?: 'expo' | 'expo-jitter' | 'fixed';
+    /** Delay before the first retry — `5`, `'5ms'`, `'1s'`. Default 5ms; only used when `backoff` is set. */
+    baseDelay?: number | string;
+    /** Ceiling the computed delay is clamped to — `250`, `'250ms'`. Default 250ms. */
+    maxDelay?: number | string;
+}
 
 /** Options for {@link denoKvStore}. */
 export interface DenoKvStoreOptions {
@@ -122,14 +169,11 @@ export interface DenoKvStoreOptions {
      */
     keyPrefix?: string;
     /**
-     * How many times {@link StitchStore.increment} retries a lost compare-and-set race
-     * before giving up. Each retry re-reads the current value, so the loop only
-     * spins under genuine contention. With N callers racing one counter, the
-     * unluckiest needs up to N−1 retries (each round exactly one commit wins, so
-     * contention drains one caller at a time); the default `100` therefore
-     * comfortably covers any realistic per-key concurrency on a single window.
+     * Compare-and-set retry policy for {@link StitchStore.increment}. A bare number
+     * is the attempts shorthand (`retry: 20` ≡ `retry: { attempts: 20 }`); the
+     * envelope adds a backoff curve. Default `{ attempts: 100 }` with no delay.
      */
-    maxIncrRetries?: number;
+    retry?: number | AtLeastOne<DenoKvRetryOptions>;
 }
 
 /**
@@ -155,7 +199,16 @@ export function denoKvStore(
     opts: DenoKvStoreOptions = {},
 ): StitchStore {
     const prefix = opts.keyPrefix;
-    const maxRetries = opts.maxIncrRetries ?? 100;
+    // P12 dominant-field shorthand: a bare number is `{ attempts }`. Normalized once
+    // here so the loop below only ever reads the envelope.
+    const retry: DenoKvRetryOptions =
+        typeof opts.retry === 'number'
+            ? { attempts: opts.retry }
+            : (opts.retry ?? {});
+    const attempts = retry.attempts ?? 100;
+    const backoff = retry.backoff;
+    const baseDelay = parseDuration(retry.baseDelay) ?? 5;
+    const maxDelay = parseDuration(retry.maxDelay) ?? 250;
     // String key → Deno KV array key. With a prefix it's a two-segment key so the
     // namespace is a real KV sub-range; without, a flat one-segment key.
     const k = (key: string): DenoKvKey =>
@@ -208,7 +261,7 @@ export function denoKvStore(
             // FIRST increment and never extended, and re-derive `expireIn` from
             // it on every commit so the fixed window always expires on time.
             const kk = k(key);
-            for (let attempt = 0; attempt <= maxRetries; attempt++) {
+            for (let attempt = 1; attempt <= attempts; attempt++) {
                 const entry = await kv.get(kk);
                 const now = Date.now();
                 const prev = asWindow(entry.value);
@@ -243,9 +296,17 @@ export function denoKvStore(
                     .set(kk, { n, deadline }, options)
                     .commit();
                 if (res.ok) return n;
+                // Lost the race. Pause only when a curve is configured — the default
+                // re-reads immediately — and never after the final attempt, which
+                // would just delay the throw.
+                if (backoff && attempt < attempts) {
+                    await sleep(
+                        backoffDelay(backoff, attempt, baseDelay, maxDelay),
+                    );
+                }
             }
             throw new Error(
-                `@stitchapi/deno-kv: increment(${key}) lost ${maxRetries + 1} compare-and-set races`,
+                `@stitchapi/deno-kv: increment(${key}) lost ${attempts} compare-and-set races`,
             );
         },
     };

--- a/packages/deno-kv/test/store-behaviour.spec.ts
+++ b/packages/deno-kv/test/store-behaviour.spec.ts
@@ -289,12 +289,96 @@ describe('denoKvStore — increment TTL window', () => {
         expect(await store.increment('legacy', 200)).toBe(2);
     });
 
-    test('throws after exhausting maxIncrRetries lost compare-and-set races', async () => {
+    test('throws after exhausting retry.attempts lost compare-and-set races', async () => {
         const rec = recordingKv({ failAtomic: true });
-        const store = denoKvStore(rec.kv, { maxIncrRetries: 3 });
+        const store = denoKvStore(rec.kv, { retry: { attempts: 3 } });
+        // `attempts` is the TOTAL including the first, so 3 means 3 reads, not 4.
+        await expect(store.increment('x', 1000)).rejects.toThrow(
+            /lost 3 compare-and-set races/,
+        );
+    });
+
+    test('a bare number is the attempts shorthand (retry: 3 ≡ { attempts: 3 })', async () => {
+        const rec = recordingKv({ failAtomic: true });
+        const store = denoKvStore(rec.kv, { retry: 3 });
+        await expect(store.increment('x', 1000)).rejects.toThrow(
+            /lost 3 compare-and-set races/,
+        );
+    });
+
+    test('the default budget is 100 attempts', async () => {
+        const rec = recordingKv({ failAtomic: true });
+        const store = denoKvStore(rec.kv);
+        await expect(store.increment('x', 1000)).rejects.toThrow(
+            /lost 100 compare-and-set races/,
+        );
+    });
+
+    test('no backoff by default: the loop re-reads with no timer in between', async () => {
+        // With a curve unset the retry path must never touch `setTimeout` — a hot
+        // re-read is the tightest path to a win when contention is brief, and it is
+        // what keeps this loop usable under fake timers.
+        const spy = vi.spyOn(globalThis, 'setTimeout');
+        const rec = recordingKv({ failAtomic: true });
+        const store = denoKvStore(rec.kv, { retry: 4 });
         await expect(store.increment('x', 1000)).rejects.toThrow(
             /lost 4 compare-and-set races/,
         );
+        expect(spy).not.toHaveBeenCalled();
+        spy.mockRestore();
+    });
+
+    test('a fixed curve sleeps baseDelay between attempts, but not after the last', async () => {
+        const delays: number[] = [];
+        const spy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((
+            fn: () => void,
+            ms?: number,
+        ) => {
+            delays.push(ms ?? 0);
+            fn();
+            return 0 as unknown as ReturnType<typeof setTimeout>;
+        }) as unknown as typeof setTimeout);
+        const rec = recordingKv({ failAtomic: true });
+        const store = denoKvStore(rec.kv, {
+            retry: { attempts: 4, backoff: 'fixed', baseDelay: '20ms' },
+        });
+        await expect(store.increment('x', 1000)).rejects.toThrow(
+            /lost 4 compare-and-set races/,
+        );
+        // 4 attempts → 3 gaps; the delay after the final loss would only stall the throw.
+        expect(delays).toEqual([20, 20, 20]);
+        spy.mockRestore();
+    });
+
+    test('an expo curve doubles and clamps at maxDelay', async () => {
+        const delays: number[] = [];
+        const spy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((
+            fn: () => void,
+            ms?: number,
+        ) => {
+            delays.push(ms ?? 0);
+            fn();
+            return 0 as unknown as ReturnType<typeof setTimeout>;
+        }) as unknown as typeof setTimeout);
+        const rec = recordingKv({ failAtomic: true });
+        const store = denoKvStore(rec.kv, {
+            retry: {
+                attempts: 5,
+                backoff: 'expo',
+                baseDelay: 10,
+                maxDelay: 30,
+            },
+        });
+        await expect(store.increment('x', 1000)).rejects.toThrow(
+            /lost 5 compare-and-set races/,
+        );
+        expect(delays).toEqual([10, 20, 30, 30]);
+        spy.mockRestore();
+    });
+
+    test('the empty object is a compile error (P20), the envelope needs a field', () => {
+        // @ts-expect-error `{}` must not satisfy AtLeastOne<DenoKvRetryOptions>
+        denoKvStore(recordingKv().kv, { retry: {} });
     });
 });
 


### PR DESCRIPTION
> Follows #505 (merged). Originally stacked on its branch, now **rebased onto `main`** as a single commit — the diff is this slice alone.

`maxIncrRetries` was the last `max`-prefixed count cap in the published surface — the P4 violation **D2** settled (a *count* is a bare plural noun; `max` survives only for a continuous **magnitude** ceiling, which is why `maxDelay` legitimately keeps it).

Rather than invent a second private spelling for a concept core already names, the compare-and-set budget becomes `retry`, speaking core's `RetryOptions` vocabulary:

```ts
denoKvStore(kv, { retry: 20 }); // ≡ { attempts: 20 }
denoKvStore(kv, { retry: { attempts: 20, backoff: 'expo-jitter' } });
```

### The shape, and why each field is what it is

- **`attempts`, not `max`** (P4). Using `max` inside the envelope would re-commit at one level down the exact error the rename exists to fix.
- **`attempts` is the TOTAL including the first**, per core's definition — so this is a semantic change on top of the rename, not just a spelling. `maxIncrRetries: 3` allowed **four** reads (first + 3 retries); `retry: 3` allows three. Add one to preserve an existing budget exactly. The default moves from 100 retries to 100 attempts — one fewer read in the worst case, which no realistic contention notices.
- **A bare number is the shorthand** (P12 dominant field): `retry: 20` ≡ `{ attempts: 20 }`.
- **`{}` is a compile error** (P20). The object form is `AtLeastOne<DenoKvRetryOptions>`, so `retry: {}` — which reads as a no-op but would silently mean "defaults" — is rejected. The all-defaults case is the scalar. Pinned by a `@ts-expect-error` test.
- **No `on`, and no `when`.** Not an oversight: a CAS loop retries exactly one condition — another isolate committed first — so a trigger slot would have nothing to match against. (`when` is also already taken, by `CookieSessionOptions.refresh.when` from the P24 fold.) The envelope is core's `RetryOptions` minus `on` and `respectRetryAfter`.

### The new capability

`backoff` / `baseDelay` / `maxDelay` did not exist. The loop re-read **immediately** on a lost race, hot-spinning against KV under contention — more reads than the contention it was waiting out.

The curve is **opt-in**: with `backoff` unset the loop behaves byte-for-byte as it does today, and a test asserts the retry path never touches `setTimeout` in that case (which is also what keeps this loop usable under fake timers). `'expo-jitter'` uses full jitter, so a thundering herd of isolates doesn't re-collide in lockstep on the same tick.

Flipping the default to a jittered curve is defensible and probably right, but it is a behaviour change under load that deserves its own decision and a benchmark — deliberately not smuggled in here.

### One core change

`parseDuration` is now **exported** from `stitchapi` (additive, non-breaking). P17 requires every consumer-authored duration to accept `number | string` parsed by **one shared `parseDuration`**, and core did not export it — so the alternative was copying the grammar into deno-kv, which is precisely the hand-mirror drift class.

Measured **zero bundle cost**: `check:size` reports 24.60 KB / 19.81 KB gzip with and without the export, because core already pulled `parseDuration` in internally. (The ~0.20 KB of remaining headroom is pre-existing, not consumed here.)

### Gates

full-workspace `check:types` (0 errors) · tests (core 1228, deno-kv **21**, up from 15 — 6 new covering the shorthand, the total-attempts semantics, the default budget, no-timer-by-default, the fixed and expo curves, and the `{}` compile error) · `check:contract` · `check:lint` · `check:exports` · `check:docs-links` · `check:size` · `check:format` · all 9 yakir tethers (0 drift) · `@stitchapi/docs` build (437/437 pages) — green.

### BREAKING CHANGE

`@stitchapi/deno-kv`'s `DenoKvStoreOptions.maxIncrRetries` is replaced by `retry`, and the count is now **total attempts** rather than retries. No `@deprecated` alias — P19 scopes that obligation to the GA channel and this lands on `rc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
