### PR TITLE
refactor!: P1/P2 name sweep — five words that each meant two things

### DIFF
--- a/apps/docs/content/blog/choosing-an-http-adapter.mdx
+++ b/apps/docs/content/blog/choosing-an-http-adapter.mdx
@@ -92,7 +92,7 @@ And if you forget — wire up `onProgress` for an upload bar but leave the call 
 
 ```
 adapter.upload-progress-unsupported — onProgress is set with a request body, but
-fetchAdapter cannot report upload progress — only 'phase: download' events fire.
+fetchAdapter cannot report upload progress — only 'direction: download' events fire.
 Use xhrAdapter() to draw an upload progress bar.
 ```
 

--- a/apps/docs/content/blog/choosing-an-http-adapter.mdx
+++ b/apps/docs/content/blog/choosing-an-http-adapter.mdx
@@ -96,7 +96,7 @@ fetchAdapter cannot report upload progress — only 'phase: download' events fir
 Use xhrAdapter() to draw an upload progress bar.
 ```
 
-It's a note, not an error: `fetch` still reports `phase: 'download'` progress, so a download bar on a `POST` keeps working — the silent gap is only the upload phase, and only that gets called out. The fix is the one field this whole article is about: `adapter: xhrAdapter()`.
+It's a note, not an error: `fetch` still reports `direction: 'download'` progress, so a download bar on a `POST` keeps working — the silent gap is only the upload phase, and only that gets called out. The fix is the one field this whole article is about: `adapter: xhrAdapter()`.
 
 ## Which one
 

--- a/apps/docs/content/blog/read-through-caching-and-coalescing.mdx
+++ b/apps/docs/content/blog/read-through-caching-and-coalescing.mdx
@@ -100,7 +100,7 @@ Why it's the default and not an option you remember to set: the dangerous failur
 
 This is where caching meets [auth as a boundary](/docs/concepts/capability-not-credential). A stitch already knows the identity it acts as — that's what the `auth` strategy resolves at call time — and the cache reuses that same notion of principal to scope the key. So the credential never reaches the caller _and_ the cached response inherits the same boundary: the cache can't become a side channel that leaks across the identity wall auth was there to enforce.
 
-When a response genuinely is the same for everyone — a public feed, a shared catalog — you opt out with `scope: 'app'` and the entry is shared across principals. That's a deliberate widening of the blast radius, and reading it in the declaration says exactly that: this data is not user-specific.
+When a response genuinely is the same for everyone — a public feed, a shared catalog — you opt out with `tenancy: 'app'` and the entry is shared across principals. That's a deliberate widening of the blast radius, and reading it in the declaration says exactly that: this data is not user-specific.
 
 ```ts twoslash
 import { stitch } from 'stitchapi';
@@ -127,7 +127,7 @@ Caching is only correct for **idempotent reads**: a request you could make twice
 
 - **Writes are out.** A `POST` that creates an order or charges a card is not a read; there's no "same answer" to reuse. (For a _retried_ write settling once instead of twice, the tool is [idempotency keys](/docs/guides/resilience/idempotency) — a different mechanism entirely.)
 - **Per-request-varying reads are out.** A response that legitimately changes every call — a fresh nonce, a timestamp, a random pick — gains nothing from a cache and risks serving something stale.
-- **Anything you can't safely share across the chosen scope.** If a response is user-specific it must stay principal-scoped; widening it to `scope: 'app'` to "improve the hit rate" is the exact move that turns a cache into a leak.
+- **Anything you can't safely share across the chosen scope.** If a response is user-specific it must stay principal-scoped; widening it to `tenancy: 'app'` to "improve the hit rate" is the exact move that turns a cache into a leak.
 
 There's a guardrail in the shape layer too: a stitch with an `output` schema caches only when that schema can be fingerprinted (or you pin a `version`). If it can't establish the shape it's storing, it **refuses to cache** rather than serve a value that no longer matches its contract. Data you never want at rest can be marked `sensitive: true` to opt out entirely.
 

