### PR TITLE
refactor(hosts)!: framework-qualified options, StitchErrorOptions, streamStitchSse (P9/P16)

### DIFF
--- a/apps/docs/content/blog/stream-a-stitch-as-sse-in-next-app-router.mdx
+++ b/apps/docs/content/blog/stream-a-stitch-as-sse-in-next-app-router.mdx
@@ -40,29 +40,26 @@ Install it alongside the core library:
 @stitchapi/next stitchapi
 ```
 
-Then `sseResponse` takes the stitch's event stream and returns a `text/event-stream` `Response`. Each `delta` becomes one SSE frame; you tell it how to pull the renderable payload out of a chunk with `data`:
+Then `streamStitchSse` takes the stitch's event stream and returns a `text/event-stream` `Response`. Each `delta` becomes one SSE frame; you tell it how to pull the renderable payload out of a chunk with `data`:
 
 ```ts twoslash
 // @noErrors
 // app/api/chat/route.ts
 import { chat } from '@/lib/api';
 
-import {
-    isStitchError,
-    sseResponse,
-    stitchErrorResponse,
-} from '@stitchapi/next';
+import { stitchErrorResponse, streamStitchSse } from '@stitchapi/next';
 
 export async function POST(request: Request) {
     const { prompt } = await request.json();
 
     try {
-        return sseResponse(chat({ body: { prompt } }).stream(), {
+        return streamStitchSse(chat({ body: { prompt } }).stream(), {
             delta: (chunk) => String(chunk), // pull text out of each delta
             signal: request.signal, // abort the stitch if the client leaves
         });
     } catch (err) {
-        if (isStitchError(err)) return stitchErrorResponse(err);
+        const mapped = stitchErrorResponse(err);
+        if (mapped) return mapped;
         throw err;
     }
 }
@@ -73,7 +70,7 @@ Two lines carry most of the value:
 -   **`data`** maps each `delta` chunk to the string you actually want to send down the wire — text out of a model chunk, a field off a JSON event, whatever the frame should carry.
 -   **`signal: request.signal`** is the cancellation story. When the browser disconnects — the user closed the tab, hit stop, or navigated away — `request.signal` aborts, and passing it through tears the stitch (and its upstream call) down instead of leaving an orphaned request burning a token budget. That early-cancel is half the reason to stream at all.
 
-The `try/catch` with `isStitchError` / `stitchErrorResponse` handles a stitch that fails _before_ the stream opens (auth wall, timeout, the upstream being down). `stitchErrorResponse` maps a `StitchError` to a safe `502` by default rather than leaking the upstream's status. Confirm the exact options for both helpers in the [`@stitchapi/next` docs](/docs/integrations/next) — the surface is small but it's the source of truth, not this post.
+The `try/catch` with `stitchErrorResponse` handles a stitch that fails _before_ the stream opens (auth wall, timeout, the upstream being down). `stitchErrorResponse` maps a `StitchError` to a safe `502` by default rather than leaking the upstream's status, and returns `undefined` for anything that isn't a stitch failure — which is why the handler rethrows when there's no mapped `Response`. Confirm the exact options for both helpers in the [`@stitchapi/next` docs](/docs/integrations/next) — the surface is small but it's the source of truth, not this post.
 
 ## The client: consuming deltas
 
@@ -107,8 +104,8 @@ Streaming over HTTP has sharp edges that have nothing to do with StitchAPI, and 
 
 -   **Buffering in the middle.** SSE only works if nothing between your server and the browser buffers the response. Reverse proxies (nginx without `proxy_buffering off;` on the route), some CDNs, and corporate proxies will happily collect the whole stream and deliver it as one lump — which silently defeats the entire exercise. Test through your real edge, not just `localhost`.
 -   **Edge vs Node runtime.** App Router handlers run on either runtime. The helpers are Web-standard so they work on both, but your _upstream_ may not — a streaming SDK that needs Node APIs, or a `fetch` quirk on the edge, will surface here. Pick the runtime deliberately (`export const runtime = 'edge' | 'nodejs'`) and test the streaming path on the one you deploy.
--   **It's not always worth it.** If your call returns in a few hundred milliseconds, or the consumer can't use partial results (it needs the whole object validated before it does anything), streaming adds plumbing and failure modes for no user-visible win. A normal JSON route — the stitch plus `stitchErrorResponse`, no `sseResponse` — is the right call there.
--   **Confirm the API surface.** The exact option names on `sseResponse` and `stitchErrorResponse` live in the package docs and may evolve. Treat the snippets above as the shape, and check [`/docs/integrations/next`](/docs/integrations/next) for the current signatures.
+-   **It's not always worth it.** If your call returns in a few hundred milliseconds, or the consumer can't use partial results (it needs the whole object validated before it does anything), streaming adds plumbing and failure modes for no user-visible win. A normal JSON route — the stitch plus `stitchErrorResponse`, no `streamStitchSse` — is the right call there.
+-   **Confirm the API surface.** The exact option names on `streamStitchSse` and `stitchErrorResponse` live in the package docs and may evolve. Treat the snippets above as the shape, and check [`/docs/integrations/next`](/docs/integrations/next) for the current signatures.
 
 ## Try it
 
@@ -116,4 +113,4 @@ Streaming over HTTP has sharp edges that have nothing to do with StitchAPI, and 
 stitchapi @stitchapi/next
 ```
 
-Declare a streaming stitch, return `sseResponse(stitch.stream())` from a route handler, and consume the deltas with `useStitchStream`. The full guides: [`@stitchapi/next`](/docs/integrations/next), [`@stitchapi/react`](/docs/integrations/react), and the [event stream](/docs/reference/events) that makes all of it one moving part.
+Declare a streaming stitch, return `streamStitchSse(stitch.stream())` from a route handler, and consume the deltas with `useStitchStream`. The full guides: [`@stitchapi/next`](/docs/integrations/next), [`@stitchapi/react`](/docs/integrations/react), and the [event stream](/docs/reference/events) that makes all of it one moving part.

--- a/apps/docs/content/docs/integrations/elysia.mdx
+++ b/apps/docs/content/docs/integrations/elysia.mdx
@@ -63,9 +63,14 @@ shutdown.
 
 Stream a streaming/SSE stitch's `.stream()` to the client by returning the
 `text/event-stream` `Response` `streamStitchSse` builds. Each `delta` becomes a
-`data:` message; a terminal `error` (or a throw) becomes a final `event: error`
-message; control events are consumed but not forwarded; and a client disconnect
-cancels the body and aborts the upstream stitch stream.
+`data:` message (shape it with `data`, name it with `event`, make the stream
+resumable with `id`); a terminal `error` (or a throw) becomes a final
+`event: error` message whose `data` is a **generic `error` token by default** —
+the raw upstream message (an internal hostname, an `HTTP 401`) never reaches the
+client. Opt in to a client-facing message with `error`, and observe the real
+failure server-side with `error.observe`. Control events are consumed but not
+forwarded, and a client disconnect cancels the body and aborts the upstream
+stitch stream.
 
 ```ts
 import { stitch, streamStitchSse } from '@stitchapi/elysia';

--- a/apps/docs/content/docs/integrations/express.mdx
+++ b/apps/docs/content/docs/integrations/express.mdx
@@ -57,15 +57,17 @@ never name another identity. **Borrow, don't own:** the middleware never calls
 `seam.close()` — you build the seam at startup and close it on shutdown.
 
 A generic helper that only holds a loosely-typed `Request` can read the same
-handle back with `currentStitch(req)`, which throws if the middleware never ran —
-so a missing `app.use(stitch(...))` fails loudly instead of silently.
+handle back with `currentStitch(req)`, which returns `undefined` if the
+middleware never ran — so a caller can fall back to an explicit seam instead of
+crashing.
 
 ## Streaming — `streamStitchSse`
 
 Stream a streaming/SSE stitch's `.stream()` to the client as Server-Sent Events.
 Each `delta` becomes a `data:` frame; a terminal `error` (or a throw) becomes a
-final `event: error` frame; control events are consumed but not forwarded; and a
-client disconnect aborts the upstream stitch stream.
+final `event: error` frame carrying a generic `error` token by default (opt in
+to a client-facing message with `error`); control events are consumed but
+not forwarded; and a client disconnect aborts the upstream stitch stream.
 
 ```ts
 import { stitch, streamStitchSse } from '@stitchapi/express';

--- a/apps/docs/content/docs/integrations/fastify.mdx
+++ b/apps/docs/content/docs/integrations/fastify.mdx
@@ -86,14 +86,15 @@ async function loadProfile() {
 
 ## SSE streaming
 
-`sendStitchSse(reply, stream, options?)` streams a stitch's `.stream()` output to a
+`streamStitchSse(reply, stream, options?)` streams a stitch's `.stream()` output to a
 `text/event-stream` reply. Each `delta` chunk becomes one SSE frame; an `error`
-event ends the stream as a named `error` frame; stream end closes the response; and
-a client disconnect aborts the upstream stitch generator rather than leaving it
-running.
+event ends the stream as a named `error` frame whose `data` is a generic `error`
+token by default (the raw upstream message never reaches the client — opt in with
+`error`); stream end closes the response; and a client disconnect aborts the
+upstream stitch generator rather than leaving it running.
 
 ```ts twoslash
-import { sendStitchSse } from '@stitchapi/fastify';
+import { streamStitchSse } from '@stitchapi/fastify';
 import Fastify from 'fastify';
 import { sse } from 'stitchapi/sse';
 
@@ -101,7 +102,7 @@ const chat = sse({ url: 'https://api.example.com/chat' });
 const app = Fastify();
 
 app.get<{ Querystring: { q: string } }>('/chat', (req, reply) =>
-    sendStitchSse(reply, chat.stream({ query: { q: req.query.q } }), {
+    streamStitchSse(reply, chat.stream({ query: { q: req.query.q } }), {
         delta: (chunk) => (chunk as { data: string }).data, // pull text out
     }),
 );

--- a/apps/docs/content/docs/integrations/hono.mdx
+++ b/apps/docs/content/docs/integrations/hono.mdx
@@ -59,8 +59,10 @@ never name another identity. **Borrow, don't own:** the middleware never calls
 
 Stream a streaming/SSE stitch's `.stream()` to the client as Server-Sent Events,
 via Hono's `streamSSE`. Each `delta` becomes a `data:` message; a terminal `error`
-(or a throw) becomes a final `event: error` message; control events are consumed
-but not forwarded; and a client disconnect aborts the upstream stitch stream.
+(or a throw) becomes a final `event: error` message carrying a generic `error`
+token by default (opt in to a client-facing message with `error`); control
+events are consumed but not forwarded; and a client disconnect aborts the upstream
+stitch stream.
 
 ```ts twoslash
 import { type StitchEnv, stitch, streamStitchSse } from '@stitchapi/hono';

--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -59,7 +59,7 @@ an SSE helper, and an error bridge.
     <Card
         title="Next.js"
         href="/docs/integrations/next"
-        description="Web-standard route-handler helpers — sseResponse (text/event-stream) and stitchErrorResponse (StitchError → Response)."
+        description="Web-standard route-handler helpers — streamStitchSse (text/event-stream) and stitchErrorResponse (StitchError → Response)."
     />
 </Cards>
 

--- a/apps/docs/content/docs/integrations/next.mdx
+++ b/apps/docs/content/docs/integrations/next.mdx
@@ -1,6 +1,6 @@
 ---
 title: Next.js
-description: Web-standard helpers for Next App Router route handlers — sseResponse streams a stitch as text/event-stream, and stitchErrorResponse maps a StitchError to a Response.
+description: Web-standard helpers for Next App Router route handlers — streamStitchSse streams a stitch as text/event-stream, and stitchErrorResponse maps a StitchError to a Response.
 prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
@@ -49,26 +49,27 @@ export async function GET(
 ```
 
 `stitchErrorResponse` returns a `Response` for a `StitchError` and `undefined` for
-anything else — map the stitch failure, rethrow the rest, no `instanceof` dance. It maps
-to `502` by default — the safe choice that never leaks the upstream's `401`/`404`
-semantics. Pass `{ status: (e) => e.status ?? 502 }` to propagate the upstream status
-instead.
+anything else — map the stitch failure, rethrow the rest, no `instanceof` dance.
+It maps to `502` by default — the safe choice that never leaks the
+upstream's `401`/`404` semantics. Pass `{ status: (e) => e.status ?? 502 }` to
+propagate the upstream status instead.
 
 ## Streaming with SSE
 
-`sseResponse` streams a stitch's events as `text/event-stream`. Each `delta` becomes
-one frame; an `error` event ends the stream with a named `event: error` frame; the
-terminal `result` closes it:
+`streamStitchSse` streams a stitch's events as `text/event-stream`. Each `delta`
+becomes one frame; an `error` event ends the stream with a named `event: error`
+frame whose `data` is a generic `error` token by default (opt in to a client-facing
+message with `error`); the terminal `result` closes it:
 
 ```ts
 // app/api/chat/route.ts
 import { chat } from '@/lib/api';
 
-import { sseResponse } from '@stitchapi/next';
+import { streamStitchSse } from '@stitchapi/next';
 
 export async function POST(request: Request) {
     const { prompt } = await request.json();
-    return sseResponse(chat({ body: { prompt } }).stream(), {
+    return streamStitchSse(chat({ body: { prompt } }).stream(), {
         delta: (c) => String(c), // pull text out of each chunk
         signal: request.signal, // abort the upstream if the client leaves
     });

--- a/packages/core/src/sse-emit.ts
+++ b/packages/core/src/sse-emit.ts
@@ -11,13 +11,30 @@
 // Zero-dep and browser-safe (no `node:*`): pure types + string building, so it satisfies the same
 // three gates as its siblings and rides the `browser` export condition. Reached only through the
 // `sse-emit` subpath — `import { stitch }` pulls in none of it.
-import type { StitchEvent } from './types';
+import type { StitchEvent, StitchEventSource } from './types';
 import { envelope } from './util';
 
-/** Anything an SSE emitter can drive: a stitch `.stream()` generator, or any event iterable. */
-export type StitchEventSource<T> =
-    | AsyncIterable<StitchEvent<T>>
-    | AsyncGenerator<StitchEvent<T>, void>;
+/**
+ * Anything an SSE emitter can drive: an event iterable (a `.stream()` generator), or anything
+ * that hands one back (a `StitchResult`, a stitch stub). RE-EXPORTED from the barrel rather than
+ * restated here, so an adapter accepts exactly what core says a source is — there is one
+ * definition, so there is nothing to keep in step. (`AsyncGenerator` needs no arm of its own: it
+ * already satisfies `AsyncIterable`.)
+ */
+export type { StitchEventSource } from './types';
+
+/**
+ * Resolve the canonical intake to the event iterable itself: a `.stream()`-bearing source (a
+ * `StitchResult`, a stitch stub) is asked for its stream; an iterable is used as-is. Every
+ * adapter's driver starts here, so the two arms are unwrapped in exactly one place.
+ */
+export function toIterable<T>(
+    source: StitchEventSource<T>,
+): AsyncIterable<StitchEvent<T>> {
+    return Symbol.asyncIterator in source
+        ? (source as AsyncIterable<StitchEvent<T>>)
+        : source.stream();
+}
 
 /** The terminal `error` event a stitch stream emits — carries `message`, `status`, `attempts`. */
 export type StitchErrorEvent = Extract<StitchEvent, { type: 'error' }>;

--- a/packages/elysia/README.md
+++ b/packages/elysia/README.md
@@ -79,11 +79,25 @@ app.get('/chat', ({ stitch, query }) => {
 });
 ```
 
-Each `delta` chunk becomes one SSE message; an `error` event ends the stream as a
-named `event: error` message; stream end closes the response; and a client
-disconnect cancels the body and aborts the upstream stitch stream rather than
-leaving it running. Control events (`start`/`progress`/`result`/`done`/…) are not
-forwarded.
+Each `delta` chunk becomes one SSE message (label it with `event`, add a
+last-event id with `id: (chunk, index) => string`); an `error` event ends the
+stream as a named `event: error` message; stream end closes the response; and a
+client disconnect cancels the body and aborts the upstream stitch stream rather
+than leaving it running. Control events (`start`/`progress`/`result`/`done`/…)
+are not forwarded.
+
+The error message's `data` is a **generic `error` token by default** — the raw
+upstream message is withheld, because it can disclose internal network topology
+(`getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status
+(`HTTP 401`) to an untrusted client. Observe the real failure server-side with
+`onError`, and opt in to shaping the client-facing frame with `errorData`:
+
+```ts
+return streamStitchSse(chat.stream(), {
+    onError: (err) => log.error(err), // the raw failure, server-side only
+    // errorData: (e) => e.message,   // opt-in: only when upstream messages are safe
+});
+```
 
 By default the `error` frame carries a generic `data: error` token, **not** the raw
 error message — echoing it can disclose internal network topology (a transport failure

--- a/packages/elysia/src/context.ts
+++ b/packages/elysia/src/context.ts
@@ -14,10 +14,11 @@ export interface PrincipalContext {
 }
 
 /**
- * The slice of Elysia's error context the error bridge reads: the thrown `error`. Elysia's real
- * context also carries `code` / `set` / `request`, but the StitchError bridge only needs `error`.
+ * The slice of Elysia's error context the error bridge reads: the thrown `error` (mirrors Elysia's
+ * `ErrorContext`, structurally). Elysia's real context also carries `code` / `set` / `request`, but
+ * the StitchError bridge only needs `error`.
  */
-export interface StitchEnvLike {
+export interface ErrorContextLike {
     error: unknown;
 }
 

--- a/packages/elysia/src/error.ts
+++ b/packages/elysia/src/error.ts
@@ -6,7 +6,7 @@
 //
 // Web-standard: builds a plain `Response` (Fetch) — no `node:*`, so it runs under Bun, Node,
 // Deno and the edge alike.
-import type { StitchEnvLike } from './context';
+import type { ErrorContextLike } from './context';
 
 /** The error a stitch rejects with on failure: a branded `Error` carrying the upstream status. */
 export type StitchErrorLike = Error & { status?: number };
@@ -96,9 +96,9 @@ export function stitchErrorResponse(
  */
 export function stitchOnError(
     options: StitchErrorOptions = {},
-): (ctx: StitchEnvLike) => Response | undefined {
+): (ctx: ErrorContextLike) => Response | undefined {
     // Elysia calls `.onError` with a rich context; we only read `.error`. Returning a value short-
     // circuits the response; returning `undefined` lets Elysia's default error handling proceed.
-    return (ctx: StitchEnvLike): Response | undefined =>
+    return (ctx: ErrorContextLike): Response | undefined =>
         stitchErrorResponse(ctx.error, options);
 }

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -19,8 +19,8 @@
 export {
     stitch,
     type ElysiaRequestSeam,
+    type ElysiaStitchPluginOptions,
     type StitchPlugin,
-    type StitchPluginOptions,
 } from './plugin';
 
 export {
@@ -37,4 +37,8 @@ export {
     type StitchErrorOptions,
 } from './error';
 
-export type { PrincipalContext, StitchContext, StitchEnvLike } from './context';
+export type {
+    ErrorContextLike,
+    PrincipalContext,
+    StitchContext,
+} from './context';

--- a/packages/elysia/src/plugin.ts
+++ b/packages/elysia/src/plugin.ts
@@ -36,7 +36,7 @@ export type StitchPlugin = Elysia<
     }
 >;
 
-export interface StitchPluginOptions {
+export interface ElysiaStitchPluginOptions {
     /**
      * The seam this plugin shares across requests. **Borrowed, not owned** — build it once at
      * startup and `seam.close()` it on shutdown yourself; the plugin never closes it (the seam
@@ -80,7 +80,7 @@ export interface StitchPluginOptions {
  *
  * The `stitch` context property is typed: a handler reads it off the destructured context.
  */
-export function stitch(options: StitchPluginOptions): StitchPlugin {
+export function stitch(options: ElysiaStitchPluginOptions): StitchPlugin {
     const { seam, principal, errorHandler } = options;
 
     // `.derive` runs per request and merges its return into the context. The principal lives in this

--- a/packages/elysia/src/sse.ts
+++ b/packages/elysia/src/sse.ts
@@ -21,6 +21,7 @@ import {
     resolveError,
     sseFrame,
     toErrorEvent,
+    toIterable,
 } from 'stitchapi/sse-emit';
 
 export type { StitchEventSource };
@@ -57,7 +58,7 @@ export function streamStitchSse<T>(
     const error = resolveError(options.error);
     const errorEvent = error.event ?? 'error';
     const enc = new TextEncoder();
-    const iterator = source[Symbol.asyncIterator]();
+    const iterator = toIterable(source)[Symbol.asyncIterator]();
     let index = 0;
 
     const body = new ReadableStream<Uint8Array>({

--- a/packages/elysia/test/elysia.spec.ts
+++ b/packages/elysia/test/elysia.spec.ts
@@ -157,7 +157,10 @@ describe('streamStitchSse bridges a stitch stream to an SSE body', () => {
 
         const res = await app.handle(GET('/events'));
         const body = await res.text();
-        expect(body).toContain('event: error');
+        // A generic `data: error` token — the raw upstream message (`HTTP 500`) is withheld
+        // so upstream status/topology is not disclosed; `errorData` is the opt-in.
+        expect(body).toContain('event: error\ndata: error');
+        expect(body).not.toContain('HTTP 500');
         await api.close();
     });
 });

--- a/packages/elysia/test/sse.spec.ts
+++ b/packages/elysia/test/sse.spec.ts
@@ -95,6 +95,19 @@ describe('streamStitchSse — delta mapping', () => {
         const body = await res.text();
         expect(body).toContain('data: line1\ndata: line2');
     });
+
+    test('a {stream()} source (the core StitchEventSource arm) is driven too', async () => {
+        const res = streamStitchSse({
+            stream: () =>
+                gen([
+                    { type: 'delta', chunk: 'via-stream', at: 0 },
+                    { type: 'done', ok: true, elapsed: 1, attempts: 1, at: 0 },
+                ]),
+        });
+
+        const body = await res.text();
+        expect(body).toContain('data: via-stream');
+    });
 });
 
 describe('streamStitchSse — control events', () => {

--- a/packages/express/src/error.ts
+++ b/packages/express/src/error.ts
@@ -18,7 +18,7 @@ export function isStitchError(err: unknown): err is StitchErrorLike {
     return err instanceof Error && err.name === 'StitchError';
 }
 
-export interface StitchErrorHandlerOptions {
+export interface StitchErrorOptions {
     /**
      * The HTTP status for a mapped stitch failure. Default `502 Bad Gateway` — **every** upstream
      * failure is reported as a gateway error, regardless of the upstream's own status. This is the
@@ -50,7 +50,7 @@ const STATUS_TEXT: Record<number, string> = {
 
 function resolveStatus(
     err: StitchErrorLike,
-    status: StitchErrorHandlerOptions['status'],
+    status: StitchErrorOptions['status'],
 ): number {
     if (status === undefined) return DEFAULT_STATUS;
     return typeof status === 'function' ? status(err) : status;
@@ -58,7 +58,7 @@ function resolveStatus(
 
 /**
  * Build an Express error-handling middleware that maps a {@link StitchErrorLike} to a JSON response
- * (status `502` by default; override via {@link StitchErrorHandlerOptions.status}) and **passes every
+ * (status `502` by default; override via {@link StitchErrorOptions.status}) and **passes every
  * other error to `next(err)`** so Express's default handler — and any error middleware registered
  * after it — stays in charge. Register it after your routes:
  *
@@ -72,7 +72,7 @@ function resolveStatus(
  * though `req` is unused here, or Express treats it as a normal middleware.
  */
 export function stitchErrorHandler(
-    options: StitchErrorHandlerOptions = {},
+    options: StitchErrorOptions = {},
 ): ErrorRequestHandler {
     return (
         err: unknown,

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -18,7 +18,7 @@ export {
     stitch,
     currentStitch,
     type ExpressRequestSeam,
-    type StitchMiddlewareOptions,
+    type ExpressStitchMiddlewareOptions,
 } from './middleware';
 
 export {
@@ -31,5 +31,5 @@ export {
     stitchErrorHandler,
     isStitchError,
     type StitchErrorLike,
-    type StitchErrorHandlerOptions,
+    type StitchErrorOptions,
 } from './error';

--- a/packages/express/src/middleware.ts
+++ b/packages/express/src/middleware.ts
@@ -18,7 +18,7 @@ import type { PrincipalSeam, Seam } from 'stitchapi';
  */
 export type ExpressRequestSeam = PrincipalSeam | Seam;
 
-export interface StitchMiddlewareOptions {
+export interface ExpressStitchMiddlewareOptions {
     /**
      * The seam this middleware shares across requests. **Borrowed, not owned** — build it once at
      * startup and `seam.close()` it on shutdown yourself; the middleware never closes it (the seam
@@ -52,7 +52,9 @@ export interface StitchMiddlewareOptions {
  * app.get('/me', async (req, res) => res.json(await req.stitch.stitch('/me')()));
  * ```
  */
-export function stitch(options: StitchMiddlewareOptions): RequestHandler {
+export function stitch(
+    options: ExpressStitchMiddlewareOptions,
+): RequestHandler {
     const { seam, principal } = options;
     return (req: Request, res: Response, next: NextFunction): void => {
         const id = principal?.(req);
@@ -68,22 +70,17 @@ export function stitch(options: StitchMiddlewareOptions): RequestHandler {
 /**
  * Read the request-scoped {@link ExpressRequestSeam} off a request as a typed value — the same handle
  * `stitch()` set on `req.stitch`. A convenience for code paths that hold a loosely-typed `Request`
- * (e.g. a generic helper) and want the seam without re-declaring the augmentation. Throws if the
- * middleware did not run for this request (so a missing `app.use(stitch(...))` fails loudly).
+ * (e.g. a generic helper) and want the seam without re-declaring the augmentation. Returns
+ * `undefined` (it never throws) when the middleware did not run for this request — check for it, or
+ * register `app.use(stitch({ seam }))` ahead of the handler.
  *
  * ```ts
  * import { currentStitch } from '@stitchapi/express';
- * const api = currentStitch(req); // the caller's principal-bound seam
+ * const api = currentStitch(req); // the caller's principal-bound seam, or undefined
  * ```
  */
-export function currentStitch(req: Request): ExpressRequestSeam {
-    const host = req.stitch as ExpressRequestSeam | undefined;
-    if (host === undefined) {
-        throw new Error(
-            'req.stitch is not set — register `app.use(stitch({ seam }))` before this handler',
-        );
-    }
-    return host;
+export function currentStitch(req: Request): ExpressRequestSeam | undefined {
+    return req.stitch as ExpressRequestSeam | undefined;
 }
 
 // Augment Express's `Request` so `req.stitch` is typed app-wide once this package is imported.

--- a/packages/express/src/sse.ts
+++ b/packages/express/src/sse.ts
@@ -17,6 +17,7 @@ import {
     resolveDelta,
     resolveError,
     sseFrame,
+    toIterable,
 } from 'stitchapi/sse-emit';
 
 export type { StitchEventSource };
@@ -32,7 +33,7 @@ export interface StreamStitchSseOptions extends SseEmitOptions {
 
 /**
  * Stream a stitch's output to an Express {@link Response} as Server-Sent Events. Pass the stitch's
- * `.stream()` generator (or any `AsyncIterable<StitchEvent>`): each `delta` becomes one SSE frame, an
+ * `.stream()` generator (or any `StitchEventSource`): each `delta` becomes one SSE frame, an
  * `error` event ends the stream with a named `event: error` frame (a generic `data: error` by
  * default — the raw message is withheld to avoid disclosing internal topology; opt in via
  * `error`), and stream end closes the response. The non-output events (`start` / `progress` /
@@ -68,7 +69,10 @@ export async function streamStitchSse<T>(
         res.flushHeaders();
     }
 
-    const iterator = source[Symbol.asyncIterator]();
+    // Accept both arms of the canonical `StitchEventSource` — the iterable itself, or a handle that
+    // hands one back (a `StitchResult`, a stitch stub) — by resolving to the event iterable up front.
+    const iterable = toIterable(source);
+    const iterator = iterable[Symbol.asyncIterator]();
     let active = true;
 
     // Client disconnect: stop consuming and abort the upstream iterator. Listen on the response and,

--- a/packages/express/test/express.spec.ts
+++ b/packages/express/test/express.spec.ts
@@ -151,10 +151,8 @@ describe('stitch() middleware puts a seam on req', () => {
         await api.close();
     });
 
-    test('currentStitch throws when the middleware did not run', () => {
-        expect(() => currentStitch(mockReq())).toThrow(
-            /req\.stitch is not set/,
-        );
+    test('currentStitch returns undefined (never throws) when the middleware did not run', () => {
+        expect(currentStitch(mockReq())).toBeUndefined();
     });
 });
 
@@ -303,6 +301,18 @@ describe('streamStitchSse writes SSE frames to res', () => {
         expect(res.body()).toBe(
             'event: token\ndata: a\n\nevent: token\ndata: b\n\n',
         );
+    });
+
+    test('accepts the { stream() } arm of StitchEventSource (e.g. a StitchResult)', async () => {
+        async function* events(): AsyncGenerator<StitchEvent<unknown>> {
+            yield { type: 'delta', chunk: 'via-stream', at: 1 };
+        }
+        const res = mockRes();
+        await streamStitchSse(res as unknown as Response, {
+            stream: () => events(),
+        });
+        expect(res.body()).toBe('data: via-stream\n\n');
+        expect(res.ended).toBe(true);
     });
 
     test('the default data mapper sends a string verbatim and JSON-stringifies an object', async () => {

--- a/packages/fastify/README.md
+++ b/packages/fastify/README.md
@@ -41,7 +41,7 @@ encapsulation and are visible app-wide.
     (default on). It logs **only metadata** (name, method, scrubbed URL, status,
     attempts, timing), never request/response bodies or headers, so it is safe on a
     secret-bearing seam.
--   **SSE bridge.** `sendStitchSse(reply, stream)` streams a stitch's `.stream()`
+-   **SSE bridge.** `streamStitchSse(reply, stream)` streams a stitch's `.stream()`
     output to a `text/event-stream` reply.
 -   **Error bridge.** A thrown `StitchError` is mapped to an HTTP response
     (`502` by default) so handlers need no try/catch.
@@ -90,10 +90,10 @@ back to an explicit seam.
 ## SSE streaming
 
 ```ts
-import { sendStitchSse } from '@stitchapi/fastify';
+import { streamStitchSse } from '@stitchapi/fastify';
 
 app.get('/chat', (req, reply) =>
-    sendStitchSse(reply, chat.stream({ query: { q: String(req.query.q) } }), {
+    streamStitchSse(reply, chat.stream({ query: { q: String(req.query.q) } }), {
         delta: (c) => c.text, // pull text out of a structured chunk
     }),
 );
@@ -110,7 +110,7 @@ status (`HTTP 401`) to the client. Pass `error` to opt in when the upstream
 messages are known safe to expose:
 
 ```ts
-sendStitchSse(reply, chat.stream({ query: { q: String(req.query.q) } }), {
+streamStitchSse(reply, chat.stream({ query: { q: String(req.query.q) } }), {
     error: (e) => e.message, // opt in to the raw upstream message
 });
 ```
@@ -155,7 +155,7 @@ events and log only retries, drift, and errors). A seam built with its own
 | -------------------- | -------- | ------------------------------------------------- |
 | `stitchPlugin`       | plugin   | `fastify.register(stitchPlugin, options)`         |
 | `currentStitch()`    | function | The request's ambient principal-bound seam        |
-| `sendStitchSse`      | function | Stream a stitch's `.stream()` to an SSE reply     |
+| `streamStitchSse`    | function | Stream a stitch's `.stream()` to an SSE reply     |
 | `stitchErrorHandler` | function | A `setErrorHandler`-compatible StitchError mapper |
 | `fastifyLoggerSink`  | function | `fastify.log` → seam `TraceSink` bridge           |
 | `isStitchError`      | function | Narrow an unknown error to a `StitchError`        |

--- a/packages/fastify/src/error-handler.ts
+++ b/packages/fastify/src/error-handler.ts
@@ -13,7 +13,7 @@ export function isStitchError(err: unknown): err is StitchErrorLike {
     return err instanceof Error && err.name === 'StitchError';
 }
 
-export interface StitchErrorHandlerOptions {
+export interface StitchErrorOptions {
     /**
      * The HTTP status for a mapped stitch failure. Default `502 Bad Gateway` — **every**
      * upstream failure is reported as a gateway error, regardless of the upstream's own
@@ -46,7 +46,7 @@ const STATUS_TEXT: Record<number, string> = {
 
 function resolveStatus(
     err: StitchErrorLike,
-    status: StitchErrorHandlerOptions['status'],
+    status: StitchErrorOptions['status'],
 ): number {
     if (status === undefined) return DEFAULT_STATUS;
     return typeof status === 'function' ? status(err) : status;
@@ -54,7 +54,7 @@ function resolveStatus(
 
 /**
  * Build a `setErrorHandler`-compatible function that maps a {@link StitchErrorLike} to an HTTP
- * response (status `502` by default; override via {@link StitchErrorHandlerOptions.status})
+ * response (status `502` by default; override via {@link StitchErrorOptions.status})
  * and **rethrows every other error** so Fastify's default handling — and any error handler
  * registered in an outer scope — stays in charge. Register it on the app or a plugin scope:
  *
@@ -66,7 +66,7 @@ function resolveStatus(
  * only to register it yourself with custom options.
  */
 export function stitchErrorHandler(
-    options: StitchErrorHandlerOptions = {},
+    options: StitchErrorOptions = {},
 ): (error: FastifyError, request: FastifyRequest, reply: FastifyReply) => void {
     return (error, _request, reply): void => {
         if (!isStitchError(error)) {

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -1,17 +1,20 @@
 export {
     stitchPlugin,
     currentStitch,
-    type StitchPluginOptions,
-    type StitchPluginSeamOptions,
-    type StitchPluginConfigOptions,
+    type FastifyStitchPluginOptions,
+    type FastifyStitchPluginSeamOptions,
+    type FastifyStitchPluginConfigOptions,
     type FastifyRequestSeam,
 } from './plugin';
-export { sendStitchSse, type SendStitchSseOptions } from './sse';
+export { streamStitchSse, type StreamStitchSseOptions } from './sse';
+// The canonical event-stream intake, re-exported from the core barrel (one shared shape
+// across every host adapter — no local unions).
+export type { StitchEventSource } from 'stitchapi';
 export {
     stitchErrorHandler,
     isStitchError,
     type StitchErrorLike,
-    type StitchErrorHandlerOptions,
+    type StitchErrorOptions,
 } from './error-handler';
 export {
     fastifyLoggerSink,

--- a/packages/fastify/src/plugin.ts
+++ b/packages/fastify/src/plugin.ts
@@ -5,16 +5,14 @@
 // genuine Node value-add over the browser-first core — makes that principal handle **ambient**
 // through `AsyncLocalStorage`, so handlers/services read it with `currentStitch()` instead of
 // threading `request.stitch` everywhere.
-import {
-    type StitchErrorHandlerOptions,
-    stitchErrorHandler,
-} from './error-handler';
+import { type StitchErrorOptions, stitchErrorHandler } from './error-handler';
 import { type FastifyLoggerSinkOptions, fastifyLoggerSink } from './logger';
 
 import type { FastifyPluginAsync, FastifyRequest } from 'fastify';
 import fp from 'fastify-plugin';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import {
+    type AtLeastOne,
     type PrincipalSeam,
     type Seam,
     type SeamConfig,
@@ -25,8 +23,8 @@ import {
 // when a `principal` resolver is set, else the root seam (both create member stitches).
 export type FastifyRequestSeam = Seam | PrincipalSeam;
 
-/** Common options shared by both `StitchPluginOptions` variants. */
-interface StitchPluginCommon {
+/** Common options shared by both `FastifyStitchPluginOptions` variants. */
+interface FastifyStitchPluginCommon {
     /**
      * Derive the request's principal id (e.g. a tenant or user id) from the incoming request.
      * When set, each request gets a `seam.as(principal)` handle (a separate session/token over
@@ -36,17 +34,18 @@ interface StitchPluginCommon {
     principal?: (req: FastifyRequest) => string | undefined;
     /**
      * Bridge `fastify.log` (Fastify's built-in Pino logger) into the seam as its `TraceSink`,
-     * so stitch events flow through Fastify's logger. Default `true`. Ignored when a prebuilt
-     * `seam` is passed *and* it already has its own `trace` — a borrowed seam keeps its sink.
-     * Set `false` to leave tracing as the seam configured it (off by default in core).
+     * so stitch events flow through Fastify's logger. Default `true` (the bridge is on) — the
+     * cross-host canonical default. Ignored when a prebuilt `seam` is passed *and* it already
+     * has its own `trace` — a borrowed seam keeps its sink. Set `false` to leave tracing as
+     * the seam configured it (off by default in core).
      */
-    logger?: boolean | FastifyLoggerSinkOptions;
+    logger?: boolean | AtLeastOne<FastifyLoggerSinkOptions>;
     /**
      * Options for the error handler the plugin registers (see {@link stitchErrorHandler}).
      * Set to `false` to register **no** error handler (you wire your own). Default: register
      * with the `502`-by-default mapping.
      */
-    errorHandler?: StitchErrorHandlerOptions | false;
+    errorHandler?: StitchErrorOptions | false;
     /**
      * Close the seam on `onClose`. Defaults to `true` **only when the plugin built the seam**
      * (from `seamConfig`); a borrowed seam (passed via `seam`) is never closed by the plugin —
@@ -57,20 +56,22 @@ interface StitchPluginCommon {
 }
 
 /** Pass a prebuilt seam the app owns — the plugin borrows it and never closes it by default. */
-export interface StitchPluginSeamOptions extends StitchPluginCommon {
+export interface FastifyStitchPluginSeamOptions
+    extends FastifyStitchPluginCommon {
     seam: Seam;
     seamConfig?: never;
 }
 
 /** Let the plugin build (and, by default, own + close) the seam from a {@link SeamConfig}. */
-export interface StitchPluginConfigOptions extends StitchPluginCommon {
+export interface FastifyStitchPluginConfigOptions
+    extends FastifyStitchPluginCommon {
     seamConfig: SeamConfig;
     seam?: never;
 }
 
-export type StitchPluginOptions =
-    | StitchPluginSeamOptions
-    | StitchPluginConfigOptions;
+export type FastifyStitchPluginOptions =
+    | FastifyStitchPluginSeamOptions
+    | FastifyStitchPluginConfigOptions;
 
 // The ambient request-scoped host. `currentStitch()` reads it; the `onRequest` hook runs each
 // request inside `als.run(host, …)` so the value is the per-request principal handle.
@@ -80,8 +81,9 @@ const als = new AsyncLocalStorage<FastifyRequestSeam>();
  * The ambient request-scoped {@link FastifyRequestSeam} for the in-flight request — the principal-bound
  * `seam.as(principal)` handle (or the root seam when no principal resolver is set). Returns
  * `undefined` outside a request (no ambient context), so a caller can fall back to an explicit
- * seam. Backed by Node's {@link AsyncLocalStorage}: a value-add a Node integration offers that
- * the browser-first core cannot.
+ * seam. Never throws on a miss — `undefined` is the whole miss contract. Backed by Node's
+ * {@link AsyncLocalStorage}: a value-add a Node integration offers that the browser-first core
+ * cannot.
  *
  * ```ts
  * import { currentStitch } from '@stitchapi/fastify';
@@ -95,7 +97,7 @@ export function currentStitch(): FastifyRequestSeam | undefined {
     return als.getStore();
 }
 
-const pluginImpl: FastifyPluginAsync<StitchPluginOptions> = async (
+const pluginImpl: FastifyPluginAsync<FastifyStitchPluginOptions> = async (
     fastify,
     options,
 ) => {

--- a/packages/fastify/src/sse.ts
+++ b/packages/fastify/src/sse.ts
@@ -9,22 +9,23 @@
 // secure-by-default error framing are shared with every other HTTP adapter via
 // `stitchapi/sse-emit`; this file keeps only Fastify's reply driver.
 import type { FastifyReply } from 'fastify';
-import type { StitchEvent } from 'stitchapi';
 import {
     DEFAULT_ERROR_DATA,
     type SseEmitOptions,
+    type StitchEventSource,
     deltaFrame,
     resolveDelta,
     resolveError,
     sseFrame,
+    toIterable,
 } from 'stitchapi/sse-emit';
 
 /** How each `delta` / terminal `error` becomes an SSE frame (see {@link SseEmitOptions}). */
-export type SendStitchSseOptions = SseEmitOptions;
+export type StreamStitchSseOptions = SseEmitOptions;
 
 /**
  * Stream a stitch's output to a Fastify {@link FastifyReply} as Server-Sent Events. Pass the
- * stitch's `.stream()` generator (or any `AsyncIterable<StitchEvent>`): each `delta` becomes
+ * stitch's `.stream()` generator (or any `StitchEventSource`): each `delta` becomes
  * one SSE frame, an `error` event ends the stream with a named `event: error` frame (a generic
  * `data: error` by default — the raw message is withheld to avoid disclosing internal topology;
  * opt in via `error`), and stream end closes the response. The non-output events (`start` /
@@ -37,15 +38,15 @@ export type SendStitchSseOptions = SseEmitOptions;
  *
  * ```ts
  * app.get('/chat', (req, reply) =>
- *   sendStitchSse(reply, chat.stream({ query: { q: req.query.q } }),
+ *   streamStitchSse(reply, chat.stream({ query: { q: req.query.q } }),
  *                 { delta: (c: any) => c.text }),
  * );
  * ```
  */
-export async function sendStitchSse<T>(
+export async function streamStitchSse<T>(
     reply: FastifyReply,
-    stream: AsyncIterable<StitchEvent<T>>,
-    options: SendStitchSseOptions = {},
+    source: StitchEventSource<T>,
+    options: StreamStitchSseOptions = {},
 ): Promise<void> {
     const delta = resolveDelta(options.delta);
     const error = resolveError(options.error);
@@ -60,7 +61,9 @@ export async function sendStitchSse<T>(
         });
     }
 
-    const iterator = stream[Symbol.asyncIterator]();
+    // Resolve the `{ stream() }` arm of StitchEventSource to its event iterable.
+    const iterable = toIterable(source);
+    const iterator = iterable[Symbol.asyncIterator]();
     let active = true;
 
     // Client disconnect: stop consuming and abort the upstream generator.

--- a/packages/fastify/test/fastify.spec.ts
+++ b/packages/fastify/test/fastify.spec.ts
@@ -2,13 +2,13 @@
 // `adapter` (no network), so every stitch call resolves against canned responses. We drive the
 // app with `fastify.inject()` and assert the four contracts: the seam is decorated, the
 // request-scoped principal binds (a route reads `currentStitch()` and `request.stitch`),
-// `sendStitchSse` streams events, and `stitchErrorHandler` maps a StitchError to a status.
+// `streamStitchSse` streams events, and `stitchErrorHandler` maps a StitchError to a status.
 import {
     currentStitch,
     isStitchError,
-    sendStitchSse,
     stitchErrorHandler,
     stitchPlugin,
+    streamStitchSse,
 } from '../src';
 
 import Fastify from 'fastify';
@@ -145,7 +145,7 @@ describe('stitchPlugin', () => {
         expect(res.json()).toEqual({ isRoot: true });
     });
 
-    test('sendStitchSse streams delta events to the reply', async () => {
+    test('streamStitchSse streams delta events to the reply', async () => {
         // A hand-built event stream — the SSE bridge consumes any AsyncIterable<StitchEvent>.
         async function* events(): AsyncGenerator<StitchEvent<unknown>> {
             yield {
@@ -173,7 +173,7 @@ describe('stitchPlugin', () => {
             },
             logger: false,
         });
-        app.get('/sse', (_request, reply) => sendStitchSse(reply, events()));
+        app.get('/sse', (_request, reply) => streamStitchSse(reply, events()));
         await app.ready();
 
         const res = await app.inject({ method: 'GET', url: '/sse' });
@@ -181,6 +181,35 @@ describe('stitchPlugin', () => {
         expect(res.headers['content-type']).toContain('text/event-stream');
         // Only the two delta chunks become frames; control events are not forwarded.
         expect(res.body).toBe('data: hello\n\ndata: world\n\n');
+    });
+
+    test('accepts the { stream() } arm of StitchEventSource', async () => {
+        async function* events(): AsyncGenerator<StitchEvent<unknown>> {
+            yield { type: 'delta', chunk: 'via-stream()', at: 1 };
+            yield { type: 'done', ok: true, elapsed: 1, attempts: 1, at: 2 };
+        }
+        // Anything with a `.stream()` handing back the iterable — e.g. a StitchResult.
+        const source = { stream: () => events() };
+        const app = Fastify();
+        apps.push(app);
+        await app.register(stitchPlugin, {
+            seamConfig: {
+                baseUrl: 'https://api.test',
+                adapter: fakeAdapter(() => ({
+                    status: 200,
+                    headers: {},
+                    body: {},
+                })).adapter,
+            },
+            logger: false,
+        });
+        app.get('/sse-source', (_request, reply) =>
+            streamStitchSse(reply, source),
+        );
+        await app.ready();
+
+        const res = await app.inject({ method: 'GET', url: '/sse-source' });
+        expect(res.body).toBe('data: via-stream()\n\n');
     });
 
     test('by default an error event yields a named event: error frame with a generic token, never the raw message', async () => {
@@ -212,7 +241,7 @@ describe('stitchPlugin', () => {
             logger: false,
         });
         app.get('/sse-err', (_request, reply) =>
-            sendStitchSse(reply, events()),
+            streamStitchSse(reply, events()),
         );
         await app.ready();
 
@@ -248,7 +277,7 @@ describe('stitchPlugin', () => {
             logger: false,
         });
         app.get('/sse-err', (_request, reply) =>
-            sendStitchSse(reply, events(), { error: (e) => e.message }),
+            streamStitchSse(reply, events(), { error: (e) => e.message }),
         );
         await app.ready();
 
@@ -285,7 +314,7 @@ describe('stitchPlugin', () => {
             logger: false,
         });
         app.get('/sse-err', (_request, reply) =>
-            sendStitchSse(reply, events(), {
+            streamStitchSse(reply, events(), {
                 error: { observe: (err) => observed.push(err) },
             }),
         );

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -18,7 +18,7 @@ export {
     STITCH_VAR,
     type HonoRequestSeam,
     type StitchEnv,
-    type StitchMiddlewareOptions,
+    type HonoStitchMiddlewareOptions,
 } from './middleware';
 
 export {

--- a/packages/hono/src/middleware.ts
+++ b/packages/hono/src/middleware.ts
@@ -18,7 +18,11 @@ import type { PrincipalSeam, Seam } from 'stitchapi';
  */
 export type HonoRequestSeam = PrincipalSeam | Seam;
 
-/** The key the seam is stored under on `c.var` / via `c.set` / `c.get`. */
+/**
+ * The key the seam is stored under on `c.var` / via `c.set` / `c.get`. Reading it before the
+ * `stitch()` middleware ran yields `undefined` (Hono's `c.get` never throws on an unset variable)
+ * — guard for it in routes mounted outside the middleware's path.
+ */
 export const STITCH_VAR = 'stitch' as const;
 
 /**
@@ -40,7 +44,7 @@ export interface StitchEnv extends Env {
     };
 }
 
-export interface StitchMiddlewareOptions {
+export interface HonoStitchMiddlewareOptions {
     /**
      * The seam this middleware shares across requests. **Borrowed, not owned** — build it once at
      * startup and `seam.close()` it on shutdown yourself; the middleware never closes it (the seam
@@ -74,7 +78,9 @@ export interface StitchMiddlewareOptions {
  * app.get('/me', (c) => c.json(c.get('stitch').stitch('/me')()));
  * ```
  */
-export function stitch(options: StitchMiddlewareOptions): MiddlewareHandler {
+export function stitch(
+    options: HonoStitchMiddlewareOptions,
+): MiddlewareHandler {
     const { seam, principal } = options;
     return createMiddleware<StitchEnv>(async (c, next) => {
         const id = principal?.(c);

--- a/packages/hono/src/sse.ts
+++ b/packages/hono/src/sse.ts
@@ -21,6 +21,7 @@ import {
     resolveDelta,
     resolveError,
     toErrorEvent,
+    toIterable,
 } from 'stitchapi/sse-emit';
 
 export type { StitchEventSource };
@@ -58,8 +59,11 @@ export function streamStitchSse<T>(
     const error = resolveError(options.error);
     const toData = delta.data ?? defaultData;
     const errorEvent = error.event ?? 'error';
+    // Core's `StitchEventSource` admits the iterable itself or a `{ stream() }` holder (a
+    // `StitchResult`, a stitch stub) — unwrap the holder once, up front.
+    const iterable = toIterable(source);
     return streamSSE(c, async (stream: SSEStreamingApi) => {
-        const iterator = source[Symbol.asyncIterator]();
+        const iterator = iterable[Symbol.asyncIterator]();
         let index = 0;
         // Write the terminal `error` message: a generic token by default so a raw message
         // (`getaddrinfo ENOTFOUND …` / `HTTP 401`) is never disclosed; `error.data` opts in.

--- a/packages/hono/test/sse.spec.ts
+++ b/packages/hono/test/sse.spec.ts
@@ -69,6 +69,21 @@ describe('streamStitchSse — delta mapping', () => {
         expect(body).toContain('data: t2');
     });
 
+    test('a { stream() } holder (StitchResult-shaped source) is unwrapped and driven', async () => {
+        const app = new Hono();
+        const holder = {
+            stream: () =>
+                gen([
+                    { type: 'delta', chunk: 'held', at: 0 },
+                    { type: 'done', ok: true, elapsed: 1, attempts: 1, at: 0 },
+                ]),
+        };
+        app.get('/x', (c) => streamStitchSse(c, holder));
+
+        const body = await (await app.request('/x')).text();
+        expect(dataLines(body)).toEqual(['data: held']);
+    });
+
     test('a custom data mapper pulls text out of a structured chunk', async () => {
         const app = new Hono();
         app.get('/x', (c) =>

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -6,7 +6,7 @@
 
 Next App Router route handlers are Web-standard — they take a `Request` and return a `Response` — so a stitch already runs in one directly: define a `seam` once and call it in the handler. What's worth a helper is the two bits you'd otherwise hand-roll on the Web platform:
 
--   **`sseResponse(stitch.stream())`** — turn a streaming stitch into a `text/event-stream` `Response`.
+-   **`streamStitchSse(stitch.stream())`** — turn a streaming stitch into a `text/event-stream` `Response`.
 -   **`stitchErrorResponse(err)`** — map a thrown `StitchError` to a `Response` with a safe status, or `undefined` for anything else so you can rethrow it.
 
 Built on Web standards only (`Response`, `ReadableStream`, `TextEncoder`) — **no `next` import** — so the same helpers also work in Remix, SvelteKit endpoints, Bun, Deno, and Workers.
@@ -48,17 +48,17 @@ export async function GET(
 
 ## Streaming with SSE
 
-`sseResponse` streams a stitch's events as `text/event-stream`. Each `delta` becomes one frame; an `error` event ends with a named `event: error` frame (a generic `data: error` by default — see below):
+`streamStitchSse` streams a stitch's events as `text/event-stream`. Each `delta` becomes one frame; an `error` event ends with a named `event: error` frame (a generic `data: error` by default — see below):
 
 ```ts
 // app/api/chat/route.ts
 import { chat } from '@/lib/api';
 
-import { sseResponse } from '@stitchapi/next';
+import { streamStitchSse } from '@stitchapi/next';
 
 export async function POST(request: Request) {
     const { prompt } = await request.json();
-    return sseResponse(chat({ body: { prompt } }).stream(), {
+    return streamStitchSse(chat({ body: { prompt } }).stream(), {
         delta: (c) => String(c), // pull text out of each chunk
         signal: request.signal, // abort the upstream if the client leaves
     });
@@ -70,7 +70,7 @@ Pass `request.signal` so a client disconnect tears the stitch down rather than l
 By default the `error` frame carries a generic `data: error` token, **not** the raw error message — echoing it can disclose internal network topology (a transport failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to the client. Pass `error` to opt in when the upstream messages are known safe to expose:
 
 ```ts
-return sseResponse(chat({ body: { prompt } }).stream(), {
+return streamStitchSse(chat({ body: { prompt } }).stream(), {
     error: (e) => e.message, // opt in to the raw upstream message
 });
 ```

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -5,7 +5,7 @@
 // then call it in the handler. What's worth a helper is the two bits you'd otherwise
 // hand-roll on the Web platform:
 //
-// - `sseResponse(stitch.stream())` — turn a streaming stitch into a `text/event-stream`
+// - `streamStitchSse(stitch.stream())` — turn a streaming stitch into a `text/event-stream`
 //   `Response` (the Web-standard twin of `@stitchapi/express`'s `streamStitchSse`,
 //   which targets a Node `ServerResponse`).
 // - `stitchErrorResponse(err)` — map a thrown `StitchError` to a `Response` with a
@@ -24,6 +24,7 @@ import {
     resolveError,
     sseFrame,
     toErrorEvent,
+    toIterable,
 } from 'stitchapi/sse-emit';
 
 // ---------------------------------------------------------------------------
@@ -51,18 +52,18 @@ export interface SseResponseOptions extends SseEmitOptions {
  *
  * ```ts
  * // app/api/chat/route.ts
- * import { sseResponse } from '@stitchapi/next';
+ * import { streamStitchSse } from '@stitchapi/next';
  *
  * export async function POST(request: Request) {
  *     const { prompt } = await request.json();
- *     return sseResponse(chat({ body: { prompt } }).stream(), {
+ *     return streamStitchSse(chat({ body: { prompt } }).stream(), {
  *         delta: (c) => String(c),
  *         signal: request.signal, // abort the upstream if the client leaves
  *     });
  * }
  * ```
  */
-export function sseResponse<T>(
+export function streamStitchSse<T>(
     source: StitchEventSource<T>,
     options: SseResponseOptions = {},
 ): Response {
@@ -73,7 +74,7 @@ export function sseResponse<T>(
     const stream = new ReadableStream<Uint8Array>({
         async start(controller) {
             try {
-                for await (const event of source) {
+                for await (const event of toIterable(source)) {
                     if (options.signal?.aborted) break;
                     if (event.type === 'delta') {
                         controller.enqueue(
@@ -153,7 +154,7 @@ const STATUS_TEXT: Record<number, string> = {
     502: 'Bad Gateway',
 };
 
-export interface ErrorResponseOptions {
+export interface StitchErrorOptions {
     /**
      * The HTTP status for the mapped failure. Default `502` for a `StitchError` (an
      * upstream gateway failure) and `500` otherwise — the safe default never leaks an
@@ -191,11 +192,11 @@ export interface ErrorResponseOptions {
  * The default body is a generic, status-tied message (`{ error: 'Bad Gateway' }`) — the
  * raw `err.message` is **not** echoed, since it can leak internal hostnames or the
  * upstream's status to an untrusted client. Opt in to a custom (or the raw) message with
- * {@link ErrorResponseOptions.body}.
+ * {@link StitchErrorOptions.body}.
  */
 export function stitchErrorResponse(
     err: unknown,
-    options: ErrorResponseOptions = {},
+    options: StitchErrorOptions = {},
 ): Response | undefined {
     if (!isStitchError(err)) return undefined;
     const status =

--- a/packages/next/test/next.spec.ts
+++ b/packages/next/test/next.spec.ts
@@ -1,6 +1,6 @@
 // @stitchapi/next behaviour — Web-standard Response helpers driven with fake event
 // sources and errors. No engine, no Next.
-import { isStitchError, sseResponse, stitchErrorResponse } from '../src';
+import { isStitchError, stitchErrorResponse, streamStitchSse } from '../src';
 
 import type { StitchEvent } from 'stitchapi';
 import { describe, expect, test } from 'vitest';
@@ -41,11 +41,11 @@ function stitchError(message: string, status?: number): Error {
     return e;
 }
 
-// --- sseResponse -----------------------------------------------------------
+// --- streamStitchSse -----------------------------------------------------------
 
-describe('sseResponse', () => {
+describe('streamStitchSse', () => {
     test('streams each delta as an SSE frame and sets the content type', async () => {
-        const res = sseResponse(
+        const res = streamStitchSse(
             events(delta('a'), delta('b'), result(['a', 'b']), done),
         );
         expect(res.headers.get('content-type')).toBe(
@@ -55,15 +55,21 @@ describe('sseResponse', () => {
         expect(body).toBe('data: a\n\ndata: b\n\n');
     });
 
+    test('accepts anything with a .stream() (the core StitchEventSource intake)', async () => {
+        const source = { stream: () => events(delta('a'), done) };
+        const res = streamStitchSse(source);
+        expect(await res.text()).toBe('data: a\n\n');
+    });
+
     test('a `delta` function shorthand pulls text out of a structured chunk', async () => {
-        const res = sseResponse(events(delta({ text: 'hi' }), done), {
+        const res = streamStitchSse(events(delta({ text: 'hi' }), done), {
             delta: (c) => (c as { text: string }).text,
         });
         expect(await res.text()).toBe('data: hi\n\n');
     });
 
     test('by default an error event yields a named event: error frame with a generic token, never the raw message', async () => {
-        const res = sseResponse(
+        const res = streamStitchSse(
             events(delta('a'), {
                 type: 'error',
                 name: 'StitchError',
@@ -84,7 +90,7 @@ describe('sseResponse', () => {
     });
 
     test('error (function shorthand) opts in to the raw message on the error frame', async () => {
-        const res = sseResponse(
+        const res = streamStitchSse(
             events(delta('a'), {
                 type: 'error',
                 name: 'StitchError',
@@ -101,14 +107,14 @@ describe('sseResponse', () => {
     });
 
     test('the delta.event option labels each frame', async () => {
-        const res = sseResponse(events(delta('a'), done), {
+        const res = streamStitchSse(events(delta('a'), done), {
             delta: { event: 'token' },
         });
         expect(await res.text()).toBe('event: token\ndata: a\n\n');
     });
 
     test('the delta.id option emits an id: line per frame with the zero-based index', async () => {
-        const res = sseResponse(events(delta('a'), delta('b'), done), {
+        const res = streamStitchSse(events(delta('a'), delta('b'), done), {
             delta: { id: (chunk, i) => `${String(chunk)}-${i}` },
         });
         expect(await res.text()).toBe(
@@ -117,12 +123,12 @@ describe('sseResponse', () => {
     });
 
     test('a multi-line chunk gets one data: prefix per line (SSE spec)', async () => {
-        const res = sseResponse(events(delta('l1\nl2'), done));
+        const res = streamStitchSse(events(delta('l1\nl2'), done));
         expect(await res.text()).toBe('data: l1\ndata: l2\n\n');
     });
 
     test('extra headers merge over the SSE defaults, with overrides winning', async () => {
-        const res = sseResponse(events(delta('a'), done), {
+        const res = streamStitchSse(events(delta('a'), done), {
             headers: { 'x-custom': '1', 'cache-control': 'no-store' },
         });
         expect(res.headers.get('x-custom')).toBe('1');
@@ -136,7 +142,7 @@ describe('sseResponse', () => {
     });
 
     test('a pre-aborted signal yields no frames', async () => {
-        const res = sseResponse(events(delta('a'), delta('b'), done), {
+        const res = streamStitchSse(events(delta('a'), delta('b'), done), {
             signal: AbortSignal.abort(),
         });
         expect(await res.text()).toBe('');
@@ -148,7 +154,7 @@ describe('sseResponse', () => {
             // A transport failure disclosing an internal hostname must not reach the client.
             throw new Error('getaddrinfo ENOTFOUND payments.internal.corp');
         }
-        const res = sseResponse(boom());
+        const res = streamStitchSse(boom());
         const body = await res.text();
         expect(body).toBe('data: a\n\nevent: error\ndata: error\n\n');
         expect(body).not.toContain('payments.internal.corp');
@@ -160,14 +166,14 @@ describe('sseResponse', () => {
             yield delta('a');
             throw new Error('stream blew up');
         }
-        const res = sseResponse(boom(), { error: (e) => e.message });
+        const res = streamStitchSse(boom(), { error: (e) => e.message });
         const body = await res.text();
         expect(body).toBe('data: a\n\nevent: error\ndata: stream blew up\n\n');
     });
 
     test('error.observe sees the real failure even when the client gets the generic token', async () => {
         const observed: unknown[] = [];
-        const res = sseResponse(
+        const res = streamStitchSse(
             events(delta('a'), {
                 type: 'error',
                 name: 'StitchError',
@@ -187,7 +193,7 @@ describe('sseResponse', () => {
     });
 
     test('error can be the full object with a custom event name', async () => {
-        const res = sseResponse(
+        const res = streamStitchSse(
             events(delta('a'), {
                 type: 'error',
                 name: 'StitchError',


### PR DESCRIPTION
Broken out of #470. Covers **elysia, express, fastify, hono, next**; nest follows separately.

Builds on #518 (`StitchEventSource` in the core barrel), now merged — this targets `main` directly.

## P9 — a per-framework type carries its framework's name

Four hosts each exported a bare `StitchPluginOptions` / `StitchMiddlewareOptions` describing four
**incompatible** shapes. A monorepo importing two of them got a name collision on types that can
never be unified, since each wraps its own framework's primitives.

| Package | Before | After |
| --- | --- | --- |
| elysia | `StitchPluginOptions` | `ElysiaStitchPluginOptions` |
| elysia | `StitchEnvLike` | `ErrorContextLike` |
| express | `StitchMiddlewareOptions` | `ExpressStitchMiddlewareOptions` |
| fastify | `StitchPluginOptions` | `FastifyStitchPluginOptions` |
| fastify | `StitchPluginSeamOptions` | `FastifyStitchPluginSeamOptions` |
| fastify | `StitchPluginConfigOptions` | `FastifyStitchPluginConfigOptions` |

`StitchEnvLike` was doubly wrong: it described an **error-handler context**, not an env.

## P16 — one SSE helper name across every host

The same job had three spellings — `sendStitchSse` (fastify), `sseResponse` (next), `stitchSse`
(elsewhere). Every host now exposes **`streamStitchSse`**: it drives a stream, and the verb says so.

```ts
fastify  sendStitchSse / SendStitchSseOptions  →  streamStitchSse / StreamStitchSseOptions
next     sseResponse                            →  streamStitchSse
```

## P16 — one error-options name, one stream intake

- `StitchErrorHandlerOptions` → **`StitchErrorOptions`** on every host that maps a `StitchError`
  onto a framework response.
- Every host SSE helper now accepts **`StitchEventSource`**, resolved through one shared
  `toIterable` in `stitchapi/sse-emit` — so passing a `StitchResult` directly works *everywhere*,
  instead of only where someone remembered to call `.stream()`.

## Fix — `currentStitch(req)` returns `ExpressRequestSeam | undefined`

It **threw** when the middleware had not run, while its type promised a seam. The type now tells
the truth, so a caller can fall back to an explicit seam instead of crashing.

## ⚠️ One deliberate deviation from #470 — please sanity-check

#470 restated `StitchEventSource` inside `sse-emit.ts` as a **second copy**, with a comment saying
the two definitions "must stay in step". That is exactly the hand-mirror drift site this repo keeps
getting bitten by. This branch **re-exports the barrel's definition** instead — one definition,
nothing to keep in step. (`AsyncGenerator` needs no arm of its own: it already satisfies
`AsyncIterable`.)

Worth knowing for future slices: the local name must be **imported as well as re-exported**. A bare
`export type { X } from './types'` does not bind `X` for `toIterable`'s own signature —
`tsc --noEmit` accepts it, but the tsup **DTS build rejects it**. Two distinct gates.

Hard break, no `@deprecated` aliases — pre-GA, per P19 as amended in #470.

## Verification

- workspace typecheck clean; **core DTS build clean**; full workspace test suite green
- eslint clean, contract ratchet **0**, prettier clean
- apps/docs production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)