### PR TITLE
refactor(aws-sigv4,react-native,rtk-query,vercel-ai,pino,sentry)!: leaf-package contract alignment (P22/P15/P12)

### DIFF
--- a/apps/docs/content/docs/integrations/aws-sigv4.mdx
+++ b/apps/docs/content/docs/integrations/aws-sigv4.mdx
@@ -97,7 +97,7 @@ const { authorization } = await signRequestV4({
     secretAccessKey: '…',
     region: 'us-east-1',
     service: 'service',
-    dateTime: '20150830T123600Z',
+    amzDate: '20150830T123600Z',
 });
 ```
 

--- a/apps/docs/content/docs/integrations/rtk-query.mdx
+++ b/apps/docs/content/docs/integrations/rtk-query.mdx
@@ -70,8 +70,9 @@ chat: build.query<number[], { prompt: string }>({
 ```
 
 The cached data is the accumulated chunks (`mode: 'append'`, default) or the latest
-chunk (`mode: 'replace'`). Streaming stops when the cache entry is removed (the last
-subscriber leaves).
+chunk — pass the mode as a scalar shorthand:
+`stitchStreamUpdater(chat, 'replace')` ≡ `stitchStreamUpdater(chat, { mode: 'replace' })`.
+Streaming stops when the cache entry is removed (the last subscriber leaves).
 
 <Callout type="info">
     Reach for these adapters when RTK Query already owns your view state and you

