### PR TITLE
feat(docs): add a /contribute page and nav link

### DIFF
--- a/apps/docs/app/(home)/contribute/page.tsx
+++ b/apps/docs/app/(home)/contribute/page.tsx
@@ -1,0 +1,209 @@
+import { Eyebrow, GithubIcon } from '../components/primitives';
+
+import {
+    contributingUrl,
+    issuesUrl,
+    newIssueUrl,
+    npmUrl,
+    repoUrl,
+    securityAdvisoryUrl,
+    securityPolicyUrl,
+} from '@/lib/shared';
+
+import {
+    ArrowRight,
+    Bug,
+    HeartHandshake,
+    Package,
+    ShieldAlert,
+} from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+/**
+ * The site's single answer to "how do I get this, tell you it's broken, or help?".
+ *
+ * Every path a visitor might want lives on one page rather than being inferred from a
+ * GitHub icon in the nav: the project's feedback and contribution routes should be
+ * discoverable from the website itself, not only by someone who already thought to go
+ * looking in the repository.
+ *
+ * Deliberately no literal install command here. Install specs carry a dist-tag suffix
+ * (`@rc` today, bare once 1.0.0 ships stable) and the docs site keeps those correct via
+ * the remark-install-channel plugin, which only processes MDX — a hardcoded command in
+ * a .tsx page would sit outside that guarantee and quietly go stale.
+ */
+export const metadata: Metadata = {
+    title: 'Contribute',
+    description:
+        'How to install StitchAPI, report a bug, request a feature, disclose a security issue, and contribute code.',
+    alternates: { canonical: '/contribute' },
+};
+
+const cardClass =
+    'rounded-xl border border-fd-border bg-fd-card p-6 transition-colors hover:border-stitch/40';
+
+const linkClass =
+    'inline-flex items-center gap-1 font-medium text-stitch hover:text-stitch-strong';
+
+export default function Page() {
+    return (
+        <main className="flex-1 px-6 py-[clamp(2rem,6vh,5rem)]">
+            <div className="mx-auto w-full max-w-4xl">
+                <Eyebrow>Get involved</Eyebrow>
+                <h1 className="font-display mt-3 text-3xl font-black tracking-[-0.035em] text-fd-foreground lg:text-4xl">
+                    Get it, report it, improve it
+                </h1>
+                <p className="mt-4 max-w-2xl text-lg leading-relaxed text-fd-muted-foreground">
+                    StitchAPI is Apache-2.0 and developed in the open. Bug
+                    reports and questions are as useful as pull requests — a
+                    reproduction you can hand over is worth more than a patch
+                    nobody can verify.
+                </p>
+
+                <div className="mt-10 grid gap-4 sm:grid-cols-2">
+                    <section className={cardClass}>
+                        <Package className="size-5 text-stitch" />
+                        <h2 className="mt-3 font-semibold text-fd-foreground">
+                            Get StitchAPI
+                        </h2>
+                        <p className="mt-2 text-sm leading-relaxed text-fd-muted-foreground">
+                            Zero runtime dependencies, one package. The install
+                            page has the current command for every package
+                            manager.
+                        </p>
+                        <p className="mt-4 flex flex-col gap-2 text-sm">
+                            <Link
+                                href="/docs/getting-started/installation"
+                                className={linkClass}
+                            >
+                                Installation
+                                <ArrowRight className="size-3.5" />
+                            </Link>
+                            <a
+                                href={npmUrl}
+                                className={linkClass}
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                View on npm
+                            </a>
+                        </p>
+                    </section>
+
+                    <section className={cardClass}>
+                        <Bug className="size-5 text-stitch" />
+                        <h2 className="mt-3 font-semibold text-fd-foreground">
+                            Report a bug
+                        </h2>
+                        <p className="mt-2 text-sm leading-relaxed text-fd-muted-foreground">
+                            Include the smallest definition that shows the
+                            problem, the version, and the runtime — a good share
+                            of bugs are runtime-specific, so &ldquo;works in
+                            Node, fails in Workers&rdquo; is the useful part.
+                        </p>
+                        <p className="mt-4 flex flex-col gap-2 text-sm">
+                            <a
+                                href={newIssueUrl}
+                                className={linkClass}
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                Open an issue
+                                <ArrowRight className="size-3.5" />
+                            </a>
+                            <a
+                                href={issuesUrl}
+                                className={linkClass}
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                Search existing issues
+                            </a>
+                        </p>
+                    </section>
+
+                    <section className={cardClass}>
+                        <HeartHandshake className="size-5 text-stitch" />
+                        <h2 className="mt-3 font-semibold text-fd-foreground">
+                            Contribute code
+                        </h2>
+                        <p className="mt-2 text-sm leading-relaxed text-fd-muted-foreground">
+                            Pull requests target <code>main</code>. The
+                            contributing guide covers the dev loop, the
+                            tests-with-changes policy, and the bundle-size
+                            budget — all enforced by CI, so the gate tells you
+                            before a reviewer has to.
+                        </p>
+                        <p className="mt-4 text-sm">
+                            <a
+                                href={contributingUrl}
+                                className={linkClass}
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                Read CONTRIBUTING.md
+                                <ArrowRight className="size-3.5" />
+                            </a>
+                        </p>
+                    </section>
+
+                    <section className={cardClass}>
+                        <ShieldAlert className="size-5 text-stitch" />
+                        <h2 className="mt-3 font-semibold text-fd-foreground">
+                            Found a vulnerability?
+                        </h2>
+                        <p className="mt-2 text-sm leading-relaxed text-fd-muted-foreground">
+                            Don&apos;t open a public issue — that discloses it
+                            to everyone before a fix exists. Report it privately
+                            and you&apos;ll get an acknowledgement within 48
+                            hours.
+                        </p>
+                        <p className="mt-4 flex flex-col gap-2 text-sm">
+                            <a
+                                href={securityAdvisoryUrl}
+                                className={linkClass}
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                Report privately
+                                <ArrowRight className="size-3.5" />
+                            </a>
+                            <a
+                                href={securityPolicyUrl}
+                                className={linkClass}
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                Security policy and scope
+                            </a>
+                        </p>
+                    </section>
+                </div>
+
+                <p className="mt-8 text-sm text-fd-muted-foreground">
+                    Not sure it&apos;s a bug?{' '}
+                    <Link href="/playground" className={linkClass}>
+                        Reproduce it in the playground
+                        <ArrowRight className="size-3.5" />
+                    </Link>{' '}
+                    and paste the link into the issue — it runs the real library
+                    in your browser.
+                </p>
+
+                <p className="mt-10 flex items-center gap-2 text-sm text-fd-muted-foreground">
+                    <GithubIcon className="size-4" />
+                    Everything happens in the open at{' '}
+                    <a
+                        href={repoUrl}
+                        className={linkClass}
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        rejifald/StitchAPI
+                    </a>
+                </p>
+            </div>
+        </main>
+    );
+}

