### PR TITLE
refactor(elysia)!: the plugin option is `onError`, not `errorHandler`

### DIFF
--- a/apps/docs/content/docs/integrations/elysia.mdx
+++ b/apps/docs/content/docs/integrations/elysia.mdx
@@ -124,12 +124,12 @@ const app = new Elysia().use(
     stitch({
         seam: api,
         // the default is a safe 502; propagate the upstream status instead:
-        errorHandler: { status: (e) => e.status ?? 502 },
+        onError: { status: (e) => e.status ?? 502 },
     }),
 );
 ```
 
-Set `errorHandler: false` to register none and wire your own with `stitchOnError`
+Set `onError: false` to register none and wire your own with `stitchOnError`
 (an `.onError`-compatible mapper) or `stitchErrorResponse(err, options)` (a one-off
 `StitchError` → `Response`); `isStitchError` narrows an unknown error first.
 

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -365,6 +365,13 @@ unassignable to react's raw shape in either direction, the `SolidStitchStore` /
 `SvelteStitchStore` case; `stitchQueryOptions` replaced the bare `queryOptions` in
 vue/solid/svelte/angular.
 
+_Where parity stops:_ a slot that mirrors a **framework hook** is named for that
+framework, not unified across hosts — `errorHandler` on fastify (`setErrorHandler`) vs
+`onError` on elysia (`.onError`). See
+[P18](#p18--adapter-mirrors-keep-upstream-spelling-house-contracts-use-house-vocabulary).
+Parity binds the **shape** behind such a slot, which is identical
+(`boolean | AtLeastOne<StitchErrorOptions>`), not the word in front of it.
+
 _Settled:_ the SSE frame options are **`delta`** and **`error`** on every SSE-capable
 host (`express` / `fastify` / `hono` / `next` / `elysia`) — symmetric envelopes, each a
 `{ data, event, … }` config that also accepts a **bare shaper function as shorthand for
@@ -420,6 +427,19 @@ teaches neither convention, and the reader has to memorize which verbs got the
 abbreviation. The Redis **command** names stay verbatim wherever the code speaks Redis
 (the Lua `INCR`, the `IoredisLike`/`NodeRedisLike`/`UpstashLike` mirrors' `del`) — that
 is the first half of this rule doing its job, not an exception to the second.
+
+_Extends to host-adapter hook slots._ A host adapter's option for a **framework hook**
+takes **that framework's word for it**, so the option reads as the framework its user
+already knows: `@stitchapi/fastify` registers via `setErrorHandler`, so its plugin option
+is **`errorHandler`**; `@stitchapi/elysia` registers via `.onError`, so its option is
+**`onError`**. One concept, two spellings, **deliberately** — this is the mirror clause,
+not a [P16](#p16--cross-surface--cross-package-parity) parity break, and a sweep that
+unifies them has removed information rather than added consistency. The _shape_ behind
+both stays identical (`boolean | AtLeastOne<StitchErrorOptions>`), which is where parity
+actually binds. Only these two hosts have the slot at all — express/hono/nest/next expose
+standalone helpers with no options object — and each of those helpers is likewise named
+for its own framework (`stitchErrorHandler` on express/fastify, `stitchOnError` on
+hono/elysia, `StitchExceptionFilter` on nest).
 
 ### P19 · The alias obligation is scoped to the GA channel
 

--- a/packages/elysia/README.md
+++ b/packages/elysia/README.md
@@ -120,14 +120,14 @@ new Elysia().use(
     stitch({
         seam: api,
         // propagate the upstream status instead of the safe 502 default:
-        errorHandler: { status: (e) => e.status ?? 502 },
+        onError: { status: (e) => e.status ?? 502 },
         // opt in to the raw message (only when upstream messages are safe to expose):
-        // errorHandler: { body: (e) => ({ error: e.message }) },
+        // onError: { body: (e) => ({ error: e.message }) },
     }),
 );
 ```
 
-Set `errorHandler: false` to register none and wire your own with
+Set `onError: false` to register none and wire your own with
 `stitchOnError(options)` or `stitchErrorResponse(err, options)`.
 
 ## API

