### PR TITLE
docs(errors): STITCH_* are catalog IDs — say so, and document real discrimination

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,9 +389,9 @@ $ stitch from-curl 'curl https://demo.stitchapi.dev/users/7 -H "authorization: B
 
 ## Errors & pitfalls
 
-A failed stitch throws a `StitchError` — an `Error` subclass carrying `.status`, `.attempts`, and (for response failures) `.body` (the parsed error payload, on a non-enumerable channel that never reaches a trace sink) and `.url`. Prefer branching? `.safe()` resolves to `{ ok, data, error }`. Each failure mode has a stable code and a docs page:
+A failed stitch throws a `StitchError` — an `Error` subclass carrying `.status`, `.attempts`, and (for response failures) `.body` (the parsed error payload, on a non-enumerable channel that never reaches a trace sink) and `.url`. Prefer branching? `.safe()` resolves to `{ ok, data, error }`. Branch on `.status` and `.attempts` (plus `instanceof RateLimitError`) — the `STITCH_*` names below are **documentation IDs, not runtime values**, so there is no `error.code` to match on:
 
-| Code                  | When                                                              |
+| Catalog ID            | When                                                              |
 | --------------------- | ----------------------------------------------------------------- |
 | `STITCH_VALIDATION`   | a response failed its output schema                               |
 | `STITCH_DRIFT`        | a response drifted past the level you allowed                     |

--- a/apps/docs/content/docs/errors/index.mdx
+++ b/apps/docs/content/docs/errors/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Errors & pitfalls'
-description: 'How StitchAPI errors work, the code-to-docs contract, and an index of every coded failure.'
+description: 'How StitchAPI errors work, how to tell failures apart at runtime, and an index of every documented failure.'
 ---
 
 When a stitch can't produce a result, it fails with a `StitchError` — an `Error`
@@ -66,24 +66,97 @@ else console.log(data); // the validated result; error is null here
 [the event stream](/docs/concepts/event-stream) for the iterate-instead-of-await
 view of the same outcomes.
 
-## The code-to-docs contract
+## Catalog IDs are documentation, not runtime values
 
-Each catalog page below owns a stable **code** (`STITCH_VALIDATION`,
-`STITCH_DRIFT`, and so on). The code's page **slug is its URL** — the failure
-documented at `/errors/<slug>` is the page the runtime will deep-link to from a
-thrown error. Slugs are an API: once a page is published its slug is never
-renamed, only added-and-redirected, so a link a runtime emitted a year ago still
-resolves.
+Each catalog page below is filed under a stable **catalog ID**
+(`STITCH_VALIDATION`, `STITCH_DRIFT`, and so on), and the ID's page **slug is its
+URL**. Slugs are an API: once a page is published its slug is never renamed, only
+added-and-redirected, so a link written a year ago still resolves.
 
 <Callout type="warn">
