### PR TITLE
refactor(postmessage)!: the message type goes first; named option bags (P15/P9/P12)

### DIFF
--- a/packages/core/src/postmessage.ts
+++ b/packages/core/src/postmessage.ts
@@ -136,15 +136,14 @@ function freshId(): string {
 // ---------------------------------------------------------------------------
 // per-method options
 // ---------------------------------------------------------------------------
-// Each verb's options extend the shared StitchConfig keys MINUS `kind` (the surface owns it) and
-// `url` (synthesised as a `postmessage:<type>` pseudo-endpoint), plus the verb's own fields. The
-// resilience chain (`retry`/`throttle`/`timeout`/`circuit`/`trace`/`signal`) all apply via the
-// engine, exactly as for every other surface.
+// The message `type` is POSITIONAL on every verb (CONTRACT.md P15 — the one required address goes
+// first, like `stitch(url)`); each verb's options extend the shared StitchConfig keys MINUS `kind`
+// (the surface owns it) and `url` (synthesised as a `postmessage:<type>` pseudo-endpoint), plus the
+// verb's own fields. The resilience chain (`retry`/`throttle`/`timeout`/`circuit`/`trace`/`signal`)
+// all apply via the engine, exactly as for every other surface.
 
 /** Options for {@link PostMessageChannel.request}. */
 export type RequestOptions = Partial<Omit<StitchConfig, 'kind' | 'url'>> & {
-    /** The message `type` posted to the peer. */
-    type: string;
     /** The `type` the correlated reply must carry. Default `` `${type}-result` ``. */
     reply?: string;
     /** Schema validating the outbound `body` payload (the call argument). */
@@ -155,19 +154,27 @@ export type RequestOptions = Partial<Omit<StitchConfig, 'kind' | 'url'>> & {
 
 /** Options for {@link PostMessageChannel.emit}. */
 export type EmitOptions = Partial<Omit<StitchConfig, 'kind' | 'url'>> & {
-    /** The message `type` posted to the peer. */
-    type: string;
     /** Schema validating the outbound `body` payload (the call argument). */
     input?: StitchConfig['input'];
 };
 
 /** Options for {@link PostMessageChannel.events}. */
 export type EventsOptions = Partial<Omit<StitchConfig, 'kind' | 'url'>> & {
-    /** The inbound event `type` to subscribe to. */
-    type: string;
     /** Schema validating each inbound event payload (the collected/streamed value). */
     output?: StitchConfig['output'];
 };
+
+/** Options for {@link PostMessageChannel.respond}. `input`/`output` are BARE schemas validating
+ *  the single inbound payload / the single result (not slotted `InputSchemas` — a responder
+ *  answers one value, not a request with `body`/`query`/… slots). */
+export interface RespondOptions {
+    /** Schema validating the inbound request payload (a failure DROPS the request). */
+    input?: SchemaLike;
+    /** Schema validating the handler result (a failure suppresses the reply). */
+    output?: SchemaLike;
+    /** The `type` the answer is posted under. Default `` `${type}-result` ``. */
+    reply?: string;
+}
 
 /**
  * The typed, validated, observable channel — the entry point this surface exposes. Built by
@@ -182,8 +189,9 @@ export interface PostMessageChannel {
      * `` `${type}-result` ``. The call argument is inferred from `opts.input`; the result tracks
      * `opts.output` (the reply payload schema). Timeout/abort reuse the engine's `timeout`/`signal`.
      */
-    request<const C extends RequestOptions>(
-        opts: C,
+    request<const C extends RequestOptions = RequestOptions>(
+        type: string,
+        opts?: C,
     ): Stitch<OutputOf<C>, InputOf<C>>;
     /**
      * Fire-and-forget send (no reply awaited): post `{ type, payload }` and resolve immediately. A
@@ -195,7 +203,10 @@ export interface PostMessageChannel {
      * `void send(input).catch(() => {})`. A bare `send(input)` whose result is never awaited sends
      * NOTHING.
      */
-    emit<const C extends EmitOptions>(opts: C): Stitch<void, InputOf<C>>;
+    emit<const C extends EmitOptions = EmitOptions>(
+        type: string,
+        opts?: C,
+    ): Stitch<void, InputOf<C>>;
     /**
      * Subscribe to inbound events of `opts.type`. A STREAMING surface (id `'postmessage-event'`):
      * `.stream()` yields live deltas; `await` collects until the stream ends (so prefer `.stream()`
@@ -205,8 +216,9 @@ export interface PostMessageChannel {
      * malformed message should NOT end the subscription, omit `output` and validate each payload in
      * the consumer — drop the bad one, keep listening (an `onInvalid: 'drop'` mode is future work).
      */
-    events<const C extends EventsOptions>(
-        opts: C,
+    events<const C extends EventsOptions = EventsOptions>(
+        type: string,
+        opts?: C,
     ): Stitch<OutputOf<C>[], InputOf<C>>;
     /**
      * Register a handler that ANSWERS inbound requests of `type` (the receiving side — e.g. an
@@ -224,14 +236,10 @@ export interface PostMessageChannel {
     respond<TIn = unknown, TOut = unknown>(
         type: string,
         handler: (payload: TIn) => TOut | Promise<TOut>,
-        opts?: {
-            input?: SchemaLike;
-            output?: SchemaLike;
-            reply?: string;
-        },
+        opts?: RespondOptions,
     ): () => void;
     /** Detach the listener, reject every pending request, close every event stream. */
-    close(): void;
+    close(): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -263,21 +271,32 @@ export const postMessageEventSurface: Surface = {
 // the channel builder
 // ---------------------------------------------------------------------------
 
+// The shared `T | T[]` list normalisation (CONTRACT.md P7): one origin reads as itself.
+const originList = (v: string | string[] | undefined): string[] =>
+    v === undefined ? [] : Array.isArray(v) ? v : [v];
+
+/** Options for {@link channel}. */
+export interface ChannelOptions {
+    /**
+     * Origin(s) inbound messages may come from. An origin-bearing transport (a Window) drops
+     * anything else BEFORE dispatch/validation; a `MessagePort` (origin `''`) skips the gate (a
+     * port is already private).
+     */
+    allowedOrigins: string | string[];
+}
+
 /**
  * Build a {@link PostMessageChannel} over ANY {@link MessageTransport} — the core builder the other
  * two delegate to (and what the tests drive with a fake transport). Attaches the single demux
  * listener at construction; binds `allowedOrigins` as the security policy.
  *
  * @param transport The raw channel (a Window / port / a fake pair in tests).
- * @param opts.allowedOrigins Origins inbound messages may come from. An origin-bearing transport
- *   (a Window) drops anything else BEFORE dispatch/validation; a `MessagePort` (origin `''`) skips
- *   the gate (a port is already private).
  */
 export function channel(
     transport: MessageTransport,
-    opts: { allowedOrigins: string[] },
+    opts: ChannelOptions,
 ): PostMessageChannel {
-    return makeChannel(transport, opts.allowedOrigins);
+    return makeChannel(transport, originList(opts.allowedOrigins));
 }
 
 /**
@@ -290,11 +309,16 @@ export function channel(
  * wildcard target posts the message to whatever document currently occupies the frame — a classic
  * postMessage data leak. The type forbids it; this catches a `as any` cast too.
  */
-export function windowChannel(opts: {
+export interface WindowChannelOptions {
+    /** The window to post to — or a thunk resolving it lazily (a frame that mounts late). */
     target: Window | (() => Window);
+    /** The concrete (non-wildcard) origin outbound messages are addressed to. */
     targetOrigin: Origin;
-    allowedOrigins?: string[];
-}): PostMessageChannel {
+    /** Origin(s) inbound messages may come from. Default `[targetOrigin]`. */
+    allowedOrigins?: string | string[];
+}
+
+export function windowChannel(opts: WindowChannelOptions): PostMessageChannel {
     if ((opts.targetOrigin as string) === '*')
         throw new Error(
             "postmessage: targetOrigin '*' is forbidden — name the exact origin (e.g. 'https://app.example.com'). A wildcard posts to whatever document occupies the frame.",
@@ -335,7 +359,12 @@ export function windowChannel(opts: {
             };
         },
     };
-    return makeChannel(transport, opts.allowedOrigins ?? [opts.targetOrigin]);
+    return makeChannel(
+        transport,
+        opts.allowedOrigins !== undefined
+            ? originList(opts.allowedOrigins)
+            : [opts.targetOrigin],
+    );
 }
 
 /**
@@ -346,7 +375,7 @@ export function windowChannel(opts: {
  */
 export function portChannel(
     port: MessagePort,
-    opts?: { allowedOrigins?: string[] },
+    opts?: { allowedOrigins?: string | string[] },
 ): PostMessageChannel {
     const transport: MessageTransport = {
         post: (message, transfer) => {
@@ -364,7 +393,7 @@ export function portChannel(
         },
     };
     // A port has no origin, so allowedOrigins is moot; carry whatever was passed for symmetry.
-    return makeChannel(transport, opts?.allowedOrigins ?? []);
+    return makeChannel(transport, originList(opts?.allowedOrigins));
 }
 
 // The single implementation behind all three builders. Holds the per-channel registry (pending
@@ -463,10 +492,12 @@ function makeChannel(
     }
 
     // ---- request: a buffered execute surface --------------------------------
-    function request<const C extends RequestOptions>(
-        opts: C,
+    function request<const C extends RequestOptions = RequestOptions>(
+        type: string,
+        opts?: C,
     ): Stitch<OutputOf<C>, InputOf<C>> {
-        const { type, reply, input, output, ...rest } = opts;
+        const { reply, input, output, ...rest } = (opts ??
+            {}) as RequestOptions;
         const replyType = reply ?? `${type}-result`;
         const url = `postmessage:${type}`;
         // `execute` (ADR 0008) replaces the transport at the engine's adapter call site, INSIDE the
@@ -552,10 +583,11 @@ function makeChannel(
     }
 
     // ---- emit: a buffered execute surface, no reply -------------------------
-    function emit<const C extends EmitOptions>(
-        opts: C,
+    function emit<const C extends EmitOptions = EmitOptions>(
+        type: string,
+        opts?: C,
     ): Stitch<void, InputOf<C>> {
-        const { type, input, ...rest } = opts;
+        const { input, ...rest } = (opts ?? {}) as EmitOptions;
         const url = `postmessage:${type}`;
         const surface: Surface = {
             id: 'postmessage',
@@ -591,10 +623,11 @@ function makeChannel(
     }
 
     // ---- events: a streaming surface ----------------------------------------
-    function events<const C extends EventsOptions>(
-        opts: C,
+    function events<const C extends EventsOptions = EventsOptions>(
+        type: string,
+        opts?: C,
     ): Stitch<OutputOf<C>[], InputOf<C>> {
-        const { type, output, ...rest } = opts;
+        const { output, ...rest } = (opts ?? {}) as EventsOptions;
         const url = `postmessage:${type}`;
         // `execute` returns a live `ReadableStream` of PAYLOADS the channel feeds via an event
         // subscription (the inbound envelope's `payload` is extracted at enqueue), so a `delta` and
@@ -689,11 +722,7 @@ function makeChannel(
     function respond<TIn = unknown, TOut = unknown>(
         type: string,
         handler: (payload: TIn) => TOut | Promise<TOut>,
-        opts?: {
-            input?: SchemaLike;
-            output?: SchemaLike;
-            reply?: string;
-        },
+        opts?: RespondOptions,
     ): () => void {
         const responder: Responder = {
             handler: handler as (payload: unknown) => unknown,
@@ -714,8 +743,10 @@ function makeChannel(
     }
 
     // ---- close: tear everything down ----------------------------------------
-    function close(): void {
-        if (closed) return;
+    // Promise-returning for interface symmetry with the other teardown verbs (`seam.close`);
+    // the teardown itself is synchronous.
+    function close(): Promise<void> {
+        if (closed) return Promise.resolve();
         closed = true;
         detach();
         for (const [id, p] of pending) {
@@ -728,6 +759,7 @@ function makeChannel(
         responders.clear();
         eventSubs.clear();
         liveStreams.clear();
+        return Promise.resolve();
     }
 
     return { request, emit, events, respond, close };

--- a/packages/core/test-d/postmessage.test-d.ts
+++ b/packages/core/test-d/postmessage.test-d.ts
@@ -23,8 +23,7 @@ const transport = null as unknown as MessageTransport;
 const ch = channel(transport, { allowedOrigins: ['https://x.test'] });
 
 // 1) request: result inferred from `opts.output`, call argument from `opts.input`.
-const sum = ch.request({
-    type: 'sum',
+const sum = ch.request('sum', {
     input: { body: z.object({ a: z.number(), b: z.number() }) },
     output: z.object({ total: z.number() }),
 });
@@ -36,12 +35,11 @@ expectError(sum({ body: { a: 1 } })); // missing `b`
 expectError(sum({ body: { a: 1, b: 'two' } })); // `b` must be a number
 
 // 2) request with NO output schema → result is unknown (no contract pinned); arg stays optional.
-const bare = ch.request({ type: 'ping' });
+const bare = ch.request('ping');
 expectType<unknown>(output(bare));
 
 // 3) emit: result is void; call argument inferred from `opts.input`.
-const log = ch.emit({
-    type: 'log',
+const log = ch.emit('log', {
     input: { body: z.object({ msg: z.string() }) },
 });
 expectType<void>(null as unknown as Result<typeof log>);
@@ -49,16 +47,15 @@ expectType<{ msg: string }>(null as unknown as CallArg<typeof log>['body']);
 expectError(log({ body: { msg: 123 } })); // msg must be a string
 
 // 4) events: result is the COLLECTED PAYLOAD ARRAY, typed from `opts.output`.
-const ticks = ch.events({
-    type: 'tick',
+const ticks = ch.events('tick', {
     output: z.object({ n: z.number() }),
 });
 expectType<{ n: number }[]>(output(ticks)); // await ⇒ payload[] (no required arg → output() is fine)
 
 // 5) events with NO output schema → unknown[] (the loose collected array).
-const loose = ch.events({ type: 'evt' });
+const loose = ch.events('evt');
 expectType<unknown[]>(output(loose));
 
 // 6) a no-input request keeps a fully-OPTIONAL call argument (backward-compatible with StitchInput).
-const noInput = ch.request({ type: 'noop' });
+const noInput = ch.request('noop');
 expectAssignable<CallArg<typeof noInput>>(undefined);

--- a/packages/core/test/postmessage-respond-fanout.spec.ts
+++ b/packages/core/test/postmessage-respond-fanout.spec.ts
@@ -59,7 +59,7 @@ const ORIGIN_B = 'https://iframe.example.com';
 function channelPair(): {
     parent: PostMessageChannel;
     iframe: PostMessageChannel;
-    closeBoth: () => void;
+    closeBoth: () => Promise<void>;
 } {
     const { a, b } = linkedPair(ORIGIN_A, ORIGIN_B);
     const parent = channel(a, { allowedOrigins: [ORIGIN_B] });
@@ -67,9 +67,9 @@ function channelPair(): {
     return {
         parent,
         iframe,
-        closeBoth: () => {
-            parent.close();
-            iframe.close();
+        closeBoth: async () => {
+            await parent.close();
+            await iframe.close();
         },
     };
 }
@@ -84,13 +84,12 @@ describe('respond() replacement', () => {
         iframe.respond('q', () => 'second', { reply: 'q-reply' });
         // The first handle must NOT remove the now-active 'second' responder.
         off1();
-        const ask = parent.request({
-            type: 'q',
+        const ask = parent.request('q', {
             reply: 'q-reply',
             timeout: { perAttempt: 300 },
         });
         await expect(ask()).resolves.toBe('second');
-        closeBoth();
+        await closeBoth();
     });
 });
 
@@ -100,22 +99,21 @@ describe('responder error handling', () => {
         iframe.respond('boom', () => {
             throw new Error('handler blew up');
         });
-        const ask = parent.request({
-            type: 'boom',
+        const ask = parent.request('boom', {
             timeout: { perAttempt: 40 },
         });
         await expect(ask({ body: { x: 1 } })).rejects.toMatchObject({
             name: 'StitchError',
         });
-        closeBoth();
+        await closeBoth();
     });
 });
 
 describe('events fan-out', () => {
     test('one inbound event reaches every matching subscription of that type', async () => {
         const { parent, iframe, closeBoth } = channelPair();
-        const subA = parent.events<{ type: 'tick' }>({ type: 'tick' });
-        const subB = parent.events<{ type: 'tick' }>({ type: 'tick' });
+        const subA = parent.events('tick');
+        const subB = parent.events('tick');
         const ctlA = new AbortController();
         const ctlB = new AbortController();
         const gotA: unknown[] = [];
@@ -130,8 +128,8 @@ describe('events fan-out', () => {
         })();
         // Let both subscriptions register before emitting.
         await tick(10);
-        await iframe.emit({ type: 'tick' as const })({ body: { n: 1 } });
-        await iframe.emit({ type: 'tick' as const })({ body: { n: 2 } });
+        await iframe.emit('tick')({ body: { n: 1 } });
+        await iframe.emit('tick')({ body: { n: 2 } });
         await tick(30);
         ctlA.abort();
         ctlB.abort();
@@ -141,6 +139,6 @@ describe('events fan-out', () => {
         ]);
         expect(gotA).toEqual([{ n: 1 }, { n: 2 }]);
         expect(gotB).toEqual([{ n: 1 }, { n: 2 }]);
-        closeBoth();
+        await closeBoth();
     });
 });

--- a/packages/core/test/postmessage.spec.ts
+++ b/packages/core/test/postmessage.spec.ts
@@ -74,17 +74,18 @@ const ORIGIN_B = 'https://iframe.example.com';
 function channelPair(): {
     parent: PostMessageChannel;
     iframe: PostMessageChannel;
-    closeBoth: () => void;
+    closeBoth: () => Promise<void>;
 } {
     const { a, b } = linkedPair(ORIGIN_A, ORIGIN_B);
     const parent = channel(a, { allowedOrigins: [ORIGIN_B] });
-    const iframe = channel(b, { allowedOrigins: [ORIGIN_A] });
+    // A single origin passes as a bare string (`T | T[]` — CONTRACT.md P7).
+    const iframe = channel(b, { allowedOrigins: ORIGIN_A });
     return {
         parent,
         iframe,
-        closeBoth: () => {
-            parent.close();
-            iframe.close();
+        closeBoth: async () => {
+            await parent.close();
+            await iframe.close();
         },
     };
 }
@@ -99,27 +100,27 @@ describe('postmessage surface identities (ADR 0005 Decision 11)', () => {
         expect(postMessageEventSurface.id).toBe('postmessage-event');
     });
 
-    test('request/emit kind round-trips through __config as "postmessage"', () => {
+    test('request/emit kind round-trips through __config as "postmessage"', async () => {
         const { parent, closeBoth } = channelPair();
-        const req = parent.request({ type: 'focus' });
-        const ev = parent.emit({ type: 'ping' });
+        const req = parent.request('focus');
+        const ev = parent.emit('ping');
         for (const s of [req, ev]) {
             const json = JSON.parse(JSON.stringify(s.__config)) as {
                 kind?: unknown;
             };
             expect(json.kind).toBe('postmessage');
         }
-        closeBoth();
+        await closeBoth();
     });
 
-    test('events kind round-trips as "postmessage-event"', () => {
+    test('events kind round-trips as "postmessage-event"', async () => {
         const { parent, closeBoth } = channelPair();
-        const sub = parent.events({ type: 'tick' });
+        const sub = parent.events('tick');
         const json = JSON.parse(JSON.stringify(sub.__config)) as {
             kind?: unknown;
         };
         expect(json.kind).toBe('postmessage-event');
-        closeBoth();
+        await closeBoth();
     });
 });
 
@@ -139,8 +140,7 @@ describe('request → response (correlated RPC)', () => {
                 output: asValidator(z.object({ total: z.number() })),
             },
         );
-        const sum = parent.request({
-            type: 'sum',
+        const sum = parent.request('sum', {
             input: { body: z.object({ a: z.number(), b: z.number() }) },
             output: asValidator(z.object({ total: z.number() })),
         });
@@ -148,18 +148,15 @@ describe('request → response (correlated RPC)', () => {
             total: 5,
         });
         off();
-        closeBoth();
+        await closeBoth();
     });
 
     test('a custom `reply` type correlates the answer', async () => {
         const { parent, iframe, closeBoth } = channelPair();
         iframe.respond('q', () => 'answered', { reply: 'q-answer' });
-        const ask = parent.request<{
-            type: 'q';
-            reply: 'q-answer';
-        }>({ type: 'q', reply: 'q-answer' });
+        const ask = parent.request('q', { reply: 'q-answer' });
         await expect(ask()).resolves.toBe('answered');
-        closeBoth();
+        await closeBoth();
     });
 
     test('the reply must match BOTH id and type — a same-type unsolicited message does not resolve it', async () => {
@@ -168,18 +165,17 @@ describe('request → response (correlated RPC)', () => {
         const iframe = channel(b, { allowedOrigins: [ORIGIN_A] });
         // The iframe emits an UNSOLICITED `sum-result` (no id) BEFORE any responder — it must NOT
         // resolve the pending request (whose reply correlates on the minted id too).
-        const sum = parent.request({
-            type: 'sum',
+        const sum = parent.request('sum', {
             timeout: { perAttempt: 60 },
         });
         const p = sum({ body: { a: 1, b: 1 } });
         // fire a bare {type:'sum-result'} with no id from the iframe side
         iframe
-            .emit({ type: 'sum-result' })()
+            .emit('sum-result')()
             .catch(() => undefined);
         await expect(p).rejects.toThrow(); // never correlated → times out
-        parent.close();
-        iframe.close();
+        await parent.close();
+        await iframe.close();
     });
 });
 
@@ -190,14 +186,13 @@ describe('request → response (correlated RPC)', () => {
 describe('request timeout reuses the engine resilience chain', () => {
     test('no responder → the engine `timeout` rejects with a StitchError', async () => {
         const { parent, closeBoth } = channelPair();
-        const lonely = parent.request({
-            type: 'noone-home',
+        const lonely = parent.request('noone-home', {
             timeout: { perAttempt: 40 },
         });
         await expect(lonely({ body: { x: 1 } })).rejects.toMatchObject({
             name: 'StitchError',
         });
-        closeBoth();
+        await closeBoth();
     });
 });
 
@@ -213,22 +208,21 @@ describe('origin gate (structural, gate-before-validation)', () => {
         const parent = channel(a, { allowedOrigins: [ORIGIN_B] }); // only the REAL iframe origin
         const evil = channel(b, { allowedOrigins: [ORIGIN_A] });
         evil.respond('sum', () => ({ total: 999 }));
-        const sum = parent.request({
-            type: 'sum',
+        const sum = parent.request('sum', {
             timeout: { perAttempt: 40 },
         });
         await expect(sum({ body: { a: 1, b: 2 } })).rejects.toMatchObject({
             name: 'StitchError',
         });
-        parent.close();
-        evil.close();
+        await parent.close();
+        await evil.close();
     });
 
     test('an event from a disallowed origin is never delivered', async () => {
         const { a, b } = linkedPair(ORIGIN_A, 'https://evil.example.com');
         const parent = channel(a, { allowedOrigins: [ORIGIN_B] });
         const evil = channel(b, { allowedOrigins: [ORIGIN_A] });
-        const events = parent.events({ type: 'tick' });
+        const events = parent.events('tick');
         const ctl = new AbortController();
         const collected: unknown[] = [];
         const drain = (async () => {
@@ -237,15 +231,13 @@ describe('origin gate (structural, gate-before-validation)', () => {
             }
         })();
         // The evil frame emits a `tick`; the parent's gate drops it (wrong origin).
-        evil.emit({ type: 'tick' as const })({ body: { n: 1 } }).catch(
-            () => undefined,
-        );
+        evil.emit('tick')({ body: { n: 1 } }).catch(() => undefined);
         await new Promise((r) => setTimeout(r, 30));
         ctl.abort();
         await drain.catch(() => undefined);
         expect(collected).toEqual([]); // nothing crossed the gate
-        parent.close();
-        evil.close();
+        await parent.close();
+        await evil.close();
     });
 });
 
@@ -260,29 +252,27 @@ describe('validation on both boundaries', () => {
             input: asValidator(z.object({ n: z.number() })),
         });
         // Send a string where a number is required → the responder validates-and-drops → no reply.
-        const call = parent.request({
-            type: 'strict',
+        const call = parent.request('strict', {
             timeout: { perAttempt: 40 },
         });
         await expect(
             call({ body: { n: 'not-a-number' } }),
         ).rejects.toMatchObject({ name: 'StitchError' });
-        closeBoth();
+        await closeBoth();
     });
 
     test('a reply that fails the request `output` schema surfaces as drift/error', async () => {
         const { parent, iframe, closeBoth } = channelPair();
         // The responder replies with the WRONG shape (no `output` guard on its side).
         iframe.respond('mismatch', () => ({ wrong: true }));
-        const call = parent.request({
-            type: 'mismatch',
+        const call = parent.request('mismatch', {
             output: asValidator(z.object({ ok: z.boolean() })),
         });
         // The reply correlates, but the buffered `output` contract rejects it → StitchError (drift).
         await expect(call({ body: {} })).rejects.toMatchObject({
             name: 'StitchError',
         });
-        closeBoth();
+        await closeBoth();
     });
 
     // A plain `Validator` (from `toValidator(...)`) exposes `.validate()` but neither `~standard`
@@ -302,14 +292,13 @@ describe('validation on both boundaries', () => {
         iframe.respond('dbl', (p: { n: number }) => ({ doubled: p.n * 2 }), {
             input: inputSchema,
         });
-        const call = parent.request({
-            type: 'dbl',
+        const call = parent.request('dbl', {
             timeout: { perAttempt: 200 },
         });
         await expect(call({ body: { n: 21 } })).resolves.toEqual({
             doubled: 42,
         });
-        closeBoth();
+        await closeBoth();
     });
 
     test('a `toValidator(...)` input schema still DROPS an invalid payload (fail-closed preserved)', async () => {
@@ -321,14 +310,13 @@ describe('validation on both boundaries', () => {
         iframe.respond('dbl2', (p: { n: number }) => ({ doubled: p.n * 2 }), {
             input: inputSchema,
         });
-        const call = parent.request({
-            type: 'dbl2',
+        const call = parent.request('dbl2', {
             timeout: { perAttempt: 40 },
         });
         await expect(
             call({ body: { n: 'not-a-number' } }),
         ).rejects.toMatchObject({ name: 'StitchError' });
-        closeBoth();
+        await closeBoth();
     });
 
     // `output` rides the same coercion — a `toValidator(...)` responder output that the result
@@ -342,14 +330,13 @@ describe('validation on both boundaries', () => {
         iframe.respond('dbl3', (p: { n: number }) => ({ doubled: p.n * 2 }), {
             output: outputSchema,
         });
-        const call = parent.request({
-            type: 'dbl3',
+        const call = parent.request('dbl3', {
             timeout: { perAttempt: 200 },
         });
         await expect(call({ body: { n: 5 } })).resolves.toEqual({
             doubled: 10,
         });
-        closeBoth();
+        await closeBoth();
     });
 });
 
@@ -360,8 +347,7 @@ describe('validation on both boundaries', () => {
 describe('events (a streaming surface, validated payloads)', () => {
     test('await collects the payloads; ordering is preserved over .stream()', async () => {
         const { parent, iframe, closeBoth } = channelPair();
-        const events = parent.events({
-            type: 'tick',
+        const events = parent.events('tick', {
             output: asValidator(z.object({ n: z.number() })),
         });
 
@@ -380,17 +366,17 @@ describe('events (a streaming surface, validated payloads)', () => {
         await new Promise((r) => setTimeout(r, 5));
         for (const n of [1, 2, 3])
             iframe
-                .emit({ type: 'tick' as const })({ body: { n } })
+                .emit('tick')({ body: { n } })
                 .catch(() => undefined);
 
         await drain.catch(() => undefined);
         expect(seen).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]); // contractValue → the payload, in order
-        closeBoth();
+        await closeBoth();
     });
 
     test('await resolves to the collected payload array when the channel closes the stream', async () => {
         const { parent, iframe } = channelPair();
-        const events = parent.events({ type: 'evt' });
+        const events = parent.events('evt');
         // Kick off consumption NOW (`.then` starts the run and registers the subscription via
         // `execute`); the same shared run is what we assert on below. A bare `events()` is lazy.
         const settled = events().then((v) => v);
@@ -398,36 +384,35 @@ describe('events (a streaming surface, validated payloads)', () => {
         await new Promise((r) => setTimeout(r, 5));
         for (const v of ['x', 'y'])
             iframe
-                .emit({ type: 'evt' as const })({ body: v })
+                .emit('evt')({ body: v })
                 .catch(() => undefined);
         await new Promise((r) => setTimeout(r, 20));
         // Closing the parent ends its live event streams GRACEFULLY → the await resolves to the
         // payloads collected so far (vs. an abort, which errors the stream — tested separately).
-        parent.close();
-        iframe.close();
+        await parent.close();
+        await iframe.close();
 
         await expect(settled).resolves.toEqual(['x', 'y']);
     });
 
     test('a payload failing the `output` schema fails the stream (the bad event is not delivered)', async () => {
         const { parent, iframe, closeBoth } = channelPair();
-        const events = parent.events({
-            type: 'num',
+        const events = parent.events('num', {
             output: asValidator(z.object({ n: z.number() })),
         });
         const ev = collectEvents(events.stream());
         await new Promise((r) => setTimeout(r, 5));
         iframe
-            .emit({ type: 'num' as const })({ body: { n: 1 } })
+            .emit('num')({ body: { n: 1 } })
             .catch(() => undefined);
         iframe
-            .emit({ type: 'num' as const })({ body: { bad: true } })
+            .emit('num')({ body: { bad: true } })
             .catch(() => undefined);
         const collected = await ev;
         expect(collected.deltas).toEqual([{ n: 1 }]);
         expect(collected.drifts[0]?.level).toBe('error');
         expect(collected.done?.ok).toBe(false);
-        closeBoth();
+        await closeBoth();
     });
 });
 
@@ -443,17 +428,17 @@ describe('emit (fire-and-forget)', () => {
             received = p;
             return null; // a reply nobody is waiting for
         });
-        const log = parent.emit({ type: 'log' });
+        const log = parent.emit('log');
         await expect(log({ body: { msg: 'hello' } })).resolves.toBeUndefined();
         // give the microtask hop time to deliver to the iframe
         await new Promise((r) => setTimeout(r, 5));
         expect(received).toEqual({ msg: 'hello' });
-        closeBoth();
+        await closeBoth();
     });
 
     test('emit is also observable as an inbound event on the peer', async () => {
         const { parent, iframe, closeBoth } = channelPair();
-        const events = iframe.events({ type: 'beacon' });
+        const events = iframe.events('beacon');
         const ctl = new AbortController();
         const seen: unknown[] = [];
         const drain = (async () => {
@@ -465,10 +450,10 @@ describe('emit (fire-and-forget)', () => {
             }
         })();
         await new Promise((r) => setTimeout(r, 5));
-        await parent.emit({ type: 'beacon' })({ body: { hit: 1 } });
+        await parent.emit('beacon')({ body: { hit: 1 } });
         await drain.catch(() => undefined);
         expect(seen).toEqual([{ hit: 1 }]);
-        closeBoth();
+        await closeBoth();
     });
 });
 
@@ -479,7 +464,7 @@ describe('emit (fire-and-forget)', () => {
 describe('abort + close', () => {
     test('aborting the call signal rejects the pending request and leaves no dangling entry', async () => {
         const { parent, closeBoth } = channelPair();
-        const call = parent.request({ type: 'never-answered' });
+        const call = parent.request('never-answered');
         const ctl = new AbortController();
         const p = call({ body: {}, signal: ctl.signal });
         ctl.abort();
@@ -489,7 +474,7 @@ describe('abort + close', () => {
         const p2 = call({ body: {}, signal: ctl2.signal });
         ctl2.abort();
         await expect(p2).rejects.toMatchObject({ name: 'StitchError' });
-        closeBoth();
+        await closeBoth();
     });
 
     test('close() rejects in-flight pending requests and detaches the listener', async () => {
@@ -506,14 +491,14 @@ describe('abort + close', () => {
             },
         };
         const ch = channel(transport, { allowedOrigins: [ORIGIN_B] });
-        const call = ch.request({ type: 'pending' });
+        const call = ch.request('pending');
         // A stitch is lazy — start consuming so `execute` actually posts and registers the pending
         // entry, then let the resilience chain reach the transport before closing.
         const p = call({ body: {} });
         p.catch(() => undefined); // begin the run
         await new Promise((r) => setTimeout(r, 10));
         expect(delivered).toBe(1); // the request was posted once before close
-        ch.close();
+        await ch.close();
         await expect(p).rejects.toThrow(/closed/);
         expect(detached).toBe(true); // close() detached the demux listener
     });
@@ -550,11 +535,11 @@ describe('windowChannel guards', () => {
             targetOrigin: 'https://app.example.com',
         });
         // Fire-and-forget so no reply is awaited; we only assert the post shape.
-        await ch.emit({ type: 'hi' })({ body: { a: 1 } });
+        await ch.emit('hi')({ body: { a: 1 } });
         expect(posts).toHaveLength(1);
         expect(posts[0]?.origin).toBe('https://app.example.com');
         expect(posts[0]?.msg).toMatchObject({ type: 'hi', payload: { a: 1 } });
-        ch.close();
+        await ch.close();
     });
 });
 
@@ -566,10 +551,10 @@ describe('portChannel (origin gating bypassed for ports)', () => {
         worker.respond<{ x: number }, { y: number }>('double', ({ x }) => ({
             y: x * 2,
         }));
-        const dbl = parent.request<{ type: 'double' }>({ type: 'double' });
+        const dbl = parent.request('double');
         await expect(dbl({ body: { x: 21 } })).resolves.toEqual({ y: 42 });
-        parent.close();
-        worker.close();
+        await parent.close();
+        await worker.close();
     });
 });
 
@@ -583,12 +568,12 @@ describe('channel() over an arbitrary transport', () => {
         const parent = channel(a, { allowedOrigins: [] }); // allow NOTHING
         const iframe = channel(b, { allowedOrigins: [ORIGIN_A] });
         iframe.respond('x', () => 'ok');
-        const call = parent.request({ type: 'x', timeout: { perAttempt: 40 } });
+        const call = parent.request('x', { timeout: { perAttempt: 40 } });
         // The iframe's reply carries origin ORIGIN_B, which is not in [] → dropped → times out.
         await expect(call({ body: {} })).rejects.toMatchObject({
             name: 'StitchError',
         });
-        parent.close();
-        iframe.close();
+        await parent.close();
+        await iframe.close();
     });
 });


### PR DESCRIPTION
Broken out of #470 — the `stitchapi/postmessage` slice, standalone and self-contained.

## What

| Principle | Change |
| --- | --- |
| **P15** | The one required address goes first, like `stitch(url)`: `request` / `emit` / `events` take the message `type` **positionally**, instead of burying it as a required key inside the options bag. The options argument becomes optional. |
| **P9** | Every anonymous inline option bag on this surface becomes a named, exported interface: `ChannelOptions`, `WindowChannelOptions`, `RespondOptions`. |
| **P12** | `allowedOrigins` accepts `string \| string[]` — one origin reads as itself, normalised to a list internally. |
| **P11** | `close()` returns `Promise<void>`, matching every other teardown on the surface, so `await ch.close()` composes. |

```ts
// before
const save = ch.request({ type: 'save', input: SaveInput, output: SaveResult });
const ping = ch.emit({ type: 'ping' });
const ticks = ch.events({ type: 'tick', output: Tick });
const c = windowChannel({ target, targetOrigin: O, allowedOrigins: [O] });

// after
const save = ch.request('save', { input: SaveInput, output: SaveResult });
const ping = ch.emit('ping');
const ticks = ch.events('tick', { output: Tick });
const c = windowChannel({ target, targetOrigin: O, allowedOrigins: O });
```

`RespondOptions` also documents why its `input`/`output` are **bare** schemas rather than slotted
`InputSchemas`: a responder answers one value, it does not take a request with `body`/`query`/… slots.

Hard break, no `@deprecated` aliases — pre-GA, per P19 as amended in #470.

## Security model unchanged

`targetOrigin: '*'` is still forbidden at both the type level **and** at runtime (defense in depth
against an `as any` cast), and the origin gate still drops non-allowed messages **before**
dispatch/validation. A `MessagePort` (origin `''`) still skips the gate — a port is already private.

## Verification

- core typecheck + `tsd` clean
- **130 test files / 1229 tests green** (full core suite)
- eslint clean, contract ratchet **0**, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)