### PR TITLE
docs: document bug reporting and the tests-with-changes policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug report
+description: Something in stitchapi or a companion package behaves differently than documented.
+labels: ['bug']
+body:
+    - type: markdown
+      attributes:
+          value: |
+              **Security vulnerability? Stop — don't file it here.** A public issue
+              discloses it to everyone before a fix exists. Report it privately instead:
+              see [SECURITY.md](https://github.com/rejifald/StitchAPI/blob/main/SECURITY.md).
+
+    - type: textarea
+      id: what-happened
+      attributes:
+          label: What happened?
+          description: What you expected, and what happened instead.
+          placeholder: I expected the retry to stop after 3 attempts, but it kept going until the timeout.
+      validations:
+          required: true
+
+    - type: textarea
+      id: reproduction
+      attributes:
+          label: Minimal reproduction
+          description: |
+              The smallest `stitch` definition that shows the problem — this is the single
+              most useful thing in the report. A link to a repo or a playground URL
+              (https://stitchapi.dev) works too.
+          render: ts
+      validations:
+          required: true
+
+    - type: input
+      id: version
+      attributes:
+          label: Version
+          description: Output of `npm ls stitchapi` (or the version of the companion package).
+          placeholder: stitchapi@1.0.0-rc.6
+      validations:
+          required: true
+
+    - type: dropdown
+      id: runtime
+      attributes:
+          label: Runtime
+          description: Where it runs. A good share of bugs are runtime-specific.
+          multiple: true
+          options:
+              - Node
+              - Browser
+              - Deno
+              - Bun
+              - Cloudflare Workers
+              - Vercel Edge
+              - React Native / Expo
+              - Other (say which below)
+      validations:
+          required: true
+
+    - type: textarea
+      id: environment
+      attributes:
+          label: Environment
+          description: Runtime version, OS, bundler, and framework adapter if you use one.
+          placeholder: |
+              Node 24.4.0, macOS 15.6
+              Vite 7, @stitchapi/react 1.0.0-rc.6
+      validations:
+          required: false
+
+    - type: textarea
+      id: logs
+      attributes:
+          label: Trace or error output
+          description: |
+              If you have a `RunResult.trace` or a stack trace, paste it. Check first that
+              it carries no real credentials — StitchAPI redacts secrets from traces, but
+              a hand-assembled snippet may not be covered.
+          render: shell
+      validations:
+          required: false
+
+    - type: checkboxes
+      id: checks
+      attributes:
+          label: Before submitting
+          options:
+              - label: This is not a security vulnerability (those go through [SECURITY.md](https://github.com/rejifald/StitchAPI/blob/main/SECURITY.md)).
+                required: true
+              - label: I searched the existing issues for a duplicate.
+                required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+# Blank issues are off so every report arrives through a template — chiefly so a
+# security problem is routed to the private channel below instead of being disclosed
+# in a public issue before a fix exists (SECURITY.md).
+blank_issues_enabled: false
+
+contact_links:
+    - name: Report a security vulnerability
+      url: https://github.com/rejifald/StitchAPI/blob/main/SECURITY.md
+      about: Never in a public issue. SECURITY.md has the private channels, the response timeline, and what's in scope.
+
+    - name: Documentation, guides and live playground
+      url: https://stitchapi.dev
+      about: Check the docs before filing — the playground reproduces most questions faster than an issue can.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Propose a capability StitchAPI doesn't have yet.
+labels: ['enhancement']
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Lead with the problem rather than the API you have in mind — the shape usually
+              falls out of the constraint, and the problem is the part we can't guess.
+
+    - type: textarea
+      id: problem
+      attributes:
+          label: What problem are you solving?
+          description: What are you trying to do today, and where does it break down?
+          placeholder: |
+              I call an API that paginates with an opaque cursor in a response header, and
+              I end up hand-rolling the loop outside the stitch, which loses the trace.
+      validations:
+          required: true
+
+    - type: textarea
+      id: proposal
+      attributes:
+          label: What would it look like?
+          description: A sketch of the API, if you have one. Rough is fine.
+          render: ts
+      validations:
+          required: false
+
+    - type: dropdown
+      id: scope
+      attributes:
+          label: Where does it belong?
+          description: |
+              `stitchapi` core carries an enforced bundle-size budget, so a capability that
+              doesn't have to live there usually shouldn't. A companion package or a
+              subpath import costs nothing to anyone who doesn't import it.
+          options:
+              - Core (stitchapi) — it can't work anywhere else
+              - A subpath import of core
+              - An existing companion package (@stitchapi/*)
+              - A new companion package
+              - Not sure
+      validations:
+          required: true
+
+    - type: textarea
+      id: alternatives
+      attributes:
+          label: What have you tried?
+          description: Workarounds you're using now, or other libraries that solve this well.
+      validations:
+          required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,28 @@ The published library is [`stitchapi`](packages/core) (in `packages/core`); the
 framework adapters and other companions live alongside it under `packages/*`. See
 the package table in the [root README](README.md) for the full map.
 
+## Reporting bugs and requesting features
+
+> **Found a security vulnerability?** Don't open an issue. Report it privately —
+> see [`SECURITY.md`](SECURITY.md) for the two channels and what to expect.
+
+Everything else belongs in the [issue tracker](https://github.com/rejifald/StitchAPI/issues).
+Pick the matching template and it will ask for what we need:
+
+-   **Bug report** — what you expected, what happened instead, and a **minimal
+    reproduction**: the smallest `stitch` definition that shows the problem. Also
+    tell us the `stitchapi` version and the runtime (Node, browser, Deno, Bun,
+    Cloudflare Workers, React Native…), because a good share of bugs are
+    runtime-specific.
+-   **Feature request** — the problem you're trying to solve, before the API you
+    have in mind. Which package it belongs in matters too: core carries an
+    [enforced bundle-size budget](#bundle-size-budget), so a capability that
+    doesn't need to live in `stitchapi` is usually better as a companion package
+    or a subpath import.
+
+Search the tracker first — an open issue you can add a reproduction to is worth
+more than a duplicate.
+
 ## Prerequisites
 
 -   **Node** — the version is pinned in [`.nvmrc`](.nvmrc) (currently `24`). With
@@ -93,10 +115,29 @@ as CI**, cheap → expensive:
 You can run any of these by hand — `pnpm check:format`, `pnpm check:lint`,
 `pnpm check:types`, `pnpm test` — to reproduce a gate locally.
 
+## Tests come with the change
+
+**New functionality lands with tests for it, and a bug fix lands with a test that
+fails without the fix.** This is the project's standing policy, not a
+case-by-case judgement call — the suites are the only thing that keeps a
+zero-dependency runtime honest across every runtime it claims to support.
+
+Tests live next to what they cover (`packages/*/test/**` and `*.spec.ts`) and run
+under [Vitest](https://vitest.dev). Core also declares coverage thresholds in
+[`packages/core/vitest.config.ts`](packages/core/vitest.config.ts), enforced by
+the `coverage` job in CI — a change that drops coverage below them fails the
+build, so untested new code tends to fail the gate on its own.
+
+Exercise the behaviour through the public API rather than reaching into
+internals: a test that pins an implementation detail blocks the next refactor
+without protecting a user.
+
 ## Opening a pull request
 
 -   **Target `main`.** It's the default branch and the base every worktree branches
     from.
+-   **Include the tests.** See [above](#tests-come-with-the-change) — new
+    functionality without them will be sent back.
 -   **Write conventional-commit-style messages** — `type(scope): summary`, e.g.
     `fix(core): …`, `test(react): …`, `refactor: …`. Browse `git log` for the
     house style.


### PR DESCRIPTION
## Why

Three OpenSSF Best Practices `passing` criteria turn on text that did not exist in this
repo:

| Criterion | What it asks for |
| --- | --- |
| `report_process` | Documented instructions for how to report a bug |
| `test_policy` | A stated policy that new functionality gets tests |
| `tests_documented_added` | That policy present *in the instructions for change proposals* |

All three describe things this project already does — every feature in the history
landed with its specs, and `CONTRIBUTING.md` already documents the dev loop and the
gates. What was missing was the written policy. The badge asks for the policy, not the
habit, and it is a public permanent attestation, so the honest fix is to write it down
rather than tick the box.

Follows [#530](https://github.com/rejifald/StitchAPI/pull/530) (Scorecard, Dependabot,
release SBOMs). Independent of it — branched from `main` after that merged.

## What changed

**`CONTRIBUTING.md` — two new sections.**

*"Reporting bugs and requesting features"*, placed **above** Prerequisites. Someone
filing a bug should not have to scroll past Corepack setup to find out where bugs go. It
opens with the security carve-out, because the one report that must never arrive as a
public issue is a vulnerability.

*"Tests come with the change"*, stating the policy plainly, plus a bullet in "Opening a
pull request" linking to it. `tests_documented_added` specifically wants the policy in
the change-proposal instructions, so it needs to be reachable from where a contributor
reads about opening a PR — not merely present somewhere in the repo.

**`.github/ISSUE_TEMPLATE/` — new.**

Issue *forms* (YAML) rather than markdown templates, so the fields that decide whether a
bug is actionable are `required: true` instead of a suggestion a reporter can skip:
minimal reproduction, version, runtime.

- `bug_report.yml` — the runtime field is a multi-select dropdown. A good share of bugs
  in a library that claims Node + browser + Deno + Bun + Workers + React Native are
  runtime-specific, and "works in Node, fails in Workers" is the single most useful thing
  a reporter can say. The trace field warns to check for real credentials first: the
  library redacts secrets from its own traces, but a hand-assembled snippet is not
  covered by that.
- `feature_request.yml` — asks for the problem before the proposed API, and includes a
  "where does it belong" dropdown. Core carries an enforced bundle-size budget, so
  steering a request toward a companion package or subpath import at intake is cheaper
  than relitigating it in review.
- `config.yml` — `blank_issues_enabled: false`. Deliberate, not incidental: it is what
  routes a security report to the private channel in `SECURITY.md` instead of letting it
  be filed publicly before a fix exists.

## Verification

- `pnpm check:format` — clean
- All three templates parse as YAML
- Pre-commit gate (format + typecheck) green; pre-push gate green
- Anchor links resolve: `#bundle-size-budget` and `#tests-come-with-the-change` match
  their headings
- Both file paths cited in the new prose verified to exist:
  `packages/core/vitest.config.ts` declares `thresholds`, and 196 of 210 test files live
  under `test/`

Docs and repo config only — no runtime code, no published package touched.

## Remaining before the badge can be submitted

- **`vulnerability_report_private`** — Settings → Security → private vulnerability
  reporting. A toggle, not a commit.
- **`report_responses` / `enhancement_responses`** — need the maintainer's own read of
  the issue history.
- **`vulnerabilities_fixed_60_days`** — blocked on the five Dependabot alerts reaching
  `@stitchapi/docs-mcp`'s published runtime tree. Ticking it while those are open would
  be a false attestation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