--- a/apps/docs/lib/layout.shared.tsx
+++ b/apps/docs/lib/layout.shared.tsx
@@ -1,4 +1,4 @@
-import { npmUrl } from './shared';
+import { contributeRoute, npmUrl } from './shared';
 
 import { GithubStarButton } from '@/app/(home)/components/github-star-button';
 import { NpmIcon } from '@/app/(home)/components/primitives';
@@ -24,6 +24,13 @@ export function baseOptions(): BaseLayoutProps {
             {
                 text: 'Playground',
                 url: '/playground',
+            },
+            // The site's own route to "how do I report this / help?". Without it the
+            // only feedback affordance is the GitHub button below, which asks a visitor
+            // to already know that issues and CONTRIBUTING.md live behind it.
+            {
+                text: 'Contribute',
+                url: contributeRoute,
             },
             {
                 type: 'icon',

--- a/apps/docs/lib/shared.ts
+++ b/apps/docs/lib/shared.ts
@@ -18,3 +18,17 @@ export const gitConfig = {
     repo: 'StitchAPI',
     branch: 'main',
 };
+
+export const contributeRoute = '/contribute';
+
+// Derived from `gitConfig` so a repo move stays a one-line change. These back the
+// /contribute page and anything else that needs to point a visitor at the project's
+// feedback and contribution paths.
+export const repoUrl = `https://github.com/${gitConfig.user}/${gitConfig.repo}`;
+export const issuesUrl = `${repoUrl}/issues`;
+export const newIssueUrl = `${repoUrl}/issues/new/choose`;
+export const contributingUrl = `${repoUrl}/blob/${gitConfig.branch}/CONTRIBUTING.md`;
+export const securityPolicyUrl = `${repoUrl}/blob/${gitConfig.branch}/SECURITY.md`;
+// Private vulnerability reporting. Deliberately NOT the issue tracker: a security
+// problem filed in public is disclosed to everyone before a fix exists.
+export const securityAdvisoryUrl = `${repoUrl}/security/advisories/new`;


### PR DESCRIPTION
## Why

While filling in the OpenSSF Best Practices form, `interact` turned out to be genuinely
unmet — and for a reason worth fixing regardless of the badge.

> The project website MUST provide information on how to: obtain, provide feedback (as
> bug reports or enhancements), and contribute to the software.

The site nav carried Docs, Blog, Playground, an npm icon, and a Star-on-GitHub button.
Against those three requirements:

| | Before |
| --- | --- |
| obtain | ✅ npm link + install docs |
| provide feedback | ❌ nothing |
| contribute | ❌ nothing |

The only feedback affordance asked a visitor to already know that issues and
`CONTRIBUTING.md` live behind a star button. Someone who hit a bug on stitchapi.dev had
nowhere to go.

## What changed

**`/contribute`** — four cards answering all three requirements plus the security path:

- **Get StitchAPI** → installation doc + npm
- **Report a bug** → issue chooser + existing-issue search, with the reproduction /
  version / runtime guidance the templates ask for
- **Contribute code** → `CONTRIBUTING.md`
- **Found a vulnerability?** → private GitHub advisory, *not* the issue tracker, because
  a vulnerability filed in the open is disclosed before a fix exists

**Nav link** in `lib/layout.shared.tsx`, so it's reachable from every page rather than
only by URL.

### Three implementation notes

**URLs derive from `gitConfig`.** `repoUrl` / `issuesUrl` / `newIssueUrl` /
`contributingUrl` / `securityPolicyUrl` / `securityAdvisoryUrl` are all built from the
config already in `lib/shared.ts`, so a repo move stays a one-line change instead of six
hardcoded strings drifting apart.

**No literal install command on the page — deliberately.** Install specs carry a
dist-tag suffix (`@rc` today, bare once 1.0.0 ships stable), and the site keeps those
correct via `lib/remark-install-channel.ts` — which only processes MDX. A hardcoded
`npm install stitchapi@rc` in a `.tsx` page would sit outside that guarantee and quietly
go stale at the 1.0.0 cut. The page links to the installation doc instead, which stays
correct by construction.

**Lives in `(home)`, not the docs IA.** Beside `/demo` and `/playground`. The docs
describe *using* StitchAPI, not contributing to it, and a docs page would additionally
have to thread through `content.manifest.ts` and its drift guard for no benefit.

## Verification

Verified against a real production build rather than assumed:

- `pnpm --filter @stitchapi/docs build` — **438 static pages generated, no errors**
- `contribute.html` renders all four sections and all nine outbound links
  (`/docs/getting-started/installation`, `/playground`, npm, and the six GitHub URLs)
- `href="/contribute"` present in both the home and docs layouts
- `check:format`, `check:lint`, `check:types` clean

Note on visual QA: I did **not** do a browser screenshot. `.claude/.preview-root` points
at a different worktree owned by another live session, and this repo's `launch.json`
invokes `pnpm` directly rather than the worktree-aware wrapper — so a preview would have
served code without this page. Rather than stomp another session's preview config, I
verified against the built HTML, which is what the `verify.yml` render gate uses.

## Follow-ups

- Flipping `interact` to **Met** on the badge form once this deploys.
- `launch.json` should route through `/Users/rejifald/.claude/scripts/preview-in-worktree.sh`
  so previews follow the session's worktree instead of the primary checkout. Separate
  change; it's why the visual check wasn't possible here.
- `/contribute` is not in `sitemap.ts` — consistent with `/demo` and `/playground`, which
  aren't either. Worth revisiting as a set rather than one-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
