### PR TITLE
feat(core): `parseBytes` — byte caps take `4096` or `'1mb'` (P25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ npm release are grouped under the in-development version that introduced them.
   lets a peer package accept `number | string` without mirroring the grammar and drifting
   from it. Additive — nothing else changes.
 
+- **`parseBytes` is exported from `stitchapi`, and byte caps now take a size token.** The size
+  analogue of `parseDuration` (CONTRACT.md **P25**): `4096`, `'64kb'`, `'1mb'` → bytes, in
+  **powers of 1024** (`'1mb'` = 1_048_576 — the npm-`bytes` convention, and the base the house
+  defaults are already written in). `'kib'`/`'mib'`/`'gib'` are accepted spellings of the same
+  values; parsing is case-insensitive.
+
+    ```ts
+    serve(registry, { maxBodyBytes: 4 * 1024 * 1024 }); // still fine
+    serve(registry, { maxBodyBytes: '4mb' }); // now equivalent
+    ```
+
+    `ServeOptions.maxBodyBytes` is widened to `number | string` — purely additive, every
+    existing numeric cap keeps working. An unparseable token resolves to `undefined` and lands
+    on the default cap, so a typo can never widen the bound to "unbounded".
+
+    It does **not** apply to the `Chars` family (`stream.maxBufferChars`,
+    `trace.maxBodyChars`): those count UTF-16 code units of decoded text, where a byte token
+    would be a category error. That is the distinction the `Bytes`/`Chars` suffixes carry, so —
+    unlike durations under P17 — a size field keeps its unit suffix.
+
 ### Changed
 
 - **BREAKING — `stream.maxBufferBytes` is renamed to `maxBufferChars`.** The cap never

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -484,6 +484,34 @@ all take `SchemaLike` and return `ValidationResult`; `JsonSchema.adapt(json, { a
 bridge from JSON Schema, producing a `SchemaLike` those consumers treat identically. The standalone
 `validate`/`compile` verbs replaced app-level `schema['~standard'].validate(…)`.
 
+### P25 · One canonical size form
+
+**Bytes are the house size unit.** Every **consumer-authored** byte cap **MUST** accept
+**`number | string`** — a raw byte count or a token like `'64kb'`/`'1mb'` — parsed by one
+shared `parseBytes`, whose units are **powers of 1024** (`'1mb'` = 1_048_576). Every
+**emitted** size is a raw-byte `number`.
+
+Unlike a duration ([P17](#p17--one-canonical-duration-form)), a size field **KEEPS** its
+unit suffix. `Ms` encodes a **scale**, which `'5s'` overrides — so the suffix becomes a
+lie and P17 drops it. `Bytes` encodes a **dimension**: octets, as opposed to the `Chars`
+family (`stream.maxBufferChars`, `trace.maxBodyChars`) that counts UTF-16 code units of
+decoded text. `'1mb'` restates the scale, never the dimension, so the suffix stays true.
+That distinction is load-bearing per [P1](#p1--one-word-one-concept-one-value-space) —
+`Bytes` denotes bytes and cannot also denote code units — and a `Chars` field therefore
+**MUST NOT** take a byte token.
+
+_Why:_ every JS-native size API (`byteLength`, `Buffer.length`, `execFile`'s `maxBuffer`)
+is already bytes, so a bare number needs no unit; and 1024-based `kb`/`mb` is what the
+Node ecosystem's de-facto parser already means by those tokens
+([P22](#p22--a-standards-interop-contract-uses-the-standards-field-names)), matching the
+base the house defaults are written in (`10 * 1024 * 1024`). An unparseable token resolves
+to `undefined` and lands on the field's default — a typo can never widen a cap to
+"unbounded".
+
+_Canonical case:_ `ServeOptions.maxBodyBytes` and `@stitchapi/shell`'s
+`ShellOptions.maxBufferBytes` each take `2 * 1024 * 1024` or `'2mb'`; `parseBytes` is
+exported from `stitchapi` so a peer package parses the grammar instead of mirroring it.
+
 ---
 
 ## 6. Migration backlog (proposed renames — confirm during sweep)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,6 +60,10 @@ export { systemClock } from './util';
 // Exported so a peer package that takes a consumer-authored duration parses it the
 // same way core does, instead of mirroring the grammar and drifting from it.
 export { parseDuration } from './util';
+// Its size analogue: `4096`, `'64kb'`, `'1mb'` → bytes (powers of 1024). Same reason it is
+// public — a peer package with a `*Bytes` cap parses it the way core does. NOT for the
+// `Chars` family, which counts UTF-16 code units rather than bytes.
+export { parseBytes } from './util';
 // `compact({ ...obj, key: value })` — a shallow copy with `undefined`-valued keys removed, typed so
 // undefined-admitting keys come back optional. Pairs with `exactOptionalPropertyTypes`: it omits an
 // absent optional without the `...(key !== undefined ? { key } : {})` spread dance.

--- a/packages/core/src/serve.ts
+++ b/packages/core/src/serve.ts
@@ -11,6 +11,7 @@ import { compact } from './compact';
 import { type StitchRegistry, selectStitch } from './registry';
 import { redactEventForTransport } from './trace';
 import type { StitchEvent, StitchInput } from './types';
+import { parseBytes } from './util';
 
 import {
     type IncomingMessage,
@@ -27,8 +28,11 @@ export interface ServeOptions {
      * {@link MAX_REQUEST_BODY_BYTES}). `serve` is unauthenticated (loopback by default, but
      * `--host` lets an operator bind a wider interface), so this bounds the memory a single
      * request can buffer. Default {@link MAX_REQUEST_BODY_BYTES}.
+     *
+     * A raw byte count or a size token — `4 * 1024 * 1024` or `'4mb'` (powers of 1024),
+     * parsed by the shared {@link parseBytes}.
      */
-    maxBodyBytes?: number;
+    maxBodyBytes?: number | string;
 }
 
 export interface ServeHandle {
@@ -41,9 +45,10 @@ export interface ServeHandle {
 // Default request-body cap. `serve` is unauthenticated (loopback by default; DESIGN.md §10), but
 // `cli.ts --host` lets an operator bind a wider interface, so an unbounded body would let a single
 // large/slow POST buffer the whole payload into memory → OOM. A few MB comfortably fits any real
-// stitch input (JSON params/query/headers/variables) while capping that exposure; the same 2 MB
-// order of magnitude as trace's body-truncation scale (`DEFAULT_MAX_BODY_BYTES`). Override per
-// server via {@link ServeOptions.maxBodyBytes}.
+// stitch input (JSON params/query/headers/variables) while capping that exposure. Unrelated to
+// trace's `DEFAULT_MAX_BODY_CHARS` (2048 code units) — that one truncates what gets *logged*,
+// this one bounds what a single request may *buffer*. Override per server via
+// {@link ServeOptions.maxBodyBytes}, as a byte count or a `'2mb'`-style token.
 export const MAX_REQUEST_BODY_BYTES = 2 * 1024 * 1024;
 
 // Thrown by `readBody` when the body exceeds the cap; the handler maps it to 413.
@@ -186,8 +191,11 @@ async function runJson(
 // defaults to {@link MAX_REQUEST_BODY_BYTES}.
 export function createServeHandler(
     registry: StitchRegistry,
-    { maxBodyBytes = MAX_REQUEST_BODY_BYTES }: { maxBodyBytes?: number } = {},
+    { maxBodyBytes }: { maxBodyBytes?: number | string } = {},
 ): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
+    // Parse the cap ONCE here, not per request. An unparseable token resolves to `undefined`
+    // and lands on the default cap — a typo can never widen this to "unbounded".
+    const limit = parseBytes(maxBodyBytes) ?? MAX_REQUEST_BODY_BYTES;
     return async (req, res) => {
         const url = new URL(req.url ?? '/', 'http://localhost');
         const path = url.pathname;
@@ -221,7 +229,7 @@ export function createServeHandler(
 
         let input: StitchInput;
         try {
-            input = parseInput(await readBody(req, maxBodyBytes));
+            input = parseInput(await readBody(req, limit));
         } catch (e) {
             if (e instanceof PayloadTooLargeError) {
                 sendJson(res, 413, { error: e.message });

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -91,6 +91,33 @@ export function parseDuration(
     return n * (scale[m[2] ?? ''] ?? 1);
 }
 
+/**
+ * Parse a size into bytes — the size analogue of {@link parseDuration}. Grammar: a number
+ * (already bytes), a numeric string (`"4096"` → 4096), or `<number><unit>` with unit
+ * `b` | `kb` | `mb` | `gb` | `tb` (`"512b"`, `"64kb"`, `"1mb"`, `"1.5gb"`; case-insensitive,
+ * fractions allowed). Anything else → `undefined`.
+ *
+ * Units are **powers of 1024** — `"1mb"` is 1_048_576, the npm-`bytes` convention every
+ * Node config parser in the ecosystem already speaks (CONTRACT.md P22) and the base the
+ * house defaults are written in (`10 * 1024 * 1024`). The IEC spellings `kib` | `mib` |
+ * `gib` | `tib` are accepted for the same values, for callers who want the base explicit.
+ *
+ * Only for fields that count **bytes**. The `Chars` family (`stream.maxBufferChars`,
+ * `trace.maxBodyChars`) counts UTF-16 code units of decoded text, where a byte token would
+ * be a category error — that distinction is what the `Bytes`/`Chars` suffixes carry (P1).
+ */
+export function parseBytes(s: number | string | undefined): number | undefined {
+    if (s == null) return undefined;
+    if (typeof s === 'number') return s;
+    const m = /^(\d+(?:\.\d+)?)\s*(?:([kmgt])i?)?b$/i.exec(s.trim());
+    if (!m) return Number(s) || undefined;
+    // Index in `bkmgt` IS the power of 1024: `b`→0, `k`→1, `m`→2… The `i` spellings collapse
+    // onto the same index (`kib` and `kb` are both 1024). A cap is a whole number of bytes, so
+    // a fractional token floors — never rounds up past what the caller asked for.
+    const pow = 'bkmgt'.indexOf(m[2]?.toLowerCase() ?? 'b');
+    return Math.floor(parseFloat(m[1] ?? '') * 1024 ** pow);
+}
+
 /** "2/s" | "10/m" -> { count, per } (window length in ms). */
 export function parseRate(r: string): { count: number; per: number } {
     const m = /^(\d+)\s*\/\s*(ms|s|m)$/.exec(r.trim());

--- a/packages/core/test/serve.spec.ts
+++ b/packages/core/test/serve.spec.ts
@@ -325,6 +325,43 @@ describe('serve caps the request body (413), so an unauthenticated server cannot
     });
 });
 
+describe('the body cap also accepts a size token (`parseBytes`)', () => {
+    // `'1kb'` must resolve to 1024 bytes. The probe body is ~1.1 KB — over a parsed `'1kb'`
+    // but far under the 2 MiB default, so a 413 here can only mean the token was honoured
+    // (an ignored/unparsed token would fall back to the default and answer 200).
+    let capped: ServeHandle;
+    beforeAll(async () => {
+        const ping = stitch({ baseUrl: api.url, path: '/ping' });
+        capped = await serve({ ping }, { port: 0, maxBodyBytes: '1kb' });
+    });
+    afterAll(async () => {
+        await capped.close();
+    });
+
+    test('a body over the token cap is rejected with 413', async () => {
+        api.route('GET', '/ping', { body: { ok: true } });
+        const res = await fetch(`${capped.url}/stitch/ping`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ query: { pad: 'y'.repeat(1100) } }),
+        });
+        expect(res.status).toBe(413);
+        await expect(res.json()).resolves.toMatchObject({
+            error: expect.stringContaining('1024'), // the parsed cap, in bytes
+        });
+    });
+
+    test('a body under the token cap still succeeds', async () => {
+        api.route('GET', '/ping', { body: { ok: true } });
+        const res = await fetch(`${capped.url}/stitch/ping`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ query: { pad: 'y'.repeat(100) } }),
+        });
+        expect(res.status).toBe(200);
+    });
+});
+
 // A fake `req`/`res` pair for driving `createServeHandler` without a socket, so a client
 // disconnect can be simulated deterministically by emitting 'close'.
 function fakeReqRes(body: string, headers: Record<string, string>) {

--- a/packages/core/test/util-helpers.spec.ts
+++ b/packages/core/test/util-helpers.spec.ts
@@ -12,6 +12,7 @@ import {
     isObj,
     matchAny,
     matchPath,
+    parseBytes,
     parseDuration,
     parseRate,
     stripTrailingSlashes,
@@ -45,6 +46,64 @@ describe('parseDuration', () => {
 
     it('returns undefined for an unparseable string', () => {
         expect(parseDuration('soon')).toBeUndefined();
+    });
+});
+
+describe('parseBytes', () => {
+    it('passes a number through unchanged', () => {
+        expect(parseBytes(4096)).toBe(4096);
+    });
+
+    it('returns undefined for nullish input', () => {
+        expect(parseBytes(undefined)).toBeUndefined();
+    });
+
+    it('parses b / kb / mb / gb / tb as powers of 1024', () => {
+        expect(parseBytes('512b')).toBe(512);
+        expect(parseBytes('64kb')).toBe(65_536);
+        expect(parseBytes('1mb')).toBe(1_048_576);
+        expect(parseBytes('2gb')).toBe(2_147_483_648);
+        expect(parseBytes('1tb')).toBe(1_099_511_627_776);
+    });
+
+    it('accepts the IEC spellings as the same values', () => {
+        expect(parseBytes('64kib')).toBe(parseBytes('64kb'));
+        expect(parseBytes('1mib')).toBe(parseBytes('1mb'));
+        expect(parseBytes('2gib')).toBe(parseBytes('2gb'));
+    });
+
+    it('is case-insensitive', () => {
+        expect(parseBytes('1MB')).toBe(1_048_576);
+        expect(parseBytes('1Mb')).toBe(1_048_576);
+        expect(parseBytes('10MiB')).toBe(10 * 1024 * 1024);
+    });
+
+    it('accepts a fractional value and surrounding whitespace', () => {
+        expect(parseBytes('1.5kb')).toBe(1536);
+        expect(parseBytes('  2 mb  ')).toBe(2_097_152);
+    });
+
+    it('floors a fraction that lands between bytes — a cap never rounds up', () => {
+        expect(parseBytes('1.1kb')).toBe(1126); // 1126.4
+    });
+
+    it('treats a bare numeric string as bytes', () => {
+        expect(parseBytes('4096')).toBe(4096);
+    });
+
+    it('returns undefined for an unparseable string', () => {
+        expect(parseBytes('big')).toBeUndefined();
+        expect(parseBytes('1gigabyte')).toBeUndefined();
+    });
+
+    it('does not accept a bare `i` prefix as a unit', () => {
+        expect(parseBytes('5ib')).toBeUndefined();
+    });
+
+    it('does not parse a duration token as a size', () => {
+        // The two grammars must not overlap: `'1m'` is a minute, never a megabyte.
+        expect(parseBytes('1m')).toBeUndefined();
+        expect(parseBytes('30s')).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
The size analogue of `parseDuration`, and the prerequisite for the same widening on
`@stitchapi/shell`'s `maxBufferBytes` (follow-up on #514).

## Why

P17 already requires every consumer-authored **duration** to accept `number | string`
through one shared `parseDuration` — and `Unreleased` just exported that parser so a peer
package can take `'5s'` *"without mirroring the grammar and drifting from it"*. Byte caps
had no such affordance: `maxBodyBytes` was a bare `number`, and `@stitchapi/shell` was
about to ship a second one.

## What

| | |
| --- | --- |
| **`parseBytes`** | `4096` \| `'64kb'` \| `'1mb'` → bytes. Exported from `stitchapi`, next to `parseDuration`. |
| **Base** | Powers of **1024** (`'1mb'` = 1_048_576) — the npm-`bytes` convention every Node config parser already speaks (P22), and the base the house defaults are written in (`10 * 1024 * 1024`). `kib`/`mib`/`gib` accepted for the same values; case-insensitive. |
| **`ServeOptions.maxBodyBytes`** | Widened to `number \| string`. Purely additive — every numeric cap keeps working. |
| **Fail-safe** | An unparseable token → `undefined` → the field's default. A typo can never widen a cap to `"unbounded"`. |
| **Not the `Chars` family** | `stream.maxBufferChars` / `trace.maxBodyChars` count UTF-16 code units; a byte token there is a category error. |

## The suffix survives — this is additive to #514's rename, not a reversal

Worth stating explicitly, because it looks like it contradicts P17:

- `Ms` encodes a **scale**. `'5s'` overrides the scale → the name becomes a lie → P17 drops it.
- `Bytes` encodes a **dimension** — octets, as against the `Chars` family's UTF-16 code
  units. `'1mb'` restates the scale and never touches the dimension → the suffix stays true.

That distinction is exactly what the `stream.maxBufferBytes`→`maxBufferChars` break bought
(*"`Bytes` already denotes bytes elsewhere on the surface and cannot also denote code
units"*), so `maxBufferBytes` in #514 is the right spelling and this rides on top of it.

## Two judgment calls for review

1. **New CONTRACT.md P25 · One canonical size form.** A field-shape rule with no principle
   behind it would be anomalous in this repo, so I wrote one. Drop it if you'd rather the
   rule live only in `parseBytes`'s JSDoc.
2. **Pre-existing, untouched:** **P24 has no heading.** It is cited four times in §6
   (backoff envelope, refresh envelope, Sentry capture, nest seam) but §5 ends at P23, so
   those four references dangle. I took P25 rather than guess at P24's wording. Flagging it
   because my addition makes the gap more visible.

## Also fixed

`serve.ts`'s default-cap comment pointed at `DEFAULT_MAX_BODY_BYTES`, which the Bytes→Chars
rename turned into `DEFAULT_MAX_BODY_CHARS` — and which is 2048 **code units**, not the
"same 2 MB order of magnitude" the comment claimed. Off by 1000×, in a comment justifying a
security bound.

## Verification

- typecheck, full core suite (1277 tests), lint, contract ratchet, docs-links, prettier — all clean
- **Size gate green with no budget bump**: whole entry **22.77 KB** gzip against the 22.90 KB
  budget (0.13 KB left); `import { stitch }` unchanged at 20.17 KB. Still rounds to the
  advertised ~23 kB, so no size-doc drift.
- New tests: 11 `parseBytes` cases (units, IEC aliases, case, fractions floor, bare numerals,
  the `'5ib'` trap, and `'1m'`/`'30s'` **not** parsing as sizes — the two grammars must not
  overlap), plus a live-server pair proving `maxBodyBytes: '1kb'` really rejects at 1024 (a
  ~1.1 KB body 413s; an ignored token would have fallen back to the 2 MiB default and 200'd).

## Follow-up

#514 rebases onto this and widens `ShellOptions.maxBufferBytes` to `number | string`. It is
`CONFLICTING` against `main` today and needs the rebase regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)