### PR TITLE
test(core): de-flake the timeout-abort assertion (ratio, not a 20ms margin)

### DIFF
--- a/packages/core/test/gaps/resource-leaks.spec.ts
+++ b/packages/core/test/gaps/resource-leaks.spec.ts
@@ -222,8 +222,10 @@ test('abort during a retry backoff rejects promptly (well under the backoff dela
     const elapsed = Date.now() - t0;
 
     expect(err).toBeDefined();
-    // The 1000ms backoff must be cut short by the abort — promptly, not slept out.
-    expect(elapsed).toBeLessThan(400);
+    // The 1000ms backoff must be cut short by the abort — promptly, not slept out. The ceiling is
+    // loose on purpose: a sleep-it-out regression lands at 1000ms+, so there is no reason to sit
+    // close to the abort and let an event-loop stall on a loaded runner red this.
+    expect(elapsed).toBeLessThan(700);
 });
 
 // An ALREADY-aborted signal must reject without ever sleeping the backoff.
@@ -254,5 +256,6 @@ test('an already-aborted signal rejects without sleeping the backoff', async () 
         (e: unknown) => e as Error,
     );
     expect(err).toBeDefined();
-    expect(Date.now() - t0).toBeLessThan(300);
+    // Same loose ceiling as above, and for the same reason: sleeping the backoff costs 1000ms+.
+    expect(Date.now() - t0).toBeLessThan(700);
 });

