### PR TITLE
docs: respell the corpus for the contract sweep — pick, throttle, elapsed, waited

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Keep the `fetch` or axios you already have — it's the adapter underneath. A st
 
 ## Motivation
 
-In almost every project there's a `src/api/` folder of thin functions that fire an HTTP request and unwrap the response. Everything that actually makes an integration reliable — auth lifecycle, retries, rate limits, timeouts, response validation, drift detection, observability — gets re-implemented at every call site, and each wrapper rots independently. `fetch` hands back opaque bytes, and raw bytes aren't what application code (or an AI agent) needs; both want structured, validated, observable results.
+In almost every project there's a `src/api/` folder of thin functions that fire an HTTP request and pull the payload out of the response. Everything that actually makes an integration reliable — auth lifecycle, retries, rate limits, timeouts, response validation, drift detection, observability — gets re-implemented at every call site, and each wrapper rots independently. `fetch` hands back opaque bytes, and raw bytes aren't what application code (or an AI agent) needs; both want structured, validated, observable results.
 
 A stitch folds all of that back into the call:
 
@@ -337,16 +337,16 @@ const getUser = stitch({
 
 A **surface** is the request _style_ a stitch speaks. `http` is the default; the rest are peer surfaces on the same engine — `auth`, `retry`, `throttle`, `timeout`, validation, and the event stream compose with every one. Each ships as its own subpath import, so `import { stitch }` pulls in `http` alone.
 
-| Surface       | Import                        | Shapes                                     | `await` resolves to            |
-| ------------- | ----------------------------- | ------------------------------------------ | ------------------------------ |
-| `http`        | `stitch` (default)            | a JSON-over-HTTP call                      | the validated body             |
-| `graphql`     | `stitchapi/graphql`           | POST `{ query, variables }`, unwrap `data` | the `data` payload             |
-| `sse`         | `stitchapi/sse`               | a `text/event-stream` reader (over fetch)  | every parsed event, collected  |
-| `stream`      | `stitchapi/stream`            | a raw `ReadableStream` reader              | every decoded chunk, collected |
-| `download`    | `stitchapi/download`          | a buffered binary GET                      | `{ blob, filename }`           |
-| `llm`         | `stitchapi/llm`               | a chat-completion via a provider contract  | the normalised `{ text, … }`   |
-| `shell`       | `@stitchapi/shell` (peer pkg) | a local command, args + stdin              | the command's stdout           |
-| `postmessage` | `stitchapi/postmessage`       | a typed iframe ↔ parent RPC / event call  | the typed RPC response         |
+| Surface       | Import                        | Shapes                                    | `await` resolves to            |
+| ------------- | ----------------------------- | ----------------------------------------- | ------------------------------ |
+| `http`        | `stitch` (default)            | a JSON-over-HTTP call                     | the validated body             |
+| `graphql`     | `stitchapi/graphql`           | POST `{ query, variables }`, picks `data` | the `data` payload             |
+| `sse`         | `stitchapi/sse`               | a `text/event-stream` reader (over fetch) | every parsed event, collected  |
+| `stream`      | `stitchapi/stream`            | a raw `ReadableStream` reader             | every decoded chunk, collected |
+| `download`    | `stitchapi/download`          | a buffered binary GET                     | `{ blob, filename }`           |
+| `llm`         | `stitchapi/llm`               | a chat-completion via a provider contract | the normalised `{ text, … }`   |
+| `shell`       | `@stitchapi/shell` (peer pkg) | a local command, args + stdin             | the command's stdout           |
+| `postmessage` | `stitchapi/postmessage`       | a typed iframe ↔ parent RPC / event call | the typed RPC response         |
 
 Full guide: [Surfaces](https://stitchapi.dev/docs/reference/surfaces).
 

--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -411,7 +411,7 @@ export const pages: Page[] = [
         path: 'guides/resilience/throttle',
         title: 'Throttle',
         description:
-            'Space requests by rate and cap concurrency, scoped per stitch or per host.',
+            'Space requests by rate and cap concurrency, pooled per stitch or per host.',
         kind: 'guide',
     },
     {

--- a/apps/docs/content/blog/test-api-code-without-the-network.mdx
+++ b/apps/docs/content/blog/test-api-code-without-the-network.mdx
@@ -103,7 +103,11 @@ const getUser = stitch({
     baseUrl: 'https://api.example.com',
     path: '/users/{id}',
     output: User,
-    retry: { attempts: 3, on: [503], backoff: 'fixed', baseMs: 0 },
+    retry: {
+        attempts: 3,
+        on: [503],
+        backoff: { curve: 'fixed', base: 0 },
+    },
     adapter,
 });
 
@@ -182,7 +186,11 @@ const getUser = stitch({
     baseUrl: 'https://api.example.com',
     path: '/users/{id}',
     output: User,
-    retry: { attempts: 3, on: [503], backoff: 'fixed', baseMs: 0 },
+    retry: {
+        attempts: 3,
+        on: [503],
+        backoff: { curve: 'fixed', base: 0 },
+    },
     adapter,
 });
 
@@ -261,7 +269,7 @@ const getUser = stitch({
     baseUrl: 'https://api.example.com',
     path: '/users/{id}',
     output: User,
-    retry: { attempts: 3, on: [503], baseMs: 1000 },
+    retry: { attempts: 3, on: [503], backoff: { base: 1000 } },
     adapter,
     clock,
 });

--- a/apps/docs/content/blog/typed-graphql-without-apollo.mdx
+++ b/apps/docs/content/blog/typed-graphql-without-apollo.mdx
@@ -9,7 +9,7 @@ prerequisites: ['/docs/concepts/the-stitch']
 
 You point a `fetch` at a GraphQL endpoint, POST `{ query, variables }`, get back a `200`, read `json.data.user` — and three weeks later that call is silently returning `undefined` because the server moved the failure into a `200`-with-`errors` body instead of a status code. The transport said success; the operation did not. Most GraphQL clients you'd reach for to close that gap — Apollo Client, urql — also bring a normalized cache, a React layer, and a build step you didn't ask for when all you wanted was to call one query and trust the result.
 
-A `graphql()` stitch is that one query as a typed function. It POSTs the operation, treats a `200` carrying an `errors` array as the failure it is, validates the response, and hands you the unwrapped `data` — without a client object, a cache, or codegen.
+A `graphql()` stitch is that one query as a typed function. It POSTs the operation, treats a `200` carrying an `errors` array as the failure it is, validates the response, and hands you the `data` payload — without a client object, a cache, or codegen.
 
 ## The honest "before"
 
@@ -24,7 +24,7 @@ async function getUser(id: string): Promise<User> {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
-            document: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
+            query: `query GetUser($id: ID!) { user(id: $id) { id name } }`,
             variables: { id },
         }),
     });
@@ -51,12 +51,12 @@ const getUser = graphql<{ user: { id: string; name: string } }>({
 });
 
 const data = await getUser({ variables: { id: '1' } });
-// data is already unwrapped from `data`: { user: { id, name } }
+// data is already the response's `data` payload: { user: { id, name } }
 ```
 
-Each field maps to glue you no longer write. `graphql()` sends the POST and the JSON body shape for you, so the `method`, the `content-type` header, and the `{ query, variables }` envelope vanish from your code — the `document` you declare travels as the envelope's `query` field. The arguments travel in the call input's `variables` field at call time, so one declared stitch serves every set of arguments — you do not interpolate values into the document and mint a stitch per call. Because `unwrap` defaults to `'data'`, the resolved value is the contents of the response's `data` field; override `unwrap` to read a different field or the raw envelope.
+Each field maps to glue you no longer write. `graphql()` sends the POST and the JSON body shape for you, so the `method`, the `content-type` header, and the `{ query, variables }` envelope vanish from your code — the `document` you declare travels as the envelope's `query` field. The arguments travel in the call input's `variables` field at call time, so one declared stitch serves every set of arguments — you do not interpolate values into the document and mint a stitch per call. Because `pick` defaults to `'data'`, the resolved value is the contents of the response's `data` field; override `pick` to read a different field or the raw envelope.
 
-The footgun closes here. A GraphQL endpoint can return HTTP `200` while carrying a top-level `errors` array; the stitch treats that as a failure and surfaces it, rather than unwrapping a `data` that isn't there. A failed query rejects the awaitable with a `StitchError` whose message carries the GraphQL error text, prefixed `GraphQL:` (joined with `; ` when there is more than one):
+The footgun closes here. A GraphQL endpoint can return HTTP `200` while carrying a top-level `errors` array; the stitch treats that as a failure and surfaces it, rather than handing you a `data` that isn't there. A failed query rejects the awaitable with a `StitchError` whose message carries the GraphQL error text, prefixed `GraphQL:` (joined with `; ` when there is more than one):
 
 ```ts twoslash
 import { StitchError, graphql } from 'stitchapi';

--- a/apps/docs/content/docs/guides/data/body-encoding.mdx
+++ b/apps/docs/content/docs/guides/data/body-encoding.mdx
@@ -36,7 +36,9 @@ because `bodyType` is `'form'`.
 -   `form` — a URL-encoded `application/x-www-form-urlencoded` body, for APIs
     that expect classic HTML-form fields (login forms, OAuth token exchanges).
 -   `multipart` — multipart form data, for file uploads and mixed
-    field-plus-binary payloads; the boundary is set for you.
+    field-plus-binary payloads; the boundary is set for you. Nested
+    objects/arrays serialize with bracket nesting by default; `multipart: 'dot'`
+    (≡ `multipart: { nesting: 'dot' }`) switches to dot-path field names.
 
 The body itself always comes from the call input (`await submit({ body })`),
 never from the config — so one stitch encodes whatever you pass it. See

--- a/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
+++ b/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
@@ -33,7 +33,8 @@ through). After `failures` consecutive failures it trips **open** and
 calls fast-fail for `cooldown`. It then goes **half-open** and lets a single
 trial call through: a success **closes** it and clears the count, another
 failure re-**opens** it for a fresh cooldown. The breaker emits `progress`