--- a/apps/docs/content/docs/integrations/vercel-ai.mdx
+++ b/apps/docs/content/docs/integrations/vercel-ai.mdx
@@ -53,6 +53,11 @@ const { text } = await generateText({
 -   `toInput` — maps the model's args onto the stitch's `{ params, query, body }`. Omit
     it when the model's args _are_ the stitch input.
 
+When the schema is all you need, pass it positionally —
+`stitchTool(getUser, z.object({ params: z.object({ id: z.string() }) }))` ≡
+`stitchTool(getUser, { inputSchema: … })` with the args used as the stitch input
+directly.
+
 The tool's result is the stitch's validated output, so the model reasons over real
 data, not a guess; a failure rejects, and the AI SDK's tool-error handling reports it.
 

--- a/packages/aws-sigv4/README.md
+++ b/packages/aws-sigv4/README.md
@@ -71,7 +71,7 @@ const { authorization, signature } = await signRequestV4({
     secretAccessKey: '…',
     region: 'us-east-1',
     service: 'service',
-    dateTime: '20150830T123600Z',
+    amzDate: '20150830T123600Z',
 });
 ```
 

--- a/packages/aws-sigv4/src/index.ts
+++ b/packages/aws-sigv4/src/index.ts
@@ -143,8 +143,9 @@ export interface SignV4Options {
     sessionToken?: string;
     region: string;
     service: string;
-    /** Amz datetime, `YYYYMMDDTHHMMSSZ`. */
-    dateTime: string;
+    /** Amz datetime, `YYYYMMDDTHHMMSSZ` — echoed back as `SignV4Result.amzDate`
+     * and sent as the `x-amz-date` header. */
+    amzDate: string;
 }
 
 export interface SignV4Result {
@@ -156,14 +157,14 @@ export interface SignV4Result {
 }
 
 /**
- * Compute a SigV4 signature for a request. Pure (given `dateTime`), so it is
+ * Compute a SigV4 signature for a request. Pure (given `amzDate`), so it is
  * verifiable against the official AWS `aws-sig-v4-test-suite` vectors. The
  * {@link awsSigV4} strategy wraps this with timestamping, payload hashing, and
  * header attachment.
  */
 export async function signRequestV4(p: SignV4Options): Promise<SignV4Result> {
     const u = new URL(p.url);
-    const amzDate = p.dateTime;
+    const amzDate = p.amzDate;
     const dateStamp = amzDate.slice(0, 8);
 
     const headers: Record<string, string> = {};
@@ -376,7 +377,7 @@ export function awsSigV4(opts: AwsSigV4Options): AuthStrategy {
                 ...(sessionToken ? { sessionToken } : {}),
                 region: opts.region,
                 service: opts.service,
-                dateTime: amzDate,
+                amzDate,
             });
 
             req.headers['authorization'] = authorization;

--- a/packages/aws-sigv4/test/sigv4.spec.ts
+++ b/packages/aws-sigv4/test/sigv4.spec.ts
@@ -47,7 +47,7 @@ describe('signRequestV4 (AWS official vectors)', () => {
                 secretAccessKey: SECRET_KEY,
                 region: 'us-east-1',
                 service: 'service',
-                dateTime: '20150830T123600Z',
+                amzDate: '20150830T123600Z',
             },
         );
 
@@ -72,7 +72,7 @@ describe('signRequestV4 (AWS official vectors)', () => {
             secretAccessKey: SECRET_KEY,
             region: 'us-east-1',
             service: 'service',
-            dateTime: '20150830T123600Z',
+            amzDate: '20150830T123600Z',
         } as const;
         const a = await signRequestV4({
             ...base,
@@ -94,7 +94,7 @@ describe('signRequestV4 (AWS official vectors)', () => {
             secretAccessKey: SECRET_KEY,
             region: 'us-east-1',
             service: 'service',
-            dateTime: '20150830T123600Z',
+            amzDate: '20150830T123600Z',
         } as const;
         // A mixed-case name and a value with leading/trailing/inner whitespace must
         // canonicalise to the already-clean form → an identical signature.
@@ -122,7 +122,7 @@ describe('signRequestV4 (AWS official vectors)', () => {
             secretAccessKey: SECRET_KEY,
             region: 'us-east-1',
             service: 'service',
-            dateTime: '20150830T123600Z',
+            amzDate: '20150830T123600Z',
         } as const;
         const explicit = await signRequestV4({
             ...base,
@@ -351,7 +351,7 @@ describe('awsSigV4 strategy', () => {
             secretAccessKey: SECRET_KEY,
             region: 'us-east-1',
             service: 's3',
-            dateTime: '20150830T123600Z',
+            amzDate: '20150830T123600Z',
         } as const;
         const aclPublic = await signRequestV4({
             ...base,

--- a/packages/deno-kv/test/store-behaviour.spec.ts
+++ b/packages/deno-kv/test/store-behaviour.spec.ts
@@ -427,6 +427,53 @@ describe('denoKvStore — increment without a window', () => {
     });
 });
 
+describe('denoKvStore — increment without a window', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    test('absent ttl = no window: the counter accumulates and never expires', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        const store = denoKvStore(expiryKv());
+
+        expect(await store.increment('count')).toBe(1);
+        // Arbitrarily far in the future — a windowless counter never resets.
+        vi.setSystemTime(1_000_000_000);
+        expect(await store.increment('count')).toBe(2);
+        expect(await store.increment('count')).toBe(3);
+        // `get` unwraps the envelope to the plain count, windowed or not.
+        expect(await store.get('count')).toBe(3);
+    });
+
+    test('ttl <= 0 unifies with absent: no window, and no commit carries an expireIn', async () => {
+        const rec = recordingKv();
+        const store = denoKvStore(rec.kv);
+
+        expect(await store.increment('count')).toBe(1);
+        expect(await store.increment('count', 0)).toBe(2);
+        expect(await store.increment('count', -5)).toBe(3);
+
+        // A windowless counter is written WITHOUT an expiry, matching `set`'s
+        // no-TTL path — the key must never silently gain a window.
+        expect(rec.atomicSets).toHaveLength(3);
+        for (const s of rec.atomicSets) expect(s.expireIn).toBeUndefined();
+    });
+
+    test('a live windowless counter keeps counting even when a later increment passes a ttl', async () => {
+        // Mirrors memoryStore: a LIVE counter keeps its original (absent) window;
+        // a later ttl neither expires it nor resets the count.
+        vi.useFakeTimers();
+        vi.setSystemTime(0);
+        const store = denoKvStore(expiryKv());
+
+        expect(await store.increment('count')).toBe(1); // windowless
+        expect(await store.increment('count', 200)).toBe(2); // ttl ignored — still live
+        vi.setSystemTime(500); // past the ttl that was ignored
+        expect(await store.increment('count')).toBe(3);
+    });
+});
+
 describe('denoKvStore — keys & lifecycle', () => {
     test('maps a string key to a flat one-segment array key by default', async () => {
         const rec = recordingKv();

--- a/packages/eval-harness/runner/prebaked.ts
+++ b/packages/eval-harness/runner/prebaked.ts
@@ -42,7 +42,7 @@ export async function run(fetchImpl: typeof fetch): Promise<User[]> {
         path: '/paged/users',
         adapter: fetchAdapter({ fetch: fetchImpl }),
         // Transient 429s before success — retry with backoff.
-        retry: { attempts: 4, on: [429, 503], backoff: 'fixed', baseMs: 0 },
+        retry: { attempts: 4, on: [429, 503], backoff: 'fixed', baseDelay: 0 },
         // Follow the cursor until nextCursor is null, aggregating items.
         paginate: {
             next: (prev) => {
@@ -50,7 +50,7 @@ export async function run(fetchImpl: typeof fetch): Promise<User[]> {
                 return cursor ? { query: { cursor } } : undefined;
             },
             items: (page) => (page as Page).items,
-            max: 20,
+            pages: 20,
         },
         // Validate every aggregated record is a real user.
         output: (v: unknown) => Array.isArray(v) && v.every(isUser),
@@ -87,7 +87,7 @@ export async function run(fetchImpl: typeof fetch): Promise<User> {
         path: '/graphql',
         adapter: fetchAdapter({ fetch: fetchImpl }),
         document: 'query { user { id name email } }',
-        // The graphql surface unwraps 'data' and treats a non-empty errors[] as a failure.
+        // The graphql surface picks from 'data' and treats a non-empty errors[] as a failure.
         pick: 'data.user',
         output: (v: unknown): v is User =>
             !!v && typeof v === 'object' &&

--- a/packages/expo/README.md
+++ b/packages/expo/README.md
@@ -67,7 +67,7 @@ import {
 
 const q = useStitch(getInbox, {});
 useAppActiveRefetch(q);
-useReconnectRefetch(q, { netInfo: NetInfo });
+useReconnectRefetch(q, NetInfo);
 ```
 
 ## The secure store

--- a/packages/pino/README.md
+++ b/packages/pino/README.md
@@ -45,6 +45,11 @@ retries, drift findings, and errors:
 pinoSink(pino(), { lifecycle: false });
 ```
 
+> [!NOTE]
+> The same `lifecycle` option in `@stitchapi/sentry` defaults to `false` — a
+> **deliberate** divergence: Pino log lines are cheap and level-filtered, while
+> Sentry breadcrumbs/events cost quota.
+
 ## Bring your own logger
 
 This package **imports no logger** — it runs on a small structural
@@ -63,7 +68,7 @@ v8 and v9.
 Concretely, it logs the stitch name, method, **redacted URL** (the query string is
 stripped — it can carry `?api_key=…`), status, attempt counts, drift
 path/level/change, progress phase, and timing. It **never** logs `event.input`
-(headers like `authorization` / `cookie` stay raw on the event), `event.value`
+(headers like `authorization` / `cookie` stay raw on the event), `event.data`
 (the response body), a `delta` chunk, or `JSON.stringify(event)`. That keeps it
 safe on a secret-bearing seam regardless of core's trace redaction — proven by a
 test that feeds a `start` event whose `input.headers.authorization` is set and

--- a/packages/pino/src/index.ts
+++ b/packages/pino/src/index.ts
@@ -52,6 +52,11 @@ export interface PinoSinkOptions {
      * `done` → `debug`. Default `true`. `start`/`done` sit at `debug` so a production
      * pino level (`info`) hides them by default; set `false` to drop the lifecycle
      * entirely and log only retries, drift findings, and errors.
+     *
+     * DELIBERATE DIVERGENCE (contract P8): `@stitchapi/sentry`'s same-named
+     * `lifecycle` defaults to `false`. Pino log lines are cheap and level-filtered,
+     * so the lifecycle is on by default here; Sentry breadcrumbs/events cost quota,
+     * so it is off by default there.
      */
     lifecycle?: boolean;
 }

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -64,7 +64,7 @@ function Chat({ prompt }: { prompt: string }) {
 }
 ```
 
-`useStitch` / `useStitchStream` / `queryOptions` and their types are re-exported here, so you import everything from `@stitchapi/react-native`.
+`useStitch` / `useStitchStream` / `stitchQueryOptions` and their types are re-exported here, so you import everything from `@stitchapi/react-native`.
 
 ## Refetch on foreground / reconnect
 
@@ -79,16 +79,16 @@ import {
 function Inbox() {
     const q = useStitch(getInbox, {});
     useAppActiveRefetch(q); // refetch when the app returns to the foreground
-    useReconnectRefetch(q, { netInfo: NetInfo }); // refetch when connectivity returns
+    useReconnectRefetch(q, NetInfo); // refetch when connectivity returns
     // ...
 }
 ```
 
-Both subscriptions are also available as plain functions — `onAppActive(appState, cb)` and `onReconnect(netInfo, cb)` — for use outside React.
+`useReconnectRefetch` takes the NetInfo module positionally; pass the options envelope (`{ netInfo, enabled }`) when you also need `enabled`. Both subscriptions are also available as plain functions — `onAppActive(appState, cb)` and `onReconnect(netInfo, cb)` — for use outside React.
 
 ## The persistent store
 
-`asyncStorageStore(storage, options?)` accepts any client matching `{ getItem, setItem, removeItem }` (the community AsyncStorage module, an MMKV shim, a test double). Values ride in a JSON envelope with an absolute expiry (AsyncStorage has no native TTL); `increment` is serialized so concurrent increments stay atomic — the throttle counter behaves exactly as it does on Redis. Pass `keyPrefix` to namespace, `now` to inject a clock in tests.
+`asyncStorageStore(storage, options?)` accepts any client matching `{ getItem, setItem, removeItem }` (the community AsyncStorage module, an MMKV shim, a test double). Values ride in a JSON envelope with an absolute expiry (AsyncStorage has no native TTL); `increment` is serialized so concurrent increments stay atomic — the throttle counter behaves exactly as it does on Redis. Pass `keyPrefix` to namespace (default `'stitch:'` — AsyncStorage is the app's one shared bucket, so the store namespaces by default), `now` to inject a clock in tests.
 
 ## License
 

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,6 +1,6 @@
 // @stitchapi/react-native — React Native bindings for StitchAPI.
 //
-// The hooks (`useStitch` / `useStitchStream` / `queryOptions`) are re-exported
+// The hooks (`useStitch` / `useStitchStream` / `stitchQueryOptions`) are re-exported
 // verbatim from `@stitchapi/react`: they are pure `useSyncExternalStore` over the
 // shared `@stitchapi/query-core` store and run unchanged on React Native. What this
 // package ADDS is the platform glue bare RN needs:

--- a/packages/react-native/src/lifecycle.ts
+++ b/packages/react-native/src/lifecycle.ts
@@ -109,25 +109,34 @@ export interface ReconnectRefetchOptions {
     /** Turn the subscription on/off without unmounting (default `true`). */
     enabled?: boolean;
     /**
-     * The NetInfo module — required, because `@react-native-community/netinfo` is
-     * an optional peer this package does not bundle. Pass the imported module.
+     * The NetInfo module — required (P15), because `@react-native-community/netinfo`
+     * is an optional peer this package does not bundle. Pass the imported module;
+     * or skip the envelope and pass the module positionally.
      */
     netInfo: NetInfoLike;
 }
 
 /**
- * Refetch a stitch query whenever connectivity returns.
+ * Refetch a stitch query whenever connectivity returns. The NetInfo module is the
+ * one required value, so it can be passed positionally (P15 shorthand); use the
+ * options envelope when you also need `enabled`.
  *
  * ```tsx
  * import NetInfo from '@react-native-community/netinfo';
- * useReconnectRefetch(q, { netInfo: NetInfo });
+ * useReconnectRefetch(q, NetInfo);
+ * // or, with the envelope:
+ * useReconnectRefetch(q, { netInfo: NetInfo, enabled: isLoggedIn });
  * ```
  */
 export function useReconnectRefetch(
     handle: Refetchable,
-    options: ReconnectRefetchOptions,
+    options: NetInfoLike | ReconnectRefetchOptions,
 ): void {
-    const { enabled = true, netInfo } = options;
+    // A NetInfoLike is distinguishable by its `addEventListener`; the envelope
+    // carries the module under `netInfo` instead.
+    const opts: ReconnectRefetchOptions =
+        'addEventListener' in options ? { netInfo: options } : options;
+    const { enabled = true, netInfo } = opts;
     const ref = useRef(handle);
     ref.current = handle;
     useEffect(() => {

--- a/packages/react-native/src/store.ts
+++ b/packages/react-native/src/store.ts
@@ -28,6 +28,11 @@ export interface AsyncStorageStoreOptions {
      * Prefix applied to every key, for sharing one AsyncStorage with other data.
      * Applied on read and write so the store stays self-consistent. Default
      * `'stitch:'`.
+     *
+     * Deliberate P8 divergence from `redisStore`'s `''` default: AsyncStorage is
+     * the app's single shared device-wide bucket — the app's own data lives right
+     * next to the store's keys — so namespacing by default prevents collisions.
+     * A Redis deployment typically dedicates a database/namespace instead.
      */
     keyPrefix?: string;
     /** Injectable clock (ms epoch) for deterministic TTL tests. Default `Date.now`. */

--- a/packages/react-native/test/lifecycle.spec.ts
+++ b/packages/react-native/test/lifecycle.spec.ts
@@ -1,7 +1,11 @@
 // The lifecycle subscription logic lives in two pure functions (onAppActive /
 // onReconnect) that take the platform module by argument; the hooks are thin
 // useEffect wrappers over them. Test the logic directly with fake emitters.
-import { onAppActive, onReconnect } from '../src/lifecycle';
+import {
+    onAppActive,
+    onReconnect,
+    useReconnectRefetch,
+} from '../src/lifecycle';
 import type { AppStateLike, NetInfoLike } from '../src/lifecycle';
 
 import { describe, expect, test } from 'vitest';
@@ -65,6 +69,17 @@ describe('onAppActive', () => {
         emit('active'); // unsubscribed: no
 
         expect(calls).toBe(2);
+    });
+});
+
+describe('useReconnectRefetch', () => {
+    test('accepts the NetInfo module positionally or in the envelope (P15, type-level)', () => {
+        const { netInfo } = fakeNetInfo();
+        type Second = Parameters<typeof useReconnectRefetch>[1];
+        const positional: Second = netInfo;
+        const envelope: Second = { netInfo, enabled: false };
+        expect(positional).toBeDefined();
+        expect(envelope).toBeDefined();
     });
 });
 

--- a/packages/rtk-query/README.md
+++ b/packages/rtk-query/README.md
@@ -16,7 +16,7 @@ pnpm add @stitchapi/rtk-query@rc stitchapi@rc @reduxjs/toolkit
 
 ## `stitchQueryFn` — a stitch as an endpoint
 
-`stitchQueryFn(stitch)` returns an endpoint `queryFn`: on success `{ data }` with the validated output, on a throw `{ error }` with a **serialisable** error (so Redux holds no non-serialisable value).
+`stitchQueryFn(stitch)` returns an endpoint `queryFn`: on success `{ data }` with the validated output, on a throw `{ error }` with a **serialisable** error (so Redux holds no non-serialisable value). The error keeps the thrown error's `name` (the discriminator), `message`, and every JSON-survivable own field — for a `StitchError` / `RateLimitError` that is the full `status` / `attempts` / `body` / `url` set, so you can branch on a stored error exactly as on the thrown one. Fields that would not survive `JSON.stringify` (functions, class instances, the raw `response` carrier) are dropped.
 
 ```ts
 import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
@@ -52,7 +52,7 @@ chat: build.query<number[], { prompt: string }>({
 }),
 ```
 
-The cached data is the accumulated chunks (`mode: 'append'`, default) or the latest chunk (`mode: 'replace'`). Streaming stops when the cache entry is removed (the last component unsubscribes).
+The cached data is the accumulated chunks (`'append'`, default) or the latest chunk — pass the mode directly: `stitchStreamUpdater(chat, 'replace')` (≡ `{ mode: 'replace' }`). Streaming stops when the cache entry is removed (the last component unsubscribes).
 
 ## License
 

--- a/packages/rtk-query/src/index.ts
+++ b/packages/rtk-query/src/index.ts
@@ -11,7 +11,7 @@
 // - `stitchStreamUpdater` — fold a streaming stitch's `delta` chunks into the cache
 //                          via an endpoint `onCacheEntryAdded` — RTK Query is the one
 //                          cache lib here that models streaming.
-import type { Stitch, StitchEvent } from 'stitchapi';
+import type { AtLeastOne, Stitch, StitchEvent } from 'stitchapi';
 
 // ---------------------------------------------------------------------------
 // The structural call contract
@@ -24,6 +24,11 @@ import type { Stitch, StitchEvent } from 'stitchapi';
 export type StitchLike<T, Input = unknown> = (input?: Input) => PromiseLike<T>;
 
 /** A callable whose result is also streamable (`sse` / `stream` surfaces). */
+// The INTENTIONAL rich tier, restated locally (CONTRACT.md P9 de-list): this is the same
+// awaitable-plus-`stream()` shape as `@stitchapi/query-core`'s canonical `StitchLike`, deliberately
+// under a DISTINCT name — two named tiers, not a unique-by-shape clash. It is restated rather than
+// imported because this package takes no `@stitchapi/query-core` dependency by design (RTK Query is
+// the store); a real stitch satisfies both tiers.
 export type StreamableStitchLike<T, Input = unknown> = (
     input?: Input,
 ) => PromiseLike<T> & { stream(): AsyncIterable<StitchEvent<T>> };
@@ -49,11 +54,21 @@ export type QueryInput<S> =
 // ---------------------------------------------------------------------------
 
 /** A serialisable representation of a thrown reason, safe to hold in Redux state:
- * the error's `name` and `message` plus any primitive own fields (e.g. a
- * `StitchError`'s `status`). */
+ * the error's `name` (the stable discriminator) and `message` plus every
+ * JSON-survivable own field. For a `StitchError` / `RateLimitError` that means the
+ * whole CONTRACT.md P10 field set — `status?`, `attempts`, `body?`, `url?` — survives
+ * into Redux state (`body` is the parsed response payload, plain JSON data), so a
+ * consumer can branch on a stored error exactly as on the thrown one. Fields that
+ * would not survive `JSON.stringify` intact (functions, class instances, cycles) are
+ * dropped, as is `RateLimitError.response`: core documents the raw `AdapterResponse`
+ * as riding on the live instance only, never a serialized surface. */
 export interface StitchQueryFnError {
     readonly name: string;
     readonly message: string;
+    readonly status?: number;
+    readonly attempts?: number;
+    readonly body?: unknown;
+    readonly url?: string;
     readonly [key: string]: unknown;
 }
 
@@ -63,14 +78,32 @@ export type QueryFnResult<Data> =
     | { data: Data; error?: undefined }
     | { data?: undefined; error: StitchQueryFnError };
 
-function isPrimitive(v: unknown): boolean {
-    return (
-        v === null ||
-        v === undefined ||
-        typeof v === 'string' ||
-        typeof v === 'number' ||
-        typeof v === 'boolean'
-    );
+/** Does `value` come back from a `JSON.stringify`/`parse` round trip intact? Plain
+ * data only: primitives (finite numbers — `NaN`/`Infinity` degrade to `null`),
+ * arrays, and plain objects. Class instances (a raw `Response`, a nested `Error`),
+ * functions, symbols, bigints, and cyclic structures do not survive, so their
+ * fields are dropped rather than mangled. `undefined` INSIDE a container is fine
+ * (JSON omits the key / nulls the array slot without throwing). */
+function isJsonSurvivable(value: unknown, seen: Set<object>): boolean {
+    if (value === null || value === undefined) return true;
+    const t = typeof value;
+    if (t === 'string' || t === 'boolean') return true;
+    if (t === 'number') return Number.isFinite(value as number);
+    if (t !== 'object') return false; // function | symbol | bigint
+    const obj = value as object;
+    if (seen.has(obj)) return false; // cycle — JSON.stringify would throw
+    seen.add(obj);
+    let ok: boolean;
+    if (Array.isArray(obj)) {
+        ok = obj.every((v) => isJsonSurvivable(v, seen));
+    } else {
+        const proto: unknown = Object.getPrototypeOf(obj);
+        ok =
+            (proto === Object.prototype || proto === null) &&
+            Object.values(obj).every((v) => isJsonSurvivable(v, seen));
+    }
+    seen.delete(obj); // path-scoped: shared (DAG) substructure is not a cycle
+    return ok;
 }
 
 function serializeError(reason: unknown): StitchQueryFnError {
@@ -78,8 +111,16 @@ function serializeError(reason: unknown): StitchQueryFnError {
         const extra: Record<string, unknown> = {};
         const own = reason as unknown as Record<string, unknown>;
         for (const key of Object.keys(reason)) {
+            // The raw response carrier stays behind: core documents
+            // `RateLimitError.response` (the full `AdapterResponse`, headers and all)
+            // as living on the thrown instance ONLY — it must never serialise into a
+            // sink, and Redux state (devtools, persistence) is exactly such a sink.
+            // The P10 projection of it (`status`/`body`/`url`) is already lifted onto
+            // the error's own fields and survives below.
+            if (key === 'response') continue;
             const value = own[key];
-            if (isPrimitive(value)) extra[key] = value;
+            if (value !== undefined && isJsonSurvivable(value, new Set()))
+                extra[key] = value;
         }
         return { name: reason.name, message: reason.message, ...extra };
     }
@@ -127,10 +168,18 @@ export function stitchQueryFn<T>(
 // stitchStreamUpdater
 // ---------------------------------------------------------------------------
 
-/** How a streaming endpoint folds `delta` chunks into its cached array. */
+/** How a streaming endpoint folds `delta` chunks into its cached array:
+ * `'append'` (default) pushes every chunk; `'replace'` keeps only the latest. */
+export type StreamUpdaterMode = 'append' | 'replace';
+
+/** The {@link stitchStreamUpdater} options envelope. At the parameter the mode is
+ * the dominant field, so its scalar is accepted directly (`'replace'` ≡
+ * `{ mode: 'replace' }`, CONTRACT.md P12) and the object form requires at least one
+ * field — `{}` is a compile error, the all-defaults case is omitting the argument
+ * (P20). */
 export interface StreamUpdaterOptions {
     /** `'append'` (default) pushes every chunk; `'replace'` keeps only the latest. */
-    readonly mode?: 'append' | 'replace';
+    readonly mode?: StreamUpdaterMode;
 }
 
 /** The slice of RTK Query's cache-lifecycle API that {@link stitchStreamUpdater}
@@ -153,18 +202,21 @@ export interface CacheLifecycleApi<Data> {
  * }),
  * ```
  *
- * The cached data is the accumulated chunks (`mode: 'append'`, default) or the
- * latest chunk (`mode: 'replace'`). Streaming stops when the cache entry is removed.
+ * The cached data is the accumulated chunks (`'append'`, default) or the latest
+ * chunk (`'replace'`): pass the mode scalar — `stitchStreamUpdater(chat, 'replace')`
+ * ≡ `{ mode: 'replace' }`. Streaming stops when the cache entry is removed.
  */
 export function stitchStreamUpdater<Chunk, Input = unknown>(
     stitch: StreamableStitchLike<unknown, Input>,
-    options?: StreamUpdaterOptions,
+    options?: StreamUpdaterMode | AtLeastOne<StreamUpdaterOptions>,
 ): (input: Input, api: CacheLifecycleApi<Chunk[]>) => Promise<void>;
 export function stitchStreamUpdater<Chunk>(
     stitch: StreamableStitchLike<unknown, unknown>,
-    options: StreamUpdaterOptions = {},
+    options?: StreamUpdaterMode | AtLeastOne<StreamUpdaterOptions>,
 ): (input: unknown, api: CacheLifecycleApi<Chunk[]>) => Promise<void> {
-    const mode = options.mode ?? 'append';
+    // The scalar shorthand normalises to the canonical `mode` field (CONTRACT.md P0/P12).
+    const mode: StreamUpdaterMode =
+        typeof options === 'string' ? options : (options?.mode ?? 'append');
     return async (
         input: unknown,
         api: CacheLifecycleApi<Chunk[]>,

--- a/packages/rtk-query/test/rtk-query.spec.ts
+++ b/packages/rtk-query/test/rtk-query.spec.ts
@@ -87,11 +87,13 @@ describe('stitchQueryFn', () => {
         expect(result.error && typeof result.error).toBe('object');
     });
 
-    test('keeps primitive own fields but DROPS non-primitive ones (Redux-serialisable)', async () => {
+    test('preserves the P10 field set — body included — across serialisation', async () => {
         class RichError extends Error {
             override name = 'StitchError';
-            status = 502; // primitive → carried
-            response = { headers: { secret: 'x' } }; // object → dropped
+            status = 502;
+            attempts = 3;
+            body = { error: 'bad gateway', upstream: ['a', 'b'] }; // parsed JSON payload → carried
+            url = 'https://api.example.com/users/1';
         }
         const qfn = stitchQueryFn(
             unaryStitch(async () => {
@@ -104,8 +106,45 @@ describe('stitchQueryFn', () => {
             name: 'StitchError',
             message: 'bad gateway',
             status: 502,
+            attempts: 3,
+            body: { error: 'bad gateway', upstream: ['a', 'b'] },
+            url: 'https://api.example.com/users/1',
         });
-        // A non-serialisable object field must never reach Redux state.
+        // The whole error survives a real JSON round trip intact (Redux persistence).
+        expect(JSON.parse(JSON.stringify(result.error))).toEqual(result.error);
+    });
+
+    test('drops non-JSON-survivable fields and the raw response carrier', async () => {
+        const cyclic: Record<string, unknown> = {};
+        cyclic['self'] = cyclic;
+        class LeakyError extends Error {
+            override name = 'RateLimitError';
+            status = 429;
+            retryAfter = 1000; // plain data → carried
+            // The full AdapterResponse lives on the thrown instance ONLY (core's rule) —
+            // its headers (set-cookie & co.) must never reach Redux state.
+            response = {
+                status: 429,
+                headers: { 'set-cookie': 'secret' },
+                body: {},
+            };
+            onRetry = (): void => {}; // function → dropped
+            inner = new RangeError('nested'); // class instance → dropped
+            loop = cyclic; // cycle → dropped (JSON.stringify would throw)
+        }
+        const qfn = stitchQueryFn(
+            unaryStitch(async () => {
+                throw new LeakyError('rate limited (HTTP 429)');
+            }),
+        );
+        const result = await qfn({});
+
+        expect(result.error).toEqual({
+            name: 'RateLimitError',
+            message: 'rate limited (HTTP 429)',
+            status: 429,
+            retryAfter: 1000,
+        });
         expect(result.error && 'response' in result.error).toBe(false);
     });
 
@@ -147,6 +186,19 @@ describe('stitchStreamUpdater', () => {
             mode: 'replace',
         })(undefined, api);
         expect(data).toEqual([3]);
+    });
+
+    test("scalar shorthand: 'replace' ≡ { mode: 'replace' } (P12), and {} is rejected (P20)", async () => {
+        const { data, api } = mockCache<number>([]);
+        await stitchStreamUpdater<number>(streamStitch(events), 'replace')(
+            undefined,
+            api,
+        );
+        expect(data).toEqual([3]);
+
+        // @ts-expect-error — P20: the empty object is not a valid options value;
+        // the all-defaults case is omitting the argument.
+        stitchStreamUpdater<number>(streamStitch(events), {});
     });
 
     test('stops when the cache entry is removed, even if the stream never ends', async () => {

--- a/packages/sentry/README.md
+++ b/packages/sentry/README.md
@@ -33,20 +33,25 @@ The same sink works on a single stitch — `stitch({ trace: sentrySink(Sentry) }
 
 ## What it sends
 
-| Event                          | Sentry                                                                |
-| ------------------------------ | --------------------------------------------------------------------- |
-| `error`                        | `captureMessage` (level `error`) + an error breadcrumb                |
-| `progress` (`retry`/`circuit`) | breadcrumb, level `warning`                                           |
-| `progress` (throttle/paginate) | breadcrumb, level `debug`                                             |
-| `drift`                        | breadcrumb (level follows the finding); captured with `capture.drift` |
-| `start` / `result` / `done`    | breadcrumb only when `lifecycle: true` (off by default)               |
-| `delta` / `info`               | **never sent** (raw response data / strategy announcements)           |
+| Event                          | Sentry                                                                           |
+| ------------------------------ | -------------------------------------------------------------------------------- |
+| `error`                        | `captureMessage` (level `error`) + an error breadcrumb                           |
+| `progress` (`retry`/`circuit`) | breadcrumb, level `warning`                                                      |
+| `progress` (throttle/paginate) | breadcrumb, level `debug`                                                        |
+| `drift`                        | breadcrumb (level follows the finding); captured with `capture: { drift: true }` |
+| `start` / `result` / `done`    | breadcrumb only when `lifecycle: true` (off by default)                          |
+| `delta` / `info`               | **never sent** (raw response data / strategy announcements)                      |
 
-Options: `{ lifecycle?, capture? }` — `capture` is `boolean | { errors?, drift? }`: `true`/omitted captures errors (not drift), `false` disables both, or set `errors`/`drift` independently.
+Options: `{ lifecycle?, capture?: boolean | { errors?, drift? } }`. `capture: false` disables both `errors` and `drift` capture (breadcrumbs still flow); `capture: true`/omitted resolves to the documented defaults (`errors: true`, `drift: false`); pass the envelope to set them independently.
+
+> [!NOTE]
+> The same `lifecycle` option in `@stitchapi/pino` defaults to `true` — a
+> **deliberate** divergence: Sentry breadcrumbs/events cost quota, while Pino log
+> lines are cheap and level-filtered.
 
 ## Safe on a secret-bearing seam
 
-> A custom `TraceSink` receives the **raw** event — core only redacts inside its own built-in sinks. This sink therefore sends **metadata only**: the stitch name, method, **redacted URL** (query stripped — it can carry `?api_key=…`), status, attempt counts, drift path/level/change, phase, and timing. It never sends `event.input` (headers still hold the live `authorization`/`cookie`), the response `value`, or a `delta` chunk.
+> A custom `TraceSink` receives the **raw** event — core only redacts inside its own built-in sinks. This sink therefore sends **metadata only**: the stitch name, method, **redacted URL** (query stripped — it can carry `?api_key=…`), status, attempt counts, drift path/level/change, phase, and timing. It never sends `event.input` (headers still hold the live `authorization`/`cookie`), the response `data`, or a `delta` chunk.
 
 ## License
 

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -66,6 +66,11 @@ export interface SentrySinkOptions {
      * Breadcrumb the happy-path lifecycle (`start` / `result` / `done`). Default
      * `false` — these are noisy in Sentry, where breadcrumbs matter most just before
      * an error. Retries, circuit trips, and drift findings are always breadcrumbed.
+     *
+     * DELIBERATE DIVERGENCE (contract P8): `@stitchapi/pino`'s same-named
+     * `lifecycle` defaults to `true`. Sentry breadcrumbs/events cost quota, so the
+     * lifecycle is off by default here; pino log lines are cheap and
+     * level-filtered, so it is on by default there.
      */
     lifecycle?: boolean;
     /**

--- a/packages/sentry/test/sentry.spec.ts
+++ b/packages/sentry/test/sentry.spec.ts
@@ -141,6 +141,33 @@ describe('sentrySink', () => {
         expect(breadcrumbs[0]!.level).toBe('error');
     });
 
+    test('capture: false disables both errors and drift capture, but keeps breadcrumbs', () => {
+        const { sentry, breadcrumbs, captures } = mockSentry();
+        const sink = sentrySink(sentry, { capture: false });
+        sink.handle(ev.error, ctx);
+        sink.handle(ev.driftError, ctx);
+
+        expect(captures).toHaveLength(0);
+        expect(breadcrumbs).toHaveLength(2);
+    });
+
+    test('capture: true resolves to the same defaults as omitting the option', () => {
+        const withTrue = mockSentry();
+        sentrySink(withTrue.sentry, { capture: true }).handle(ev.error, ctx);
+        sentrySink(withTrue.sentry, { capture: true }).handle(
+            ev.driftError,
+            ctx,
+        );
+
+        const omitted = mockSentry();
+        sentrySink(omitted.sentry).handle(ev.error, ctx);
+        sentrySink(omitted.sentry).handle(ev.driftError, ctx);
+
+        // errors: true (captured), drift: false (breadcrumb only) in both cases.
+        expect(withTrue.captures).toHaveLength(1);
+        expect(omitted.captures).toHaveLength(1);
+    });
+
     test('capture.drift only captures an error-level finding — a warn-level drift is breadcrumbed only', () => {
         const driftWarn: StitchEvent = {
             type: 'drift',
@@ -163,14 +190,14 @@ describe('sentrySink', () => {
         });
     });
 
-    test('capture:false disables both errors and drift — only breadcrumbs (P24 toggle)', () => {
-        const { sentry, breadcrumbs, captures } = mockSentry();
-        const sink = sentrySink(sentry, { capture: false });
-        sink.handle(ev.error, ctx);
-        sink.handle(ev.driftError, ctx);
-        // Both the error and the error-level drift are trailed but never captured as issues.
-        expect(captures).toHaveLength(0);
-        expect(breadcrumbs).toHaveLength(2);
+    test('old flat spellings are DELETED and the empty capture bag is rejected (compile-time)', () => {
+        // @ts-expect-error — `captureErrors` was folded into `capture` (no alias, P24)
+        void sentrySink(mockSentry().sentry, { captureErrors: false });
+        // @ts-expect-error — `captureDrift` was folded into `capture` (no alias, P24)
+        void sentrySink(mockSentry().sentry, { captureDrift: true });
+        // @ts-expect-error — `{}` is not a valid capture envelope (CONTRACT.md P20): use `true`/omit
+        void sentrySink(mockSentry().sentry, { capture: {} });
+        expect(true).toBe(true);
     });
 
     test('delta and info events are never sent (raw data / announcements)', () => {
@@ -207,7 +234,7 @@ describe('sentrySink', () => {
         });
     });
 
-    test('metadata only: no secret query, no input/value/chunk reaches Sentry', () => {
+    test('metadata only: no secret query, no input/data/chunk reaches Sentry', () => {
         const { sentry, breadcrumbs, captures } = mockSentry();
         const sink = sentrySink(sentry, { lifecycle: true });
         for (const e of Object.values(ev)) sink.handle(e, ctx);

--- a/packages/vercel-ai/README.md
+++ b/packages/vercel-ai/README.md
@@ -41,6 +41,15 @@ const { text } = await generateText({
 -   `inputSchema` — the schema the model fills (a Zod schema, or any AI SDK `Schema`).
 -   `toInput` — maps the model's args onto the stitch's `{ params, query, body }`. Omit it when the args _are_ the stitch input.
 
+`inputSchema` is the one required field, so it also goes positionally: when the model's args _are_ the stitch input and no description is needed, pass the schema directly —
+
+```ts
+stitchTool(getUser, z.object({ params: z.object({ id: z.string() }) }));
+// ≡ stitchTool(getUser, { inputSchema: z.object({ … }) })
+```
+
+The two forms are told apart by the `inputSchema` key: an object carrying one is the options envelope, anything else is the schema itself.
+
 The tool's result is the stitch's validated output, so the model reasons over real data, not a guess. A failure rejects, so the AI SDK's tool-error handling reports it.
 
 ## `stitchExecute`

--- a/packages/vercel-ai/src/index.ts
+++ b/packages/vercel-ai/src/index.ts
@@ -113,6 +113,24 @@ export interface StitchToolOptions<Args, Input> {
 }
 
 /**
+ * A schema value accepted positionally by {@link stitchTool} — any object (a Zod
+ * schema, an AI SDK `Schema`, …) that does NOT carry an `inputSchema` key. An object
+ * that DOES carry one is read as the {@link StitchToolOptions} envelope instead;
+ * that key is what tells the two apart.
+ */
+export type StitchToolSchema = object & { inputSchema?: never };
+
+/** The envelope form is the one whose second argument carries an `inputSchema` key —
+ * a schema itself never does. */
+function isToolOptions(
+    value: StitchToolOptions<unknown, unknown> | StitchToolSchema,
+): value is StitchToolOptions<unknown, unknown> {
+    return (
+        typeof value === 'object' && value !== null && 'inputSchema' in value
+    );
+}
+
+/**
  * Wrap a stitch as a Vercel AI SDK tool. Drop it into a `tools` map:
  *
  * ```ts
@@ -133,6 +151,14 @@ export interface StitchToolOptions<Args, Input> {
  * });
  * ```
  *
+ * `inputSchema` is the one required field, so it gets a positional shorthand: when the
+ * model's args ARE the stitch input and no description is needed,
+ * `stitchTool(stitch, schema)` ≡ `stitchTool(stitch, { inputSchema: schema })`:
+ *
+ * ```ts
+ * tools: { getUser: stitchTool(getUser, z.object({ params: z.object({ id: z.string() }) })) }
+ * ```
+ *
  * Works with AI SDK v4 (reads `parameters`) and v5 (reads `inputSchema`) — the tool
  * carries both.
  */
@@ -147,10 +173,23 @@ export function stitchTool<T, Input = unknown, Args = Input>(
     stitch: StitchLike<T, Input>,
     options: StitchToolOptions<Args, Input>,
 ): StitchTool<Args, T>;
+export function stitchTool<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    inputSchema: StitchToolSchema,
+): StitchTool<QueryInput<S>, QueryOutput<S>>;
+export function stitchTool<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    inputSchema: StitchToolSchema,
+): StitchTool<Input, T>;
 export function stitchTool<T>(
     stitch: StitchLike<T, unknown>,
-    options: StitchToolOptions<unknown, unknown>,
+    optionsOrSchema: StitchToolOptions<unknown, unknown> | StitchToolSchema,
 ): StitchTool<unknown, T> {
+    const options: StitchToolOptions<unknown, unknown> = isToolOptions(
+        optionsOrSchema,
+    )
+        ? optionsOrSchema
+        : { inputSchema: optionsOrSchema };
     // `compact` is the wrong tool here: `parameters`/`inputSchema` are required `unknown`
     // keys it would optionalize. Keep the explicit spread to omit only `description`.
     return {

--- a/packages/vercel-ai/test/ai.spec.ts
+++ b/packages/vercel-ai/test/ai.spec.ts
@@ -95,4 +95,42 @@ describe('stitchTool', () => {
         );
         expect('description' in tool).toBe(false);
     });
+
+    // --- positional shorthand (P15): stitchTool(stitch, schema) -------------
+
+    test('positional shorthand ≡ stitchTool(stitch, { inputSchema: schema })', async () => {
+        let seen: unknown;
+        const stitch = unaryStitch(async (input) => {
+            seen = input;
+            return { name: 'Ada' };
+        });
+        const tool = stitchTool(stitch, schema);
+
+        expect(tool.parameters).toBe(schema);
+        expect(tool.inputSchema).toBe(schema);
+        expect('description' in tool).toBe(false);
+        // The args ARE the stitch input — no toInput in the shorthand.
+        await expect(tool.execute({ params: { id: '7' } })).resolves.toEqual({
+            name: 'Ada',
+        });
+        expect(seen).toEqual({ params: { id: '7' } });
+    });
+
+    test('the two forms are told apart by the inputSchema key, not shape', () => {
+        const stitch = unaryStitch(async () => 1);
+        // A schema-like arg WITHOUT an inputSchema key is the schema itself —
+        // even one carrying envelope-sounding keys like `description`.
+        const schemaWithDescription: { description: string; type: string } = {
+            description: 'a JSON-schema description field',
+            type: 'object',
+        };
+        const positional = stitchTool(stitch, schemaWithDescription);
+        expect(positional.inputSchema).toBe(schemaWithDescription);
+        expect(positional.parameters).toBe(schemaWithDescription);
+        expect('description' in positional).toBe(false);
+
+        // An arg WITH an inputSchema key is the options envelope.
+        const envelope = stitchTool(stitch, { inputSchema: schema });
+        expect(envelope.inputSchema).toBe(schema);
+    });
 });


### PR DESCRIPTION
Broken out of #470 — the leaf packages, each self-contained.

## aws-sigv4 — P22, a standards-interop contract uses the standard's field names

SigV4's own wire name for the signing timestamp is `X-Amz-Date`, and `SignV4Result` **already**
echoed it back as `amzDate`. The *input* spelled the same value `dateTime` — one concept, two names,
across one function call. The input is now `amzDate` too, so what you pass in is what you read back out.

## react-native — P15, the one required collaborator goes first

`reconnectRefetch(stitch, opts)` required `{ netInfo }` and nothing else in the common case:

```ts
reconnectRefetch(s, netInfo)            // new
reconnectRefetch(s, { netInfo })        // still works
```

Discriminated structurally on `addEventListener`, so both arms stay type-safe.

`asyncStorageStore` also documents its `keyPrefix` default (`'stitch:'`) — AsyncStorage is the app's
one shared bucket, so this store namespaces by default where a dedicated store would not. A **P8
divergence, deliberate and now recorded** rather than implicit.

## vercel-ai — P12 scalar shorthand

```ts
stitchStreamUpdater(chat, 'replace')  ≡  stitchStreamUpdater(chat, { mode: 'replace' })
```

The mode is extracted as the named `StreamUpdaterMode`; the envelope arm is
`AtLeastOne<StreamUpdaterOptions>` so the opaque `{}` stays a type error (P20). `stitchTool` gains
the same overload pair every other binding has, plus `StitchToolSchema` — which stops a caller
passing an `inputSchema`-bearing object where a **bare** schema belongs.

## rtk-query — a correctness fix found while aligning the surface

The serializability guard was `isPrimitive`. It:

- **accepted** `NaN` and `Infinity`, both of which silently become `null` through JSON
- **rejected** plain objects and arrays outright, even though they round-trip fine

It is now `isJsonSurvivable`: a real round-trip check that walks plain objects/arrays, rejects
functions/symbols/bigints and non-finite numbers, and **detects cycles** before `JSON.stringify`
would throw on them.

## pino / sentry

README + JSDoc record their P8 default divergences explicitly rather than leaving them implicit.

Hard break, no `@deprecated` aliases — pre-GA, per P19 as amended in #470.

## Verification

- workspace typecheck clean; full workspace test suite green
- contract ratchet **0**; docs-links 110 routes OK; prettier clean
- apps/docs production build passes — twoslash compiles the aws-sigv4 `amzDate` snippet and the rtk-query shorthand

🤖 Generated with [Claude Code](https://claude.com/claude-code)