### PR TITLE
refactor(core,docs-mcp,json-schema,swr)!: every option bag is a named exported type (P9/P14)

### DIFF
--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -186,6 +186,13 @@ interface Inflight<T> {
     onCancel?: () => void;
 }
 
+/** Options for {@link InflightCoalescer.join}: ref-count this participant via `signal`; the
+ *  leader may set `onCancel` to be told when the LAST participant aborts. */
+export interface CoalesceJoinOptions {
+    signal?: AbortSignal;
+    onCancel?: () => void;
+}
+
 export interface LeaderClaim<T> {
     leader: true;
     promise: Promise<T>;
@@ -209,7 +216,7 @@ export class InflightCoalescer<T> {
      *  run is dropped and `onCancel` (set by the leader) is invoked. */
     join(
         key: string,
-        opts?: { signal?: AbortSignal; onCancel?: () => void },
+        opts?: CoalesceJoinOptions,
     ): LeaderClaim<T> | FollowerClaim<T> {
         let entry = this.map.get(key);
         const leading = entry === undefined;

--- a/packages/core/src/otlp.ts
+++ b/packages/core/src/otlp.ts
@@ -362,14 +362,15 @@ export function toOtlpJson(spans: OtelSpan[]): unknown {
     };
 }
 
+/** Options for {@link otlpHttpExporter} — {@link OtlpOptions} minus the exporter it builds. */
+export type OtlpExporterOptions = Omit<OtlpOptions, 'exporter'>;
+
 /**
  * Default exporter: POST spans as OTLP/JSON to `${endpoint}/v1/traces` (endpoint defaults to
  * `OTEL_EXPORTER_OTLP_ENDPOINT` or `http://localhost:4318`). Fire-and-forget — failures are
  * swallowed so a missing collector never breaks a stitch call.
  */
-export function otlpHttpExporter(
-    opts: { endpoint?: string; headers?: Record<string, string> } = {},
-): SpanExporter {
+export function otlpHttpExporter(opts: OtlpExporterOptions = {}): SpanExporter {
     const base =
         opts.endpoint ??
         readEnv('OTEL_EXPORTER_OTLP_ENDPOINT') ??

--- a/packages/docs-mcp/README.md
+++ b/packages/docs-mcp/README.md
@@ -78,8 +78,10 @@ derivations:
     weights, and query-length cap **must** match `apps/docs/lib/search-index/*`
     exactly, or a query embeds into a different vector space than the bundled
     index was built in.
--   `src/doc-path.ts` — a verbatim copy (that file has no fumadocs
-    dependency either, so it's a straight copy, not a re-derivation).
+-   `src/doc-path.ts` — a behavior-verbatim copy (that file has no fumadocs
+    dependency either, so it's a straight copy, not a re-derivation; the one
+    textual difference is the named `GetDocOptions` input interface, which
+    apps/docs keeps inline).
 -   `src/server.ts`'s `SITE_URL`/`EXCERPT_LEN` mirror `apps/docs/lib/shared.ts`'s
     `siteUrl` and `apps/docs/app/api/mcp/route.ts`'s `EXCERPT_LEN`.
 
@@ -99,6 +101,10 @@ intentional.
     of running the `stitchapi-docs-mcp` bin)
 -   `searchDocs(query, options?)`, `getDoc({ url?, slug? })` — the underlying
     retrieval functions
+-   Option interfaces (all exported): `SearchOptions` — with `HybridWeights`
+    and `FieldBoost` naming its `hybridWeights`/`boost` slots (field names are
+    Orama's, passed through unchanged) — and `GetDocOptions`, the
+    `{ url?, slug? }` input shape `getDoc` takes
 
 ## Contributing
 

--- a/packages/docs-mcp/src/doc-path.ts
+++ b/packages/docs-mcp/src/doc-path.ts
@@ -1,20 +1,34 @@
 // Normalize a get_doc input (URL or slug) into page slug segments. Ported
-// verbatim from apps/docs/lib/search-index/doc-path.ts (pure — no fumadocs
-// import there either — so this is a straight copy, not a re-derivation) since
-// this package can't depend on apps/docs's source. See README.md "Keeping this
-// in sync" if that file's normalization rules ever change.
+// from apps/docs/lib/search-index/doc-path.ts (pure — no fumadocs import
+// there either — so this is a straight copy, not a re-derivation) since this
+// package can't depend on apps/docs's source. Behavior is byte-identical; the
+// only local difference is the named `GetDocOptions` interface (CONTRACT P14),
+// which apps/docs keeps inline — the docs-mcp-config-parity tether measures
+// behavior, not source text. See README.md "Keeping this in sync" if that
+// file's normalization rules ever change.
 
 const DOCS_PREFIX = 'docs';
+
+/**
+ * A docs-page reference: an absolute URL
+ * (https://stitchapi.dev/docs/guides/throttle#x), a root-relative path
+ * (/docs/guides/throttle), or a bare slug (guides/throttle). When both fields
+ * are set, `slug` wins. `{}` is accepted and resolves to nothing (`getDoc`
+ * returns null, `parseDocPath` returns null).
+ *
+ * The input shape of both `getDoc` and `parseDocPath`.
+ */
+export interface GetDocOptions {
+    url?: string | undefined;
+    slug?: string | undefined;
+}
 
 /**
  * Accepts an absolute URL (https://stitchapi.dev/docs/guides/throttle#x), a
  * root-relative path (/docs/guides/throttle), or a bare slug (guides/throttle).
  * Returns null only when nothing usable was given; `[]` means the docs index.
  */
-export function parseDocPath(input: {
-    url?: string | undefined;
-    slug?: string | undefined;
-}): string[] | null {
+export function parseDocPath(input: GetDocOptions): string[] | null {
     let path = (input.slug ?? input.url)?.trim();
     if (!path) return null;
 

--- a/packages/docs-mcp/src/get-doc.ts
+++ b/packages/docs-mcp/src/get-doc.ts
@@ -5,7 +5,7 @@
 // apps/docs/scripts/build-docs-pages.ts at build:mcp-bundle time), so it needs
 // no fumadocs machinery at runtime.
 import { DATA_DIR, PAGES_FILE } from './config';
-import { parseDocPath } from './doc-path';
+import { type GetDocOptions, parseDocPath } from './doc-path';
 
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
@@ -63,10 +63,7 @@ function loadPages(): Map<string, BundledPage> {
     return cached;
 }
 
-export function getDoc(input: {
-    url?: string | undefined;
-    slug?: string | undefined;
-}): DocResult | null {
+export function getDoc(input: GetDocOptions): DocResult | null {
     const slug = parseDocPath(input);
     if (slug === null) return null;
 

--- a/packages/docs-mcp/src/index.ts
+++ b/packages/docs-mcp/src/index.ts
@@ -1,5 +1,12 @@
 // Library entry — for embedding the local docs server in another process
 // (e.g. a custom MCP host) instead of running the `stitchapi-docs-mcp` bin.
 export { createServer } from './server';
+export type { GetDocOptions } from './doc-path';
 export { type DocResult, getDoc } from './get-doc';
-export { type DocSearchHit, type SearchOptions, searchDocs } from './search';
+export {
+    type DocSearchHit,
+    type FieldBoost,
+    type HybridWeights,
+    type SearchOptions,
+    searchDocs,
+} from './search';

--- a/packages/docs-mcp/src/search.ts
+++ b/packages/docs-mcp/src/search.ts
@@ -30,10 +30,30 @@ export interface DocSearchHit {
     score: number;
 }
 
+/**
+ * Relative weight of each retrieval mode in hybrid scoring. Identity
+ * pass-through to Orama's `hybridWeights` slot, so the field names are
+ * Orama's, not house vocabulary (CONTRACT P18/P22).
+ */
+export interface HybridWeights {
+    text: number;
+    vector: number;
+}
+
+/**
+ * Per-field full-text score boost. Identity pass-through to Orama's `boost`
+ * slot; the field names are the bundled index's schema fields (CONTRACT
+ * P18/P22).
+ */
+export interface FieldBoost {
+    pageTitle: number;
+    heading: number;
+}
+
 export interface SearchOptions {
     limit?: number;
-    hybridWeights?: { text: number; vector: number };
-    boost?: { pageTitle: number; heading: number };
+    hybridWeights?: HybridWeights;
+    boost?: FieldBoost;
 }
 
 let cached: Promise<AnyOrama> | undefined;
@@ -98,7 +118,11 @@ export async function searchDocs(
         vector: { value: vector, property: VECTOR_FIELD },
         properties: ['pageTitle', 'heading', 'text'],
         hybridWeights,
-        boost,
+        // Fresh object literal, not the interface value: named interfaces get
+        // no implicit index signature (unlike the anonymous type this replaced),
+        // so FieldBoost isn't directly assignable to Orama's
+        // Partial<Record<string, number>>. Same fields, identity pass-through.
+        boost: { ...boost },
         similarity: 0,
         includeVectors: false,
         limit,

--- a/packages/docs-mcp/test/index.spec.ts
+++ b/packages/docs-mcp/test/index.spec.ts
@@ -12,4 +12,35 @@ describe('package public API (src/index.ts barrel)', () => {
         expect(typeof docsMcp.getDoc).toBe('function');
         expect(typeof docsMcp.searchDocs).toBe('function');
     });
+
+    it('re-exports the named option interfaces (CONTRACT P14)', () => {
+        // Types are erased at runtime, so pin them at the type level: if the
+        // barrel drops any of these re-exports, this block stops compiling.
+        const getDocOptions: docsMcp.GetDocOptions = {
+            url: '/docs/guides/resilience/throttle',
+            slug: 'guides/resilience/throttle',
+        };
+        const hybridWeights: docsMcp.HybridWeights = { text: 0.2, vector: 0.8 };
+        const boost: docsMcp.FieldBoost = { pageTitle: 3, heading: 2 };
+        const searchOptions: docsMcp.SearchOptions = {
+            limit: 8,
+            hybridWeights,
+            boost,
+        };
+        const hit: docsMcp.DocSearchHit = {
+            pageUrl: '/docs/guides/x',
+            pageTitle: 'X Guide',
+            heading: 'Retries',
+            anchor: 'retries',
+            text: 'body text',
+            score: 1,
+        };
+        const doc: docsMcp.DocResult = {
+            title: 'X Guide',
+            url: '/docs/guides/x',
+            markdown: '# X Guide',
+        };
+
+        expect({ getDocOptions, searchOptions, hit, doc }).toBeTruthy();
+    });
 });

--- a/packages/json-schema/README.md
+++ b/packages/json-schema/README.md
@@ -23,20 +23,24 @@ usable anywhere a Standard Schema is — not only with StitchAPI.
 
 ```ts
 import Ajv from 'ajv';
+import { validate } from 'stitchapi';
 import { JsonSchema } from '@stitchapi/json-schema';
 
 const ajv = new Ajv(); // your app's configured engine — formats, keywords, $refs, draft
 // `discovered` is a JSON Schema you obtained at runtime.
-const validator = JsonSchema.adapt(discovered, { ajv });
+const schema = JsonSchema.adapt(discovered, { ajv });
 
-const result = await validator['~standard'].validate(payload);
-if (result.issues) {
+const result = await validate(schema, payload);
+if (!result.ok) {
     // Structured, per-path — hand it back to the sender to correct.
     // [{ message: 'must be <= 50', path: ['limit'] }]
     return respondWithErrors(result.issues);
 }
 handle(result.value); // `unknown` — a runtime schema carries no static shape
 ```
+
+The adapted schema is a plain Standard Schema: pass it to a stitch's `input`/`output`, to
+`validate`/`compile`, or to any other Standard-Schema consumer — they all treat it identically.
 
 `JsonSchema.adapt<T>()` takes an optional type argument. Leave it `unknown` for a
 runtime-obtained schema; pass `T` only when you already know the shape at authoring time.

--- a/packages/json-schema/src/index.ts
+++ b/packages/json-schema/src/index.ts
@@ -36,9 +36,10 @@ export type JsonSchemaCheck = (value: unknown) => {
 /**
  * The slice of an Ajv instance we use — just `ajv.compile(schema)`. Declared structurally so this
  * package imports nothing from `ajv`: your configured instance satisfies it, and a `{ check }`-only
- * consumer needs `ajv` neither installed nor in their type graph.
+ * consumer needs `ajv` neither installed nor in their type graph. Member spellings mirror Ajv's own
+ * (`compile`, `errors`, `instancePath`) so a real instance matches without translation.
  */
-export interface AjvInstance {
+export interface AjvLike {
     compile(schema: JsonSchemaObject): AjvValidate;
 }
 interface AjvValidate {
@@ -58,7 +59,7 @@ interface AjvError {
  * custom compiled `check` (a Workers-safe validator, a draft-2020-12 engine, a shared instance).
  */
 export type JsonSchemaEngine =
-    | { readonly ajv: AjvInstance }
+    | { readonly ajv: AjvLike }
     | { readonly check: JsonSchemaCheck };
 
 /**
@@ -67,12 +68,13 @@ export type JsonSchemaEngine =
  *
  * ```ts
  * import Ajv from 'ajv';
+ * import { validate } from 'stitchapi';
  * import { JsonSchema } from '@stitchapi/json-schema';
  *
  * const ajv = new Ajv();                               // your app's configured engine
- * const validator = JsonSchema.adapt(discovered, { ajv });
- * const result = await validator['~standard'].validate(payload);
- * if (result.issues) repair(result.issues);           // [{ message: 'must be <= 50', path: ['limit'] }]
+ * const schema = JsonSchema.adapt(discovered, { ajv });
+ * const result = await validate(schema, payload);      // { ok: true, value } | { ok: false, issues }
+ * if (!result.ok) repair(result.issues);               // [{ message: 'must be <= 50', path: ['limit'] }]
  * ```
  *
  * The output type is `T` (default `unknown`): a schema discovered at runtime carries no static
@@ -122,7 +124,7 @@ function pointerToPath(pointer: string): (string | number)[] {
         });
 }
 
-function ajvCheck(ajv: AjvInstance, schema: JsonSchemaObject): JsonSchemaCheck {
+function ajvCheck(ajv: AjvLike, schema: JsonSchemaObject): JsonSchemaCheck {
     const validate = ajv.compile(schema);
     return (value) => {
         if (validate(value)) return { valid: true, issues: [] };

--- a/packages/json-schema/test/json-schema.spec.ts
+++ b/packages/json-schema/test/json-schema.spec.ts
@@ -1,6 +1,7 @@
 import { JsonSchema, type JsonSchemaCheck } from '../src/index';
 
 import Ajv from 'ajv';
+import { compile, validate } from 'stitchapi';
 
 // A JSON Schema you obtained at runtime — the shape a discovery hands you.
 const toolSchema = {
@@ -93,5 +94,33 @@ describe('JsonSchema.adapt (bring-your-own check)', () => {
         });
         const result = await validator['~standard'].validate({ query: 'x' });
         expect(result).toEqual({ value: { query: 'x' } });
+    });
+});
+
+// P23 — one schema intake: the adapted schema enters core through the same `SchemaLike`
+// intake as any Standard Schema and yields core's `ValidationResult` shape
+// (`{ ok: true, value } | { ok: false, issues }`), with issues nominally matching core's
+// `Issue` (`{ message, path }`). Verified through the workspace dev-dependency; this
+// package's runtime still depends on nothing from core.
+describe('JsonSchema.adapt feeds core validate/compile (P23)', () => {
+    it('validate() returns { ok: true, value } for a conforming payload', async () => {
+        const schema = JsonSchema.adapt(toolSchema, { ajv });
+        const result = await validate(schema, { query: 'shoes', limit: 5 });
+        expect(result).toEqual({
+            ok: true,
+            value: { query: 'shoes', limit: 5 },
+        });
+    });
+
+    it('compile() returns { ok: false, issues } with { message, path } per failure', async () => {
+        const check = compile(JsonSchema.adapt(toolSchema, { ajv }));
+        const result = await check({ query: 42 });
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.issues).toContainEqual({
+                message: expect.any(String),
+                path: ['query'],
+            });
+        }
     });
 });

--- a/packages/swr/src/index.ts
+++ b/packages/swr/src/index.ts
@@ -27,6 +27,13 @@ import useSWR, { type SWRConfiguration, type SWRResponse } from 'swr';
 // streamable) lives in `@stitchapi/query-core`; a real stitch satisfies both.
 export type StitchLike<T, Input = unknown> = (input?: Input) => PromiseLike<T>;
 
+// `QueryOutput` / `QueryInput` deliberately re-state `@stitchapi/query-core`'s
+// inference helpers over THIS package's minimal `StitchLike` tier (CONTRACT.md P9
+// de-list): same identifier, same conditional shape, but inferring from the
+// await-only duck-type above — a cross-package import would add a runtime
+// dependency this adapter intentionally does not have. query-core's rich tier is
+// assignable to the minimal one, so both spellings agree on any real stitch.
+
 /** The validated output type of a stitch (or `StitchLike`). */
 export type QueryOutput<S> =
     S extends Stitch<infer O, infer _I>
@@ -184,26 +191,28 @@ export function swrKey<T>(
  * Pass SWR options as the third argument (`{ revalidateOnFocus, refreshInterval,
  * … }`). For conditional fetching use {@link swrKey} with a bare `useSWR`.
  */
+// The third parameter is `options` (house vocabulary); its TYPE stays SWR's own
+// `SWRConfiguration` — an adapter mirror keeps upstream spelling (CONTRACT.md P18).
 export function useStitchSWR<S extends StitchLike<unknown, never>>(
     stitch: S,
     input: QueryInput<S>,
-    config?: SWRConfiguration<QueryOutput<S>>,
+    options?: SWRConfiguration<QueryOutput<S>>,
 ): SWRResponse<QueryOutput<S>>;
 export function useStitchSWR<T, Input = unknown>(
     stitch: StitchLike<T, Input>,
     input: Input,
-    config?: SWRConfiguration<T>,
+    options?: SWRConfiguration<T>,
 ): SWRResponse<T>;
 export function useStitchSWR<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
-    config?: SWRConfiguration<T>,
+    options?: SWRConfiguration<T>,
 ): SWRResponse<T> {
     // The stitch is the fetcher; SWR caches by `swrKey`. `Promise.resolve` lifts
     // the stitch's thenable result into a real Promise for SWR.
     return useSWR<T>(
         swrKey(stitch, input),
         () => Promise.resolve(stitch(input)),
-        config,
+        options,
     );
 }

--- a/packages/swr/test/swr.spec.tsx
+++ b/packages/swr/test/swr.spec.tsx
@@ -193,7 +193,7 @@ describe('useStitchSWR', () => {
         expect(calls).toBe(1);
     });
 
-    test('forwards the SWR config (third argument) to useSWR', async () => {
+    test('forwards the SWR options (third argument) to useSWR', async () => {
         const getUser = unaryStitch(async () => ({ name: 'fresh' }));
         const { result } = renderHook(
             () =>
@@ -205,7 +205,7 @@ describe('useStitchSWR', () => {
             { wrapper },
         );
 
-        // `fallbackData` is a config option, so its presence proves the third
+        // `fallbackData` is an SWR option, so its presence proves the third
         // argument reached useSWR: the cached value shows immediately…
         expect(result.current.data).toEqual({ name: 'cached' });
         // …then the stitch fetcher revalidates to the fresh value.


### PR DESCRIPTION
Broken out of #470 — the "name the anonymous bags" slice.

## P9/P14 — an options bag is a named, exported interface, not an inline literal

A caller can't name, extend, or re-export a type spelled inline at the parameter; and a duck-type
that mirrors a third party should say so in its name.

| Package | Before | After |
| --- | --- | --- |
| core | `InflightCoalescer.join(key, { signal, onCancel })` | `CoalesceJoinOptions` |
| core | `otlpHttpExporter({ endpoint, headers })` | `OtlpExporterOptions` (= `Omit<OtlpOptions, 'exporter'>`) |
| docs-mcp | `getDoc`/`parseDocPath` each inline `{ url?, slug? }` | `GetDocOptions`, exported from the barrel |
| docs-mcp | `SearchOptions.hybridWeights` / `.boost` | `HybridWeights` / `FieldBoost` |
| json-schema | `AjvInstance` | `AjvLike` |
| swr | `config?: SWRConfiguration` | `options?` (all three overloads) |

Two judgement calls worth naming:

- **`HybridWeights` / `FieldBoost`** are identity pass-throughs to Orama's own slots, so the
  **field** names stay Orama's (P18/P22) while the **type** gets a house name.
- **`AjvLike`** is a structural duck-type for consumers who have neither `ajv` installed nor in
  their type graph, so it takes the `*Like` suffix core already uses (`LoggerLike`, `StitchLike`,
  `StitchErrorLike`) rather than implying it *is* an Ajv instance.

## P23 — one schema intake

`@stitchapi/json-schema`'s README drove the adapted schema through the raw
`schema['~standard'].validate(...)` protocol. An adapted schema is a plain Standard Schema, so it
enters core through the same `SchemaLike` intake as any other and yields core's `ValidationResult`:

```ts
const schema = JsonSchema.adapt(discovered, { ajv });
const result = await validate(schema, payload);  // { ok: true, value } | { ok: false, issues }
if (!result.ok) repair(result.issues);
```

A new spec pins that path end-to-end. The package's **runtime still depends on nothing from core** —
the check rides the workspace dev-dependency.

## Mirror note

`docs-mcp/src/doc-path.ts` is a hand-copy of `apps/docs/lib/search-index/doc-path.ts`. Its header
comment now records the one intentional divergence (the named interface, kept inline upstream);
the `docs-mcp-config-parity` tether measures **behavior**, not source text, so the mirror does not move.

Hard break, no `@deprecated` aliases — pre-GA, per P19 as amended in #470.

## Verification

- workspace typecheck clean; full workspace test suite green
- eslint clean, contract ratchet **0**, prettier clean
- apps/docs production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)