### PR TITLE
refactor(core)!: the stream buffer cap counts characters — stream.maxBufferBytes → maxBufferChars (P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,27 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Changed
 
+-   **BREAKING — `stream.maxBufferBytes` is renamed to `maxBufferChars`.** The cap never
+    counted bytes. Every guard it feeds compares `.length` on a string the `TextDecoder` has
+    already produced (`line-reader.ts`, `json-stream.ts`, `sse.ts`), so it measures characters
+    of the decoded text — UTF-16 code units — not bytes off the socket:
+
+    ```ts
+    // before
+    stream: { decode: 'json', maxBufferBytes: 8 * 1024 * 1024 }
+    // after
+    stream: { decode: 'json', maxBufferChars: 8 * 1024 * 1024 }
+    ```
+
+    Default and behaviour are unchanged; the name, its JSDoc, and the thrown error text
+    (`… exceeded maxBufferChars (…)`) are all that move. The old name mattered because it
+    understated the guard it exists to be: 8M code units of CJK is ~24 MB of UTF-8 on the wire
+    and ~16 MB of string memory, so an OOM bound that read as "8 MB" was 2–3× looser than it
+    looked. Per P1, `Bytes` already denotes bytes elsewhere on the surface (`ServeOptions.maxBodyBytes`,
+    byte progress) and cannot also denote code units.
+
+    No `@deprecated` alias: P19 scopes that obligation to the GA channel and this lands on `rc`.
+
 -   **BREAKING — `retry`'s backoff fields fold into one `backoff` envelope.**
     `RetryOptions.backoff` / `baseDelay` / `maxDelay` were three flat members configuring a
     single concept, two of them sharing a `Delay` suffix. They are now one envelope:

--- a/packages/core/src/json-stream.ts
+++ b/packages/core/src/json-stream.ts
@@ -19,11 +19,12 @@
 
 /**
  * Default cap on the chars the `'json'` decoder will buffer for a single in-progress value before
- * it throws. ~8 MB: generous for real records, but bounded so a malformed / never-closing value
- * (e.g. an unterminated `[`) can't grow the buffer without limit. Overridable per-stream via
- * `stream.maxBufferBytes`. The engine (`runStreaming`) turns the throw into an `error` event.
+ * it throws — characters of the DECODED text (UTF-16 code units), not bytes off the socket. ~8M:
+ * generous for real records, but bounded so a malformed / never-closing value (e.g. an unterminated
+ * `[`) can't grow the buffer without limit. Overridable per-stream via `stream.maxBufferChars`. The
+ * engine (`runStreaming`) turns the throw into an `error` event.
  */
-export const JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
+export const JSON_STREAM_DEFAULT_MAX_BUFFER_CHARS = 8 * 1024 * 1024;
 
 // Whitespace JSON permits between values (RFC 8259): space, tab, LF, CR.
 function isJsonWhitespace(code: number): boolean {
@@ -43,12 +44,12 @@ function isJsonWhitespace(code: number): boolean {
  *     closing delimiter, so its boundary is whitespace, the start of a following value, or EOF.
  *
  * Each emitted slice is `JSON.parse`d; the parsed value is the delta. Throws if a single in-progress
- * value's buffer exceeds `maxBufferBytes`, or if the stream ends mid-value, or if a slice fails to
+ * value's buffer exceeds `maxBufferChars`, or if the stream ends mid-value, or if a slice fails to
  * parse (a thrown error becomes an `error` event in the engine).
  */
 export async function* jsonStream(
     stream: ReadableStream<Uint8Array>,
-    maxBufferBytes: number = JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES,
+    maxBufferChars: number = JSON_STREAM_DEFAULT_MAX_BUFFER_CHARS,
 ): AsyncGenerator<unknown, void> {
     const reader = stream.getReader();
     const decoder = new TextDecoder();
@@ -86,10 +87,10 @@ export async function* jsonStream(
     };
 
     const guard = (): void => {
-        if (buf.length > maxBufferBytes) {
+        if (buf.length > maxBufferChars) {
             throw new Error(
-                `json decoder: in-progress value exceeded maxBufferBytes (${String(
-                    maxBufferBytes,
+                `json decoder: in-progress value exceeded maxBufferChars (${String(
+                    maxBufferChars,
                 )}); a malformed or never-closing value was streamed`,
             );
         }

--- a/packages/core/src/line-reader.ts
+++ b/packages/core/src/line-reader.ts
@@ -7,17 +7,18 @@
 // `stream`'s `'lines'` / `'ndjson'` decoders consume these lines directly; `sse`'s frame parser
 // layers the event-stream grammar on top (stripping a trailing `\r`, grouping by blank lines). They
 // share this plumbing, not a decoder — `text/event-stream` is a protocol, "lines" is not.
-import { JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES } from './json-stream';
+import { JSON_STREAM_DEFAULT_MAX_BUFFER_CHARS } from './json-stream';
 
 /**
  * Read UTF-8 lines off `stream`, splitting on `\n` and yielding each line WITHOUT its terminator.
  *
- * `maxBufferBytes` caps the length of a single UN-TERMINATED line held in `buf`: an upstream that
- * streams bytes with no `\n` would otherwise grow client memory without limit (an OOM DoS), so once
- * the carry exceeds the cap we throw a descriptive Error instead. This mirrors the `'json'` decoder's
- * per-value cap (`json-stream.ts`) — same default (~8 MB), same "the engine turns the throw into an
+ * `maxBufferChars` caps the length — in characters of the DECODED text, not bytes off the socket —
+ * of a single UN-TERMINATED line held in `buf`: an upstream that streams bytes with no `\n` would
+ * otherwise grow client memory without limit (an OOM DoS), so once the carry exceeds the cap we throw
+ * a descriptive Error instead. This mirrors the `'json'` decoder's per-value cap (`json-stream.ts`)
+ * — same default (~8M chars), same "the engine turns the throw into an
  * `error` event" contract (`runStreaming`), so an abusive body fails the stream cleanly rather than
- * OOM-ing. Overridable per-stream via `stream.maxBufferBytes`.
+ * OOM-ing. Overridable per-stream via `stream.maxBufferChars`.
  *
  * On any completion — normal end OR an early generator `.return()` (a consumer `break`s without
  * aborting a signal) — the `finally` proactively `cancel()`s the underlying stream before releasing
@@ -27,18 +28,18 @@ import { JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES } from './json-stream';
  */
 export async function* lineReader(
     stream: ReadableStream<Uint8Array>,
-    maxBufferBytes: number = JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES,
+    maxBufferChars: number = JSON_STREAM_DEFAULT_MAX_BUFFER_CHARS,
 ): AsyncGenerator<string, void> {
     const reader = stream.getReader();
     const decoder = new TextDecoder();
     let buf = '';
-    // Guard the un-terminated carry: `buf` here holds only the bytes AFTER the last `\n`, so a
+    // Guard the un-terminated carry: `buf` here holds only the decoded text AFTER the last `\n`, so a
     // legitimate long-but-terminated line stream never trips it — only a run with no line break does.
     const guard = (): void => {
-        if (buf.length > maxBufferBytes) {
+        if (buf.length > maxBufferChars) {
             throw new Error(
-                `line reader: un-terminated line exceeded maxBufferBytes (${String(
-                    maxBufferBytes,
+                `line reader: un-terminated line exceeded maxBufferChars (${String(
+                    maxBufferChars,
                 )}); a stream with no newline was sent`,
             );
         }

--- a/packages/core/src/sse.ts
+++ b/packages/core/src/sse.ts
@@ -10,7 +10,7 @@
 // Bundle-frugal (Decision 10): this module — and the frame parser — is reached only through the
 // `sse` subpath, never from the root entry; `import { stitch }` pulls in no SSE code.
 import type { InputOf, OutputOf } from './infer';
-import { JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES } from './json-stream';
+import { JSON_STREAM_DEFAULT_MAX_BUFFER_CHARS } from './json-stream';
 import { lineReader } from './line-reader';
 import { seam as makeSeam } from './seam';
 import { makeStitch } from './stitch';
@@ -101,20 +101,21 @@ function dispatchFrame(frame: SseFrame): SseEvent | undefined {
 // `:`-prefixed lines are comments; exactly one leading space after the field colon is stripped. A
 // trailing event with no terminating blank line is discarded (spec), as is a block with no `data:`.
 //
-// `maxBufferBytes` bounds the accumulated `data:` payload of a SINGLE in-progress frame (a run of
+// `maxBufferChars` bounds the accumulated `data:` payload of a SINGLE in-progress frame (a run of
 // `data:` lines with no dispatching blank line): without this an upstream that streams endless
 // `data:` fields — or one giant unterminated line — would grow client memory without limit (an OOM
 // DoS). `lineReader` caps a single un-terminated LINE with the same knob; this caps the frame that
-// spans many terminated lines. Same default (~8 MB) and thrown-error → `error` event contract as the
-// `'json'` decoder (`json-stream.ts` / `runStreaming`). Overridable per-stream via `stream.maxBufferBytes`.
+// spans many terminated lines. Counted in characters of the decoded text, not bytes off the socket.
+// Same default (~8M chars) and thrown-error → `error` event contract as the
+// `'json'` decoder (`json-stream.ts` / `runStreaming`). Overridable per-stream via `stream.maxBufferChars`.
 async function* parseEventStream(
     body: ReadableStream<Uint8Array>,
-    maxBufferBytes: number = JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES,
+    maxBufferChars: number = JSON_STREAM_DEFAULT_MAX_BUFFER_CHARS,
 ): AsyncGenerator<SseEvent, void> {
     let frame = freshFrame();
-    let frameBytes = 0; // accumulated length of the current frame's data lines (+1 per join `\n`)
+    let frameChars = 0; // accumulated length of the current frame's data lines (+1 per join `\n`)
 
-    for await (const raw of lineReader(body, maxBufferBytes)) {
+    for await (const raw of lineReader(body, maxBufferChars)) {
         // lineReader splits on `\n`; strip a trailing `\r` so CRLF streams parse (the SSE plumbing
         // shared with `stream`'s `'lines'` stays a literal `\n` split — Q3).
         const line = raw.endsWith('\r') ? raw.slice(0, -1) : raw;
@@ -123,7 +124,7 @@ async function* parseEventStream(
             const ev = dispatchFrame(frame);
             if (ev !== undefined) yield ev;
             frame = freshFrame();
-            frameBytes = 0;
+            frameChars = 0;
         } else if (!line.startsWith(':')) {
             const before = frame.dataLines.length;
             applyFieldLine(frame, line); // non-comment field line
@@ -132,11 +133,11 @@ async function* parseEventStream(
             // past the cap.
             if (frame.dataLines.length > before) {
                 const added = frame.dataLines[frame.dataLines.length - 1] ?? '';
-                frameBytes += added.length + (before > 0 ? 1 : 0);
-                if (frameBytes > maxBufferBytes) {
+                frameChars += added.length + (before > 0 ? 1 : 0);
+                if (frameChars > maxBufferChars) {
                     throw new Error(
-                        `sse parser: un-dispatched event data exceeded maxBufferBytes (${String(
-                            maxBufferBytes,
+                        `sse parser: un-dispatched event data exceeded maxBufferChars (${String(
+                            maxBufferChars,
                         )}); a frame with no terminating blank line was streamed`,
                     );
                 }
@@ -158,7 +159,7 @@ export const sseSurface: Surface<StitchInput, SseEvent[]> = {
         if (body instanceof ReadableStream)
             yield* parseEventStream(
                 body as ReadableStream<Uint8Array>,
-                cfg.stream?.maxBufferBytes,
+                cfg.stream?.maxBufferChars,
             );
     },
     contractValue: (chunk) => (chunk as SseEvent).data,

--- a/packages/core/src/stream.ts
+++ b/packages/core/src/stream.ts
@@ -69,16 +69,16 @@ async function* decodeStream(
     const stream = body as ReadableStream<Uint8Array>;
     const decode = cfg.stream?.decode ?? 'bytes';
 
-    // `maxBufferBytes` caps a single un-terminated line for the line-based decoders too (an upstream
+    // `maxBufferChars` caps a single un-terminated line for the line-based decoders too (an upstream
     // that never sends a `\n` would otherwise grow memory without limit); a throw becomes an `error`
     // event in the engine. Same default (~8 MB) / knob as the `'json'` decoder below.
-    const maxBufferBytes = cfg.stream?.maxBufferBytes;
+    const maxBufferChars = cfg.stream?.maxBufferChars;
     if (decode === 'lines') {
-        yield* lineReader(stream, maxBufferBytes);
+        yield* lineReader(stream, maxBufferChars);
         return;
     }
     if (decode === 'ndjson') {
-        for await (const line of lineReader(stream, maxBufferBytes)) {
+        for await (const line of lineReader(stream, maxBufferChars)) {
             if (line.trim() === '') continue; // tolerate blank lines between records
             const parsed: unknown = JSON.parse(line);
             yield parsed;
@@ -87,9 +87,9 @@ async function* decodeStream(
     }
     if (decode === 'json') {
         // Structural, unframed streaming-JSON (issue #111): one delta per complete value / top-level
-        // array element. `maxBufferBytes` (if set) bounds a single in-progress value; a throw on
+        // array element. `maxBufferChars` (if set) bounds a single in-progress value; a throw on
         // overflow / mid-value EOF becomes an `error` event in the engine.
-        yield* jsonStream(stream, cfg.stream?.maxBufferBytes);
+        yield* jsonStream(stream, cfg.stream?.maxBufferChars);
         return;
     }
     // 'bytes' (default): hand back raw chunks exactly as they arrive on the wire.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -137,15 +137,17 @@ export interface StreamOptions {
     /** Decoder for a `stream` surface body. Default `'bytes'` (total + lossless). */
     decode?: StreamDecode;
     /**
-     * Max bytes a streaming decoder will buffer for a single un-terminated unit before throwing (the
-     * engine turns the throw into an `error` event). Guards every un-framed / never-closing case
-     * against growing client memory without limit (an OOM DoS):
+     * Max characters a streaming decoder will buffer for a single un-terminated unit before throwing
+     * (the engine turns the throw into an `error` event). Counts characters of the DECODED text —
+     * UTF-16 code units, so an astral character costs 2 — not bytes off the socket. Guards every
+     * un-framed / never-closing case against growing client memory without limit (an OOM DoS):
      *   - `'json'` — a single in-progress value (e.g. an unclosed `[`).
-     *   - `'lines'` / `'ndjson'` — a single un-terminated line (a run of bytes with no `\n`).
+     *   - `'lines'` / `'ndjson'` — a single un-terminated line (a run of text with no `\n`).
      *   - the `sse` surface — one un-dispatched event's `data:` payload (a frame with no blank line).
-     * Default ~8 MB (see `json-stream.ts`). Not meaningful for `decode: 'bytes'` (raw, unbuffered).
+     * Default ~8M characters (see `json-stream.ts`). Not meaningful for `decode: 'bytes'` (raw,
+     * unbuffered).
      */
-    maxBufferBytes?: number;
+    maxBufferChars?: number;
 }
 /**
  * Tuning for resumable SSE reconnection (issue #71). When enabled, the engine reopens a dropped

--- a/packages/core/test/json-stream-buffer.spec.ts
+++ b/packages/core/test/json-stream-buffer.spec.ts
@@ -1,6 +1,6 @@
 // Two behaviours of the `'json'` streaming tokenizer (src/json-stream.ts) that json-stream.spec.ts
 // leaves open. That suite proves chunk-split correctness exhaustively and that a *single*
-// never-closing value trips the maxBufferBytes guard — but not:
+// never-closing value trips the maxBufferChars guard — but not:
 //   1. that the cap is PER-VALUE, not cumulative: the sliding-window compaction drops each emitted
 //      value, so a long run of small complete values whose TOTAL dwarfs the cap streams fine. This
 //      is the whole reason compact()/base exist; without them this stream would false-trip the guard.
@@ -26,16 +26,16 @@ function streamOfBytes(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
 
 async function decode(
     chunks: Uint8Array[],
-    maxBufferBytes?: number,
+    maxBufferChars?: number,
 ): Promise<unknown[]> {
     const out: unknown[] = [];
-    for await (const v of jsonStream(streamOfBytes(chunks), maxBufferBytes))
+    for await (const v of jsonStream(streamOfBytes(chunks), maxBufferChars))
         out.push(v);
     return out;
 }
 
 describe('json-stream: the buffer cap bounds a VALUE, not the whole stream', () => {
-    test('many small complete values whose total dwarfs maxBufferBytes all stream (compaction works)', async () => {
+    test('many small complete values whose total dwarfs maxBufferChars all stream (compaction works)', async () => {
         const COUNT = 500;
         const cap = 1024; // each value is ~12 bytes; the total (~6 KB) is far over the cap.
         // One object per chunk forces cross-read compaction (each read appends, emits, compacts).

--- a/packages/core/test/json-stream.spec.ts
+++ b/packages/core/test/json-stream.spec.ts
@@ -4,7 +4,7 @@
 // byte offset (incl. mid-string, mid-escape, mid-multibyte-UTF8, mid-number, between values) and
 // byte-by-byte, and must yield identical deltas every time.
 import {
-    JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES,
+    JSON_STREAM_DEFAULT_MAX_BUFFER_CHARS,
     jsonStream,
 } from '../src/json-stream';
 
@@ -27,17 +27,17 @@ function streamOfBytes(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
 /** Drain the tokenizer over `chunks` into the array of emitted deltas. */
 async function decode(
     chunks: Uint8Array[],
-    maxBufferBytes?: number,
+    maxBufferChars?: number,
 ): Promise<unknown[]> {
     const out: unknown[] = [];
-    for await (const v of jsonStream(streamOfBytes(chunks), maxBufferBytes))
+    for await (const v of jsonStream(streamOfBytes(chunks), maxBufferChars))
         out.push(v);
     return out;
 }
 
 /** Feed a single string as one UTF-8 chunk. */
-function decodeText(s: string, maxBufferBytes?: number): Promise<unknown[]> {
-    return decode([enc.encode(s)], maxBufferBytes);
+function decodeText(s: string, maxBufferChars?: number): Promise<unknown[]> {
+    return decode([enc.encode(s)], maxBufferChars);
 }
 
 describe('json-stream tokenizer: value boundaries', () => {
@@ -211,18 +211,18 @@ describe('json-stream tokenizer: chunk-split robustness (the load-bearing matrix
 
 describe('json-stream tokenizer: max-buffer guard + incomplete streams', () => {
     test('the default cap is a few MB (exported)', () => {
-        expect(JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES).toBeGreaterThan(
+        expect(JSON_STREAM_DEFAULT_MAX_BUFFER_CHARS).toBeGreaterThan(
             1024 * 1024,
         );
     });
 
-    test('a never-closing value throws once the buffer exceeds maxBufferBytes', async () => {
+    test('a never-closing value throws once the buffer exceeds maxBufferChars', async () => {
         // An open `[` whose content never closes; cap at 64 bytes so it trips quickly.
         const chunks = [
             enc.encode('['),
             ...Array.from({ length: 50 }, () => enc.encode('1234567890')),
         ];
-        await expect(decode(chunks, 64)).rejects.toThrow(/maxBufferBytes/);
+        await expect(decode(chunks, 64)).rejects.toThrow(/maxBufferChars/);
     });
 
     test('a stream that ends mid-value throws (complete-value semantics)', async () => {

--- a/packages/core/test/sse.spec.ts
+++ b/packages/core/test/sse.spec.ts
@@ -19,14 +19,14 @@ import {
 import { z } from 'zod';
 
 // Run the SSE frame parser over the given chunk boundaries and collect the parsed events. A small
-// `maxBufferBytes` cap can be threaded through `stream.maxBufferBytes` (unbounded-buffer guard).
+// `maxBufferChars` cap can be threaded through `stream.maxBufferChars` (unbounded-buffer guard).
 async function parse(
     chunks: string[],
-    cfg: { stream?: { maxBufferBytes?: number } } = {},
+    cfg: { stream?: { maxBufferChars?: number } } = {},
 ): Promise<SseEvent[]> {
     const res = { status: 200, headers: {}, body: streamOf(chunks) };
     const out: SseEvent[] = [];
-    // `stream` is defined on a streaming surface; tests may assert non-null. Only `stream.maxBufferBytes`
+    // `stream` is defined on a streaming surface; tests may assert non-null. Only `stream.maxBufferChars`
     // is read off `cfg`, so this partial config (a resolved config's fields are all optional) suffices.
     for await (const ev of sseSurface.stream!(res, cfg))
         out.push(ev as SseEvent);
@@ -123,8 +123,8 @@ describe('sse buffer cap — an unbounded body fails instead of OOM-ing (securit
         // carry grows past the cap. Without the cap this would buffer the whole (unbounded) body.
         const noNewline = 'data: ' + 'x'.repeat(CAP * 4); // no trailing "\n\n"
         await expect(
-            parse([noNewline], { stream: { maxBufferBytes: CAP } }),
-        ).rejects.toThrow(/un-terminated line exceeded maxBufferBytes/);
+            parse([noNewline], { stream: { maxBufferChars: CAP } }),
+        ).rejects.toThrow(/un-terminated line exceeded maxBufferChars/);
     });
 
     test('endless data: lines with NO dispatching blank line past the cap throws (frame guard)', async () => {
@@ -134,15 +134,15 @@ describe('sse buffer cap — an unbounded body fails instead of OOM-ing (securit
         const manyDataLines =
             Array.from({ length: 200 }, () => 'data: chunk').join('\n') + '\n'; // no blank line ⇒ never dispatched
         await expect(
-            parse([manyDataLines], { stream: { maxBufferBytes: CAP } }),
-        ).rejects.toThrow(/un-dispatched event data exceeded maxBufferBytes/);
+            parse([manyDataLines], { stream: { maxBufferChars: CAP } }),
+        ).rejects.toThrow(/un-dispatched event data exceeded maxBufferChars/);
     });
 
     test('a normal stream UNDER the cap still parses (no false positive)', async () => {
         // Well under 64 bytes of data per frame, each properly blank-line terminated.
         expect(
             await parse(['data: {"n":1}\n\ndata: {"n":2}\n\n'], {
-                stream: { maxBufferBytes: CAP },
+                stream: { maxBufferChars: CAP },
             }),
         ).toEqual([{ data: { n: 1 } }, { data: { n: 2 } }]);
     });
@@ -156,9 +156,9 @@ describe('sse buffer cap — an unbounded body fails instead of OOM-ing (securit
         );
         await expect(
             parse([lines.join('\n') + '\n'], {
-                stream: { maxBufferBytes: CAP },
+                stream: { maxBufferChars: CAP },
             }),
-        ).rejects.toThrow(/un-dispatched event data exceeded maxBufferBytes/);
+        ).rejects.toThrow(/un-dispatched event data exceeded maxBufferChars/);
     });
 });
 
@@ -231,19 +231,19 @@ describe('sse over the engine (event spine + await)', () => {
         expect(ev.done?.ok).toBe(false);
     });
 
-    test('an unbounded body past maxBufferBytes fails the stream with error+done (not OOM)', async () => {
+    test('an unbounded body past maxBufferChars fails the stream with error+done (not OOM)', async () => {
         // A body that streams a long run with no newline / no dispatching blank line. The parser's
         // buffer cap throws; runStreaming turns the throw into error+done — a clean failure, not an
         // unbounded-memory grow. (This is the engine-spine counterpart to the frame-parser unit tests.)
         const s = sse({
             url: 'https://x.test/flood',
-            stream: { maxBufferBytes: 64 },
+            stream: { maxBufferChars: 64 },
             adapter: streamAdapter(streamOf(['data: ' + 'x'.repeat(4096)])), // no "\n\n" terminator
         });
         const ev = await collectEvents(s.stream());
         expect(ev.deltas).toEqual([]); // nothing was ever dispatched
         expect(ev.types).toContain('error');
-        expect(ev.error?.message).toMatch(/maxBufferBytes/);
+        expect(ev.error?.message).toMatch(/maxBufferChars/);
         expect(ev.done?.ok).toBe(false);
     });
 });
@@ -471,13 +471,13 @@ describe('lineReader teardown + cap (shared streaming plumbing)', () => {
         expect(lines).toEqual(['a', 'b', 'c']);
     });
 
-    test('a single un-terminated line past maxBufferBytes throws a descriptive error', async () => {
+    test('a single un-terminated line past maxBufferChars throws a descriptive error', async () => {
         // No `\n` ever arrives, so the carry grows unbounded — the cap turns that into a clean throw.
         await expect(async () => {
             for await (const _ of lineReader(streamOf(['x'.repeat(200)]), 64)) {
                 void _;
             }
-        }).rejects.toThrow(/un-terminated line exceeded maxBufferBytes/);
+        }).rejects.toThrow(/un-terminated line exceeded maxBufferChars/);
     });
 });
 

--- a/packages/core/test/stream.spec.ts
+++ b/packages/core/test/stream.spec.ts
@@ -185,10 +185,10 @@ describe('stream event spine (Decisions 5, 12)', () => {
         expect(ev.done?.ok).toBe(false);
     });
 
-    test('decode "json": a never-closing value past maxBufferBytes surfaces an error event', async () => {
+    test('decode "json": a never-closing value past maxBufferChars surfaces an error event', async () => {
         const s = stream({
             url: 'https://x.test/overflow',
-            stream: { decode: 'json', maxBufferBytes: 64 },
+            stream: { decode: 'json', maxBufferChars: 64 },
             // an open object whose single string value never closes — the in-progress slice grows
             // without bound (nothing can be emitted/compacted), so the cap trips.
             adapter: streamAdapter(
@@ -198,7 +198,7 @@ describe('stream event spine (Decisions 5, 12)', () => {
 
         const ev = await collectEvents(s.stream());
         expect(ev.types).toContain('error');
-        expect(ev.error?.message).toMatch(/maxBufferBytes/);
+        expect(ev.error?.message).toMatch(/maxBufferChars/);
         expect(ev.done?.ok).toBe(false);
     });
 });


### PR DESCRIPTION
`stream.maxBufferBytes` has never counted bytes. Every guard it feeds compares
`.length` on a string the `TextDecoder` has already produced:

| guard | comparison | buffer |
| --- | --- | --- |
| [`line-reader.ts:39`](https://github.com/rejifald/StitchAPI/blob/refactor/stream-buffer-chars/packages/core/src/line-reader.ts#L39) | `buf.length > maxBufferChars` | un-terminated line carry |
| [`json-stream.ts:90`](https://github.com/rejifald/StitchAPI/blob/refactor/stream-buffer-chars/packages/core/src/json-stream.ts#L90) | `buf.length > maxBufferChars` | in-progress JSON value |
| [`sse.ts:137`](https://github.com/rejifald/StitchAPI/blob/refactor/stream-buffer-chars/packages/core/src/sse.ts#L137) | `frameChars > maxBufferChars` | un-dispatched `data:` frame |

So the cap measures characters of the decoded text (UTF-16 code units), never
bytes off the socket. `json-stream.ts` even contradicted itself in one paragraph
— *"Default cap on the **chars** … overridable via `stream.maxBufferBytes`"*.

## Why it matters beyond the name

P1 forbids one token denoting two value-spaces across the surface, and `Bytes`
is genuinely bytes elsewhere: `ServeOptions.maxBodyBytes` counts `Buffer` chunks
off a socket, and byte-progress reporting counts transferred bytes.

It also understated the OOM guard this field exists to be. 8M code units is
~8 MB of ASCII, but ~24 MB of UTF-8 on the wire and ~16 MB of string memory for
CJK — a bound that read as "8 MB" was 2–3× looser than it looked. The number is
unchanged here; only the claim about it is now true.

## What changes

- `stream.maxBufferBytes` → `stream.maxBufferChars` (`StreamOptions`, the one
  public field).
- Internal followers: `JSON_STREAM_DEFAULT_MAX_BUFFER_BYTES` → `…_CHARS` (never
  exported from the package entry, so not itself a break), the SSE parser's
  `frameBytes` accumulator, and the thrown error text.
- JSDoc on all three guards now states the unit — characters of the decoded
  text, UTF-16 code units, an astral character costs 2 — and drops the "~8 MB"
  figure for "~8M characters".

Default, thresholds, and behaviour are untouched: 1229 core tests pass unchanged
apart from the renamed field.

## Migration

```ts
// before
stream: { decode: 'json', maxBufferBytes: 8 * 1024 * 1024 }
// after
stream: { decode: 'json', maxBufferChars: 8 * 1024 * 1024 }
```

Rename the field; the value means what it always did. No `@deprecated` alias —
P19 scopes that obligation to the GA channel and this lands on `rc`.

## Relation to #517

Same defect class, different subsystem, independent of it: #517 fixes the trace
sink's `maxBodyBytes` → `maxBodyChars`, this fixes the stream decoders' buffer
cap. Branched off `main`, no overlapping files, mergeable in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
