### PR TITLE
refactor(nest)!: adopt the shared SSE envelope — by lifting nest's extras into it

### DIFF
--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -252,8 +252,12 @@ stream-less adapters (swr / rtk-query / vercel-ai) use an intentional MINIMAL
 await-only `(input?) => PromiseLike<T>` — they never call `.stream()`. A real stitch
 satisfies both tiers. `StreamableStitchLike` is rtk-query's streaming tier of the same
 family; swr's `QueryOutput`/`QueryInput` inference helpers are also surfaced by
-vercel-ai. `StreamStitchSseOptions` / `StitchErrorOptions` are intentionally
-**identical** envelopes declared per host adapter — same name, same shape, by design;
+vercel-ai. `StreamStitchSseOptions` / `StitchErrorOptions` are intentionally **identical** per host
+adapter — and `StreamStitchSseOptions` is identical _by construction_: all six hosts now
+derive it from core's one `SseEmitOptions` (five `extends` it, nest aliases it), rather
+than each declaring a shape that merely happens to match. Nest was the exception until it
+was folded in; its two extras (a frame `index` on `delta.data`, a function form of
+`delta.event`) were lifted INTO the shared envelope so every host gained them;
 `StitchEventSource` is core-owned and re-exported verbatim.
 
 ### P10 · Error-class taxonomy parity

