### PR TITLE
refactor(query-core)!: single-source StitchQueryOptions + query-key derivation (P16)

### DIFF
--- a/apps/docs/content/docs/integrations/svelte.mdx
+++ b/apps/docs/content/docs/integrations/svelte.mdx
@@ -85,8 +85,7 @@ latest chunk (`mode: 'replace'`), and `status` is `'streaming'` until the termin
 {#if $tokens.isStreaming}<Cursor />{/if}
 ```
 
-Same state shape as `stitchStore`. `useStitch` / `useStitchStream` are exported as
-aliases of these two, for callers who prefer the `use*` naming.
+Same state shape as `stitchStore`.
 
 ## The shared store: `@stitchapi/query-core`
 

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -2,7 +2,7 @@
     "name": "@stitchapi/angular",
     "version": "1.0.0-rc.6",
     "type": "commonjs",
-    "description": "Angular bindings for StitchAPI — injectStitch/injectStitchStream expose a stitch's lifecycle as both signals and an RxJS observable over @stitchapi/query-core. Streaming-first: re-render as `delta` chunks arrive. Plus an optional TanStack Query queryOptions helper.",
+    "description": "Angular bindings for StitchAPI — injectStitch/injectStitchStream expose a stitch's lifecycle as both signals and an RxJS observable over @stitchapi/query-core. Streaming-first: re-render as `delta` chunks arrive. Plus an optional TanStack Query stitchQueryOptions helper.",
     "main": "lib/index.js",
     "module": "lib/index.mjs",
     "types": "lib/index.d.ts",

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -11,8 +11,11 @@
 // - `injectStitchStream` — the streaming primitive: emits as `delta` chunks
 //                          arrive. This is the differentiator over plain
 //                          request/response query libraries.
-// - `stitchQueryOptions` — an OPTIONAL TanStack Query adapter (returns a plain
-//                          POJO, so it needs no import of the Angular adapter).
+// - `stitchQueryOptions` — an OPTIONAL TanStack Query adapter, re-exported from
+//                          `@stitchapi/query-core` (returns a plain POJO, so it
+//                          needs no import of the Angular adapter; named with
+//                          the `stitch` prefix because TanStack exports its own
+//                          `queryOptions`, see ADR 0012).
 //
 // The observable is the bridge off the store; the signal is derived from it via
 // `toSignal`, so a single query feeds both. `state$` and the signals share one
@@ -50,8 +53,21 @@ export type {
     QueryOutput,
     StitchLike,
     StitchQuery,
+    StitchQueryOptions,
     StitchQueryResult,
     StitchQueryStatus,
+} from '@stitchapi/query-core';
+
+// The TanStack Query adapter and its key derivation live in
+// `@stitchapi/query-core` — ONE shared implementation across every framework
+// binding, so the key format (and its secret-redaction guarantees) cannot drift
+// between frameworks. Re-exported here so Angular apps import everything from
+// `@stitchapi/angular`.
+export {
+    deriveQueryKey,
+    keyInputFor,
+    nameOf,
+    stitchQueryOptions,
 } from '@stitchapi/query-core';
 
 // ---------------------------------------------------------------------------
@@ -59,11 +75,20 @@ export type {
 // ---------------------------------------------------------------------------
 
 /** A value, a `Signal` of it, or a zero-arg getter — Angular's idiom for "static
- * or reactive". Passing a signal/getter recreates the query (and re-fetches) when
- * the tracked value changes; a plain value is read once. */
-export type InjectInput<T> = T | Signal<T> | (() => T);
+ * or reactive" (the sibling of Vue's `MaybeRefOrGetter` and Solid's
+ * `MaybeAccessor`). Passing a signal/getter recreates the query (and re-fetches)
+ * when the tracked value changes; a plain value is read once. */
+export type MaybeSignal<T> = T | Signal<T> | (() => T);
 
-export interface InjectStitchOptions<T> extends CreateStitchQueryOptions<T> {
+/**
+ * Options accepted by {@link injectStitch} / {@link injectStitchStream}.
+ *
+ * The store's `streaming` flag is deliberately OMITTED: each injector hard-sets
+ * it (`injectStitch` → unary, `injectStitchStream` → streaming), so passing it
+ * would be silently ignored — the type forbids it instead.
+ */
+export interface InjectStitchOptions<T>
+    extends Omit<CreateStitchQueryOptions<T>, 'streaming'> {
     /** Injection context to use when `injectStitch` is called outside one (e.g. a
      * test, or a non-injection callback). Defaults to the ambient context. */
     injector?: Injector;
@@ -105,85 +130,6 @@ export interface InjectStitchResult<T> {
 // Shared driver
 // ---------------------------------------------------------------------------
 
-// --- key derivation (shared logic; duplicated in @stitchapi/react) ----------
-// These helpers are intentionally copied verbatim from `@stitchapi/react`'s key
-// derivation: they are separate published packages, so a cross-package import
-// would add a runtime dependency. Keep the copies in lock-step.
-
-/** The `__config` slice a key derives from. Mirrors core's `nameOf`
- * (`name ?? path ?? 'stitch'`) plus a `url` fallback for URL-configured stitches. */
-type KeyConfig = { name?: string; path?: string; url?: string };
-
-/** A stable, human-meaningful name for the stitch. Mirrors core's `nameOf`
- * (`packages/core/src/engine.ts`) — `name ?? path ?? url ?? 'stitch'` — so two
- * DISTINCT nameless stitches (`/users/{id}` vs `/orders/{id}`) don't collapse to
- * the literal `'stitch'` and collide on one cache entry. */
-function nameOf(stitch: unknown): string {
-    const cfg = (stitch as { __config?: KeyConfig }).__config;
-    return cfg?.name ?? cfg?.path ?? cfg?.url ?? 'stitch';
-}
-
-// Header names whose VALUES are secrets — mirrors core's private `SECRET_HEADERS`
-// trace denylist (`packages/core/src/trace.ts`), which is not exported. We redact
-// the value (rather than dropping the header) so the key stays stable per token
-// AND callers who legitimately vary a response by a non-secret header (e.g.
-// `accept-language`) keep separate cache entries. Compared case-insensitively; the
-// `*-token` / `*-api-key` suffix rules catch vendor spellings without enumerating.
-const SECRET_HEADERS = new Set([
-    'authorization',
-    'proxy-authorization',
-    'cookie',
-    'set-cookie',
-    'x-api-key',
-    'x-auth-token',
-]);
-const REDACTED = '[redacted]';
-
-function isSecretHeader(name: string): boolean {
-    const k = name.toLowerCase();
-    return (
-        SECRET_HEADERS.has(k) || k.endsWith('-token') || k.endsWith('-api-key')
-    );
-}
-
-/**
- * Build the value that goes into a cache/query key from a stitch's per-call input.
- * Never puts the raw input in the key:
- *
- * - drops `signal` / `onProgress` — runtime-only, never-serialised (CONTRACT.md);
- *   `onProgress` in particular churns identity every render, which would refetch
- *   forever if it entered the key;
- * - redacts the VALUES of secret-bearing headers (`authorization`, `cookie`, …)
- *   so a bearer token can't leak into a persisted / devtools-visible key, while
- *   keeping non-secret headers so they still vary the cache;
- * - keeps every other field (`params` / `query` / `body` / `variables` / …) as-is.
- *
- * `null` / `undefined` inputs stay `null`; a primitive input is returned unchanged.
- */
-function keyInputFor(input: unknown): unknown {
-    if (input === null || input === undefined) return null;
-    if (typeof input !== 'object') return input;
-
-    const {
-        signal: _signal,
-        onProgress: _onProgress,
-        ...rest
-    } = input as {
-        signal?: unknown;
-        onProgress?: unknown;
-        headers?: Record<string, unknown>;
-    } & Record<string, unknown>;
-
-    if (rest.headers && typeof rest.headers === 'object') {
-        const headers: Record<string, unknown> = {};
-        for (const [k, v] of Object.entries(rest.headers)) {
-            headers[k] = isSecretHeader(k) ? REDACTED : v;
-        }
-        rest.headers = headers;
-    }
-    return rest;
-}
-
 // The store's seed value, surfaced before the first real snapshot (an instant).
 // It matches core's idle snapshot exactly so the signals are well-formed from the
 // start.
@@ -202,7 +148,7 @@ const IDLE_STATE: StitchQueryResult<unknown> = {
  * A signal/getter becomes a `toObservable(computed(...))` that re-emits on change;
  * a plain value becomes a single-shot `of(value)`. */
 function inputObservable<I>(
-    input: InjectInput<I>,
+    input: MaybeSignal<I>,
     injector: Injector,
 ): Observable<I> {
     if (typeof input === 'function') {
@@ -216,23 +162,22 @@ function inputObservable<I>(
 
 function injectStitchInternal<T>(
     stitch: StitchLike<T, unknown>,
-    input: InjectInput<unknown>,
+    input: MaybeSignal<unknown>,
     options: InjectStitchOptions<T>,
-    stream: boolean,
+    streaming: boolean,
 ): InjectStitchResult<T> {
     if (!options.injector) assertInInjectionContext(injectStitch);
     const injector = options.injector ?? inject(Injector);
     const destroyRef = injector.get(DestroyRef);
 
     const { mode, enabled, onSuccess, onError } = options;
-    const coreOptions: CreateStitchQueryOptions<T> & { stream: boolean } =
-        compact({
-            stream,
-            mode,
-            enabled,
-            onSuccess,
-            onError,
-        });
+    const coreOptions: CreateStitchQueryOptions<T> = compact({
+        streaming,
+        mode,
+        enabled,
+        onSuccess,
+        onError,
+    });
 
     // The live query handle, captured for the imperative refetch/cancel. It is
     // reassigned whenever the input changes (switchMap tears down the old one).
@@ -310,17 +255,17 @@ function injectStitchInternal<T>(
  */
 export function injectStitch<S extends StitchLike<unknown, never>>(
     stitch: S,
-    input: InjectInput<QueryInput<S>>,
+    input: MaybeSignal<QueryInput<S>>,
     options?: InjectStitchOptions<QueryOutput<S>>,
 ): InjectStitchResult<QueryOutput<S>>;
 export function injectStitch<T, Input = unknown>(
     stitch: StitchLike<T, Input>,
-    input: InjectInput<Input>,
+    input: MaybeSignal<Input>,
     options?: InjectStitchOptions<T>,
 ): InjectStitchResult<T>;
 export function injectStitch<T>(
     stitch: StitchLike<T, unknown>,
-    input: InjectInput<unknown>,
+    input: MaybeSignal<unknown>,
     options: InjectStitchOptions<T> = {},
 ): InjectStitchResult<T> {
     return injectStitchInternal<T>(stitch, input, options, false);
@@ -345,67 +290,18 @@ export function injectStitch<T>(
  */
 export function injectStitchStream<S extends StitchLike<unknown, never>>(
     stitch: S,
-    input: InjectInput<QueryInput<S>>,
+    input: MaybeSignal<QueryInput<S>>,
     options?: InjectStitchOptions<QueryOutput<S>>,
 ): InjectStitchResult<QueryOutput<S>>;
 export function injectStitchStream<T, Input = unknown>(
     stitch: StitchLike<T, Input>,
-    input: InjectInput<Input>,
+    input: MaybeSignal<Input>,
     options?: InjectStitchOptions<T>,
 ): InjectStitchResult<T>;
 export function injectStitchStream<T>(
     stitch: StitchLike<T, unknown>,
-    input: InjectInput<unknown>,
+    input: MaybeSignal<unknown>,
     options: InjectStitchOptions<T> = {},
 ): InjectStitchResult<T> {
     return injectStitchInternal<T>(stitch, input, options, true);
-}
-
-// ---------------------------------------------------------------------------
-// stitchQueryOptions — optional TanStack Query adapter
-// ---------------------------------------------------------------------------
-
-// IDENTICAL to the other bindings' `stitchQueryOptions` (no framework import) —
-// the POJO shape `@tanstack/angular-query-experimental`'s `injectQuery(() => ...)`
-// consumes is the same `{ queryKey, queryFn }` TanStack uses everywhere.
-
-/** The plain object {@link stitchQueryOptions} returns — structurally compatible with
- * TanStack Query's options without importing the library. */
-export interface StitchQueryOptions<T> {
-    queryKey: readonly unknown[];
-    queryFn: (ctx?: { signal?: AbortSignal }) => Promise<T>;
-}
-
-/**
- * Build a TanStack-Query-compatible options object for a stitch, WITHOUT a hard
- * dependency on `@tanstack/angular-query-experimental` — it just returns a POJO:
- *
- * ```ts
- * import { injectQuery } from '@tanstack/angular-query-experimental';
- * import { stitchQueryOptions } from '@stitchapi/angular';
- *
- * readonly user = injectQuery(() => stitchQueryOptions(getUser, { params: { id: this.id() } }));
- * ```
- *
- * The `queryFn` awaits the stitch (the validated output); the `queryKey` is a
- * stable name for the stitch plus a sanitised copy of the input (secret header
- * values redacted, runtime-only `signal`/`onProgress` dropped), so TanStack caches
- * per call without leaking a bearer token into the key or refetching every render.
- */
-export function stitchQueryOptions<S extends StitchLike<unknown, never>>(
-    stitch: S,
-    input: QueryInput<S>,
-): StitchQueryOptions<QueryOutput<S>>;
-export function stitchQueryOptions<T, Input = unknown>(
-    stitch: StitchLike<T, Input>,
-    input: Input,
-): StitchQueryOptions<T>;
-export function stitchQueryOptions<T>(
-    stitch: StitchLike<T, unknown>,
-    input: unknown,
-): StitchQueryOptions<T> {
-    return {
-        queryKey: [nameOf(stitch), keyInputFor(input)],
-        queryFn: () => Promise.resolve(stitch(input)),
-    };
 }

--- a/packages/angular/test/bindings.spec.ts
+++ b/packages/angular/test/bindings.spec.ts
@@ -300,6 +300,24 @@ describe('state$', () => {
     });
 });
 
+// --- InjectStitchOptions surface ---------------------------------------------
+
+describe('InjectStitchOptions', () => {
+    test("the store's 'streaming' flag cannot be passed to the injectors", () => {
+        const stitch = unaryStitch(async () => 1);
+        // Never executed — compile-time assertions only: each injector hard-sets
+        // `streaming`, so passing it must be a TYPE ERROR rather than being
+        // silently ignored.
+        void function TypeOnly(): void {
+            // @ts-expect-error — 'streaming' is omitted from InjectStitchOptions
+            injectStitch(stitch, {}, { streaming: true });
+            // @ts-expect-error — 'streaming' is omitted from InjectStitchOptions
+            injectStitchStream(stitch, {}, { streaming: false });
+        };
+        expect(true).toBe(true);
+    });
+});
+
 // --- stitchQueryOptions ----------------------------------------------------------
 
 describe('stitchQueryOptions', () => {
@@ -320,9 +338,10 @@ describe('stitchQueryOptions', () => {
 });
 
 // --- stitchQueryOptions: cache-key derivation regressions ------------------
-// The `queryKey` derivation shared the same three bugs as `@stitchapi/react`'s
-// (fixed there in #406). Each of these FAILED before the port. Keep in lock-step
-// with `@stitchapi/react`'s `packages/react/test/hooks.spec.tsx`.
+// The derivation now lives in `@stitchapi/query-core` (`deriveQueryKey`) and is
+// re-exported here; these regressions stay to guard the re-export wiring. Each
+// of these FAILED before the original fix (the local copy shared the same three
+// bugs as `@stitchapi/react`'s, fixed there in #406).
 
 describe('stitchQueryOptions — no cache collision between nameless stitches', () => {
     // Bug 1 (correctness): `name ?? 'stitch'` keyed every nameless stitch as the

--- a/packages/query-core/README.md
+++ b/packages/query-core/README.md
@@ -16,7 +16,7 @@ A `stitch` is a typed declarative call: invoking it returns a `StitchResult<T>` 
 pnpm add @stitchapi/query-core@rc stitchapi@rc
 ```
 
-`stitchapi` is a peer dependency (`>=0.7.0`).
+`stitchapi` is a peer dependency (`^1.0.0-rc.1`).
 
 ## API
 
@@ -55,11 +55,30 @@ Snapshots are **identity-stable** between real changes — the store only hands 
 
 | Option      | Default    | Meaning                                                                                                   |
 | ----------- | ---------- | --------------------------------------------------------------------------------------------------------- |
-| `stream`    | `false`    | Drive the call through `.stream()` and update state per `delta` (for `sse`/`stream` surfaces).            |
+| `streaming` | `false`    | Drive the call through `.stream()` and update state per `delta` (for `sse`/`stream` surfaces).            |
 | `mode`      | `'append'` | Streaming fold: `'append'` collects chunks into `data`/`chunks`; `'replace'` keeps only the latest chunk. |
 | `enabled`   | `true`     | Run immediately on creation. `false` starts `idle`; fetch lazily via `refetch()`.                         |
 | `onSuccess` | —          | Called with the validated value on success.                                                               |
 | `onError`   | —          | Called with the thrown reason on failure.                                                                 |
+
+### TanStack Query interop
+
+`@stitchapi/query-core` also owns the one shared implementation behind every framework binding's TanStack adapter — the key format cannot drift between frameworks:
+
+```ts
+import { deriveQueryKey, stitchQueryOptions } from '@stitchapi/query-core';
+import type { StitchQueryOptions } from '@stitchapi/query-core';
+
+// [name, sanitised input] — signal/onProgress dropped, secret header values redacted
+const key = deriveQueryKey(getUser, { params: { id: '1' } });
+
+// A TanStack-compatible `{ queryKey, queryFn }` POJO — no @tanstack/* dependency
+const options = stitchQueryOptions(getUser, { params: { id: '1' } });
+```
+
+-   **`stitchQueryOptions(stitch, input)`** returns a `StitchQueryOptions<T>` (`{ queryKey, queryFn }` — TanStack's own field names, kept verbatim as a standards-interop carve-out). Pass it straight to `useQuery` / `createQuery` / `injectQuery`.
+-   **`deriveQueryKey(stitch, input)`** builds the canonical cache key: a stable stitch name plus a sanitised input.
+-   **`nameOf(stitch)`** and **`keyInputFor(input)`** expose the two key segments for bindings that compose keys themselves. `keyInputFor` never puts the raw input in a key: it drops runtime-only `signal`/`onProgress` and redacts the values of secret-bearing headers (`authorization`, `cookie`, `*-token`, `*-api-key`, plus core's `isSecretKey` names — including anything widened via `registerSecretKey`).
 
 ## Example
 
@@ -87,7 +106,7 @@ import { createStitchQuery } from '@stitchapi/query-core';
 import { sse } from 'stitchapi';
 
 const tokens = sse({ url: 'https://api.example.com/chat' });
-const q = createStitchQuery(tokens, undefined, { stream: true });
+const q = createStitchQuery(tokens, undefined, { streaming: true });
 // q.getSnapshot().chunks grows as each `delta` arrives; status is 'streaming'
 // until the terminal `result`, then 'success'.
 ```

--- a/packages/query-core/src/index.ts
+++ b/packages/query-core/src/index.ts
@@ -8,13 +8,15 @@
 // that one-shot call into a SUBSCRIBABLE store: a `getSnapshot()` / `subscribe()`
 // handle that drives React's `useSyncExternalStore` (see `@stitchapi/react`) and,
 // later, the equivalent primitives in Vue / Svelte / Solid. It imports NO
-// framework and NO `node:*`, so it is browser- and edge-safe.
+// framework and NO `node:*` — its only runtime import is its `stitchapi` peer
+// (for the shared secret-key predicate) — so it is browser- and edge-safe.
 //
 // The store owns the lifecycle the engine deliberately leaves to a host: it runs
 // the call under an `AbortController`, publishes status transitions to listeners,
 // `cancel()`s by aborting, and `refetch()`es by re-running. For a streaming
 // surface it consumes `.stream()` and pushes a state update as each `delta`
 // arrives — the reactive differentiator over plain request/response query libs.
+import { isSecretKey } from 'stitchapi';
 import type { Stitch, StitchEvent, StitchResult } from 'stitchapi';
 
 // ---------------------------------------------------------------------------
@@ -43,7 +45,7 @@ export interface StitchQueryResult<T> {
     /** The thrown reason on failure (a `StitchError` from core, or any throw). */
     readonly error: unknown;
     /** Accumulated `delta` chunks, in arrival order. Empty for a unary call, or
-     * when `accumulate: false` (only the latest chunk is kept on `data`). */
+     * when `mode: 'replace'` (only the latest chunk is kept on `data`). */
     readonly chunks: readonly unknown[];
     /** `status === 'pending'` — a convenience flag for the common render branch. */
     readonly isPending: boolean;
@@ -63,7 +65,7 @@ export interface CreateStitchQueryOptions<T> {
      * a streaming surface (`sse` / `stream`), set this so chunks render as they
      * arrive.
      */
-    readonly stream?: boolean;
+    readonly streaming?: boolean;
     /**
      * For a streaming query, how `data` reflects the stream. `'append'` (default)
      * collects every chunk into `chunks` and sets `data` to the running array.
@@ -197,7 +199,7 @@ export function createStitchQuery<T>(
     options: CreateStitchQueryOptions<T> = {},
 ): StitchQuery<T> {
     const {
-        stream = false,
+        streaming = false,
         mode = 'append',
         enabled = true,
         onSuccess,
@@ -328,7 +330,7 @@ export function createStitchQuery<T>(
             }),
         );
         // `void` the promise: errors are folded into state, never unhandled.
-        void (stream ? runStream(token) : runUnary(token));
+        void (streaming ? runStream(token) : runUnary(token));
     }
 
     if (enabled) start();
@@ -366,6 +368,165 @@ class DOMExceptionLike extends Error {
     constructor(message: string) {
         super(message);
     }
+}
+
+// ---------------------------------------------------------------------------
+// TanStack Query interop — the canonical options shape + key derivation
+// ---------------------------------------------------------------------------
+// The one shared implementation behind every TanStack binding's
+// `stitchQueryOptions` (react / vue / svelte / solid / angular) and the swr
+// binding's key builder. Bindings import from here instead of carrying private
+// copies, so the key format — and its secret-redaction guarantees — cannot
+// drift between frameworks (CONTRACT.md P9).
+
+/**
+ * The canonical options object a binding's `stitchQueryOptions(...)` returns —
+ * structurally what TanStack Query's `useQuery` / `createQuery` / `injectQuery`
+ * consume, WITHOUT importing the library.
+ *
+ * `queryKey` / `queryFn` — and the `*Options` name itself, which TanStack uses
+ * for exactly this shape — are TanStack Query's own vocabulary, kept verbatim
+ * as a deliberate standards-interop carve-out (CONTRACT.md P22): this type
+ * exists solely to be handed to TanStack, so renaming any part of it would buy
+ * a translation seam and nothing else. The name is blessed; do not rename.
+ */
+export interface StitchQueryOptions<T> {
+    queryKey: readonly unknown[];
+    queryFn: (ctx?: { signal?: AbortSignal }) => Promise<T>;
+}
+
+/** The `__config` slice a key derives from. Mirrors core's `nameOf`
+ * (`name ?? path ?? 'stitch'`) plus a `url` fallback for URL-configured stitches. */
+type KeyConfig = { name?: string; path?: string; url?: string };
+
+/** A stable, human-meaningful name for the stitch — the first segment of a
+ * derived query key. Mirrors core's `nameOf` (`packages/core/src/engine.ts`) —
+ * `name ?? path ?? url ?? 'stitch'` — so two DISTINCT nameless stitches
+ * (`/users/{id}` vs `/orders/{id}`) don't collapse to the literal `'stitch'`
+ * and collide on one cache entry. */
+export function nameOf(stitch: unknown): string {
+    const cfg = (stitch as { __config?: KeyConfig }).__config;
+    return cfg?.name ?? cfg?.path ?? cfg?.url ?? 'stitch';
+}
+
+// Header names whose VALUES are secrets — the header-specific denylist on top of
+// core's `isSecretKey` predicate (which contributes the secret stems — `token`,
+// `secret`, `apikey`, … — and any caller-registered names via
+// `registerSecretKey`). We redact the value (rather than dropping the header) so
+// the key stays stable per token AND callers who legitimately vary a response by
+// a non-secret header (e.g. `accept-language`) keep separate cache entries.
+// Compared case-insensitively; the `*-token` / `*-api-key` suffix rules catch
+// vendor spellings the stems miss (dashes defeat the `api_key`/`apikey` stems).
+const SECRET_HEADERS = new Set([
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+    'set-cookie',
+    'x-api-key',
+    'x-auth-token',
+]);
+const REDACTED = '[redacted]';
+
+function isSecretHeader(name: string): boolean {
+    const k = name.toLowerCase();
+    return (
+        SECRET_HEADERS.has(k) ||
+        k.endsWith('-token') ||
+        k.endsWith('-api-key') ||
+        isSecretKey(k)
+    );
+}
+
+/**
+ * Build the value that goes into a cache/query key from a stitch's per-call
+ * input — the second segment of a derived query key. Never puts the raw input
+ * in the key:
+ *
+ * - drops `signal` / `onProgress` — runtime-only, never-serialised (CONTRACT.md);
+ *   `onProgress` in particular churns identity every render, which would refetch
+ *   forever if it entered the key;
+ * - redacts the VALUES of secret-bearing headers (`authorization`, `cookie`, …)
+ *   so a bearer token can't leak into a persisted / devtools-visible key, while
+ *   keeping non-secret headers so they still vary the cache;
+ * - keeps every other field (`params` / `query` / `body` / `variables` / …) as-is.
+ *
+ * `null` / `undefined` inputs stay `null`; a primitive input is returned unchanged.
+ */
+export function keyInputFor(input: unknown): unknown {
+    if (input === null || input === undefined) return null;
+    if (typeof input !== 'object') return input;
+
+    const {
+        signal: _signal,
+        onProgress: _onProgress,
+        ...rest
+    } = input as {
+        signal?: unknown;
+        onProgress?: unknown;
+        headers?: Record<string, unknown>;
+    } & Record<string, unknown>;
+
+    if (rest.headers && typeof rest.headers === 'object') {
+        const headers: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(rest.headers)) {
+            headers[k] = isSecretHeader(k) ? REDACTED : v;
+        }
+        rest.headers = headers;
+    }
+    return rest;
+}
+
+/**
+ * Derive the canonical cache/query key for a stitch call: a stable name for the
+ * stitch (see {@link nameOf}) plus a sanitised copy of the input (see
+ * {@link keyInputFor}). Every binding — the five TanStack adapters' query keys
+ * and the swr key builder — derives from here, so a stitch keys identically no
+ * matter which framework reads it.
+ */
+export function deriveQueryKey(
+    stitch: unknown,
+    input: unknown,
+): readonly [string, unknown] {
+    return [nameOf(stitch), keyInputFor(input)];
+}
+
+/**
+ * Build a TanStack-Query-compatible options object for a stitch, WITHOUT a hard
+ * dependency on any `@tanstack/*-query` package — it just returns a POJO. The
+ * framework bindings re-export this; pass it straight to `useQuery` /
+ * `createQuery` / `injectQuery`:
+ *
+ * ```ts
+ * import { useQuery } from '@tanstack/react-query';
+ * import { stitchQueryOptions } from '@stitchapi/react';
+ *
+ * const { data } = useQuery(stitchQueryOptions(getUser, { params: { id } }));
+ * ```
+ *
+ * The `queryFn` awaits the stitch (the validated output); the `queryKey` is
+ * {@link deriveQueryKey}'s stable, secret-redacted key, so TanStack caches per
+ * call without leaking a bearer token into the key or refetching every render.
+ *
+ * Named `stitchQueryOptions` (not a bare `queryOptions`) because TanStack Query
+ * itself exports a `queryOptions` — the bare name would clash on import. See
+ * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md).
+ */
+export function stitchQueryOptions<S extends StitchLike<unknown, never>>(
+    stitch: S,
+    input: QueryInput<S>,
+): StitchQueryOptions<QueryOutput<S>>;
+export function stitchQueryOptions<T, Input = unknown>(
+    stitch: StitchLike<T, Input>,
+    input: Input,
+): StitchQueryOptions<T>;
+export function stitchQueryOptions<T>(
+    stitch: StitchLike<T, unknown>,
+    input: unknown,
+): StitchQueryOptions<T> {
+    return {
+        queryKey: deriveQueryKey(stitch, input),
+        queryFn: () => Promise.resolve(stitch(input)),
+    };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/query-core/test/query.spec.ts
+++ b/packages/query-core/test/query.spec.ts
@@ -1,9 +1,16 @@
 // @stitchapi/query-core behaviour. Driven by FAKE stitches (plain callables that
 // return a `StitchResult`-shaped value) — no engine, no network. We exercise the
 // unary lifecycle, cancel/refetch, and the streaming `delta` accumulation.
-import { createStitchQuery } from '../src';
+import {
+    createStitchQuery,
+    deriveQueryKey,
+    keyInputFor,
+    nameOf,
+    stitchQueryOptions,
+} from '../src';
 import type { StitchCallResult, StitchLike } from '../src';
 
+import { registerSecretKey } from 'stitchapi';
 import type { StitchEvent } from 'stitchapi';
 import { describe, expect, test, vi } from 'vitest';
 
@@ -15,7 +22,7 @@ function unaryStitch<T>(settle: (input: unknown) => Promise<T>): StitchLike<T> {
         const promise = settle(input);
         return {
             then: (onf, onr) => promise.then(onf, onr),
-            // A unary fake never streams; the store only calls this in stream mode.
+            // A unary fake never streams; the store only calls this when `streaming`.
             stream() {
                 async function* gen(): AsyncGenerator<StitchEvent<T>> {
                     const value = await promise;
@@ -253,7 +260,7 @@ describe('streaming query', () => {
             { type: 'done', ok: true, elapsed: 1, attempts: 1, at: 0 },
         ];
         const q = createStitchQuery(streamStitch(events), undefined, {
-            stream: true,
+            streaming: true,
         });
 
         const seen: number[][] = [];
@@ -282,7 +289,7 @@ describe('streaming query', () => {
             { type: 'result', data: 20, status: 200, attempts: 1, at: 0 },
         ];
         const q = createStitchQuery(streamStitch(events), undefined, {
-            stream: true,
+            streaming: true,
             mode: 'replace',
         });
         await new Promise((r) => setTimeout(r, 10));
@@ -304,7 +311,7 @@ describe('streaming query', () => {
             },
         ];
         const q = createStitchQuery(streamStitch(events), undefined, {
-            stream: true,
+            streaming: true,
         });
         await new Promise((r) => setTimeout(r, 10));
         const s = q.getSnapshot();
@@ -319,7 +326,7 @@ describe('streaming query', () => {
         ];
         const statuses: string[] = [];
         const q = createStitchQuery(streamStitch(events), undefined, {
-            stream: true,
+            streaming: true,
             mode: 'replace',
         });
         q.subscribe(() => statuses.push(q.getSnapshot().status));
@@ -394,7 +401,7 @@ describe('onSuccess / onError callbacks', () => {
             { type: 'result', data: 'final', status: 200, attempts: 1, at: 0 },
         ];
         const q = createStitchQuery(streamStitch(events), undefined, {
-            stream: true,
+            streaming: true,
             onSuccess,
         });
         await tick();
@@ -415,7 +422,7 @@ describe('onSuccess / onError callbacks', () => {
             },
         ];
         const q = createStitchQuery(streamStitch(events), undefined, {
-            stream: true,
+            streaming: true,
             onError,
         });
         await tick();
@@ -437,5 +444,101 @@ describe('onSuccess / onError callbacks', () => {
         await tick();
         expect(onSuccess).not.toHaveBeenCalled();
         q.destroy();
+    });
+});
+
+// --- key derivation (the one shared implementation behind every binding) ----
+
+describe('nameOf()', () => {
+    const withConfig = (cfg: Record<string, unknown>): StitchLike<string> =>
+        Object.assign(
+            unaryStitch<string>(async () => 'x'),
+            { __config: cfg },
+        );
+
+    test('prefers name, then path, then url, then the literal fallback', () => {
+        expect(nameOf(withConfig({ name: 'getUser', path: '/u/{id}' }))).toBe(
+            'getUser',
+        );
+        expect(nameOf(withConfig({ path: '/users/{id}' }))).toBe('/users/{id}');
+        expect(nameOf(withConfig({ url: 'https://x.dev/feed' }))).toBe(
+            'https://x.dev/feed',
+        );
+        expect(nameOf(withConfig({}))).toBe('stitch');
+    });
+
+    test('a bare callable without __config falls back to the literal', () => {
+        expect(nameOf(unaryStitch(async () => 1))).toBe('stitch');
+    });
+});
+
+describe('keyInputFor()', () => {
+    test('null / undefined stay null; primitives pass through', () => {
+        expect(keyInputFor(null)).toBeNull();
+        expect(keyInputFor(undefined)).toBeNull();
+        expect(keyInputFor(7)).toBe(7);
+        expect(keyInputFor('q')).toBe('q');
+    });
+
+    test('drops runtime-only signal / onProgress, keeps everything else', () => {
+        const out = keyInputFor({
+            params: { id: '1' },
+            signal: new AbortController().signal,
+            onProgress: () => {},
+        });
+        expect(out).toEqual({ params: { id: '1' } });
+    });
+
+    test('redacts secret header VALUES but keeps benign headers varying the key', () => {
+        const out = keyInputFor({
+            headers: {
+                Authorization: 'Bearer tok',
+                'x-csrf-token': 'abc',
+                'x-goog-api-key': 'k',
+                'accept-language': 'uk',
+            },
+        }) as { headers: Record<string, unknown> };
+        expect(out.headers['Authorization']).toBe('[redacted]');
+        expect(out.headers['x-csrf-token']).toBe('[redacted]');
+        expect(out.headers['x-goog-api-key']).toBe('[redacted]');
+        expect(out.headers['accept-language']).toBe('uk');
+    });
+
+    test("reuses core's isSecretKey: registerSecretKey widens header redaction", () => {
+        registerSecretKey('x-querycore-spec-credential');
+        const out = keyInputFor({
+            headers: { 'x-querycore-spec-credential': 'v' },
+        }) as { headers: Record<string, unknown> };
+        expect(out.headers['x-querycore-spec-credential']).toBe('[redacted]');
+    });
+});
+
+describe('deriveQueryKey() / stitchQueryOptions()', () => {
+    test('the key is [name, sanitised input]', () => {
+        const stitch = Object.assign(
+            unaryStitch<string>(async () => 'x'),
+            { __config: { path: '/users/{id}' } },
+        );
+        expect(
+            deriveQueryKey(stitch, {
+                params: { id: '1' },
+                headers: { authorization: 'Bearer t' },
+            }),
+        ).toEqual([
+            '/users/{id}',
+            { params: { id: '1' }, headers: { authorization: '[redacted]' } },
+        ]);
+    });
+
+    test('stitchQueryOptions returns the derived key and an awaiting queryFn', async () => {
+        const stitch = Object.assign(
+            unaryStitch(async (input) => ({ echoed: input })),
+            { __config: { name: 'echo' } },
+        );
+        const options = stitchQueryOptions(stitch, { body: { a: 1 } });
+        expect(options.queryKey).toEqual(['echo', { body: { a: 1 } }]);
+        await expect(options.queryFn()).resolves.toEqual({
+            echoed: { body: { a: 1 } },
+        });
     });
 });

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -10,9 +10,11 @@
 // - `useStitchStream` — the streaming hook: re-renders as `delta` chunks arrive.
 //                       This is the differentiator over plain request/response
 //                       query libraries.
-// - `stitchQueryOptions` — an OPTIONAL TanStack Query adapter (returns a plain POJO,
-//                       so it needs no import of `@tanstack/react-query`; named with the
-//                       `stitch` prefix because TanStack exports its own `queryOptions`).
+// - `stitchQueryOptions` — an OPTIONAL TanStack Query adapter, re-exported from
+//                       `@stitchapi/query-core` (returns a plain POJO, so it needs
+//                       no import of `@tanstack/react-query`; named with the
+//                       `stitch` prefix because TanStack exports its own
+//                       `queryOptions`, see ADR 0012).
 import {
     type CreateStitchQueryOptions,
     type QueryInput,
@@ -21,6 +23,8 @@ import {
     type StitchQuery,
     type StitchQueryResult,
     createStitchQuery,
+    keyInputFor,
+    nameOf,
 } from '@stitchapi/query-core';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSyncExternalStore } from 'react';
@@ -32,12 +36,40 @@ export type {
     QueryOutput,
     StitchLike,
     StitchQuery,
+    StitchQueryOptions,
     StitchQueryResult,
 } from '@stitchapi/query-core';
 
+// The TanStack Query adapter and its key derivation live in
+// `@stitchapi/query-core` — ONE shared implementation across every framework
+// binding, so the key format (and its secret-redaction guarantees) cannot drift
+// between frameworks. Re-exported here so React apps import everything from
+// `@stitchapi/react`.
+export {
+    deriveQueryKey,
+    keyInputFor,
+    nameOf,
+    stitchQueryOptions,
+} from '@stitchapi/query-core';
+
 // ---------------------------------------------------------------------------
-// Hook result
+// Hook options & result
 // ---------------------------------------------------------------------------
+
+/**
+ * Options accepted by {@link useStitch} / {@link useStitchStream}.
+ *
+ * The store's `streaming` flag is deliberately OMITTED: each hook hard-sets it
+ * (`useStitch` → unary, `useStitchStream` → streaming), so passing it would be
+ * silently ignored — the type forbids it instead.
+ */
+export interface UseStitchOptions<T>
+    extends Omit<CreateStitchQueryOptions<T>, 'streaming'> {
+    /** Explicit re-create trigger. When provided, the handle is re-created only
+     * when one of these changes (by `Object.is`), instead of the default
+     * structural key of `input`. */
+    deps?: readonly unknown[];
+}
 
 /** What `useStitch` / `useStitchStream` return: the reactive state plus the
  * imperative `refetch` / `cancel` handles. */
@@ -52,94 +84,16 @@ export interface UseStitchResult<T> extends StitchQueryResult<T> {
 // Shared driver
 // ---------------------------------------------------------------------------
 
-// --- key derivation (shared logic; duplicated in @stitchapi/swr) -----------
-// These helpers are intentionally copied verbatim into `@stitchapi/swr`'s
-// `swrKey`: they are separate published packages, so a cross-package import would
-// add a runtime dependency. Keep the two copies in lock-step.
-
-/** The `__config` slice a key derives from. Mirrors core's `nameOf`
- * (`name ?? path ?? 'stitch'`) plus a `url` fallback for URL-configured stitches. */
-type KeyConfig = { name?: string; path?: string; url?: string };
-
-/** A stable, human-meaningful name for the stitch. Mirrors core's `nameOf`
- * (`packages/core/src/engine.ts`) — `name ?? path ?? url ?? 'stitch'` — so two
- * DISTINCT nameless stitches (`/users/{id}` vs `/orders/{id}`) don't collapse to
- * the literal `'stitch'` and collide on one cache entry. */
-function nameOf(stitch: unknown): string {
-    const cfg = (stitch as { __config?: KeyConfig }).__config;
-    return cfg?.name ?? cfg?.path ?? cfg?.url ?? 'stitch';
-}
-
-// Header names whose VALUES are secrets — mirrors core's private `SECRET_HEADERS`
-// trace denylist (`packages/core/src/trace.ts`), which is not exported. We redact
-// the value (rather than dropping the header) so the key stays stable per token
-// AND callers who legitimately vary a response by a non-secret header (e.g.
-// `accept-language`) keep separate cache entries. Compared case-insensitively; the
-// `*-token` / `*-api-key` suffix rules catch vendor spellings without enumerating.
-const SECRET_HEADERS = new Set([
-    'authorization',
-    'proxy-authorization',
-    'cookie',
-    'set-cookie',
-    'x-api-key',
-    'x-auth-token',
-]);
-const REDACTED = '[redacted]';
-
-function isSecretHeader(name: string): boolean {
-    const k = name.toLowerCase();
-    return (
-        SECRET_HEADERS.has(k) || k.endsWith('-token') || k.endsWith('-api-key')
-    );
-}
-
-/**
- * Build the value that goes into a cache/query key from a stitch's per-call input.
- * Never puts the raw input in the key:
- *
- * - drops `signal` / `onProgress` — runtime-only, never-serialised (CONTRACT.md);
- *   `onProgress` in particular churns identity every render, which would refetch
- *   forever if it entered the key;
- * - redacts the VALUES of secret-bearing headers (`authorization`, `cookie`, …)
- *   so a bearer token can't leak into a persisted / devtools-visible key, while
- *   keeping non-secret headers so they still vary the cache;
- * - keeps every other field (`params` / `query` / `body` / `variables` / …) as-is.
- *
- * `null` / `undefined` inputs stay `null`; a primitive input is returned unchanged.
- */
-function keyInputFor(input: unknown): unknown {
-    if (input === null || input === undefined) return null;
-    if (typeof input !== 'object') return input;
-
-    const {
-        signal: _signal,
-        onProgress: _onProgress,
-        ...rest
-    } = input as {
-        signal?: unknown;
-        onProgress?: unknown;
-        headers?: Record<string, unknown>;
-    } & Record<string, unknown>;
-
-    if (rest.headers && typeof rest.headers === 'object') {
-        const headers: Record<string, unknown> = {};
-        for (const [k, v] of Object.entries(rest.headers)) {
-            headers[k] = isSecretHeader(k) ? REDACTED : v;
-        }
-        rest.headers = headers;
-    }
-    return rest;
-}
-
 // `deps` lets the caller control when the query handle is re-created. By default
 // we derive a stable identity from the stitch + a structural key of the input, so
 // `{ id: 1 }` !== `{ id: 2 }` re-fetches but a re-render with an equal-shaped
 // literal does not. A caller who keys differently passes explicit `deps`.
 function defaultKey(input: unknown): string {
     try {
-        // Sanitise first: an inline `onProgress` (fresh identity per render) would
-        // otherwise churn the structural key and loop; a per-call `signal` would
-        // add non-deterministic noise. Both are runtime-only, so drop them.
+        // Sanitise first (via query-core's `keyInputFor`): an inline `onProgress`
+        // (fresh identity per render) would otherwise churn the structural key
+        // and loop; a per-call `signal` would add non-deterministic noise. Both
+        // are runtime-only, so they are dropped.
         return JSON.stringify(keyInputFor(input));
     } catch {
         // Non-serialisable input (a function, a cyclic object) → opt out of
@@ -148,19 +102,12 @@ function defaultKey(input: unknown): string {
     }
 }
 
-interface UseStitchOptions<T> extends CreateStitchQueryOptions<T> {
-    /** Explicit re-create trigger. When provided, the handle is re-created only
-     * when one of these changes (by `Object.is`), instead of the default
-     * structural key of `input`. */
-    deps?: readonly unknown[];
-}
-
 function useStitchInternal<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
-    options: UseStitchOptions<T> & { stream: boolean },
+    options: UseStitchOptions<T> & { streaming: boolean },
 ): UseStitchResult<T> {
-    const { deps, stream, mode, enabled, onSuccess, onError } = options;
+    const { deps, streaming, mode, enabled, onSuccess, onError } = options;
 
     // Keep the latest callbacks in a ref so changing them does not re-create the
     // handle (and so the store never holds a stale closure).
@@ -184,11 +131,12 @@ function useStitchInternal<T>(
 
     // The dependency list that triggers a fresh handle (and re-fetch). Default: a
     // structural key of the input + a stable name for the stitch (NOT its function
-    // identity; via `nameOf`, so two nameless stitches on different paths don't
-    // share a dep key) + the streaming flags. Pass `options.deps` to override.
+    // identity; via query-core's `nameOf`, so two nameless stitches on different
+    // paths don't share a dep key) + the streaming flags. Pass `options.deps` to
+    // override.
     const depKey = deps
         ? deps
-        : [nameOf(stitch), defaultKey(input), stream, mode, enabled];
+        : [nameOf(stitch), defaultKey(input), streaming, mode, enabled];
 
     const query: StitchQuery<T> = useMemo(
         () =>
@@ -196,7 +144,7 @@ function useStitchInternal<T>(
                 stableStitch,
                 input,
                 compact({
-                    stream,
+                    streaming,
                     mode,
                     enabled,
                     onSuccess: (d: T) => cbRef.current.onSuccess?.(d),
@@ -262,7 +210,10 @@ export function useStitch<T>(
     input: unknown,
     options: UseStitchOptions<T> = {},
 ): UseStitchResult<T> {
-    return useStitchInternal<T>(stitch, input, { ...options, stream: false });
+    return useStitchInternal<T>(stitch, input, {
+        ...options,
+        streaming: false,
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -297,55 +248,5 @@ export function useStitchStream<T>(
     input: unknown,
     options: UseStitchOptions<T> = {},
 ): UseStitchResult<T> {
-    return useStitchInternal<T>(stitch, input, { ...options, stream: true });
-}
-
-// ---------------------------------------------------------------------------
-// stitchQueryOptions — optional TanStack Query adapter
-// ---------------------------------------------------------------------------
-
-/** The plain object {@link stitchQueryOptions} returns — structurally compatible with
- * TanStack Query's `useQuery(options)` without importing the library. */
-export interface StitchQueryOptions<T> {
-    queryKey: readonly unknown[];
-    queryFn: (ctx?: { signal?: AbortSignal }) => Promise<T>;
-}
-
-/**
- * Build a TanStack-Query-compatible options object for a stitch, WITHOUT a hard
- * dependency on `@tanstack/react-query` — it just returns a POJO. Pass it
- * straight to `useQuery`:
- *
- * ```tsx
- * import { useQuery } from '@tanstack/react-query';
- * import { stitchQueryOptions } from '@stitchapi/react';
- *
- * const { data } = useQuery(stitchQueryOptions(getUser, { params: { id } }));
- * ```
- *
- * The `queryFn` awaits the stitch (the validated output); the `queryKey` is a
- * stable name for the stitch plus a sanitised copy of the input (secret header
- * values redacted, runtime-only `signal`/`onProgress` dropped), so TanStack caches
- * per call without leaking a bearer token into the key or refetching every render.
- *
- * Named `stitchQueryOptions` (not a bare `queryOptions`) because TanStack Query
- * itself exports a `queryOptions` — the bare name would clash on import. See
- * [ADR 0012](../../../docs/adr/0012-integration-symbol-naming.md).
- */
-export function stitchQueryOptions<S extends StitchLike<unknown, never>>(
-    stitch: S,
-    input: QueryInput<S>,
-): StitchQueryOptions<QueryOutput<S>>;
-export function stitchQueryOptions<T, Input = unknown>(
-    stitch: StitchLike<T, Input>,
-    input: Input,
-): StitchQueryOptions<T>;
-export function stitchQueryOptions<T>(
-    stitch: StitchLike<T, unknown>,
-    input: unknown,
-): StitchQueryOptions<T> {
-    return {
-        queryKey: [nameOf(stitch), keyInputFor(input)],
-        queryFn: () => Promise.resolve(stitch(input)),
-    };
+    return useStitchInternal<T>(stitch, input, { ...options, streaming: true });
 }

--- a/packages/react/test/hooks.spec.tsx
+++ b/packages/react/test/hooks.spec.tsx
@@ -282,6 +282,24 @@ describe('useStitchStream', () => {
     });
 });
 
+// --- UseStitchOptions surface ------------------------------------------------
+
+describe('UseStitchOptions', () => {
+    test("the store's 'streaming' flag cannot be passed to the hooks", () => {
+        const stitch = unaryStitch(async () => 1);
+        // Never executed — compile-time assertions only: each hook hard-sets
+        // `streaming`, so passing it must be a TYPE ERROR rather than being
+        // silently ignored.
+        void function TypeOnly(): void {
+            // @ts-expect-error — 'streaming' is omitted from UseStitchOptions
+            useStitch(stitch, {}, { streaming: true });
+            // @ts-expect-error — 'streaming' is omitted from UseStitchOptions
+            useStitchStream(stitch, {}, { streaming: false });
+        };
+        expect(true).toBe(true);
+    });
+});
+
 // --- stitchQueryOptions ----------------------------------------------------------
 
 describe('stitchQueryOptions', () => {
@@ -302,8 +320,10 @@ describe('stitchQueryOptions', () => {
 });
 
 // --- stitchQueryOptions: cache-key derivation regressions ------------------
-// The `queryKey` derivation shared the same three bugs as `@stitchapi/swr`'s
-// `swrKey`. Each of these FAILED before the fix.
+// The derivation now lives in `@stitchapi/query-core` (`deriveQueryKey`) and is
+// re-exported here; these regressions stay to guard the re-export wiring. Each
+// of these FAILED before the original fix (the local copy shared the same three
+// bugs as `@stitchapi/swr`'s `swrKey`).
 
 describe('stitchQueryOptions — no cache collision between nameless stitches', () => {
     // Bug 1 (correctness): `name ?? 'stitch'` keyed every nameless stitch as the

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -2,7 +2,7 @@
     "name": "@stitchapi/solid",
     "version": "1.0.0-rc.6",
     "type": "commonjs",
-    "description": "Solid bindings for StitchAPI — createStitch/createStitchStream primitives that reconcile a Solid store from the query-core reactive store. Streaming-first: re-render as `delta` chunks arrive. Plus an optional TanStack Query queryOptions helper.",
+    "description": "Solid bindings for StitchAPI — createStitch/createStitchStream primitives that reconcile a Solid store from the query-core reactive store. Streaming-first: re-render as `delta` chunks arrive. Plus an optional TanStack Query stitchQueryOptions helper.",
     "main": "lib/index.js",
     "module": "lib/index.mjs",
     "types": "lib/index.d.ts",

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -31,6 +31,7 @@ export type {
     QueryOutput,
     StitchLike,
     StitchQuery,
+    StitchQueryOptions,
     StitchQueryResult,
 } from '@stitchapi/query-core';
 
@@ -70,85 +71,6 @@ export interface CreateStitchOptions<T> extends CreateStitchQueryOptions<T> {}
 // Shared driver
 // ---------------------------------------------------------------------------
 
-// --- key derivation (shared logic; duplicated in @stitchapi/react) ----------
-// These helpers are intentionally copied verbatim from `@stitchapi/react`'s key
-// derivation: they are separate published packages, so a cross-package import
-// would add a runtime dependency. Keep the copies in lock-step.
-
-/** The `__config` slice a key derives from. Mirrors core's `nameOf`
- * (`name ?? path ?? 'stitch'`) plus a `url` fallback for URL-configured stitches. */
-type KeyConfig = { name?: string; path?: string; url?: string };
-
-/** A stable, human-meaningful name for the stitch. Mirrors core's `nameOf`
- * (`packages/core/src/engine.ts`) — `name ?? path ?? url ?? 'stitch'` — so two
- * DISTINCT nameless stitches (`/users/{id}` vs `/orders/{id}`) don't collapse to
- * the literal `'stitch'` and collide on one cache entry. */
-function nameOf(stitch: unknown): string {
-    const cfg = (stitch as { __config?: KeyConfig }).__config;
-    return cfg?.name ?? cfg?.path ?? cfg?.url ?? 'stitch';
-}
-
-// Header names whose VALUES are secrets — mirrors core's private `SECRET_HEADERS`
-// trace denylist (`packages/core/src/trace.ts`), which is not exported. We redact
-// the value (rather than dropping the header) so the key stays stable per token
-// AND callers who legitimately vary a response by a non-secret header (e.g.
-// `accept-language`) keep separate cache entries. Compared case-insensitively; the
-// `*-token` / `*-api-key` suffix rules catch vendor spellings without enumerating.
-const SECRET_HEADERS = new Set([
-    'authorization',
-    'proxy-authorization',
-    'cookie',
-    'set-cookie',
-    'x-api-key',
-    'x-auth-token',
-]);
-const REDACTED = '[redacted]';
-
-function isSecretHeader(name: string): boolean {
-    const k = name.toLowerCase();
-    return (
-        SECRET_HEADERS.has(k) || k.endsWith('-token') || k.endsWith('-api-key')
-    );
-}
-
-/**
- * Build the value that goes into a cache/query key from a stitch's per-call input.
- * Never puts the raw input in the key:
- *
- * - drops `signal` / `onProgress` — runtime-only, never-serialised (CONTRACT.md);
- *   `onProgress` in particular churns identity every render, which would refetch
- *   forever if it entered the key;
- * - redacts the VALUES of secret-bearing headers (`authorization`, `cookie`, …)
- *   so a bearer token can't leak into a persisted / devtools-visible key, while
- *   keeping non-secret headers so they still vary the cache;
- * - keeps every other field (`params` / `query` / `body` / `variables` / …) as-is.
- *
- * `null` / `undefined` inputs stay `null`; a primitive input is returned unchanged.
- */
-function keyInputFor(input: unknown): unknown {
-    if (input === null || input === undefined) return null;
-    if (typeof input !== 'object') return input;
-
-    const {
-        signal: _signal,
-        onProgress: _onProgress,
-        ...rest
-    } = input as {
-        signal?: unknown;
-        onProgress?: unknown;
-        headers?: Record<string, unknown>;
-    } & Record<string, unknown>;
-
-    if (rest.headers && typeof rest.headers === 'object') {
-        const headers: Record<string, unknown> = {};
-        for (const [k, v] of Object.entries(rest.headers)) {
-            headers[k] = isSecretHeader(k) ? REDACTED : v;
-        }
-        rest.headers = headers;
-    }
-    return rest;
-}
-
 // The store's seed value, read before the effect mirrors the first real snapshot
 // (the effect is non-deferred, so this is only ever visible for an instant). It
 // matches core's idle snapshot exactly so `state` is well-formed from the start.
@@ -167,7 +89,7 @@ function createStitchInternal<T>(
     stitch: StitchLike<T, unknown>,
     input: MaybeAccessor<unknown>,
     options: MaybeAccessor<CreateStitchOptions<T>>,
-    stream: boolean,
+    streaming: boolean,
 ): SolidStitchStore<T> {
     // The Solid store we reconcile from the core query's snapshots. `reconcile`
     // does a structural diff so only the fields that actually changed notify
@@ -202,7 +124,7 @@ function createStitchInternal<T>(
                     stableStitch,
                     currentInput,
                     compact({
-                        stream,
+                        streaming,
                         mode,
                         enabled,
                         onSuccess,
@@ -318,48 +240,14 @@ export function createStitchStream<T>(
 // stitchQueryOptions — optional TanStack Query adapter
 // ---------------------------------------------------------------------------
 
-// IDENTICAL to `@stitchapi/react`'s `stitchQueryOptions` (no framework import) —
-// the POJO shape `@tanstack/solid-query`'s `createQuery(options)` consumes is the
-// same `{ queryKey, queryFn }` TanStack uses everywhere.
-
-/** The plain object {@link stitchQueryOptions} returns — structurally compatible with
- * TanStack Query's `createQuery(options)` without importing the library. */
-export interface StitchQueryOptions<T> {
-    queryKey: readonly unknown[];
-    queryFn: (ctx?: { signal?: AbortSignal }) => Promise<T>;
-}
-
-/**
- * Build a TanStack-Query-compatible options object for a stitch, WITHOUT a hard
- * dependency on `@tanstack/solid-query` — it just returns a POJO. Pass it straight
- * to `createQuery`:
- *
- * ```tsx
- * import { createQuery } from '@tanstack/solid-query';
- * import { stitchQueryOptions } from '@stitchapi/solid';
- *
- * const query = createQuery(() => stitchQueryOptions(getUser, { params: { id: id() } }));
- * ```
- *
- * The `queryFn` awaits the stitch (the validated output); the `queryKey` is a
- * stable name for the stitch plus a sanitised copy of the input (secret header
- * values redacted, runtime-only `signal`/`onProgress` dropped), so TanStack caches
- * per call without leaking a bearer token into the key or refetching every render.
- */
-export function stitchQueryOptions<S extends StitchLike<unknown, never>>(
-    stitch: S,
-    input: QueryInput<S>,
-): StitchQueryOptions<QueryOutput<S>>;
-export function stitchQueryOptions<T, Input = unknown>(
-    stitch: StitchLike<T, Input>,
-    input: Input,
-): StitchQueryOptions<T>;
-export function stitchQueryOptions<T>(
-    stitch: StitchLike<T, unknown>,
-    input: unknown,
-): StitchQueryOptions<T> {
-    return {
-        queryKey: [nameOf(stitch), keyInputFor(input)],
-        queryFn: () => Promise.resolve(stitch(input)),
-    };
-}
+// The single implementation lives in `@stitchapi/query-core` (already a runtime
+// peer of this package): `stitchQueryOptions(stitch, input)` returns the plain
+// `{ queryKey, queryFn }` POJO that `@tanstack/solid-query`'s
+// `createQuery(options)` consumes — no import of TanStack itself. The key is
+// `deriveQueryKey`'s stable, secret-redacted derivation, shared verbatim across
+// every framework binding (CONTRACT.md P9). Named `stitchQueryOptions` (not a
+// bare `queryOptions`) because TanStack Query exports its own `queryOptions` —
+// see ADR 0012.
+// Need the key alone (e.g. for TanStack invalidation)? Import `deriveQueryKey`
+// from `@stitchapi/query-core` — it is already an installed peer.
+export { stitchQueryOptions } from '@stitchapi/query-core';

--- a/packages/solid/test/primitives.spec.ts
+++ b/packages/solid/test/primitives.spec.ts
@@ -360,8 +360,9 @@ describe('stitchQueryOptions', () => {
 
 // --- stitchQueryOptions: cache-key derivation regressions ------------------
 // The `queryKey` derivation shared the same three bugs as `@stitchapi/react`'s
-// (fixed there in #406). Each of these FAILED before the port. Keep in lock-step
-// with `@stitchapi/react`'s `packages/react/test/hooks.spec.tsx`.
+// (fixed there in #406). Each of these FAILED before the port. The derivation
+// now lives once in `@stitchapi/query-core` (`deriveQueryKey`); these stay as
+// re-export-level regression coverage of the behaviours this binding promises.
 
 describe('stitchQueryOptions — no cache collision between nameless stitches', () => {
     // Bug 1 (correctness): `name ?? 'stitch'` keyed every nameless stitch as the

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -2,7 +2,7 @@
     "name": "@stitchapi/svelte",
     "version": "1.0.0-rc.6",
     "type": "commonjs",
-    "description": "Svelte bindings for StitchAPI — stitchStore/stitchStreamStore Svelte stores over @stitchapi/query-core (unary + streaming deltas), plus an optional TanStack-shaped queryOptions helper. Works on Svelte 4 and 5.",
+    "description": "Svelte bindings for StitchAPI — stitchStore/stitchStreamStore Svelte stores over @stitchapi/query-core (unary + streaming deltas), plus an optional TanStack-shaped stitchQueryOptions helper. Works on Svelte 4 and 5.",
     "main": "lib/index.js",
     "module": "lib/index.mjs",
     "types": "lib/index.d.ts",

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -13,10 +13,11 @@
 // - `stitchStreamStore` — the streaming store: emits a new state as each `delta`
 //                         chunk arrives. The differentiator over plain
 //                         request/response query libraries.
-// - `useStitch` / `useStitchStream` — hook-style aliases for the two above, for
-//                         callers who prefer the `use*` naming.
 // - `stitchQueryOptions` — an OPTIONAL TanStack Query adapter (returns a plain
 //                         POJO, so it needs no import of `@tanstack/svelte-query`).
+//                         Re-exported verbatim from `@stitchapi/query-core`, the
+//                         single shared implementation, so a stitch keys
+//                         identically no matter which framework binding built it.
 import {
     type CreateStitchQueryOptions,
     type QueryInput,
@@ -34,7 +35,19 @@ export type {
     QueryOutput,
     StitchLike,
     StitchQuery,
+    StitchQueryOptions,
     StitchQueryResult,
+} from '@stitchapi/query-core';
+
+// The TanStack Query adapter is the ONE shared implementation in query-core
+// (`deriveQueryKey` and its helpers included, for callers who key their own
+// caches). Named `stitchQueryOptions` — not a bare `queryOptions` — because
+// TanStack Query itself exports a `queryOptions` (ADR 0012).
+export {
+    deriveQueryKey,
+    keyInputFor,
+    nameOf,
+    stitchQueryOptions,
 } from '@stitchapi/query-core';
 
 // ---------------------------------------------------------------------------
@@ -62,7 +75,7 @@ export interface SvelteStitchStore<T> extends Readable<StitchQueryResult<T>> {
 function makeStore<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
-    options: CreateStitchQueryOptions<T> & { stream: boolean },
+    options: CreateStitchQueryOptions<T>,
 ): SvelteStitchStore<T> {
     // The query is created EAGERLY (so `getSnapshot` has a real handle to seed
     // the store and `refetch`/`cancel` work before the first subscriber), but its
@@ -109,6 +122,9 @@ function makeStore<T>(
  * The run starts on the store's first subscriber (so `$store` in a component
  * fetches when the component mounts) and is aborted when the last subscriber
  * leaves (component teardown). Call `refetch()` to re-run, `cancel()` to abort.
+ * The returned value is a Svelte store — re-create it when `input`/`options`
+ * change (e.g. derive it inside a `$:` block keyed on those) and let scope
+ * teardown destroy it.
  *
  * @example
  * ```svelte
@@ -137,7 +153,7 @@ export function stitchStore<T>(
     input: unknown,
     options: CreateStitchQueryOptions<T> = {},
 ): SvelteStitchStore<T> {
-    return makeStore<T>(stitch, input, { ...options, stream: false });
+    return makeStore<T>(stitch, input, { ...options, streaming: false });
 }
 
 // ---------------------------------------------------------------------------
@@ -176,148 +192,5 @@ export function stitchStreamStore<T>(
     input: unknown,
     options: CreateStitchQueryOptions<T> = {},
 ): SvelteStitchStore<T> {
-    return makeStore<T>(stitch, input, { ...options, stream: true });
-}
-
-// ---------------------------------------------------------------------------
-// useStitch / useStitchStream — hook-style aliases
-// ---------------------------------------------------------------------------
-
-/** Alias for {@link stitchStore}, for callers who prefer the `use*` naming. The
- * returned value is a Svelte store — re-create it when `input`/`options` change
- * (e.g. derive it inside a `$:` block keyed on those) and let scope teardown
- * destroy it. */
-export const useStitch = stitchStore;
-
-/** Alias for {@link stitchStreamStore}. */
-export const useStitchStream = stitchStreamStore;
-
-// ---------------------------------------------------------------------------
-// stitchQueryOptions — optional TanStack Query adapter
-// ---------------------------------------------------------------------------
-
-// IDENTICAL to `@stitchapi/react`'s `stitchQueryOptions` — it imports no
-// framework, so the POJO is framework-neutral and feeds `@tanstack/svelte-query`'s
-// `createQuery` exactly as it feeds React's `useQuery`.
-
-// --- key derivation (shared logic; duplicated in @stitchapi/react + swr) ----
-// These helpers are intentionally copied verbatim from `@stitchapi/react`
-// (`packages/react/src/index.ts`, landed in #406) and `@stitchapi/swr`: they are
-// separate published packages, so a cross-package import would add a runtime
-// dependency. Keep the copies in lock-step.
-
-/** The `__config` slice a key derives from. Mirrors core's `nameOf`
- * (`name ?? path ?? 'stitch'`) plus a `url` fallback for URL-configured stitches. */
-type KeyConfig = { name?: string; path?: string; url?: string };
-
-/** A stable, human-meaningful name for the stitch. Mirrors core's `nameOf`
- * (`packages/core/src/engine.ts`) — `name ?? path ?? url ?? 'stitch'` — so two
- * DISTINCT nameless stitches (`/users/{id}` vs `/orders/{id}`) don't collapse to
- * the literal `'stitch'` and collide on one cache entry. */
-function nameOf(stitch: unknown): string {
-    const cfg = (stitch as { __config?: KeyConfig }).__config;
-    return cfg?.name ?? cfg?.path ?? cfg?.url ?? 'stitch';
-}
-
-// Header names whose VALUES are secrets — mirrors core's private `SECRET_HEADERS`
-// trace denylist (`packages/core/src/trace.ts`), which is not exported. We redact
-// the value (rather than dropping the header) so the key stays stable per token
-// AND callers who legitimately vary a response by a non-secret header (e.g.
-// `accept-language`) keep separate cache entries. Compared case-insensitively; the
-// `*-token` / `*-api-key` suffix rules catch vendor spellings without enumerating.
-const SECRET_HEADERS = new Set([
-    'authorization',
-    'proxy-authorization',
-    'cookie',
-    'set-cookie',
-    'x-api-key',
-    'x-auth-token',
-]);
-const REDACTED = '[redacted]';
-
-function isSecretHeader(name: string): boolean {
-    const k = name.toLowerCase();
-    return (
-        SECRET_HEADERS.has(k) || k.endsWith('-token') || k.endsWith('-api-key')
-    );
-}
-
-/**
- * Build the value that goes into a cache/query key from a stitch's per-call input.
- * Never puts the raw input in the key:
- *
- * - drops `signal` / `onProgress` — runtime-only, never-serialised (CONTRACT.md);
- *   `onProgress` in particular churns identity every render, which would refetch
- *   forever if it entered the key;
- * - redacts the VALUES of secret-bearing headers (`authorization`, `cookie`, …)
- *   so a bearer token can't leak into a persisted / devtools-visible key, while
- *   keeping non-secret headers so they still vary the cache;
- * - keeps every other field (`params` / `query` / `body` / `variables` / …) as-is.
- *
- * `null` / `undefined` inputs stay `null`; a primitive input is returned unchanged.
- */
-function keyInputFor(input: unknown): unknown {
-    if (input === null || input === undefined) return null;
-    if (typeof input !== 'object') return input;
-
-    const {
-        signal: _signal,
-        onProgress: _onProgress,
-        ...rest
-    } = input as {
-        signal?: unknown;
-        onProgress?: unknown;
-        headers?: Record<string, unknown>;
-    } & Record<string, unknown>;
-
-    if (rest.headers && typeof rest.headers === 'object') {
-        const headers: Record<string, unknown> = {};
-        for (const [k, v] of Object.entries(rest.headers)) {
-            headers[k] = isSecretHeader(k) ? REDACTED : v;
-        }
-        rest.headers = headers;
-    }
-    return rest;
-}
-
-/** The plain object {@link stitchQueryOptions} returns — structurally compatible with
- * TanStack Query's `createQuery(options)` without importing the library. */
-export interface StitchQueryOptions<T> {
-    queryKey: readonly unknown[];
-    queryFn: (ctx?: { signal?: AbortSignal }) => Promise<T>;
-}
-
-/**
- * Build a TanStack-Query-compatible options object for a stitch, WITHOUT a hard
- * dependency on `@tanstack/svelte-query` — it just returns a POJO. Pass it
- * straight to `createQuery`:
- *
- * ```ts
- * import { createQuery } from '@tanstack/svelte-query';
- * import { stitchQueryOptions } from '@stitchapi/svelte';
- *
- * const query = createQuery(stitchQueryOptions(getUser, { params: { id } }));
- * ```
- *
- * The `queryFn` awaits the stitch (the validated output); the `queryKey` is a
- * stable name for the stitch plus a sanitised copy of the input (secret header
- * values redacted, runtime-only `signal`/`onProgress` dropped), so TanStack caches
- * per call without leaking a bearer token into the key or refetching every render.
- */
-export function stitchQueryOptions<S extends StitchLike<unknown, never>>(
-    stitch: S,
-    input: QueryInput<S>,
-): StitchQueryOptions<QueryOutput<S>>;
-export function stitchQueryOptions<T, Input = unknown>(
-    stitch: StitchLike<T, Input>,
-    input: Input,
-): StitchQueryOptions<T>;
-export function stitchQueryOptions<T>(
-    stitch: StitchLike<T, unknown>,
-    input: unknown,
-): StitchQueryOptions<T> {
-    return {
-        queryKey: [nameOf(stitch), keyInputFor(input)],
-        queryFn: () => Promise.resolve(stitch(input)),
-    };
+    return makeStore<T>(stitch, input, { ...options, streaming: true });
 }

--- a/packages/svelte/test/stores.spec.ts
+++ b/packages/svelte/test/stores.spec.ts
@@ -1,15 +1,13 @@
 // @stitchapi/svelte store behaviour, driven by FAKE stitches in node env (no DOM):
 // we subscribe to the readable store and assert the emitted state transitions —
 // exactly how Svelte's `$store` / `subscribe` would observe them at runtime.
-import {
-    stitchQueryOptions,
-    stitchStore,
-    stitchStreamStore,
-    useStitch,
-    useStitchStream,
-} from '../src';
+import { stitchQueryOptions, stitchStore, stitchStreamStore } from '../src';
 
-import type { StitchCallResult, StitchLike } from '@stitchapi/query-core';
+import {
+    type StitchCallResult,
+    type StitchLike,
+    stitchQueryOptions as coreStitchQueryOptions,
+} from '@stitchapi/query-core';
 import type { StitchEvent } from 'stitchapi';
 import { describe, expect, test, vi } from 'vitest';
 
@@ -171,10 +169,6 @@ describe('stitchStore', () => {
         unsubscribe();
     });
 
-    test('useStitch is an alias of stitchStore', () => {
-        expect(useStitch).toBe(stitchStore);
-    });
-
     test('forwards onSuccess to the underlying query (fires on success after subscribe)', async () => {
         let received: unknown;
         const store = stitchStore(
@@ -265,15 +259,18 @@ describe('stitchStreamStore', () => {
         expect(last?.chunks).toEqual([]);
         unsubscribe();
     });
-
-    test('useStitchStream is an alias of stitchStreamStore', () => {
-        expect(useStitchStream).toBe(stitchStreamStore);
-    });
 });
 
 // --- stitchQueryOptions ----------------------------------------------------------
+// The implementation is HOISTED into `@stitchapi/query-core` (nameOf /
+// keyInputFor / deriveQueryKey own the deep coverage there); these tests verify
+// the re-export wiring and one end-to-end shape through this package's entry.
 
 describe('stitchQueryOptions', () => {
+    test('is the ONE shared query-core implementation, re-exported', () => {
+        expect(stitchQueryOptions).toBe(coreStitchQueryOptions);
+    });
+
     test('returns a TanStack-shaped POJO with key + async queryFn', async () => {
         const stitch = unaryStitch(async () => ({ ok: true }), {
             name: 'getThing',
@@ -294,37 +291,9 @@ describe('stitchQueryOptions', () => {
         const opts = stitchQueryOptions(stitch, { params: { id: '7' } });
         expect(opts.queryKey[1]).toEqual({ params: { id: '7' } });
     });
-});
 
-// --- stitchQueryOptions: cache-key derivation regressions ------------------
-// The `queryKey` derivation shared the same three bugs @stitchapi/react fixed in
-// #406 (nameless-collision, secret-header leak, refetch storm). Each of these
-// FAILED before the port. Kept in lock-step with `packages/react/test/hooks.spec.tsx`.
-
-describe('stitchQueryOptions — no cache collision between nameless stitches', () => {
-    // Bug 1 (correctness): `name ?? 'stitch'` keyed every nameless stitch as the
-    // literal 'stitch', so two distinct endpoints with same-shaped input collided
-    // on one TanStack Query cache entry. Fixed by mirroring core's `nameOf`
-    // (name ?? path ?? url ?? 'stitch').
-    test('two nameless stitches with different paths get DIFFERENT keys', () => {
-        const getUser = unaryStitch(async () => 1, { path: '/users/{id}' });
-        const getOrder = unaryStitch(async () => 1, { path: '/orders/{id}' });
-        const input = { params: { id: '1' } };
-
-        const userKey = stitchQueryOptions(getUser, input).queryKey;
-        const orderKey = stitchQueryOptions(getOrder, input).queryKey;
-
-        expect(userKey).not.toEqual(orderKey);
-        expect(userKey[0]).toBe('/users/{id}');
-        expect(orderKey[0]).toBe('/orders/{id}');
-    });
-});
-
-describe('stitchQueryOptions — no secret leak in the query key', () => {
-    // Bug 2 (security): the raw `input` went straight into the queryKey, so a
-    // per-call `authorization` header serialised the bearer token into the
-    // TanStack Query key (persisted, and shown in the devtools panel). Fixed by
-    // redacting denylisted header VALUES.
+    // Smoke test through THIS package's entry (deep redaction coverage lives in
+    // query-core): a per-call bearer token must never serialise into the key.
     test('a per-call authorization header does not put the token in the key', () => {
         const getUser = unaryStitch(async () => 1, { name: 'getUser' });
         const { queryKey } = stitchQueryOptions(getUser, {
@@ -333,57 +302,5 @@ describe('stitchQueryOptions — no secret leak in the query key', () => {
         });
 
         expect(JSON.stringify(queryKey)).not.toContain('SECRET123');
-    });
-
-    test('redacts the secret header but keeps a benign one (no fresh collision)', () => {
-        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
-        const [, keyInput] = stitchQueryOptions(getUser, {
-            params: { id: '1' },
-            headers: {
-                authorization: 'Bearer SECRET123',
-                'accept-language': 'en-US',
-            },
-        }).queryKey;
-
-        const headers = (keyInput as { headers: Record<string, string> })
-            .headers;
-        expect(headers['authorization']).not.toContain('SECRET123');
-        expect(headers['accept-language']).toBe('en-US');
-    });
-});
-
-describe('stitchQueryOptions — no refetch storm from runtime-only input fields', () => {
-    // Bug 3 (reliability): `signal`/`onProgress` are runtime-only (never
-    // serialised, per CONTRACT.md). An inline `onProgress` churns identity every
-    // render, so keying it re-fetched forever. Fixed by excluding both fields.
-    test('two distinct inline onProgress functions produce EQUAL keys', () => {
-        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
-        const base = { params: { id: '1' } };
-
-        const keyA = stitchQueryOptions(getUser, {
-            ...base,
-            onProgress: () => {},
-        }).queryKey;
-        const keyB = stitchQueryOptions(getUser, {
-            ...base,
-            onProgress: () => {},
-        }).queryKey;
-
-        expect(keyA).toEqual(keyB);
-    });
-
-    test('a per-call signal does not enter the key', () => {
-        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
-        const controller = new AbortController();
-
-        const withSignal = stitchQueryOptions(getUser, {
-            params: { id: '1' },
-            signal: controller.signal,
-        }).queryKey;
-        const without = stitchQueryOptions(getUser, {
-            params: { id: '1' },
-        }).queryKey;
-
-        expect(withSignal).toEqual(without);
     });
 });

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -2,7 +2,7 @@
     "name": "@stitchapi/vue",
     "version": "1.0.0-rc.6",
     "type": "commonjs",
-    "description": "Vue 3 bindings for StitchAPI — reactive useStitch/useStitchStream composables over @stitchapi/query-core, plus an optional TanStack Query queryOptions helper. Streaming-first: re-render as `delta` chunks arrive.",
+    "description": "Vue 3 bindings for StitchAPI — reactive useStitch/useStitchStream composables over @stitchapi/query-core, plus an optional TanStack Query stitchQueryOptions helper. Streaming-first: re-render as `delta` chunks arrive.",
     "main": "lib/index.js",
     "module": "lib/index.mjs",
     "types": "lib/index.d.ts",

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -11,8 +11,9 @@
 // - `useStitchStream` — the streaming composable: re-renders as `delta` chunks
 //                       arrive. This is the differentiator over plain
 //                       request/response query libraries.
-// - `stitchQueryOptions` — an OPTIONAL TanStack Query adapter (returns a plain
-//                       POJO, so it needs no import of `@tanstack/vue-query`).
+// - `stitchQueryOptions` — an OPTIONAL TanStack Query adapter (a plain POJO, so
+//                       it needs no import of `@tanstack/vue-query`). Implemented
+//                       once in `@stitchapi/query-core` and re-exported here.
 import {
     type CreateStitchQueryOptions,
     type QueryInput,
@@ -21,6 +22,8 @@ import {
     type StitchQuery,
     type StitchQueryResult,
     createStitchQuery,
+    keyInputFor,
+    nameOf,
 } from '@stitchapi/query-core';
 import { compact } from 'stitchapi';
 import {
@@ -39,7 +42,18 @@ export type {
     QueryOutput,
     StitchLike,
     StitchQuery,
+    StitchQueryOptions,
     StitchQueryResult,
+} from '@stitchapi/query-core';
+
+// The TanStack Query adapter is implemented once in `@stitchapi/query-core`
+// (`deriveQueryKey` + `stitchQueryOptions`) so a stitch keys identically in every
+// framework binding. Re-exported here so Vue apps import from one place.
+export {
+    deriveQueryKey,
+    keyInputFor,
+    nameOf,
+    stitchQueryOptions,
 } from '@stitchapi/query-core';
 
 // ---------------------------------------------------------------------------
@@ -70,97 +84,26 @@ export interface UseStitchResult<T> {
 }
 
 // ---------------------------------------------------------------------------
+// Composable options
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link useStitch} / {@link useStitchStream}: the query-core
+ * options minus `streaming` — which composable you call decides that
+ * (`useStitch` is unary, `useStitchStream` streams).
+ */
+export interface UseStitchOptions<T>
+    extends Omit<CreateStitchQueryOptions<T>, 'streaming'> {}
+
+// ---------------------------------------------------------------------------
 // Shared driver
 // ---------------------------------------------------------------------------
 
-interface UseStitchOptions<T> extends CreateStitchQueryOptions<T> {}
-
-// --- key derivation (shared logic; duplicated in @stitchapi/react + swr) ----
-// These helpers are intentionally copied verbatim from `@stitchapi/react`
-// (`packages/react/src/index.ts`, landed in #406) and `@stitchapi/swr`: they are
-// separate published packages, so a cross-package import would add a runtime
-// dependency. Keep the copies in lock-step. Used BOTH by the reactive dep key
-// below and by `stitchQueryOptions`.
-
-/** The `__config` slice a key derives from. Mirrors core's `nameOf`
- * (`name ?? path ?? 'stitch'`) plus a `url` fallback for URL-configured stitches. */
-type KeyConfig = { name?: string; path?: string; url?: string };
-
-/** A stable, human-meaningful name for the stitch. Mirrors core's `nameOf`
- * (`packages/core/src/engine.ts`) — `name ?? path ?? url ?? 'stitch'` — so two
- * DISTINCT nameless stitches (`/users/{id}` vs `/orders/{id}`) don't collapse to
- * the literal `'stitch'` and collide on one cache entry. */
-function nameOf(stitch: unknown): string {
-    const cfg = (stitch as { __config?: KeyConfig }).__config;
-    return cfg?.name ?? cfg?.path ?? cfg?.url ?? 'stitch';
-}
-
-// Header names whose VALUES are secrets — mirrors core's private `SECRET_HEADERS`
-// trace denylist (`packages/core/src/trace.ts`), which is not exported. We redact
-// the value (rather than dropping the header) so the key stays stable per token
-// AND callers who legitimately vary a response by a non-secret header (e.g.
-// `accept-language`) keep separate cache entries. Compared case-insensitively; the
-// `*-token` / `*-api-key` suffix rules catch vendor spellings without enumerating.
-const SECRET_HEADERS = new Set([
-    'authorization',
-    'proxy-authorization',
-    'cookie',
-    'set-cookie',
-    'x-api-key',
-    'x-auth-token',
-]);
-const REDACTED = '[redacted]';
-
-function isSecretHeader(name: string): boolean {
-    const k = name.toLowerCase();
-    return (
-        SECRET_HEADERS.has(k) || k.endsWith('-token') || k.endsWith('-api-key')
-    );
-}
-
-/**
- * Build the value that goes into a cache/query key from a stitch's per-call input.
- * Never puts the raw input in the key:
- *
- * - drops `signal` / `onProgress` — runtime-only, never-serialised (CONTRACT.md);
- *   `onProgress` in particular churns identity every render, which would refetch
- *   forever if it entered the key;
- * - redacts the VALUES of secret-bearing headers (`authorization`, `cookie`, …)
- *   so a bearer token can't leak into a persisted / devtools-visible key, while
- *   keeping non-secret headers so they still vary the cache;
- * - keeps every other field (`params` / `query` / `body` / `variables` / …) as-is.
- *
- * `null` / `undefined` inputs stay `null`; a primitive input is returned unchanged.
- */
-function keyInputFor(input: unknown): unknown {
-    if (input === null || input === undefined) return null;
-    if (typeof input !== 'object') return input;
-
-    const {
-        signal: _signal,
-        onProgress: _onProgress,
-        ...rest
-    } = input as {
-        signal?: unknown;
-        onProgress?: unknown;
-        headers?: Record<string, unknown>;
-    } & Record<string, unknown>;
-
-    if (rest.headers && typeof rest.headers === 'object') {
-        const headers: Record<string, unknown> = {};
-        for (const [k, v] of Object.entries(rest.headers)) {
-            headers[k] = isSecretHeader(k) ? REDACTED : v;
-        }
-        rest.headers = headers;
-    }
-    return rest;
-}
-
 // A structural key of the input so an equal-shaped literal does not re-create the
 // handle, but `{ id: 1 }` → `{ id: 2 }` does. Mirrors `@stitchapi/react`. Sanitises
-// first via `keyInputFor` so an inline `onProgress` (fresh identity per render)
-// can't churn the key and loop, and a per-call `signal` adds no non-deterministic
-// noise — both are runtime-only.
+// first via query-core's `keyInputFor` so an inline `onProgress` (fresh identity
+// per render) can't churn the key and loop, and a per-call `signal` adds no
+// non-deterministic noise — both are runtime-only.
 function defaultKey(input: unknown): string {
     try {
         return JSON.stringify(keyInputFor(input));
@@ -178,7 +121,7 @@ function useStitchInternal<T>(
     stitch: StitchLike<T, unknown>,
     input: MaybeRefOrGetter<unknown>,
     options: MaybeRefOrGetter<UseStitchOptions<T>>,
-    stream: boolean,
+    streaming: boolean,
 ): UseStitchResult<T> {
     // The single reactive cell every consumer reads through. The core hands out a
     // NEW frozen snapshot only on a real change, so swapping the ref is cheap and
@@ -205,7 +148,7 @@ function useStitchInternal<T>(
             stitch,
             resolvedInput,
             compact({
-                stream,
+                streaming,
                 mode: opts.mode,
                 enabled: opts.enabled,
                 onSuccess: opts.onSuccess,
@@ -235,7 +178,7 @@ function useStitchInternal<T>(
         return JSON.stringify([
             name,
             defaultKey(toValue(input)),
-            stream,
+            streaming,
             opts.mode ?? null,
             opts.enabled ?? null,
         ]);
@@ -318,7 +261,7 @@ export function useStitch<T>(
 
 /**
  * Run a streaming stitch (an `sse` / `stream` surface) and re-render as each
- * `delta` chunk arrives. Same return shape as {@link useStitch}; `data` is the
+ * `delta` chunk arrives. Same result shape as {@link useStitch}; `data` is the
  * accumulated chunks (`mode: 'append'`, default) or the latest chunk
  * (`mode: 'replace'`), and `chunks` is the running list. `status` is
  * `'streaming'` until the terminal `result`, then `'success'`.
@@ -348,54 +291,4 @@ export function useStitchStream<T>(
     options: MaybeRefOrGetter<UseStitchOptions<T>> = {},
 ): UseStitchResult<T> {
     return useStitchInternal<T>(stitch, input, options, true);
-}
-
-// ---------------------------------------------------------------------------
-// stitchQueryOptions — optional TanStack Query adapter
-// ---------------------------------------------------------------------------
-
-// IDENTICAL to `@stitchapi/react`'s `stitchQueryOptions` — a plain POJO with no
-// framework import, so it feeds `@tanstack/vue-query`'s `useQuery(options)`
-// (or any other) just the same.
-
-/** The plain object {@link stitchQueryOptions} returns — structurally compatible with
- * TanStack Query's `useQuery(options)` without importing the library. */
-export interface StitchQueryOptions<T> {
-    queryKey: readonly unknown[];
-    queryFn: (ctx?: { signal?: AbortSignal }) => Promise<T>;
-}
-
-/**
- * Build a TanStack-Query-compatible options object for a stitch, WITHOUT a hard
- * dependency on `@tanstack/vue-query` — it just returns a POJO. Pass it straight
- * to `useQuery`:
- *
- * ```ts
- * import { useQuery } from '@tanstack/vue-query';
- * import { stitchQueryOptions } from '@stitchapi/vue';
- *
- * const { data } = useQuery(stitchQueryOptions(getUser, { params: { id } }));
- * ```
- *
- * The `queryFn` awaits the stitch (the validated output); the `queryKey` is a
- * stable name for the stitch plus a sanitised copy of the input (secret header
- * values redacted, runtime-only `signal`/`onProgress` dropped), so TanStack caches
- * per call without leaking a bearer token into the key or refetching every render.
- */
-export function stitchQueryOptions<S extends StitchLike<unknown, never>>(
-    stitch: S,
-    input: QueryInput<S>,
-): StitchQueryOptions<QueryOutput<S>>;
-export function stitchQueryOptions<T, Input = unknown>(
-    stitch: StitchLike<T, Input>,
-    input: Input,
-): StitchQueryOptions<T>;
-export function stitchQueryOptions<T>(
-    stitch: StitchLike<T, unknown>,
-    input: unknown,
-): StitchQueryOptions<T> {
-    return {
-        queryKey: [nameOf(stitch), keyInputFor(input)],
-        queryFn: () => Promise.resolve(stitch(input)),
-    };
 }

--- a/packages/vue/test/composables.spec.ts
+++ b/packages/vue/test/composables.spec.ts
@@ -269,9 +269,13 @@ describe('useStitchStream', () => {
     });
 });
 
-// --- stitchQueryOptions ----------------------------------------------------------
+// --- stitchQueryOptions ----------------------------------------------------
+// `stitchQueryOptions` is implemented ONCE in `@stitchapi/query-core` (which owns
+// the full key-derivation test suite — nameless-collision, secret-header
+// redaction, runtime-only field dropping) and re-exported here. These are smoke
+// tests that the re-export is wired and behaves through this barrel.
 
-describe('stitchQueryOptions', () => {
+describe('stitchQueryOptions (re-exported from @stitchapi/query-core)', () => {
     test('returns a TanStack-shaped POJO with key + async queryFn', async () => {
         const stitch = unaryStitch(async () => ({ ok: true }), {
             name: 'getThing',
@@ -285,97 +289,5 @@ describe('stitchQueryOptions', () => {
         const stitch = unaryStitch(async () => 1);
         const opts = stitchQueryOptions(stitch, null);
         expect(opts.queryKey[0]).toBe('stitch');
-    });
-});
-
-// --- stitchQueryOptions: cache-key derivation regressions ------------------
-// The `queryKey` derivation shared the same three bugs @stitchapi/react fixed in
-// #406 (nameless-collision, secret-header leak, refetch storm). Each of these
-// FAILED before the port. Kept in lock-step with `packages/react/test/hooks.spec.tsx`.
-
-describe('stitchQueryOptions — no cache collision between nameless stitches', () => {
-    // Bug 1 (correctness): `name ?? 'stitch'` keyed every nameless stitch as the
-    // literal 'stitch', so two distinct endpoints with same-shaped input collided
-    // on one TanStack Query cache entry. Fixed by mirroring core's `nameOf`
-    // (name ?? path ?? url ?? 'stitch').
-    test('two nameless stitches with different paths get DIFFERENT keys', () => {
-        const getUser = unaryStitch(async () => 1, { path: '/users/{id}' });
-        const getOrder = unaryStitch(async () => 1, { path: '/orders/{id}' });
-        const input = { params: { id: '1' } };
-
-        const userKey = stitchQueryOptions(getUser, input).queryKey;
-        const orderKey = stitchQueryOptions(getOrder, input).queryKey;
-
-        expect(userKey).not.toEqual(orderKey);
-        expect(userKey[0]).toBe('/users/{id}');
-        expect(orderKey[0]).toBe('/orders/{id}');
-    });
-});
-
-describe('stitchQueryOptions — no secret leak in the query key', () => {
-    // Bug 2 (security): the raw `input` went straight into the queryKey, so a
-    // per-call `authorization` header serialised the bearer token into the
-    // TanStack Query key (persisted, and shown in the devtools panel). Fixed by
-    // redacting denylisted header VALUES.
-    test('a per-call authorization header does not put the token in the key', () => {
-        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
-        const { queryKey } = stitchQueryOptions(getUser, {
-            params: { id: '1' },
-            headers: { authorization: 'Bearer SECRET123' },
-        });
-
-        expect(JSON.stringify(queryKey)).not.toContain('SECRET123');
-    });
-
-    test('redacts the secret header but keeps a benign one (no fresh collision)', () => {
-        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
-        const [, keyInput] = stitchQueryOptions(getUser, {
-            params: { id: '1' },
-            headers: {
-                authorization: 'Bearer SECRET123',
-                'accept-language': 'en-US',
-            },
-        }).queryKey;
-
-        const headers = (keyInput as { headers: Record<string, string> })
-            .headers;
-        expect(headers['authorization']).not.toContain('SECRET123');
-        expect(headers['accept-language']).toBe('en-US');
-    });
-});
-
-describe('stitchQueryOptions — no refetch storm from runtime-only input fields', () => {
-    // Bug 3 (reliability): `signal`/`onProgress` are runtime-only (never
-    // serialised, per CONTRACT.md). An inline `onProgress` churns identity every
-    // render, so keying it re-fetched forever. Fixed by excluding both fields.
-    test('two distinct inline onProgress functions produce EQUAL keys', () => {
-        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
-        const base = { params: { id: '1' } };
-
-        const keyA = stitchQueryOptions(getUser, {
-            ...base,
-            onProgress: () => {},
-        }).queryKey;
-        const keyB = stitchQueryOptions(getUser, {
-            ...base,
-            onProgress: () => {},
-        }).queryKey;
-
-        expect(keyA).toEqual(keyB);
-    });
-
-    test('a per-call signal does not enter the key', () => {
-        const getUser = unaryStitch(async () => 1, { name: 'getUser' });
-        const controller = new AbortController();
-
-        const withSignal = stitchQueryOptions(getUser, {
-            params: { id: '1' },
-            signal: controller.signal,
-        }).queryKey;
-        const without = stitchQueryOptions(getUser, {
-            params: { id: '1' },
-        }).queryKey;
-
-        expect(withSignal).toEqual(without);
     });
 });


### PR DESCRIPTION
Broken out of #470. **Stacked on #501** — base is `refactor/query-family-result-rename`; retargets to `main` once #501 merges.

## P16 — one implementation, five consumers

`StitchQueryOptions` and the whole query-key derivation path were **byte-copied into all five
framework bindings**. react, vue, svelte, solid and angular each carried their own private
`nameOf`, `isSecretHeader`, `keyInputFor` and `stitchQueryOptions`.

Five copies of a security-relevant redaction list is five chances to drift — **and the copies had
already drifted from each other.**

They move into `@stitchapi/query-core`, the framework-agnostic keystone the bindings already depend
on, and are exported for the bindings to re-export:

| Export | Role |
| --- | --- |
| `nameOf(stitch)` | the stable, human-meaningful first key segment |
| `keyInputFor(input)` | the sanitised input copy (secret headers/params redacted) |
| `deriveQueryKey(stitch, input)` | `[nameOf(stitch), keyInputFor(input)]` |
| `StitchQueryOptions<T>` | the TanStack-shaped options type |
| `stitchQueryOptions(…)` | the overloaded helper |

**~715 lines deleted from the bindings against ~166 added in query-core.**

## The secret denylist is no longer a copy either

`keyInputFor` now calls core's exported **`isSecretKey`** predicate instead of each binding
maintaining its own hard-coded header list. A stem registered with `registerSecretKey` is now
honoured by **every** binding's query key — which was never true of the copies.

This is the drift that mattered most: a missed stem means a **credential lands in a TanStack cache key**.

## Fix — react and angular no longer accept-and-ignore a streaming flag

`UseStitchOptions` and `InjectStitchOptions` extended the core options **including `streaming`**,
then never read it — setting it compiled and silently did nothing. Both now `Omit` it, so the
mistake is a type error instead of a shrug.

## P9 — angular `InjectInput` → `MaybeSignal`

The type describes *"a value, a signal, or a thunk"*, which is neither an input nor
angular-specific. `MaybeSignal` says what it is.

Hard break, no `@deprecated` aliases — pre-GA, per P19 as amended in #470.

## Note on the contract ratchet

It reports **"5 known, baselined"** here rather than `0`, because #501's branch predates #507, which
cleared those five R6 entries on `main`. **The baseline file is unchanged by this commit** — no new
violations are introduced. It returns to `0` once #501 catches up with `main`.

## Verification

- workspace typecheck clean; full workspace test suite green
- **`check:exports` green** for every package + companion (query-core's `stitchapi` peer dep already covers the new value import)
- contract ratchet introduces nothing new; docs-links 110 routes OK; prettier clean
- apps/docs production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)