### PR TITLE
fix(docs-mcp)!: the embedder is an optional peer — default install is clean

### DIFF
--- a/packages/docs-mcp/README.md
+++ b/packages/docs-mcp/README.md
@@ -31,10 +31,11 @@ package exists for the cases where that's not an option:
 
 - **No third-party network dependency.** Every `search_docs`/`get_doc` call
   runs against the bundled index and the bundled Markdown — nothing you
-  search for, and nothing in your docs, is ever transmitted. The only
-  network activity is a one-time download of the embedding model
-  (`Xenova/all-MiniLM-L6-v2`, via `transformers.js`) into a local OS cache
-  directory on first use; every call after that is fully offline.
+  search for, and nothing in your docs, is ever transmitted. With the
+  optional embedder installed (see below), the only network activity is a
+  one-time download of the model (`Xenova/all-MiniLM-L6-v2`, via
+  `transformers.js`) into a local OS cache directory on first use; every call
+  after that is fully offline. Without it, there is no network activity at all.
 - **Air-gapped / strict egress environments.** Since content is bundled at
   publish time (not fetched at runtime), the only network dependency at all
   is the ordinary `npm install` / `npx` resolution — the same as any npm
@@ -47,12 +48,32 @@ package exists for the cases where that's not an option:
 
 Identical contract to the hosted server:
 
-- **`search_docs({ query, limit? })`** — hybrid (BM25 + vector) search over
-  the docs. Returns the most relevant sections as `{ title, url, excerpt,
-score }` — never full pages.
+- **`search_docs({ query, limit? })`** — search over the docs. Returns the most
+  relevant sections as `{ title, url, excerpt, score }` — never full pages.
+  **Hybrid (BM25 + vector)** when the optional embedder is installed, **BM25**
+  otherwise; same tool, same result shape, same bundled index either way.
 - **`get_doc({ url?, slug? })`** — fetches a full page as Markdown, given
   either a `url` (as returned by `search_docs`) or a bare `slug` like
   `"guides/resilience/throttle"`.
+
+### Semantic search is opt-in
+
+The vector half needs `@huggingface/transformers`, which is declared as an
+**optional peer** rather than a dependency. A plain install therefore pulls
+nothing extra and reports **zero advisories** — that package's transitive tree
+carries several that no dependency range here can move (it pins
+`onnxruntime-node` exactly, which requires `adm-zip ^0.5.16`, disjoint from the
+patched `0.6.0`; and it wants `sharp ^0.34.5`, disjoint from `0.35.x`).
+
+Turn it on when you want semantic retrieval and accept that tree:
+
+```bash
+npm i @huggingface/transformers
+```
+
+Nothing else changes — the server detects it at first search and upgrades from
+BM25 to hybrid on its own. If the package is present but broken, that is
+surfaced as an error rather than silently downgraded.
 
 ## Keeping docs fresh
 
@@ -108,10 +129,14 @@ intentional.
 
 ## Dependency advisories
 
-This package has real runtime dependencies (core `stitchapi` has none), so
-`npm audit` has something to report here. Each open finding was triaged against
-the code that actually runs — a stdio server that embeds text locally and reads
-a docs index bundled at publish time — and none of them is reachable:
+**A default install reports none.** `npm i @stitchapi/docs-mcp` resolves clean —
+verified against a real consumer tree, not just this workspace's lockfile, since
+the repo's root `pnpm.overrides` would otherwise mask exactly these findings.
+
+The notes below apply **only if you opt into `@huggingface/transformers`**, which
+brings its own transitive tree. Each was triaged against the code that actually
+runs — a stdio server that embeds text locally and reads a docs index bundled at
+publish time — and none is reachable:
 
 - **`sharp`** (inherited libvips CVEs) — statically imported by
   `@huggingface/transformers`, so it loads, but this package only runs text
@@ -129,7 +154,8 @@ a docs index bundled at publish time — and none of them is reachable:
   the validator on `elicitation/create` responses. This server registers two
   tools and never elicits.
 - **`@hono/node-server`** — the SDK's HTTP transport only. This server speaks
