### PR TITLE
refactor(core)!: fold retry backoff into one envelope; reconnect.backoff → delay (P24 + P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,42 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Changed
 
+-   **BREAKING — `retry`'s backoff fields fold into one `backoff` envelope.**
+    `RetryOptions.backoff` / `baseDelay` / `maxDelay` were three flat members configuring a
+    single concept, two of them sharing a `Delay` suffix. They are now one envelope:
+
+    ```ts
+    // before
+    retry: { attempts: 3, backoff: 'expo', baseDelay: 200, maxDelay: '10s' }
+    // after
+    retry: { attempts: 3, backoff: { curve: 'expo', base: 200, max: '10s' } }
+    ```
+
+    `backoff: 'expo-jitter'` still works — a bare curve is the shorthand for `{ curve }`, so
+    the common case is unchanged. Only configs that set `baseDelay` or `maxDelay` need editing:
+    move them under `backoff` as `base` / `max`. Inside the envelope the `Delay` suffix is
+    redundant — there is only one thing there to measure. `backoff: {}` is a compile error;
+    pass a curve, or set at least one bound.
+
+    `@stitchapi/deno-kv`'s `retry.backoff` folds identically in the same release, so the
+    store's compare-and-set policy and a stitch's retry policy keep spelling the same
+    concept the same way.
+
+-   **BREAKING — `sse.reconnect.backoff` is renamed to `delay`.** It is a flat fallback
+    duration, while `retry.backoff` is a curve policy — one token meaning two things, and since
+    both accept strings, `backoff: 'expo'` and `backoff: '1s'` were indistinguishable by shape.
+    `backoff` now means "the curve policy" everywhere; the reconnect fallback is a `delay`:
+
+    ```ts
+    sse: { reconnect: { attempts: 5, delay: '1s' } }
+    ```
+
+    Behaviour is unchanged — a server-sent `retry:` still wins, and with no `delay` the stitch's
+    `retry.backoff` still supplies the wait.
+
+    Neither carries a `@deprecated` alias: P19 scopes that obligation to the GA channel and this
+    lands on `rc`.
+
 -   **BREAKING — `@stitchapi/deno-kv`'s `maxIncrRetries` becomes `retry`.** The
     compare-and-set budget for `increment` is now `retry?: number | AtLeastOne<DenoKvRetryOptions>`,
     speaking core's `retry` vocabulary rather than a second private spelling. A bare number
@@ -42,8 +78,9 @@ npm release are grouped under the in-development version that introduced them.
         rejected; write `retry: 100` for the all-defaults case.
 
     `backoff` is **off by default**, preserving today's behaviour — the loop re-reads
-    immediately on a lost race. Set `'expo'`, `'expo-jitter'` or `'fixed'` (with `baseDelay`
-    5ms, `maxDelay` 250ms) when many isolates contend on one key. No `@deprecated` alias:
+    immediately on a lost race. Set `'expo'`, `'expo-jitter'` or `'fixed'` — or the
+    `{ curve, base, max }` envelope, `base` 5ms and `max` 250ms — when many isolates contend
+    on one key. No `@deprecated` alias:
     P19 scopes that obligation to the GA channel and this lands on `rc`.
 
 -   **BREAKING — the store contract speaks whole words: `incr` is now `increment`, and

--- a/apps/docs/app/(home)/playground/playground-examples.ts
+++ b/apps/docs/app/(home)/playground/playground-examples.ts
@@ -33,10 +33,7 @@ const api = stitch({
   retry: {
     attempts: 4,
     on: [429, 502, 503, 504],
-    backoff: 'expo-jitter',
-    baseDelay: 100,
-    maxDelay: 400,
-  },
+    backoff: { curve: 'expo-jitter', base: 100, max: 400 },},
   timeout: { total: '4s', perAttempt: '2s' }, // fail fast instead of hanging
   throttle: { rate: '50/s' }, // client-side rate limit
   circuit: { failures: 5, cooldown: 1000 }, // stop hammering a dead dep

--- a/apps/docs/content/blog/retry-fetch-in-typescript.mdx
+++ b/apps/docs/content/blog/retry-fetch-in-typescript.mdx
@@ -111,8 +111,7 @@ const getUser = stitch({
     retry: {
         attempts: 3,
         on: [429, 503],
-        backoff: 'expo-jitter',
-        baseDelay: 200,
+        backoff: { curve: 'expo-jitter', base: 200 },
         respectRetryAfter: true,
     },
 });
@@ -120,7 +119,7 @@ const getUser = stitch({
 const user = await getUser({ params: { id: '42' } }); // retried, backed off, Retry-After honored
 ```
 
-Every pitfall above is now a named field. `attempts` is the **total** number of tries including the first, so `attempts: 3` means up to two retries. `on` lists the status codes that trigger a retry — defaulting to the transient set `[429, 502, 503, 504]`, which is what keeps a dead `4xx` from being retried at all. `backoff: 'expo-jitter'` doubles the delay each attempt and spreads it randomly to break up the herd, paced from `baseDelay` and clamped to `maxDelay`; `'expo'` and `'fixed'` are there when you want a different curve. And `respectRetryAfter: true` uses the server's `Retry-After` header in place of the computed backoff when the response carries one.
+Every pitfall above is now a named field. `attempts` is the **total** number of tries including the first, so `attempts: 3` means up to two retries. `on` lists the status codes that trigger a retry — defaulting to the transient set `[429, 502, 503, 504]`, which is what keeps a dead `4xx` from being retried at all. `backoff: 'expo-jitter'` doubles the delay each attempt and spreads it randomly to break up the herd, paced from `backoff.base` and clamped to `backoff.max`; `'expo'` and `'fixed'` are there when you want a different curve. And `respectRetryAfter: true` uses the server's `Retry-After` header in place of the computed backoff when the response carries one.
 
 The non-idempotent-write pitfall doesn't vanish — nothing can make a blind `POST` retry safe — but it stops being a silent default. Adding `retry` to a write is a deliberate line you write, and the [retry guide](/docs/guides/resilience/retry) flags it: pair it with an idempotency key so the server collapses the duplicate, or leave retry off. The policy is declared where you can see it, not buried in a shared helper three files away.
 
@@ -142,4 +141,4 @@ That's the line, and crossing it is a field, not a rewrite: the same call gains 
 stitchapi
 ```
 
-Declare one endpoint with a `retry` field and the loop, the backoff math, the status-code allowlist, and the `Retry-After` parsing collapse into five lines of policy you can read at a glance. The full option list — every `backoff` curve, `baseDelay`, `maxDelay`, and the idempotency caveat — lives in [Retry & backoff](/docs/guides/resilience/retry).
+Declare one endpoint with a `retry` field and the loop, the backoff math, the status-code allowlist, and the `Retry-After` parsing collapse into five lines of policy you can read at a glance. The full option list — every `backoff` curve plus its `base` and `max` bounds, and the idempotency caveat — lives in [Retry & backoff](/docs/guides/resilience/retry).

--- a/apps/docs/content/docs/errors/stitch-timeout.mdx
+++ b/apps/docs/content/docs/errors/stitch-timeout.mdx
@@ -42,7 +42,7 @@ import { stitch } from 'stitchapi';
 const report = stitch({
     baseUrl: 'https://api.example.com',
     path: '/reports/slow',
-    retry: { attempts: 3, baseDelay: 200 },
+    retry: { attempts: 3, backoff: { base: 200 } },
     timeout: {
         // Each attempt gets 5s; the whole call (3 attempts + backoff) gets 20s.
         perAttempt: '5s',

--- a/apps/docs/content/docs/guides/resilience/retry.mdx
+++ b/apps/docs/content/docs/guides/resilience/retry.mdx
@@ -19,8 +19,7 @@ const getUser = stitch({
     retry: {
         attempts: 3,
         on: [429, 503],
-        backoff: 'expo-jitter',
-        baseDelay: 200,
+        backoff: { curve: 'expo-jitter', base: 200 },
         respectRetryAfter: true,
     },
 });
@@ -37,10 +36,18 @@ single status, a list, or a predicate `(status) => boolean` (`on: 429` ≡
 `on: [429]`). It defaults to `[429, 502, 503, 504]` — the usual transient set —
 and you narrow or widen it per stitch.
 
-`backoff` chooses how long to wait between attempts, paced from `baseDelay` and
-clamped to `maxDelay`: `'expo'` doubles the delay each attempt, `'expo-jitter'`
+`backoff` chooses how long to wait between attempts. A bare curve is the whole
+policy — `backoff: 'expo-jitter'` — and the object form adds the two bounds that
+shape it, `base` and `max`:
+
+```ts
+retry: { attempts: 3, backoff: { curve: 'expo', base: 200, max: '10s' } }
+```
+
+`'expo'` doubles the delay each attempt starting from `base`, `'expo-jitter'`
 spreads it randomly up to that exponential value to avoid thundering herds, and
-`'fixed'` waits a constant `baseDelay` every time.
+`'fixed'` waits a constant `base` every time. Every computed delay is clamped to
+`max`.
 
 `respectRetryAfter` honors a `Retry-After` header on the failing response —
 delta-seconds or an HTTP-date — using it in place of the computed backoff when

--- a/apps/docs/content/docs/guides/testing/mocking.mdx
+++ b/apps/docs/content/docs/guides/testing/mocking.mdx
@@ -100,7 +100,7 @@ const call = stitch({
     baseUrl: 'https://api.test',
     path: '/flaky',
     adapter: api,
-    retry: { attempts: 3, on: [503], baseDelay: 1 },
+    retry: { attempts: 3, on: [503], backoff: { base: 1 } },
 });
 
 await call(); // { ok: true } — the third reply
@@ -310,7 +310,7 @@ const call = stitch({
     baseUrl: 'https://api.test',
     path: '/flaky',
     adapter: api,
-    retry: { attempts: 2, on: [503], baseDelay: 10_000 },
+    retry: { attempts: 2, on: [503], backoff: { base: 10_000 } },
     clock,
 });
 

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -89,6 +89,12 @@ These are real, distinct concepts → **`throttle.scope` is renamed to `pool`**,
 `scope` to mean tenancy everywhere. (This is a rename, **not** an assertion that they
 were the same concept.)
 
+_Second case:_ `backoff` was a **curve policy** (`'expo'|'expo-jitter'|'fixed'`) in
+`RetryOptions` and a flat **duration** (`number | string`) in `ReconnectOptions` — one token,
+two value-spaces, and both accept strings, so `backoff: 'expo'` and `backoff: '1s'` were
+indistinguishable by shape. → **`reconnect.backoff` is renamed to `delay`**, leaving `backoff`
+to mean "the curve policy" everywhere.
+
 ### P3 · One suffix system
 
 A type's role **MUST** be predictable from its suffix:
@@ -594,13 +600,23 @@ cut; the lint skips the deprecated members so each rename ratchets the baseline 
 -   **P4 + P12/P14/P20 (`deno-kv` CAS retries)** `maxIncrRetries` — the last `max`-prefixed
     count cap — becomes `retry?: number | AtLeastOne<DenoKvRetryOptions>`, reusing core's
     `retry` vocabulary for the same concept instead of a second private spelling:
-    `attempts` (P4 bare noun, total incl. the first), plus `backoff`/`baseDelay`/`maxDelay`
-    for a curve the loop never had. A bare number is the P12 dominant-field shorthand
+    `attempts` (P4 bare noun, total incl. the first), plus a `backoff` envelope for a curve
+    the loop never had (folded to `{ curve, base, max }` in the same sweep as core's). A bare number is the P12 dominant-field shorthand
     (`retry: 20` ≡ `{ attempts: 20 }`), and the object form is `AtLeastOne`, so `{}` is a
     compile error (P20). No `on`: a CAS loop retries exactly one condition. Durations parse
     through core's `parseDuration`, now **exported** so a peer package satisfies P17's "one
     shared parser" instead of mirroring the grammar. Backoff stays **off by default** — the
     hot re-read is today's behaviour and flipping it is a separate call.
+-   **P24 (backoff envelope) + P2 (`backoff` disambiguated)** `RetryOptions`'
+    `backoff`/`baseDelay`/`maxDelay` — three flat members configuring one concept, two of them
+    sharing a `Delay` suffix — fold into `backoff?: BackoffCurve | AtLeastOne<BackoffOptions>`
+    (`{ curve, base, max }`). A bare curve is the P12 dominant-field shorthand
+    (`backoff: 'fixed'` ≡ `{ curve: 'fixed' }`), folded by a **nested** `envelope()` call in
+    `expandShorthand` so the string never reaches `__config` (P0); `{}` is a compile error (P20).
+    Inside the envelope the bounds need no suffix (P1), and `max` bounds a **magnitude**, the case
+    P4 leaves it. In the same pass `ReconnectOptions.backoff` — a flat duration, not a curve —
+    becomes **`delay`**, so `backoff` names one concept with one value-space across the surface.
+    Genuine breaking flat→envelope, no alias (P19, `rc` channel).
 -   **P24 (refresh envelope)** the auth strategies' `refresh`-prefixed flat members fold into one
     envelope (genuine breaking flat→envelope, no alias): `OAuth2Options.refreshOn`/`refreshSkew` →
     `refresh?: StatusMatch | AtLeastOne<OAuth2RefreshOptions>` (`{ on, skew }`), and

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -398,7 +398,7 @@ const listUsers = stitch({
 ```
 
 -   **`throttle` is proactive** - a rate (`'1/s'`) and a concurrency cap that keep you under a vendor's limit before it bites; `pool: 'host'` shares one limiter across every stitch hitting the same host.
--   **`retry` is reactive** - `attempts` is the total including the first; retried statuses default to `[429, 502, 503, 504]`; backoff is `'expo'` / `'expo-jitter'` / `'fixed'` with `baseDelay` / `maxDelay` clamps; `respectRetryAfter` honors the `Retry-After` header (delta-seconds or HTTP-date).
+-   **`retry` is reactive** - `attempts` is the total including the first; retried statuses default to `[429, 502, 503, 504]`; backoff is `'expo'` / `'expo-jitter'` / `'fixed'`, with `backoff.base` / `backoff.max` bounds; `respectRetryAfter` honors the `Retry-After` header (delta-seconds or HTTP-date).
 -   **`timeout` aborts** - `total` and/or `perAttempt`, as milliseconds or `'30s'`-style strings, enforced with a real `AbortSignal` instead of a request left hanging.
 
 Throttle waits and retries emit `throttled` / `retry` events on the stream, so the waiting is visible in the trace for free.

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -1375,12 +1375,10 @@ async function* runStreaming(
         }
 
         // Backoff: a server-sent `retry:` (seen on any connection this run) wins; else the explicit
-        // `reconnect.backoff`; else the stitch's `retry` backoff math. `attempt` is now the count
+        // `reconnect.delay`; else the stitch's `retry` backoff math. `attempt` is now the count
         // of opens DONE, so `attempt + 1` is the upcoming reconnect for the expo curve.
         const backoff =
-            lastRetryMs ??
-            policy.backoff ??
-            backoffDelay(attempt + 1, cfg.retry);
+            lastRetryMs ?? policy.delay ?? backoffDelay(attempt + 1, cfg.retry);
         yield {
             type: 'progress',
             phase: 'reconnect',
@@ -1397,22 +1395,20 @@ async function* runStreaming(
 
 // Resolve the resumable-SSE reconnect policy from config (issue #71) — the ONE place the engine
 // reads the `sse` config slot, keeping `runStreaming` free of SSE-isms. `sse.reconnect` is off by
-// default; `true` enables it with sane defaults; the object form tunes the cap / fallback backoff.
-// `backoff` stays `undefined` when unset so the caller can fall back to the `retry` policy.
+// default; `true` enables it with sane defaults; the object form tunes the cap / fallback delay.
+// `delay` stays `undefined` when unset so the caller can fall back to the `retry` policy.
 function resolveReconnect(cfg: ResolvedStitchConfig): {
     enabled: boolean;
     maxAttempts: number;
-    backoff: number | undefined;
+    delay: number | undefined;
 } {
     const r = cfg.sse?.reconnect;
-    if (!r) return { enabled: false, maxAttempts: 0, backoff: undefined };
-    if (r === true)
-        return { enabled: true, maxAttempts: 3, backoff: undefined };
-    const backoff = parseDuration(r.backoff);
+    if (!r) return { enabled: false, maxAttempts: 0, delay: undefined };
+    if (r === true) return { enabled: true, maxAttempts: 3, delay: undefined };
     return {
         enabled: true,
         maxAttempts: r.attempts ?? 3,
-        backoff,
+        delay: parseDuration(r.delay),
     };
 }
 

--- a/packages/core/src/resilience.ts
+++ b/packages/core/src/resilience.ts
@@ -4,6 +4,7 @@
 import type {
     AcquireOptions,
     AdapterResponse,
+    BackoffOptions,
     CircuitOptions,
     Clock,
     RetryOptions,
@@ -36,9 +37,14 @@ export function acceptsStatus(
  * 'fixed' = base. Result is clamped to max.
  */
 export function backoffDelay(attempt: number, opts?: RetryOptions): number {
-    const kind = opts?.backoff ?? 'expo-jitter';
-    const base = parseDuration(opts?.baseDelay) ?? 100;
-    const max = parseDuration(opts?.maxDelay) ?? 10_000;
+    // `expandShorthand` folds a bare curve into the envelope before the engine sees it, but
+    // `backoffDelay` is also called directly (tests, the reconnect path), so accept both.
+    const b = opts?.backoff;
+    const policy: BackoffOptions =
+        typeof b === 'string' ? { curve: b } : (b ?? {});
+    const kind = policy.curve ?? 'expo-jitter';
+    const base = parseDuration(policy.base) ?? 100;
+    const max = parseDuration(policy.max) ?? 10_000;
     const exp = Math.max(0, attempt - 2); // attempt 2 -> 2^0
     let delay: number;
     if (kind === 'fixed') {

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -145,7 +145,16 @@ function expandShorthand(cfg: Partial<StitchConfig>): void {
     // P12/P14: each slot's dominant-field scalar folds into its envelope, so the opaque `{}` never
     // reaches the slot (P20) and the engine only ever sees the object form. One `envelope` call per
     // slot — the slot and its dominant field, nothing else to keep in sync.
-    if (cfg.retry !== undefined) cfg.retry = envelope(cfg.retry, 'attempts');
+    if (cfg.retry !== undefined) {
+        cfg.retry = envelope(cfg.retry, 'attempts');
+        // Nested fold (P24): `backoff` is itself a scalar-or-envelope slot, so the bare curve
+        // normalizes too — `__config` never carries the string form (P0).
+        if (cfg.retry.backoff !== undefined)
+            cfg.retry = {
+                ...cfg.retry,
+                backoff: envelope(cfg.retry.backoff, 'curve'),
+            };
+    }
     if (cfg.timeout !== undefined) cfg.timeout = envelope(cfg.timeout, 'total');
     if (cfg.cache !== undefined) cfg.cache = envelope(cfg.cache, 'ttl');
     if (cfg.stream !== undefined) cfg.stream = envelope(cfg.stream, 'decode');

--- a/packages/core/src/test-clock.ts
+++ b/packages/core/src/test-clock.ts
@@ -35,7 +35,7 @@ const drainMicrotasks = (): Promise<void> =>
  *
  * ```ts
  * const clock = manualClock();
- * const call = stitch({ url, adapter, retry: { attempts: 3, baseDelay: 10_000 }, clock });
+ * const call = stitch({ url, adapter, retry: { attempts: 3, backoff: { base: 10_000 }}, clock });
  * const p = call.safe();
  * await clock.advance(0); // run the first attempt
  * await clock.advance(10_000); // fire the backoff → next attempt

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -160,19 +160,21 @@ export interface ReconnectOptions {
      */
     attempts?: number;
     /**
-     * Fallback reconnect backoff when the server has NOT sent a `retry:` field on the dropped
-     * connection — `1000`, `'1s'`. When omitted, the stitch's `retry` (`RetryOptions` —
-     * `backoff`/`baseDelay`/`maxDelay`) supplies the delay. A server-sent `retry:` on the connection
-     * always wins over both.
+     * Fallback reconnect delay when the server has NOT sent a `retry:` field on the dropped
+     * connection — `1000`, `'1s'`. When omitted, the stitch's `retry.backoff` supplies it. A
+     * server-sent `retry:` on the connection always wins over both.
+     *
+     * Named `delay`, not `backoff`: this is a flat duration, while `retry.backoff` is a curve
+     * policy. One token, one value-space (P1/P2).
      */
-    backoff?: number | string;
+    delay?: number | string;
 }
 /**
  * Resumable SSE (issue #71) — how the `sse` surface recovers from a dropped stream. **Off by
  * default**: with no `sse.reconnect` block the engine opens the body exactly once (today's
  * behaviour, byte-identical). When enabled the engine tracks the last `id:` seen and replays it as
  * `Last-Event-ID` on each reconnect, honours a server-sent `retry:` as the backoff (falling back to
- * `reconnect.backoff` / the stitch's `retry` policy), and caps reconnects at `attempts`.
+ * `reconnect.delay` / the stitch's `retry` policy), and caps reconnects at `attempts`.
  *
  * `true` = enabled with sane defaults; the object form tunes the cap / fallback backoff. Plain JSON
  * (the contract gate). Only the `sse` surface acts on this; other surfaces ignore it.
@@ -274,14 +276,31 @@ export type Adapter = ((req: AdapterRequest) => Promise<AdapterResponse>) & {
  * (`on: 429` ≡ `on: [429]`).
  */
 export type StatusMatch = number | number[] | ((status: number) => boolean);
+/** The delay curve a backoff walks. The dominant field of {@link BackoffOptions} (P12). */
+export type BackoffCurve = 'expo' | 'expo-jitter' | 'fixed';
+/**
+ * How the wait between attempts grows (CONTRACT.md P24). The curve and the two bounds
+ * that shape it are one concept, so they are one envelope rather than three sibling
+ * fields sharing a `Delay` suffix. Inside it `base` and `max` need no suffix — there is
+ * only one thing here to measure (P1), and `max` bounds a **magnitude**, which is the
+ * case P4 leaves it.
+ */
+export interface BackoffOptions {
+    /** Delay curve. Default `'expo-jitter'`. */
+    curve?: BackoffCurve;
+    /** Delay before the first retry — `100`, `'100ms'`, `'1s'`. Default 100ms. */
+    base?: number | string;
+    /** Ceiling the computed delay is clamped to — `10_000`, `'10s'`. Default 10s. */
+    max?: number | string;
+}
 export interface RetryOptions {
     attempts?: number; // total attempts incl. the first (default 1 = no retry)
     on?: StatusMatch; // status(es) (or a predicate) that trigger a retry (default [429,502,503,504])
-    backoff?: 'expo' | 'expo-jitter' | 'fixed';
-    /** Base backoff delay before the first retry — `100`, `'100ms'`, `'1s'`. Default 100ms. */
-    baseDelay?: number | string;
-    /** Backoff ceiling the computed delay is clamped to — `10_000`, `'10s'`. Default 10s. */
-    maxDelay?: number | string;
+    /**
+     * Backoff policy. A bare curve is the P12 shorthand for `{ curve }`
+     * (`backoff: 'fixed'` ≡ `backoff: { curve: 'fixed' }`); the envelope adds `base`/`max`.
+     */
+    backoff?: BackoffCurve | AtLeastOne<BackoffOptions>;
     respectRetryAfter?: boolean;
 }
 export interface ThrottleOptions {

--- a/packages/core/test/clock-seam.spec.ts
+++ b/packages/core/test/clock-seam.spec.ts
@@ -19,8 +19,7 @@ describe('manualClock drives retry backoff (ADR 0010)', () => {
             retry: {
                 attempts: 3,
                 on: [503],
-                backoff: 'fixed',
-                baseDelay: 10_000,
+                backoff: { curve: 'fixed', base: 10_000 },
             },
             clock,
         });
@@ -55,8 +54,7 @@ describe('manualClock drives retry backoff (ADR 0010)', () => {
             retry: {
                 attempts: 2,
                 on: [503],
-                backoff: 'fixed',
-                baseDelay: 10_000,
+                backoff: { curve: 'fixed', base: 10_000 },
             },
             clock,
         });

--- a/packages/core/test/composition.spec.ts
+++ b/packages/core/test/composition.spec.ts
@@ -188,21 +188,21 @@ test('predefined query merges with call-time query (input wins on conflict)', as
     expect(call?.query).toEqual({ sort: 'name', type: 'user' });
 });
 
-// 3) Objects deep-merge across layers: base retry {attempts,on} survives a child adding {baseDelay}.
-test('deep-merge keeps base retry.attempts/on when child adds retry.baseDelay', async () => {
+// 3) Objects deep-merge across layers: base retry {attempts,on} survives a child adding {backoff}.
+test('deep-merge keeps base retry.attempts/on when child adds retry.backoff.base', async () => {
     server.route('GET', '/flaky', {
         statuses: [503, 503, 200],
         body: { ok: true },
     });
 
     const retryPreset = { retry: { attempts: 3, on: [503] } };
-    // Child only sets baseDelay; if merge replaced the object wholesale, attempts/on would be lost
+    // Child only sets backoff; if merge replaced the object wholesale, attempts/on would be lost
     // and the stitch would NOT retry the two 503s.
     const flaky = stitch({
         baseUrl: server.url,
         path: '/flaky',
         extends: [retryPreset],
-        retry: { baseDelay: 5 },
+        retry: { backoff: { base: 5 } },
     });
 
     const events = await collect(flaky.stream());
@@ -277,6 +277,24 @@ test('scalar shorthands (retry/timeout/cache/throttle) expand to option objects'
     expect(resolved.timeout).toEqual({ total: '5s' });
     expect(resolved.cache).toEqual({ ttl: '1m' });
     expect(resolved.throttle).toEqual({ rate: '1/s' });
+});
+
+// 6-nested) P24/P12: `retry.backoff` is itself a scalar-or-envelope slot, so the bare curve folds
+// too — the string form must never reach `__config` (P0), and the fold must survive the outer
+// `retry` scalar shorthand being applied in the same pass.
+test('retry.backoff folds its bare curve into the envelope', () => {
+    expect(
+        compose({ path: '/x', retry: { attempts: 2, backoff: 'fixed' } }).retry,
+    ).toEqual({ attempts: 2, backoff: { curve: 'fixed' } });
+
+    // Already an envelope → passed through untouched, not double-wrapped.
+    expect(
+        compose({ path: '/x', retry: { backoff: { base: 50, max: 500 } } })
+            .retry,
+    ).toEqual({ backoff: { base: 50, max: 500 } });
+
+    // No `backoff` at all → the slot stays absent rather than gaining an empty envelope.
+    expect(compose({ path: '/x', retry: 3 }).retry).toEqual({ attempts: 3 });
 });
 
 // 6a) P20/P12/P13: the stream/multipart dominant-field scalars and the `sse` toggle fold to their

--- a/packages/core/test/config-at-least-one.spec.ts
+++ b/packages/core/test/config-at-least-one.spec.ts
@@ -38,6 +38,12 @@ test('the opaque `{}` is rejected at each Scalar|AtLeastOne slot (P20)', () => {
             // @ts-expect-error — `stream: {}` is rejected; use `'ndjson'` or set `decode`.
             stream: {},
         }),
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
+            // @ts-expect-error — `retry.backoff: {}` is rejected; use a curve or set base/max.
+            retry: { attempts: 2, backoff: {} },
+        }),
     ];
     // The assertions that matter are the @ts-expect-error directives above (checked by `check:types`).
     expect(typeof rejected).toBe('function');
@@ -53,6 +59,22 @@ test('the scalar / ≥1-field forms are accepted at each slot (P12/P13/P20)', ()
             baseUrl: 'https://x',
             path: '/y',
             hooks: { onRequest: () => undefined },
+        }),
+        // P24/P12: `retry.backoff` takes the bare curve or a ≥1-field envelope.
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
+            retry: { backoff: 'expo' },
+        }),
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
+            retry: { backoff: { curve: 'expo', base: '1s', max: '10s' } },
+        }),
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
+            retry: { backoff: { base: 5 } },
         }),
     ];
     expect(typeof accepted).toBe('function');

--- a/packages/core/test/gaps/accept-status.spec.ts
+++ b/packages/core/test/gaps/accept-status.spec.ts
@@ -141,7 +141,7 @@ test('a status in both retry.on and acceptStatus is retried, then accepted on th
     const call = stitch<{ ok: boolean; last: boolean }>({
         baseUrl: server.url,
         path: '/retry-then-accept',
-        retry: { attempts: 3, on: [503], backoff: 'fixed', baseDelay: 1 },
+        retry: { attempts: 3, on: [503], backoff: { curve: 'fixed', base: 1 } },
         acceptStatus: [503],
     });
 

--- a/packages/core/test/gaps/delegate-backoff.spec.ts
+++ b/packages/core/test/gaps/delegate-backoff.spec.ts
@@ -204,7 +204,7 @@ test('throttle.on selects which statuses delegate (503 delegates, 429 retries)',
     const retried = stitch<{ ok: boolean }>({
         baseUrl: server.url,
         path: '/retry-429',
-        retry: { attempts: 3, on: [429], backoff: 'fixed', baseDelay: 1 },
+        retry: { attempts: 3, on: [429], backoff: { curve: 'fixed', base: 1 } },
         throttle: { delegate: true, on: [503] },
     });
     await expect(retried()).resolves.toEqual({ ok: true });
@@ -287,7 +287,7 @@ test('retry.on accepts a predicate (P7): retries while the predicate matches', a
     const call = stitch({
         baseUrl: server.url,
         path: '/retry-pred',
-        retry: { attempts: 2, on: (s) => s === 503, baseDelay: 1 },
+        retry: { attempts: 2, on: (s) => s === 503, backoff: { base: 1 } },
     });
     await expect(call()).resolves.toEqual({ ok: true });
     expect(server.calls('/retry-pred').length).toBe(2); // 503 retried, then 200

--- a/packages/core/test/gaps/resource-leaks.spec.ts
+++ b/packages/core/test/gaps/resource-leaks.spec.ts
@@ -201,7 +201,11 @@ test('abort during a retry backoff rejects promptly (well under the backoff dela
         baseUrl: 'http://test',
         path: '/always-503',
         adapter: always503,
-        retry: { attempts: 5, on: [503], backoff: 'fixed', baseDelay: 1000 },
+        retry: {
+            attempts: 5,
+            on: [503],
+            backoff: { curve: 'fixed', base: 1000 },
+        },
     });
 
     const ac = new AbortController();
@@ -235,7 +239,11 @@ test('an already-aborted signal rejects without sleeping the backoff', async () 
         baseUrl: 'http://test',
         path: '/x',
         adapter: always503,
-        retry: { attempts: 5, on: [503], backoff: 'fixed', baseDelay: 1000 },
+        retry: {
+            attempts: 5,
+            on: [503],
+            backoff: { curve: 'fixed', base: 1000 },
+        },
     });
 
     const ac = new AbortController();

--- a/packages/core/test/gaps/timeout-total.spec.ts
+++ b/packages/core/test/gaps/timeout-total.spec.ts
@@ -50,7 +50,11 @@ test('timeout.total caps the whole retry/backoff loop, not just one attempt', as
     const call = stitch({
         baseUrl: server.url,
         path: '/always-503',
-        retry: { attempts: 5, on: [503], backoff: 'fixed', baseDelay: 300 },
+        retry: {
+            attempts: 5,
+            on: [503],
+            backoff: { curve: 'fixed', base: 300 },
+        },
         timeout: { total: 400 },
     });
 
@@ -77,7 +81,7 @@ test('timeout.total is enforced alongside timeout.perAttempt across retries', as
     const call = stitch({
         baseUrl: server.url,
         path: '/glacial',
-        retry: { attempts: 5, backoff: 'fixed', baseDelay: 50 },
+        retry: { attempts: 5, backoff: { curve: 'fixed', base: 50 } },
         timeout: { total: 400, perAttempt: 350 },
     });
 

--- a/packages/core/test/idempotency.spec.ts
+++ b/packages/core/test/idempotency.spec.ts
@@ -33,7 +33,7 @@ test('injects a stable Idempotency-Key on a write, unchanged across a retry', as
         method: 'POST',
         baseUrl: server.url,
         path: '/create',
-        retry: { attempts: 2, on: [503], baseDelay: 5 },
+        retry: { attempts: 2, on: [503], backoff: { base: 5 } },
         idempotency: true, // default header + random per-call key
     });
 
@@ -55,7 +55,7 @@ test('uses a custom keyOf function derived from the input', async () => {
         method: 'POST',
         baseUrl: server.url,
         path: '/orders',
-        retry: { attempts: 2, on: [503], baseDelay: 5 },
+        retry: { attempts: 2, on: [503], backoff: { base: 5 } },
         idempotency: {
             header: 'X-Idempotency-Key',
             keyOf: (input) => `order-${(input.body as { id: number }).id}`,

--- a/packages/core/test/integration-patterns.spec.ts
+++ b/packages/core/test/integration-patterns.spec.ts
@@ -70,7 +70,11 @@ describe('GraphQL-over-HTTP API (ApiKey header, 1 req/s bucket, retry on 429/5xx
             baseUrl: server.url,
             path: '/graphql',
             auth: apiKey({ header: 'apikey', value: env('METADATA_API_KEY') }),
-            retry: { attempts: 5, on: [429, 500, 502, 503], baseDelay: 5 },
+            retry: {
+                attempts: 5,
+                on: [429, 500, 502, 503],
+                backoff: { base: 5 },
+            },
             pick: 'data',
         });
 

--- a/packages/core/test/report.spec.ts
+++ b/packages/core/test/report.spec.ts
@@ -130,7 +130,7 @@ test('report: attempts reflects retries', async () => {
         url: URL,
         adapter,
         trace: false,
-        retry: { attempts: 3, baseDelay: 0 },
+        retry: { attempts: 3, backoff: { base: 0 } },
     });
     const r = await s.report();
     expect(r.error).toBeNull();

--- a/packages/core/test/resilience-backoff.spec.ts
+++ b/packages/core/test/resilience-backoff.spec.ts
@@ -1,8 +1,8 @@
 // Direct unit tests for the pure retry helpers in src/resilience.ts. resilience.spec.ts exercises
 // retry/Retry-After through the ENGINE; the formula and the header parser themselves are never
 // asserted directly. These pin them:
-//   backoffDelay   — fixed (constant), expo (2^(attempt-2), clamped at attempt 1), the maxDelay cap,
-//                    and expo-jitter (the default) staying within [0, computed) and under maxDelay.
+//   backoffDelay   — fixed (constant), expo (2^(attempt-2), clamped at attempt 1), the backoff.max cap,
+//                    and expo-jitter (the default) staying within [0, computed) and under backoff.max.
 //   parseRetryAfter— nullish/empty → undefined, delta-seconds → ms (whitespace tolerated), an
 //                    HTTP-date → ms-until-then against the clock, a past date clamped to 0, and an
 //                    unparseable value → undefined.
@@ -12,45 +12,41 @@ import type { RetryOptions } from '../src/types';
 
 describe('backoffDelay', () => {
     test('fixed backoff is constant regardless of attempt', () => {
-        const o: RetryOptions = { backoff: 'fixed', baseDelay: 50 };
+        const o: RetryOptions = { backoff: { curve: 'fixed', base: 50 } };
         expect(backoffDelay(2, o)).toBe(50);
         expect(backoffDelay(7, o)).toBe(50);
     });
 
-    test('expo backoff doubles from attempt 2 (baseDelay * 2^(attempt-2))', () => {
-        const o: RetryOptions = { backoff: 'expo', baseDelay: 100 };
+    test('expo backoff doubles from attempt 2 (base * 2^(attempt-2))', () => {
+        const o: RetryOptions = { backoff: { curve: 'expo', base: 100 } };
         expect(backoffDelay(1, o)).toBe(100); // exp clamped to 0
         expect(backoffDelay(2, o)).toBe(100); // 100 * 2^0
         expect(backoffDelay(3, o)).toBe(200); // 100 * 2^1
         expect(backoffDelay(4, o)).toBe(400); // 100 * 2^2
     });
 
-    test('expo backoff is capped at maxDelay', () => {
+    test('expo backoff is capped at backoff.max', () => {
         const o: RetryOptions = {
-            backoff: 'expo',
-            baseDelay: 100,
-            maxDelay: 1000,
+            backoff: { curve: 'expo', base: 100, max: 1000 },
         };
         expect(backoffDelay(20, o)).toBe(1000);
     });
 
-    test('baseDelay/maxDelay accept duration strings (P17 widening)', () => {
+    test('backoff.base/backoff.max accept duration strings (P17 widening)', () => {
         const o: RetryOptions = {
-            backoff: 'expo',
-            baseDelay: '1s',
-            maxDelay: '3s',
+            backoff: { curve: 'expo', base: '1s', max: '3s' },
         };
         expect(backoffDelay(2, o)).toBe(1000); // '1s' → 1000ms
         expect(backoffDelay(4, o)).toBe(3000); // 4000 clamped to '3s'
     });
 
-    test('expo-jitter (the default) stays within [0, computed) and under maxDelay', () => {
+    test('expo-jitter (the default) stays within [0, computed) and under backoff.max', () => {
         for (let i = 0; i < 100; i++) {
-            const d = backoffDelay(3); // default baseDelay 100 → computed 200
+            const d = backoffDelay(3); // default backoff.base 100 → computed 200
             expect(d).toBeGreaterThanOrEqual(0);
             expect(d).toBeLessThan(200);
         }
-        const capped: RetryOptions = { baseDelay: 100, maxDelay: 500 };
+        const capped: RetryOptions = { backoff: { base: 100, max: 500 } };
         for (let i = 0; i < 100; i++) {
             // attempt 10 → computed 25_600; jitter is large but the cap holds.
             expect(backoffDelay(10, capped)).toBeLessThanOrEqual(500);

--- a/packages/core/test/resilience.spec.ts
+++ b/packages/core/test/resilience.spec.ts
@@ -41,7 +41,7 @@ test('retries on 503 then succeeds, reporting attempts and retry progress', asyn
     const call = stitch({
         baseUrl: server.url,
         path: '/flaky',
-        retry: { attempts: 3, on: [503], baseDelay: 5 },
+        retry: { attempts: 3, on: [503], backoff: { base: 5 } },
     });
 
     const events = await collect(call());
@@ -68,7 +68,7 @@ test('rejects with status 503 after exhausting all retry attempts', async () => 
     const call = stitch({
         baseUrl: server.url,
         path: '/down',
-        retry: { attempts: 3, on: [503], baseDelay: 5 },
+        retry: { attempts: 3, on: [503], backoff: { base: 5 } },
     });
 
     await expect(call()).rejects.toMatchObject({ status: 503 });
@@ -89,7 +89,7 @@ test('honors the Retry-After header instead of the short backoff', async () => {
             attempts: 2,
             on: [429],
             respectRetryAfter: true,
-            baseDelay: 5,
+            backoff: { base: 5 },
         },
     });
 

--- a/packages/core/test/run-identity.spec.ts
+++ b/packages/core/test/run-identity.spec.ts
@@ -270,7 +270,7 @@ test('OTLP: a retried call emits flat per-attempt child spans parented to the ru
         name: 'flaky',
         baseUrl: server.url,
         path: '/flaky',
-        retry: { attempts: 3, on: [503], backoff: 'fixed', baseDelay: 1 },
+        retry: { attempts: 3, on: [503], backoff: { curve: 'fixed', base: 1 } },
         trace: otlpSink({ exporter }),
     });
 

--- a/packages/core/test/safe-unwrap.spec.ts
+++ b/packages/core/test/safe-unwrap.spec.ts
@@ -37,7 +37,7 @@ test('safe() returns { ok: false, data: null, error } instead of throwing', asyn
     const call = stitch({
         baseUrl: server.url,
         path: '/down',
-        retry: { attempts: 3, on: [503], baseDelay: 5 },
+        retry: { attempts: 3, on: [503], backoff: { base: 5 } },
     });
 
     const res = await call.safe();

--- a/packages/core/test/sse-reconnect.spec.ts
+++ b/packages/core/test/sse-reconnect.spec.ts
@@ -1,6 +1,6 @@
 // Resumable SSE (issue #71): the `sse` surface reconnects a dropped `text/event-stream`, replaying
 // the last `id:` as the `Last-Event-ID` request header and honouring a server-sent `retry:` as the
-// reconnect backoff (falling back to `reconnect.backoff` / the stitch's `retry` policy). Off by
+// reconnect backoff (falling back to `reconnect.delay` / the stitch's `retry` policy). Off by
 // default — these specs prove both the unchanged default and the opt-in reconnect loop, driving
 // timing the way the repo's other backoff tests do: small distinct delays + real elapsed bounds
 // (no fake timers anywhere in this package).
@@ -124,7 +124,7 @@ describe('sse reconnect replays Last-Event-ID (issue #71)', () => {
         ]);
         const s = sse({
             url: 'https://x.test/e',
-            sse: { reconnect: { attempts: 2, backoff: 1 } },
+            sse: { reconnect: { attempts: 2, delay: 1 } },
             adapter,
         });
 
@@ -147,7 +147,7 @@ describe('sse reconnect replays Last-Event-ID (issue #71)', () => {
     });
 });
 
-describe('sse reconnect backoff: server retry: vs fallback (issue #71)', () => {
+describe('sse reconnect delay: server retry: vs fallback (issue #71)', () => {
     test('a server-sent retry: paces the reconnect (it dominates the tiny fallback)', async () => {
         // The event carries retry: 120 (ms). With a 1ms fallback, only the server value can produce
         // a ≥100ms wait — proving the server `retry:` won. One reconnect, then stop.
@@ -156,7 +156,7 @@ describe('sse reconnect backoff: server retry: vs fallback (issue #71)', () => {
         ]);
         const s = sse({
             url: 'https://x.test/e',
-            sse: { reconnect: { attempts: 1, backoff: 1 } },
+            sse: { reconnect: { attempts: 1, delay: 1 } },
             adapter,
         });
 
@@ -168,13 +168,13 @@ describe('sse reconnect backoff: server retry: vs fallback (issue #71)', () => {
         expect(out.doneOk).toBe(true);
     });
 
-    test('with no server retry:, the configured reconnect.backoff is used', async () => {
+    test('with no server retry:, the configured reconnect.delay is used', async () => {
         const { adapter } = scriptedAdapter([
             () => streamOf(['id: 1\ndata: a\n\n']),
         ]);
         const s = sse({
             url: 'https://x.test/e',
-            sse: { reconnect: { attempts: 1, backoff: 90 } },
+            sse: { reconnect: { attempts: 1, delay: 90 } },
             adapter,
         });
 
@@ -186,15 +186,15 @@ describe('sse reconnect backoff: server retry: vs fallback (issue #71)', () => {
         expect(out.doneOk).toBe(true);
     });
 
-    test('with neither, the stitch retry backoff (fixed baseDelay) supplies the delay', async () => {
-        // No server retry:, no reconnect.backoff → fall back to the `retry` policy: fixed 70ms.
+    test('with neither, the stitch retry backoff (fixed backoff.base) supplies the delay', async () => {
+        // No server retry:, no reconnect.delay → fall back to the `retry` policy: fixed 70ms.
         const { adapter } = scriptedAdapter([
             () => streamOf(['id: 1\ndata: a\n\n']),
         ]);
         const s = sse({
             url: 'https://x.test/e',
             sse: { reconnect: { attempts: 1 } },
-            retry: { backoff: 'fixed', baseDelay: 70 },
+            retry: { backoff: { curve: 'fixed', base: 70 } },
             adapter,
         });
 
@@ -216,7 +216,7 @@ describe('sse reconnect respects the attempts cap (issue #71)', () => {
         });
         const s = sse({
             url: 'https://x.test/e',
-            sse: { reconnect: { attempts: 2, backoff: 1 } },
+            sse: { reconnect: { attempts: 2, delay: 1 } },
             adapter,
         });
 
@@ -238,7 +238,7 @@ describe('sse reconnect respects the attempts cap (issue #71)', () => {
         const s = sse({
             url: 'https://x.test/e',
             sse: { reconnect: true },
-            retry: { backoff: 'fixed', baseDelay: 1 }, // keep the default-attempt fallback fast
+            retry: { backoff: { curve: 'fixed', base: 1 } }, // keep the default-attempt fallback fast
             adapter,
         });
 
@@ -258,7 +258,7 @@ describe('sse reconnect resumes from the last id after a mid-stream ERROR (issue
         ]);
         const s = sse({
             url: 'https://x.test/e',
-            sse: { reconnect: { attempts: 1, backoff: 1 } },
+            sse: { reconnect: { attempts: 1, delay: 1 } },
             adapter,
         });
 
@@ -281,7 +281,7 @@ describe('sse reconnect resumes from the last id after a mid-stream ERROR (issue
         ]);
         const s = sse({
             url: 'https://x.test/e',
-            sse: { reconnect: { attempts: 1, backoff: 1 } },
+            sse: { reconnect: { attempts: 1, delay: 1 } },
             adapter,
         });
 
@@ -305,7 +305,7 @@ describe('sse per-delta output validation keeps firing across a reconnect (issue
         const s = sse({
             url: 'https://x.test/e',
             output: asValidator(z.object({ tok: z.string() })),
-            sse: { reconnect: { attempts: 2, backoff: 1 } },
+            sse: { reconnect: { attempts: 2, delay: 1 } },
             adapter,
         });
 
@@ -328,16 +328,16 @@ describe('sse reconnect config round-trips as JSON (contract-not-dependency gate
         expect(json.sse).toEqual({ reconnect: true });
     });
 
-    test('the object form (attempts + backoff) survives the round-trip intact', () => {
+    test('the object form (attempts + delay) survives the round-trip intact', () => {
         const cfg = {
             url: 'https://x.test/e',
-            sse: { reconnect: { attempts: 5, backoff: 250 } },
+            sse: { reconnect: { attempts: 5, delay: 250 } },
         };
         const s = sse(cfg);
         const json = JSON.parse(JSON.stringify(s.__config)) as {
-            sse?: { reconnect?: { attempts?: number; backoff?: number } };
+            sse?: { reconnect?: { attempts?: number; delay?: number } };
         };
-        expect(json.sse?.reconnect).toEqual({ attempts: 5, backoff: 250 });
+        expect(json.sse?.reconnect).toEqual({ attempts: 5, delay: 250 });
     });
 });
 

--- a/packages/core/test/surface-execute.spec.ts
+++ b/packages/core/test/surface-execute.spec.ts
@@ -47,7 +47,7 @@ test('the resilience chain wraps execute — a retry-on-status re-runs it', asyn
         name: 'flaky-exec',
         url: 'exec://x',
         kind: execSurface(execute),
-        retry: { attempts: 3, on: [503], backoff: 'fixed', baseDelay: 1 },
+        retry: { attempts: 3, on: [503], backoff: { curve: 'fixed', base: 1 } },
     });
 
     await expect(s()).resolves.toEqual({ ok: true });

--- a/packages/core/test/testing-kit.spec.ts
+++ b/packages/core/test/testing-kit.spec.ts
@@ -52,7 +52,7 @@ describe('mockAdapter — testing a stitch definition', () => {
             baseUrl: 'https://api.test',
             path: '/flaky',
             adapter: api,
-            retry: { attempts: 3, on: [503], baseDelay: 1 },
+            retry: { attempts: 3, on: [503], backoff: { base: 1 } },
         });
 
         await expect(call()).resolves.toEqual({ ok: true });

--- a/packages/deno-kv/README.md
+++ b/packages/deno-kv/README.md
@@ -87,7 +87,7 @@ isolate committed first — so there is nothing to match against.
 
 `backoff` is **off by default**: the loop re-reads immediately, which is the tightest
 path to a win when contention is brief. Set a curve (`'expo'`, `'expo-jitter'`,
-`'fixed'`, with `baseDelay` 5ms and `maxDelay` 250ms) when many isolates hammer one
+`'fixed'`, or the envelope `{ curve, base, max }` with `base` 5ms and `max` 250ms) when many isolates hammer one
 key and the hot spin costs more KV reads than it saves — `'expo-jitter'` is the one to
 reach for there, since full jitter stops a thundering herd re-colliding in lockstep.
 

--- a/packages/deno-kv/src/index.ts
+++ b/packages/deno-kv/src/index.ts
@@ -17,7 +17,12 @@
 // Compliance with the store contract is proven against `verifyStoreContract` from
 // `stitchapi/testing` (see test/conformance.spec.ts).
 import { parseDuration } from 'stitchapi';
-import type { AtLeastOne, StitchStore } from 'stitchapi';
+import type {
+    AtLeastOne,
+    BackoffCurve,
+    BackoffOptions,
+    StitchStore,
+} from 'stitchapi';
 
 // ---------------------------------------------------------------------------
 // the Deno KV surface
@@ -147,16 +152,13 @@ export interface DenoKvRetryOptions {
      */
     attempts?: number;
     /**
-     * Delay curve between attempts. Omitted (the default) means **no delay** — the
-     * loop re-reads immediately, which is the tightest path to a win when contention
-     * is brief. Set a curve when many isolates hammer one key and the hot spin costs
-     * more KV reads than it saves.
+     * Delay policy between attempts, the same envelope core's `retry.backoff` uses — a
+     * bare curve is the shorthand for `{ curve }`. Omitted (the default) means **no
+     * delay**: the loop re-reads immediately, which is the tightest path to a win when
+     * contention is brief. Set a curve when many isolates hammer one key and the hot spin
+     * costs more KV reads than it saves. `base` defaults to 5ms, `max` to 250ms.
      */
-    backoff?: 'expo' | 'expo-jitter' | 'fixed';
-    /** Delay before the first retry — `5`, `'5ms'`, `'1s'`. Default 5ms; only used when `backoff` is set. */
-    baseDelay?: number | string;
-    /** Ceiling the computed delay is clamped to — `250`, `'250ms'`. Default 250ms. */
-    maxDelay?: number | string;
+    backoff?: BackoffCurve | AtLeastOne<BackoffOptions>;
 }
 
 /** Options for {@link denoKvStore}. */
@@ -206,9 +208,13 @@ export function denoKvStore(
             ? { attempts: opts.retry }
             : (opts.retry ?? {});
     const attempts = retry.attempts ?? 100;
-    const backoff = retry.backoff;
-    const baseDelay = parseDuration(retry.baseDelay) ?? 5;
-    const maxDelay = parseDuration(retry.maxDelay) ?? 250;
+    // Same nested fold core does (P12): a bare curve is `{ curve }`.
+    const b = retry.backoff;
+    const curve: BackoffOptions | undefined =
+        typeof b === 'string' ? { curve: b } : b;
+    const backoff = curve?.curve ?? (curve ? 'expo-jitter' : undefined);
+    const base = parseDuration(curve?.base) ?? 5;
+    const max = parseDuration(curve?.max) ?? 250;
     // String key → Deno KV array key. With a prefix it's a two-segment key so the
     // namespace is a real KV sub-range; without, a flat one-segment key.
     const k = (key: string): DenoKvKey =>
@@ -300,9 +306,7 @@ export function denoKvStore(
                 // re-reads immediately — and never after the final attempt, which
                 // would just delay the throw.
                 if (backoff && attempt < attempts) {
-                    await sleep(
-                        backoffDelay(backoff, attempt, baseDelay, maxDelay),
-                    );
+                    await sleep(backoffDelay(backoff, attempt, base, max));
                 }
             }
             throw new Error(

--- a/packages/deno-kv/test/store-behaviour.spec.ts
+++ b/packages/deno-kv/test/store-behaviour.spec.ts
@@ -328,7 +328,7 @@ describe('denoKvStore — increment TTL window', () => {
         spy.mockRestore();
     });
 
-    test('a fixed curve sleeps baseDelay between attempts, but not after the last', async () => {
+    test('a fixed curve sleeps backoff.base between attempts, but not after the last', async () => {
         const delays: number[] = [];
         const spy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((
             fn: () => void,
@@ -340,7 +340,7 @@ describe('denoKvStore — increment TTL window', () => {
         }) as unknown as typeof setTimeout);
         const rec = recordingKv({ failAtomic: true });
         const store = denoKvStore(rec.kv, {
-            retry: { attempts: 4, backoff: 'fixed', baseDelay: '20ms' },
+            retry: { attempts: 4, backoff: { curve: 'fixed', base: '20ms' } },
         });
         await expect(store.increment('x', 1000)).rejects.toThrow(
             /lost 4 compare-and-set races/,
@@ -350,7 +350,7 @@ describe('denoKvStore — increment TTL window', () => {
         spy.mockRestore();
     });
 
-    test('an expo curve doubles and clamps at maxDelay', async () => {
+    test('an expo curve doubles and clamps at backoff.max', async () => {
         const delays: number[] = [];
         const spy = vi.spyOn(globalThis, 'setTimeout').mockImplementation(((
             fn: () => void,
@@ -364,9 +364,7 @@ describe('denoKvStore — increment TTL window', () => {
         const store = denoKvStore(rec.kv, {
             retry: {
                 attempts: 5,
-                backoff: 'expo',
-                baseDelay: 10,
-                maxDelay: 30,
+                backoff: { curve: 'expo', base: 10, max: 30 },
             },
         });
         await expect(store.increment('x', 1000)).rejects.toThrow(


### PR DESCRIPTION
`RetryOptions` carried three flat members configuring a single concept — `backoff`, `baseDelay`, `maxDelay`, two of them sharing a `Delay` suffix. They fold into one envelope (P24):

```ts
// before
retry: { attempts: 3, backoff: 'expo', baseDelay: 200, maxDelay: '10s' }
// after
retry: { attempts: 3, backoff: { curve: 'expo', base: 200, max: '10s' } }
```

**`backoff: 'expo-jitter'` still works** — a bare curve is the P12 dominant-field shorthand for `{ curve }` — so the common case is untouched. Only configs that actually set `baseDelay`/`maxDelay` need editing.

Inside the envelope the `Delay` suffix is redundant: there is exactly one thing here to measure (P1). And `max` bounds a **magnitude**, which is the case P4 explicitly leaves it — `maxDelay` was never the P4 violation `maxAttempts`/`maxEntries` were.

### `reconnect.backoff` → `delay` (P2)

This started as an optional extra and turned out to be **required by the fold**.

`backoff` meant two different things: a curve policy in `RetryOptions`, a flat duration in `ReconnectOptions`. Both accept strings, so `backoff: 'expo'` and `backoff: '1s'` were indistinguishable by shape. Folding retry's into an envelope would have put an envelope-or-curve and a bare duration under one name — sharpening the collision rather than resolving it.

```ts
sse: { reconnect: { attempts: 5, delay: '1s' } }
```

`backoff` now names one concept with one value-space across the surface. Behaviour is unchanged: a server-sent `retry:` still wins, and with no `delay` the stitch's `retry.backoff` still supplies the wait. Recorded as P2's second canonical case in CONTRACT.md, alongside `throttle.scope`→`pool`.

### Implementation notes

- **The fold is nested.** `expandShorthand` runs `envelope(cfg.retry, 'attempts')` and then `envelope(retry.backoff, 'curve')`, so the string form never reaches `__config` (P0). Tested for three cases: bare curve folds, an already-folded envelope is *not* double-wrapped, and an absent `backoff` does not gain an empty envelope.
- **`backoffDelay()` accepts both shapes.** It is called directly by the reconnect path and by tests, not only through `compose`, so narrowing it to the envelope alone would have been a trap for any caller that skips normalization.
- **`resolveReconnect` already parsed its duration** to a number, so `delay` stays parsed there and the engine reads it directly — no double `parseDuration`.
- The 26 call-site edits were applied by a **brace-matching transform**, not a line regex: several sites spanned multiple lines (`backoff:` / `baseDelay:` / `maxDelay:` on separate lines), which a line-wise rewrite would have corrupted. Hunks reviewed after Prettier normalized spacing.

### Gates

full-workspace `check:types` (0 errors) · tests (core **1229**, up from 1228 — a new nested-fold test plus P20 accept/reject cases; deno-kv 21; all packages pass) · `check:contract` · `check:types-d` · `check:lint` · `check:exports` · `check:docs-links` · `check:size` · `check:format` · all 9 yakir tethers (0 drift) · `@stitchapi/docs` build (437/437 pages) — green.

### `@stitchapi/deno-kv` folds identically

Included here rather than deferred. `DenoKvRetryOptions.backoff` (added in #512) was `'expo' | ...` plus flat `baseDelay`/`maxDelay`, copied from core's pre-fold vocabulary — leaving it would have re-created the core/deno-kv divergence one release after fixing it.

```ts
denoKvStore(kv, { retry: { attempts: 20, backoff: { curve: 'expo', base: 10, max: 30 } } });
```

It now imports core's `BackoffCurve` / `BackoffOptions` directly rather than redeclaring them, and does the same bare-curve fold. This makes the PR a two-package change; the alternative was shipping the flat shape for exactly one release and breaking it again.

### Stale prose swept

After the type change ~12 test names and comments still named `baseDelay`/`maxDelay` — e.g. `test('expo backoff is capped at maxDelay')`. They compile fine but name fields that no longer exist, so they are updated too.

### BREAKING CHANGE

`RetryOptions.baseDelay`/`maxDelay` move under `backoff` as `base`/`max`; `sse.reconnect.backoff` is renamed to `delay`. No `@deprecated` aliases — P19 scopes that obligation to the GA channel and this lands on `rc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
