### PR TITLE
feat(core)!: positional basic(user, pass); BasicOptions is a named export (P15/P9)

### DIFF
--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -228,7 +228,23 @@ export function apiKey(
     };
 }
 
-export function basic(opts: { user: Secret; pass: Secret }): AuthStrategy {
+export interface BasicOptions {
+    user: Secret;
+    pass: Secret;
+}
+
+/** HTTP Basic auth. Positional `basic(user, pass)` ≡ `basic({ user, pass })` (CONTRACT.md P15). */
+export function basic(user: Secret, pass: Secret): AuthStrategy;
+export function basic(opts: BasicOptions): AuthStrategy;
+export function basic(
+    userOrOpts: Secret | BasicOptions,
+    pass?: Secret,
+): AuthStrategy {
+    // A Secret is a string or a thunk, never a plain object — so an object IS the options form.
+    const opts: BasicOptions =
+        typeof userOrOpts === 'string' || typeof userOrOpts === 'function'
+            ? { user: userOrOpts, pass: pass as Secret }
+            : userOrOpts;
     return {
         name: 'basic',
         scheme: { type: 'http', scheme: 'basic' },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,12 @@ export {
     secretsFile,
     secretFrom,
 } from './auth';
-export type { SecretSource, AuthFailureResult, RefreshResult } from './auth';
+export type {
+    BasicOptions,
+    SecretSource,
+    AuthFailureResult,
+    RefreshResult,
+} from './auth';
 export { fetchAdapter } from './http-adapter';
 export type { FetchAdapterOptions } from './http-adapter';
 export { axiosAdapter } from './axios-adapter';

--- a/packages/core/test/gaps/secrets-file-rename.spec.ts
+++ b/packages/core/test/gaps/secrets-file-rename.spec.ts
@@ -127,3 +127,18 @@ test('basic() sends Authorization: Basic <base64(user:pass)> header', async () =
     const expected = `Basic ${Buffer.from('alice:s3cret').toString('base64')}`;
     expect(req!.headers['authorization']).toBe(expected);
 });
+
+test('positional basic(user, pass) is the P15 shorthand for basic({ user, pass })', async () => {
+    server.route('GET', '/secure', { body: { ok: true } });
+
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/secure',
+        auth: basic('alice', 's3cret'),
+    });
+
+    await expect(call()).resolves.toEqual({ ok: true });
+
+    const expected = `Basic ${Buffer.from('alice:s3cret').toString('base64')}`;
+    expect(server.calls('/secure')[0]!.headers['authorization']).toBe(expected);
+});


### PR DESCRIPTION
Broken out of #470.

## P15 — the required fields go positionally

`basic` has exactly two required fields and no optional ones, so the options bag was pure ceremony:

```ts
basic('alice', 's3cret')   ≡   basic({ user: 'alice', pass: 's3cret' })
```

Both spellings stay; the envelope form is unchanged. Discrimination is sound **without a runtime
sniff of object shape**: a `Secret` is a string or a thunk and never a plain object, so an object
argument *is* the options form.

## P9 — `BasicOptions` is a named, exported type

Was inline at the parameter; now exported from `./auth` and re-exported from the core barrel like
every other option type.

## Why this one is its own PR

This is an **orphan** from #470 that no other in-flight PR carries. I checked both auth branches —
#485 (`worktree-apikey-name-in-triad`) and #487 (`claude/adr-20-03641e`) — and **each still has only
the object-form `basic(opts)`**. Landing it separately keeps it from falling through the cracks
between them. It touches only the `basic` block of `auth.ts`, so it should rebase cleanly under either.

## Verification

- core typecheck + **DTS build clean**; **130 files / 1230 tests green** (including the new positional spec)
- eslint clean, contract ratchet **0**, prettier clean
- **bundle-size gate passes with room to spare** — 24.68 / 19.86 against 24.80 / 20.00; the overload adds no runtime weight

🤖 Generated with [Claude Code](https://claude.com/claude-code)