### PR TITLE
fix: close the last three small contract violations — and a bug in `AtLeastOne`

### DIFF
--- a/packages/core/src/mcp.ts
+++ b/packages/core/src/mcp.ts
@@ -290,8 +290,16 @@ export function createMcpServer(
 }
 
 export interface StdioOptions {
-    input?: Readable;
-    output?: Writable;
+    /** The stream JSON-RPC messages are read from. Default `process.stdin`.
+     *
+     *  Spelled `stdin`, not `input`: `input` is the request **schema** slot everywhere else on the
+     *  surface (`StitchConfig.input`, `InputSchemas`, postmessage's `RequestOptions`), and one word
+     *  may not mean two things (CONTRACT.md P2). `stdin` is also what Node and the MCP SDK's
+     *  `StdioServerTransport` call it, so P18 points the same way. */
+    stdin?: Readable;
+    /** The stream JSON-RPC responses are written to. Default `process.stdout`. See {@link
+     *  StdioOptions.stdin} for why it is not `output`. */
+    stdout?: Writable;
     /**
      * Identity this server reports (see {@link McpServerOptions}). A bare string is shorthand for
      * the name — `server: 'orders-api'` ≡ `server: { name: 'orders-api' }` (CONTRACT.md P14); the
@@ -301,16 +309,16 @@ export interface StdioOptions {
 }
 
 // Wire an McpServer to the stdio transport: read newline-delimited JSON-RPC from
-// `input`, write newline-delimited responses to `output`. Messages are processed in
+// `stdin`, write newline-delimited responses to `stdout`. Messages are processed in
 // order. Returns a handle that detaches the listener.
 export function serveStdio(
     registry: StitchRegistry,
     opts: StdioOptions = {},
 ): { server: McpServer; close: () => void } {
     const server = createMcpServer(registry, opts.server);
-    const input = opts.input ?? process.stdin;
-    const output = opts.output ?? process.stdout;
-    input.setEncoding('utf8');
+    const stdin = opts.stdin ?? process.stdin;
+    const stdout = opts.stdout ?? process.stdout;
+    stdin.setEncoding('utf8');
 
     let buffer = '';
     let chain: Promise<void> = Promise.resolve();
@@ -320,13 +328,13 @@ export function serveStdio(
         try {
             message = JSON.parse(line) as JsonRpcMessage;
         } catch {
-            output.write(
+            stdout.write(
                 `${JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'parse error' } })}\n`,
             );
             return;
         }
         const response = await server.handle(message);
-        if (response) output.write(`${JSON.stringify(response)}\n`);
+        if (response) stdout.write(`${JSON.stringify(response)}\n`);
     };
 
     const onData = (chunk: string): void => {
@@ -339,6 +347,6 @@ export function serveStdio(
         }
     };
 
-    input.on('data', onData);
-    return { server, close: () => input.off('data', onData) };
+    stdin.on('data', onData);
+    return { server, close: () => stdin.off('data', onData) };
 }

--- a/packages/core/src/test-mock.ts
+++ b/packages/core/src/test-mock.ts
@@ -5,7 +5,12 @@
 // runner or a browser. For deep transport semantics over a real socket the lib still uses the node
 // mock server internally; this is the published, isomorphic counterpart.
 import { streamOf } from './test-stream';
-import type { Adapter, AdapterRequest, AdapterResponse } from './types';
+import type {
+    Adapter,
+    AdapterRequest,
+    AdapterResponse,
+    AtLeastOne,
+} from './types';
 import { parseDuration } from './util';
 
 /** One canned response. Omitted fields default sensibly (`status` 200, empty headers). */
@@ -37,9 +42,14 @@ export interface MockCall {
     req: AdapterRequest;
 }
 
-/** A route's response: one fixed reply, a per-call sequence (last entry repeats), or a function. */
+/** A route's response: one fixed reply, a per-call sequence (last entry repeats), or a function.
+ *
+ *  The single-reply form is `AtLeastOne<MockResponse>`, so the opaque `respond: {}` is a compile
+ *  error (CONTRACT.md P20) — say `{ status: 200 }` if that is what you mean. A responder FUNCTION
+ *  may still return a bare `MockResponse` (computed, not authored), and a SEQUENCE entry stays
+ *  plain: inside an explicit list, a default-200 slot is a positional statement, not an opaque bag. */
 export type MockResponder =
-    | MockResponse
+    | AtLeastOne<MockResponse>
     | MockResponse[]
     | ((call: MockCall) => MockResponse | Promise<MockResponse>);
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -22,7 +22,12 @@ import type { Validator } from './validator';
  * (`true`), never the opaque `{}` (CONTRACT.md P20).
  */
 export type AtLeastOne<T, K extends keyof T = keyof T> = {
-    [P in K]: Required<Pick<T, P>> & Partial<Omit<T, P>>;
+    // `-?` is load-bearing. This mapped type is HOMOMORPHIC (`P in K` where `K extends keyof T`),
+    // so without it the `?` of every source property is preserved — and since the envelopes this
+    // wraps are all-optional by construction, indexing `[K]` then yields `… | undefined`. The
+    // resulting type still rejects `{}`, so P20 held, but the stray `undefined` leaked into every
+    // consumer that narrowed one of these unions (it surfaced on `MockResponder`).
+    [P in K]-?: Required<Pick<T, P>> & Partial<Omit<T, P>>;
 }[K];
 
 export interface StitchInput {

--- a/packages/core/test/mcp-stdio-transport.spec.ts
+++ b/packages/core/test/mcp-stdio-transport.spec.ts
@@ -25,7 +25,7 @@ function setup(): {
     const input = new PassThrough();
     const output = new PassThrough();
     output.setEncoding('utf8');
-    const { close } = serveStdio({}, { input, output });
+    const { close } = serveStdio({}, { stdin: input, stdout: output });
     return { input, output, close };
 }
 

--- a/packages/core/test/mcp.spec.ts
+++ b/packages/core/test/mcp.spec.ts
@@ -295,7 +295,7 @@ test('serveStdio speaks newline-delimited JSON-RPC (tools/list)', async () => {
     const input = new PassThrough();
     const output = new PassThrough();
     output.setEncoding('utf8');
-    const { close } = serveStdio({ ping }, { input, output });
+    const { close } = serveStdio({ ping }, { stdin: input, stdout: output });
     try {
         const pending = nextMessage(output);
         input.write(`${JSON.stringify(req('tools/list'))}\n`);
@@ -314,7 +314,7 @@ test('a run_stitch call over stdio returns the result', async () => {
     const input = new PassThrough();
     const output = new PassThrough();
     output.setEncoding('utf8');
-    const { close } = serveStdio({ ping }, { input, output });
+    const { close } = serveStdio({ ping }, { stdin: input, stdout: output });
     try {
         const pending = nextMessage(output);
         input.write(

--- a/packages/core/test/mock-adapter-extras.spec.ts
+++ b/packages/core/test/mock-adapter-extras.spec.ts
@@ -85,7 +85,9 @@ describe('mockAdapter spy', () => {
     });
 
     test('lastRequest() is undefined before any call', () => {
-        expect(mockAdapter({ respond: {} }).lastRequest()).toBeUndefined();
+        expect(
+            mockAdapter({ respond: { status: 200 } }).lastRequest(),
+        ).toBeUndefined();
     });
 
     test('reset() clears the log and restarts each route counter', async () => {

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -65,7 +65,17 @@ function access<T>(value: MaybeAccessor<T>): T {
     return typeof value === 'function' ? (value as () => T)() : value;
 }
 
-export interface CreateStitchOptions<T> extends CreateStitchQueryOptions<T> {}
+/**
+ * Options accepted by {@link createStitch} / {@link createStitchStream}.
+ *
+ * The store's `streaming` flag is deliberately OMITTED: each primitive hard-sets it
+ * (`createStitch` → unary, `createStitchStream` → streaming), so passing it would be
+ * silently ignored — the type forbids it instead. Matches react/vue/angular (CONTRACT.md P16).
+ */
+export interface CreateStitchOptions<T> extends Omit<
+    CreateStitchQueryOptions<T>,
+    'streaming'
+> {}
 
 // ---------------------------------------------------------------------------
 // Shared driver

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -141,17 +141,17 @@ function makeStore<T>(
 export function stitchStore<S extends StitchLike<unknown, never>>(
     stitch: S,
     input: QueryInput<S>,
-    options?: CreateStitchQueryOptions<QueryOutput<S>>,
+    options?: Omit<CreateStitchQueryOptions<QueryOutput<S>>, 'streaming'>,
 ): SvelteStitchStore<QueryOutput<S>>;
 export function stitchStore<T, Input = unknown>(
     stitch: StitchLike<T, Input>,
     input: Input,
-    options?: CreateStitchQueryOptions<T>,
+    options?: Omit<CreateStitchQueryOptions<T>, 'streaming'>,
 ): SvelteStitchStore<T>;
 export function stitchStore<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
-    options: CreateStitchQueryOptions<T> = {},
+    options: Omit<CreateStitchQueryOptions<T>, 'streaming'> = {},
 ): SvelteStitchStore<T> {
     return makeStore<T>(stitch, input, { ...options, streaming: false });
 }
@@ -180,17 +180,17 @@ export function stitchStore<T>(
 export function stitchStreamStore<S extends StitchLike<unknown, never>>(
     stitch: S,
     input: QueryInput<S>,
-    options?: CreateStitchQueryOptions<QueryOutput<S>>,
+    options?: Omit<CreateStitchQueryOptions<QueryOutput<S>>, 'streaming'>,
 ): SvelteStitchStore<QueryOutput<S>>;
 export function stitchStreamStore<T, Input = unknown>(
     stitch: StitchLike<T, Input>,
     input: Input,
-    options?: CreateStitchQueryOptions<T>,
+    options?: Omit<CreateStitchQueryOptions<T>, 'streaming'>,
 ): SvelteStitchStore<T>;
 export function stitchStreamStore<T>(
     stitch: StitchLike<T, unknown>,
     input: unknown,
-    options: CreateStitchQueryOptions<T> = {},
+    options: Omit<CreateStitchQueryOptions<T>, 'streaming'> = {},
 ): SvelteStitchStore<T> {
     return makeStore<T>(stitch, input, { ...options, streaming: true });
 }


### PR DESCRIPTION
GA blockers **4, 5 and 6** — plus a latent defect the third one exposed, which is the part worth
reading.

Closes [#560](https://github.com/rejifald/StitchAPI/issues/560),
[#561](https://github.com/rejifald/StitchAPI/issues/561),
[#564](https://github.com/rejifald/StitchAPI/issues/564).

## The three fixes

**P16 — solid and svelte accepted a `streaming` they ignored.** Both hard-set it
(`createStitch` → unary, `createStitchStream` → streaming) while still typing the caller's option
in, so passing it did nothing at all. react, vue and angular already `Omit` it for exactly this
reason; now all five agree.

**P2 — `StdioOptions.input`/`output` → `stdin`/`stdout`.** `input` and `output` are the request
**schema** slots everywhere else on the surface (`StitchConfig.input`, `InputSchemas`, postmessage's
`RequestOptions`); here they were Node streams. P18 points the same way — Node itself and the MCP
SDK's `StdioServerTransport` both say `stdin`/`stdout`, so the house name was the odd one out.

**P20 — `MockRoute.respond: {}` compiled**, on the published `stitchapi/testing` surface, silently
meaning "default 200". The single-reply arm is now `AtLeastOne<MockResponse>`.

The **sequence** arm deliberately stays plain `MockResponse[]`: inside an explicit list, a
default-200 slot is a *positional statement* (`[{ status: 503 }, {}, { body }]` reads fine), not an
opaque bag. P20 is about the slot you author, not every nested position.

## The bug underneath — worth a look even if you skim the rest

Narrowing the new `MockResponder` union would not compile, and **the cause was not this change**:

```ts
export type AtLeastOne<T, K extends keyof T = keyof T> = {
    [P in K]: Required<Pick<T, P>> & Partial<Omit<T, P>>;
}[K];
```

That mapped type is **homomorphic** (`P in K` where `K extends keyof T`), so it preserves the `?`
of every source property. The envelopes `AtLeastOne` wraps are all-optional *by construction* —
that is its entire purpose — so indexing `[K]` yielded `… | undefined`.

**P20 still held**: `{}` was always correctly rejected. But the stray `undefined` leaked into every
consumer that narrowed one of these unions, everywhere `AtLeastOne` is used across the codebase.
Nothing caught it because it only becomes an error when such a union is narrowed three ways and
assigned to a bare type — which `MockResponder` is the first place to do.

One `-?` fixes it at the source, for every slot.

This is the second time in this GA pass that fixing a violation exposed a defect in the machinery
meant to *enforce* the rule — first R6 could not see four P20 slots
([#556](https://github.com/rejifald/StitchAPI/pull/556)), now `AtLeastOne` was quietly widening the
type it exists to narrow.

## Verification

- `pnpm -r check:types` — **39 packages**, clean
- `pnpm -r test` — full workspace suite green (core 1303, and every peer package)
- `check:contract` → 0 violations
- full pre-push gate green; prettier clean

No `@deprecated` aliases — pre-GA hard break per **D5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