--- a/packages/core/test/resilience.spec.ts
+++ b/packages/core/test/resilience.spec.ts
@@ -149,7 +149,14 @@ test('throttle concurrency:1 serializes concurrent calls', async () => {
 
 // ── 6. Timeout aborts ──────────────────────────────────────────────────────
 test('timeout aborts a slow request instead of waiting it out', async () => {
-    server.route('GET', '/slow', { delay: 200, body: { ok: true } });
+    // The route answers only after 2s — 40× the timeout budget. That ratio, not a tight absolute
+    // margin, is what separates "aborted at the deadline" from "waited the server out". A loaded
+    // runner (parallel vitest workers, a concurrent build) stalls the event loop and pushes the
+    // measured elapsed up by however long the stall lasted; the old shape (200ms delay, ceiling
+    // 180) reddened at a ~160ms stall, which is an ordinary amount of noise — measured elapsed 206
+    // on a failing run. Widening the delay buys the ceiling room: this shape survives a ~950ms
+    // stall. Don't narrow the gap between `delay`, `total` and the ceiling below.
+    server.route('GET', '/slow', { delay: 2000, body: { ok: true } });
     const call = stitch({
         baseUrl: server.url,
         path: '/slow',
@@ -157,9 +164,18 @@ test('timeout aborts a slow request instead of waiting it out', async () => {
     });
 
     const t0 = Date.now();
-    await expect(call()).rejects.toBeDefined();
+    const err = await call().then(
+        () => undefined,
+        (e: unknown) => e as Error,
+    );
     const elapsed = Date.now() - t0;
 
-    // Aborted near the 50ms deadline, not after the full 200ms server delay.
-    expect(elapsed).toBeLessThan(180);
+    // The call must fail, and fail *because the budget ran out* — not with some other error, and
+    // certainly not resolve with the body a non-aborting timeout would have waited around for.
+    expect(err).toBeDefined();
+    expect(err?.message ?? '').toMatch(/timed?\s?out|timeout/i);
+    // And it must give up promptly rather than rejecting only once the response lands. The
+    // ceiling is deliberately loose — 20× the 50ms budget, still 2× under the server's 2s delay —
+    // so scheduling noise can't red it while a timeout that stopped aborting still can.
+    expect(elapsed).toBeLessThan(1000);
 });

--- a/packages/core/test/support/mock-server.ts
+++ b/packages/core/test/support/mock-server.ts
@@ -91,6 +91,11 @@ export function startMockServer(): Promise<MockServer> {
     const routes = new Map<string, RouteBehavior>();
     const counters = new Map<string, number>();
     const log: ReqInfo[] = [];
+    // Armed `delay` timers, so a pending response can't outlive the test that asked for it. A
+    // timeout/abort test deliberately walks away from a slow route long before it answers; without
+    // this the stray timer keeps the worker's event loop alive past `close()` and then writes to a
+    // socket the client already dropped. Cleared on reset() and close().
+    const pendingResponses = new Set<ReturnType<typeof setTimeout>>();
     const key = (method: string, path: string): string =>
         `${method.toUpperCase()} ${path}`;
 
@@ -244,10 +249,18 @@ export function startMockServer(): Promise<MockServer> {
         else if (typeof behavior.delay === 'number') delay = behavior.delay;
 
         const respond = (): void => {
+            // The client may have aborted while we were sleeping out `delay` — writing to a
+            // destroyed response emits an unhandled 'error' on it. Nothing to answer: drop it.
+            if (res.writableEnded || res.destroyed) return;
             send(status, body, behavior);
         };
-        if (delay > 0) setTimeout(respond, delay);
-        else respond();
+        if (delay > 0) {
+            const timer = setTimeout(() => {
+                pendingResponses.delete(timer);
+                respond();
+            }, delay);
+            pendingResponses.add(timer);
+        } else respond();
     };
 
     const server: Server = createServer((req, res) => {
@@ -260,6 +273,11 @@ export function startMockServer(): Promise<MockServer> {
 
     const filter = (path?: string): ReqInfo[] =>
         path ? log.filter((r) => r.path === path) : log.slice();
+
+    const clearPending = (): void => {
+        for (const timer of pendingResponses) clearTimeout(timer);
+        pendingResponses.clear();
+    };
 
     return new Promise((resolve) => {
         server.listen(0, '127.0.0.1', () => {
@@ -276,9 +294,11 @@ export function startMockServer(): Promise<MockServer> {
                     routes.clear();
                     counters.clear();
                     log.length = 0;
+                    clearPending();
                 },
                 close: () =>
                     new Promise<void>((res) => {
+                        clearPending();
                         // Force-drop any still-open connection (a half-read stream from an early
                         // break) so close() can't hang waiting on it (Node ≥ 18.2).
                         server.closeAllConnections();

--- a/packages/core/test/testing-kit.spec.ts
+++ b/packages/core/test/testing-kit.spec.ts
@@ -75,9 +75,12 @@ describe('mockAdapter — testing a stitch definition', () => {
     });
 
     test('delay is abortable: a per-attempt timeout cancels the slow response', async () => {
+        // Same shape as resilience.spec.ts §6: the 2s delay is 100× the deadline so the RATIO
+        // separates "aborted" from "waited it out", instead of a tight absolute margin that an
+        // event-loop stall on a loaded runner can cross. See that test for the measurements.
         const api = mockAdapter({
             match: '/slow',
-            respond: { delay: 1000, body: { ok: true } },
+            respond: { delay: 2000, body: { ok: true } },
         });
         const call = stitch({
             baseUrl: 'https://api.test',
@@ -90,8 +93,11 @@ describe('mockAdapter — testing a stitch definition', () => {
         const res = await call.safe();
         const elapsed = Date.now() - t0;
 
+        // Failed, and failed *because the deadline passed* — not merely "not ok".
         expect(res.ok).toBe(false);
-        expect(elapsed).toBeLessThan(300); // aborted near 20ms, not after the 1000ms delay
+        expect(res.error?.message ?? '').toMatch(/timed?\s?out|timeout/i);
+        // Aborted near the 20ms deadline; loose ceiling, still 2× under the 2s delay.
+        expect(elapsed).toBeLessThan(1000);
     });
 
     test('an unmatched request throws by default', async () => {


### PR DESCRIPTION
## The flake

`packages/core/test/resilience.spec.ts` §6 — `timeout aborts a slow request instead of
waiting it out` — failed about 1 run in 3 on a loaded machine, and reddened a pre-push gate
on a docs-only branch that touches no runtime code.

The assertion had no room in it:

```ts
server.route('GET', '/slow', { delay: 200, body: { ok: true } });   // "didn't abort" = 200ms
const call = stitch({ ..., timeout: { total: 50 } });               // deadline    =  50ms
...
expect(elapsed).toBeLessThan(180);                                  // ceiling     = 180ms
```

The ceiling sat **20ms below the value that represents the bug it was guarding against**, which
left only ~130ms of scheduling slack for everything else. The mock server runs in the same
process as the test, so any event-loop stall — parallel vitest workers, a concurrent build —
delays the abort timer and the server's response together. The reported failure measured
**206ms**: the server response had simply won.

## The fix

Two changes to the assertion's *shape*, not its strictness:

1. **Assert the contract, not just the clock.** The call must reject *because the budget ran
   out*, matching the `/timed?\s?out|timeout/i` convention already used throughout
   `test/gaps/timeout-total.spec.ts`. A prompt-but-wrong error can no longer pass.
2. **Let the ratio carry the timing claim.** The route now answers after 2s — 40× the budget —
   against a 1000ms ceiling. The gap absorbs the noise instead of a hand-tuned margin.

The slow route is never waited on in the passing path, so this costs the suite no wall-clock
time; it only lengthens the *failing* path.

## Verification

**Mutation-tested** — three independent breaks of the timeout path in `src/resilience.ts`, each
caught by a *different* assertion, so no assertion is dead weight and the test is not a tautology:

| Mutation | Behaviour | Caught by |
| --- | --- | --- |
| timeout never arms | resolves `{ok:true}` at 2034ms | `expect(err).toBeDefined()` |
| rejects correctly, but only once the transport settles | `TimeoutError` at 2039ms | `elapsed < 1000` |
| aborts on time, surfaces a non-timeout error | `"connection reset"` at ~50ms | the message match |

**Stall sweep** — the event loop was stalled synchronously mid-flight to reproduce the reported
condition mechanically and measure how much noise each shape survives:

```
stall=100ms | OLD elapsed= 150 ceiling180=PASS | NEW elapsed= 123 ceiling1000=PASS
stall=150ms | OLD elapsed= 174 ceiling180=PASS | NEW elapsed= 169 ceiling1000=PASS
stall=200ms | OLD elapsed= 248 ceiling180=FAIL | NEW elapsed= 238 ceiling1000=PASS
stall=300ms | OLD elapsed= 328 ceiling180=FAIL | NEW elapsed= 321 ceiling1000=PASS
stall=500ms | OLD elapsed= 522 ceiling180=FAIL | NEW elapsed= 523 ceiling1000=PASS
stall=800ms | OLD elapsed= 833 ceiling180=FAIL | NEW elapsed= 823 ceiling1000=PASS
stall=950ms |                                  | NEW elapsed= 972 ceiling1000=PASS
stall=1000ms|                                  | NEW elapsed=1046 ceiling1000=FAIL
```

Tolerance to an event-loop stall: **~160ms → ~950ms**. Note the rejection stayed a *timeout
error* at every stall level, including past the server's own 2s delay — the identity assertion
never degrades, so the only way this reds now is a real regression.

**Runs**: 13 clean full-suite runs (`pnpm --filter stitchapi test`, 1237 tests), 8 of them under
10 added CPU hog processes. Pre-push gate run in full, never bypassed.

## Also in this PR

**`test/support/mock-server.ts`** now tracks armed `delay` timers and clears them on `reset()`
and `close()`, and drops a delayed response whose client has already gone away. A 2s route that a
timeout test abandons at 50ms would otherwise keep the worker's event loop alive past `close()`
and then write to a destroyed socket.

**Sibling audit.** Every wall-clock assertion in `packages/core/test/` was reviewed. The
important asymmetry: **lower bounds are structurally safe** — load can only push `elapsed` further
into passing, and Node timers never fire early — so the `toBeGreaterThanOrEqual` checks in
`resilience.spec.ts`, `sse-reconnect.spec.ts`, `seam.spec.ts`, `integration-patterns.spec.ts` and
`throttle-host-pooling.spec.ts` are left alone. Only **upper** bounds on elapsed time are
fragile. Of those, three others were tightened up:

- `testing-kit.spec.ts` — the sibling timeout-abort test. Given the same shape (2s delay, 1000ms
  ceiling) and the same timeout-identity assertion; it previously asserted only `res.ok === false`.
  Mutation-tested the same way: disarming the timeout gives `expected true to be false`, and a
  wrong error type gives `expected 'connection reset' to match /timed?\s?out|timeout/i`.
- `gaps/resource-leaks.spec.ts` ×2 — caller-abort tests whose ceilings (400ms / 300ms) sat
  needlessly close to an abort expected at ~0-20ms. Raised to 700ms; a sleep-it-out regression
  costs 1000ms+, so no sensitivity is lost.

The upper bounds in `gaps/timeout-total.spec.ts` and `gaps/delegate-backoff.spec.ts` already carry
600-1700ms of slack and were left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
