### PR TITLE
docs(readme): trim the badge header to six — drop what GitHub already says

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,34 +18,20 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/stitchapi"><img alt="npm version" src="https://img.shields.io/npm/v/stitchapi?color=2563EB&label=npm" /></a>
   <a href="https://www.npmjs.com/package/stitchapi?activeTab=dependencies"><img alt="Dependencies: 0" src="https://img.shields.io/badge/dependencies-0-brightgreen" /></a>
-  <img alt="npm bundle size (minified + gzipped)" src="https://img.shields.io/bundlephobia/minzip/stitchapi" />
   <img alt="Bundle: ~23 kB min+gzip" src="https://img.shields.io/badge/min%2Bgzip-~23%20kB-2563EB" />
-</p>
-
-<p align="center">
   <a href="https://scorecard.dev/viewer/?uri=github.com/rejifald/StitchAPI"><img alt="OpenSSF Scorecard" src="https://api.scorecard.dev/projects/github.com/rejifald/StitchAPI/badge" /></a>
   <a href="https://www.npmjs.com/package/stitchapi"><img alt="npm provenance: signed" src="https://img.shields.io/badge/provenance-signed-brightgreen" /></a>
-  <a href="SECURITY.md"><img alt="security policy" src="https://img.shields.io/badge/security-policy-2563EB" /></a>
 </p>
 
 <!-- yakir:readme-badges -->
 
 <p align="center">
-  <a href="https://stand-with-ukraine.pp.ua"><img alt="StandWithUkraine" src="https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg" /></a>
   <img alt="code health: 77 (B)" src="https://img.shields.io/badge/code_health-77_%28B%29-green" />
   <img alt="coverage: 90% lines · 78% branches" src="https://img.shields.io/badge/coverage-90%25_lines_%C2%B7_78%25_branches-green" />
-  <a href="LICENSE"><img alt="license: Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue" /></a>
 </p>
 
 <!-- /yakir:readme-badges -->
-
-<p align="center">
-  <a href="https://glama.ai/mcp/servers/@rejifald/StitchAPI">
-    <img width="380" height="200" src="https://glama.ai/mcp/servers/@rejifald/StitchAPI/badge" alt="StitchAPI Docs — MCP server listed on Glama" />
-  </a>
-</p>
 
 <p align="center">
   <strong>Zero runtime dependencies · ~23&nbsp;kB min+gzip</strong> — a typical <code>import { stitch }</code> tree-shakes to ~20&nbsp;kB, and with no transitive tree there is nothing else to install or audit. The size is an <a href="packages/core/scripts/bundle-size.mjs">enforced budget in CI</a>, not an aspiration.

