### PR TITLE
fix(p20)!: `{}` no longer type-checks at four config slots

### DIFF
--- a/packages/core/src/sse-emit.ts
+++ b/packages/core/src/sse-emit.ts
@@ -11,7 +11,7 @@
 // Zero-dep and browser-safe (no `node:*`): pure types + string building, so it satisfies the same
 // three gates as its siblings and rides the `browser` export condition. Reached only through the
 // `sse-emit` subpath — `import { stitch }` pulls in none of it.
-import type { StitchEvent, StitchEventSource } from './types';
+import type { AtLeastOne, StitchEvent, StitchEventSource } from './types';
 import { envelope } from './util';
 
 /**
@@ -106,26 +106,26 @@ export interface SseEmitOptions {
      * (`delta: (c) => c.text`), or the full `{ data, event, id }` object to set the SSE
      * `event:` / `id:` lines too.
      */
-    delta?: DeltaShaper | DeltaFrameOptions;
+    delta?: DeltaShaper | AtLeastOne<DeltaFrameOptions>;
     /**
      * How the terminal error becomes the final frame. Pass a **function** as shorthand for
      * `{ data }` (`error: (e) => e.message`), or the full `{ data, event, observe }` object. By
      * default the client gets a generic `data: error` token — the raw message is withheld to avoid
      * disclosing internal topology.
      */