-  stdio, so it is never loaded.
+  stdio, so it is never loaded. (Without the optional embedder in the tree it
+  now resolves to the patched 2.x anyway.)
 
 If you find a way to actually reach one of these, please report it — see
 [SECURITY.md](../../SECURITY.md).

--- a/packages/docs-mcp/package.json
+++ b/packages/docs-mcp/package.json
@@ -3,7 +3,7 @@
     "mcpName": "dev.stitchapi/docs",
     "version": "1.0.0-rc.6",
     "type": "commonjs",
-    "description": "StitchAPI documentation search, running locally over MCP stdio. Bundled docs, no network calls per query — the offline/air-gapped counterpart to the hosted stitchapi.dev/api/mcp server.",
+    "description": "StitchAPI documentation search, running locally over MCP stdio. Bundled docs, no network calls per query \u2014 the offline/air-gapped counterpart to the hosted stitchapi.dev/api/mcp server.",
     "bin": {
         "stitchapi-docs-mcp": "bin/docs-mcp"
     },
@@ -63,7 +63,6 @@
         "node": ">=18.18.0"
     },
     "dependencies": {
-        "@huggingface/transformers": "^4.2.0",
         "@modelcontextprotocol/sdk": "1.30.0",
         "@orama/orama": "3.1.18",
         "@orama/plugin-data-persistence": "3.1.18",
@@ -73,6 +72,15 @@
         "@types/node": "^22.10.0",
         "tsup": "^8.3.0",
         "typescript": "^5.9.3",
-        "vitest": "^4.1.10"
+        "vitest": "^4.1.10",
+        "@huggingface/transformers": "^4.2.0"
+    },
+    "peerDependencies": {
+        "@huggingface/transformers": "^4.2.0"
+    },
+    "peerDependenciesMeta": {
+        "@huggingface/transformers": {
+            "optional": true
+        }
     }
 }

--- a/packages/docs-mcp/src/embed.ts
+++ b/packages/docs-mcp/src/embed.ts
@@ -9,15 +9,34 @@
 // stable, persistent OS cache directory: the model downloads once per machine,
 // then every later launch — `npx` or otherwise — reuses it, with zero network
 // calls after that first run.
+// `@huggingface/transformers` is an OPTIONAL peer, imported dynamically below and never at module
+// load. It is optional because it is unfixably vulnerable in transitive form: it pins
+// `onnxruntime-node` exactly (which requires `adm-zip ^0.5.16`, disjoint from the patched `0.6.0`)
+// and wants `sharp ^0.34.5` (disjoint from the patched `0.35.x`), so a plain
+// `npm i @stitchapi/docs-mcp` used to resolve five HIGH advisories that no dependency range in
+// this package could move. As an optional peer it is not installed unless asked for, and search
+// degrades to BM25 (see search.ts) rather than failing.
 import { EMBED_DTYPE, EMBED_MODEL } from './config';
 