--- a/packages/docs-mcp/README.md
+++ b/packages/docs-mcp/README.md
@@ -2,6 +2,8 @@
 
 [![npm](https://img.shields.io/npm/v/@stitchapi/docs-mcp?color=2563EB&label=npm)](https://www.npmjs.com/package/@stitchapi/docs-mcp)
 
+<a href="https://glama.ai/mcp/servers/@rejifald/StitchAPI"><img width="380" height="200" src="https://glama.ai/mcp/servers/@rejifald/StitchAPI/badge" alt="StitchAPI Docs — MCP server listed on Glama" /></a>
+
 **StitchAPI documentation search, running entirely on your machine.** The docs
 corpus and its semantic search index ship bundled inside this package — no
 network call per query, no query or doc content ever sent anywhere. This is

--- a/scripts/gen-readme-metrics.mjs
+++ b/scripts/gen-readme-metrics.mjs
@@ -10,13 +10,14 @@
 //                                # refresh the snapshot from fallow + coverage, then rewrite
 //
 // The README carries a generated badge row between yakir region markers
-// `<!-- yakir:readme-badges -->` / `<!-- /yakir:readme-badges -->`: the
-// StandWithUkraine badge plus three self-describing metric badges (code health,
-// test coverage, license). Each metric badge is a static shields.io URL with the
-// value baked into the URL — nothing phones home; the number, already public in
-// this file, is all that travels (GitHub's camo proxies the image).
+// `<!-- yakir:readme-badges -->` / `<!-- /yakir:readme-badges -->`: two
+// self-describing metric badges (code health, test coverage). Each is a static
+// shields.io URL with the value baked into the URL — nothing phones home; the
+// number, already public in this file, is all that travels (GitHub's camo
+// proxies the image). The row is metrics only: badges that assert a fact GitHub
+// already renders (license, security policy) were dropped as noise.
 //
-// Two of the three metrics come from heavy tools whose output is gitignored:
+// Both metrics come from heavy tools whose output is gitignored:
 //   • code health — fallow's maintainability score (`.metrics/fallow.json`,
 //     written by `fallow --format json --score`).
 //   • coverage    — Vitest line/branch totals (`packages/<pkg>/coverage/
@@ -24,8 +25,7 @@
 // `--refresh` snapshots both into the committed `scripts/readme-metrics.snapshot.json`
 // so the yakir drift check (which runs `--emit` and compares to the committed region)
 // never has to run a tool: `--emit` renders from the snapshot. Refresh the numbers
-// with `pnpm metrics` (runs fallow + coverage, then `--refresh`). The license is a
-// static fact read straight from the root package.json.
+// with `pnpm metrics` (runs fallow + coverage, then `--refresh`).
 //
 // The block is `<p align="center">` HTML (one badge per line) to match the rest
 // of the README hero and stay prettier-stable: prettier does not reflow these
@@ -107,9 +107,6 @@ function groupFor(dir) {
     return 'other';
 }
 
-const STAND_WITH_UKRAINE =
-    '<a href="https://stand-with-ukraine.pp.ua"><img alt="StandWithUkraine" src="https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg" /></a>';
-
 // --- shields.io static-badge encoding ---------------------------------------
 // Field separator is `-`, so a literal `-` becomes `--` and `_` becomes `__`; a
 // space becomes `_`. Parens are percent-encoded so they can't be mistaken for
@@ -155,11 +152,6 @@ function coverageColor(pct) {
 // --- snapshot ---------------------------------------------------------------
 function readSnapshot() {
     return JSON.parse(readFileSync(snapshotPath, 'utf8'));
-}
-
-function readLicense() {
-    return JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8'))
-        .license;
 }
 
 /**
@@ -239,9 +231,7 @@ function refreshSnapshot() {
 /** The inner badge row (no markers) — what `--emit readme-badges` prints and yakir compares. */
 function badgesRow(snapshot) {
     const { health, coverage } = snapshot;
-    const license = readLicense();
     const badges = [
-        STAND_WITH_UKRAINE,
         `<img alt="code health: ${health.score} (${health.grade})" src="${badgeUrl(
             'code health',
             `${health.score} (${health.grade})`,
@@ -256,11 +246,6 @@ function badgesRow(snapshot) {
             )}% branches`,
             coverageColor(coverage.lines),
         )}" />`,
-        `<a href="LICENSE"><img alt="license: ${license}" src="${badgeUrl(
-            'license',
-            license,
-            'blue',
-        )}" /></a>`,
     ];
     return `<p align="center">\n  ${badges.join('\n  ')}\n</p>`;
 }


### PR DESCRIPTION
## What

The README hero had grown to **twelve badges across four rows** plus a 380×200 Glama card. Cut to **six badges in two rows**, which lets the two rows that carry real information actually read as information.

Final header: `dependencies 0` · `~23 kB min+gzip` · `OpenSSF Scorecard` · `provenance signed`, then the generated `code health` · `coverage`.

### Removed

| Badge | Why |
| --- | --- |
| npm version | The `NOTE` block below already states the release, kept in sync by yakir's `release-version` tether. npm stays linked from the dependencies badge. |
| bundlephobia minzip | One of **two** size badges, and the weaker one — a third-party service measuring the published entry point rather than the number this repo enforces. The custom `~23 kB min+gzip` badge stays, gated against `bundle-size.mjs` by the `bundle-advertised-size` tether. |
| security policy | A static badge asserting only that `SECURITY.md` exists — which GitHub already surfaces in the Security tab and sidebar. `SECURITY.md` itself is untouched. |
| license | Apache-2.0 renders in GitHub's About sidebar, on npm, and in the README's own `## License` section. Three renderings was two too many. |
| StandWithUkraine badge | Duplicated the banner at the top of the file. **The banner is kept** — only the duplicate in the metrics row goes. |

### Moved

The Glama card goes to `packages/docs-mcp/README.md`, where it is on-topic for the MCP audience and renders on npm for that package. It advertises the *docs MCP server* listing, not the library, so it was paying for hero space with someone else's message.

Glama serves exactly one badge size — `?style=` and `?compact=` return a byte-identical 16 KB PNG, and `/badge/small` and `/badge.svg` both 404 — so shrinking it in place was not an option.

## Reviewer notes

**The second row is generated.** Editing the README alone would have been reverted by the next `pnpm gen:readme`, so the StandWithUkraine and license badges came out of `badgesRow()` in `scripts/gen-readme-metrics.mjs` and the region was regenerated. Two helpers (`STAND_WITH_UKRAINE`, `readLicense`) are dead as a result and removed; the file's header comment is updated to match.

## Verification

- `prettier --check .` — clean.
- `yakir check --tier token` — passes.
- `yakir check --tier executable` — `readme-badges` passes.
- `bundle-advertised-size` **cannot run in a fresh worktree** (`lib/index.mjs not found — run pnpm build first`). Unrelated to this change, and confirmed harmless: the `~NN kB` values README hands that tether are byte-identical before and after — `~23 kB ~23%20kB ~23&nbsp;kB ~20&nbsp;kB ~23 kB ~20 kB`. CI builds first, so it will run there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)