-    error?: ErrorShaper | ErrorFrameOptions;
+    error?: ErrorShaper | AtLeastOne<ErrorFrameOptions>;
 }
 
 // The bare function form of each frame option is the `data` shorthand — `envelope` folds it to
 // `{ data }`, passes a full object through, and turns the `= {}` default into an empty object.
 /** Fold the `delta` option's function shorthand (`(c) => …` ≡ `{ data: (c) => … }`). */
 export const resolveDelta = (
-    o: DeltaShaper | DeltaFrameOptions = {},
-): DeltaFrameOptions => envelope(o, 'data');
+    o?: DeltaShaper | AtLeastOne<DeltaFrameOptions>,
+): DeltaFrameOptions => envelope(o, 'data') ?? {};
 /** Fold the `error` option's function shorthand (`(e) => …` ≡ `{ data: (e) => … }`). */
 export const resolveError = (
-    o: ErrorShaper | ErrorFrameOptions = {},
-): ErrorFrameOptions => envelope(o, 'data');
+    o?: ErrorShaper | AtLeastOne<ErrorFrameOptions>,
+): ErrorFrameOptions => envelope(o, 'data') ?? {};
 
 /** The default `delta` mapping: a string chunk verbatim, anything else `JSON.stringify`-ed. */
 export function defaultData(chunk: unknown): string {

--- a/packages/core/test/sse-emit-options.spec.ts
+++ b/packages/core/test/sse-emit-options.spec.ts
@@ -1,0 +1,46 @@
+// `stitchapi/sse-emit`'s frame options are a P12 shorthand over a P20-safe envelope: a bare
+// function is the `data` shorthand, the object form must set at least one field, and `{}` is a
+// compile error. The `AtLeastOne` narrowing forced the fold's default from a `= {}` parameter
+// default to a `?? {}` after the fold, so these assert the RESOLVED value at each spelling —
+// a narrowed type is not a changed runtime, and the no-argument path is the one that moved.
+import { resolveDelta, resolveError } from '../src/sse-emit';
+
+test('no argument still resolves to the empty frame (the default moved, the behaviour did not)', () => {
+    expect(resolveDelta()).toEqual({});
+    expect(resolveError()).toEqual({});
+});
+
+test('undefined resolves to the empty frame — an absent slot is not an error', () => {
+    expect(resolveDelta(undefined)).toEqual({});
+    expect(resolveError(undefined)).toEqual({});
+});
+
+test('the bare function is the `data` shorthand (P12), folded to the envelope', () => {
+    const shape = (c: unknown) => String(c);
+    expect(resolveDelta(shape)).toEqual({ data: shape });
+
+    const onErr = (e: unknown) => String(e);
+    expect(resolveError(onErr)).toEqual({ data: onErr });
+});
+
+test('the object form passes through by reference, extra fields intact', () => {
+    const data = (c: unknown) => String(c);
+    const full = { data, event: 'tick', id: (_: unknown, i: number) => `${i}` };
+    expect(resolveDelta(full)).toBe(full);
+
+    const err = { data: (e: unknown) => String(e), event: 'failed' };
+    expect(resolveError(err)).toBe(err);
+});
+
+test('a single field is enough — AtLeastOne narrows the bag, it does not require all of it', () => {
+    expect(resolveDelta({ event: 'tick' })).toEqual({ event: 'tick' });
+    expect(resolveError({ event: 'failed' })).toEqual({ event: 'failed' });
+});
+
+test('the empty bag is rejected (compile-time, P20)', () => {
+    // @ts-expect-error — `{}` sets no field: omit the slot for the default instead
+    void resolveDelta({});
+    // @ts-expect-error — same for the terminal error frame
+    void resolveError({});
+    expect(true).toBe(true);
+});

--- a/packages/elysia/src/plugin.ts
+++ b/packages/elysia/src/plugin.ts
@@ -10,7 +10,7 @@ import type { PrincipalContext, StitchContext } from './context';
 import { type StitchErrorOptions, stitchOnError } from './error';
 
 import { Elysia } from 'elysia';
-import type { PrincipalSeam, Seam } from 'stitchapi';
+import type { AtLeastOne, PrincipalSeam, Seam } from 'stitchapi';
 
 /**
  * The context value `.derive` adds and handlers read: the request's seam. It is a
@@ -54,10 +54,11 @@ export interface ElysiaStitchPluginOptions {
     principal?: (ctx: PrincipalContext) => string | undefined;
     /**
      * Options for the StitchError → HTTP mapping the plugin's `.onError` applies (see
-     * {@link stitchOnError}). Set to `false` to register **no** error handler (you wire your own).
-     * Default: register with the `502`-by-default mapping.
+     * {@link stitchOnError}). `false` registers **no** error handler (you wire your own); `true`
+     * (the default) registers the `502`-by-default mapping. The object form must set at least one
+     * field — enable-with-defaults is spelled `true`, never `{}` (CONTRACT.md P13/P20).
      */
-    errorHandler?: StitchErrorOptions | false;
+    errorHandler?: boolean | AtLeastOne<StitchErrorOptions>;
 }
 
 /**
@@ -102,7 +103,12 @@ export function stitch(options: ElysiaStitchPluginOptions): StitchPlugin {
     const app =
         errorHandler === false
             ? base
-            : base.onError({ as: 'global' }, stitchOnError(errorHandler ?? {}));
+            : base.onError(
+                  { as: 'global' },
+                  stitchOnError(
+                      typeof errorHandler === 'object' ? errorHandler : {},
+                  ),
+              );
 
     return app as unknown as StitchPlugin;
 }

--- a/packages/elysia/test/elysia.spec.ts
+++ b/packages/elysia/test/elysia.spec.ts
@@ -222,6 +222,32 @@ describe('stitchOnError / stitchErrorResponse map a StitchError to HTTP', () => 
         await api.close();
     });
 
+    test('errorHandler:true registers the default mapping (the new P13 spelling, at runtime)', async () => {
+        // `true` never type-checked before, so this asserts the RUNTIME honours it — not just
+        // that the signature widened. It must behave exactly like omitting the key: register
+        // the 502-by-default mapping, NOT pass `true` through to `stitchOnError`.
+        const api = seam({ baseUrl: 'https://api.test' });
+        const app = new Elysia()
+            .use(stitch({ seam: api, errorHandler: true }))
+            .get('/boom', ({ stitch }) =>
+                stitch.stitch({
+                    path: '/missing',
+                    adapter: jsonAdapter(404, { error: 'not found' }),
+                })(),
+            );
+
+        const res = await app.handle(GET('/boom'));
+        expect(res.status).toBe(502);
+        await api.close();
+    });
+
+    test('the empty errorHandler bag is rejected (compile-time, P20)', () => {
+        const api = seam({ baseUrl: 'https://api.test' });
+        // @ts-expect-error — `{}` is not a valid bag: enable-with-defaults is `true` (P13/P20)
+        void stitch({ seam: api, errorHandler: {} });
+        expect(true).toBe(true);
+    });
+
     test('stitchErrorResponse returns undefined for a non-Stitch error (caller falls through)', async () => {
         expect(stitchErrorResponse(new Error('plain'))).toBeUndefined();
         const mapped = stitchErrorResponse(

--- a/packages/fastify/src/plugin.ts
+++ b/packages/fastify/src/plugin.ts
@@ -42,10 +42,11 @@ interface FastifyStitchPluginCommon {
     logger?: boolean | AtLeastOne<FastifyLoggerSinkOptions>;
     /**
      * Options for the error handler the plugin registers (see {@link stitchErrorHandler}).
-     * Set to `false` to register **no** error handler (you wire your own). Default: register
-     * with the `502`-by-default mapping.
+     * `false` registers **no** error handler (you wire your own); `true` (the default) registers
+     * the `502`-by-default mapping. The object form must set at least one field — enable-with-
+     * defaults is spelled `true`, never `{}` (CONTRACT.md P13/P20), matching `logger` above.
      */