-events with phase `circuit`.
+events with phase `circuit`. The positional form names both knobs at once:
+`circuit: [5, '30s']` ≡ `circuit: { failures: 5, cooldown: '30s' }`.
 
 `failures` and `cooldown` are both required — `failures` is
 the count of consecutive failures that trips the breaker open, and `cooldown`

--- a/apps/docs/content/docs/guides/resilience/throttle.mdx
+++ b/apps/docs/content/docs/guides/resilience/throttle.mdx
@@ -29,7 +29,8 @@ silently stalled.
 
 `rate` is a string like `"5/s"` — a minimum spacing between successive calls,
 not a token bucket. `concurrency` caps simultaneous in-flight calls; either may
-be set on its own.
+be set on its own. When rate is all you need, the scalar form reads best:
+`throttle: '2/s'` ≡ `throttle: { rate: '2/s' }`.
 
 When the rate is all you need, pass it directly — a bare string is shorthand for
 `rate`, exactly like `timeout: '5s'` is shorthand for `timeout: { total: '5s' }`:

--- a/apps/docs/content/docs/recipes/inspect-what-the-server-sent.mdx
+++ b/apps/docs/content/docs/recipes/inspect-what-the-server-sent.mdx
@@ -89,6 +89,9 @@ const getUser = stitch({
 const cached = await getUser.inspect({ params: { id: 1 } }, { cache: true });
 ```
 
+`true` is shorthand for `{ cache: true }` — `getUser.inspect(input, true)` reads
+the same way at a call site.
+
 `raw` is `null` on a [streaming surface](/docs/concepts/event-stream) too — the
 engine refuses to buffer an unbounded delta spine — while `findings` and `status`
 still populate; use `.stream()` for incremental inspection there.

--- a/apps/docs/content/docs/reference/conformance-kits.mdx
+++ b/apps/docs/content/docs/reference/conformance-kits.mdx
@@ -169,7 +169,7 @@ fails with every broken rule named:
 
 ```
 Error: StitchAPI store contract: 2 violation(s), 8 rule(s) passed
-  - set: a ttlMs entry expires: value survived its 250ms TTL: got "soon-gone"
+  - set: a ttl entry expires: value survived its 250ms TTL: got "soon-gone"
   - increment: 20 concurrent calls net exactly +20: sorted results of 20 concurrent increments ...
 ```
 

--- a/apps/docs/content/docs/reference/events.mdx
+++ b/apps/docs/content/docs/reference/events.mdx
@@ -25,7 +25,7 @@ fields. Every event carries an `at` field — a millisecond timestamp.
 -   **`start`** — the request is about to go out. Fields: `name` (the stitch
     label), `method`, `url`, `input` (the `StitchInput` for this call), `at`.
 -   **`progress`** — a lifecycle beat within an attempt. Fields: `phase` (a
-    `ProgressPhase`), `attempt` (1-based), `detail?`, `waitedMs?` (set when the
+    `ProgressPhase`), `attempt` (1-based), `detail?`, `waited?` (set when the
     phase involved a wait, e.g. `throttled` or `retry`), `at`.
 -   **`info`** — an auth strategy announcing a decision it made (e.g. which env
     var a `bearer` token resolved from, or that `oauth2` fetched a token); it
@@ -39,7 +39,7 @@ fields. Every event carries an `at` field — a millisecond timestamp.
     `T`), `status` (HTTP status), `attempts` (how many it took), `at`.
 -   **`error`** — the call failed. Fields: `name`, `message`, `status?`,
     `attempts`, `at`.
--   **`done`** — the stream is finished, success or failure. Fields: `ok`, `ms`
+-   **`done`** — the stream is finished, success or failure. Fields: `ok`, `elapsed`
     (total duration), `attempts`, `at`.
 
 `ProgressPhase` is one of `'auth'`, `'request'`, `'throttled'`, `'retry'`,

--- a/apps/docs/content/docs/reference/surfaces.mdx
+++ b/apps/docs/content/docs/reference/surfaces.mdx
@@ -106,9 +106,10 @@ concurrency budget.
 
 A streaming surface has no single response body, so an `output` contract
 validates **each `delta` before it is emitted** — never the collected array. A
-value that fails a `critical`/schema check fails the stream and is never
-delivered; a `drift` `watch` path warns and the value still flows, so a
-`.stream()` consumer only ever sees values that passed the contract.
+value that fails the schema fails the stream and is never delivered; soft
+drift (a coerced or undeclared field) surfaces as a leveled `drift` finding
+and the value still flows, so a `.stream()` consumer only ever sees values
+that passed the contract.
 
 ```ts
 import { stream } from 'stitchapi/stream';
@@ -123,8 +124,7 @@ const logs = stream({
 
 For `sse` the contract describes the event's `data` payload, not the
 `{ event, data, id, retry }` envelope. `transform` and `pick` reshape a whole
-buffered body and aren't applied to the delta path, and drift **snapshots** are
-a whole-body concept — not taken per-`delta`.
+buffered body and aren't applied to the delta path.
 
 ## download
 

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -101,8 +101,8 @@ const config = {
     // The playground consumes the in-repo sandbox engine (@stitchapi/sandbox), a
     // workspace package that ships raw TS/TSX source — Next must transpile it.
     transpilePackages: ['@stitchapi/sandbox'],
-    // The config key `unwrap` was renamed to `pick`; the guide page moved with
-    // it. Permanent redirect keeps published links alive.
+    // The 2026-07 contract sweep renamed the config key `unwrap` to `pick`; the
+    // guide page moved with it. Permanent redirect keeps published links alive.
     async redirects() {
         return [
             {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -202,7 +202,7 @@ This is a concrete cookie wall (`GET /api/websites` needs a `session_token` cook
 ## 6. Resilience — retry, throttle, timeout
 
 ```ts
-retry:    { attempts: 3, backoff: 'expo+jitter', on: [429, 503], respectRetryAfter: true },
+retry:    { attempts: 3, backoff: 'expo-jitter', on: [429, 503], respectRetryAfter: true },
 throttle: { rate: '1/s', concurrency: 2, pool: 'host' },   // proactive limiter
 timeout:  { total: '30s', perAttempt: '10s' },
 ```
@@ -247,7 +247,7 @@ type StitchEvent<T> =
   | { type: 'progress'; phase: 'auth'|'request'|'throttled'|'retry'|'paginate'; ... }
   | { type: 'delta';    chunk }          // streamed body / LLM tokens (future kinds)
   | { type: 'drift';    level: 'error'|'warn'|'info'; path; change }
-  | { type: 'result';   data: T }         // validated, unwrapped
+  | { type: 'result';   data: T }          // validated, picked
   | { type: 'error';    error }
   | { type: 'done';     timing; usage };
 ```

--- a/docs/sandbox/B1-SPIKE.md
+++ b/docs/sandbox/B1-SPIKE.md
@@ -5,6 +5,7 @@
 > **Answers open risk:** [SANDBOX.md](./SANDBOX.md) §10.4 ("browser `stitch` build … largest single unknown") · [REQUIREMENTS.md](../playground/REQUIREMENTS.md) §6, §10.1
 > **Keys on:** [`contracts/dispatch.ts`](./contracts/dispatch.ts) `NODE_ONLY_SURFACES` · **Fallback if NO-GO:** [RATIONALE.md](../playground/RATIONALE.md) §"Confidence & escape hatch" (self-hosted LiveCodes)
 > **Downstream:** R1 (Worker runner — injects this build), D1 (dispatcher)
+> **Note (2026-07):** this is a point-in-time record; `otlpTrace` was renamed to `otlpSink` (and `toValidator` was replaced by `validate`/`compile`) in the 2026-07 contract sweep — the current lists live in `contracts/surface.ts` and `runtime/stitch-browser.ts`.
 
 ## Verdict
 

--- a/docs/sandbox/runtime/stitch-browser.ts
+++ b/docs/sandbox/runtime/stitch-browser.ts
@@ -38,7 +38,7 @@ export {
     seam,
     drift,
     graphql,
-    // `validate`/`compile` are pure schema-normalisation (validator.ts → toValidator);
+    // `validate`/`compile` are pure schema-normalisation (validator.ts);
     // no Node touch-points — safe to re-export verbatim. Needed so the blog's
     // runtime-schema snippets (`compile(JsonSchema.adapt(...))`) run in the playground.
     validate,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -410,7 +410,7 @@ Three more knobs round out the resilience set:
 -   **`circuit`** fast-fails a dependency that is already down — after `failures` consecutive failures the breaker opens for `cooldown`, then allows a half-open trial. A repeatedly-failing dependency stops eating your latency budget (and throws `STITCH_CIRCUIT_OPEN` while open):
 
     ```ts
-    circuit: { failures: 5, cooldown: 30_000 }
+    circuit: { failures: 5, cooldown: '30s' } // or the positional [5, '30s']
     ```
 
 -   **`idempotency`** injects a stable `Idempotency-Key` header on writes, so a safe retry can't duplicate a side effect:
@@ -427,7 +427,7 @@ Three more knobs round out the resilience set:
     acceptStatus: [404]; // resource-gone → fall back, no try/catch on the happy path
     ```
 
-When an _outer_ gate owns backoff (its own `Retry-After` budget, a DB-persisted limiter), `rateLimit: { delegate: true }` surfaces a `RateLimitError` (carrying `retryAfter`) instead of retrying internally — so StitchAPI's retry + throttle don't double-count against it.
+When an _outer_ gate owns backoff (its own `Retry-After` budget, a DB-persisted limiter), `throttle: { delegate: true }` surfaces a `RateLimitError` (carrying `retryAfter`) instead of retrying internally — so StitchAPI's retry + throttle don't double-count against it.
 
 ## Caching
 

--- a/packages/core/test/gaps/cli-since-exit.spec.ts
+++ b/packages/core/test/gaps/cli-since-exit.spec.ts
@@ -25,7 +25,7 @@ function makeTraceFile(): string {
             name: 'test',
             type: 'done',
             ok: true,
-            ms: 5,
+            elapsed: 5,
             at: Date.now(),
         }) + '\n',
     );
@@ -44,14 +44,12 @@ describe('CLI trace --since with unparseable value', () => {
     });
 
     /**
-     * CONTRACT (desired, not yet implemented):
-     *   `stitch trace --since not-a-date` must:
-     *     1. exit with code 2  (not 0)
-     *     2. write a message to stderr that mentions "--since"
+     * CONTRACT: `stitch trace --since not-a-date` must:
+     *   1. exit with code 2  (not 0)
+     *   2. write a message to stderr that mentions "--since"
      *
-     * TODAY (bug): parseSince('not-a-date') returns undefined, the code falls
-     * through to `cutoff = io.now() - (undefined ?? 0) = now`, silently filters
-     * out all records, and exits 0 with an empty summary.
+     * Guards the fix: parseDuration('not-a-date') returns undefined and the
+     * command reports bad usage instead of silently filtering everything out.
      */
     test('exits 2 and writes a --since error to stderr for unparseable input', async () => {
         const exitCode = await main(

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -79,7 +79,7 @@ The generator is also a pure library:
 ```ts
 import { type OpenApiDoc, planGen } from '@stitchapi/openapi';
 
-const result = planGen(doc as OpenApiDoc, { tags: ['pet'] });
+const result = planGen(doc as OpenApiDoc, { tags: 'pet' }); // or tags: ['pet', 'store']
 for (const f of result.files) console.log(f.path, f.contents);
 ```
 


### PR DESCRIPTION
Broken out of #470 — the prose/docs half. **Every edit was re-checked against *current* `main`
rather than copied from #470**, because several of #470's docs edits are themselves stale now.

## What changed

- **`unwrap` → `pick`**, and *"unwrapped"* → *"the `data` payload"* (README surface table, the
  GraphQL blog, the openapi README, `DESIGN.md`). The config rename landed in #481; the prose never followed.
- **`rateLimit` → `throttle`** in the core README's delegate note (the key was dropped in #503).
- **Emitted-field respells that landed in the P17 sweep but never reached the docs**: the `progress`
  event's `waitedMs` → `waited`, and the sandbox runtime's `done` event `ms` → `elapsed`.
- The conformance-kit failure sample shows `set: a ttl entry expires` (`ttlMs` → `ttl` landed in #505).
- **Shorthands documented in prose** — deliberately *not* in typechecked fences, so this page reads
  correctly both before and after the code PRs land: `circuit: [5, '30s']`, `throttle: '2/s'`,
  `multipart: 'dot'`, `inspect(input, true)`.
- `surfaces.mdx` drops two claims that no longer hold: a `critical`/`drift`-`watch` split on the
  streaming path, and per-`delta` drift snapshots.
- `cli-since-exit.spec.ts`'s header still described the `--since` exit-code bug as *"desired, not yet
  implemented"* — it was fixed a while ago. The comment now says the test guards the fix. (Verified:
  the spec passes on `main` unchanged.)

## Three deliberate exclusions

Each is a case where #470 is itself stale, or the change belongs to another PR:

1. **`retry-fetch-in-typescript.mdx`** — #470 renames the **hand-rolled "before" snippet's** locals
   `baseMs`/`maxMs` → `baseDelay`/`maxDelay`. Those names no longer match anything: #513 folded
   backoff into an envelope, so the library's words are now `backoff: { base, max }`. Renaming to a
   *third* spelling would add a new inconsistency, so the ad-hoc snippet stays ad-hoc.
2. **`package.json` / `pnpm-lock.yaml`** — #470 carries `next@16.2.7` and `hono@^4.0.0`, both
   **behind** main (`16.2.11`, `^4.12.27`). Taking them would be a silent dependency **downgrade**.
3. **The core bundle budget bump (24.80 → 25.25 KB)** — that headroom is for #477's P0 redaction,
   not for anything here, so it belongs in #477.

## One regression guarded

#470's core README reverts `{ truncated, chars, preview }` back to `bytes`, undoing the fix from
#517. Kept as **`chars`**, which is what the sink actually emits.

## Verification

- core **130 files / 1229 tests green**
- contract ratchet **0**; docs-links 110 routes OK; prettier clean
- apps/docs production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)