-    These codes are **provisional**. Today the runtime throws a `StitchError`
-    with a `message` and optional `.status` — the stable `code` and `url` fields
-    land with the error-taxonomy refactor. The slugs below are already fixed, so
-    you can rely on the URLs even while the in-runtime codes are still on the
-    way.
+    These IDs name **documentation pages** — they are not values the runtime
+    puts on the error. A thrown `StitchError` has no `.code` property, so
+    `err.code` is `undefined` and `if (err.code === 'STITCH_DRIFT')` never
+    matches. Use the IDs to refer to a failure mode (in this catalog, in the
+    docs MCP, in an issue report); to branch in code, use [the fields
+    below](#telling-failures-apart-at-runtime).
 </Callout>
 
-## Every coded failure
+## Telling failures apart at runtime
+
+Every failure arrives as a `StitchError` except the delegate-backoff rate limit,
+which is its own exported `RateLimitError`. So narrow with `instanceof` first,
+then branch on `.status` and `.attempts` — together they separate every failure
+mode in the catalog:
+
+| What you see                           | What happened                                                                                        |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `attempts === 0`                       | No request was made — input validation (`status` `undefined`) or an open circuit (`status` `503`).   |
+| `status` is a **2xx**                  | The response arrived and broke its contract — an `output` schema/drift failure, or GraphQL `errors`. |
+| `status` is **non-2xx**                | The upstream rejected it, after any retries — a `401` auth wall, a `5xx`, and so on.                 |
+| `status` `undefined`, `attempts` ≥ `1` | The request went out but never produced a response — a timeout or a transport error.                 |
+
+```ts twoslash
+import { RateLimitError, StitchError, stitch } from 'stitchapi';
+
+const report = stitch({ baseUrl: 'https://api.example.com', path: '/report' });
+
+try {
+    await report();
+} catch (e) {
+    if (e instanceof RateLimitError) {
+        // The one catalog entry that IS a runtime identity of its own.
+        console.error('back off for', e.retryAfter);
+    } else if (e instanceof StitchError) {
+        if (e.attempts === 0) {
+            // Nothing left the process: bad input, or the breaker is open.
+            console.error(e.status === 503 ? 'circuit open' : 'bad input');
+        } else if (e.status !== undefined && e.status < 300) {
+            // A 2xx that still failed: the body broke the declared contract.
+            console.error('contract violation', e.status);
+        } else {
+            console.error('upstream failed', e.status ?? 'no response');
+        }
+    }
+}
+```
+
+<Callout type="info">
+    `.message` is human-readable, not a contract — today it is
+    `invalid <slot>: <issue>` for input validation,
+    `contract violation (drift)` for a response that failed `output`,
+    `timed out after <n>ms`, `circuit open`, `GraphQL: <message>`, or
+    `HTTP <status>`. Match on it only as a last resort, and expect the wording
+    to change.
+</Callout>
+
+Two catalog IDs share one runtime failure: a plain `output` schema failure
+(`STITCH_VALIDATION`) and a hard [`drift()`](/docs/guides/validation/drift)
+failure (`STITCH_DRIFT`) both throw the same `contract violation (drift)`
+`StitchError`. The thrown error does not say **which** path broke — that detail
+rides the `drift` events on [the event stream](/docs/concepts/event-stream),
+where a hard failure appears as a finding with `level: 'error'` and
+`change: 'invalid'`:
+
+```ts twoslash
+import { drift, stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const user = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/user',
+    output: drift(z.object({ id: z.number() })),
+});
+
+for await (const ev of user().stream()) {
+    if (ev.type === 'drift' && ev.finding.level === 'error') {
+        // The structured signal: which path broke, and how.
+        console.error(ev.finding.path, ev.finding.change, ev.finding.detail);
+    }
+}
+```
+
+## Every documented failure
 
 <Callout type="info">
     Debugging one of these with an agent? Connect the [docs

--- a/apps/docs/content/docs/errors/rate-limit.mdx
+++ b/apps/docs/content/docs/errors/rate-limit.mdx
@@ -41,6 +41,14 @@ try {
 - **`response`** — the raw `AdapterResponse`, so you can read other rate
   headers the API sent (`X-RateLimit-Remaining`, a reset timestamp, and so on).
 
+<Callout type="info">
+    This is the one entry in the [error catalog](/docs/errors) that is a real
+    runtime identity rather than a documentation ID: `RateLimitError` is an
+    exported class you can `instanceof`. The `STITCH_*` entries are page IDs —
+    those failures all arrive as a plain `StitchError` with no `.code`, told
+    apart by [their fields](/docs/errors#telling-failures-apart-at-runtime).
+</Callout>
+
 ## Why it happens
 
 You opted into delegate-backoff because an **outer** gate or circuit — not

--- a/apps/docs/content/docs/errors/stitch-auth-wall.mdx
+++ b/apps/docs/content/docs/errors/stitch-auth-wall.mdx
@@ -13,6 +13,16 @@ surfaces the failure instead of looping. The downstream response keeps coming
 back unauthenticated — most often a `401`, sometimes a `200` whose body is
 actually the login page.
 
+<Callout type="warn">
+    `STITCH_AUTH_WALL` is this page's [catalog ID](/docs/errors), not a runtime
+    value — the thrown error has no `.code`. This failure has no distinct
+    runtime identity of its own: a hard wall surfaces as an ordinary upstream
+    rejection (a `StitchError` with `status: 401` and the message `HTTP 401`),
+    and an **uncaught soft 200 wall does not throw at all** — the login page
+    arrives as a normal result, and usually fails your `output` schema instead.
+    That silent case is the reason for `refresh.when` below.
+</Callout>
+
 ## Why it happens
 
 Two distinct triggers land here:

--- a/apps/docs/content/docs/errors/stitch-circuit-open.mdx
+++ b/apps/docs/content/docs/errors/stitch-circuit-open.mdx
@@ -6,17 +6,19 @@ description: 'The circuit breaker is open after repeated failures and short-circ
 ## What you'll see
 
 A stitch configured with a [`circuit`](/docs/guides/resilience/circuit-breaker)
-fails _immediately_ — no request leaves the process — with a `StitchError`
-surfaced on the event stream as an `error` event (phase `circuit`). The
-dependency itself isn't being hit: the breaker tripped open after repeated
-failures and is now fast-failing every call to protect it. This is the breaker
-doing its job, not a fresh failure.
+fails _immediately_ — no request leaves the process — with a `StitchError`,
+surfaced on the event stream as an `error` event. The dependency itself isn't
+being hit: the breaker tripped open after repeated failures and is now
+fast-failing every call to protect it. This is the breaker doing its job, not a
+fresh failure.
 
-<Callout type="info">
-    `STITCH_CIRCUIT_OPEN` is provisional — the stable error-code registry lands
-    with the runtime taxonomy refactor. Today the short-circuit surfaces as a
-    `StitchError`; match on the breaker's `circuit` phase rather than the code
-    string.
+<Callout type="warn">
+    `STITCH_CIRCUIT_OPEN` is this page's [catalog ID](/docs/errors), not a
+    runtime value — the thrown error has no `.code`. Recognise a short-circuit
+    by its fields instead: `status === 503` with `attempts === 0`, the
+    combination that means the breaker answered before any request was made (the
+    message is `circuit open`). See [telling failures
+    apart](/docs/errors#telling-failures-apart-at-runtime).
 </Callout>
 
 ## Why it happens

--- a/apps/docs/content/docs/errors/stitch-drift.mdx
+++ b/apps/docs/content/docs/errors/stitch-drift.mdx
@@ -7,8 +7,16 @@ description: 'A required field was missing or incompatible, breaking the respons
 
 A call fails during validation with a `drift` finding that carries
 `level: 'error'` and `change: 'invalid'`. The finding names the offending
-`path` and the call surfaces a `StitchError` with code `STITCH_DRIFT` instead of
-a result.
+`path`, and the call throws a `StitchError` instead of returning a result.
+
+<Callout type="warn">
+    `STITCH_DRIFT` is this page's [catalog ID](/docs/errors), not a runtime
+    value — the thrown error has no `.code`. At runtime this failure is a
+    `StitchError` with the message `contract violation (drift)` and the upstream
+    `status` (a 2xx: the response arrived, the contract broke). The offending
+    `path` is on the `drift` event, not on the error — see [telling failures
+    apart](/docs/errors#telling-failures-apart-at-runtime).
+</Callout>
 
 <Callout type="info">
     Soft drift findings — `undeclared` (`info`), `coerced` (`warn`), `defaulted`
@@ -55,7 +63,7 @@ const user = stitch({
     path: '/user',
     output: drift(
         z.object({
-            // `id` is required — its absence or type mismatch throws STITCH_DRIFT.
+            // `id` is required — its absence or type mismatch throws.
             id: z.number(),
             // `displayName` is optional — its absence is tolerated, no error thrown.
             displayName: z.string().optional(),

--- a/apps/docs/content/docs/errors/stitch-graphql.mdx
+++ b/apps/docs/content/docs/errors/stitch-graphql.mdx
@@ -30,8 +30,13 @@ try {
 }
 ```
 
-(`STITCH_GRAPHQL` is the provisional registry code for this failure; the runtime
-throws a `StitchError` today.)
+<Callout type="warn">
+    `STITCH_GRAPHQL` is this page's [catalog ID](/docs/errors), not a runtime
+    value — the thrown error has no `.code`. Recognise this failure by its
+    shape: a `StitchError` whose `status` is `200` (a success at the transport
+    layer) with a message prefixed `GraphQL:`. See [telling failures
+    apart](/docs/errors#telling-failures-apart-at-runtime).
+</Callout>
 
 ## Why it happens
 

--- a/apps/docs/content/docs/errors/stitch-timeout.mdx
+++ b/apps/docs/content/docs/errors/stitch-timeout.mdx
@@ -11,9 +11,13 @@ A call aborts and throws a `StitchError` once a configured timeout elapses.
 real `AbortSignal`, so the in-flight request is actually aborted rather than left
 running while the call gives up — the underlying request receives the abort.
 
-<Callout type="info">
-    The stable code `STITCH_TIMEOUT` is provisional: the error surfaces as a
-    `StitchError` today, and the code is pending the runtime taxonomy refactor.
+<Callout type="warn">
+    `STITCH_TIMEOUT` is this page's [catalog ID](/docs/errors), not a runtime
+    value — the thrown error has no `.code`. A timed-out call is a
+    `StitchError` with **no** `status` and `attempts` of at least `1`: the
+    request went out, but no response ever came back (the message is
+    `timed out after <n>ms`). See
+    [telling failures apart](/docs/errors#telling-failures-apart-at-runtime).
 </Callout>
 
 ## Why it happens

--- a/apps/docs/content/docs/errors/stitch-validation.mdx
+++ b/apps/docs/content/docs/errors/stitch-validation.mdx
@@ -5,25 +5,32 @@ description: 'Input or response failed schema validation.'
 
 ## What you'll see
 
-A stitch with an `input` or `output` schema throws a `StitchError` whose message
-names the failing path and the issue, e.g. `invalid body: name is required` or a
-type mismatch on the response. Where it throws tells you which side failed:
+A stitch with an `input` or `output` schema throws a `StitchError`. Where it
+throws tells you which side failed — and the two sides report very differently:
 
 - **Input, before the request.** When call input doesn't match the `input`
   schema, the stitch fails fast — the error is thrown _before_ any network call,
-  so nothing leaves the process. This is the common case for a malformed
-  `params`, `query`, `body`, or `headers`.
+  so nothing leaves the process. The message names the failing slot and issue
+  (`invalid body: name is required`), and the error carries `attempts: 0` with
+  no `status`. This is the common case for a malformed `params`, `query`,
+  `body`, or `headers`.
 - **Response, after the request.** When the response doesn't match `output`, the
   error is thrown after the response returns and has been transformed and
-  picked — the request did go out, and the failure describes how the payload
-  diverged from the contract.
+  picked — the request did go out. The message is the generic
+  `contract violation (drift)` and the `status` is the upstream one (a 2xx: the
+  response arrived, the contract broke). **The failing path is not on the
+  error** — it rides the `drift` event on
+  [the event stream](/docs/concepts/event-stream), as a finding with
+  `level: 'error'` and `change: 'invalid'`.
 
 <Callout type="warn">
-    The stable code `STITCH_VALIDATION` is provisional. Today the runtime throws
-    a `StitchError` carrying the failing path and message; the coded error
-    taxonomy that will populate `error.code` and `error.url` is still landing,
-    so don't match on a literal code string yet — match on the path in the
-    message.
+    `STITCH_VALIDATION` is this page's [catalog ID](/docs/errors), not a runtime
+    value — the thrown error has no `.code`. Note too that the response side
+    shares its runtime failure with a hard
+    [`drift()`](/docs/guides/validation/drift) breach: both throw the same
+    `contract violation (drift)` error, so `STITCH_VALIDATION` and
+    `STITCH_DRIFT` name one failure at runtime, not two. See [telling failures
+    apart](/docs/errors#telling-failures-apart-at-runtime).
 </Callout>
 
 ## Why it happens
@@ -39,14 +46,15 @@ The value didn't satisfy the schema you adapted onto the config:
 
 ## How to fix
 
-Read the failing path off the message and check it against the schema:
+Find the failing path, then check it against the schema:
 
-- **If input failed,** fix the call input — or relax the `input` schema if the
-  field really is optional. The request never went out, so there's nothing to
-  retry once the input is correct.
-- **If the response failed,** decide whether the schema or the API is wrong.
-  Update the `output` schema to match the real payload, or fix the expectation
-  if the API contract genuinely changed.
+- **If input failed,** the path is in the message — fix the call input, or relax
+  the `input` schema if the field really is optional. The request never went
+  out, so there's nothing to retry once the input is correct.
+- **If the response failed,** read the path off the `drift` event rather than
+  the message, then decide whether the schema or the API is wrong. Update the
+  `output` schema to match the real payload, or fix the expectation if the API
+  contract genuinely changed.
 
 For a response whose shape shifts in noisy-but-nonbreaking ways, don't reach for
 hard validation — a single new optional field shouldn't throw. Pass a

--- a/apps/docs/content/docs/guides/validation/drift.mdx
+++ b/apps/docs/content/docs/guides/validation/drift.mdx
@@ -34,8 +34,10 @@ These are distinct layers, not options on a dial.
 ### Validation — the hard contract
 
 Validation runs first. A **missing required field** or **incompatible value**
-throws immediately with error code `STITCH_DRIFT` (a finding with
-`change: 'invalid'`, `level: 'error'`). On success the call **returns the
+throws immediately — a `StitchError` reading `contract violation (drift)`,
+alongside a finding with `change: 'invalid'`, `level: 'error'` (documented as
+[`STITCH_DRIFT`](/docs/errors/stitch-drift), a docs ID rather than a runtime
+`.code`). On success the call **returns the
 validated value** — defaults applied, types coerced, unknown keys stripped — so
 the result matches the declared TypeScript type exactly.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -879,9 +879,9 @@ try {
 }
 ```
 
-Prefer to branch rather than wrap in `try`/`catch`? `.safe()` never throws — it resolves to `{ ok, data, error }`. Each failure mode has a stable code and a docs page (the slug _is_ the URL the runtime deep-links to):
+Prefer to branch rather than wrap in `try`/`catch`? `.safe()` never throws — it resolves to `{ ok, data, error }`. Branch on `.status` and `.attempts` (plus `instanceof RateLimitError`) — the `STITCH_*` names below are **documentation IDs, not runtime values**, so there is no `error.code` to match on. Each has a docs page whose slug is a stable URL:
 
-| Code                  | When                                                                |
+| Catalog ID            | When                                                                |
 | --------------------- | ------------------------------------------------------------------- |
 | `STITCH_VALIDATION`   | a response failed its output schema — the shape you got isn't asked |
 | `STITCH_DRIFT`        | a response drifted past the level you allowed, so it was refused    |


### PR DESCRIPTION
## The bug

`apps/docs/content/docs/errors/stitch-drift.mdx` promised the call "surfaces a `StitchError` with code `STITCH_DRIFT`". It does not. `StitchError` declares only `status` / `attempts` / `body` / `url` (`packages/core/src/types.ts:914`), so `err.code` is `undefined` and `if (err.code === 'STITCH_DRIFT')` never matches.

Most of the catalog already hedged this — 5 of 7 pages carried "these codes are provisional" callouts. Three places had simply lost the hedge, and two of the hedged pages pointed readers at a remedy that does not exist either.

## Three defects, all verified against a built core

1. **`stitch-drift.mdx`** — the flat false claim above.
2. **`stitch-circuit-open.mdx`** — worse, because it *was* the remedy: "match on the breaker's `circuit` phase rather than the code string". `error` events carry no `phase` field at all (`types.ts:598-609`). A short-circuit is `{type:'error', message:'circuit open', attempts:0, status:503}`.
3. **`stitch-validation.mdx`** — "match on the path in the message". True on the input side (`invalid body: Required`); on the response side the message is a generic `contract violation (drift)` carrying no path, which lives only on the `drift` event.

Same claim also lived outside `docs/errors/*`, so it's fixed in `guides/validation/drift.mdx` ("throws immediately with error code `STITCH_DRIFT`") and in both READMEs ("Each failure mode has a stable code").

## Why docs, not an `err.code`

Adding a real `code` is a public-surface change, and it needs a taxonomy decision first: a plain `output` schema breach (`STITCH_VALIDATION`) and a hard `drift()` breach (`STITCH_DRIFT`) throw the **same** error today — two catalog IDs, one runtime failure. The IDs do not map 1:1 onto throw paths, so shipping `code` means first deciding whether those are one mode or two. That is the "error-taxonomy refactor" the pages were already deferring to.

`docs/CONTRACT.md:248` (P10) requires "a stable discriminator" on every thrown error; that stays satisfied by the error class plus `status`/`attempts`. `check:contract` holds at 0 new violations. No changeset — the repo doesn't use them, and nothing in `packages/core/src` changed.

## What replaces it

The `STITCH_*` names are now framed consistently as documentation identifiers, and `errors/index.mdx` gains a **"Telling failures apart at runtime"** section built from the probe results:

| What you see | What happened |
| --- | --- |
| `attempts === 0` | No request was made — input validation (`status` `undefined`) or an open circuit (`status` `503`) |
| `status` is a 2xx | The response arrived and broke its contract — schema/drift failure, or GraphQL `errors` |
| `status` is non-2xx | The upstream rejected it, after any retries |
| `status` `undefined`, `attempts` ≥ 1 | Went out, never produced a response — timeout or transport error |

…plus an `instanceof` example, the `drift`-event route for the path detail a thrown error cannot carry, and message strings documented as best-effort only. `rate-limit.mdx` is now marked as the one catalog entry that *is* a real runtime identity (`RateLimitError`); its `.safe()` claim was checked and is accurate.

## Verification

Probed all 9 throw paths against a built core (`err.code === undefined` everywhere) — that's where defects 2 and 3 and the shared-failure finding came from. Docs pages have no twoslash spec (only blog/drafts do), so all 17 blocks in the edited pages were run through the drafts spec's twoslasher config: 0 failures. Pre-push replayed the full CI sequence: format, lint, contract, media-fresh, typecheck, typecheck-d, test, exports, **build-docs**, yakir — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)