-    errorHandler?: StitchErrorOptions | false;
+    errorHandler?: boolean | AtLeastOne<StitchErrorOptions>;
     /**
      * Close the seam on `onClose`. Defaults to `true` **only when the plugin built the seam**
      * (from `seamConfig`); a borrowed seam (passed via `seam`) is never closed by the plugin —
@@ -144,7 +145,13 @@ const pluginImpl: FastifyPluginAsync<FastifyStitchPluginOptions> = async (
 
     // Map StitchErrors to HTTP responses (unless the app opted out).
     if (options.errorHandler !== false) {
-        fastify.setErrorHandler(stitchErrorHandler(options.errorHandler ?? {}));
+        fastify.setErrorHandler(
+            stitchErrorHandler(
+                typeof options.errorHandler === 'object'
+                    ? options.errorHandler
+                    : {},
+            ),
+        );
     }
 
     // Tear down a seam we own when the Fastify instance closes.

--- a/packages/fastify/test/fastify.spec.ts
+++ b/packages/fastify/test/fastify.spec.ts
@@ -375,6 +375,41 @@ describe('stitchPlugin', () => {
         expect(res.statusCode).toBe(429);
     });
 
+    test('errorHandler:true registers the default mapping (the new P13 spelling, at runtime)', async () => {
+        // `true` never type-checked before, so this asserts the RUNTIME honours it — not just
+        // that the signature widened. It must behave exactly like omitting the key: register
+        // the 502-by-default mapping, NOT pass `true` through to `stitchErrorHandler`.
+        const { adapter } = fakeAdapter(() => ({
+            status: 503,
+            headers: {},
+            body: {},
+        }));
+        const app = Fastify();
+        apps.push(app);
+        await app.register(stitchPlugin, {
+            seamConfig: { baseUrl: 'https://api.test', adapter },
+            logger: false,
+            errorHandler: true,
+        });
+        app.get('/boom', async (request) =>
+            request.stitch.stitch({ path: '/boom' })(),
+        );
+        await app.ready();
+
+        const res = await app.inject({ method: 'GET', url: '/boom' });
+        expect(res.statusCode).toBe(502);
+    });
+
+    test('the empty errorHandler bag is rejected (compile-time, P20)', () => {
+        void (() =>
+            // @ts-expect-error — `{}` is not a valid bag: enable-with-defaults is `true`
+            Fastify().register(stitchPlugin, {
+                seamConfig: { baseUrl: 'https://api.test' },
+                errorHandler: {},
+            }));
+        expect(true).toBe(true);
+    });
+
     test('non-stitch errors are rethrown for Fastify default handling', async () => {
         const { adapter } = fakeAdapter(() => ({
             status: 200,

--- a/scripts/contract-violations.baseline.json
+++ b/scripts/contract-violations.baseline.json
@@ -1,6 +1,6 @@
 {
     "generatedBy": "scripts/check-contract.mjs --update",
-    "count": 5,
+    "count": 1,
     "violations": [
         {
             "rule": "R5",
@@ -9,38 +9,6 @@
             "detail": "exported by react, vue — must be unique-by-shape (P9/P16)",
             "line": null,
             "key": "R5|packages/<multiple>|UseStitchResult"
-        },
-        {
-            "rule": "R6",
-            "file": "packages/core/src/sse-emit.ts",
-            "symbol": "SseEmitOptions.delta",
-            "detail": "all-optional DeltaFrameOptions in the union — {} type-checks → AtLeastOne<DeltaFrameOptions> (P20)",
-            "line": 108,
-            "key": "R6|packages/core/src/sse-emit.ts|SseEmitOptions.delta"
-        },
-        {
-            "rule": "R6",
-            "file": "packages/core/src/sse-emit.ts",
-            "symbol": "SseEmitOptions.error",
-            "detail": "all-optional ErrorFrameOptions in the union — {} type-checks → AtLeastOne<ErrorFrameOptions> (P20)",
-            "line": 115,
-            "key": "R6|packages/core/src/sse-emit.ts|SseEmitOptions.error"
-        },
-        {
-            "rule": "R6",
-            "file": "packages/elysia/src/plugin.ts",
-            "symbol": "ElysiaStitchPluginOptions.errorHandler",
-            "detail": "all-optional StitchErrorOptions in the union — {} type-checks → AtLeastOne<StitchErrorOptions> (P20)",
-            "line": 59,
-            "key": "R6|packages/elysia/src/plugin.ts|ElysiaStitchPluginOptions.errorHandler"
-        },
-        {
-            "rule": "R6",
-            "file": "packages/fastify/src/plugin.ts",
-            "symbol": "FastifyStitchPluginCommon.errorHandler",
-            "detail": "all-optional StitchErrorOptions in the union — {} type-checks → AtLeastOne<StitchErrorOptions> (P20)",
-            "line": 47,
-            "key": "R6|packages/fastify/src/plugin.ts|FastifyStitchPluginCommon.errorHandler"
         }
     ]
 }


### PR DESCRIPTION
Clears the four **R6** findings [#556](https://github.com/rejifald/StitchAPI/pull/556)'s widened
ratchet surfaced. Baseline **5 → 1**.

> **Stacked on #556** — merge that first. This branch is cut from it, so its diff is the four
> fixes plus their tests.

## The change

```ts
// core/sse-emit.ts
delta?: DeltaShaper | DeltaFrameOptions   →  DeltaShaper | AtLeastOne<DeltaFrameOptions>
error?: ErrorShaper | ErrorFrameOptions   →  ErrorShaper | AtLeastOne<ErrorFrameOptions>

// elysia + fastify plugin options
errorHandler?: StitchErrorOptions | false →  boolean | AtLeastOne<StitchErrorOptions>
```

## `errorHandler` was worse than "accepts `{}`"

It was an **asymmetric toggle**: `false` disabled it, `{}` enabled it silently, and `true` — the
spelling anyone would reach for — was a type error. Now:

| Spelling | Before | After |
| --- | --- | --- |
| omitted | default 502 mapping | unchanged |
| `true` | ✗ type error | enable-with-defaults (P13) |
| `false` | no handler | unchanged |
| `{}` | enabled silently | ✗ type error (P20) |
| `{ status }` | honoured | unchanged |

Fastify's own `logger?: boolean | AtLeastOne<FastifyLoggerSinkOptions>` sits four lines above
`errorHandler` and already read this way — the two are finally consistent. Both hosts resolve the
object form with that same idiom (`typeof x === 'object' ? x : {}`), so `true` reaches
`stitchOnError` / `stitchErrorHandler` as the default bag and never leaks through as a boolean.

## One knock-on worth reviewing

`AtLeastOne` also rejects the `= {}` **parameter default** `resolveDelta`/`resolveError` used, so
the fold now takes an optional argument and defaults *after* it:

```ts
- (o: DeltaShaper | DeltaFrameOptions = {}): DeltaFrameOptions => envelope(o, 'data')
+ (o?: DeltaShaper | AtLeastOne<DeltaFrameOptions>): DeltaFrameOptions => envelope(o, 'data') ?? {}
```

Same resolved value, different mechanism — which is why the no-argument path gets a test rather
than an assurance.

## Tests assert the runtime, not the signature

A narrowed type is not a changed runtime, so:

- **`errorHandler: true` really registers the 502 mapping** on both elysia and fastify. Nothing
  existing could have covered this — the spelling did not compile before.
- **`resolveDelta()` / `resolveError()` still resolve to `{}`** through the moved default, plus
  the function shorthand, by-reference object passthrough, and the single-field case (`AtLeastOne`
  narrows the bag, it does not demand all of it).
- **Five `@ts-expect-error`** pin the rejections. `pnpm -r check:types` fails on an *unused*
  expect-error, so a green typecheck proves these are live assertions, not comments.

New spec: `packages/core/test/sse-emit-options.spec.ts` (`stitchapi/sse-emit` is a published
subpath that had no dedicated coverage).

## Verification

- `check:contract` → `no new violations (1 known, baselined)`; the 4 R6 keys are gone
- `pnpm -r check:types` — 38 packages, clean
- core **1295 → 1301** tests; elysia **26 → 28**; fastify **24 → 26**; all passing
- prettier clean

Hard break on `{}` at four slots — pre-GA, sanctioned by **D5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
