### PR TITLE
refactor(vue)!: framework-qualify the hook result → `VueUseStitchResult`

### DIFF
--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -157,11 +157,14 @@ _Resolved (2026-07 sweep):_ the caps this rule called out are bare plural nouns 
 overhaul), `paginate.max`→`pages`, `deno-kv maxIncrRetries`→`retry.attempts`
 (see [§6](#6-migration-record-2026-07-08-hard-break-sweep)).
 
-_Still open:_ `LlmOptions.maxTokens` / `LlmRequest.maxTokens` (the `stitchapi/llm`
-subpath) — a **count** cap carrying a `max` prefix. It is **not** sheltered by
-[P22](#p22--a-standards-interop-contract-uses-the-standards-field-names): `LlmRequest` is
-the house-**normalised** shape, and each provider's `buildBody` emits the vendor's
-`max_tokens` separately. → `tokens`.
+The 2026-07-31 audit found one more the sweep had missed and it is now fixed too:
+`LlmOptions.maxTokens` / `LlmRequest.maxTokens` (the `stitchapi/llm` subpath)
+→ **`tokens`**. It was **not** sheltered by
+[P22](#p22--a-standards-interop-contract-uses-the-standards-field-names), which is where
+the first reading of it went wrong: `LlmRequest` is the house-**normalised** shape, and
+each provider's `buildBody` emits the vendor's `max_tokens` separately, at the wire. A
+standard's field name is owed to the standard's own message, not to the house type that
+feeds it.
 
 A `max*` spelling survives legitimately only on **resolved internals** — the reconnect
 policy in `engine.ts`, the local `maxEntries` in `cache.ts`, the `failureThreshold` local
@@ -664,8 +667,8 @@ widened first, and each finding is then fixed against a gate that holds it:
   compiled. **Fixed** (`AtLeastOne`, and `errorHandler` gained the `true` spelling).
 - **P9** — `UseStitchResult` declared incompatibly by react and vue. **Fixed** (the vue
   side is framework-qualified `VueUseStitchResult`).
-- **P4** — `maxTokens` (see the still-open note under
-  [P4](#p4--one-cap-vocabulary)). **Open.**
+- **P4** — `maxTokens` on the `stitchapi/llm` types. **Fixed**
+  ([P4](#p4--one-cap-vocabulary) → `tokens`; the wire keeps `max_tokens`).
 - **P16** — nest's SSE options carry the flat spellings the _Settled_ clause above forbids;
   solid and svelte accept a `streaming` they hard-set and ignore. **Open.**
 - **P14** — an anonymous inline shape on `SecurityScheme`'s oauth2 arm. **Open.**

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -355,8 +355,11 @@ adapters, not react only.
 _Resolved (2026-07 sweep):_ the SSE helper is `streamStitchSse` on every host (was
 also `sendStitchSse` / `stitchSse`); error-options is one `StitchErrorOptions` shape
 (with `body`) everywhere (was `StitchErrorHandlerOptions` / `ToHttpExceptionOptions`);
-the hook result is `UseStitchResult` / `InjectStitchResult` over query-core's shared
-`StitchQueryResult`; `stitchQueryOptions` replaced the bare `queryOptions` in
+the hook result is `UseStitchResult` (react) / `VueUseStitchResult` /
+`InjectStitchResult` (angular) over query-core's shared `StitchQueryResult` — the vue one
+is framework-qualified because wrapping each field in a `ComputedRef` makes it
+unassignable to react's raw shape in either direction, the `SolidStitchStore` /
+`SvelteStitchStore` case; `stitchQueryOptions` replaced the bare `queryOptions` in
 vue/solid/svelte/angular.
 
 _Settled:_ the SSE frame options are **`delta`** and **`error`** on every SSE-capable
@@ -653,13 +656,19 @@ the GA channel. Severity = consumer blast radius.
 **Still open.** The row below is CLI-internal — `from-curl.ts` is imported by `cli.ts`
 alone, exported from no index and behind no subpath — but it is **not** the whole open
 set. A follow-up audit (2026-07-31) swept every principle against the published surface
-and found further violations that no rule in [§7](#7-enforcement) was tracking, across
-**P4** (`maxTokens`), **P9** (`UseStitchResult` declared incompatibly by react and vue),
-**P14**, **P16** (nest's SSE options, and solid/svelte accepting a `streaming` they
-ignore) and **P20** (slots typed `Fn | Options` or `Options | false`, so `{}` still
-compiles). They are tracked and fixed separately; the ratchet is being widened first so
-the gate holds them once fixed. A green baseline meant "nothing the rules can see", not
-"nothing there".
+and found further violations that no rule in [§7](#7-enforcement) was tracking. A green
+baseline meant "nothing the rules can see", not "nothing there" — so the rules were
+widened first, and each finding is then fixed against a gate that holds it:
+
+- **P20** — four slots typed `Fn | Options` or `Options | false`, where `{}` still
+  compiled. **Fixed** (`AtLeastOne`, and `errorHandler` gained the `true` spelling).
+- **P9** — `UseStitchResult` declared incompatibly by react and vue. **Fixed** (the vue
+  side is framework-qualified `VueUseStitchResult`).
+- **P4** — `maxTokens` (see the still-open note under
+  [P4](#p4--one-cap-vocabulary)). **Open.**
+- **P16** — nest's SSE options carry the flat spellings the _Settled_ clause above forbids;
+  solid and svelte accept a `streaming` they hard-set and ignore. **Open.**
+- **P14** — an anonymous inline shape on `SecurityScheme`'s oauth2 arm. **Open.**
 
 | Sev | Current                | Proposed   | Rule |
 | --- | ---------------------- | ---------- | ---- |

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -34,7 +34,11 @@ export interface LlmRequest {
     model: string;
     messages: LlmMessage[];
     system?: string;
-    maxTokens?: number;
+    /** Cap on tokens generated. A **count**, so it is a bare plural noun — CONTRACT.md P4 bans
+     *  the `max` prefix there, and leaves `max` only for a magnitude ceiling. This is the HOUSE
+     *  shape, so it uses house vocabulary; each provider's `buildBody` emits the vendor's own
+     *  `max_tokens` (P18/P22 keep the upstream spelling at the wire, not here). */
+    tokens?: number;
     temperature?: number;
 }
 
@@ -73,7 +77,7 @@ interface LlmDefaults {
     provider: LlmProvider;
     model?: string;
     system?: string;
-    maxTokens?: number;
+    tokens?: number;
     temperature?: number;
 }
 
@@ -92,8 +96,8 @@ function toRequest(d: LlmDefaults, input: StitchInput): LlmRequest {
     const req: LlmRequest = { model, messages: over.messages ?? [] };
     const system = over.system ?? d.system;
     if (system !== undefined) req.system = system;
-    const maxTokens = over.maxTokens ?? d.maxTokens;
-    if (maxTokens !== undefined) req.maxTokens = maxTokens;
+    const tokens = over.tokens ?? d.tokens;
+    if (tokens !== undefined) req.tokens = tokens;
     const temperature = over.temperature ?? d.temperature;
     if (temperature !== undefined) req.temperature = temperature;
     return req;
@@ -135,18 +139,20 @@ export type LlmOptions = Partial<Omit<StitchConfig, 'kind'>> & {
     provider: LlmProvider;
     model?: string;
     system?: string;
-    maxTokens?: number;
+    /** Default cap on tokens generated; a call's `body` may override it. See
+     *  {@link LlmRequest.tokens} for why the house name is not the wire's `max_tokens`. */
+    tokens?: number;
     temperature?: number;
 };
 
 // Split an LlmOptions into the surface-bound defaults and the plain stitch config carrying the
 // live surface — shared by the standalone stitch and the seam binder.
 function llmConfig(config: LlmOptions): Partial<StitchConfig> {
-    const { provider, model, system, maxTokens, temperature, ...rest } = config;
+    const { provider, model, system, tokens, temperature, ...rest } = config;
     const defaults: LlmDefaults = { provider };
     if (model !== undefined) defaults.model = model;
     if (system !== undefined) defaults.system = system;
-    if (maxTokens !== undefined) defaults.maxTokens = maxTokens;
+    if (tokens !== undefined) defaults.tokens = tokens;
     if (temperature !== undefined) defaults.temperature = temperature;
     const urlless = rest.url === undefined && rest.path === undefined;
     return {
@@ -158,7 +164,7 @@ function llmConfig(config: LlmOptions): Partial<StitchConfig> {
 
 /**
  * `llm({ provider, ... })` — a chat-completion stitch resolving to an {@link LlmResult}. The
- * provider (and `model`/`system`/`maxTokens`/`temperature` defaults) bind to the surface; the call
+ * provider (and `model`/`system`/`tokens`/`temperature` defaults) bind to the surface; the call
  * passes `{ body: { messages: [...] } }` (and may override the defaults). The `url` defaults to
  * the provider's. Bring the credential as the stitch's `auth` (`bearer(env(...))` for OpenAI,
  * `apiKey({ name: 'x-api-key', ... })` for Anthropic).
@@ -234,7 +240,7 @@ export const anthropic: LlmProvider = {
         ].join('\n\n');
         return compact({
             model: req.model,
-            max_tokens: req.maxTokens ?? 1024,
+            max_tokens: req.tokens ?? 1024,
             messages: req.messages
                 .filter((m) => m.role !== 'system')
                 .map((m) => ({ role: m.role, content: m.content })),
@@ -284,7 +290,7 @@ export const openai: LlmProvider = {
                     content: m.content,
                 })),
             ],
-            max_tokens: req.maxTokens,
+            max_tokens: req.tokens,
             temperature: req.temperature,
         }),
     parse: (body) => {

--- a/packages/core/test/llm.spec.ts
+++ b/packages/core/test/llm.spec.ts
@@ -30,7 +30,7 @@ test('anthropic: builds the Messages API body (system out of messages) and parse
     const chat = llm({
         provider: anthropic,
         model: 'claude-opus-4-8',
-        maxTokens: 256,
+        tokens: 256,
         adapter,
     });
 
@@ -145,4 +145,34 @@ test('llm honours an explicit url over the provider default', async () => {
 
     await chat({ body: { messages: [{ role: 'user', content: 'hi' }] } });
     expect(calls[0]!.url).toBe('https://gateway.internal/llm');
+});
+
+test('a per-call `tokens` override reaches the wire as the vendor `max_tokens` (openai)', async () => {
+    // The house name is `tokens` (P4: a count cap is a bare plural noun); the vendor spelling
+    // lives only in `buildBody`. This pins BOTH ends of that mapping on the openai path — the
+    // anthropic one is covered above — and proves the call-level override still wins over the
+    // surface default after the rename.
+    const { adapter, calls } = captureAdapter({
+        choices: [{ message: { content: 'ok' } }],
+        model: 'gpt-4o',
+    });
+    const chat = llm({
+        provider: openai,
+        model: 'gpt-4o',
+        tokens: 16,
+        adapter,
+    });
+
+    await chat({
+        body: { messages: [{ role: 'user', content: 'hi' }], tokens: 512 },
+    });
+
+    const body = calls[0]!.body as { max_tokens?: number };
+    expect(body.max_tokens).toBe(512);
+});
+
+test('the old `maxTokens` spelling is gone (compile-time, P4)', () => {
+    // @ts-expect-error — renamed to `tokens`; no alias (pre-GA hard break, D5)
+    void llm({ provider: openai, model: 'gpt-4o', maxTokens: 16 });
+    expect(true).toBe(true);
 });

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -74,7 +74,7 @@ Same return shape as `useStitch`. `data` is the accumulated chunks (`mode: 'appe
 Each field is a `ComputedRef`, so destructuring keeps reactivity (and `.value` is unwrapped automatically in templates):
 
 ```ts
-interface UseStitchResult<T> {
+interface VueUseStitchResult<T> {
     status: ComputedRef<'idle' | 'pending' | 'streaming' | 'success' | 'error'>;
     data: ComputedRef<T | undefined>;
     error: ComputedRef<unknown>;

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -64,8 +64,14 @@ export {
  * What `useStitch` / `useStitchStream` return: each reactive state field as its
  * own `ComputedRef` (so the object stays destructurable WITHOUT losing
  * reactivity, the Vue idiom) plus the imperative `refetch` / `cancel` handles.
+ *
+ * **Framework-qualified** (CONTRACT.md P9, ADR 0012 rule 6). React's `useStitch` returns a
+ * `UseStitchResult` carrying the RAW `StitchQueryResult` fields; wrapping each one in a
+ * `ComputedRef` makes this shape unassignable to that one in either direction, so the two
+ * cannot share a name — exactly the case `SolidStitchStore` / `SvelteStitchStore` are
+ * qualified for. The divergent side takes the prefix; react keeps the bare name.
  */
-export interface UseStitchResult<T> {
+export interface VueUseStitchResult<T> {
     readonly status: ComputedRef<StitchQueryResult<T>['status']>;
     /** The validated output (unary) or the latest streamed value (streaming). */
     readonly data: ComputedRef<T | undefined>;
@@ -124,7 +130,7 @@ function useStitchInternal<T>(
     input: MaybeRefOrGetter<unknown>,
     options: MaybeRefOrGetter<UseStitchOptions<T>>,
     streaming: boolean,
-): UseStitchResult<T> {
+): VueUseStitchResult<T> {
     // The single reactive cell every consumer reads through. The core hands out a
     // NEW frozen snapshot only on a real change, so swapping the ref is cheap and
     // never tears. `shallowRef` is deliberate: the snapshot is already immutable,
@@ -243,17 +249,17 @@ export function useStitch<S extends StitchLike<unknown, never>>(
     stitch: S,
     input: MaybeRefOrGetter<QueryInput<S>>,
     options?: MaybeRefOrGetter<UseStitchOptions<QueryOutput<S>>>,
-): UseStitchResult<QueryOutput<S>>;
+): VueUseStitchResult<QueryOutput<S>>;
 export function useStitch<T, Input = unknown>(
     stitch: StitchLike<T, Input>,
     input: MaybeRefOrGetter<Input>,
     options?: MaybeRefOrGetter<UseStitchOptions<T>>,
-): UseStitchResult<T>;
+): VueUseStitchResult<T>;
 export function useStitch<T>(
     stitch: StitchLike<T, unknown>,
     input: MaybeRefOrGetter<unknown>,
     options: MaybeRefOrGetter<UseStitchOptions<T>> = {},
-): UseStitchResult<T> {
+): VueUseStitchResult<T> {
     return useStitchInternal<T>(stitch, input, options, false);
 }
 
@@ -281,16 +287,16 @@ export function useStitchStream<S extends StitchLike<unknown, never>>(
     stitch: S,
     input: MaybeRefOrGetter<QueryInput<S>>,
     options?: MaybeRefOrGetter<UseStitchOptions<QueryOutput<S>>>,
-): UseStitchResult<QueryOutput<S>>;
+): VueUseStitchResult<QueryOutput<S>>;
 export function useStitchStream<T, Input = unknown>(
     stitch: StitchLike<T, Input>,
     input: MaybeRefOrGetter<Input>,
     options?: MaybeRefOrGetter<UseStitchOptions<T>>,
-): UseStitchResult<T>;
+): VueUseStitchResult<T>;
 export function useStitchStream<T>(
     stitch: StitchLike<T, unknown>,
     input: MaybeRefOrGetter<unknown>,
     options: MaybeRefOrGetter<UseStitchOptions<T>> = {},
-): UseStitchResult<T> {
+): VueUseStitchResult<T> {
     return useStitchInternal<T>(stitch, input, options, true);
 }

--- a/packages/vue/test/composables.spec.ts
+++ b/packages/vue/test/composables.spec.ts
@@ -291,3 +291,18 @@ describe('stitchQueryOptions (re-exported from @stitchapi/query-core)', () => {
         expect(opts.queryKey[0]).toBe('stitch');
     });
 });
+
+describe('P9 — the result type is framework-qualified', () => {
+    test('the bare `UseStitchResult` is gone; react owns that name (compile-time)', () => {
+        // Vue wraps every state field in a `ComputedRef`, so its result is unassignable to
+        // react's raw `StitchQueryResult`-based one in either direction. Two exported
+        // declarations of one name with two shapes is the P9 clash the ratchet's R5 watches
+        // for, so the divergent side is prefixed — as with `SolidStitchStore`/`SvelteStitchStore`.
+        // Pinned as a compile error so the bare name cannot quietly return here.
+        // @ts-expect-error — vue's is `VueUseStitchResult`; the bare name is react's
+        const _check: import('../src').UseStitchResult<number> | undefined =
+            undefined;
+        void _check;
+        expect(true).toBe(true);
+    });
+});

--- a/scripts/contract-violations.baseline.json
+++ b/scripts/contract-violations.baseline.json
@@ -1,14 +1,5 @@
 {
     "generatedBy": "scripts/check-contract.mjs --update",
-    "count": 1,
-    "violations": [
-        {
-            "rule": "R5",
-            "file": "packages/<multiple>",
-            "symbol": "UseStitchResult",
-            "detail": "exported by react, vue — must be unique-by-shape (P9/P16)",
-            "line": null,
-            "key": "R5|packages/<multiple>|UseStitchResult"
-        }
-    ]
+    "count": 0,
+    "violations": []
 }


### PR DESCRIPTION
Clears the last baselined violation. **Baseline 1 → 0** — and this is the first zero the
widened rules actually produce, rather than one that meant "nothing the rules can see".

> **Stacked on [#556](https://github.com/rejifald/StitchAPI/pull/556)**, which now carries the ratchet
> widening and the P20 fixes (#557 was squash-merged into it). Merge 556 first, then this.

## The clash

React and vue each **declared** — not re-exported — an exported `UseStitchResult<T>` from their
sole public entry:

```ts
// react/src/index.ts:78
export interface UseStitchResult<T> extends StitchQueryResult<T> { refetch; cancel }

// vue/src/index.ts:68
export interface UseStitchResult<T> {
    readonly status: ComputedRef<StitchQueryResult<T>['status']>;
    readonly data: ComputedRef<T | undefined>;
    …
}
```

Neither is assignable to the other in either direction. This is **not** drift to reconcile: vue
wraps each field in a `ComputedRef` precisely so the object survives destructuring with its
reactivity intact — the Vue idiom, and the right shape for that framework.

One name, two shapes, both public is the P9 clash, and the precedent already exists:
`SolidStitchStore` / `SvelteStitchStore` are prefixed for exactly this (ADR 0012 rule 6).

## The fix

The **divergent side takes the prefix** → `VueUseStitchResult`. React keeps the bare name;
angular's `InjectStitchResult` was already distinct via its own verb.

No `@deprecated` alias — pre-GA hard break per **D5**, and **R7** would flag one.

## Kept honest two ways

- `UseStitchResult` **stays on R5's watch list**, so if the bare name ever reappears in a second
  package the ratchet catches it. Removing the entry would delete the guard along with the bug.
- Pinned in vue's own suite as a **compile error**, so the bare name cannot quietly return to
  this package. `pnpm -r check:types` fails on an *unused* `@ts-expect-error`, so a green
  typecheck proves the assertion is live.

## Contract updates

- **P16**'s parity list now names all three spellings (`UseStitchResult` react /
  `VueUseStitchResult` / `InjectStitchResult` angular) and why the vue one diverges.
- **§6**'s open set becomes a live ledger — **P20 fixed**, **P9 fixed**, leaving **P4**
  (`maxTokens`), **P16** (nest's flat SSE knobs; solid/svelte accepting a `streaming` they
  hard-set and ignore) and **P14** (`SecurityScheme`'s anonymous oauth2 inline shape).

## Verification

- `check:contract` → `no new violations (0 known, baselined)`
- `pnpm -r check:types` — 38 packages, clean
- `@stitchapi/vue` 13 tests, `@stitchapi/react` 16 tests — passing
- prettier clean; `check-docs-links` green (110 routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
