### PR TITLE
refactor(nest)!: converge on StitchErrorOptions / streamStitchSse; logger is a toggle (P16/P13)

### DIFF
--- a/apps/docs/content/blog/stream-a-stitch-as-sse-in-next-app-router.mdx
+++ b/apps/docs/content/blog/stream-a-stitch-as-sse-in-next-app-router.mdx
@@ -40,29 +40,26 @@ Install it alongside the core library:
 @stitchapi/next stitchapi
 ```
 
-Then `sseResponse` takes the stitch's event stream and returns a `text/event-stream` `Response`. Each `delta` becomes one SSE frame; you tell it how to pull the renderable payload out of a chunk with `data`:
+Then `streamStitchSse` takes the stitch's event stream and returns a `text/event-stream` `Response`. Each `delta` becomes one SSE frame; you tell it how to pull the renderable payload out of a chunk with `data`:
 
 ```ts twoslash
 // @noErrors
 // app/api/chat/route.ts
 import { chat } from '@/lib/api';
 
-import {
-    isStitchError,
-    sseResponse,
-    stitchErrorResponse,
-} from '@stitchapi/next';
+import { stitchErrorResponse, streamStitchSse } from '@stitchapi/next';
 
 export async function POST(request: Request) {
     const { prompt } = await request.json();
 
     try {
-        return sseResponse(chat({ body: { prompt } }).stream(), {
+        return streamStitchSse(chat({ body: { prompt } }).stream(), {
             delta: (chunk) => String(chunk), // pull text out of each delta
             signal: request.signal, // abort the stitch if the client leaves
         });
     } catch (err) {
-        if (isStitchError(err)) return stitchErrorResponse(err);
+        const mapped = stitchErrorResponse(err);
+        if (mapped) return mapped;
         throw err;
     }
 }
@@ -73,7 +70,7 @@ Two lines carry most of the value:
 -   **`data`** maps each `delta` chunk to the string you actually want to send down the wire — text out of a model chunk, a field off a JSON event, whatever the frame should carry.
 -   **`signal: request.signal`** is the cancellation story. When the browser disconnects — the user closed the tab, hit stop, or navigated away — `request.signal` aborts, and passing it through tears the stitch (and its upstream call) down instead of leaving an orphaned request burning a token budget. That early-cancel is half the reason to stream at all.
 
-The `try/catch` with `isStitchError` / `stitchErrorResponse` handles a stitch that fails _before_ the stream opens (auth wall, timeout, the upstream being down). `stitchErrorResponse` maps a `StitchError` to a safe `502` by default rather than leaking the upstream's status. Confirm the exact options for both helpers in the [`@stitchapi/next` docs](/docs/integrations/next) — the surface is small but it's the source of truth, not this post.
+The `try/catch` with `stitchErrorResponse` handles a stitch that fails _before_ the stream opens (auth wall, timeout, the upstream being down). `stitchErrorResponse` maps a `StitchError` to a safe `502` by default rather than leaking the upstream's status, and returns `undefined` for anything that isn't a stitch failure — which is why the handler rethrows when there's no mapped `Response`. Confirm the exact options for both helpers in the [`@stitchapi/next` docs](/docs/integrations/next) — the surface is small but it's the source of truth, not this post.
 
 ## The client: consuming deltas
 
@@ -107,8 +104,8 @@ Streaming over HTTP has sharp edges that have nothing to do with StitchAPI, and 
 
 -   **Buffering in the middle.** SSE only works if nothing between your server and the browser buffers the response. Reverse proxies (nginx without `proxy_buffering off;` on the route), some CDNs, and corporate proxies will happily collect the whole stream and deliver it as one lump — which silently defeats the entire exercise. Test through your real edge, not just `localhost`.
 -   **Edge vs Node runtime.** App Router handlers run on either runtime. The helpers are Web-standard so they work on both, but your _upstream_ may not — a streaming SDK that needs Node APIs, or a `fetch` quirk on the edge, will surface here. Pick the runtime deliberately (`export const runtime = 'edge' | 'nodejs'`) and test the streaming path on the one you deploy.
--   **It's not always worth it.** If your call returns in a few hundred milliseconds, or the consumer can't use partial results (it needs the whole object validated before it does anything), streaming adds plumbing and failure modes for no user-visible win. A normal JSON route — the stitch plus `stitchErrorResponse`, no `sseResponse` — is the right call there.
--   **Confirm the API surface.** The exact option names on `sseResponse` and `stitchErrorResponse` live in the package docs and may evolve. Treat the snippets above as the shape, and check [`/docs/integrations/next`](/docs/integrations/next) for the current signatures.
+-   **It's not always worth it.** If your call returns in a few hundred milliseconds, or the consumer can't use partial results (it needs the whole object validated before it does anything), streaming adds plumbing and failure modes for no user-visible win. A normal JSON route — the stitch plus `stitchErrorResponse`, no `streamStitchSse` — is the right call there.
+-   **Confirm the API surface.** The exact option names on `streamStitchSse` and `stitchErrorResponse` live in the package docs and may evolve. Treat the snippets above as the shape, and check [`/docs/integrations/next`](/docs/integrations/next) for the current signatures.
 
 ## Try it
 
@@ -116,4 +113,4 @@ Streaming over HTTP has sharp edges that have nothing to do with StitchAPI, and 
 stitchapi @stitchapi/next
 ```
 
-Declare a streaming stitch, return `sseResponse(stitch.stream())` from a route handler, and consume the deltas with `useStitchStream`. The full guides: [`@stitchapi/next`](/docs/integrations/next), [`@stitchapi/react`](/docs/integrations/react), and the [event stream](/docs/reference/events) that makes all of it one moving part.
+Declare a streaming stitch, return `streamStitchSse(stitch.stream())` from a route handler, and consume the deltas with `useStitchStream`. The full guides: [`@stitchapi/next`](/docs/integrations/next), [`@stitchapi/react`](/docs/integrations/react), and the [event stream](/docs/reference/events) that makes all of it one moving part.

--- a/apps/docs/content/docs/integrations/elysia.mdx
+++ b/apps/docs/content/docs/integrations/elysia.mdx
@@ -63,9 +63,14 @@ shutdown.
 
 Stream a streaming/SSE stitch's `.stream()` to the client by returning the
 `text/event-stream` `Response` `streamStitchSse` builds. Each `delta` becomes a
-`data:` message; a terminal `error` (or a throw) becomes a final `event: error`
-message; control events are consumed but not forwarded; and a client disconnect
-cancels the body and aborts the upstream stitch stream.
+`data:` message (shape it with `data`, name it with `event`, make the stream
+resumable with `id`); a terminal `error` (or a throw) becomes a final
+`event: error` message whose `data` is a **generic `error` token by default** —
+the raw upstream message (an internal hostname, an `HTTP 401`) never reaches the
+client. Opt in to a client-facing message with `error`, and observe the real
+failure server-side with `error.observe`. Control events are consumed but not
+forwarded, and a client disconnect cancels the body and aborts the upstream
+stitch stream.
 
 ```ts
 import { stitch, streamStitchSse } from '@stitchapi/elysia';

--- a/apps/docs/content/docs/integrations/express.mdx
+++ b/apps/docs/content/docs/integrations/express.mdx
@@ -57,15 +57,17 @@ never name another identity. **Borrow, don't own:** the middleware never calls
 `seam.close()` — you build the seam at startup and close it on shutdown.
 
 A generic helper that only holds a loosely-typed `Request` can read the same
-handle back with `currentStitch(req)`, which throws if the middleware never ran —
-so a missing `app.use(stitch(...))` fails loudly instead of silently.
+handle back with `currentStitch(req)`, which returns `undefined` if the
+middleware never ran — so a caller can fall back to an explicit seam instead of
+crashing.
 
 ## Streaming — `streamStitchSse`
 
 Stream a streaming/SSE stitch's `.stream()` to the client as Server-Sent Events.
 Each `delta` becomes a `data:` frame; a terminal `error` (or a throw) becomes a
-final `event: error` frame; control events are consumed but not forwarded; and a
-client disconnect aborts the upstream stitch stream.
+final `event: error` frame carrying a generic `error` token by default (opt in
+to a client-facing message with `error`); control events are consumed but
+not forwarded; and a client disconnect aborts the upstream stitch stream.
 
 ```ts
 import { stitch, streamStitchSse } from '@stitchapi/express';

--- a/apps/docs/content/docs/integrations/fastify.mdx
+++ b/apps/docs/content/docs/integrations/fastify.mdx
@@ -86,14 +86,15 @@ async function loadProfile() {
 
 ## SSE streaming
 
-`sendStitchSse(reply, stream, options?)` streams a stitch's `.stream()` output to a
+`streamStitchSse(reply, stream, options?)` streams a stitch's `.stream()` output to a
 `text/event-stream` reply. Each `delta` chunk becomes one SSE frame; an `error`
-event ends the stream as a named `error` frame; stream end closes the response; and
-a client disconnect aborts the upstream stitch generator rather than leaving it
-running.
+event ends the stream as a named `error` frame whose `data` is a generic `error`
+token by default (the raw upstream message never reaches the client — opt in with
+`error`); stream end closes the response; and a client disconnect aborts the
+upstream stitch generator rather than leaving it running.
 
 ```ts twoslash
-import { sendStitchSse } from '@stitchapi/fastify';
+import { streamStitchSse } from '@stitchapi/fastify';
 import Fastify from 'fastify';
 import { sse } from 'stitchapi/sse';
 
@@ -101,7 +102,7 @@ const chat = sse({ url: 'https://api.example.com/chat' });
 const app = Fastify();
 
 app.get<{ Querystring: { q: string } }>('/chat', (req, reply) =>
-    sendStitchSse(reply, chat.stream({ query: { q: req.query.q } }), {
+    streamStitchSse(reply, chat.stream({ query: { q: req.query.q } }), {
         delta: (chunk) => (chunk as { data: string }).data, // pull text out
     }),
 );

--- a/apps/docs/content/docs/integrations/hono.mdx
+++ b/apps/docs/content/docs/integrations/hono.mdx
@@ -59,8 +59,10 @@ never name another identity. **Borrow, don't own:** the middleware never calls
 
 Stream a streaming/SSE stitch's `.stream()` to the client as Server-Sent Events,
 via Hono's `streamSSE`. Each `delta` becomes a `data:` message; a terminal `error`
-(or a throw) becomes a final `event: error` message; control events are consumed
-but not forwarded; and a client disconnect aborts the upstream stitch stream.
+(or a throw) becomes a final `event: error` message carrying a generic `error`
+token by default (opt in to a client-facing message with `error`); control
+events are consumed but not forwarded; and a client disconnect aborts the upstream
+stitch stream.
 
 ```ts twoslash
 import { type StitchEnv, stitch, streamStitchSse } from '@stitchapi/hono';

--- a/apps/docs/content/docs/integrations/index.mdx
+++ b/apps/docs/content/docs/integrations/index.mdx
@@ -59,7 +59,7 @@ an SSE helper, and an error bridge.
     <Card
         title="Next.js"
         href="/docs/integrations/next"
-        description="Web-standard route-handler helpers — sseResponse (text/event-stream) and stitchErrorResponse (StitchError → Response)."
+        description="Web-standard route-handler helpers — streamStitchSse (text/event-stream) and stitchErrorResponse (StitchError → Response)."
     />
 </Cards>
 

--- a/apps/docs/content/docs/integrations/nestjs.mdx
+++ b/apps/docs/content/docs/integrations/nestjs.mdx
@@ -22,8 +22,8 @@ Install the package alongside core:
 
 Configure the shared client once in your root module. `forRootAsync` resolves its
 options from an injected factory, which is how `ConfigService` reaches the base
-URL, secrets, and store. `trace: 'logger'` sends the event stream to the Nest
-`Logger`:
+URL, secrets, and store. The event stream is bridged to the Nest `Logger` by
+default — nothing to switch on:
 
 ```ts twoslash
 // app.module.ts
@@ -40,7 +40,6 @@ import { bearer } from 'stitchapi';
             useFactory: (config: ConfigService) => ({
                 baseUrl: config.getOrThrow('API_BASE_URL'),
                 auth: bearer(fromNestConfig(config)('API_TOKEN')),
-                trace: 'logger',
             }),
         }),
     ],
@@ -108,10 +107,13 @@ trace — `seam: { config, token? }` (its `config` is the feature seam's
 
 Two bridges connect the framework, and neither changes core:
 
--   **`trace: 'logger'`** forwards a stitch's
-    [event stream](/docs/concepts/event-stream) to the Nest `Logger`. It logs
-    method, URL, and status only, and strips the query string; tracing is
-    otherwise [off by default](/docs/guides/observability/trace-sinks).
+-   **`logger`** bridges a stitch's
+    [event stream](/docs/concepts/event-stream) into the Nest `Logger` as the
+    seam's `TraceSink` — **on by default**, matching the Fastify plugin. It logs
+    only metadata (name, method, scrubbed URL, status, attempts, timing) — never
+    bodies or headers. Disable it with `logger: false`, or drop the happy path
+    with `logger: { lifecycle: false }`; an explicit `trace` wins over the
+    bridge.
 -   **`fromNestConfig(config)('KEY')`** is a `ConfigService`-backed
     [secret resolver](/docs/guides/auth/secret-resolvers) — the `ConfigService`
     twin of `env()`. It resolves synchronously at call time, so the credential

--- a/apps/docs/content/docs/integrations/next.mdx
+++ b/apps/docs/content/docs/integrations/next.mdx
@@ -1,6 +1,6 @@
 ---
 title: Next.js
-description: Web-standard helpers for Next App Router route handlers — sseResponse streams a stitch as text/event-stream, and stitchErrorResponse maps a StitchError to a Response.
+description: Web-standard helpers for Next App Router route handlers — streamStitchSse streams a stitch as text/event-stream, and stitchErrorResponse maps a StitchError to a Response.
 prerequisites: ['/docs/concepts/the-stitch', '/docs/concepts/the-seam']
 ---
 
@@ -49,26 +49,27 @@ export async function GET(
 ```
 
 `stitchErrorResponse` returns a `Response` for a `StitchError` and `undefined` for
-anything else — map the stitch failure, rethrow the rest, no `instanceof` dance. It maps
-to `502` by default — the safe choice that never leaks the upstream's `401`/`404`
-semantics. Pass `{ status: (e) => e.status ?? 502 }` to propagate the upstream status
-instead.
+anything else — map the stitch failure, rethrow the rest, no `instanceof` dance.
+It maps to `502` by default — the safe choice that never leaks the
+upstream's `401`/`404` semantics. Pass `{ status: (e) => e.status ?? 502 }` to
+propagate the upstream status instead.
 
 ## Streaming with SSE
 
-`sseResponse` streams a stitch's events as `text/event-stream`. Each `delta` becomes
-one frame; an `error` event ends the stream with a named `event: error` frame; the
-terminal `result` closes it:
+`streamStitchSse` streams a stitch's events as `text/event-stream`. Each `delta`
+becomes one frame; an `error` event ends the stream with a named `event: error`
+frame whose `data` is a generic `error` token by default (opt in to a client-facing
+message with `error`); the terminal `result` closes it:
 
 ```ts
 // app/api/chat/route.ts
 import { chat } from '@/lib/api';
 
-import { sseResponse } from '@stitchapi/next';
+import { streamStitchSse } from '@stitchapi/next';
 
 export async function POST(request: Request) {
     const { prompt } = await request.json();
-    return sseResponse(chat({ body: { prompt } }).stream(), {
+    return streamStitchSse(chat({ body: { prompt } }).stream(), {
         delta: (c) => String(c), // pull text out of each chunk
         signal: request.signal, // abort the upstream if the client leaves
     });

--- a/packages/core/src/sse-emit.ts
+++ b/packages/core/src/sse-emit.ts
@@ -11,13 +11,30 @@
 // Zero-dep and browser-safe (no `node:*`): pure types + string building, so it satisfies the same
 // three gates as its siblings and rides the `browser` export condition. Reached only through the
 // `sse-emit` subpath — `import { stitch }` pulls in none of it.
-import type { StitchEvent } from './types';
+import type { StitchEvent, StitchEventSource } from './types';
 import { envelope } from './util';
 
-/** Anything an SSE emitter can drive: a stitch `.stream()` generator, or any event iterable. */
-export type StitchEventSource<T> =
-    | AsyncIterable<StitchEvent<T>>
-    | AsyncGenerator<StitchEvent<T>, void>;
+/**
+ * Anything an SSE emitter can drive: an event iterable (a `.stream()` generator), or anything
+ * that hands one back (a `StitchResult`, a stitch stub). RE-EXPORTED from the barrel rather than
+ * restated here, so an adapter accepts exactly what core says a source is — there is one
+ * definition, so there is nothing to keep in step. (`AsyncGenerator` needs no arm of its own: it
+ * already satisfies `AsyncIterable`.)
+ */
+export type { StitchEventSource } from './types';
+
+/**
+ * Resolve the canonical intake to the event iterable itself: a `.stream()`-bearing source (a
+ * `StitchResult`, a stitch stub) is asked for its stream; an iterable is used as-is. Every
+ * adapter's driver starts here, so the two arms are unwrapped in exactly one place.
+ */
+export function toIterable<T>(
+    source: StitchEventSource<T>,
+): AsyncIterable<StitchEvent<T>> {
+    return Symbol.asyncIterator in source
+        ? (source as AsyncIterable<StitchEvent<T>>)
+        : source.stream();
+}
 
 /** The terminal `error` event a stitch stream emits — carries `message`, `status`, `attempts`. */
 export type StitchErrorEvent = Extract<StitchEvent, { type: 'error' }>;

--- a/packages/elysia/README.md
+++ b/packages/elysia/README.md
@@ -79,11 +79,25 @@ app.get('/chat', ({ stitch, query }) => {
 });
 ```
 
-Each `delta` chunk becomes one SSE message; an `error` event ends the stream as a
-named `event: error` message; stream end closes the response; and a client
-disconnect cancels the body and aborts the upstream stitch stream rather than
-leaving it running. Control events (`start`/`progress`/`result`/`done`/…) are not
-forwarded.
+Each `delta` chunk becomes one SSE message (label it with `event`, add a
+last-event id with `id: (chunk, index) => string`); an `error` event ends the
+stream as a named `event: error` message; stream end closes the response; and a
+client disconnect cancels the body and aborts the upstream stitch stream rather
+than leaving it running. Control events (`start`/`progress`/`result`/`done`/…)
+are not forwarded.
+
+The error message's `data` is a **generic `error` token by default** — the raw
+upstream message is withheld, because it can disclose internal network topology
+(`getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status
+(`HTTP 401`) to an untrusted client. Observe the real failure server-side with
+`onError`, and opt in to shaping the client-facing frame with `errorData`:
+
+```ts
+return streamStitchSse(chat.stream(), {
+    onError: (err) => log.error(err), // the raw failure, server-side only
+    // errorData: (e) => e.message,   // opt-in: only when upstream messages are safe
+});
+```
 
 By default the `error` frame carries a generic `data: error` token, **not** the raw
 error message — echoing it can disclose internal network topology (a transport failure

--- a/packages/elysia/src/context.ts
+++ b/packages/elysia/src/context.ts
@@ -14,10 +14,11 @@ export interface PrincipalContext {
 }
 
 /**
- * The slice of Elysia's error context the error bridge reads: the thrown `error`. Elysia's real
- * context also carries `code` / `set` / `request`, but the StitchError bridge only needs `error`.
+ * The slice of Elysia's error context the error bridge reads: the thrown `error` (mirrors Elysia's
+ * `ErrorContext`, structurally). Elysia's real context also carries `code` / `set` / `request`, but
+ * the StitchError bridge only needs `error`.
  */
-export interface StitchEnvLike {
+export interface ErrorContextLike {
     error: unknown;
 }
 

--- a/packages/elysia/src/error.ts
+++ b/packages/elysia/src/error.ts
@@ -6,7 +6,7 @@
 //
 // Web-standard: builds a plain `Response` (Fetch) — no `node:*`, so it runs under Bun, Node,
 // Deno and the edge alike.
-import type { StitchEnvLike } from './context';
+import type { ErrorContextLike } from './context';
 
 /** The error a stitch rejects with on failure: a branded `Error` carrying the upstream status. */
 export type StitchErrorLike = Error & { status?: number };
@@ -96,9 +96,9 @@ export function stitchErrorResponse(
  */
 export function stitchOnError(
     options: StitchErrorOptions = {},
-): (ctx: StitchEnvLike) => Response | undefined {
+): (ctx: ErrorContextLike) => Response | undefined {
     // Elysia calls `.onError` with a rich context; we only read `.error`. Returning a value short-
     // circuits the response; returning `undefined` lets Elysia's default error handling proceed.
-    return (ctx: StitchEnvLike): Response | undefined =>
+    return (ctx: ErrorContextLike): Response | undefined =>
         stitchErrorResponse(ctx.error, options);
 }

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -19,8 +19,8 @@
 export {
     stitch,
     type ElysiaRequestSeam,
+    type ElysiaStitchPluginOptions,
     type StitchPlugin,
-    type StitchPluginOptions,
 } from './plugin';
 
 export {
@@ -37,4 +37,8 @@ export {
     type StitchErrorOptions,
 } from './error';
 
-export type { PrincipalContext, StitchContext, StitchEnvLike } from './context';
+export type {
+    ErrorContextLike,
+    PrincipalContext,
+    StitchContext,
+} from './context';

--- a/packages/elysia/src/plugin.ts
+++ b/packages/elysia/src/plugin.ts
@@ -36,7 +36,7 @@ export type StitchPlugin = Elysia<
     }
 >;
 
-export interface StitchPluginOptions {
+export interface ElysiaStitchPluginOptions {
     /**
      * The seam this plugin shares across requests. **Borrowed, not owned** — build it once at
      * startup and `seam.close()` it on shutdown yourself; the plugin never closes it (the seam
@@ -80,7 +80,7 @@ export interface StitchPluginOptions {
  *
  * The `stitch` context property is typed: a handler reads it off the destructured context.
  */
-export function stitch(options: StitchPluginOptions): StitchPlugin {
+export function stitch(options: ElysiaStitchPluginOptions): StitchPlugin {
     const { seam, principal, errorHandler } = options;
 
     // `.derive` runs per request and merges its return into the context. The principal lives in this

--- a/packages/elysia/src/sse.ts
+++ b/packages/elysia/src/sse.ts
@@ -21,6 +21,7 @@ import {
     resolveError,
     sseFrame,
     toErrorEvent,
+    toIterable,
 } from 'stitchapi/sse-emit';
 
 export type { StitchEventSource };
@@ -57,7 +58,7 @@ export function streamStitchSse<T>(
     const error = resolveError(options.error);
     const errorEvent = error.event ?? 'error';
     const enc = new TextEncoder();
-    const iterator = source[Symbol.asyncIterator]();
+    const iterator = toIterable(source)[Symbol.asyncIterator]();
     let index = 0;
 
     const body = new ReadableStream<Uint8Array>({

--- a/packages/elysia/test/elysia.spec.ts
+++ b/packages/elysia/test/elysia.spec.ts
@@ -157,7 +157,10 @@ describe('streamStitchSse bridges a stitch stream to an SSE body', () => {
 
         const res = await app.handle(GET('/events'));
         const body = await res.text();
-        expect(body).toContain('event: error');
+        // A generic `data: error` token — the raw upstream message (`HTTP 500`) is withheld
+        // so upstream status/topology is not disclosed; `errorData` is the opt-in.
+        expect(body).toContain('event: error\ndata: error');
+        expect(body).not.toContain('HTTP 500');
         await api.close();
     });
 });

--- a/packages/elysia/test/sse.spec.ts
+++ b/packages/elysia/test/sse.spec.ts
@@ -95,6 +95,19 @@ describe('streamStitchSse — delta mapping', () => {
         const body = await res.text();
         expect(body).toContain('data: line1\ndata: line2');
     });
+
+    test('a {stream()} source (the core StitchEventSource arm) is driven too', async () => {
+        const res = streamStitchSse({
+            stream: () =>
+                gen([
+                    { type: 'delta', chunk: 'via-stream', at: 0 },
+                    { type: 'done', ok: true, elapsed: 1, attempts: 1, at: 0 },
+                ]),
+        });
+
+        const body = await res.text();
+        expect(body).toContain('data: via-stream');
+    });
 });
 
 describe('streamStitchSse — control events', () => {

--- a/packages/express/src/error.ts
+++ b/packages/express/src/error.ts
@@ -18,7 +18,7 @@ export function isStitchError(err: unknown): err is StitchErrorLike {
     return err instanceof Error && err.name === 'StitchError';
 }
 
-export interface StitchErrorHandlerOptions {
+export interface StitchErrorOptions {
     /**
      * The HTTP status for a mapped stitch failure. Default `502 Bad Gateway` — **every** upstream
      * failure is reported as a gateway error, regardless of the upstream's own status. This is the
@@ -50,7 +50,7 @@ const STATUS_TEXT: Record<number, string> = {
 
 function resolveStatus(
     err: StitchErrorLike,
-    status: StitchErrorHandlerOptions['status'],
+    status: StitchErrorOptions['status'],
 ): number {
     if (status === undefined) return DEFAULT_STATUS;
     return typeof status === 'function' ? status(err) : status;
@@ -58,7 +58,7 @@ function resolveStatus(
 
 /**
  * Build an Express error-handling middleware that maps a {@link StitchErrorLike} to a JSON response
- * (status `502` by default; override via {@link StitchErrorHandlerOptions.status}) and **passes every
+ * (status `502` by default; override via {@link StitchErrorOptions.status}) and **passes every
  * other error to `next(err)`** so Express's default handler — and any error middleware registered
  * after it — stays in charge. Register it after your routes:
  *
@@ -72,7 +72,7 @@ function resolveStatus(
  * though `req` is unused here, or Express treats it as a normal middleware.
  */
 export function stitchErrorHandler(
-    options: StitchErrorHandlerOptions = {},
+    options: StitchErrorOptions = {},
 ): ErrorRequestHandler {
     return (
         err: unknown,

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -18,7 +18,7 @@ export {
     stitch,
     currentStitch,
     type ExpressRequestSeam,
-    type StitchMiddlewareOptions,
+    type ExpressStitchMiddlewareOptions,
 } from './middleware';
 
 export {
@@ -31,5 +31,5 @@ export {
     stitchErrorHandler,
     isStitchError,
     type StitchErrorLike,
-    type StitchErrorHandlerOptions,
+    type StitchErrorOptions,
 } from './error';

--- a/packages/express/src/middleware.ts
+++ b/packages/express/src/middleware.ts
@@ -18,7 +18,7 @@ import type { PrincipalSeam, Seam } from 'stitchapi';
  */
 export type ExpressRequestSeam = PrincipalSeam | Seam;
 
-export interface StitchMiddlewareOptions {
+export interface ExpressStitchMiddlewareOptions {
     /**
      * The seam this middleware shares across requests. **Borrowed, not owned** — build it once at
      * startup and `seam.close()` it on shutdown yourself; the middleware never closes it (the seam
@@ -52,7 +52,9 @@ export interface StitchMiddlewareOptions {
  * app.get('/me', async (req, res) => res.json(await req.stitch.stitch('/me')()));
  * ```
  */
-export function stitch(options: StitchMiddlewareOptions): RequestHandler {
+export function stitch(
+    options: ExpressStitchMiddlewareOptions,
+): RequestHandler {
     const { seam, principal } = options;
     return (req: Request, res: Response, next: NextFunction): void => {
         const id = principal?.(req);
@@ -68,22 +70,17 @@ export function stitch(options: StitchMiddlewareOptions): RequestHandler {
 /**
  * Read the request-scoped {@link ExpressRequestSeam} off a request as a typed value — the same handle
  * `stitch()` set on `req.stitch`. A convenience for code paths that hold a loosely-typed `Request`
- * (e.g. a generic helper) and want the seam without re-declaring the augmentation. Throws if the
- * middleware did not run for this request (so a missing `app.use(stitch(...))` fails loudly).
+ * (e.g. a generic helper) and want the seam without re-declaring the augmentation. Returns
+ * `undefined` (it never throws) when the middleware did not run for this request — check for it, or
+ * register `app.use(stitch({ seam }))` ahead of the handler.
  *
  * ```ts
  * import { currentStitch } from '@stitchapi/express';
- * const api = currentStitch(req); // the caller's principal-bound seam
+ * const api = currentStitch(req); // the caller's principal-bound seam, or undefined
  * ```
  */
-export function currentStitch(req: Request): ExpressRequestSeam {
-    const host = req.stitch as ExpressRequestSeam | undefined;
-    if (host === undefined) {
-        throw new Error(
-            'req.stitch is not set — register `app.use(stitch({ seam }))` before this handler',
-        );
-    }
-    return host;
+export function currentStitch(req: Request): ExpressRequestSeam | undefined {
+    return req.stitch as ExpressRequestSeam | undefined;
 }
 
 // Augment Express's `Request` so `req.stitch` is typed app-wide once this package is imported.

--- a/packages/express/src/sse.ts
+++ b/packages/express/src/sse.ts
@@ -17,6 +17,7 @@ import {
     resolveDelta,
     resolveError,
     sseFrame,
+    toIterable,
 } from 'stitchapi/sse-emit';
 
 export type { StitchEventSource };
@@ -32,7 +33,7 @@ export interface StreamStitchSseOptions extends SseEmitOptions {
 
 /**
  * Stream a stitch's output to an Express {@link Response} as Server-Sent Events. Pass the stitch's
- * `.stream()` generator (or any `AsyncIterable<StitchEvent>`): each `delta` becomes one SSE frame, an
+ * `.stream()` generator (or any `StitchEventSource`): each `delta` becomes one SSE frame, an
  * `error` event ends the stream with a named `event: error` frame (a generic `data: error` by
  * default — the raw message is withheld to avoid disclosing internal topology; opt in via
  * `error`), and stream end closes the response. The non-output events (`start` / `progress` /
@@ -68,7 +69,10 @@ export async function streamStitchSse<T>(
         res.flushHeaders();
     }
 
-    const iterator = source[Symbol.asyncIterator]();
+    // Accept both arms of the canonical `StitchEventSource` — the iterable itself, or a handle that
+    // hands one back (a `StitchResult`, a stitch stub) — by resolving to the event iterable up front.
+    const iterable = toIterable(source);
+    const iterator = iterable[Symbol.asyncIterator]();
     let active = true;
 
     // Client disconnect: stop consuming and abort the upstream iterator. Listen on the response and,

--- a/packages/express/test/express.spec.ts
+++ b/packages/express/test/express.spec.ts
@@ -151,10 +151,8 @@ describe('stitch() middleware puts a seam on req', () => {
         await api.close();
     });
 
-    test('currentStitch throws when the middleware did not run', () => {
-        expect(() => currentStitch(mockReq())).toThrow(
-            /req\.stitch is not set/,
-        );
+    test('currentStitch returns undefined (never throws) when the middleware did not run', () => {
+        expect(currentStitch(mockReq())).toBeUndefined();
     });
 });
 
@@ -303,6 +301,18 @@ describe('streamStitchSse writes SSE frames to res', () => {
         expect(res.body()).toBe(
             'event: token\ndata: a\n\nevent: token\ndata: b\n\n',
         );
+    });
+
+    test('accepts the { stream() } arm of StitchEventSource (e.g. a StitchResult)', async () => {
+        async function* events(): AsyncGenerator<StitchEvent<unknown>> {
+            yield { type: 'delta', chunk: 'via-stream', at: 1 };
+        }
+        const res = mockRes();
+        await streamStitchSse(res as unknown as Response, {
+            stream: () => events(),
+        });
+        expect(res.body()).toBe('data: via-stream\n\n');
+        expect(res.ended).toBe(true);
     });
 
     test('the default data mapper sends a string verbatim and JSON-stringifies an object', async () => {

--- a/packages/fastify/README.md
+++ b/packages/fastify/README.md
@@ -41,7 +41,7 @@ encapsulation and are visible app-wide.
     (default on). It logs **only metadata** (name, method, scrubbed URL, status,
     attempts, timing), never request/response bodies or headers, so it is safe on a
     secret-bearing seam.
--   **SSE bridge.** `sendStitchSse(reply, stream)` streams a stitch's `.stream()`
+-   **SSE bridge.** `streamStitchSse(reply, stream)` streams a stitch's `.stream()`
     output to a `text/event-stream` reply.
 -   **Error bridge.** A thrown `StitchError` is mapped to an HTTP response
     (`502` by default) so handlers need no try/catch.
@@ -90,10 +90,10 @@ back to an explicit seam.
 ## SSE streaming
 
 ```ts
-import { sendStitchSse } from '@stitchapi/fastify';
+import { streamStitchSse } from '@stitchapi/fastify';
 
 app.get('/chat', (req, reply) =>
-    sendStitchSse(reply, chat.stream({ query: { q: String(req.query.q) } }), {
+    streamStitchSse(reply, chat.stream({ query: { q: String(req.query.q) } }), {
         delta: (c) => c.text, // pull text out of a structured chunk
     }),
 );
@@ -110,7 +110,7 @@ status (`HTTP 401`) to the client. Pass `error` to opt in when the upstream
 messages are known safe to expose:
 
 ```ts
-sendStitchSse(reply, chat.stream({ query: { q: String(req.query.q) } }), {
+streamStitchSse(reply, chat.stream({ query: { q: String(req.query.q) } }), {
     error: (e) => e.message, // opt in to the raw upstream message
 });
 ```
@@ -155,7 +155,7 @@ events and log only retries, drift, and errors). A seam built with its own
 | -------------------- | -------- | ------------------------------------------------- |
 | `stitchPlugin`       | plugin   | `fastify.register(stitchPlugin, options)`         |
 | `currentStitch()`    | function | The request's ambient principal-bound seam        |
-| `sendStitchSse`      | function | Stream a stitch's `.stream()` to an SSE reply     |
+| `streamStitchSse`    | function | Stream a stitch's `.stream()` to an SSE reply     |
 | `stitchErrorHandler` | function | A `setErrorHandler`-compatible StitchError mapper |
 | `fastifyLoggerSink`  | function | `fastify.log` → seam `TraceSink` bridge           |
 | `isStitchError`      | function | Narrow an unknown error to a `StitchError`        |

--- a/packages/fastify/src/error-handler.ts
+++ b/packages/fastify/src/error-handler.ts
@@ -13,7 +13,7 @@ export function isStitchError(err: unknown): err is StitchErrorLike {
     return err instanceof Error && err.name === 'StitchError';
 }
 
-export interface StitchErrorHandlerOptions {
+export interface StitchErrorOptions {
     /**
      * The HTTP status for a mapped stitch failure. Default `502 Bad Gateway` — **every**
      * upstream failure is reported as a gateway error, regardless of the upstream's own
@@ -46,7 +46,7 @@ const STATUS_TEXT: Record<number, string> = {
 
 function resolveStatus(
     err: StitchErrorLike,
-    status: StitchErrorHandlerOptions['status'],
+    status: StitchErrorOptions['status'],
 ): number {
     if (status === undefined) return DEFAULT_STATUS;
     return typeof status === 'function' ? status(err) : status;
@@ -54,7 +54,7 @@ function resolveStatus(
 
 /**
  * Build a `setErrorHandler`-compatible function that maps a {@link StitchErrorLike} to an HTTP
- * response (status `502` by default; override via {@link StitchErrorHandlerOptions.status})
+ * response (status `502` by default; override via {@link StitchErrorOptions.status})
  * and **rethrows every other error** so Fastify's default handling — and any error handler
  * registered in an outer scope — stays in charge. Register it on the app or a plugin scope:
  *
@@ -66,7 +66,7 @@ function resolveStatus(
  * only to register it yourself with custom options.
  */
 export function stitchErrorHandler(
-    options: StitchErrorHandlerOptions = {},
+    options: StitchErrorOptions = {},
 ): (error: FastifyError, request: FastifyRequest, reply: FastifyReply) => void {
     return (error, _request, reply): void => {
         if (!isStitchError(error)) {

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -1,17 +1,20 @@
 export {
     stitchPlugin,
     currentStitch,
-    type StitchPluginOptions,
-    type StitchPluginSeamOptions,
-    type StitchPluginConfigOptions,
+    type FastifyStitchPluginOptions,
+    type FastifyStitchPluginSeamOptions,
+    type FastifyStitchPluginConfigOptions,
     type FastifyRequestSeam,
 } from './plugin';
-export { sendStitchSse, type SendStitchSseOptions } from './sse';
+export { streamStitchSse, type StreamStitchSseOptions } from './sse';
+// The canonical event-stream intake, re-exported from the core barrel (one shared shape
+// across every host adapter — no local unions).
+export type { StitchEventSource } from 'stitchapi';
 export {
     stitchErrorHandler,
     isStitchError,
     type StitchErrorLike,
-    type StitchErrorHandlerOptions,
+    type StitchErrorOptions,
 } from './error-handler';
 export {
     fastifyLoggerSink,

--- a/packages/fastify/src/plugin.ts
+++ b/packages/fastify/src/plugin.ts
@@ -5,16 +5,14 @@
 // genuine Node value-add over the browser-first core — makes that principal handle **ambient**
 // through `AsyncLocalStorage`, so handlers/services read it with `currentStitch()` instead of
 // threading `request.stitch` everywhere.
-import {
-    type StitchErrorHandlerOptions,
-    stitchErrorHandler,
-} from './error-handler';
+import { type StitchErrorOptions, stitchErrorHandler } from './error-handler';
 import { type FastifyLoggerSinkOptions, fastifyLoggerSink } from './logger';
 
 import type { FastifyPluginAsync, FastifyRequest } from 'fastify';
 import fp from 'fastify-plugin';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import {
+    type AtLeastOne,
     type PrincipalSeam,
     type Seam,
     type SeamConfig,
@@ -25,8 +23,8 @@ import {
 // when a `principal` resolver is set, else the root seam (both create member stitches).
 export type FastifyRequestSeam = Seam | PrincipalSeam;
 
-/** Common options shared by both `StitchPluginOptions` variants. */
-interface StitchPluginCommon {
+/** Common options shared by both `FastifyStitchPluginOptions` variants. */
+interface FastifyStitchPluginCommon {
     /**
      * Derive the request's principal id (e.g. a tenant or user id) from the incoming request.
      * When set, each request gets a `seam.as(principal)` handle (a separate session/token over
@@ -36,17 +34,18 @@ interface StitchPluginCommon {
     principal?: (req: FastifyRequest) => string | undefined;
     /**
      * Bridge `fastify.log` (Fastify's built-in Pino logger) into the seam as its `TraceSink`,
-     * so stitch events flow through Fastify's logger. Default `true`. Ignored when a prebuilt
-     * `seam` is passed *and* it already has its own `trace` — a borrowed seam keeps its sink.
-     * Set `false` to leave tracing as the seam configured it (off by default in core).
+     * so stitch events flow through Fastify's logger. Default `true` (the bridge is on) — the
+     * cross-host canonical default. Ignored when a prebuilt `seam` is passed *and* it already
+     * has its own `trace` — a borrowed seam keeps its sink. Set `false` to leave tracing as
+     * the seam configured it (off by default in core).
      */
-    logger?: boolean | FastifyLoggerSinkOptions;
+    logger?: boolean | AtLeastOne<FastifyLoggerSinkOptions>;
     /**
      * Options for the error handler the plugin registers (see {@link stitchErrorHandler}).
      * Set to `false` to register **no** error handler (you wire your own). Default: register
      * with the `502`-by-default mapping.
      */
-    errorHandler?: StitchErrorHandlerOptions | false;
+    errorHandler?: StitchErrorOptions | false;
     /**
      * Close the seam on `onClose`. Defaults to `true` **only when the plugin built the seam**
      * (from `seamConfig`); a borrowed seam (passed via `seam`) is never closed by the plugin —
@@ -57,20 +56,22 @@ interface StitchPluginCommon {
 }
 
 /** Pass a prebuilt seam the app owns — the plugin borrows it and never closes it by default. */
-export interface StitchPluginSeamOptions extends StitchPluginCommon {
+export interface FastifyStitchPluginSeamOptions
+    extends FastifyStitchPluginCommon {
     seam: Seam;
     seamConfig?: never;
 }
 
 /** Let the plugin build (and, by default, own + close) the seam from a {@link SeamConfig}. */
-export interface StitchPluginConfigOptions extends StitchPluginCommon {
+export interface FastifyStitchPluginConfigOptions
+    extends FastifyStitchPluginCommon {
     seamConfig: SeamConfig;
     seam?: never;
 }
 
-export type StitchPluginOptions =
-    | StitchPluginSeamOptions
-    | StitchPluginConfigOptions;
+export type FastifyStitchPluginOptions =
+    | FastifyStitchPluginSeamOptions
+    | FastifyStitchPluginConfigOptions;
 
 // The ambient request-scoped host. `currentStitch()` reads it; the `onRequest` hook runs each
 // request inside `als.run(host, …)` so the value is the per-request principal handle.
@@ -80,8 +81,9 @@ const als = new AsyncLocalStorage<FastifyRequestSeam>();
  * The ambient request-scoped {@link FastifyRequestSeam} for the in-flight request — the principal-bound
  * `seam.as(principal)` handle (or the root seam when no principal resolver is set). Returns
  * `undefined` outside a request (no ambient context), so a caller can fall back to an explicit
- * seam. Backed by Node's {@link AsyncLocalStorage}: a value-add a Node integration offers that
- * the browser-first core cannot.
+ * seam. Never throws on a miss — `undefined` is the whole miss contract. Backed by Node's
+ * {@link AsyncLocalStorage}: a value-add a Node integration offers that the browser-first core
+ * cannot.
  *
  * ```ts
  * import { currentStitch } from '@stitchapi/fastify';
@@ -95,7 +97,7 @@ export function currentStitch(): FastifyRequestSeam | undefined {
     return als.getStore();
 }
 
-const pluginImpl: FastifyPluginAsync<StitchPluginOptions> = async (
+const pluginImpl: FastifyPluginAsync<FastifyStitchPluginOptions> = async (
     fastify,
     options,
 ) => {

--- a/packages/fastify/src/sse.ts
+++ b/packages/fastify/src/sse.ts
@@ -9,22 +9,23 @@
 // secure-by-default error framing are shared with every other HTTP adapter via
 // `stitchapi/sse-emit`; this file keeps only Fastify's reply driver.
 import type { FastifyReply } from 'fastify';
-import type { StitchEvent } from 'stitchapi';
 import {
     DEFAULT_ERROR_DATA,
     type SseEmitOptions,
+    type StitchEventSource,
     deltaFrame,
     resolveDelta,
     resolveError,
     sseFrame,
+    toIterable,
 } from 'stitchapi/sse-emit';
 
 /** How each `delta` / terminal `error` becomes an SSE frame (see {@link SseEmitOptions}). */
-export type SendStitchSseOptions = SseEmitOptions;
+export type StreamStitchSseOptions = SseEmitOptions;
 
 /**
  * Stream a stitch's output to a Fastify {@link FastifyReply} as Server-Sent Events. Pass the
- * stitch's `.stream()` generator (or any `AsyncIterable<StitchEvent>`): each `delta` becomes
+ * stitch's `.stream()` generator (or any `StitchEventSource`): each `delta` becomes
  * one SSE frame, an `error` event ends the stream with a named `event: error` frame (a generic
  * `data: error` by default — the raw message is withheld to avoid disclosing internal topology;
  * opt in via `error`), and stream end closes the response. The non-output events (`start` /
@@ -37,15 +38,15 @@ export type SendStitchSseOptions = SseEmitOptions;
  *
  * ```ts
  * app.get('/chat', (req, reply) =>
- *   sendStitchSse(reply, chat.stream({ query: { q: req.query.q } }),
+ *   streamStitchSse(reply, chat.stream({ query: { q: req.query.q } }),
  *                 { delta: (c: any) => c.text }),
  * );
  * ```
  */
-export async function sendStitchSse<T>(
+export async function streamStitchSse<T>(
     reply: FastifyReply,
-    stream: AsyncIterable<StitchEvent<T>>,
-    options: SendStitchSseOptions = {},
+    source: StitchEventSource<T>,
+    options: StreamStitchSseOptions = {},
 ): Promise<void> {
     const delta = resolveDelta(options.delta);
     const error = resolveError(options.error);
@@ -60,7 +61,9 @@ export async function sendStitchSse<T>(
         });
     }
 
-    const iterator = stream[Symbol.asyncIterator]();
+    // Resolve the `{ stream() }` arm of StitchEventSource to its event iterable.
+    const iterable = toIterable(source);
+    const iterator = iterable[Symbol.asyncIterator]();
     let active = true;
 
     // Client disconnect: stop consuming and abort the upstream generator.

--- a/packages/fastify/test/fastify.spec.ts
+++ b/packages/fastify/test/fastify.spec.ts
@@ -2,13 +2,13 @@
 // `adapter` (no network), so every stitch call resolves against canned responses. We drive the
 // app with `fastify.inject()` and assert the four contracts: the seam is decorated, the
 // request-scoped principal binds (a route reads `currentStitch()` and `request.stitch`),
-// `sendStitchSse` streams events, and `stitchErrorHandler` maps a StitchError to a status.
+// `streamStitchSse` streams events, and `stitchErrorHandler` maps a StitchError to a status.
 import {
     currentStitch,
     isStitchError,
-    sendStitchSse,
     stitchErrorHandler,
     stitchPlugin,
+    streamStitchSse,
 } from '../src';
 
 import Fastify from 'fastify';
@@ -145,7 +145,7 @@ describe('stitchPlugin', () => {
         expect(res.json()).toEqual({ isRoot: true });
     });
 
-    test('sendStitchSse streams delta events to the reply', async () => {
+    test('streamStitchSse streams delta events to the reply', async () => {
         // A hand-built event stream — the SSE bridge consumes any AsyncIterable<StitchEvent>.
         async function* events(): AsyncGenerator<StitchEvent<unknown>> {
             yield {
@@ -173,7 +173,7 @@ describe('stitchPlugin', () => {
             },
             logger: false,
         });
-        app.get('/sse', (_request, reply) => sendStitchSse(reply, events()));
+        app.get('/sse', (_request, reply) => streamStitchSse(reply, events()));
         await app.ready();
 
         const res = await app.inject({ method: 'GET', url: '/sse' });
@@ -181,6 +181,35 @@ describe('stitchPlugin', () => {
         expect(res.headers['content-type']).toContain('text/event-stream');
         // Only the two delta chunks become frames; control events are not forwarded.
         expect(res.body).toBe('data: hello\n\ndata: world\n\n');
+    });
+
+    test('accepts the { stream() } arm of StitchEventSource', async () => {
+        async function* events(): AsyncGenerator<StitchEvent<unknown>> {
+            yield { type: 'delta', chunk: 'via-stream()', at: 1 };
+            yield { type: 'done', ok: true, elapsed: 1, attempts: 1, at: 2 };
+        }
+        // Anything with a `.stream()` handing back the iterable — e.g. a StitchResult.
+        const source = { stream: () => events() };
+        const app = Fastify();
+        apps.push(app);
+        await app.register(stitchPlugin, {
+            seamConfig: {
+                baseUrl: 'https://api.test',
+                adapter: fakeAdapter(() => ({
+                    status: 200,
+                    headers: {},
+                    body: {},
+                })).adapter,
+            },
+            logger: false,
+        });
+        app.get('/sse-source', (_request, reply) =>
+            streamStitchSse(reply, source),
+        );
+        await app.ready();
+
+        const res = await app.inject({ method: 'GET', url: '/sse-source' });
+        expect(res.body).toBe('data: via-stream()\n\n');
     });
 
     test('by default an error event yields a named event: error frame with a generic token, never the raw message', async () => {
@@ -212,7 +241,7 @@ describe('stitchPlugin', () => {
             logger: false,
         });
         app.get('/sse-err', (_request, reply) =>
-            sendStitchSse(reply, events()),
+            streamStitchSse(reply, events()),
         );
         await app.ready();
 
@@ -248,7 +277,7 @@ describe('stitchPlugin', () => {
             logger: false,
         });
         app.get('/sse-err', (_request, reply) =>
-            sendStitchSse(reply, events(), { error: (e) => e.message }),
+            streamStitchSse(reply, events(), { error: (e) => e.message }),
         );
         await app.ready();
 
@@ -285,7 +314,7 @@ describe('stitchPlugin', () => {
             logger: false,
         });
         app.get('/sse-err', (_request, reply) =>
-            sendStitchSse(reply, events(), {
+            streamStitchSse(reply, events(), {
                 error: { observe: (err) => observed.push(err) },
             }),
         );

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -18,7 +18,7 @@ export {
     STITCH_VAR,
     type HonoRequestSeam,
     type StitchEnv,
-    type StitchMiddlewareOptions,
+    type HonoStitchMiddlewareOptions,
 } from './middleware';
 
 export {

--- a/packages/hono/src/middleware.ts
+++ b/packages/hono/src/middleware.ts
@@ -18,7 +18,11 @@ import type { PrincipalSeam, Seam } from 'stitchapi';
  */
 export type HonoRequestSeam = PrincipalSeam | Seam;
 
-/** The key the seam is stored under on `c.var` / via `c.set` / `c.get`. */
+/**
+ * The key the seam is stored under on `c.var` / via `c.set` / `c.get`. Reading it before the
+ * `stitch()` middleware ran yields `undefined` (Hono's `c.get` never throws on an unset variable)
+ * — guard for it in routes mounted outside the middleware's path.
+ */
 export const STITCH_VAR = 'stitch' as const;
 
 /**
@@ -40,7 +44,7 @@ export interface StitchEnv extends Env {
     };
 }
 
-export interface StitchMiddlewareOptions {
+export interface HonoStitchMiddlewareOptions {
     /**
      * The seam this middleware shares across requests. **Borrowed, not owned** — build it once at
      * startup and `seam.close()` it on shutdown yourself; the middleware never closes it (the seam
@@ -74,7 +78,9 @@ export interface StitchMiddlewareOptions {
  * app.get('/me', (c) => c.json(c.get('stitch').stitch('/me')()));
  * ```
  */
-export function stitch(options: StitchMiddlewareOptions): MiddlewareHandler {
+export function stitch(
+    options: HonoStitchMiddlewareOptions,
+): MiddlewareHandler {
     const { seam, principal } = options;
     return createMiddleware<StitchEnv>(async (c, next) => {
         const id = principal?.(c);

--- a/packages/hono/src/sse.ts
+++ b/packages/hono/src/sse.ts
@@ -21,6 +21,7 @@ import {
     resolveDelta,
     resolveError,
     toErrorEvent,
+    toIterable,
 } from 'stitchapi/sse-emit';
 
 export type { StitchEventSource };
@@ -58,8 +59,11 @@ export function streamStitchSse<T>(
     const error = resolveError(options.error);
     const toData = delta.data ?? defaultData;
     const errorEvent = error.event ?? 'error';
+    // Core's `StitchEventSource` admits the iterable itself or a `{ stream() }` holder (a
+    // `StitchResult`, a stitch stub) — unwrap the holder once, up front.
+    const iterable = toIterable(source);
     return streamSSE(c, async (stream: SSEStreamingApi) => {
-        const iterator = source[Symbol.asyncIterator]();
+        const iterator = iterable[Symbol.asyncIterator]();
         let index = 0;
         // Write the terminal `error` message: a generic token by default so a raw message
         // (`getaddrinfo ENOTFOUND …` / `HTTP 401`) is never disclosed; `error.data` opts in.

--- a/packages/hono/test/sse.spec.ts
+++ b/packages/hono/test/sse.spec.ts
@@ -69,6 +69,21 @@ describe('streamStitchSse — delta mapping', () => {
         expect(body).toContain('data: t2');
     });
 
+    test('a { stream() } holder (StitchResult-shaped source) is unwrapped and driven', async () => {
+        const app = new Hono();
+        const holder = {
+            stream: () =>
+                gen([
+                    { type: 'delta', chunk: 'held', at: 0 },
+                    { type: 'done', ok: true, elapsed: 1, attempts: 1, at: 0 },
+                ]),
+        };
+        app.get('/x', (c) => streamStitchSse(c, holder));
+
+        const body = await (await app.request('/x')).text();
+        expect(dataLines(body)).toEqual(['data: held']);
+    });
+
     test('a custom data mapper pulls text out of a structured chunk', async () => {
         const app = new Hono();
         app.get('/x', (c) =>

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -25,10 +25,13 @@ pnpm add @stitchapi/nest@rc stitchapi@rc
 
 ## Configure the shared client — `forRoot` / `forRootAsync`
 
-`forRoot` configures the app-wide shared infrastructure (one `store`, one `trace`
+`forRoot` configures the app-wide shared infrastructure (one `store`, one trace
 sink) and a default seam carrying your `SeamConfig` defaults (`baseUrl`, `headers`,
-`auth`, `retry`, `throttle`, `cache`, …). Tracing is **off by default**; opt in with the
-`'logger'` sentinel.
+`auth`, `retry`, `throttle`, `cache`, …). The **Nest `Logger` bridge is on by
+default** (`logger: true` → `nestLoggerSink(new Logger('Stitch'))`, the same default
+as `@stitchapi/fastify`'s plugin): pass sink options (`logger: { lifecycle: false }`),
+set `logger: false` to leave tracing as core configures it (off), or set an explicit
+`trace` — it wins over the bridge.
 
 ```ts
 import { StitchModule, fromNestConfig } from '@stitchapi/nest';
@@ -43,7 +46,7 @@ import { bearer } from 'stitchapi';
                 baseUrl: config.getOrThrow('API_BASE_URL'),
                 store: new RedisStore(config.getOrThrow('REDIS_URL')), // any StitchStore
                 auth: bearer(fromNestConfig(config)('API_TOKEN')),
-                trace: 'logger', // → nestLoggerSink(new Logger('Stitch'))
+                // logger: false, // opt out of the default Nest Logger trace bridge
             }),
         }),
     ],
@@ -56,8 +59,8 @@ export class AppModule {}
 Declare stitches with `defineStitch(build)` — the injection **token is optional** (a
 unique `Symbol` is generated; pass `defineStitch(token, build)` only when you need a
 stable, well-known token). Register them per feature module, which may also own its
-**own upstream seam** (its `baseUrl`/`auth`), built over the shared store + trace — omit
-`seam` to attach the stitches to the default seam.
+**own upstream seam** (a `seam.config` with its `baseUrl`/`auth`), built over the shared
+store + trace — omit `seam` to attach the stitches to the default seam.
 
 ```ts
 // users.stitches.ts
@@ -161,39 +164,45 @@ app.useGlobalFilters(new StitchExceptionFilter(app.getHttpAdapter()));
 // …or as a provider: { provide: APP_FILTER, useClass: StitchExceptionFilter }
 ```
 
-`status` takes a fixed number or a `(err) => number` function. Outside a filter, use
-`toHttpException(err, { status })` / `isStitchError(err)` directly.
+The options envelope is `StitchErrorOptions` — the same `{ status?, body? }` shape as
+`@stitchapi/hono`'s and `@stitchapi/elysia`'s error helpers. `status` takes a fixed number
+or a `(err) => number` function. Outside a filter, use `toHttpException(err, { status })` /
+`isStitchError(err)` directly.
 
-The client-facing **message** is a fixed `'Upstream request failed'` by default — the raw
-`err.message` is withheld, because it can disclose an internal hostname (a transport
-failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status
-(`HTTP 401`). The original error is always attached as the exception's `cause` for
-server-side logging. Opt in to a message when you need one: `{ exposeMessage: true }` for
-the raw message, or `{ message: 'Payment provider unavailable' }` / `{ message: (e) => … }`
-for a curated one.
+The client-facing **body** defaults to Nest's rendering of a fixed
+`'Upstream request failed'` — the raw `err.message` is withheld, because it can disclose an
+internal hostname (a transport failure reads like
+`getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`). The
+original error is always attached as the exception's `cause` for server-side logging. Shape
+your own envelope with `body`: `{ body: (e, status) => ({ error: 'Payment provider unavailable' }) }`,
+or opt in to the raw message with `{ body: (e) => ({ error: e.message }) }` when the
+upstream messages are known safe.
 
-## Streaming → SSE — `stitchSse`
+## Streaming → SSE — `streamStitchSse`
 
-Return a stitch's `stream()` from a Nest `@Sse()` endpoint: `delta` chunks become messages,
-an `error` event errors the stream (a fixed, safe message by default — see below), and a
-client disconnect aborts the upstream generator.
+Return a stitch's `stream()` (or any `StitchEventSource`) from a Nest `@Sse()` endpoint:
+`delta` chunks become messages, an `error` event errors the stream (a generic `data: error`
+frame by default — see below), and a client disconnect aborts the upstream generator. The
+options (`StreamStitchSseOptions`) are the canonical host set shared with
+`@stitchapi/express` / `@stitchapi/hono`: `data`, `event`, `id`, `errorData`, `onError`.
 
 ```ts
 @Sse('chat')
 chat(@Query('q') q: string) {
-    return stitchSse(this.complete.stream({ body: { prompt: q } }), {
+    return streamStitchSse(this.complete.stream({ body: { prompt: q } }), {
         data: (c: any) => c.text, // map a delta chunk → message data
     });
 }
 ```
 
 Nest renders an errored `@Sse()` observable's message to the client as the final `event: error`
-frame, so the client-facing **message** defaults to a fixed `'Upstream request failed'` — the raw
+frame, so the client-facing **data** defaults to a generic `error` token — the raw
 `event.message` is withheld, since it can disclose an internal hostname (a transport failure reads
-like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`). The
-original error is always attached as the errored observable's `cause` for server-side logging. Opt
-in when you need a message: `{ exposeMessage: true }` for the raw message, or
-`{ message: 'Stream unavailable' }` / `{ message: (e) => … }` for a curated one.
+like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`). Observe
+the real failure server-side with `onError`; it is also attached as the errored observable's
+`cause`. Shape the client frame with `errorData` when you need to:
+`{ errorData: (e) => e.message }` opts in to the raw message,
+`{ errorData: () => 'Stream unavailable' }` sets a curated one.
 
 ## Testing
 

--- a/packages/nest/src/exception-filter.ts
+++ b/packages/nest/src/exception-filter.ts
@@ -22,7 +22,7 @@ export function isStitchError(err: unknown): err is StitchErrorLike {
 /** The safe, fixed message the mapped exception carries by default. */
 const SAFE_MESSAGE = 'Upstream request failed';
 
-export interface ToHttpExceptionOptions {
+export interface StitchErrorOptions {
     /**
      * The HTTP status for the mapped exception. Default `502 Bad Gateway` — **every**
      * upstream failure is reported as a gateway error, regardless of the upstream's own
@@ -33,50 +33,45 @@ export interface ToHttpExceptionOptions {
      */
     status?: number | ((err: StitchErrorLike) => number);
     /**
-     * Set the client-facing message. **Default: a fixed `'Upstream request failed'`** — the
-     * raw `err.message` is deliberately *not* forwarded, because it can disclose internal
-     * network topology (a transport failure reads like
-     * `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`)
-     * to an untrusted client. The original error is always attached as the exception's
-     * `cause` for server-side logging. Provide a fixed string, or a function for a
-     * per-error message. Prefer this over {@link exposeMessage} when you want a specific,
-     * curated message.
+     * The response body for a mapped failure. **Default: Nest's rendering of a fixed, generic
+     * message** (`{ statusCode, message: 'Upstream request failed' }`) — the raw `err.message`
+     * is deliberately *not* echoed, because it can disclose internal network topology (a
+     * transport failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the
+     * upstream's status (`HTTP 401`) to an untrusted client. Override to shape your own error
+     * envelope; pass `(e) => ({ error: e.message })` to opt in to the raw message when the
+     * upstream messages are known to be safe to expose. Receives the mapped status alongside
+     * the error. The original error is always attached as the exception's `cause` for
+     * server-side logging.
      */
-    message?: string | ((err: StitchErrorLike) => string);
-    /**
-     * Opt in to forwarding the raw `err.message` as the client-facing message. **Default
-     * `false`** — see {@link message} for why the raw message is withheld by default. Ignored
-     * when {@link message} is set. Only enable this when the upstream messages are known to
-     * be safe to expose to your clients.
-     */
-    exposeMessage?: boolean;
+    body?: (err: StitchErrorLike, status: number) => unknown;
 }
 
 /**
  * Map a thrown stitch failure to a Nest {@link HttpException}, or `undefined` when `err`
  * is not a {@link StitchErrorLike} (so a caller can rethrow it untouched). The status is
- * `502` by default; override it via {@link ToHttpExceptionOptions.status}.
+ * `502` by default; override it via {@link StitchErrorOptions.status}.
  *
- * The client-facing message defaults to a fixed `'Upstream request failed'` — the raw
- * `err.message` is **not** forwarded, since it can leak internal hostnames or the
- * upstream's status to an untrusted client. The original error is attached as the
- * exception's `cause` for server-side logging. Opt in to the raw message with
- * {@link ToHttpExceptionOptions.exposeMessage}, or set your own with
- * {@link ToHttpExceptionOptions.message}.
+ * The client-facing body defaults to Nest's rendering of a fixed
+ * `'Upstream request failed'` — the raw `err.message` is **not** forwarded, since it can
+ * leak internal hostnames or the upstream's status to an untrusted client. The original
+ * error is attached as the exception's `cause` for server-side logging. Shape your own
+ * envelope (or opt in to the raw message) with {@link StitchErrorOptions.body}.
  */
 export function toHttpException(
     err: unknown,
-    options: ToHttpExceptionOptions = {},
+    options: StitchErrorOptions = {},
 ): HttpException | undefined {
     if (!isStitchError(err)) return undefined;
-    const { status = HttpStatus.BAD_GATEWAY, message, exposeMessage } = options;
+    const { status = HttpStatus.BAD_GATEWAY } = options;
     const code = typeof status === 'function' ? status(err) : status;
-    const clientMessage =
-        typeof message === 'function'
-            ? message(err)
-            : (message ??
-              (exposeMessage ? err.message || SAFE_MESSAGE : SAFE_MESSAGE));
-    return new HttpException(clientMessage, code, { cause: err });
+    // The default body is Nest's own rendering of the safe, fixed message — the raw
+    // `err.message` is deliberately withheld so an internal hostname (`getaddrinfo
+    // ENOTFOUND …`) or the upstream's status (`HTTP 401`) never reaches the client.
+    // Opt in / shape the envelope via `options.body`.
+    const response = options.body
+        ? (options.body(err, code) as string | Record<string, unknown>)
+        : SAFE_MESSAGE;
+    return new HttpException(response, code, { cause: err });
 }
 
 /**
@@ -98,7 +93,7 @@ export function toHttpException(
 export class StitchExceptionFilter extends BaseExceptionFilter {
     constructor(
         applicationRef?: HttpServer,
-        private readonly options: ToHttpExceptionOptions = {},
+        private readonly options: StitchErrorOptions = {},
     ) {
         super(applicationRef);
     }

--- a/packages/nest/src/index.ts
+++ b/packages/nest/src/index.ts
@@ -29,6 +29,11 @@ export {
     toHttpException,
     isStitchError,
     type StitchErrorLike,
-    type ToHttpExceptionOptions,
+    type StitchErrorOptions,
 } from './exception-filter';
-export { stitchSse, type MessageEventLike, type StitchSseOptions } from './sse';
+export {
+    streamStitchSse,
+    type MessageEventLike,
+    type StitchEventSource,
+    type StreamStitchSseOptions,
+} from './sse';

--- a/packages/nest/src/module.ts
+++ b/packages/nest/src/module.ts
@@ -2,7 +2,11 @@
 // configure shared infrastructure (store + trace) and a default seam; forFeature
 // registers injectable stitches and, optionally, a per-upstream feature seam built over
 // that shared infrastructure. `SeamRegistry` owns the shutdown lifecycle.
-import { nestBorrowStore, nestLoggerSink } from './bridges';
+import {
+    type NestLoggerSinkOptions,
+    nestBorrowStore,
+    nestLoggerSink,
+} from './bridges';
 import type { AnyStitchDef, NestRequestSeam } from './define-stitch';
 import { STITCH_SEAM, STITCH_STORE, STITCH_TRACE } from './tokens';
 
@@ -29,10 +33,17 @@ import {
     seam,
 } from 'stitchapi';
 
-/** forRoot options: the shared `SeamConfig` defaults + infra, plus the `'logger'` trace sentinel. */
-export interface StitchModuleOptions extends Omit<SeamOptions, 'trace'> {
-    /** A `TraceSink`, `'console'`, `false`, or the `'logger'` sentinel (→ Nest Logger). Default: off. */
-    trace?: SeamOptions['trace'] | 'logger';
+/** forRoot options: the shared `SeamConfig` defaults + infra, plus the Nest `logger` bridge. */
+export interface StitchModuleOptions extends SeamOptions {
+    /**
+     * Bridge stitch events into a Nest `Logger` (via {@link nestLoggerSink}) as the seam's
+     * `TraceSink`. **Default `true`** — aligned with `@stitchapi/fastify`'s plugin `logger`
+     * default, so every host integration traces through its framework logger out of the box.
+     * Pass sink options to customise (`{ lifecycle: false }`), or `false` to leave tracing as
+     * core configures it (off). Ignored when `trace` is set — an explicit trace sink wins,
+     * exactly as a `trace` on a Fastify `seamConfig` wins over its `logger` bridge.
+     */
+    logger?: boolean | AtLeastOne<NestLoggerSinkOptions>;
     /** Register as a global module (default `true`). */
     isGlobal?: boolean;
 }
@@ -88,19 +99,27 @@ interface Infra {
 }
 
 // Normalise module options into shared infra: borrow an app-provided store (else own a
-// memoryStore), expand the `'logger'` trace sentinel, default tracing OFF.
+// memoryStore), resolve the `logger` bridge (default ON, matching @stitchapi/fastify) —
+// an explicit `trace` wins over it.
 function resolveInfra(options: StitchModuleOptions): Infra {
-    const { store, trace } = options;
+    const { store, trace, logger } = options;
     const defaults: Record<string, unknown> = { ...options };
     delete defaults['store'];
     delete defaults['trace'];
+    delete defaults['logger'];
     delete defaults['isGlobal'];
+    const sinkOptions: NestLoggerSinkOptions =
+        typeof logger === 'object' ? logger : {};
     return {
         store: store ? nestBorrowStore(store) : memoryStore(),
+        // An explicit `trace` wins; otherwise bridge the Nest Logger unless `logger: false`
+        // (the same precedence as the Fastify plugin's `seamConfig.trace` vs `logger`).
         trace:
-            trace === 'logger'
-                ? nestLoggerSink(new Logger('Stitch'))
-                : (trace ?? false),
+            trace !== undefined
+                ? trace
+                : logger !== false
+                  ? nestLoggerSink(new Logger('Stitch'), sinkOptions)
+                  : false,
         defaults: defaults as Omit<SeamOptions, 'store' | 'trace'>,
     };
 }

--- a/packages/nest/src/sse.ts
+++ b/packages/nest/src/sse.ts
@@ -3,18 +3,26 @@
 // This bridges the two so a streaming endpoint is one line, and aborts the upstream
 // generator when the client disconnects (the subscription tears down).
 import { Observable } from 'rxjs';
-import type { StitchEvent } from 'stitchapi';
+import type { StitchEvent, StitchEventSource } from 'stitchapi';
+
+// The canonical intake for event-stream consumers, re-exported from the core barrel: the
+// event iterable itself (a `.stream()` generator) or anything that hands one back (a
+// `StitchResult`, a stitch stub).
+export type { StitchEventSource } from 'stitchapi';
 
 /** The terminal `error` event a stitch stream emits — carries `message`, `status`, `attempts`. */
 type StitchErrorEvent = Extract<StitchEvent, { type: 'error' }>;
 
-/** The safe, fixed message the errored observable carries by default (mirrors the exception filter). */
-const SAFE_MESSAGE = 'Upstream request failed';
+// The generic token an `error` frame carries by default: the raw upstream message is withheld so an
+// internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`) never reaches
+// the client. Override with `options.errorData`.
+const DEFAULT_ERROR_DATA = 'error';
 
 /**
  * The SSE message shape Nest's `@Sse()` consumes — declared structurally so this
  * package does not import Nest's `MessageEvent` type (one less coupling); Nest's
- * `MessageEvent` satisfies it. `data` is the only field the bridge sets.
+ * `MessageEvent` satisfies it. The bridge sets `data` (always), plus `type`/`id`
+ * when the `event`/`id` options are given.
  */
 export interface MessageEventLike {
     data: string | object;
@@ -23,37 +31,55 @@ export interface MessageEventLike {
     retry?: number;
 }
 
-export interface StitchSseOptions {
+export interface StreamStitchSseOptions {
     /**
-     * Map a `delta` chunk to the SSE message `data`. Default: the chunk itself (a
-     * string is sent as-is; an object is JSON-serialised by Nest). Use this to pull
-     * the text out of a structured chunk, e.g. `data: (c) => c.choices[0].delta`.
+     * Map a `delta` chunk to the SSE message `data` string. The default sends a string chunk
+     * as-is and `JSON.stringify`-s anything else. Use this to pull the text out of a structured
+     * chunk, e.g. `data: (c) => c.choices[0].delta.content`. Receives the zero-based message
+     * index alongside the chunk.
      */
-    data?: (chunk: unknown) => string | object;
+    data?: (chunk: unknown, index: number) => string;
     /**
-     * Set the client-facing message for a terminal `error` event. Nest renders an errored
-     * `@Sse()` observable's `message` to the client as the final `event: error` frame's data,
-     * so this controls what the browser's `EventSource` receives. **Default: a fixed
-     * `'Upstream request failed'`** — the raw `event.message` is deliberately *not* forwarded,
-     * because it can disclose internal network topology (a transport failure reads like
-     * `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to
-     * an untrusted client. The original error is always attached as the errored observable's
-     * `cause` for server-side logging. Provide a fixed string, or a function for a per-error
-     * message. Prefer this over {@link exposeMessage} when you want a specific, curated message.
+     * Emit an `event:` line per delta message (the SSE event name — Nest's `MessageEvent.type`):
+     * a fixed name, or a function of the chunk for per-message names. Default: none (an unnamed
+     * `message` event, which `EventSource.onmessage` receives).
      */
-    message?: string | ((event: StitchErrorEvent) => string);
+    event?: string | ((chunk: unknown) => string);
     /**
-     * Opt in to forwarding the raw `event.message` as the client-facing message. **Default
-     * `false`** — see {@link message} for why the raw message is withheld by default. Ignored
-     * when {@link message} is set. Only enable this when the upstream messages are known to be
-     * safe to expose to your clients.
+     * Provide an `id:` line per delta message (the SSE last-event id), e.g. for resumable
+     * streams. Receives the chunk and the zero-based message index.
      */
-    exposeMessage?: boolean;
+    id?: (chunk: unknown, index: number) => string;
+    /**
+     * Shape the SSE `data` written for a terminal `error` event (or an uncaught throw
+     * mid-stream, normalised to an error event). Nest renders an errored `@Sse()` observable's
+     * `message` to the client as the final `event: error` frame's data, so this controls what
+     * the browser's `EventSource` receives. **Default: a generic token (`data: error`)** — the
+     * raw `event.message` is deliberately *not* echoed, because it can disclose internal network
+     * topology (a transport failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`)
+     * or the upstream's status (`HTTP 401`) to an untrusted client. Opt in with
+     * `(e) => e.message` when the upstream messages are known safe, or return your own payload
+     * (e.g. `() => JSON.stringify({ error: 'stream failed' })`).
+     */
+    errorData?: (event: StitchErrorEvent) => string;
+    /**
+     * Called once, server-side, if the underlying stream errors (a stitch `error` event, or a
+     * throw) — use it to observe/log the real failure. It does **not** shape the client-facing
+     * frame: the SSE `data` sent to the client is controlled by `errorData` (a generic token by
+     * default), so the raw message reaches your logs here but not the client. Host-specific
+     * extra: the original failure is *also* attached as the errored observable's `cause`.
+     */
+    onError?: (err: unknown) => void;
 }
 
-// Normalise a thrown value into the terminal `error` event shape, so a `message` opt-in sees a
+// One delta chunk → the message `data` string: a string chunk as-is, anything else JSON.
+function defaultData(chunk: unknown): string {
+    return typeof chunk === 'string' ? chunk : JSON.stringify(chunk);
+}
+
+// Normalise a thrown value into the terminal `error` event shape, so an `errorData` opt-in sees a
 // consistent argument whether the failure arrived as a surfaced `error` event or an unexpected
-// throw. `attempts`/`at` are best-effort placeholders — a `message` hook keys off `name`/`message`.
+// throw. `attempts`/`at` are best-effort placeholders — an `errorData` hook keys off `name`/`message`.
 function toErrorEvent(err: unknown): StitchErrorEvent {
     const e = err instanceof Error ? err : new Error(String(err));
     return {
@@ -65,66 +91,89 @@ function toErrorEvent(err: unknown): StitchErrorEvent {
     };
 }
 
-// The Error the observable is errored with. By default it carries the safe, fixed message — the
+// The Error the observable is errored with. By default it carries the generic `error` token — the
 // raw `event.message` is withheld, since Nest writes an errored observable's `message` straight to
-// the client (an internal hostname / `HTTP 401` would leak). `exposeMessage`/`message` opt in; the
-// original failure is always attached as `cause` for server-side logging.
+// the client (an internal hostname / `HTTP 401` would leak). `errorData` opts in; the original
+// failure is always attached as `cause` for server-side logging.
 function clientError(
     event: StitchErrorEvent,
-    options: StitchSseOptions,
+    options: StreamStitchSseOptions,
     cause: unknown,
 ): Error {
-    const { message, exposeMessage } = options;
-    const text =
-        typeof message === 'function'
-            ? message(event)
-            : (message ??
-              (exposeMessage ? event.message || SAFE_MESSAGE : SAFE_MESSAGE));
+    const text = options.errorData
+        ? options.errorData(event)
+        : DEFAULT_ERROR_DATA;
     return new Error(text, { cause });
 }
 
+// Accept both arms of core's `StitchEventSource`: the event iterable itself, or anything that
+// hands one back (a `StitchResult`, a stitch stub). Kept local — this bridge is the one adapter
+// that drives an rxjs `Observable` rather than the shared `stitchapi/sse-emit` frame kit.
+function toIterable<T>(
+    source: StitchEventSource<T>,
+): AsyncIterable<StitchEvent<T>> {
+    return Symbol.asyncIterator in source
+        ? (source as AsyncIterable<StitchEvent<T>>)
+        : source.stream();
+}
+
 /**
- * Adapt a stitch's `stream()` (or any `AsyncIterable<StitchEvent>`) into an
+ * Adapt a stitch's `stream()` (or any {@link StitchEventSource}) into an
  * `Observable<MessageEventLike>` for an `@Sse()` endpoint: each `delta` becomes a
  * message, an `error` event errors the observable (Nest renders that to the client as a
- * final `event: error` frame — a fixed, safe message by default, the raw message withheld to
- * avoid disclosing internal topology; opt in via `exposeMessage`/`message`), and stream end
- * completes it. The non-output events (`start` / `progress` / `drift` / `result` / `done`) are
- * control signals and are not forwarded to the client.
+ * final `event: error` frame — a generic `data: error` by default, the raw message withheld to
+ * avoid disclosing internal topology; opt in via `errorData`, observe the real failure
+ * server-side via `onError`), and stream end completes it. The non-output events
+ * (`start` / `progress` / `drift` / `result` / `done`) are control signals and are not
+ * forwarded to the client.
  *
  * ```ts
  * @Sse('chat')
  * chat(@Query('q') q: string) {
- *   return stitchSse(this.complete.stream({ body: { prompt: q } }),
- *                    { data: (c: any) => c.text });
+ *   return streamStitchSse(this.complete.stream({ body: { prompt: q } }),
+ *                          { data: (c: any) => c.text });
  * }
  * ```
  *
  * When the client disconnects, Nest unsubscribes; the teardown calls the iterator's
  * `return()` so the underlying stitch stream is aborted rather than left running.
  */
-export function stitchSse<T>(
-    stream: AsyncIterable<StitchEvent<T>>,
-    options: StitchSseOptions = {},
+export function streamStitchSse<T>(
+    source: StitchEventSource<T>,
+    options: StreamStitchSseOptions = {},
 ): Observable<MessageEventLike> {
-    const toData =
-        options.data ?? ((chunk: unknown) => chunk as string | object);
+    const toData: (chunk: unknown, index: number) => string =
+        options.data ?? defaultData;
     return new Observable<MessageEventLike>((subscriber) => {
-        const iterator = stream[Symbol.asyncIterator]();
+        const iterator = toIterable(source)[Symbol.asyncIterator]();
         let active = true;
         void (async () => {
+            let index = 0;
             try {
                 while (active) {
                     const { value: event, done } = await iterator.next();
                     if (done) break;
                     if (event.type === 'delta') {
-                        subscriber.next({ data: toData(event.chunk) });
+                        const message: MessageEventLike = {
+                            data: toData(event.chunk, index),
+                        };
+                        if (options.event !== undefined)
+                            message.type =
+                                typeof options.event === 'function'
+                                    ? options.event(event.chunk)
+                                    : options.event;
+                        if (options.id)
+                            message.id = options.id(event.chunk, index);
+                        subscriber.next(message);
+                        index += 1;
                     } else if (event.type === 'error') {
-                        // Error the observable — but by default with a safe, fixed message, never
-                        // the raw `event.message`: Nest writes an errored `@Sse()` observable's
-                        // `message` straight to the client, so echoing it would disclose an internal
-                        // hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`).
-                        // The event is attached as `cause`; opt in via `exposeMessage`/`message`.
+                        // Error the observable — but by default with the generic token, never the
+                        // raw `event.message`: Nest writes an errored `@Sse()` observable's
+                        // `message` straight to the client, so echoing it would disclose an
+                        // internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status
+                        // (`HTTP 401`). `onError` gets the real failure server-side; the event is
+                        // also attached as `cause`; `errorData` shapes the client frame.
+                        options.onError?.(new Error(event.message));
                         subscriber.error(clientError(event, options, event));
                         return;
                     }
@@ -132,8 +181,9 @@ export function stitchSse<T>(
                 subscriber.complete();
             } catch (err) {
                 // A throw (not a surfaced `error` event): withhold the raw message the same way —
-                // normalise it to an error event so a `message` opt-in sees a consistent shape, and
-                // attach the original as `cause`.
+                // normalise it to an error event so an `errorData` opt-in sees a consistent shape,
+                // and attach the original as `cause`.
+                options.onError?.(err);
                 subscriber.error(clientError(toErrorEvent(err), options, err));
             }
         })();

--- a/packages/nest/test/exception-filter.spec.ts
+++ b/packages/nest/test/exception-filter.spec.ts
@@ -95,23 +95,26 @@ describe('toHttpException', () => {
             expect(ex.cause).toBe(original);
         });
 
-        it('opt-in `exposeMessage: true` includes the raw message', () => {
+        it('opt-in `body` can echo the raw message when the caller chooses to', () => {
             const ex = toHttpException(
                 stitchError('getaddrinfo ENOTFOUND payments.internal.corp'),
-                { exposeMessage: true },
+                { body: (e) => ({ error: e.message }) },
             )!;
             expect(bodyOf(ex)).toContain('payments.internal.corp');
         });
 
-        it('opt-in `message` override sets a caller-chosen message', () => {
-            const fixed = toHttpException(stitchError('HTTP 401', 401), {
-                message: 'Payment provider unavailable',
+        it('`body` shapes a caller-chosen error envelope, receiving the mapped status', () => {
+            const ex = toHttpException(stitchError('HTTP 401', 401), {
+                body: (_e, status) => ({
+                    error: 'Payment provider unavailable',
+                    status,
+                }),
             })!;
-            expect(fixed.message).toBe('Payment provider unavailable');
-            const fromFn = toHttpException(stitchError('HTTP 429', 429), {
-                message: (e) => `upstream said ${e.status}`,
-            })!;
-            expect(fromFn.message).toBe('upstream said 429');
+            expect(ex.getResponse()).toEqual({
+                error: 'Payment provider unavailable',
+                status: 502, // the mapped status, not the upstream 401
+            });
+            expect(bodyOf(ex)).not.toContain('HTTP 401');
         });
     });
 });

--- a/packages/nest/test/module.spec.ts
+++ b/packages/nest/test/module.spec.ts
@@ -43,6 +43,7 @@ describe('StitchModule.forRoot', () => {
         const mod = StitchModule.forRoot({
             baseUrl: 'https://api.test',
             adapter: recordingAdapter(calls),
+            logger: false, // keep the default Nest Logger bridge out of the test output
         });
         expect(mod.global).toBe(true);
 
@@ -60,19 +61,37 @@ describe('StitchModule.forRoot', () => {
         await reg.closeAll(); // must not throw
     });
 
-    it('defaults tracing OFF (no STITCH_TRACE sink)', () => {
+    // The `logger` bridge defaults ON — aligned with @stitchapi/fastify's plugin default.
+    it('defaults the Nest Logger bridge ON (STITCH_TRACE is a sink)', () => {
         const providers = StitchModule.forRoot().providers as FProv[];
-        const traceProv = providers.find((p) => p.provide === STITCH_TRACE);
-        expect(traceProv?.useValue).toBe(false);
-    });
-
-    it("expands the 'logger' trace sentinel to a sink", () => {
-        const providers = StitchModule.forRoot({ trace: 'logger' })
-            .providers as FProv[];
         const traceProv = providers.find((p) => p.provide === STITCH_TRACE);
         expect(
             typeof (traceProv?.useValue as { handle?: unknown }).handle,
         ).toBe('function');
+    });
+
+    it('logger: false turns the bridge off (tracing falls back to core’s off default)', () => {
+        const providers = StitchModule.forRoot({ logger: false })
+            .providers as FProv[];
+        const traceProv = providers.find((p) => p.provide === STITCH_TRACE);
+        expect(traceProv?.useValue).toBe(false);
+    });
+
+    it('logger accepts sink options (AtLeastOne envelope) and still yields a sink', () => {
+        const providers = StitchModule.forRoot({
+            logger: { lifecycle: false },
+        }).providers as FProv[];
+        const traceProv = providers.find((p) => p.provide === STITCH_TRACE);
+        expect(
+            typeof (traceProv?.useValue as { handle?: unknown }).handle,
+        ).toBe('function');
+    });
+
+    it('an explicit trace wins over the logger bridge', () => {
+        const providers = StitchModule.forRoot({ trace: false, logger: true })
+            .providers as FProv[];
+        const traceProv = providers.find((p) => p.provide === STITCH_TRACE);
+        expect(traceProv?.useValue).toBe(false);
     });
 });
 
@@ -126,6 +145,39 @@ describe('StitchModule.forFeature', () => {
         expect(providers[0]?.inject).toEqual([STITCH_SEAM]);
     });
 
+    // P20/P24: `seam` is `AtLeastOne<NestFeatureSeamOptions>` — an empty `{}` is
+    // indistinguishable from omitting the envelope entirely, so it must not compile.
+    // `config`/`token` compose freely (each independently satisfies AtLeastOne).
+    it('rejects an empty seam envelope at compile time, but config + token compose', () => {
+        const GetThing = defineStitch('GET_THING_3', (h) =>
+            h.stitch({ path: '/thing' }),
+        );
+        const TOKEN = Symbol('feature-seam-token');
+
+        // @ts-expect-error — `seam: {}` satisfies neither `config` nor `token`; P20/P24.
+        StitchModule.forFeature({ seam: {}, stitches: [GetThing] });
+
+        // Both facets together — config builds the seam, token exposes it under a
+        // caller-chosen DI token (not just the root/default XOR one-of-them cases above).
+        const providers = StitchModule.forFeature({
+            seam: {
+                config: {
+                    baseUrl: 'https://feat.test',
+                    adapter: recordingAdapter([]),
+                },
+                token: TOKEN,
+            },
+            stitches: [GetThing],
+        }).providers as FProv[];
+        const seamProv = providers.find((p) => p.provide === TOKEN);
+        expect(seamProv).toBeDefined();
+        expect(seamProv?.inject).toEqual([
+            STITCH_STORE,
+            STITCH_TRACE,
+            SeamRegistry,
+        ]);
+    });
+
     // Regression (path-vars fallout, #114): a templated-path def's call argument now *requires*
     // `params`, so its `StitchDef` has a narrower (contravariant) input than the loose default.
     // The feature registry must still admit it — `stitches` is bound to the any-input
@@ -173,6 +225,8 @@ describe('StitchModule.forFeatureScoped', () => {
         const TENANT = Symbol('tenant');
         const GetThing = defineStitch((h) => h.stitch({ path: '/thing' }));
         const mod = StitchModule.forFeatureScoped({
+            // Both facets of the envelope together: config builds the feature seam, token
+            // exposes it under a caller-chosen DI token — proving they compose (P24).
             seam: {
                 config: {
                     baseUrl: 'https://feat.test',

--- a/packages/nest/test/sse.spec.ts
+++ b/packages/nest/test/sse.spec.ts
@@ -1,20 +1,24 @@
-import { stitchSse } from '../src';
+import { streamStitchSse } from '../src';
+import type { MessageEventLike } from '../src';
 
 import type { StitchEvent } from 'stitchapi';
 import { describe, expect, it } from 'vitest';
 
-// Subscribe and collect message data until the observable terminates.
+// Subscribe and collect messages until the observable terminates.
 const collect = (
-    obs: ReturnType<typeof stitchSse>,
-): Promise<{ data: unknown[]; error?: Error }> =>
+    obs: ReturnType<typeof streamStitchSse>,
+): Promise<{ messages: MessageEventLike[]; error?: Error }> =>
     new Promise((resolve) => {
-        const data: unknown[] = [];
+        const messages: MessageEventLike[] = [];
         obs.subscribe({
-            next: (m) => data.push(m.data),
-            error: (error: Error) => resolve({ data, error }),
-            complete: () => resolve({ data }),
+            next: (m) => messages.push(m),
+            error: (error: Error) => resolve({ messages, error }),
+            complete: () => resolve({ messages }),
         });
     });
+
+const dataOf = (messages: MessageEventLike[]): unknown[] =>
+    messages.map((m) => m.data);
 
 async function* events(
     ...evs: StitchEvent[]
@@ -22,10 +26,10 @@ async function* events(
     for (const e of evs) yield e;
 }
 
-describe('stitchSse', () => {
+describe('streamStitchSse', () => {
     it('forwards delta chunks as messages and completes at stream end', async () => {
-        const { data, error } = await collect(
-            stitchSse(
+        const { messages, error } = await collect(
+            streamStitchSse(
                 events(
                     {
                         type: 'start',
@@ -42,12 +46,21 @@ describe('stitchSse', () => {
             ),
         );
         expect(error).toBeUndefined();
-        expect(data).toEqual(['a', 'b']); // control events not forwarded
+        expect(dataOf(messages)).toEqual(['a', 'b']); // control events not forwarded
     });
 
-    it('by default errors the observable with a safe message, withholding the raw upstream message', async () => {
-        const { data, error } = await collect(
-            stitchSse(
+    it('accepts a { stream() } source (the core StitchEventSource intake)', async () => {
+        const source = {
+            stream: () => events({ type: 'delta', chunk: 'a', at: 0 }),
+        };
+        const { messages, error } = await collect(streamStitchSse(source));
+        expect(error).toBeUndefined();
+        expect(dataOf(messages)).toEqual(['a']);
+    });
+
+    it('by default errors the observable with the generic token, withholding the raw upstream message', async () => {
+        const { messages, error } = await collect(
+            streamStitchSse(
                 events(
                     { type: 'delta', chunk: 'a', at: 0 },
                     {
@@ -63,9 +76,10 @@ describe('stitchSse', () => {
                 ),
             ),
         );
-        expect(data).toEqual(['a']); // prior deltas are still delivered
-        // Nest renders an errored observable's `message` to the client, so it must be the safe token.
-        expect(error?.message).toBe('Upstream request failed');
+        expect(dataOf(messages)).toEqual(['a']); // prior deltas are still delivered
+        // Nest renders an errored observable's `message` to the client, so it must be the
+        // generic token — the same default `data: error` the express/hono helpers write.
+        expect(error?.message).toBe('error');
         expect(error?.message).not.toContain('payments.internal.corp');
         // …but the raw failure is preserved server-side as the error's `cause`.
         expect(
@@ -73,47 +87,23 @@ describe('stitchSse', () => {
         ).toBe('getaddrinfo ENOTFOUND payments.internal.corp');
     });
 
-    it('exposeMessage opts in to forwarding the raw upstream message', async () => {
-        const { data, error } = await collect(
-            stitchSse(
-                events(
-                    { type: 'delta', chunk: 'a', at: 0 },
-                    {
-                        type: 'error',
-                        name: 'StitchError',
-                        message: 'upstream blew up',
-                        attempts: 1,
-                        at: 0,
-                    },
-                ),
-                { exposeMessage: true },
-            ),
-        );
-        expect(data).toEqual(['a']);
-        expect(error?.message).toBe('upstream blew up');
-    });
-
-    it('message sets a curated client-facing message (string or function), overriding exposeMessage', async () => {
-        const fixed = await collect(
-            stitchSse(
+    it('errorData shapes the client-facing error frame (raw message opt-in)', async () => {
+        const raw = await collect(
+            streamStitchSse(
                 events({
                     type: 'error',
                     name: 'StitchError',
-                    message: 'getaddrinfo ENOTFOUND payments.internal.corp',
+                    message: 'upstream blew up',
                     attempts: 1,
                     at: 0,
                 }),
-                {
-                    message: 'Payment provider unavailable',
-                    exposeMessage: true,
-                },
+                { errorData: (e) => e.message },
             ),
         );
-        expect(fixed.error?.message).toBe('Payment provider unavailable');
-        expect(fixed.error?.message).not.toContain('payments.internal.corp');
+        expect(raw.error?.message).toBe('upstream blew up');
 
-        const dynamic = await collect(
-            stitchSse(
+        const curated = await collect(
+            streamStitchSse(
                 events({
                     type: 'error',
                     name: 'StitchError',
@@ -122,33 +112,125 @@ describe('stitchSse', () => {
                     attempts: 1,
                     at: 0,
                 }),
-                { message: (e) => `upstream ${e.status ?? '???'}` },
+                { errorData: (e) => `upstream ${e.status ?? '???'}` },
             ),
         );
-        expect(dynamic.error?.message).toBe('upstream 503');
+        expect(curated.error?.message).toBe('upstream 503');
     });
 
-    it('by default withholds the raw message on a thrown error too, preserving it as cause', async () => {
+    it('onError observes the real failure server-side without shaping the client frame', async () => {
+        const seen: unknown[] = [];
+        const { error } = await collect(
+            streamStitchSse(
+                events({
+                    type: 'error',
+                    name: 'StitchError',
+                    message: 'getaddrinfo ENOTFOUND payments.internal.corp',
+                    attempts: 1,
+                    at: 0,
+                }),
+                { onError: (err) => seen.push(err) },
+            ),
+        );
+        expect(seen).toHaveLength(1);
+        expect((seen[0] as Error).message).toBe(
+            'getaddrinfo ENOTFOUND payments.internal.corp',
+        );
+        // The client frame stays generic — onError is observation only.
+        expect(error?.message).toBe('error');
+    });
+
+    it('by default withholds the raw message on a thrown error too, preserving it as cause and reporting via onError', async () => {
         async function* boom(): AsyncGenerator<StitchEvent, void> {
             yield { type: 'delta', chunk: 'a', at: 0 };
             throw new Error('getaddrinfo ENOTFOUND payments.internal.corp');
         }
-        const { data, error } = await collect(stitchSse(boom()));
-        expect(data).toEqual(['a']);
-        expect(error?.message).toBe('Upstream request failed');
+        const seen: unknown[] = [];
+        const { messages, error } = await collect(
+            streamStitchSse(boom(), { onError: (err) => seen.push(err) }),
+        );
+        expect(dataOf(messages)).toEqual(['a']);
+        expect(error?.message).toBe('error');
         expect(error?.message).not.toContain('payments.internal.corp');
         expect((error?.cause as Error | undefined)?.message).toBe(
             'getaddrinfo ENOTFOUND payments.internal.corp',
         );
+        expect((seen[0] as Error).message).toBe(
+            'getaddrinfo ENOTFOUND payments.internal.corp',
+        );
     });
 
-    it('applies the data mapper to each chunk', async () => {
-        const { data } = await collect(
-            stitchSse(events({ type: 'delta', chunk: { text: 'hi' }, at: 0 }), {
-                data: (c) => (c as { text: string }).text,
-            }),
+    it('applies the data mapper to each chunk; the default JSON-stringifies non-strings', async () => {
+        const mapped = await collect(
+            streamStitchSse(
+                events({ type: 'delta', chunk: { text: 'hi' }, at: 0 }),
+                { data: (c) => (c as { text: string }).text },
+            ),
         );
-        expect(data).toEqual(['hi']);
+        expect(dataOf(mapped.messages)).toEqual(['hi']);
+
+        const stringified = await collect(
+            streamStitchSse(
+                events({ type: 'delta', chunk: { text: 'hi' }, at: 0 }),
+            ),
+        );
+        expect(dataOf(stringified.messages)).toEqual(['{"text":"hi"}']);
+    });
+
+    it('the data mapper receives the zero-based message index', async () => {
+        const { messages } = await collect(
+            streamStitchSse(
+                events(
+                    { type: 'delta', chunk: 'a', at: 0 },
+                    { type: 'delta', chunk: 'b', at: 0 },
+                ),
+                { data: (c, index) => `${String(c)}#${index}` },
+            ),
+        );
+        expect(dataOf(messages)).toEqual(['a#0', 'b#1']);
+    });
+
+    it('event accepts a function of the chunk for per-message event names', async () => {
+        const { messages } = await collect(
+            streamStitchSse(
+                events(
+                    {
+                        type: 'delta',
+                        chunk: { kind: 'token', text: 'a' },
+                        at: 0,
+                    },
+                    {
+                        type: 'delta',
+                        chunk: { kind: 'usage', text: 'b' },
+                        at: 0,
+                    },
+                ),
+                {
+                    event: (c) => (c as { kind: string }).kind,
+                    data: (c) => (c as { text: string }).text,
+                },
+            ),
+        );
+        expect(messages).toEqual([
+            { data: 'a', type: 'token' },
+            { data: 'b', type: 'usage' },
+        ]);
+    });
+
+    it('event names each message and id stamps the (chunk, index) last-event id', async () => {
+        const { messages } = await collect(
+            streamStitchSse(
+                events(
+                    { type: 'delta', chunk: 'a', at: 0 },
+                    { type: 'delta', chunk: 'b', at: 0 },
+                ),
+                { event: 'token', id: (_chunk, index) => `#${index}` },
+            ),
+        );
+        expect(messages).toEqual([
+            { data: 'a', type: 'token', id: '#0' },
+            { data: 'b', type: 'token', id: '#1' },
+        ]);
     });
 
     it('aborts the upstream generator when the subscription tears down', async () => {
@@ -170,7 +252,7 @@ describe('stitchSse', () => {
                 };
             },
         };
-        const sub = stitchSse(gen).subscribe({ next: () => {} });
+        const sub = streamStitchSse(gen).subscribe({ next: () => {} });
         sub.unsubscribe();
         expect(returned).toBe(true); // teardown called iterator.return()
     });

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -6,7 +6,7 @@
 
 Next App Router route handlers are Web-standard — they take a `Request` and return a `Response` — so a stitch already runs in one directly: define a `seam` once and call it in the handler. What's worth a helper is the two bits you'd otherwise hand-roll on the Web platform:
 
--   **`sseResponse(stitch.stream())`** — turn a streaming stitch into a `text/event-stream` `Response`.
+-   **`streamStitchSse(stitch.stream())`** — turn a streaming stitch into a `text/event-stream` `Response`.
 -   **`stitchErrorResponse(err)`** — map a thrown `StitchError` to a `Response` with a safe status, or `undefined` for anything else so you can rethrow it.
 
 Built on Web standards only (`Response`, `ReadableStream`, `TextEncoder`) — **no `next` import** — so the same helpers also work in Remix, SvelteKit endpoints, Bun, Deno, and Workers.
@@ -48,17 +48,17 @@ export async function GET(
 
 ## Streaming with SSE
 
-`sseResponse` streams a stitch's events as `text/event-stream`. Each `delta` becomes one frame; an `error` event ends with a named `event: error` frame (a generic `data: error` by default — see below):
+`streamStitchSse` streams a stitch's events as `text/event-stream`. Each `delta` becomes one frame; an `error` event ends with a named `event: error` frame (a generic `data: error` by default — see below):
 
 ```ts
 // app/api/chat/route.ts
 import { chat } from '@/lib/api';
 
-import { sseResponse } from '@stitchapi/next';
+import { streamStitchSse } from '@stitchapi/next';
 
 export async function POST(request: Request) {
     const { prompt } = await request.json();
-    return sseResponse(chat({ body: { prompt } }).stream(), {
+    return streamStitchSse(chat({ body: { prompt } }).stream(), {
         delta: (c) => String(c), // pull text out of each chunk
         signal: request.signal, // abort the upstream if the client leaves
     });
@@ -70,7 +70,7 @@ Pass `request.signal` so a client disconnect tears the stitch down rather than l
 By default the `error` frame carries a generic `data: error` token, **not** the raw error message — echoing it can disclose internal network topology (a transport failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`) or the upstream's status (`HTTP 401`) to the client. Pass `error` to opt in when the upstream messages are known safe to expose:
 
 ```ts
-return sseResponse(chat({ body: { prompt } }).stream(), {
+return streamStitchSse(chat({ body: { prompt } }).stream(), {
     error: (e) => e.message, // opt in to the raw upstream message
 });
 ```

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -5,7 +5,7 @@
 // then call it in the handler. What's worth a helper is the two bits you'd otherwise
 // hand-roll on the Web platform:
 //
-// - `sseResponse(stitch.stream())` — turn a streaming stitch into a `text/event-stream`
+// - `streamStitchSse(stitch.stream())` — turn a streaming stitch into a `text/event-stream`
 //   `Response` (the Web-standard twin of `@stitchapi/express`'s `streamStitchSse`,
 //   which targets a Node `ServerResponse`).
 // - `stitchErrorResponse(err)` — map a thrown `StitchError` to a `Response` with a
@@ -24,6 +24,7 @@ import {
     resolveError,
     sseFrame,
     toErrorEvent,
+    toIterable,
 } from 'stitchapi/sse-emit';
 
 // ---------------------------------------------------------------------------
@@ -51,18 +52,18 @@ export interface SseResponseOptions extends SseEmitOptions {
  *
  * ```ts
  * // app/api/chat/route.ts
- * import { sseResponse } from '@stitchapi/next';
+ * import { streamStitchSse } from '@stitchapi/next';
  *
  * export async function POST(request: Request) {
  *     const { prompt } = await request.json();
- *     return sseResponse(chat({ body: { prompt } }).stream(), {
+ *     return streamStitchSse(chat({ body: { prompt } }).stream(), {
  *         delta: (c) => String(c),
  *         signal: request.signal, // abort the upstream if the client leaves
  *     });
  * }
  * ```
  */
-export function sseResponse<T>(
+export function streamStitchSse<T>(
     source: StitchEventSource<T>,
     options: SseResponseOptions = {},
 ): Response {
@@ -73,7 +74,7 @@ export function sseResponse<T>(
     const stream = new ReadableStream<Uint8Array>({
         async start(controller) {
             try {
-                for await (const event of source) {
+                for await (const event of toIterable(source)) {
                     if (options.signal?.aborted) break;
                     if (event.type === 'delta') {
                         controller.enqueue(
@@ -153,7 +154,7 @@ const STATUS_TEXT: Record<number, string> = {
     502: 'Bad Gateway',
 };
 
-export interface ErrorResponseOptions {
+export interface StitchErrorOptions {
     /**
      * The HTTP status for the mapped failure. Default `502` for a `StitchError` (an
      * upstream gateway failure) and `500` otherwise — the safe default never leaks an
@@ -191,11 +192,11 @@ export interface ErrorResponseOptions {
  * The default body is a generic, status-tied message (`{ error: 'Bad Gateway' }`) — the
  * raw `err.message` is **not** echoed, since it can leak internal hostnames or the
  * upstream's status to an untrusted client. Opt in to a custom (or the raw) message with
- * {@link ErrorResponseOptions.body}.
+ * {@link StitchErrorOptions.body}.
  */
 export function stitchErrorResponse(
     err: unknown,
-    options: ErrorResponseOptions = {},
+    options: StitchErrorOptions = {},
 ): Response | undefined {
     if (!isStitchError(err)) return undefined;
     const status =

--- a/packages/next/test/next.spec.ts
+++ b/packages/next/test/next.spec.ts
@@ -1,6 +1,6 @@
 // @stitchapi/next behaviour — Web-standard Response helpers driven with fake event
 // sources and errors. No engine, no Next.
-import { isStitchError, sseResponse, stitchErrorResponse } from '../src';
+import { isStitchError, stitchErrorResponse, streamStitchSse } from '../src';
 
 import type { StitchEvent } from 'stitchapi';
 import { describe, expect, test } from 'vitest';
@@ -41,11 +41,11 @@ function stitchError(message: string, status?: number): Error {
     return e;
 }
 
-// --- sseResponse -----------------------------------------------------------
+// --- streamStitchSse -----------------------------------------------------------
 
-describe('sseResponse', () => {
+describe('streamStitchSse', () => {
     test('streams each delta as an SSE frame and sets the content type', async () => {
-        const res = sseResponse(
+        const res = streamStitchSse(
             events(delta('a'), delta('b'), result(['a', 'b']), done),
         );
         expect(res.headers.get('content-type')).toBe(
@@ -55,15 +55,21 @@ describe('sseResponse', () => {
         expect(body).toBe('data: a\n\ndata: b\n\n');
     });
 
+    test('accepts anything with a .stream() (the core StitchEventSource intake)', async () => {
+        const source = { stream: () => events(delta('a'), done) };
+        const res = streamStitchSse(source);
+        expect(await res.text()).toBe('data: a\n\n');
+    });
+
     test('a `delta` function shorthand pulls text out of a structured chunk', async () => {
-        const res = sseResponse(events(delta({ text: 'hi' }), done), {
+        const res = streamStitchSse(events(delta({ text: 'hi' }), done), {
             delta: (c) => (c as { text: string }).text,
         });
         expect(await res.text()).toBe('data: hi\n\n');
     });
 
     test('by default an error event yields a named event: error frame with a generic token, never the raw message', async () => {
-        const res = sseResponse(
+        const res = streamStitchSse(
             events(delta('a'), {
                 type: 'error',
                 name: 'StitchError',
@@ -84,7 +90,7 @@ describe('sseResponse', () => {
     });
 
     test('error (function shorthand) opts in to the raw message on the error frame', async () => {
-        const res = sseResponse(
+        const res = streamStitchSse(
             events(delta('a'), {
                 type: 'error',
                 name: 'StitchError',
@@ -101,14 +107,14 @@ describe('sseResponse', () => {
     });
 
     test('the delta.event option labels each frame', async () => {
-        const res = sseResponse(events(delta('a'), done), {
+        const res = streamStitchSse(events(delta('a'), done), {
             delta: { event: 'token' },
         });
         expect(await res.text()).toBe('event: token\ndata: a\n\n');
     });
 
     test('the delta.id option emits an id: line per frame with the zero-based index', async () => {
-        const res = sseResponse(events(delta('a'), delta('b'), done), {
+        const res = streamStitchSse(events(delta('a'), delta('b'), done), {
             delta: { id: (chunk, i) => `${String(chunk)}-${i}` },
         });
         expect(await res.text()).toBe(
@@ -117,12 +123,12 @@ describe('sseResponse', () => {
     });
 
     test('a multi-line chunk gets one data: prefix per line (SSE spec)', async () => {
-        const res = sseResponse(events(delta('l1\nl2'), done));
+        const res = streamStitchSse(events(delta('l1\nl2'), done));
         expect(await res.text()).toBe('data: l1\ndata: l2\n\n');
     });
 
     test('extra headers merge over the SSE defaults, with overrides winning', async () => {
-        const res = sseResponse(events(delta('a'), done), {
+        const res = streamStitchSse(events(delta('a'), done), {
             headers: { 'x-custom': '1', 'cache-control': 'no-store' },
         });
         expect(res.headers.get('x-custom')).toBe('1');
@@ -136,7 +142,7 @@ describe('sseResponse', () => {
     });
 
     test('a pre-aborted signal yields no frames', async () => {
-        const res = sseResponse(events(delta('a'), delta('b'), done), {
+        const res = streamStitchSse(events(delta('a'), delta('b'), done), {
             signal: AbortSignal.abort(),
         });
         expect(await res.text()).toBe('');
@@ -148,7 +154,7 @@ describe('sseResponse', () => {
             // A transport failure disclosing an internal hostname must not reach the client.
             throw new Error('getaddrinfo ENOTFOUND payments.internal.corp');
         }
-        const res = sseResponse(boom());
+        const res = streamStitchSse(boom());
         const body = await res.text();
         expect(body).toBe('data: a\n\nevent: error\ndata: error\n\n');
         expect(body).not.toContain('payments.internal.corp');
@@ -160,14 +166,14 @@ describe('sseResponse', () => {
             yield delta('a');
             throw new Error('stream blew up');
         }
-        const res = sseResponse(boom(), { error: (e) => e.message });
+        const res = streamStitchSse(boom(), { error: (e) => e.message });
         const body = await res.text();
         expect(body).toBe('data: a\n\nevent: error\ndata: stream blew up\n\n');
     });
 
     test('error.observe sees the real failure even when the client gets the generic token', async () => {
         const observed: unknown[] = [];
-        const res = sseResponse(
+        const res = streamStitchSse(
             events(delta('a'), {
                 type: 'error',
                 name: 'StitchError',
@@ -187,7 +193,7 @@ describe('sseResponse', () => {
     });
 
     test('error can be the full object with a custom event name', async () => {
-        const res = sseResponse(
+        const res = streamStitchSse(
             events(delta('a'), {
                 type: 'error',
                 name: 'StitchError',


### PR DESCRIPTION
Broken out of #470 — the **nest** half of the host convergence (#520 covered the other five).

> Stacked on #520. Base is `refactor/hosts-converge`; it retargets to `main` once #520 merges.

## P16 — the same names every other host now uses

```ts
ToHttpExceptionOptions → StitchErrorOptions
stitchSse              → streamStitchSse
StitchSseOptions       → StreamStitchSseOptions
```

The SSE bridge also takes `StitchEventSource` (re-exported from the core barrel) like every other
host, so a `StitchResult` can be handed straight to it.

## P16 — the error body is one envelope

`exposeMessage` was a boolean bolted beside the message override. Both fold into **`body`**,
matching the `delta` / `error` envelopes the SSE hosts converged on in #484.

## P13/P20 — the Nest logger bridge is a toggle, not a magic string in an unrelated slot

It was spelled `trace: 'logger'` — a sentinel **string** smuggled into the `TraceSink` slot, which
forced `StitchModuleOptions` to `Omit` and re-declare `trace`. It becomes its own field:

```ts
logger?: boolean | AtLeastOne<NestLoggerSinkOptions>
```

so `StitchModuleOptions extends SeamOptions` cleanly again, and `trace` means only what it means
everywhere else.

## ⚠️ Behavior change — the Nest logger bridge is now ON by default

This is the one non-mechanical change in the slice, so calling it out explicitly.

**P8, same concept → same default across packages.** `@stitchapi/fastify`'s plugin already defaults
its logger bridge **on** (`packages/fastify/src/plugin.ts`: *"Default `true` (the bridge is on)"*) —
nest was the outlier at off. I verified fastify's actual default before making the change rather
than taking #470's word for it.

**This does not weaken "no side effects by default."** That principle governs a bare `stitch()`,
which still writes and prints nothing. A host **module** is explicit infrastructure you mounted,
into a framework whose logger is already running. Opt out with `logger: false`, or keep it quiet on
the happy path with `logger: { lifecycle: false }`; an explicit `trace` still wins over the bridge.

If you'd rather nest stayed opt-in and fastify changed instead, say so — that's a one-line flip in
the other direction.

## Deferred out of this PR

#470's amendment to `docs/adr/0006-nestjs-integration.md` is **not** here. It links to CONTRACT.md's
`P24` heading and a renamed `§6`, **neither of which exists on `main` yet** — so it lands with the
contract/ratchet slice that adds them, rather than shipping a dangling anchor now.

## Verification

- nest typecheck clean; **4 files / 56 tests green**; full workspace suite green
- contract ratchet **0**; docs-links 110 routes OK; prettier clean
- apps/docs production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)