### PR TITLE
refactor(llm)!: `maxTokens` → `tokens` (P4)

### DIFF
--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -157,11 +157,14 @@ _Resolved (2026-07 sweep):_ the caps this rule called out are bare plural nouns 
 overhaul), `paginate.max`→`pages`, `deno-kv maxIncrRetries`→`retry.attempts`
 (see [§6](#6-migration-record-2026-07-08-hard-break-sweep)).
 
-_Still open:_ `LlmOptions.maxTokens` / `LlmRequest.maxTokens` (the `stitchapi/llm`
-subpath) — a **count** cap carrying a `max` prefix. It is **not** sheltered by
-[P22](#p22--a-standards-interop-contract-uses-the-standards-field-names): `LlmRequest` is
-the house-**normalised** shape, and each provider's `buildBody` emits the vendor's
-`max_tokens` separately. → `tokens`.
+The 2026-07-31 audit found one more the sweep had missed and it is now fixed too:
+`LlmOptions.maxTokens` / `LlmRequest.maxTokens` (the `stitchapi/llm` subpath)
+→ **`tokens`**. It was **not** sheltered by
+[P22](#p22--a-standards-interop-contract-uses-the-standards-field-names), which is where
+the first reading of it went wrong: `LlmRequest` is the house-**normalised** shape, and
+each provider's `buildBody` emits the vendor's `max_tokens` separately, at the wire. A
+standard's field name is owed to the standard's own message, not to the house type that
+feeds it.
 
 A `max*` spelling survives legitimately only on **resolved internals** — the reconnect
 policy in `engine.ts`, the local `maxEntries` in `cache.ts`, the `failureThreshold` local
@@ -664,8 +667,8 @@ widened first, and each finding is then fixed against a gate that holds it:
   compiled. **Fixed** (`AtLeastOne`, and `errorHandler` gained the `true` spelling).
 - **P9** — `UseStitchResult` declared incompatibly by react and vue. **Fixed** (the vue
   side is framework-qualified `VueUseStitchResult`).
-- **P4** — `maxTokens` (see the still-open note under
-  [P4](#p4--one-cap-vocabulary)). **Open.**
+- **P4** — `maxTokens` on the `stitchapi/llm` types. **Fixed**
+  ([P4](#p4--one-cap-vocabulary) → `tokens`; the wire keeps `max_tokens`).
 - **P16** — nest's SSE options carry the flat spellings the _Settled_ clause above forbids;
   solid and svelte accept a `streaming` they hard-set and ignore. **Open.**
 - **P14** — an anonymous inline shape on `SecurityScheme`'s oauth2 arm. **Open.**

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -34,7 +34,11 @@ export interface LlmRequest {
     model: string;
     messages: LlmMessage[];
     system?: string;
-    maxTokens?: number;
+    /** Cap on tokens generated. A **count**, so it is a bare plural noun — CONTRACT.md P4 bans
+     *  the `max` prefix there, and leaves `max` only for a magnitude ceiling. This is the HOUSE
+     *  shape, so it uses house vocabulary; each provider's `buildBody` emits the vendor's own
+     *  `max_tokens` (P18/P22 keep the upstream spelling at the wire, not here). */
+    tokens?: number;
     temperature?: number;
 }
 
@@ -73,7 +77,7 @@ interface LlmDefaults {
     provider: LlmProvider;
     model?: string;
     system?: string;
-    maxTokens?: number;
+    tokens?: number;
     temperature?: number;
 }
 
@@ -92,8 +96,8 @@ function toRequest(d: LlmDefaults, input: StitchInput): LlmRequest {
     const req: LlmRequest = { model, messages: over.messages ?? [] };
     const system = over.system ?? d.system;
     if (system !== undefined) req.system = system;
-    const maxTokens = over.maxTokens ?? d.maxTokens;
-    if (maxTokens !== undefined) req.maxTokens = maxTokens;
+    const tokens = over.tokens ?? d.tokens;
+    if (tokens !== undefined) req.tokens = tokens;
     const temperature = over.temperature ?? d.temperature;
     if (temperature !== undefined) req.temperature = temperature;
     return req;
@@ -135,18 +139,20 @@ export type LlmOptions = Partial<Omit<StitchConfig, 'kind'>> & {
     provider: LlmProvider;
     model?: string;
     system?: string;
-    maxTokens?: number;
+    /** Default cap on tokens generated; a call's `body` may override it. See
+     *  {@link LlmRequest.tokens} for why the house name is not the wire's `max_tokens`. */
+    tokens?: number;
     temperature?: number;
 };
 
 // Split an LlmOptions into the surface-bound defaults and the plain stitch config carrying the
 // live surface — shared by the standalone stitch and the seam binder.
 function llmConfig(config: LlmOptions): Partial<StitchConfig> {
-    const { provider, model, system, maxTokens, temperature, ...rest } = config;
+    const { provider, model, system, tokens, temperature, ...rest } = config;
     const defaults: LlmDefaults = { provider };
     if (model !== undefined) defaults.model = model;
     if (system !== undefined) defaults.system = system;
-    if (maxTokens !== undefined) defaults.maxTokens = maxTokens;
+    if (tokens !== undefined) defaults.tokens = tokens;
     if (temperature !== undefined) defaults.temperature = temperature;
     const urlless = rest.url === undefined && rest.path === undefined;
     return {
@@ -158,7 +164,7 @@ function llmConfig(config: LlmOptions): Partial<StitchConfig> {
 
 /**
  * `llm({ provider, ... })` — a chat-completion stitch resolving to an {@link LlmResult}. The
- * provider (and `model`/`system`/`maxTokens`/`temperature` defaults) bind to the surface; the call
+ * provider (and `model`/`system`/`tokens`/`temperature` defaults) bind to the surface; the call
  * passes `{ body: { messages: [...] } }` (and may override the defaults). The `url` defaults to
  * the provider's. Bring the credential as the stitch's `auth` (`bearer(env(...))` for OpenAI,
  * `apiKey({ name: 'x-api-key', ... })` for Anthropic).
@@ -234,7 +240,7 @@ export const anthropic: LlmProvider = {
         ].join('\n\n');
         return compact({
             model: req.model,
-            max_tokens: req.maxTokens ?? 1024,
+            max_tokens: req.tokens ?? 1024,
             messages: req.messages
                 .filter((m) => m.role !== 'system')
                 .map((m) => ({ role: m.role, content: m.content })),
@@ -284,7 +290,7 @@ export const openai: LlmProvider = {
                     content: m.content,
                 })),
             ],
-            max_tokens: req.maxTokens,
+            max_tokens: req.tokens,
             temperature: req.temperature,
         }),
     parse: (body) => {

--- a/packages/core/test/llm.spec.ts
+++ b/packages/core/test/llm.spec.ts
@@ -30,7 +30,7 @@ test('anthropic: builds the Messages API body (system out of messages) and parse
     const chat = llm({
         provider: anthropic,
         model: 'claude-opus-4-8',
-        maxTokens: 256,
+        tokens: 256,
         adapter,
     });
 
@@ -145,4 +145,34 @@ test('llm honours an explicit url over the provider default', async () => {
 
     await chat({ body: { messages: [{ role: 'user', content: 'hi' }] } });
     expect(calls[0]!.url).toBe('https://gateway.internal/llm');
+});
+
+test('a per-call `tokens` override reaches the wire as the vendor `max_tokens` (openai)', async () => {
+    // The house name is `tokens` (P4: a count cap is a bare plural noun); the vendor spelling
+    // lives only in `buildBody`. This pins BOTH ends of that mapping on the openai path — the
+    // anthropic one is covered above — and proves the call-level override still wins over the
+    // surface default after the rename.
+    const { adapter, calls } = captureAdapter({
+        choices: [{ message: { content: 'ok' } }],
+        model: 'gpt-4o',
+    });
+    const chat = llm({
+        provider: openai,
+        model: 'gpt-4o',
+        tokens: 16,
+        adapter,
+    });
+
+    await chat({
+        body: { messages: [{ role: 'user', content: 'hi' }], tokens: 512 },
+    });
+
+    const body = calls[0]!.body as { max_tokens?: number };
+    expect(body.max_tokens).toBe(512);
+});
+
+test('the old `maxTokens` spelling is gone (compile-time, P4)', () => {
+    // @ts-expect-error — renamed to `tokens`; no alias (pre-GA hard break, D5)
+    void llm({ provider: openai, model: 'gpt-4o', maxTokens: 16 });
+    expect(true).toBe(true);
 });


### PR DESCRIPTION
The last code finding from the 2026-07-31 contract sweep. Tokens are a **count**, so P4/D2 wants a
bare plural noun — `attempts`, `entries`, `pages`, `failures`, and now **`tokens`**. The `max`
prefix P4 leaves only for a *magnitude* ceiling, which this is not.

> **Stacked on [#558](https://github.com/rejifald/StitchAPI/pull/558)** (itself on
> [#556](https://github.com/rejifald/StitchAPI/pull/556)). Merge 556 → 558 → this.

## The interesting part: why P22 does not shelter it

This was waved through earlier as vendor-interop, on the grounds that both Anthropic and OpenAI
spell it `max_tokens`. That reading was wrong, and the correction is the reusable bit:

> **P22 owes a standard's field name to the standard's own message, not to the house type that
> feeds it.**

`LlmRequest` is documented, in the repo, as *"the normalised LLM request a provider maps to its
wire body"*. The normalisation boundary is exactly where house vocabulary starts — and the vendor
spelling is produced separately, downstream, in each provider's `buildBody`:

```ts
// unchanged by this PR
max_tokens: req.tokens ?? 1024,   // anthropic
max_tokens: req.tokens,           // openai
```

The wire is untouched. Only the house name moves. That sentence is now in P4, because the same
mistake is available at every adapter boundary in the repo.

## What changed

| Type | Visibility | |
| --- | --- | --- |
| `LlmOptions.maxTokens` | public (`stitchapi/llm`) | → `tokens` |
| `LlmRequest.maxTokens` | public (`stitchapi/llm`) | → `tokens` |
| `LlmDefaults.maxTokens` | internal, mirrors the above | → `tokens` |

No `@deprecated` alias — pre-GA hard break per **D5**, and **R7** would flag one.

## Tests

The existing anthropic test already spanned the mapping end to end (config `tokens: 256` → wire
`max_tokens: 256`), so it converts into proof of this rename rather than needing a rewrite.

Added, because a rename can pass a green typecheck and still be wrong at runtime:

- **the openai path with a per-call override** — `tokens: 16` on the surface, `tokens: 512` in the
  call body, asserting `max_tokens: 512` on the wire. That is the path where a rename can silently
  stop winning over the surface default and still look fine.
- **`@ts-expect-error`** pinning `maxTokens` as deleted. `pnpm -r check:types` fails on an *unused*
  expect-error, so a green typecheck proves the assertion is live.

## Known gap, filed separately

No ratchet rule catches a `max`-prefixed count, which is why a hand audit found this while
`check:contract` reported a clean baseline. R2 covers the `Ms` duration suffix; there is no cap
equivalent, and a naive one would flag four legitimate magnitude ceilings
(`BackoffOptions.max`, `ServeOptions.maxBodyBytes`, `TraceOptions.maxBodyChars`,
`StreamOptions.maxBufferChars`). Proposed as **R9** in
[#565](https://github.com/rejifald/StitchAPI/issues/565).

## Verification

- `pnpm --filter stitchapi test -- llm` — 1301 passed
- `pnpm -r check:types` — 38 packages, clean
- `check:contract` → `no new violations (0 known, baselined)`
- prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