--- a/packages/elysia/src/plugin.ts
+++ b/packages/elysia/src/plugin.ts
@@ -54,11 +54,16 @@ export interface ElysiaStitchPluginOptions {
     principal?: (ctx: PrincipalContext) => string | undefined;
     /**
      * Options for the StitchError → HTTP mapping the plugin's `.onError` applies (see
-     * {@link stitchOnError}). `false` registers **no** error handler (you wire your own); `true`
+     * {@link stitchOnError}). `false` registers **no** handler (you wire your own); `true`
      * (the default) registers the `502`-by-default mapping. The object form must set at least one
      * field — enable-with-defaults is spelled `true`, never `{}` (CONTRACT.md P13/P20).
+     *
+     * Named for **Elysia's own hook**, per CONTRACT.md P18: a host adapter's slot for a framework
+     * hook takes that framework's word for it. Elysia registers via `.onError`, so the option is
+     * `onError`; fastify registers via `setErrorHandler`, so its option is `errorHandler`. The two
+     * differ on purpose — each reads as the framework its user already knows.
      */
-    errorHandler?: boolean | AtLeastOne<StitchErrorOptions>;
+    onError?: boolean | AtLeastOne<StitchErrorOptions>;
 }
 
 /**
@@ -82,7 +87,7 @@ export interface ElysiaStitchPluginOptions {
  * The `stitch` context property is typed: a handler reads it off the destructured context.
  */
 export function stitch(options: ElysiaStitchPluginOptions): StitchPlugin {
-    const { seam, principal, errorHandler } = options;
+    const { seam, principal, onError } = options;
 
     // `.derive` runs per request and merges its return into the context. The principal lives in this
     // closure (resolved from the request), never in a call argument, so a handler can never name
@@ -101,13 +106,11 @@ export function stitch(options: ElysiaStitchPluginOptions): StitchPlugin {
     // for a non-Stitch error leaves Elysia's default handling in charge. Both branches expose the
     // same `stitch` context, so the public {@link StitchPlugin} return type is stable either way.
     const app =
-        errorHandler === false
+        onError === false
             ? base
             : base.onError(
                   { as: 'global' },
-                  stitchOnError(
-                      typeof errorHandler === 'object' ? errorHandler : {},
-                  ),
+                  stitchOnError(typeof onError === 'object' ? onError : {}),
               );
 
     return app as unknown as StitchPlugin;

--- a/packages/elysia/test/elysia.spec.ts
+++ b/packages/elysia/test/elysia.spec.ts
@@ -190,7 +190,7 @@ describe('stitchOnError / stitchErrorResponse map a StitchError to HTTP', () => 
             .use(
                 stitch({
                     seam: api,
-                    errorHandler: { status: (e) => e.status ?? 502 },
+                    onError: { status: (e) => e.status ?? 502 },
                 }),
             )
             .get('/boom', ({ stitch }) =>
@@ -205,10 +205,10 @@ describe('stitchOnError / stitchErrorResponse map a StitchError to HTTP', () => 
         await api.close();
     });
 
-    test('errorHandler:false registers no mapping (upstream error is not mapped to 502)', async () => {
+    test('onError:false registers no mapping (upstream error is not mapped to 502)', async () => {
         const api = seam({ baseUrl: 'https://api.test' });
         const app = new Elysia()
-            .use(stitch({ seam: api, errorHandler: false }))
+            .use(stitch({ seam: api, onError: false }))
             .get('/boom', ({ stitch }) =>
                 stitch.stitch({
                     path: '/missing',
@@ -222,13 +222,13 @@ describe('stitchOnError / stitchErrorResponse map a StitchError to HTTP', () => 
         await api.close();
     });
 
-    test('errorHandler:true registers the default mapping (the new P13 spelling, at runtime)', async () => {
+    test('onError:true registers the default mapping (the new P13 spelling, at runtime)', async () => {
         // `true` never type-checked before, so this asserts the RUNTIME honours it — not just
         // that the signature widened. It must behave exactly like omitting the key: register
         // the 502-by-default mapping, NOT pass `true` through to `stitchOnError`.
         const api = seam({ baseUrl: 'https://api.test' });
         const app = new Elysia()
-            .use(stitch({ seam: api, errorHandler: true }))
+            .use(stitch({ seam: api, onError: true }))
             .get('/boom', ({ stitch }) =>
                 stitch.stitch({
                     path: '/missing',
@@ -241,10 +241,10 @@ describe('stitchOnError / stitchErrorResponse map a StitchError to HTTP', () => 
         await api.close();
     });
 
-    test('the empty errorHandler bag is rejected (compile-time, P20)', () => {
+    test('the empty onError bag is rejected (compile-time, P20)', () => {
         const api = seam({ baseUrl: 'https://api.test' });
         // @ts-expect-error — `{}` is not a valid bag: enable-with-defaults is `true` (P13/P20)
-        void stitch({ seam: api, errorHandler: {} });
+        void stitch({ seam: api, onError: {} });
         expect(true).toBe(true);
     });
 

--- a/packages/fastify/src/plugin.ts
+++ b/packages/fastify/src/plugin.ts
@@ -45,6 +45,11 @@ interface FastifyStitchPluginCommon {
      * `false` registers **no** error handler (you wire your own); `true` (the default) registers
      * the `502`-by-default mapping. The object form must set at least one field — enable-with-
      * defaults is spelled `true`, never `{}` (CONTRACT.md P13/P20), matching `logger` above.
+     *
+     * Named for **Fastify's own hook**, per CONTRACT.md P18: a host adapter's slot for a framework
+     * hook takes that framework's word for it. Fastify registers via `setErrorHandler`, so the
+     * option is `errorHandler`; `@stitchapi/elysia` registers via `.onError`, so its option is
+     * `onError`. The two differ on purpose — each reads as the framework its user already knows.
      */
     errorHandler?: boolean | AtLeastOne<StitchErrorOptions>;
     /**


### PR DESCRIPTION
A host adapter's slot for a framework hook should read as the framework its user already knows.

```ts
stitch({ seam, onError: { status: … } })              // elysia  — registers via .onError
app.register(stitchPlugin, { errorHandler: { … } })   // fastify — registers via setErrorHandler
```

## Why

Elysia's option was the **only** thing in its own file still saying `errorHandler`. Everything
around it says `onError`:

| | |
| --- | --- |
| the native call | `base.onError({ as: 'global' }, …)` — `plugin.ts:106` |
| the exported helper | `stitchOnError` |
| the option's own doc comment | *"the plugin's `.onError` applies (see `stitchOnError`)"* |
| the option itself | ~~`errorHandler`~~ → **`onError`** |

Fastify keeps `errorHandler`, because that is **its** hook (`fastify.setErrorHandler`, `plugin.ts:148`).

So this is not "elysia diverges from the house word" — it is one rule applied consistently:
**a host adapter's option for a framework hook takes that framework's word for it.** Both packages
were already following it; only elysia's field had drifted.

## The part that outlives the rename

A parity sweep looking at two hosts spelling one concept differently will unify them — and would
thereby *delete* information. This session's own sweep did exactly that kind of reasoning. So the
rule is now written down in two places:

- **P18** gains *"Extends to host-adapter hook slots"* — stating the rule, naming both spellings,
  and noting that the *shape* behind the slot stays identical
  (`boolean | AtLeastOne<StitchErrorOptions>`), which is where parity actually binds.
- **P16** gains a *"Where parity stops"* note pointing at P18, so the carve-out is visible from the
  parity side too.

Both JSDoc blocks now explain the pair from their own side, so a reader landing on either learns
why the other differs.

## Not changed

- **Semantics.** `false` registers nothing, `true` is enable-with-defaults, `{}` is rejected
  (P13/P20). Only the name moved, so the existing suite renames straight across — including the
  `true` runtime assertion and the `{}` compile-time rejection added in #557.
- **Fastify.** Its option, its docs page, and its helper are untouched.
- **`stitchOnError` / `stitchErrorResponse`.** Already correctly named for their framework (P18).

No `@deprecated` alias — pre-GA hard break per **D5**.

## Verification

- `pnpm -r check:types` — 38 packages, clean
- `@stitchapi/elysia` 28 tests, `@stitchapi/fastify` 26 tests — passing
- `check:contract` → `no new violations (0 known, baselined)`
- `check-docs-links` green (110 routes); prettier clean
- `apps/docs/content/docs/integrations/elysia.mdx` and the package README updated;
  `fastify.mdx` deliberately left alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