--- a/apps/docs/content/blog/read-through-caching-and-coalescing.mdx
+++ b/apps/docs/content/blog/read-through-caching-and-coalescing.mdx
@@ -79,7 +79,7 @@ const listAnnouncements = stitch({
     pick: 'data',
     cache: {
         ttl: '1h',
-        scope: 'app', // shared across principals — see below
+        tenancy: 'app', // shared across principals — see below
         vary: ['accept-language'], // fold a header into the key
         entries: 500,
     },
@@ -117,7 +117,7 @@ const getProfile = stitch({
 // App-scoped: genuinely shared, identical for everyone.
 const getStatusPage = stitch({
     path: 'https://api.example.com/status',
-    cache: { ttl: '10s', scope: 'app' },
+    cache: { ttl: '10s', tenancy: 'app' },
 });
 ```
 

--- a/apps/docs/content/blog/upload-a-file-with-a-progress-bar.mdx
+++ b/apps/docs/content/blog/upload-a-file-with-a-progress-bar.mdx
@@ -70,13 +70,13 @@ A multipart **file part** in the body can be a `Blob` (a `File` is a `Blob`), a 
 
 ```ts twoslash
 type AdapterProgress = {
-    phase: 'upload' | 'download';
+    direction: 'upload' | 'download';
     loaded: number;
     total?: number;
 };
 ```
 
-`loaded` is the number of bytes transferred so far; `total` is the full size when the transport knows it. Tag by `phase` so you only move the upload bar while the request body is going out:
+`loaded` is the number of bytes transferred so far; `total` is the full size when the transport knows it. Tag by `direction` so you only move the upload bar while the request body is going out:
 
 ```ts twoslash
 import { stitch, xhrAdapter } from 'stitchapi';
@@ -98,7 +98,7 @@ async function send(file: File, onPct: (pct: number) => void) {
     const result = await uploadVideo({
         body: { file },
         onProgress: (p) => {
-            if (p.phase === 'upload') {
+            if (p.direction === 'upload') {
                 onPct(Math.round((p.loaded / (p.total ?? 1)) * 100));
             }
         },
@@ -163,15 +163,15 @@ uploadVideo({ body: { file }, onProgress, signal: controller.signal });
 
 ## Upload progress, not just any progress
 
-The `phase` tag exists because progress runs **both directions**:
+The `direction` tag exists because progress runs **both directions**:
 
-| Axis        | `phase: 'upload'`              | `phase: 'download'`             |
+| Axis        | `direction: 'upload'`          | `direction: 'download'`         |
 | ----------- | ------------------------------ | ------------------------------- |
 | Measures    | bytes of the request body sent | bytes of the response body read |
 | Transport   | needs `xhrAdapter()`           | works on `fetchAdapter()` too   |
 | Typical use | a file/video upload bar        | a large-download bar            |
 
-Download progress is the easier half — `fetchAdapter()`, the default transport, reports it by reading the response stream — so if you only need a download bar you do not have to switch adapters at all. The reason this article reaches for `xhrAdapter()` is the upload direction, which `fetch` cannot measure at all. Filter on `p.phase === 'upload'` and the same callback ignores the download tail.
+Download progress is the easier half — `fetchAdapter()`, the default transport, reports it by reading the response stream — so if you only need a download bar you do not have to switch adapters at all. The reason this article reaches for `xhrAdapter()` is the upload direction, which `fetch` cannot measure at all. Filter on `p.direction === 'upload'` and the same callback ignores the download tail.
 
 This stays inside the stitch contract, not beside it. `auth` still resolves the token at call time; `timeout` still bounds the call (a generous `'2m'` here, because a large upload is slow, not stuck); `output` still validates the response, so a corrupt or unexpected body throws a `StitchError` carrying the offending `.body` instead of slipping through as `any`. You traded the transport, not the guarantees.
 

--- a/apps/docs/content/docs/guides/auth/cookie-session.mdx
+++ b/apps/docs/content/docs/guides/auth/cookie-session.mdx
@@ -75,7 +75,7 @@ never crashes the call.
   `'unauthenticated'` (a `refresh` status, e.g. `401` — bad/expired creds),
   `'rate-limited'` (`429`, with `retryAfter` parsed from `Retry-After`),
   `'network'` (the login threw before any response — with the thrown `error`),
-  or `'unknown'`. `info.phase` is `'apply'` for a cold session or `'refresh'`
+  or `'unknown'`. `info.step` is `'apply'` for a cold session or `'refresh'`
   for a wall that was hit mid-stream.
 
 ```ts twoslash

--- a/apps/docs/content/docs/reference/helpers.mdx
+++ b/apps/docs/content/docs/reference/helpers.mdx
@@ -120,7 +120,7 @@ adapter's `supports` omits `'uploadProgress'` (only `fetch`, among the built-ins
 sink, pointing you at `xhrAdapter`:
 
 > onProgress is set with a request body, but fetchAdapter cannot report upload
-> progress — only 'phase: download' events fire. Use xhrAdapter() to draw an
+> progress — only 'direction: download' events fire. Use xhrAdapter() to draw an
 > upload progress bar.
 
 It is a **note, not an error**: `fetch` still reports `direction: 'download'`

--- a/apps/docs/content/docs/reference/helpers.mdx
+++ b/apps/docs/content/docs/reference/helpers.mdx
@@ -123,7 +123,7 @@ sink, pointing you at `xhrAdapter`:
 > progress — only 'phase: download' events fire. Use xhrAdapter() to draw an
 > upload progress bar.
 
-It is a **note, not an error**: `fetch` still reports `phase: 'download'`
+It is a **note, not an error**: `fetch` still reports `direction: 'download'`
 progress, so a download bar on a `POST` keeps working — only the upload phase is
 dark. To see the note, attach any `trace` sink (e.g. `consoleSink`); to act on it,
 switch the call to `xhrAdapter()`.

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -600,8 +600,11 @@ export function oauth2(opts: OAuth2Options): AuthStrategy {
  * hands the host a categorised outcome instead. Surfaced via {@link CookieSessionOptions.onAuthFailure}.
  */
 export interface AuthFailureResult {
-    /** `'apply'` = cold session had no stored cookie; `'refresh'` = a 401-style wall was hit. */
-    phase: 'apply' | 'refresh';
+    /** Which half of the auth attempt failed: `'apply'` = cold session had no stored cookie;
+     *  `'refresh'` = a 401-style wall was hit. Spelled `step`, not `phase`, because `phase` is
+     *  the request-lifecycle enum on `StitchEvent` (`ProgressPhase`) — one word may not carry two
+     *  value-spaces (CONTRACT.md P1). Transfer direction is the third, and is now `direction`. */
+    step: 'apply' | 'refresh';
     /** The login response status when the login responded at all (absent when it threw). */
     status?: number;
     /** `Retry-After` parsed to ms when the login was rate-limited (status 429). */
@@ -754,7 +757,7 @@ export function cookieSession(opts: CookieSessionOptions): AuthStrategy {
     // rate-limited (back off per `Retry-After`); a status matched by `refresh` (e.g. 401) means the
     // creds were rejected; anything else — including a soft 200 wall that set no cookie — is `unknown`.
     const classify = (
-        phase: 'apply' | 'refresh',
+        step: 'apply' | 'refresh',
         status: number,
         headers: Record<string, string>,
     ): AuthFailureResult => {
@@ -762,15 +765,15 @@ export function cookieSession(opts: CookieSessionOptions): AuthStrategy {
             // Omit `retryAfter` entirely when the header is absent/unparseable —
             // `exactOptionalPropertyTypes` forbids setting an optional prop to `undefined`.
             return compact({
-                phase,
+                step,
                 status,
                 category: 'rate-limited',
                 retryAfter: parseRetryAfter(headers['retry-after']),
             });
         }
         if (refreshMatch(status))
-            return { phase, status, category: 'unauthenticated' };
-        return { phase, status, category: 'unknown' };
+            return { step, status, category: 'unauthenticated' };
+        return { step, status, category: 'unknown' };
     };
 
     // Announce one login attempt's outcome to the host. `onRefresh` fires for EVERY attempt; on a
@@ -803,7 +806,7 @@ export function cookieSession(opts: CookieSessionOptions): AuthStrategy {
         ctx: AuthContext,
         key: string,
         principal: string | undefined,
-        phase: 'apply' | 'refresh',
+        step: 'apply' | 'refresh',
     ) => {
         ctx.emit('auth', 'login');
         // `__raw` runs the login once and returns its raw AdapterResponse (headers and all);
@@ -835,8 +838,8 @@ export function cookieSession(opts: CookieSessionOptions): AuthStrategy {
             const status = typeof e.status === 'number' ? e.status : undefined;
             const failure: AuthFailureResult =
                 status === undefined
-                    ? { phase, category: 'network', error }
-                    : classify(phase, status, e.response?.headers ?? {});
+                    ? { step, category: 'network', error }
+                    : classify(step, status, e.response?.headers ?? {});
             await report(ctx, false, status, failure);
             // Re-throw so the caller sees the original error exactly as before these hooks existed.
             throw error;
@@ -868,7 +871,7 @@ export function cookieSession(opts: CookieSessionOptions): AuthStrategy {
             ctx,
             captured,
             status,
-            captured ? undefined : classify(phase, status, res.headers),
+            captured ? undefined : classify(step, status, res.headers),
         );
     };
 

--- a/packages/core/src/axios-adapter.ts
+++ b/packages/core/src/axios-adapter.ts
@@ -79,18 +79,18 @@ export function axiosAdapter(
         }
 
         // Byte progress: axios reports both phases natively, so translate its progress events into
-        // the adapter's `{ phase, loaded, total? }` shape and wire them only when the call asked.
+        // the adapter's `{ direction, loaded, total? }` shape and wire them only when the call asked.
         const onProgress = req.onProgress;
         const progress = (
-            phase: AdapterProgress['phase'],
+            direction: AdapterProgress['direction'],
         ): ((e: AxiosLikeProgressEvent) => void) | undefined => {
             if (onProgress === undefined) return undefined;
             const cb = onProgress;
             return (e) => {
                 cb(
                     e.total !== undefined
-                        ? { phase, loaded: e.loaded, total: e.total }
-                        : { phase, loaded: e.loaded },
+                        ? { direction, loaded: e.loaded, total: e.total }
+                        : { direction, loaded: e.loaded },
                 );
             };
         };

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -111,7 +111,7 @@ function varyHeaderObject(
 }
 
 /** The resolved request the key is derived from. `principal` here is already scope-resolved
- *  (absent under `scope: 'app'`). */
+ *  (absent under `tenancy: 'app'`). */
 export interface RequestDescriptor {
     method: string;
     url: string;
@@ -363,7 +363,7 @@ export interface CacheControllerOptions {
 export function createCache(opts: CacheControllerOptions): CacheController {
     const { config, store, stitchId } = opts;
     const ttlMs = parseDuration(config.ttl) ?? 0;
-    const scope = config.scope ?? 'principal';
+    const tenancy = config.tenancy ?? 'principal';
     const methods = (config.methods ?? ['GET', 'HEAD']).map((m) =>
         m.toUpperCase(),
     );
@@ -395,7 +395,7 @@ export function createCache(opts: CacheControllerOptions): CacheController {
     // 'cluster' is reserved for the deferred cross-process protocol; v1 degrades it to process.
     const coalesce: 'process' | false =
         config.coalesce === false ? false : 'process';
-    const principalForScope = scope === 'app' ? undefined : opts.principal;
+    const principalForScope = tenancy === 'app' ? undefined : opts.principal;
     const coalescer = new InflightCoalescer<CacheHit>();
     // In-process LRU of keys THIS process has written; insertion order = recency (Map preserves
     // it; a re-touch deletes+re-sets to move the key to the most-recent end).

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -965,7 +965,7 @@ function outputSchemaSource(cfg: ResolvedStitchConfig): unknown {
     // an always-true one against the `'drift'` literal.
     const isDrift = (out as { __kind?: unknown }).__kind === 'drift';
     const validator = isDrift ? (out as DriftSpec).schema : out;
-    return (validator as { source?: unknown }).source ?? validator;
+    return (validator as { schema?: unknown }).schema ?? validator;
 }
 
 // The resolved request the cache key is derived from. The principal it scopes by is sourced from
@@ -1014,7 +1014,7 @@ const cacheEvt = (detail: string): StitchEvent => ({
 
 // A buffered upload bar that never moves is the quiet trap behind the adapter seam: a call passes
 // `onProgress` with a body expecting bytes-sent, but the default `fetch` reports only
-// `phase: 'download'` — the upload phase stays dark, no error, no events. When the active adapter
+// `direction: 'download'` — the upload phase stays dark, no error, no events. When the active adapter
 // declares its capabilities and `'uploadProgress'` is NOT among them (ADR 0005 Decision 9), say so
 // once — an `info` event pointing at xhrAdapter — instead of no-op'ing. Deliberately a teaching
 // note, not a throw: a body with `onProgress` can also legitimately want DOWNLOAD progress on a
@@ -1034,7 +1034,7 @@ function uploadProgressWarning(
         topic: 'adapter.upload-progress-unsupported',
         detail:
             `onProgress is set with a request body, but ${cap.name ?? 'the active adapter'} cannot ` +
-            `report upload progress — only 'phase: download' events fire. Use xhrAdapter() to draw ` +
+            `report upload progress — only 'direction: download' events fire. Use xhrAdapter() to draw ` +
             `an upload progress bar.`,
         at: now(),
     };

--- a/packages/core/src/fingerprint.ts
+++ b/packages/core/src/fingerprint.ts
@@ -69,8 +69,11 @@ export interface SchemaFingerprint {
 export interface SchemaFingerprinter {
     /** The `~standard.vendor` this strategy handles, e.g. `'zod'`. */
     readonly vendor: string;
-    /** The validator major-version range it is proven against, e.g. `'^4'`. */
-    readonly supports: string;
+    /** The validator major-version range it is proven against, e.g. `'^4'`. Named `range`, not
+     *  `supports`: `AdapterCapabilities.supports` is a LIST of capabilities, and one word may not
+     *  carry two value-spaces across the surface (CONTRACT.md P1) — least of all on two seams a
+     *  third party implements (P21). */
+    readonly range: string;
     fingerprint(schema: StandardSchemaV1): SchemaFingerprint;
 }
 

--- a/packages/core/src/http-adapter.ts
+++ b/packages/core/src/http-adapter.ts
@@ -144,7 +144,7 @@ export function fetchAdapter(opts?: FetchAdapterOptions): Adapter {
             url: finalUrl,
         };
     };
-    // `fetch` streams a response (so `stream`/`sse` ride it) and reports `phase: 'download'`
+    // `fetch` streams a response (so `stream`/`sse` ride it) and reports `direction: 'download'`
     // progress while reading a buffered body, but cannot report bytes SENT — the upload phase stays
     // silent, so `'uploadProgress'` is absent from `supports`. Declaring it lets the engine teach
     // instead of no-op when a call asks for upload progress.
@@ -169,8 +169,8 @@ async function readWithProgress(
     if (!reader) {
         onProgress(
             total !== undefined
-                ? { phase: 'download', loaded: 0, total }
-                : { phase: 'download', loaded: 0 },
+                ? { direction: 'download', loaded: 0, total }
+                : { direction: 'download', loaded: 0 },
         );
         return new ArrayBuffer(0);
     }
@@ -183,8 +183,8 @@ async function readWithProgress(
         loaded += value.byteLength;
         onProgress(
             total !== undefined
-                ? { phase: 'download', loaded, total }
-                : { phase: 'download', loaded },
+                ? { direction: 'download', loaded, total }
+                : { direction: 'download', loaded },
         );
     }
     const out = new Uint8Array(loaded);

--- a/packages/core/src/openapi.ts
+++ b/packages/core/src/openapi.ts
@@ -72,7 +72,7 @@ export interface OpenApiExportOptions {
      * response BODY schemas come from the stitch's `input.body` / `output` schemas, and the
      * `params` / `query` object schemas are converted then DECOMPOSED into a JSON Schema per
      * URL-template parameter (instead of `{}`). It receives the raw schema (a `Validator`'s
-     * `.source`) plus the slot and the detected Standard Schema `vendor`; return a JSON Schema
+     * `.schema`) plus the slot and the detected Standard Schema `vendor`; return a JSON Schema
      * object, or `undefined` to fall back to `{}`. For `params` / `query` the converter is called
      * once on the whole object schema; its `properties[name]` becomes each parameter's schema.
      */
@@ -95,9 +95,9 @@ const EMPTY_SCHEMA: Record<string, unknown> = {};
 
 // A Validator carries its raw schema on a non-enumerable `.source` (validator.ts); pull it out so a
 // converter can turn it into JSON Schema. Anything else (a DriftSpec, a sourceless validator) → none.
-function sourceOf(slot: unknown): unknown {
-    return slot && typeof slot === 'object' && 'source' in slot
-        ? (slot as { source?: unknown }).source
+function schemaOf(slot: unknown): unknown {
+    return slot && typeof slot === 'object' && 'schema' in slot
+        ? (slot as { schema?: unknown }).schema
         : undefined;
 }
 
@@ -110,7 +110,7 @@ function bodySchema(
     convert: OpenApiExportOptions['toJsonSchema'],
 ): Record<string, unknown> {
     if (!convert) return EMPTY_SCHEMA;
-    const source = sourceOf(slot);
+    const source = schemaOf(slot);
     if (source === undefined) return EMPTY_SCHEMA;
     const vendor = isStandardSchema(source)
         ? source['~standard'].vendor
@@ -129,7 +129,7 @@ function decomposeParamObject(
 ): { properties: Record<string, unknown>; required: Set<string> } {
     const empty = { properties: {}, required: new Set<string>() };
     if (!convert) return empty;
-    const source = sourceOf(slot);
+    const source = schemaOf(slot);
     if (source === undefined) return empty;
     const vendor = isStandardSchema(source)
         ? source['~standard'].vendor

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -196,7 +196,7 @@ export interface SseOptions {
  * sent, `'download'` as the response body arrives. `total` is the content length when known.
  */
 export interface AdapterProgress {
-    phase: 'upload' | 'download';
+    direction: 'upload' | 'download';
     loaded: number;
     total?: number;
 }
@@ -217,8 +217,8 @@ export interface AdapterRequest {
      */
     stream?: boolean;
     /**
-     * Byte-progress callback (ADR 0005 Decision 9). Fires with `phase: 'download'` as the
-     * response is read, and `phase: 'upload'` as the request body is sent (upload progress needs
+     * Byte-progress callback (ADR 0005 Decision 9). Fires with `direction: 'download'` as the
+     * response is read, and `direction: 'upload'` as the request body is sent (upload progress needs
      * `xhrAdapter` — `fetch` cannot report it). Orthogonal to {@link AdapterRequest.stream}.
      */
     onProgress?: (progress: AdapterProgress) => void;
@@ -241,10 +241,10 @@ export interface AdapterResponse {
  *
  * -   `'stream'` — honours {@link AdapterRequest.stream}, handing back a live `ReadableStream`
  *     instead of rejecting it. `fetch` only among the built-ins (`xhr`/axios buffer and reject it).
- * -   `'uploadProgress'` — reports `phase: 'upload'` byte progress through
+ * -   `'uploadProgress'` — reports `direction: 'upload'` byte progress through
  *     {@link AdapterRequest.onProgress}. `xhr` and axios can; `fetch` cannot (it leaves the upload
  *     phase silent).
- * -   `'downloadProgress'` — reports `phase: 'download'` byte progress through
+ * -   `'downloadProgress'` — reports `direction: 'download'` byte progress through
  *     {@link AdapterRequest.onProgress} as the response arrives. `fetch`, `xhr`, and axios all can.
  */
 export type AdapterCapability =
@@ -253,7 +253,7 @@ export type AdapterCapability =
  * What a transport supports, declared on the adapter itself (ADR 0005 Decision 9). An adapter is
  * still just a function — this is an OPTIONAL hint hung off it. A descriptor lists the features the
  * transport HAS in `supports`; anything not listed, it can't do. Built-in adapters declare one so
- * the engine can turn a silent no-op into a teaching note: a call that asks for `phase: 'upload'`
+ * the engine can turn a silent no-op into a teaching note: a call that asks for `direction: 'upload'`
  * progress on a transport whose `supports` omits `'uploadProgress'` (`fetch`, axios) gets an `info`
  * event pointing at `xhrAdapter`, instead of an upload bar that never moves. A custom adapter that
  * declares nothing is treated as unknown — no checks, the open contract stands.
@@ -404,8 +404,13 @@ export interface CacheOptions {
      * Whose responses an entry may be served to. `'principal'` (default, **fail-closed**) folds
      * the bound principal into the key so user A can never be served user B's cached response;
      * `'app'` shares one entry across callers — correct only for public, unauthenticated data.
+     *
+     * Spelled `tenancy`, matching `OAuth2Options.tenancy` / `CookieSessionOptions.tenancy` — the
+     * identical `'principal' | 'app'` axis. It was `scope`, which P2 already freed for the OAuth
+     * permission string (`OAuth2Options.scope`); the cache slot was the last holdout, so one word
+     * still meant two things.
      */
-    scope?: 'principal' | 'app';
+    tenancy?: 'principal' | 'app';
     /**
      * Request header(s) whose values vary the response and so must be part of the key (e.g.
      * `'accept-language'` or a list). An explicit allowlist **overrides** the default of honouring

--- a/packages/core/src/validator.ts
+++ b/packages/core/src/validator.ts
@@ -19,15 +19,20 @@ export interface Validator<T = unknown> {
      * fingerprint the output contract (ADR 0004): the wrapper itself hides the original
      * `~standard.vendor` the fingerprint strategy dispatches on. Non-enumerable, so it never lands
      * in `__config`, JSON, or trace payloads.
+     *
+     * Named `schema`, not `source`: `Inspection.source` is data PROVENANCE
+     * (`'live' | 'cache' | 'stream'`), and one word may not carry two concepts and two
+     * value-spaces across the surface (CONTRACT.md P1). Both are exported from the `stitchapi`
+     * root barrel, so the collision was reachable in a single import.
      */
-    readonly source?: unknown;
+    readonly schema?: unknown;
 }
 
 // Attach the raw schema to a wrapper non-enumerably, so the cache can fingerprint the output
 // contract (ADR 0004) without the schema leaking through enumerable copies into `__config`/traces.
-function withSource(validator: Validator, source: unknown): Validator {
-    return Object.defineProperty(validator, 'source', {
-        value: source,
+function withSchema(validator: Validator, schema: unknown): Validator {
+    return Object.defineProperty(validator, 'schema', {
+        value: schema,
         enumerable: false,
     });
 }
@@ -53,7 +58,7 @@ export function toValidator(schema: unknown): Validator | undefined {
     const zodLike = schema as { safeParse?: (v: unknown) => ZodResult };
     const { safeParse } = zodLike;
     if (typeof safeParse === 'function') {
-        return withSource(
+        return withSchema(
             {
                 async validate(value) {
                     const r = safeParse(value);
@@ -73,7 +78,7 @@ export function toValidator(schema: unknown): Validator | undefined {
 
     // Standard Schema
     if (isStandardSchema(schema)) {
-        return withSource(
+        return withSchema(
             {
                 async validate(value) {
                     const r = await schema['~standard'].validate(value);
@@ -100,7 +105,7 @@ export function toValidator(schema: unknown): Validator | undefined {
     // Plain predicate: (value: unknown) => boolean
     if (typeof schema === 'function') {
         const predicate = schema as (v: unknown) => boolean;
-        return withSource(
+        return withSchema(
             {
                 async validate(value) {
                     if (predicate(value)) return { ok: true, value };

--- a/packages/core/src/xhr-adapter.ts
+++ b/packages/core/src/xhr-adapter.ts
@@ -86,22 +86,22 @@ export function xhrAdapter(XHR?: XhrLikeCtor): Adapter {
                     onProgress(
                         e.lengthComputable
                             ? {
-                                  phase: 'upload',
+                                  direction: 'upload',
                                   loaded: e.loaded,
                                   total: e.total,
                               }
-                            : { phase: 'upload', loaded: e.loaded },
+                            : { direction: 'upload', loaded: e.loaded },
                     );
                 };
                 xhr.onprogress = (e) => {
                     onProgress(
                         e.lengthComputable
                             ? {
-                                  phase: 'download',
+                                  direction: 'download',
                                   loaded: e.loaded,
                                   total: e.total,
                               }
-                            : { phase: 'download', loaded: e.loaded },
+                            : { direction: 'download', loaded: e.loaded },
                     );
                 };
             }
@@ -150,7 +150,7 @@ export function xhrAdapter(XHR?: XhrLikeCtor): Adapter {
         });
     };
     // The one reason xhr exists over fetch: `xhr.upload` reports bytes SENT, so it is a built-in
-    // that can drive an upload progress bar. It also reports `phase: 'download'` progress via
+    // that can drive an upload progress bar. It also reports `direction: 'download'` progress via
     // `xhr.onprogress`. It is buffered-only — it rejects `stream`, so `supports` carries both
     // progress phases but not `'stream'`.
     xhrAdapterRequest.capabilities = {

--- a/packages/core/test/adapter-streaming.spec.ts
+++ b/packages/core/test/adapter-streaming.spec.ts
@@ -75,7 +75,7 @@ describe('fetchAdapter streaming (ADR 0005 Decision 9)', () => {
         // buffered path: the body is still decoded to JSON
         expect(res.body).toEqual(payload);
         expect(events.length).toBeGreaterThan(0);
-        expect(events.every((e) => e.phase === 'download')).toBe(true);
+        expect(events.every((e) => e.direction === 'download')).toBe(true);
         const last = events[events.length - 1];
         expect(last?.loaded).toBe(len);
         expect(last?.total).toBe(len);
@@ -94,7 +94,7 @@ describe('fetchAdapter streaming (ADR 0005 Decision 9)', () => {
 
         expect(events.length).toBeGreaterThan(0);
         const last = events[events.length - 1];
-        expect(last?.phase).toBe('download');
+        expect(last?.direction).toBe('download');
         expect(last?.loaded).toBeGreaterThan(0);
         expect(last?.total).toBeUndefined(); // omitted, never guessed
     });

--- a/packages/core/test/adapter-upload-progress.spec.ts
+++ b/packages/core/test/adapter-upload-progress.spec.ts
@@ -201,8 +201,12 @@ describe('the teaching event stays quiet when it should', () => {
         // ...and translates an axios progress event into AdapterProgress.
         cfg?.onUploadProgress?.({ loaded: 5, total: 10 });
         cfg?.onDownloadProgress?.({ loaded: 3 });
-        expect(seen).toContainEqual({ phase: 'upload', loaded: 5, total: 10 });
-        expect(seen).toContainEqual({ phase: 'download', loaded: 3 });
+        expect(seen).toContainEqual({
+            direction: 'upload',
+            loaded: 5,
+            total: 10,
+        });
+        expect(seen).toContainEqual({ direction: 'download', loaded: 3 });
     });
 
     test('axios with onProgress but no body does not wire progress on a GET', async () => {

--- a/packages/core/test/cache.spec.ts
+++ b/packages/core/test/cache.spec.ts
@@ -32,7 +32,7 @@ function fpSchema(
 // Reference strategy: distinct `__desc` → distinct token; ABSTAINS (value null) on `{ opaque }`.
 const testFingerprinter: SchemaFingerprinter = {
     vendor: 'test',
-    supports: '*',
+    range: '*',
     fingerprint(schema) {
         const desc = (schema as { __desc?: unknown }).__desc;
         if (desc && typeof desc === 'object' && 'opaque' in desc)
@@ -85,7 +85,7 @@ describe('cache — hit / miss', () => {
             url: URL,
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
         });
         expect(await s()).toEqual({ n: 1 });
         expect(await s()).toEqual({ n: 1 }); // same value, no second origin call
@@ -98,7 +98,7 @@ describe('cache — hit / miss', () => {
             url: URL,
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
         });
         await s({ query: { id: 1 } });
         await s({ query: { id: 2 } });
@@ -116,7 +116,7 @@ describe('cache — hit / miss', () => {
             url: URL,
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app', vary: 'accept-language' },
+            cache: { ttl: '60s', tenancy: 'app', vary: 'accept-language' },
         });
         await s({ headers: { 'accept-language': 'en' } });
         await s({ headers: { 'accept-language': 'fr' } });
@@ -131,7 +131,7 @@ describe('cache — hit / miss', () => {
             url: URL,
             adapter,
             trace: false,
-            cache: { ttl: 30, scope: 'app' },
+            cache: { ttl: 30, tenancy: 'app' },
         });
         await s();
         await s();
@@ -148,7 +148,7 @@ describe('cache — hit / miss', () => {
             method: 'POST',
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
         });
         await s();
         await s();
@@ -163,7 +163,7 @@ describe('cache — in-process coalescing', () => {
             url: URL,
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
         });
         const results = await Promise.all([s(), s(), s(), s(), s()]);
         for (const r of results) expect(r).toEqual({ n: 1 });
@@ -178,7 +178,7 @@ describe('cache — in-process coalescing', () => {
             url: URL,
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
         });
         const settled = await Promise.allSettled([s(), s(), s()]);
         const rejected = settled.filter((r) => r.status === 'rejected');
@@ -192,7 +192,7 @@ describe('cache — in-process coalescing', () => {
             url: URL,
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app', coalesce: false },
+            cache: { ttl: '60s', tenancy: 'app', coalesce: false },
         });
         await Promise.all([s(), s(), s()]); // not collapsed
         expect(calls()).toBe(3);
@@ -208,7 +208,7 @@ describe('cache — invalidation', () => {
             url: URL,
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
         });
         await s({ query: { id: 1 } });
         await s({ query: { id: 2 } });
@@ -226,7 +226,7 @@ describe('cache — invalidation', () => {
             url: URL,
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
         });
         await s({ query: { id: 1 } });
         await s({ query: { id: 2 } });
@@ -247,7 +247,7 @@ describe('cache — invalidation', () => {
         });
         const users = api.stitch({
             path: '/users',
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
         });
         await users();
         await users();
@@ -267,11 +267,11 @@ describe('cache — invalidation', () => {
         });
         const users = api.stitch({
             path: '/users',
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
         });
         const orders = api.stitch({
             path: '/orders',
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
         });
         await users();
         await orders();
@@ -289,7 +289,7 @@ describe('cache — invalidation', () => {
             url: URL,
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
         });
         const k1 = await s.cache.keyOf({ query: { id: 1 } });
         const k2 = await s.cache.keyOf({ query: { id: 1 } });
@@ -307,7 +307,7 @@ describe('cache — LRU bound', () => {
             url: URL,
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app', entries: 2 },
+            cache: { ttl: '60s', tenancy: 'app', entries: 2 },
         });
         await s({ query: { id: 1 } }); // 1
         await s({ query: { id: 2 } }); // 2
@@ -348,7 +348,7 @@ describe('cache — LRU bound', () => {
                 adapter,
                 trace: false,
                 store: rejectingOnEvict,
-                cache: { ttl: '60s', scope: 'app', entries: 1 },
+                cache: { ttl: '60s', tenancy: 'app', entries: 1 },
             });
             // entries:1 → the second distinct key evicts the first via `store.set(oldest, undefined)`.
             await expect(s({ query: { id: 1 } })).resolves.toEqual({ n: 1 });
@@ -370,7 +370,7 @@ describe('cache — sensitive bypass', () => {
             url: URL,
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
             sensitive: true,
         });
         await Promise.all([s(), s()]); // not coalesced
@@ -388,7 +388,7 @@ describe('cache — scope isolation', () => {
             adapter,
             trace: false,
         });
-        const def = { path: '/me', cache: { ttl: '60s' } }; // default scope: 'principal'
+        const def = { path: '/me', cache: { ttl: '60s' } }; // default tenancy: 'principal'
         const alice = api.as('alice').stitch(def);
         const bob = api.as('bob').stitch(def);
 
@@ -410,7 +410,7 @@ describe('cache — scope isolation', () => {
         });
         const def = {
             path: '/pub',
-            cache: { ttl: '60s', scope: 'app' as const },
+            cache: { ttl: '60s', tenancy: 'app' as const },
         };
         const alice = api.as('alice').stitch(def);
         const bob = api.as('bob').stitch(def);
@@ -441,7 +441,7 @@ describe('cache — re-validate on hit vs version fast path', () => {
             trace: false as const,
             cache: {
                 ttl: '60s',
-                scope: 'app' as const,
+                tenancy: 'app' as const,
                 onUnfingerprintable: 'revalidate' as const,
             },
         };
@@ -471,7 +471,7 @@ describe('cache — re-validate on hit vs version fast path', () => {
             adapter,
             store,
             trace: false as const,
-            cache: { ttl: '60s', scope: 'app' as const, version: '1' },
+            cache: { ttl: '60s', tenancy: 'app' as const, version: '1' },
         };
         const writer = stitch(base);
         const reader = stitch({
@@ -498,7 +498,7 @@ describe('cache — schema fingerprint fold (ADR 0004)', () => {
             url: URL,
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
         });
         expect(await s()).toEqual({ n: 1 });
         const trace = await cacheTrace(s.stream());
@@ -517,7 +517,7 @@ describe('cache — schema fingerprint fold (ADR 0004)', () => {
             adapter,
             store,
             trace: false as const,
-            cache: { ttl: '60s', scope: 'app' as const },
+            cache: { ttl: '60s', tenancy: 'app' as const },
         };
         const v1 = stitch({ ...base, output: fpSchema('v1') });
         expect(await v1()).toEqual({ n: 1 });
@@ -541,7 +541,7 @@ describe('cache — schema fingerprint fold (ADR 0004)', () => {
             url: URL,
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
             output: fpSchema({ opaque: true }),
         });
         const trace = await cacheTrace(s.stream());
@@ -560,7 +560,7 @@ describe('cache — schema fingerprint fold (ADR 0004)', () => {
             trace: false,
             cache: {
                 ttl: '60s',
-                scope: 'app',
+                tenancy: 'app',
                 onUnfingerprintable: 'revalidate',
             },
             output: fpSchema({ opaque: true }), // abstains → policy 'revalidate'
@@ -578,7 +578,7 @@ describe('cache — schema fingerprint fold (ADR 0004)', () => {
             name: 'tx',
             adapter: refused.adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
             transform: (b) => b, // opaque closure, no transformVersion/trustTransform → refuse
         });
         const trace = await cacheTrace(r.stream());
@@ -593,7 +593,7 @@ describe('cache — schema fingerprint fold (ADR 0004)', () => {
             name: 'txv',
             adapter: versioned.adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app', transformVersion: '1' },
+            cache: { ttl: '60s', tenancy: 'app', transformVersion: '1' },
             transform: (b) => b, // now sound (version named) → fast
         });
         await v();
@@ -612,7 +612,7 @@ describe('cache — GraphQL opt-in', () => {
             document: '{ me { id } }',
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app', methods: ['POST'] },
+            cache: { ttl: '60s', tenancy: 'app', methods: ['POST'] },
         });
         expect(await q()).toEqual({ me: { id: 1 } });
         await q();
@@ -628,7 +628,7 @@ describe('cache — GraphQL opt-in', () => {
             document: '{ me { id } }',
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app', methods: 'POST' },
+            cache: { ttl: '60s', tenancy: 'app', methods: 'POST' },
         });
         expect(await q()).toEqual({ me: { id: 1 } });
         await q();
@@ -644,7 +644,7 @@ describe('cache — GraphQL opt-in', () => {
             document: '{ me { id } }',
             adapter,
             trace: false,
-            cache: { ttl: '60s', scope: 'app' }, // default methods GET/HEAD → POST excluded
+            cache: { ttl: '60s', tenancy: 'app' }, // default methods GET/HEAD → POST excluded
         });
         await q();
         await q();
@@ -660,7 +660,7 @@ describe('cache — non-storable pass-through', () => {
             adapter,
             responseType: 'arrayBuffer',
             trace: false,
-            cache: { ttl: '60s', scope: 'app' },
+            cache: { ttl: '60s', tenancy: 'app' },
         });
         let bypass = false;
         for await (const ev of s.stream()) {

--- a/packages/core/test/download.spec.ts
+++ b/packages/core/test/download.spec.ts
@@ -151,8 +151,8 @@ describe('filename parsing (Decision 8)', () => {
 describe('byte progress (Decision 9, threaded per-call)', () => {
     test('input.onProgress is threaded into the request and fired', async () => {
         const adapter: Adapter = (req) => {
-            req.onProgress?.({ phase: 'download', loaded: 5, total: 10 });
-            req.onProgress?.({ phase: 'download', loaded: 10, total: 10 });
+            req.onProgress?.({ direction: 'download', loaded: 5, total: 10 });
+            req.onProgress?.({ direction: 'download', loaded: 10, total: 10 });
             return Promise.resolve({
                 status: 200,
                 headers: {},
@@ -168,8 +168,8 @@ describe('byte progress (Decision 9, threaded per-call)', () => {
             },
         });
         expect(seen).toEqual([
-            { phase: 'download', loaded: 5, total: 10 },
-            { phase: 'download', loaded: 10, total: 10 },
+            { direction: 'download', loaded: 5, total: 10 },
+            { direction: 'download', loaded: 10, total: 10 },
         ]);
     });
 });
@@ -241,7 +241,7 @@ describe('download over real fetch + mock server (browser-first)', () => {
         );
         // progress fired for the download phase
         expect(seen.length).toBeGreaterThan(0);
-        expect(seen.every((p) => p.phase === 'download')).toBe(true);
+        expect(seen.every((p) => p.direction === 'download')).toBe(true);
         expect(server.calls('/file')[0]?.method).toBe('GET');
     });
 

--- a/packages/core/test/fingerprint.spec.ts
+++ b/packages/core/test/fingerprint.spec.ts
@@ -50,7 +50,7 @@ function canonical(value: unknown): string {
 // Reference strategy: canonicalise + hash the descriptor; abstain on `opaque`.
 const refFingerprinter: SchemaFingerprinter = {
     vendor: 'test',
-    supports: '*',
+    range: '*',
     fingerprint(schema) {
         const desc = (schema as { __desc?: unknown }).__desc;
         if (desc && typeof desc === 'object' && 'opaque' in desc) {
@@ -93,7 +93,7 @@ describe('registry', () => {
     it('last registration for a vendor wins', () => {
         const other: SchemaFingerprinter = {
             vendor: 'test',
-            supports: '*',
+            range: '*',
             fingerprint: () => ({ token: 'x', strength: 'strong' }),
         };
         registerFingerprinter(refFingerprinter);
@@ -314,7 +314,7 @@ describe('verifyFingerprintContract', () => {
     it('a constant-token strategy fails distinct + abstain, as a report', () => {
         const broken: SchemaFingerprinter = {
             vendor: 'test',
-            supports: '*',
+            range: '*',
             fingerprint: () => ({ token: 'CONST', strength: 'strong' }),
         };
         const report = verifyFingerprintContract(broken, goodFixtures);
@@ -335,7 +335,7 @@ describe('verifyFingerprintContract', () => {
         // Deliberately violates the synchronous contract (cast through unknown).
         const asyncFp = {
             vendor: 'test',
-            supports: '*',
+            range: '*',
             fingerprint: () =>
                 Promise.resolve({ token: 'x', strength: 'strong' }),
         } as unknown as SchemaFingerprinter;

--- a/packages/core/test/gaps/cookie-session-hooks.spec.ts
+++ b/packages/core/test/gaps/cookie-session-hooks.spec.ts
@@ -164,7 +164,7 @@ test("onAuthFailure fires category 'unauthenticated' when the login returns 401 
     await expect(data()).rejects.toThrow();
 
     expect(failures).toEqual([
-        { phase: 'apply', status: 401, category: 'unauthenticated' },
+        { step: 'apply', status: 401, category: 'unauthenticated' },
     ]);
     // onRefresh still fired, reporting the failed outcome.
     expect(refreshes).toEqual([{ ok: false, status: 401 }]);
@@ -201,7 +201,7 @@ test("onAuthFailure fires category 'rate-limited' + retryAfter when the login re
 
     expect(failures).toEqual([
         {
-            phase: 'apply',
+            step: 'apply',
             status: 429,
             category: 'rate-limited',
             retryAfter: 7000,
@@ -243,7 +243,7 @@ test("onAuthFailure fires category 'network' + error when the login stitch throw
 
     expect(failures).toHaveLength(1);
     const f = failures[0]!;
-    expect(f.phase).toBe('apply');
+    expect(f.step).toBe('apply');
     expect(f.category).toBe('network');
     expect(f.status).toBeUndefined(); // no response, so no status
     expect(f.error).toBeInstanceOf(Error); // the thrown transport error rides along

--- a/packages/core/test/inspect-redact.spec.ts
+++ b/packages/core/test/inspect-redact.spec.ts
@@ -205,7 +205,7 @@ test('redact: true leaves raw null on a streaming surface (no-op)', async () => 
         url: URL,
         adapter,
         trace: false,
-        cache: { ttl: '60s', scope: 'app' },
+        cache: { ttl: '60s', tenancy: 'app' },
     });
     await s(); // warm the cache
     const r = await s.inspect(undefined, { cache: true, redact: true });

--- a/packages/core/test/inspect.spec.ts
+++ b/packages/core/test/inspect.spec.ts
@@ -153,7 +153,7 @@ test('default .inspect() neither reads nor writes the cache (repeatable)', async
         url: URL,
         adapter,
         trace: false,
-        cache: { ttl: '60s', scope: 'app' },
+        cache: { ttl: '60s', tenancy: 'app' },
     });
     // Two inspects → two live origin calls: it never serves a prior entry (no read) ...
     await s.inspect();
@@ -177,7 +177,7 @@ test('{ cache: true }: a cache hit yields value but raw null', async () => {
         url: URL,
         adapter,
         trace: false,
-        cache: { ttl: '60s', scope: 'app' },
+        cache: { ttl: '60s', tenancy: 'app' },
     });
     expect(await s()).toEqual({ n: 1 }); // warm the cache
     expect(calls()).toBe(1);
@@ -196,7 +196,7 @@ test('the bare `true` is the `{ cache: true }` probe (P13)', async () => {
         url: URL,
         adapter,
         trace: false,
-        cache: { ttl: '60s', scope: 'app' },
+        cache: { ttl: '60s', tenancy: 'app' },
     });
     expect(await s()).toEqual({ n: 1 }); // warm the cache
     expect(calls()).toBe(1);

--- a/packages/core/test/report.spec.ts
+++ b/packages/core/test/report.spec.ts
@@ -85,7 +85,7 @@ test('source: a cache hit is "cache" with raw null', async () => {
         url: URL,
         adapter,
         trace: false,
-        cache: { ttl: '60s', scope: 'app' },
+        cache: { ttl: '60s', tenancy: 'app' },
     });
     expect(await s()).toEqual({ n: 1 }); // warm the cache
     expect(calls()).toBe(1);
@@ -172,7 +172,7 @@ test('report: cache is "bypass" by default on a cached stitch', async () => {
         url: URL,
         adapter,
         trace: false,
-        cache: { ttl: '60s', scope: 'app' },
+        cache: { ttl: '60s', tenancy: 'app' },
     });
     const r = await s.report(); // default → bypassCache
     expect(r.cache).toBe('bypass');
@@ -189,7 +189,7 @@ test('report: cache is "miss" then "hit" with { cache: true }', async () => {
         url: URL,
         adapter,
         trace: false,
-        cache: { ttl: '60s', scope: 'app' },
+        cache: { ttl: '60s', tenancy: 'app' },
     });
     const miss = await s.report(undefined, { cache: true }); // cold cache → miss
     expect(miss.cache).toBe('miss');

--- a/packages/core/test/validator.spec.ts
+++ b/packages/core/test/validator.spec.ts
@@ -93,9 +93,9 @@ describe('toValidator: source attachment (ADR 0004)', () => {
     test('attaches the raw schema as a NON-enumerable `source`', () => {
         const zodLike = { safeParse: () => ({ success: true, data: 1 }) };
         const v = toValidator(zodLike)!;
-        expect(v.source).toBe(zodLike); // readable for cache fingerprinting
-        expect(Object.keys(v)).not.toContain('source'); // never enumerated
-        expect(Object.getOwnPropertyDescriptor(v, 'source')?.enumerable).toBe(
+        expect(v.schema).toBe(zodLike); // readable for cache fingerprinting
+        expect(Object.keys(v)).not.toContain('schema'); // never enumerated
+        expect(Object.getOwnPropertyDescriptor(v, 'schema')?.enumerable).toBe(
             false,
         );
     });

--- a/packages/core/test/xhr-adapter.spec.ts
+++ b/packages/core/test/xhr-adapter.spec.ts
@@ -101,14 +101,14 @@ describe('xhrAdapter (ADR 0005 Decision 9)', () => {
             headers: { 'content-type': 'application/json' },
             body: { ok: true },
         });
-        const phases = events.map((e) => e.phase);
+        const phases = events.map((e) => e.direction);
         expect(phases).toContain('upload');
         expect(phases).toContain('download');
         expect(phases.indexOf('upload')).toBeLessThan(
             phases.indexOf('download'),
         );
         // upload progress carries byte counts (the whole point of this adapter)
-        expect(events.find((e) => e.phase === 'upload')).toMatchObject({
+        expect(events.find((e) => e.direction === 'upload')).toMatchObject({
             loaded: 5,
             total: 10,
         });

--- a/packages/fingerprint-arktype/src/index.ts
+++ b/packages/fingerprint-arktype/src/index.ts
@@ -114,7 +114,7 @@ function describe(schema: unknown): string {
  */
 export const arktypeFingerprinter: SchemaFingerprinter = {
     vendor: 'arktype',
-    supports: '^2.0.0',
+    range: '^2.0.0',
     fingerprint(schema) {
         try {
             // `afp1` tags the descriptor format: bump it to force a one-time,

--- a/packages/fingerprint-arktype/test/conformance.spec.ts
+++ b/packages/fingerprint-arktype/test/conformance.spec.ts
@@ -151,7 +151,7 @@ describe('@stitchapi/fingerprint-arktype', () => {
 
     it('declares the arktype vendor and a supported range', () => {
         expect(arktypeFingerprinter.vendor).toBe('arktype');
-        expect(arktypeFingerprinter.supports).toBe('^2.0.0');
+        expect(arktypeFingerprinter.range).toBe('^2.0.0');
     });
 
     it('abstains (null) on an opaque morph but fingerprints its base shape', () => {

--- a/packages/fingerprint-effect/src/index.ts
+++ b/packages/fingerprint-effect/src/index.ts
@@ -147,7 +147,7 @@ function describeAst(ast: AnyAst): string {
  */
 export const effectFingerprinter: SchemaFingerprinter = {
     vendor: 'effect',
-    supports: '^3.0.0',
+    range: '^3.0.0',
     fingerprint(schema) {
         try {
             const ast = (schema as { ast?: unknown }).ast;

--- a/packages/fingerprint-effect/test/conformance.spec.ts
+++ b/packages/fingerprint-effect/test/conformance.spec.ts
@@ -132,7 +132,7 @@ describe('@stitchapi/fingerprint-effect', () => {
 
     it('declares the effect vendor and a supported range', () => {
         expect(effectFingerprinter.vendor).toBe('effect');
-        expect(effectFingerprinter.supports).toBe('^3.0.0');
+        expect(effectFingerprinter.range).toBe('^3.0.0');
     });
 
     it('abstains (null) on an opaque refinement but fingerprints its base type', () => {

--- a/packages/fingerprint-typebox/src/index.ts
+++ b/packages/fingerprint-typebox/src/index.ts
@@ -143,7 +143,7 @@ function describeRoot(schema: unknown): string {
  */
 export const typeboxFingerprinter: SchemaFingerprinter = {
     vendor: 'typebox',
-    supports: '^0.34.0',
+    range: '^0.34.0',
     fingerprint(schema) {
         try {
             // `tbfp1` tags the descriptor format: bump it to force a one-time,

--- a/packages/fingerprint-typebox/test/conformance.spec.ts
+++ b/packages/fingerprint-typebox/test/conformance.spec.ts
@@ -216,7 +216,7 @@ describe('@stitchapi/fingerprint-typebox', () => {
 
     it('declares the typebox vendor and a supported range', () => {
         expect(typeboxFingerprinter.vendor).toBe('typebox');
-        expect(typeboxFingerprinter.supports).toContain('0.34');
+        expect(typeboxFingerprinter.range).toContain('0.34');
     });
 
     it('abstains (null) on an opaque transform but fingerprints its base shape', () => {

--- a/packages/fingerprint-valibot/src/index.ts
+++ b/packages/fingerprint-valibot/src/index.ts
@@ -239,7 +239,7 @@ function describe(schema: unknown): string {
  */
 export const valibotFingerprinter: SchemaFingerprinter = {
     vendor: 'valibot',
-    supports: '^1.0.0',
+    range: '^1.0.0',
     fingerprint(schema) {
         try {
             // `vfp1` tags the descriptor format: bump it to force a one-time,

--- a/packages/fingerprint-valibot/test/conformance.spec.ts
+++ b/packages/fingerprint-valibot/test/conformance.spec.ts
@@ -205,7 +205,7 @@ describe('@stitchapi/fingerprint-valibot', () => {
 
     it('declares the valibot vendor and a supported range', () => {
         expect(valibotFingerprinter.vendor).toBe('valibot');
-        expect(valibotFingerprinter.supports).toBe('^1.0.0');
+        expect(valibotFingerprinter.range).toBe('^1.0.0');
     });
 
     it('abstains (null) on an opaque check but fingerprints its base shape', () => {

--- a/packages/fingerprint-zod/src/index.ts
+++ b/packages/fingerprint-zod/src/index.ts
@@ -292,7 +292,7 @@ function describe(schema: unknown): string {
  */
 export const zodFingerprinter: SchemaFingerprinter = {
     vendor: 'zod',
-    supports: '^3.24.0 || ^4.0.0',
+    range: '^3.24.0 || ^4.0.0',
     fingerprint(schema) {
         try {
             // `zfp1` tags the descriptor format: bump it to force a one-time,

--- a/packages/fingerprint-zod/test/conformance.spec.ts
+++ b/packages/fingerprint-zod/test/conformance.spec.ts
@@ -169,7 +169,7 @@ describe('@stitchapi/fingerprint-zod', () => {
 
     it('declares the zod vendor and a supported range', () => {
         expect(zodFingerprinter.vendor).toBe('zod');
-        expect(zodFingerprinter.supports).toContain('3.24');
+        expect(zodFingerprinter.range).toContain('3.24');
     });
 
     it('abstains (null) on an opaque refine but fingerprints its base shape', () => {


### PR DESCRIPTION
Five public tokens each carried two concepts or two value-spaces. **Pre-GA each is one commit;
after the tag, [P19](https://github.com/rejifald/StitchAPI/blob/main/docs/CONTRACT.md) makes each a
deprecation cycle plus a major.** That asymmetry is the whole reason these go now.

GA blocker #2 from the readiness assessment.

## The renames

| was | now | why |
| --- | --- | --- |
| `CacheOptions.scope` | **`tenancy`** | the identical `'principal' \| 'app'` axis is `tenancy` on `OAuth2Options` / `CookieSessionOptions`; `scope` is the OAuth **permission string**, so one word meant two things |
| `Validator.source` | **`schema`** | `Inspection.source` is data **provenance** (`'live' \| 'cache' \| 'stream'`); both are exported from the `stitchapi` root barrel, so the collision was reachable in one import |
| `SchemaFingerprinter.supports` | **`range`** | holds a **semver range** (`'^4'`), while `AdapterCapabilities.supports` holds a **list** — and both sit on P21 seams third parties implement |
| `AdapterProgress.phase` | **`direction`** | `'upload' \| 'download'` is a direction, not a phase |
| `AuthFailureResult.phase` | **`step`** | leaves `phase` meaning exactly one thing |

`phase` had **three** value-spaces, not two. Renaming the two that were not the request lifecycle
leaves `ProgressPhase` on `StitchEvent` untouched — so every existing progress handler, and
`event.phase` throughout the docs, keeps working unchanged.

## Read this before reviewing: the rename was partly *silent*

After renaming `scope` → `tenancy`, nine call sites still passing `cache: { ttl, scope: 'app' }`
**did not fail to compile**. `AtLeastOne<CacheOptions>` is a union of intersections, and
TypeScript's excess-property check does not fire through it — so those sites silently degraded to
the `'principal'` default. Only the runtime tests caught it.

A consumer migrating across this hits the same silence: no error, just a cache that quietly stops
being shared. That is an argument for landing it **now**, with a migration note, rather than
discovering it after GA.

## Scope decisions

- **ADRs keep the old spellings.** They record what was decided at the time — the same reasoning
  that keeps §6's Shipped list in the past tense.
- **Docs migrated only where they name a renamed field.** `event.phase` on a progress event is
  still correct and is untouched; `AdapterCapabilities.supports` keeps its name.
- **Two pages quoted the engine's runtime warning string verbatim** and had to move with it — it
  now reads `only 'direction: download' events fire`.
- **The blog fences compile.** `upload-a-file-with-a-progress-bar.mdx` uses ```ts twoslash, so it
  failed the docs **build** on `p.phase` — a grep of the docs would not have caught it. Fixed and
  verified by a full build.

No `@deprecated` aliases — pre-GA hard break per **D5**, and **R7** would flag one.

## Verification

- `pnpm -r check:types` — 38 packages, clean
- `pnpm -r test` — ~1,700 tests green across every package
- `pnpm --filter @stitchapi/docs build` — **438 pages, no twoslash failures**
- `check:contract` → 0 violations; prettier clean; docs links green (110 routes)

## Still open from the same P1/P2 family

`StdioOptions.input`/`output` → `stdin`/`stdout`
([#561](https://github.com/rejifald/StitchAPI/issues/561)) — deliberately not bundled here, since
it lands on the `stitchapi/mcp` subpath rather than core's shared vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