--- a/packages/core/src/sse-emit.ts
+++ b/packages/core/src/sse-emit.ts
@@ -39,8 +39,11 @@ export function toIterable<T>(
 /** The terminal `error` event a stitch stream emits — carries `message`, `status`, `attempts`. */
 export type StitchErrorEvent = Extract<StitchEvent, { type: 'error' }>;
 
-/** Shape a `delta` chunk into the SSE frame `data`. */
-export type DeltaShaper = (chunk: unknown) => string;
+/** Shape a `delta` chunk into the SSE frame `data`. Receives the zero-based frame index alongside
+ *  the chunk, so a shaper can number, batch or checkpoint without keeping its own counter. A
+ *  one-argument shaper stays valid — JS ignores extra arguments and TS accepts the narrower
+ *  signature — so `data: (c) => c.text` needs no change. */
+export type DeltaShaper = (chunk: unknown, index: number) => string;
 /** Shape a terminal `error` event into the SSE frame `data`. */
 export type ErrorShaper = (event: StitchErrorEvent) => string;
 
@@ -52,15 +55,17 @@ export interface DeltaFrameOptions {
     /**
      * Map a `delta` chunk to the SSE frame `data`. Default: the chunk itself (a string is sent
      * as-is; anything else is `JSON.stringify`-ed — see {@link defaultData}). Pull the text out of
-     * a structured chunk with, e.g., `(c) => c.choices[0].delta.content ?? ''`.
+     * a structured chunk with, e.g., `(c) => c.choices[0].delta.content ?? ''`. Receives the
+     * zero-based frame index as a second argument.
      */
     data?: DeltaShaper;
     /**
      * Emit an `event:` line per frame (the SSE event name). Default: none (an unnamed `message`
-     * event, which `EventSource.onmessage` receives). Set it to label the stream's messages on the
-     * client (`event: 'token'`).
+     * event, which `EventSource.onmessage` receives). A fixed string labels every message
+     * (`event: 'token'`); a **function** names them per chunk — e.g. routing tool-calls and text
+     * to different client handlers off one stream.
      */
-    event?: string;
+    event?: string | ((chunk: unknown, index: number) => string);
     /**
      * Provide an `id:` line per frame (the SSE last-event id), e.g. for resumable streams. Receives
      * the chunk and the zero-based frame index.
@@ -181,7 +186,24 @@ export function deltaFrame(
     index: number,
     delta: DeltaFrameOptions,
 ): string {
-    const raw = delta.data?.(chunk) ?? defaultData(chunk);
+    const raw = delta.data?.(chunk, index) ?? defaultData(chunk);
     const id = delta.id ? delta.id(chunk, index) : undefined;
-    return sseFrame(raw, delta.event, id);
+    return sseFrame(raw, deltaEvent(chunk, index, delta), id);
+}
+
+/**
+ * Resolve {@link DeltaFrameOptions.event} for one frame: a fixed name passes through, a function
+ * is called with the chunk and its index, and `undefined` stays `undefined` (an unnamed `message`
+ * event). Exported because the STRUCTURED emitters — Hono's `writeSSE`, Nest's `MessageEvent` —
+ * build their own frame objects instead of going through {@link deltaFrame}, and must not each
+ * re-implement the function-form check.
+ */
+export function deltaEvent(
+    chunk: unknown,
+    index: number,
+    delta: DeltaFrameOptions,
+): string | undefined {
+    return typeof delta.event === 'function'
+        ? delta.event(chunk, index)
+        : delta.event;
 }

--- a/packages/core/test/sse-emit-options.spec.ts
+++ b/packages/core/test/sse-emit-options.spec.ts
@@ -3,7 +3,12 @@
 // compile error. The `AtLeastOne` narrowing forced the fold's default from a `= {}` parameter
 // default to a `?? {}` after the fold, so these assert the RESOLVED value at each spelling —
 // a narrowed type is not a changed runtime, and the no-argument path is the one that moved.
-import { resolveDelta, resolveError } from '../src/sse-emit';
+import {
+    deltaEvent,
+    deltaFrame,
+    resolveDelta,
+    resolveError,
+} from '../src/sse-emit';
 
 test('no argument still resolves to the empty frame (the default moved, the behaviour did not)', () => {
     expect(resolveDelta()).toEqual({});
@@ -43,4 +48,44 @@ test('the empty bag is rejected (compile-time, P20)', () => {
     // @ts-expect-error — same for the terminal error frame
     void resolveError({});
     expect(true).toBe(true);
+});
+
+// The two capabilities lifted out of @stitchapi/nest into the shared envelope (P16), so all six
+// hosts gained them. Asserted on core's own frame builder, because that is what the raw-writer
+// hosts (express/fastify/elysia/next) go through — and `deltaEvent` is what the structured
+// emitters (hono's writeSSE, nest's MessageEvent) call instead.
+describe('delta frames: index + function-form event', () => {
+    test('data receives the zero-based frame index', () => {
+        const delta = { data: (c: unknown, i: number) => `${String(c)}#${i}` };
+        expect(deltaFrame('a', 0, delta)).toContain('data: a#0');
+        expect(deltaFrame('b', 1, delta)).toContain('data: b#1');
+    });
+
+    test('a one-argument shaper still works — widening the signature broke nothing', () => {
+        const delta = { data: (c: unknown) => String(c).toUpperCase() };
+        expect(deltaFrame('a', 7, delta)).toContain('data: A');
+    });
+
+    test('event may be a function of the chunk, naming each frame', () => {
+        const delta = {
+            event: (c: unknown) => (c as { kind: string }).kind,
+            data: (c: unknown) => (c as { text: string }).text,
+        };
+        expect(deltaFrame({ kind: 'token', text: 'a' }, 0, delta)).toContain(
+            'event: token',
+        );
+        expect(deltaFrame({ kind: 'usage', text: 'b' }, 1, delta)).toContain(
+            'event: usage',
+        );
+    });
+
+    test('a fixed event string still labels every frame', () => {
+        expect(deltaFrame('a', 0, { event: 'tick' })).toContain('event: tick');
+    });
+
+    test('deltaEvent resolves both forms and passes undefined through', () => {
+        expect(deltaEvent('a', 0, {})).toBeUndefined();
+        expect(deltaEvent('a', 0, { event: 'tick' })).toBe('tick');
+        expect(deltaEvent('a', 3, { event: (_c, i) => `f${i}` })).toBe('f3');
+    });
 });

--- a/packages/hono/src/sse.ts
+++ b/packages/hono/src/sse.ts
@@ -18,6 +18,7 @@ import {
     type StitchErrorEvent,
     type StitchEventSource,
     defaultData,
+    deltaEvent,
     resolveDelta,
     resolveError,
     toErrorEvent,
@@ -81,8 +82,11 @@ export function streamStitchSse<T>(
                 const { value: event, done } = await iterator.next();
                 if (done) break;
                 if (event.type === 'delta') {
-                    const message: SSEMessage = { data: toData(event.chunk) };
-                    if (delta.event !== undefined) message.event = delta.event;
+                    const message: SSEMessage = {
+                        data: toData(event.chunk, index),
+                    };
+                    const name = deltaEvent(event.chunk, index, delta);
+                    if (name !== undefined) message.event = name;
                     if (delta.id) message.id = delta.id(event.chunk, index);
                     index += 1;
                     await stream.writeSSE(message);

--- a/packages/nest/src/sse.ts
+++ b/packages/nest/src/sse.ts
@@ -3,20 +3,24 @@
 // This bridges the two so a streaming endpoint is one line, and aborts the upstream
 // generator when the client disconnects (the subscription tears down).
 import { Observable } from 'rxjs';
-import type { StitchEvent, StitchEventSource } from 'stitchapi';
+import type { StitchEventSource } from 'stitchapi';
+import {
+    DEFAULT_ERROR_DATA,
+    type ErrorFrameOptions,
+    type SseEmitOptions,
+    type StitchErrorEvent,
+    defaultData,
+    deltaEvent,
+    resolveDelta,
+    resolveError,
+    toErrorEvent,
+    toIterable,
+} from 'stitchapi/sse-emit';
 
 // The canonical intake for event-stream consumers, re-exported from the core barrel: the
 // event iterable itself (a `.stream()` generator) or anything that hands one back (a
 // `StitchResult`, a stitch stub).
 export type { StitchEventSource } from 'stitchapi';
-
-/** The terminal `error` event a stitch stream emits — carries `message`, `status`, `attempts`. */
-type StitchErrorEvent = Extract<StitchEvent, { type: 'error' }>;
-
-// The generic token an `error` frame carries by default: the raw upstream message is withheld so an
-// internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status (`HTTP 401`) never reaches
-// the client. Override with `options.errorData`.
-const DEFAULT_ERROR_DATA = 'error';
 
 /**
  * The SSE message shape Nest's `@Sse()` consumes — declared structurally so this
@@ -31,65 +35,17 @@ export interface MessageEventLike {
     retry?: number;
 }
 
-export interface StreamStitchSseOptions {
-    /**
-     * Map a `delta` chunk to the SSE message `data` string. The default sends a string chunk
-     * as-is and `JSON.stringify`-s anything else. Use this to pull the text out of a structured
-     * chunk, e.g. `data: (c) => c.choices[0].delta.content`. Receives the zero-based message
-     * index alongside the chunk.
-     */
-    data?: (chunk: unknown, index: number) => string;
-    /**
-     * Emit an `event:` line per delta message (the SSE event name — Nest's `MessageEvent.type`):
-     * a fixed name, or a function of the chunk for per-message names. Default: none (an unnamed
-     * `message` event, which `EventSource.onmessage` receives).
-     */
-    event?: string | ((chunk: unknown) => string);
-    /**
-     * Provide an `id:` line per delta message (the SSE last-event id), e.g. for resumable
-     * streams. Receives the chunk and the zero-based message index.
-     */
-    id?: (chunk: unknown, index: number) => string;
-    /**
-     * Shape the SSE `data` written for a terminal `error` event (or an uncaught throw
-     * mid-stream, normalised to an error event). Nest renders an errored `@Sse()` observable's
-     * `message` to the client as the final `event: error` frame's data, so this controls what
-     * the browser's `EventSource` receives. **Default: a generic token (`data: error`)** — the
-     * raw `event.message` is deliberately *not* echoed, because it can disclose internal network
-     * topology (a transport failure reads like `getaddrinfo ENOTFOUND payments.internal.corp`)
-     * or the upstream's status (`HTTP 401`) to an untrusted client. Opt in with
-     * `(e) => e.message` when the upstream messages are known safe, or return your own payload
-     * (e.g. `() => JSON.stringify({ error: 'stream failed' })`).
-     */
-    errorData?: (event: StitchErrorEvent) => string;
-    /**
-     * Called once, server-side, if the underlying stream errors (a stitch `error` event, or a
-     * throw) — use it to observe/log the real failure. It does **not** shape the client-facing
-     * frame: the SSE `data` sent to the client is controlled by `errorData` (a generic token by
-     * default), so the raw message reaches your logs here but not the client. Host-specific
-     * extra: the original failure is *also* attached as the errored observable's `cause`.
-     */
-    onError?: (err: unknown) => void;
-}
-
-// One delta chunk → the message `data` string: a string chunk as-is, anything else JSON.
-function defaultData(chunk: unknown): string {
-    return typeof chunk === 'string' ? chunk : JSON.stringify(chunk);
-}
-
-// Normalise a thrown value into the terminal `error` event shape, so an `errorData` opt-in sees a
-// consistent argument whether the failure arrived as a surfaced `error` event or an unexpected
-// throw. `attempts`/`at` are best-effort placeholders — an `errorData` hook keys off `name`/`message`.
-function toErrorEvent(err: unknown): StitchErrorEvent {
-    const e = err instanceof Error ? err : new Error(String(err));
-    return {
-        type: 'error',
-        name: e.name,
-        message: e.message,
-        attempts: 0,
-        at: 0,
-    };
-}
+/**
+ * Options for {@link streamStitchSse} — core's shared {@link SseEmitOptions}, identical to every
+ * other host (CONTRACT.md P16). The `delta` / `error` envelopes replace the flat `data` / `event` /
+ * `id` / `errorData` / `onError` spellings this package used to declare on its own; P16's *Settled*
+ * clause names those verbatim as the thing not to reintroduce.
+ *
+ * Nest's two genuine extras were not dropped to get here — they were lifted INTO the shared
+ * envelope, so all six hosts gained them: `delta.data` now receives the frame `index`, and
+ * `delta.event` accepts a function for per-message names.
+ */
+export type StreamStitchSseOptions = SseEmitOptions;
 
 // The Error the observable is errored with. By default it carries the generic `error` token — the
 // raw `event.message` is withheld, since Nest writes an errored observable's `message` straight to
@@ -97,24 +53,11 @@ function toErrorEvent(err: unknown): StitchErrorEvent {
 // failure is always attached as `cause` for server-side logging.
 function clientError(
     event: StitchErrorEvent,
-    options: StreamStitchSseOptions,
+    error: ErrorFrameOptions,
     cause: unknown,
 ): Error {
-    const text = options.errorData
-        ? options.errorData(event)
-        : DEFAULT_ERROR_DATA;
+    const text = error.data ? error.data(event) : DEFAULT_ERROR_DATA;
     return new Error(text, { cause });
-}
-
-// Accept both arms of core's `StitchEventSource`: the event iterable itself, or anything that
-// hands one back (a `StitchResult`, a stitch stub). Kept local — this bridge is the one adapter
-// that drives an rxjs `Observable` rather than the shared `stitchapi/sse-emit` frame kit.
-function toIterable<T>(
-    source: StitchEventSource<T>,
-): AsyncIterable<StitchEvent<T>> {
-    return Symbol.asyncIterator in source
-        ? (source as AsyncIterable<StitchEvent<T>>)
-        : source.stream();
 }
 
 /**
@@ -122,8 +65,8 @@ function toIterable<T>(
  * `Observable<MessageEventLike>` for an `@Sse()` endpoint: each `delta` becomes a
  * message, an `error` event errors the observable (Nest renders that to the client as a
  * final `event: error` frame — a generic `data: error` by default, the raw message withheld to
- * avoid disclosing internal topology; opt in via `errorData`, observe the real failure
- * server-side via `onError`), and stream end completes it. The non-output events
+ * avoid disclosing internal topology; opt in via `error.data`, observe the real failure
+ * server-side via `error.observe`), and stream end completes it. The non-output events
  * (`start` / `progress` / `drift` / `result` / `done`) are control signals and are not
  * forwarded to the client.
  *
@@ -131,7 +74,7 @@ function toIterable<T>(
  * @Sse('chat')
  * chat(@Query('q') q: string) {
  *   return streamStitchSse(this.complete.stream({ body: { prompt: q } }),
- *                          { data: (c: any) => c.text });
+ *                          { delta: (c: any) => c.text });
  * }
  * ```
  *
@@ -142,8 +85,12 @@ export function streamStitchSse<T>(
     source: StitchEventSource<T>,
     options: StreamStitchSseOptions = {},
 ): Observable<MessageEventLike> {
-    const toData: (chunk: unknown, index: number) => string =
-        options.data ?? defaultData;
+    // Fold each slot's shorthand once (`delta: (c) => …` ≡ `{ data: (c) => … }`), exactly as the
+    // other five hosts do — this bridge builds Nest `MessageEvent`s rather than raw frames, so it
+    // uses the resolved options directly instead of `deltaFrame`.
+    const delta = resolveDelta(options.delta);
+    const error = resolveError(options.error);
+    const toData = delta.data ?? defaultData;
     return new Observable<MessageEventLike>((subscriber) => {
         const iterator = toIterable(source)[Symbol.asyncIterator]();
         let active = true;
@@ -157,13 +104,9 @@ export function streamStitchSse<T>(
                         const message: MessageEventLike = {
                             data: toData(event.chunk, index),
                         };
-                        if (options.event !== undefined)
-                            message.type =
-                                typeof options.event === 'function'
-                                    ? options.event(event.chunk)
-                                    : options.event;
-                        if (options.id)
-                            message.id = options.id(event.chunk, index);
+                        const name = deltaEvent(event.chunk, index, delta);
+                        if (name !== undefined) message.type = name;
+                        if (delta.id) message.id = delta.id(event.chunk, index);
                         subscriber.next(message);
                         index += 1;
                     } else if (event.type === 'error') {
@@ -171,20 +114,20 @@ export function streamStitchSse<T>(
                         // raw `event.message`: Nest writes an errored `@Sse()` observable's
                         // `message` straight to the client, so echoing it would disclose an
                         // internal hostname (`getaddrinfo ENOTFOUND …`) or the upstream's status
-                        // (`HTTP 401`). `onError` gets the real failure server-side; the event is
-                        // also attached as `cause`; `errorData` shapes the client frame.
-                        options.onError?.(new Error(event.message));
-                        subscriber.error(clientError(event, options, event));
+                        // (`HTTP 401`). `error.observe` gets the real failure server-side; the
+                        // event is also attached as `cause`; `error.data` shapes the client frame.
+                        error.observe?.(new Error(event.message));
+                        subscriber.error(clientError(event, error, event));
                         return;
                     }
                 }
                 subscriber.complete();
             } catch (err) {
                 // A throw (not a surfaced `error` event): withhold the raw message the same way —
-                // normalise it to an error event so an `errorData` opt-in sees a consistent shape,
+                // normalise it to an error event so an `error.data` opt-in sees a consistent shape,
                 // and attach the original as `cause`.
-                options.onError?.(err);
-                subscriber.error(clientError(toErrorEvent(err), options, err));
+                error.observe?.(err);
+                subscriber.error(clientError(toErrorEvent(err), error, err));
             }
         })();
         // Teardown on unsubscribe (client disconnect): stop consuming and abort upstream.

--- a/packages/nest/test/sse.spec.ts
+++ b/packages/nest/test/sse.spec.ts
@@ -87,7 +87,7 @@ describe('streamStitchSse', () => {
         ).toBe('getaddrinfo ENOTFOUND payments.internal.corp');
     });
 
-    it('errorData shapes the client-facing error frame (raw message opt-in)', async () => {
+    it('error.data shapes the client-facing error frame (raw message opt-in)', async () => {
         const raw = await collect(
             streamStitchSse(
                 events({
@@ -97,7 +97,7 @@ describe('streamStitchSse', () => {
                     attempts: 1,
                     at: 0,
                 }),
-                { errorData: (e) => e.message },
+                { error: (e) => e.message },
             ),
         );
         expect(raw.error?.message).toBe('upstream blew up');
@@ -112,13 +112,13 @@ describe('streamStitchSse', () => {
                     attempts: 1,
                     at: 0,
                 }),
-                { errorData: (e) => `upstream ${e.status ?? '???'}` },
+                { error: (e) => `upstream ${e.status ?? '???'}` },
             ),
         );
         expect(curated.error?.message).toBe('upstream 503');
     });
 
-    it('onError observes the real failure server-side without shaping the client frame', async () => {
+    it('error.observe sees the real failure server-side without shaping the client frame', async () => {
         const seen: unknown[] = [];
         const { error } = await collect(
             streamStitchSse(
@@ -129,7 +129,7 @@ describe('streamStitchSse', () => {
                     attempts: 1,
                     at: 0,
                 }),
-                { onError: (err) => seen.push(err) },
+                { error: { observe: (err) => seen.push(err) } },
             ),
         );
         expect(seen).toHaveLength(1);
@@ -140,14 +140,16 @@ describe('streamStitchSse', () => {
         expect(error?.message).toBe('error');
     });
 
-    it('by default withholds the raw message on a thrown error too, preserving it as cause and reporting via onError', async () => {
+    it('by default withholds the raw message on a thrown error too, preserving it as cause and reporting via error.observe', async () => {
         async function* boom(): AsyncGenerator<StitchEvent, void> {
             yield { type: 'delta', chunk: 'a', at: 0 };
             throw new Error('getaddrinfo ENOTFOUND payments.internal.corp');
         }
         const seen: unknown[] = [];
         const { messages, error } = await collect(
-            streamStitchSse(boom(), { onError: (err) => seen.push(err) }),
+            streamStitchSse(boom(), {
+                error: { observe: (err) => seen.push(err) },
+            }),
         );
         expect(dataOf(messages)).toEqual(['a']);
         expect(error?.message).toBe('error');
@@ -160,11 +162,11 @@ describe('streamStitchSse', () => {
         );
     });
 
-    it('applies the data mapper to each chunk; the default JSON-stringifies non-strings', async () => {
+    it('applies the delta.data mapper to each chunk; the default JSON-stringifies non-strings', async () => {
         const mapped = await collect(
             streamStitchSse(
                 events({ type: 'delta', chunk: { text: 'hi' }, at: 0 }),
-                { data: (c) => (c as { text: string }).text },
+                { delta: (c) => (c as { text: string }).text },
             ),
         );
         expect(dataOf(mapped.messages)).toEqual(['hi']);
@@ -177,20 +179,20 @@ describe('streamStitchSse', () => {
         expect(dataOf(stringified.messages)).toEqual(['{"text":"hi"}']);
     });
 
-    it('the data mapper receives the zero-based message index', async () => {
+    it('delta.data receives the zero-based message index', async () => {
         const { messages } = await collect(
             streamStitchSse(
                 events(
                     { type: 'delta', chunk: 'a', at: 0 },
                     { type: 'delta', chunk: 'b', at: 0 },
                 ),
-                { data: (c, index) => `${String(c)}#${index}` },
+                { delta: { data: (c, index) => `${String(c)}#${index}` } },
             ),
         );
         expect(dataOf(messages)).toEqual(['a#0', 'b#1']);
     });
 
-    it('event accepts a function of the chunk for per-message event names', async () => {
+    it('delta.event accepts a function of the chunk for per-message event names', async () => {
         const { messages } = await collect(
             streamStitchSse(
                 events(
@@ -206,8 +208,10 @@ describe('streamStitchSse', () => {
                     },
                 ),
                 {
-                    event: (c) => (c as { kind: string }).kind,
-                    data: (c) => (c as { text: string }).text,
+                    delta: {
+                        event: (c) => (c as { kind: string }).kind,
+                        data: (c) => (c as { text: string }).text,
+                    },
                 },
             ),
         );
@@ -217,14 +221,19 @@ describe('streamStitchSse', () => {
         ]);
     });
 
-    it('event names each message and id stamps the (chunk, index) last-event id', async () => {
+    it('delta.event names each message and delta.id stamps the (chunk, index) last-event id', async () => {
         const { messages } = await collect(
             streamStitchSse(
                 events(
                     { type: 'delta', chunk: 'a', at: 0 },
                     { type: 'delta', chunk: 'b', at: 0 },
                 ),
-                { event: 'token', id: (_chunk, index) => `#${index}` },
+                {
+                    delta: {
+                        event: 'token',
+                        id: (_chunk, index) => `#${index}`,
+                    },
+                },
             ),
         );
         expect(messages).toEqual([

--- a/packages/nest/tsconfig.json
+++ b/packages/nest/tsconfig.json
@@ -28,6 +28,7 @@
         "baseUrl": ".",
         "paths": {
             "stitchapi/auth": ["../core/src/auth.ts"],
+            "stitchapi/sse-emit": ["../core/src/sse-emit.ts"],
             "stitchapi": ["../core/src/index.ts"]
         }
     },

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -247,8 +247,11 @@ const UNIQUE_WATCH = new Set([
     //    the stream-less adapters (swr/rtk-query/vercel-ai), which never call `.stream()`.
     //  - StreamableStitchLike: rtk-query's streaming tier of the same blessed family.
     //  - StreamStitchSseOptions + StitchErrorOptions: intentionally IDENTICAL option
-    //    envelopes declared per host adapter (elysia/hono/express/fastify/nest/next) —
-    //    one structural contract, same-name-same-shape by design (P9).
+    //    envelopes per host adapter (elysia/hono/express/fastify/nest/next) — one
+    //    structural contract, same-name-same-shape by design (P9). StreamStitchSseOptions
+    //    is identical BY CONSTRUCTION: every host derives it from core's single
+    //    `SseEmitOptions` (five `extends`, nest aliases), so the de-listing rests on a
+    //    shared declaration rather than on six shapes that happen to agree today.
     //  - StitchEventSource: core-owned; host adapters re-export core's type verbatim.
     //  - StitchQueryOptions / stitchQueryOptions / deriveQueryKey / nameOf / keyInputFor
     //    (and the rest of the query family): query-core-owned canonicals re-exported


### PR DESCRIPTION
**GA blocker #3.** `packages/nest/src/sse.ts` declared flat `data` / `event` / `id` / `errorData` /
`onError` — the exact spellings P16's *Settled* clause names as the thing not to reintroduce —
while the other five hosts take core's `delta` / `error` envelopes.

Closes [#559](https://github.com/rejifald/StitchAPI/issues/559).

## Nest's extras were lifted, not dropped

The easy fix would have been to shrink nest to fit the shared shape. That would have **deleted two
real capabilities**, because nest's options carried things core's did not. Both were improvements,
so they moved the other way — into core, where every host gets them:

```diff
- export type DeltaShaper = (chunk: unknown) => string;
+ export type DeltaShaper = (chunk: unknown, index: number) => string;

- event?: string;
+ event?: string | ((chunk: unknown, index: number) => string);
```

Widening the shaper is **source-compatible**: a one-argument `data: (c) => c.text` still
type-checks (TS accepts the narrower signature) and still runs (JS ignores extra arguments). That
is pinned by a test rather than asserted.

## Why this is a small diff for five of the six hosts

Both capabilities land in core's `deltaFrame`, which already received the `index`. The
**raw-writer** hosts — express, fastify, elysia, next — go through it, so they inherit both with
**no change at all**.

Only the two **structured** emitters build their own frame objects and so cannot use `deltaFrame`:
hono's `writeSSE` and nest's `MessageEvent`. Rather than have each re-implement the function-form
check, core now exports:

```ts
deltaEvent(chunk, index, delta): string | undefined
```

and both call it. One resolution rule, three call sites, no drift.

## Nest was also duplicating core

`defaultData`, `DEFAULT_ERROR_DATA`, `toErrorEvent` and `toIterable` were local copies — a comment
justified `toIterable` as "kept local, this bridge drives an rxjs Observable rather than the shared
frame kit", a rationale that evaporates once it adopts the kit. All four are now imports.

Its `tsconfig.json` was also missing the `stitchapi/sse-emit` paths entry every other host has: the
peer tsconfigs map `stitchapi` to core **source**, so each subpath needs its own mapping or the
import cannot resolve.

## The contract's claim is now true for a better reason

`CONTRACT.md` and `check-contract.mjs` both asserted these envelopes were "intentionally identical
per host adapter" — which the GA audit flagged as resting on a **false premise**, since nest's was
demonstrably different.

It is now true **by construction**: all six derive from core's single `SseEmitOptions` (five
`extends` it, nest aliases it). Both notes say so, so the R5 de-listing rests on a shared
declaration rather than on six shapes that happen to agree today.

## Migration

```diff
- streamStitchSse(src, { data: (c) => c.text, event: 'token', errorData: (e) => e.message })
+ streamStitchSse(src, { delta: { data: (c) => c.text, event: 'token' }, error: (e) => e.message })
```

`delta: (c) => …` remains the P12 shorthand for `{ data: (c) => … }`. No `@deprecated` aliases —
pre-GA hard break per **D5**.

## Verification

- `pnpm -r check:types` — 39 packages, clean
- `pnpm -r test` — full suite green; core **1303 → 1308** (new frame tests cover the index, the
  function-form event, the fixed-string event, and the one-argument shaper), nest's 56 still pass
- `check:contract` → 0 violations; full pre-push gate green; prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