-import {
-    type FeatureExtractionPipeline,
-    env,
-    pipeline,
-} from '@huggingface/transformers';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+
+// Structural shapes for the optional dependency, so this module type-checks whether or not
+// `@huggingface/transformers` is installed — a hard `import type` from an absent optional peer is
+// itself a compile error in a consumer's tree.
+type Tensor = { tolist(): unknown };
+type FeatureExtractionPipeline = (
+    texts: string[],
+    opts: { pooling: 'mean'; normalize: boolean },
+) => Promise<Tensor>;
+interface TransformersModule {
+    env: { cacheDir?: string };
+    pipeline: (
+        task: 'feature-extraction',
+        model: string,
+        opts: { dtype: string },
+    ) => Promise<FeatureExtractionPipeline>;
+}
 
 function cacheRoot(): string {
     // XDG_CACHE_HOME (Linux/macOS convention) → LOCALAPPDATA (Windows) → ~/.cache.
@@ -28,39 +47,90 @@ function cacheRoot(): string {
     return join(base, 'stitchapi-docs-mcp', 'transformers');
 }
 
-env.cacheDir = cacheRoot();
-
 const BATCH_SIZE = 32;
 
-let extractor: Promise<FeatureExtractionPipeline> | undefined;
+let extractor: Promise<FeatureExtractionPipeline | undefined> | undefined;
 
 /**
- * Lazily load (and cache) the feature-extraction pipeline. This process is
- * long-lived (a stdio server, not a per-request serverless function like the
- * hosted route), so a transient failure — e.g. a network blip while fetching
- * the model into the cache dir on first use — must not wedge every later
- * search_docs call: reset the cache on rejection so the next call retries
- * instead of replaying the same stale rejection forever.
+ * Load `@huggingface/transformers` if the consumer installed the optional peer, else `undefined`.
+ * The specifier is built at runtime so a bundler cannot hoist it into a hard requirement, and only
+ * a genuine "module not found" is treated as absence — any other failure (a corrupt install, a
+ * native binding that will not load) still throws, because silently degrading to BM25 there would
+ * hide a real fault behind quietly worse results.
  */
-export function getEmbedder(): Promise<FeatureExtractionPipeline> {
+async function loadTransformers(): Promise<TransformersModule | undefined> {
+    const specifier = '@huggingface/transformers';
+    try {
+        return (await import(specifier)) as TransformersModule;
+    } catch (e) {
+        if (isModuleNotFound(e)) return undefined;
+        throw e;
+    }
+}
+
+/**
+ * Is this "the package is not installed", as opposed to "it is installed and broken"?
+ *
+ * Checks the whole `cause` CHAIN, not just the top-level error: every loader between us and Node —
+ * a bundler, `tsx`, a test runner's module mocker — wraps the original resolution failure in its
+ * own error, which strips `.code` off the value we actually catch. The message check is the
+ * fallback for wrappers that do not preserve `cause` either.
+ */
+function isModuleNotFound(e: unknown): boolean {
+    for (let cur = e, depth = 0; cur && depth < 8; depth++) {
+        const err = cur as NodeJS.ErrnoException & { cause?: unknown };
+        if (
+            err.code === 'ERR_MODULE_NOT_FOUND' ||
+            err.code === 'MODULE_NOT_FOUND'
+        )
+            return true;
+        if (
+            typeof err.message === 'string' &&
+            /Cannot find (package|module) ['"]?@huggingface\/transformers/.test(
+                err.message,
+            )
+        )
+            return true;
+        cur = err.cause;
+    }
+    return false;
+}
+
+/**
+ * Lazily load (and cache) the feature-extraction pipeline, or `undefined` when the optional peer
+ * is not installed. This process is long-lived (a stdio server, not a per-request serverless
+ * function like the hosted route), so a transient failure — e.g. a network blip while fetching
+ * the model into the cache dir on first use — must not wedge every later search_docs call: reset
+ * the cache on rejection so the next call retries instead of replaying the same stale rejection
+ * forever.
+ */
+export function getEmbedder(): Promise<FeatureExtractionPipeline | undefined> {
     if (!extractor) {
-        extractor = pipeline('feature-extraction', EMBED_MODEL, {
-            dtype: EMBED_DTYPE,
-        }).catch((e: unknown) => {
-            extractor = undefined;
-            throw e;
-        });
+        extractor = loadTransformers()
+            .then(async (mod) => {
+                if (!mod) return undefined;
+                mod.env.cacheDir = cacheRoot();
+                return mod.pipeline('feature-extraction', EMBED_MODEL, {
+                    dtype: EMBED_DTYPE,
+                });
+            })
+            .catch((e: unknown) => {
+                extractor = undefined;
+                throw e;
+            });
     }
     return extractor;
 }
 
-/** Embed texts into mean-pooled, L2-normalized vectors, batched. */
+/** Embed texts into mean-pooled, L2-normalized vectors, batched. Returns `undefined` when the
+ *  optional `@huggingface/transformers` peer is not installed — callers fall back to BM25. */
 export async function embed(
     texts: string[],
     onProgress?: (done: number, total: number) => void,
-): Promise<number[][]> {
+): Promise<number[][] | undefined> {
     if (texts.length === 0) return [];
     const run = await getEmbedder();
+    if (!run) return undefined;
     const vectors: number[][] = [];
     for (let i = 0; i < texts.length; i += BATCH_SIZE) {
         const batch = texts.slice(i, i + BATCH_SIZE);
@@ -71,9 +141,12 @@ export async function embed(
     return vectors;
 }
 
-/** Embed a single text (the query path — search.ts). */
-export async function embedOne(text: string): Promise<number[]> {
-    const [vector] = await embed([text]);
+/** Embed a single text (the query path — search.ts). `undefined` when the optional peer is absent,
+ *  which `searchDocs` reads as "run BM25 only". */
+export async function embedOne(text: string): Promise<number[] | undefined> {
+    const vectors = await embed([text]);
+    if (vectors === undefined) return undefined;
+    const [vector] = vectors;
     if (!vector) throw new Error('embedOne: embed() returned no vectors');
     return vector;
 }

--- a/packages/docs-mcp/src/search.ts
+++ b/packages/docs-mcp/src/search.ts
@@ -111,22 +111,34 @@ export async function searchDocs(
     if (!term) return [];
 
     const db = await loadIndex();
+    // `undefined` means the optional `@huggingface/transformers` peer is not installed, so there is
+    // no query vector to search with. Degrade to BM25 over the same bundled index rather than
+    // failing: full-text still answers the question, just without the semantic half. Installing the
+    // peer restores hybrid scoring with no other change.
     const vector = await embedOne(term);
-    const params: SearchParams<AnyOrama> = {
-        mode: 'hybrid',
+    const common = {
         term,
-        vector: { value: vector, property: VECTOR_FIELD },
         properties: ['pageTitle', 'heading', 'text'],
-        hybridWeights,
         // Fresh object literal, not the interface value: named interfaces get
         // no implicit index signature (unlike the anonymous type this replaced),
         // so FieldBoost isn't directly assignable to Orama's
         // Partial<Record<string, number>>. Same fields, identity pass-through.
         boost: { ...boost },
-        similarity: 0,
-        includeVectors: false,
         limit,
     };
+    // `similarity` and `includeVectors` are vector-search knobs — Orama's `SearchParamsFullText`
+    // does not accept them, so they live in the hybrid arm rather than the shared half.
+    const params: SearchParams<AnyOrama> =
+        vector === undefined
+            ? { ...common, mode: 'fulltext' }
+            : {
+                  ...common,
+                  mode: 'hybrid',
+                  vector: { value: vector, property: VECTOR_FIELD },
+                  hybridWeights,
+                  similarity: 0,
+                  includeVectors: false,
+              };
     const results = await search(db, params);
 
     return results.hits.map((hit) => {

--- a/packages/docs-mcp/test/embed-error-recovery.spec.ts
+++ b/packages/docs-mcp/test/embed-error-recovery.spec.ts
@@ -43,7 +43,7 @@ describe('getEmbedder retry on failure', () => {
     });
 });
 
-describe('cacheRoot precedence (via env.cacheDir set on module load)', () => {
+describe('cacheRoot precedence (via env.cacheDir set on first getEmbedder)', () => {
     const ORIGINAL_ENV = { ...process.env };
 
     beforeEach(() => {
@@ -59,7 +59,8 @@ describe('cacheRoot precedence (via env.cacheDir set on module load)', () => {
     it('prefers XDG_CACHE_HOME when set', async () => {
         process.env['XDG_CACHE_HOME'] = '/xdg-cache';
         process.env['LOCALAPPDATA'] = '/local-appdata';
-        await import('../src/embed');
+        const { getEmbedder } = await import('../src/embed');
+        await getEmbedder();
         expect(env.cacheDir).toBe(
             join('/xdg-cache', 'stitchapi-docs-mcp', 'transformers'),
         );
@@ -67,14 +68,16 @@ describe('cacheRoot precedence (via env.cacheDir set on module load)', () => {
 
     it('falls back to LOCALAPPDATA when XDG_CACHE_HOME is unset', async () => {
         process.env['LOCALAPPDATA'] = '/local-appdata';
-        await import('../src/embed');
+        const { getEmbedder } = await import('../src/embed');
+        await getEmbedder();
         expect(env.cacheDir).toBe(
             join('/local-appdata', 'stitchapi-docs-mcp', 'transformers'),
         );
     });
 
     it('falls back to ~/.cache when neither is set', async () => {
-        await import('../src/embed');
+        const { getEmbedder } = await import('../src/embed');
+        await getEmbedder();
         expect(env.cacheDir).toBe(
             join(homedir(), '.cache', 'stitchapi-docs-mcp', 'transformers'),
         );
@@ -83,7 +86,8 @@ describe('cacheRoot precedence (via env.cacheDir set on module load)', () => {
     it('treats an empty-string XDG_CACHE_HOME as unset (falls through)', async () => {
         process.env['XDG_CACHE_HOME'] = '';
         process.env['LOCALAPPDATA'] = '/local-appdata';
-        await import('../src/embed');
+        const { getEmbedder } = await import('../src/embed');
+        await getEmbedder();
         expect(env.cacheDir).toBe(
             join('/local-appdata', 'stitchapi-docs-mcp', 'transformers'),
         );

--- a/packages/docs-mcp/test/optional-embedder.spec.ts
+++ b/packages/docs-mcp/test/optional-embedder.spec.ts
@@ -1,0 +1,71 @@
+// `@huggingface/transformers` is an OPTIONAL peer: it is unfixably vulnerable in transitive form
+// (it pins `onnxruntime-node`, which needs `adm-zip ^0.5.16` — disjoint from the patched 0.6.0 —
+// and wants `sharp ^0.34.5`, disjoint from 0.35.x), so a default `npm i @stitchapi/docs-mcp` must
+// not install it. These assert the ABSENT-peer path end to end: no throw, no vector, BM25 instead.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Stand in for a consumer who never installed the optional peer. Node reports a missing package
+// as ERR_MODULE_NOT_FOUND; `loadTransformers` treats exactly that as "absent" and anything else
+// as a real fault worth surfacing.
+function moduleNotFound(): Error {
+    const e = new Error(
+        "Cannot find package '@huggingface/transformers'",
+    ) as NodeJS.ErrnoException;
+    e.code = 'ERR_MODULE_NOT_FOUND';
+    return e;
+}
+
+describe('the optional embedder is absent', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    it('getEmbedder resolves to undefined instead of throwing', async () => {
+        vi.doMock('@huggingface/transformers', () => {
+            throw moduleNotFound();
+        });
+        const { getEmbedder } = await import('../src/embed');
+        await expect(getEmbedder()).resolves.toBeUndefined();
+    });
+
+    it('embed / embedOne report absence rather than inventing a vector', async () => {
+        vi.doMock('@huggingface/transformers', () => {
+            throw moduleNotFound();
+        });
+        const { embed, embedOne } = await import('../src/embed');
+        await expect(embed(['hello'])).resolves.toBeUndefined();
+        await expect(embedOne('hello')).resolves.toBeUndefined();
+    });
+
+    it('an empty batch still short-circuits to [] — absence is not the only early return', async () => {
+        vi.doMock('@huggingface/transformers', () => {
+            throw moduleNotFound();
+        });
+        const { embed } = await import('../src/embed');
+        await expect(embed([])).resolves.toEqual([]);
+    });
+
+    it('a NON-absence failure still throws — a broken install must not read as "no peer"', async () => {
+        // A corrupt install or an unloadable native binding would otherwise be silently downgraded
+        // to worse search results, which is exactly the kind of fault that should be loud.
+        vi.doMock('@huggingface/transformers', () => {
+            throw new Error('dlopen failed: onnxruntime binding is corrupt');
+        });
+        const { getEmbedder } = await import('../src/embed');
+
+        // Assert the BEHAVIOUR (it rejects) and that the real cause survives somewhere in the
+        // chain — not the top-level message, which the runner's module mocker rewrites with its
+        // own wrapper. That wrapping is the same reason `isModuleNotFound` walks `cause`.
+        const err = await getEmbedder().then(
+            () => undefined,
+            (e: unknown) => e,
+        );
+        expect(err).toBeInstanceOf(Error);
+        const chain: string[] = [];
+        for (let cur: unknown = err, i = 0; cur && i < 8; i++) {
+            chain.push(String((cur as Error).message));
+            cur = (cur as { cause?: unknown }).cause;
+        }
+        expect(chain.join(' | ')).toMatch(/dlopen failed/);
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,9 +408,6 @@ importers:
 
   packages/docs-mcp:
     dependencies:
-      '@huggingface/transformers':
-        specifier: ^4.2.0
-        version: 4.2.0(@types/node@22.19.21)
       '@modelcontextprotocol/sdk':
         specifier: 1.30.0
         version: 1.30.0(zod@4.4.3)
@@ -424,6 +421,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@huggingface/transformers':
+        specifier: ^4.2.0
+        version: 4.2.0(@types/node@22.19.21)
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.21


### PR DESCRIPTION
**GA blocker #7 — the last one.** `npm i @stitchapi/docs-mcp@1.0.0-rc.6` resolved **7 advisories,
5 of them HIGH**.

Measured against a **real consumer tree**, not this workspace. That distinction *is* the bug: the
root `pnpm.overrides` force the patched versions locally, so `pnpm audit` and Dependabot both read
clean while every consumer got the vulnerable ones.

```
adm-zip@0.5.18   HIGH   crafted ZIP → 4GB allocation      GHSA-xcpc-8h2w-3j85
sharp@0.34.5     HIGH   inherited libvips CVEs            GHSA-f88m-g3jw-g9cj
@hono/node-server@1.19.17  MODERATE  path traversal       GHSA-frvp-7c67-39w9
```

## Why no version bump could fix it

| chain | why it is stuck |
| --- | --- |
| `adm-zip` | `@huggingface/transformers` pins `onnxruntime-node` **exactly**, and that requires `adm-zip ^0.5.16` — a `0.x` caret **cannot** reach the patched `0.6.0` |
| `sharp` | transformers wants `^0.34.5`, disjoint from the patched `0.35.x` |
| `@hono/node-server` | npm **nests** the MCP SDK's own `1.19.17` even when the root asks for `^2.0.5` |

`@huggingface/transformers@4.2.0` is **already the latest**, so there was no upstream to move to.
And a direct pin does not reach a nested resolution — I measured that rather than assuming it:

```
node_modules/@hono/node-server                              → 2.0.12
node_modules/@modelcontextprotocol/sdk/node_modules/@hono/node-server → 1.19.17   ← still vulnerable
```

A published package's `overrides` do not apply to consumers. There was no range-level fix.

## The change

`@huggingface/transformers` becomes an **optional peer** — not installed unless asked for.

- `embed.ts` loads it **dynamically**, returning `undefined` when absent.
- `searchDocs` degrades to Orama's **BM25** over the same bundled index: same tool, same result
  shape, same corpus, without the semantic half.
- Installing the peer restores hybrid scoring with **no other change** — the server detects it on
  first search.

### Measured result: 7 → 0

Better than expected. I predicted this would clear 5 of 7; with transformers out of the default
tree `@hono/node-server` also resolves to the patched **2.0.12**, so **all three chains clear**.

## Two details worth reviewing

**Absence is distinguished from breakage.** Only a module-not-found becomes "no peer". A corrupt
install or an unloadable native binding still **throws** — silently serving worse results would
hide a real fault behind quietly degraded search.

**The check walks the `cause` chain**, not just the top-level error. Every loader between us and
Node — a bundler, `tsx`, the test runner's module mocker — rewraps the resolution failure and
strips `.code`. This began as a test-harness problem and turned out to be a production robustness
issue too.

## Docs

The README already carried a careful triage arguing these advisories are unreachable in a
text-only server. That reasoning is **kept and rescoped**: it now applies only if you opt in, and
states plainly that a default install reports none.

## Verification

- consumer-tree audit of the shipped dependency set → **`found 0 vulnerabilities`**
- `pnpm -r check:types` — 38 packages, clean
- `pnpm -r test` — full suite green; docs-mcp **43 → 47**, covering absent-peer, `embed`/`embedOne`
  returning `undefined`, the empty-batch early return, and the broken-install-still-throws case
- `check:contract` → 0; full pre-push gate green; prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
