### PR TITLE
refactor(core)!: pre-GA field-naming sweep — apiKey secret, size envelopes, named oauth2 flow, bodyType

### DIFF
--- a/apps/docs/content/blog/call-any-llm-as-a-typed-function.mdx
+++ b/apps/docs/content/blog/call-any-llm-as-a-typed-function.mdx
@@ -45,7 +45,7 @@ import { anthropic, llm } from 'stitchapi/llm';
 const chat = llm({
     provider: anthropic,
     model: 'claude-opus-4-8',
-    auth: apiKey({ name: 'x-api-key', value: env('ANTHROPIC_API_KEY') }),
+    auth: apiKey({ name: 'x-api-key', secret: env('ANTHROPIC_API_KEY') }),
 });
 
 const { text } = await chat({
@@ -85,7 +85,7 @@ const { text } = await chat({
 });
 ```
 
-`openai` authenticates with `bearer(env('OPENAI_API_KEY'))`; `anthropic` authenticates with `apiKey({ name: 'x-api-key', value: env('ANTHROPIC_API_KEY') })`. The provider absorbs the wire difference — different URL, different header, different body and response shapes — and `result.text` is the same on both sides. The code that sends messages and reads the completion does not move.
+`openai` authenticates with `bearer(env('OPENAI_API_KEY'))`; `anthropic` authenticates with `apiKey({ name: 'x-api-key', secret: env('ANTHROPIC_API_KEY') })`. The provider absorbs the wire difference — different URL, different header, different body and response shapes — and `result.text` is the same on both sides. The code that sends messages and reads the completion does not move.
 
 When you need a provider that does not ship first-party, you implement the same contract the built-ins do. An `LlmProvider` declares its `id`, its full completions `url`, optional non-secret `headers`, an optional `defaultModel`, a `buildBody` that maps a normalised `LlmRequest` to that vendor's wire body, and a `parse` that lifts the response back into an `LlmResult`:
 
@@ -136,7 +136,7 @@ const fast = llm({
 const deep = llm({
     provider: anthropic,
     model: 'claude-opus-4-8',
-    auth: apiKey({ name: 'x-api-key', value: env('ANTHROPIC_API_KEY') }),
+    auth: apiKey({ name: 'x-api-key', secret: env('ANTHROPIC_API_KEY') }),
 });
 
 async function summarize(input: string, hard: boolean) {
@@ -162,7 +162,7 @@ import { anthropic, llm } from 'stitchapi/llm';
 const chat = llm({
     provider: anthropic,
     model: 'claude-opus-4-8',
-    auth: apiKey({ name: 'x-api-key', value: env('ANTHROPIC_API_KEY') }),
+    auth: apiKey({ name: 'x-api-key', secret: env('ANTHROPIC_API_KEY') }),
     retry: {
         attempts: 3,
         on: [429, 529],

--- a/apps/docs/content/blog/scaffold-a-stitch-from-curl.mdx
+++ b/apps/docs/content/blog/scaffold-a-stitch-from-curl.mdx
@@ -76,7 +76,7 @@ The CLI recognises three credential shapes, each from the header (or query param
 
 - **`Authorization: Bearer <token>`** → `auth: bearer(env('API_TOKEN'))`
 - **`Authorization: Basic <base64>`** → `auth: basic({ user: env('API_USER'), pass: env('API_PASSWORD') })`
-- **An `X-API-Key` header or an API-key query param** → `auth: apiKey({ value: env('API_KEY') })` for a header, or `auth: apiKey({ in: 'query', name: 'api_key', value: env('API_KEY') })` for a query param
+- **An `X-API-Key` header or an API-key query param** → `auth: apiKey({ secret: env('API_KEY') })` for a header, or `auth: apiKey({ in: 'query', name: 'api_key', secret: env('API_KEY') })` for a query param
 
 In every case the value is an `env(...)` placeholder, not the captured secret — `basic` and `apiKey` each take a single options object, so the generated call is the real API you would have written. (curl's `-u user:password` flag is a different story: `from-curl` does not parse it and warns it as an unknown flag. Basic auth is recognised from an `Authorization: Basic …` header, the form a browser's **Copy as cURL** actually emits.)
 

--- a/apps/docs/content/blog/trace-api-calls-without-leaking-secrets.mdx
+++ b/apps/docs/content/blog/trace-api-calls-without-leaking-secrets.mdx
@@ -125,7 +125,7 @@ const trace = createTrace({
     console: true,
     file: './traces.jsonl',
     redactHeaders: ['x-internal-token', 'x-customer-id'],
-    maxBodyChars: 4096,
+    body: 4096,
 });
 const c = stitch({ url, trace });
 
@@ -136,7 +136,7 @@ const d = stitch({
 });
 ```
 
-`createTrace` is where you tune the two things you might want to widen. `redactHeaders` **adds** your own header names to the built-in denylist — it does not replace `authorization` and `cookie`, it joins them. `maxBodyChars` defaults to `2048`; pass `maxBodyChars: false` to capture full bodies when you are debugging in a place you trust and have decided the size is fine.
+`createTrace` is where you tune the two things you might want to widen. `redactHeaders` **adds** your own header names to the built-in denylist — it does not replace `authorization` and `cookie`, it joins them. `body` defaults to a `2048`-character cap; pass `body: { chars: false }` to capture full bodies when you are debugging in a place you trust and have decided the size is fine.
 
 ## What gets redacted, before anything is written
 
@@ -147,7 +147,7 @@ The redaction is not a post-processing pass you hope ran. It happens between the
 | Secret headers      | You print `headers`; the token is in it | `authorization`, `cookie`, and your `redactHeaders` names become `[REDACTED]` |
 | URL credentials     | `https://user:pass@host` logged whole   | `scrubUrl` strips inline credentials from the URL string                      |
 | Secret query values | The token in `?token=...` is plaintext  | Scrubbed from the URL string **and** the structured `input.query`             |
-| Large bodies        | Full PII body, however big              | Truncated to `maxBodyChars` (2048 by default)                                 |
+| Large bodies        | Full PII body, however big              | Truncated to the `body.chars` cap (2048 by default)                           |
 | New secret field    | You must remember to redact it          | On the denylist, or one `redactHeaders` entry away                            |
 
 The contrast is the whole point: with a logger, safety is a habit you maintain. With a stitch, safety is the default and capturing more is the explicit choice.
@@ -164,7 +164,7 @@ If your logs go to an OpenTelemetry pipeline, there is an OTLP exporter that tur
 
 ## Start narrow, widen on purpose
 
-The smallest safe trace is one field: `trace: 'console'`, and the secrets are already handled. That is the call you have right now, made visible without making it dangerous. When you need durable traces, swap `'console'` for `fileSink(...)`; when you need to fan out, wrap them in `multiplex(...)`; when you need a span pipeline, point the OTLP exporter at your collector. Each step is one edit, and at every step redaction stays on by default — widening capture (`maxBodyChars: false`, extra `redactHeaders`) is a thing you choose, never a thing you forget. The field that costs nothing when absent is the field that protects you the moment it is present.
+The smallest safe trace is one field: `trace: 'console'`, and the secrets are already handled. That is the call you have right now, made visible without making it dangerous. When you need durable traces, swap `'console'` for `fileSink(...)`; when you need to fan out, wrap them in `multiplex(...)`; when you need a span pipeline, point the OTLP exporter at your collector. Each step is one edit, and at every step redaction stays on by default — widening capture (`body: { chars: false }`, extra `redactHeaders`) is a thing you choose, never a thing you forget. The field that costs nothing when absent is the field that protects you the moment it is present.
 
 ## Try it
 

--- a/apps/docs/content/docs/agents/author-from-one-example.mdx
+++ b/apps/docs/content/docs/agents/author-from-one-example.mdx
@@ -38,7 +38,7 @@ The origin becomes `baseUrl`, the rest becomes `path`, and id-like segments
 (`/users/1`) are lifted into `{param}` slots — each lift is announced on stderr so
 you can revert a false positive. A recognised credential is **never** emitted: an
 `Authorization: Bearer …` header becomes `auth: bearer(env('API_TOKEN'))`, an
-`x-api-key` header becomes `auth: apiKey({ value: env('API_KEY') })`, and the
+`x-api-key` header becomes `auth: apiKey({ secret: env('API_KEY') })`, and the
 captured token stays in your shell, out of committed code. Read a single HAR entry
 instead with `--from-har request.har`.
 

--- a/apps/docs/content/docs/getting-started/migration-notes.mdx
+++ b/apps/docs/content/docs/getting-started/migration-notes.mdx
@@ -86,7 +86,7 @@ import { apiKey, env } from 'stitchapi/auth';
 const getItem = stitch({
     baseUrl: 'https://api.example.com',
     path: '/items/{id}',
-    auth: apiKey({ name: 'X-Catalog-Token', value: env('CATALOG_TOKEN') }),
+    auth: apiKey({ name: 'X-Catalog-Token', secret: env('CATALOG_TOKEN') }),
 });
 // On the wire, the request header is `x-catalog-token`, not `X-Catalog-Token`.
 ```

--- a/apps/docs/content/docs/guides/auth/api-key.mdx
+++ b/apps/docs/content/docs/guides/auth/api-key.mdx
@@ -18,7 +18,7 @@ import { apiKey, env } from 'stitchapi/auth';
 const search = stitch({
     baseUrl: 'https://api.example.com',
     path: '/search',
-    auth: apiKey({ value: env('API_KEY') }),
+    auth: apiKey({ secret: env('API_KEY') }),
 });
 ```
 
@@ -37,7 +37,7 @@ call time and never committed.
 `name` labels the key in every arm — the header name, the query-parameter name,
 or the cookie name. It defaults to `X-API-Key` for a header and `api_key` for a
 query parameter or cookie. For a custom header, pass
-`apiKey({ name: 'X-My-Key', value: env('API_KEY') })`. A header name goes on the
+`apiKey({ name: 'X-My-Key', secret: env('API_KEY') })`. A header name goes on the
 wire **lowercased** (`x-my-key`) — case-insensitive per HTTP, but worth knowing
 if a fixture asserts the original casing. See
 [Migration notes](/docs/getting-started/migration-notes).
@@ -55,7 +55,7 @@ import { apiKey, env } from 'stitchapi/auth';
 const search = stitch({
     baseUrl: 'https://api.example.com',
     path: '/search?type=full', // an existing query is preserved
-    auth: apiKey({ in: 'query', name: 'api_key', value: env('API_KEY') }),
+    auth: apiKey({ in: 'query', name: 'api_key', secret: env('API_KEY') }),
 });
 ```
 
@@ -87,7 +87,7 @@ import { apiKey, env } from 'stitchapi/auth';
 const search = stitch({
     baseUrl: 'https://api.example.com',
     path: '/search',
-    auth: apiKey({ in: 'cookie', name: 'api_key', value: env('API_KEY') }),
+    auth: apiKey({ in: 'cookie', name: 'api_key', secret: env('API_KEY') }),
 });
 ```
 

--- a/apps/docs/content/docs/guides/observability/trace-sinks.mdx
+++ b/apps/docs/content/docs/guides/observability/trace-sinks.mdx
@@ -248,7 +248,7 @@ marker:
 { "truncated": true, "chars": 51234, "preview": "{\"items\":[{\"id\":1,…" }
 ```
 
-`preview` is the first `maxBodyChars` characters of the (already header-redacted)
+`preview` is the first `body.chars` characters of the (already header-redacted)
 JSON, so you keep a readable head of the payload without storing all of it. The
 default cap is **2048 characters**; `0` keeps only the marker, no preview.
 
@@ -257,7 +257,7 @@ still contain a body-embedded secret. Header and URL secrets are redacted (above
 regardless of the cap.
 
 Opt into **full capture** — the whole body, untruncated — when you need it, with
-`maxBodyChars: false` on the file sink:
+`body: { chars: false }` on the file sink:
 
 ```ts twoslash
 import { fileSink, stitch } from 'stitchapi';
@@ -266,7 +266,7 @@ const report = stitch({
     baseUrl: 'https://api.example.com',
     path: '/report',
     // false = capture the whole body; a number sets a custom character cap.
-    trace: fileSink('./runs/today.jsonl', { maxBodyChars: false }),
+    trace: fileSink('./runs/today.jsonl', { body: { chars: false } }),
 });
 ```
 
@@ -287,7 +287,7 @@ STITCH_TRACE_MAX_BODY=8192 node run.js
     values scrubbed. No API changed shape and nothing was removed — if a tool or
     `stitch trace` workflow relied on whole bodies on disk, restore the old
     behaviour with `STITCH_TRACE_MAX_BODY=full` (or
-    `fileSink(path, { maxBodyChars: false })`). A custom `TraceSink` is unaffected:
+    `fileSink(path, { body: { chars: false } })`). A custom `TraceSink` is unaffected:
     it receives the live events and decides for itself.
 </Callout>
 

--- a/apps/docs/content/docs/reference/helpers.mdx
+++ b/apps/docs/content/docs/reference/helpers.mdx
@@ -150,14 +150,14 @@ const sink = consoleSink();
 A file-only sink: append every event as JSONL to `path` (defaults to
 `~/.stitch/runs/proto.jsonl`). Writing to disk is a side effect, so you pass it
 explicitly — a stitch never opens a trace file on its own. An optional second
-argument tunes privacy: `maxBodyChars` (default `2048`; `false` for full capture)
+argument tunes privacy: `body` (a character cap, default `2048`; `{ chars: false }` for full capture)
 caps body/result [truncation](/docs/guides/observability/trace-sinks#body-truncation-and-full-capture),
 and `redactHeaders` widens the redaction denylist.
 
 ```ts twoslash
 import { fileSink } from 'stitchapi';
 
-const sink = fileSink('./runs/today.jsonl', { maxBodyChars: false });
+const sink = fileSink('./runs/today.jsonl', { body: { chars: false } });
 ```
 
 ### createTrace
@@ -165,7 +165,7 @@ const sink = fileSink('./runs/today.jsonl', { maxBodyChars: false });
 Build a zero-infra trace sink: a compact one-line-per-event summary on the
 console and/or an appended JSONL record per event. `console` defaults to `true`;
 `file` defaults to a path under `$HOME`, or `false` to disable the JSONL stream;
-`maxBodyChars` and `redactHeaders` tune the JSONL sink's
+`body` and `redactHeaders` tune the JSONL sink's
 [privacy defaults](/docs/guides/observability/trace-sinks#default-secret-redaction)
 (header/URL redaction and body truncation are always applied to the file stream).
 (This is the low-level builder behind `consoleSink`/`fileSink`; the off-by-default

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -93,9 +93,9 @@ _Resolved (2026-07 sweep):_ the key-derivation functions in `IdempotencyOptions`
 `key` is a string everywhere; the GraphQL document string moved off `query` to
 **`document`**, leaving `query` to mean URL params only; `retry.on` and `throttle.on`
 share one shape and one meaning — the statuses that trigger that envelope's capability
-(`StatusMatch`, [P7](#p7--status-classification-parity)); `bodyKind` survives only on
-the CLI-internal `from-curl` parser type (`ParsedRequest`), off the published surface —
-every published field is `bodyType`.
+(`StatusMatch`, [P7](#p7--status-classification-parity)); `bodyKind` is gone — the
+2026-08-01 sweep renamed the last holdout, on the CLI-internal `from-curl` parser type
+(`ParsedRequest`), so `bodyType` is the one spelling everywhere, published or internal.
 
 ### P2 · Don't reuse one word for genuinely different concepts — rename one
 
@@ -190,7 +190,10 @@ success payload as **`data`** and its failure payload as **`error`**.
 
 _Resolved (2026-07 sweep):_ success is `data` on every runtime envelope that had
 drifted to `value` — `Inspection`, `StitchEvent.result`, `SurfaceOutcome`, `CacheHit`;
-`SchemaFingerprint.value`→`token`.
+`SchemaFingerprint.value`→`token`. _(2026-08-01:)_ `ApiKeyOptions.value`→**`secret`** —
+the credential field rode the reserved word too (the shape is inlined into `apiKey`'s
+emitted `.d.ts`, so it is published surface; OpenAPI's `apiKey` scheme carries no
+credential field, so no mirror was owed).
 
 ### P6 · `key` is a string; `keyOf` is a function
 
@@ -630,32 +633,34 @@ plugin-extension-hook bag, are all real shapes this rule does not reach.
 shared `parseBytes`, whose units are **powers of 1024** (`'1mb'` = 1_048_576). Every
 **emitted** size is a raw-byte `number`.
 
-Unlike a duration ([P17](#p17--one-canonical-duration-form)), a **top-level** size field
-**KEEPS** its unit suffix. `Ms` encodes a **scale**, which `'5s'` overrides — so the
-suffix becomes a lie and P17 drops it. `Bytes` encodes a **dimension**: octets, as opposed
-to the `Chars` family (`stream.maxBufferChars`, `trace.maxBodyChars`) that counts UTF-16
-code units of decoded text. `'1mb'` restates the scale, never the dimension, so the suffix
-stays true. That distinction is load-bearing per
-[P1](#p1--one-word-one-concept-one-value-space) — `Bytes` denotes bytes and cannot also
-denote code units — and a `Chars` field therefore **MUST NOT** take a byte token.
+**A size cap never rides a flat, suffixed top-level field — it lives inside the envelope
+that names its subject** (P12/P14/P24: `serve`'s `body`, trace's `body`, `stream`'s and
+shell's `buffer`). Inside the envelope the subject is named once, so the ceiling field
+carries only the **dimension**:
 
-**Inside a named envelope, the suffix is dropped.** When the envelope already names the one
-thing being measured, its ceiling is a bare **`max`** — there is only one thing there to
-measure (P1), and `max` bounds a **magnitude**, the case [P4](#p4--one-cap-vocabulary)
-leaves it. This is the size analogue of `BackoffOptions.max` (`{ curve, base, max }` under
-`backoff`), and it is where the unmarked default does the work: bytes are the house size
-unit, so an unsuffixed size ceiling **IS** bytes, and only the `Chars` family is marked.
-A `Chars` cap therefore **MUST NOT** shed its suffix into a bare `max` — the marked member
-of a pair cannot be the one that goes unmarked.
+- a **byte** ceiling is the bare **`max`** — the unmarked default does the work (bytes are
+  the house size unit, so an unsuffixed size ceiling **IS** bytes), `max` bounds a
+  **magnitude** (the case [P4](#p4--one-cap-vocabulary) leaves it, the size analogue of
+  `BackoffOptions.max`), and it accepts `number | string`;
+- a **character-count** ceiling is **`chars`** — a bare plural count noun (P4's own
+  `tokens` case: UTF-16 code units of decoded text are countable units) — and it **MUST
+  NOT** accept a byte token, so its type is `number` with **no string arm**. A `'64kb'`
+  on decoded text is a category error, and the grammar makes it a **compile** error.
 
-_The pair that proves it:_ `ServeOptions.maxBodyBytes` bounds what a single request may
-**buffer** (413 past it); `TraceOptions.maxBodyChars` bounds what a sink **logs**
-(truncated past it). Same noun, two dimensions, both top-level — the suffix is the only
-thing telling them apart. So neither may drop it, and neither may be folded into an
-envelope that would: an envelope is licensed where it names an unambiguous subject
-(`buffer` on a subprocess), **never** as a route around a live `Bytes`/`Chars` contrast.
-A later consistency sweep that "finishes the job" on these two would delete the
-distinction, not tidy it.
+The Bytes/Chars contrast is load-bearing per
+[P1](#p1--one-word-one-concept-one-value-space) — a byte cap and a code-unit cap are
+different value-spaces — and this rule carries it **twice**: in the inner field name
+(`max` vs `chars`) and in the type (`number | string` vs `number`). Both marks survive
+every fold; neither depends on a suffix a rename could shed.
+
+_History:_ until 2026-08-01 this section mandated the opposite for top-level fields —
+keep the `Bytes`/`Chars` suffix — defending the flat `ServeOptions.maxBodyBytes` /
+`TraceOptions.maxBodyChars` pair on the grounds that the suffix was the only thing
+telling the two dimensions apart. The amendment folded all three flat caps into
+envelopes ([§6](#6-migration-record-2026-07-08-hard-break-sweep)): `serve`'s
+`body: '2mb'` ≡ `{ max: '2mb' }`, trace's `body: 2048` ≡ `{ chars: 2048 }`, and
+`stream`'s `buffer: 4_000_000` ≡ `{ chars: 4_000_000 }`. The contrast the old clause
+protected did not dissolve — it moved into names and types, where the compiler holds it.
 
 _Why:_ every JS-native size API (`byteLength`, `Buffer.length`, `execFile`'s `maxBuffer`)
 is already bytes, so a bare number needs no unit; and 1024-based `kb`/`mb` is what the
@@ -665,11 +670,13 @@ base the house defaults are written in (`10 * 1024 * 1024`). An unparseable toke
 to `undefined` and lands on the field's default — a typo can never widen a cap to
 "unbounded".
 
-_Canonical case:_ `ServeOptions.maxBodyBytes` (top-level, so suffixed) and
-`@stitchapi/shell`'s `buffer` slot (`ShellBufferOptions.max`, under an envelope, plus its
-[P12](#p12--envelope--scalar-shorthand) shorthand `buffer: '2mb'`) each take
-`2 * 1024 * 1024` or `'2mb'`; `parseBytes` is exported from `stitchapi` so a peer package
-parses the grammar instead of mirroring it.
+_Canonical case:_ the two **byte** envelopes — `serve`'s `body`
+(`ServeBodyOptions.max`, shorthand `body: '2mb'`) and `@stitchapi/shell`'s `buffer`
+(`ShellBufferOptions.max`, shorthand `buffer: '2mb'`) — each take `2 * 1024 * 1024` or
+`'2mb'`; the two **chars** envelopes — trace's `body` (`TraceBodyOptions.chars`,
+shorthand `body: 2048`) and `stream`'s `buffer` (`StreamBufferOptions.chars`, shorthand
+`buffer: 4_000_000`) — take a bare count, never a token. `parseBytes` is exported from
+`stitchapi` so a peer package parses the grammar instead of mirroring it.
 
 ---
 
@@ -680,12 +687,12 @@ While the line is pre-GA, a rename may land as a hard break or under a `@depreca
 — [P19](#p19--the-alias-obligation-is-scoped-to-the-ga-channel) scopes the obligation to
 the GA channel. Severity = consumer blast radius.
 
-**Still open.** The row below is CLI-internal — `from-curl.ts` is imported by `cli.ts`
-alone, exported from no index and behind no subpath — but it is **not** the whole open
-set. A follow-up audit (2026-07-31) swept every principle against the published surface
-and found further violations that no rule in [§7](#7-enforcement) was tracking. A green
-baseline meant "nothing the rules can see", not "nothing there" — so the rules were
-widened first, and each finding is then fixed against a gate that holds it:
+**The open set is empty.** A follow-up audit (2026-07-31) swept every principle against
+the published surface and found violations no rule in [§7](#7-enforcement) was tracking —
+a green baseline meant "nothing the rules can see", not "nothing there" — so the rules
+were widened first, and each finding was fixed against a gate that holds it. A second
+exhaustive pass (2026-08-01) then verified every multi-word field name on the published
+surface — 249 of them — against P1/P4/P17/P18/P22/P24/P25 and closed what it found:
 
 - **P20** — four slots typed `Fn | Options` or `Options | false`, where `{}` still
   compiled. **Fixed** (`AtLeastOne`, and `errorHandler` gained the `true` spelling).
@@ -693,15 +700,36 @@ widened first, and each finding is then fixed against a gate that holds it:
   side is framework-qualified `VueUseStitchResult`).
 - **P4** — `maxTokens` on the `stitchapi/llm` types. **Fixed**
   ([P4](#p4--one-cap-vocabulary) → `tokens`; the wire keeps `max_tokens`).
-- **P16** — nest's SSE options carry the flat spellings the _Settled_ clause above forbids;
-  solid and svelte accept a `streaming` they hard-set and ignore. **Open.**
-- **P14** — an anonymous inline shape on `SecurityScheme`'s oauth2 arm. **Open.**
+- **P16** — nest's SSE options carried the flat spellings the _Settled_ clause above
+  forbids. **Fixed** (PR #574: all six hosts derive from core's one `SseEmitOptions`;
+  nest's extras were lifted into the shared envelope). Solid and svelte accepted a
+  `streaming` they hard-set and ignored. **Fixed** (PR #573: the flag is
+  `Omit`-ted from their option types, matching react/vue/angular).
+- **P14** — an anonymous inline shape on `SecurityScheme`'s oauth2 arm. **Fixed**
+  (2026-08-01: the flow shape is the named, exported `OAuth2ClientCredentialsFlow`;
+  every field keeps the OpenAPI/RFC spelling per P22 — the shape mirrors the standard,
+  the name is ours).
+- **P5 + P15** — `apiKey`'s credential field was `value`, the one word P5 reserves for
+  the Standard-Schema success payload (the `SchemaFingerprint.value`→`token` precedent;
+  the shape is inlined into `apiKey`'s emitted `.d.ts`, so it is published surface).
+  **Fixed** (2026-08-01: `apiKey({ secret })` — OpenAPI's `apiKey` scheme carries no
+  credential field, so there was no upstream spelling to mirror; and per P15 the one
+  required field names its scalar shorthand, `apiKey(env('X'))` ≡
+  `apiKey({ secret: env('X') })`, matching `bearer`'s positional secret).
+- **P1** — the CLI-internal `from-curl` parser's `bodyKind`. **Fixed** (2026-08-01:
+  `bodyType`, the one spelling every published field already used; CLI-internal, no
+  consumer impact).
+- **P25** — the flat, suffix-carrying size caps (`ServeOptions.maxBodyBytes`,
+  `TraceOptions.maxBodyChars`, `StreamOptions.maxBufferChars`). **Fixed** (2026-08-01:
+  folded into subject-named envelopes — `serve`'s `body` (`{ max }`), trace's `body`
+  (`{ chars }`), `stream`'s `buffer` (`{ chars }`) — under the amended
+  [P25](#p25--one-canonical-size-form), which now carries the Bytes/Chars contrast in
+  the inner field name and the type grammar instead of a top-level suffix. The trace
+  fold also closed a latent trap: full capture was the too-easy `maxBodyChars: false`;
+  it is now the deliberate `body: { chars: false }`, while `body: false` means the
+  intuitive "never persist a payload".)
 
-| Sev | Current                | Proposed   | Rule |
-| --- | ---------------------- | ---------- | ---- |
-| Low | `bodyKind` (from-curl) | `bodyType` | P1   |
-
-Everything else this table used to list has **shipped** and moved to the record below —
+Everything else this section once listed has **shipped** and moved to the record below —
 the cross-package `StitchStore`/`StitchLike`/`RequestSeam` clashes (qualified per-framework
 and per-ecosystem), `queryOptions`→`stitchQueryOptions`, `OAuth2Opts`/`CookieSessionOpts`,
 the anonymous `paginate` shape, the SSE helper, the error-options types, and

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -723,7 +723,7 @@ import { anthropic, llm } from 'stitchapi/llm';
 const chat = llm({
     provider: anthropic,
     model: 'claude-opus-4-8',
-    auth: apiKey({ name: 'x-api-key', value: env('ANTHROPIC_API_KEY') }),
+    auth: apiKey({ name: 'x-api-key', secret: env('ANTHROPIC_API_KEY') }),
 });
 
 const { text } = await chat({
@@ -813,7 +813,7 @@ STITCH_EXPORT=otlp node app.js
 STITCH_TRACE_MAX_BODY=full node app.js
 ```
 
-That is per-call latency, status, attempts, throttle waits, and drift findings — recorded for free once you opt in, inspectable with [`stitch trace`](#the-stitch-cli) or plain `jq`. Drift rides the same events, so a leveled drift signal shows up in the trace with no extra wiring. The built-in JSONL and console sinks are safe by default — scrubbing happens at the sink boundary, so the live request is never touched, only the trace copy. Header values on a secret denylist (`authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-api-key`; widen it with `redactHeaders`) become `[REDACTED]`; credentials in the resolved URL are scrubbed (userinfo removed, secret query values like `api_key`/`access_token` replaced with `REDACTED`); and request bodies and response values are truncated to 2048 characters, with anything larger replaced by a `{ truncated, chars, preview }` marker. Opt into full, untruncated capture with `STITCH_TRACE_MAX_BODY=full` (or `fileSink(path, { maxBodyChars: false })`). Need a custom sink? Consume `.stream()` yourself — the built-in trace is just one consumer of the same events.
+That is per-call latency, status, attempts, throttle waits, and drift findings — recorded for free once you opt in, inspectable with [`stitch trace`](#the-stitch-cli) or plain `jq`. Drift rides the same events, so a leveled drift signal shows up in the trace with no extra wiring. The built-in JSONL and console sinks are safe by default — scrubbing happens at the sink boundary, so the live request is never touched, only the trace copy. Header values on a secret denylist (`authorization`, `proxy-authorization`, `cookie`, `set-cookie`, `x-api-key`; widen it with `redactHeaders`) become `[REDACTED]`; credentials in the resolved URL are scrubbed (userinfo removed, secret query values like `api_key`/`access_token` replaced with `REDACTED`); and request bodies and response values are truncated to 2048 characters, with anything larger replaced by a `{ truncated, chars, preview }` marker. Opt into full, untruncated capture with `STITCH_TRACE_MAX_BODY=full` (or `fileSink(path, { body: { chars: false } })`). Need a custom sink? Consume `.stream()` yourself — the built-in trace is just one consumer of the same events.
 
 ## The stitch CLI
 

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -198,7 +198,10 @@ export function bearer(token: Secret | OptionalSecret): AuthStrategy {
 /**
  * Options for {@link apiKey}. `in` selects where the key goes and `name` labels it there — the same
  * two fields for every location (they no longer diverge by arm), so the shape maps 1:1 onto
- * OpenAPI's `apiKey` security scheme (`{ name, in }`, CONTRACT.md P22).
+ * OpenAPI's `apiKey` security scheme (`{ name, in }`, CONTRACT.md P22). The key itself is `secret`
+ * — NOT `value`, which P5 reserves surface-wide for the Standard-Schema success payload (the same
+ * overload that renamed `SchemaFingerprint.value` to `token`); OpenAPI's scheme carries no
+ * credential material, so there is no upstream spelling to mirror for it.
  *
  * Local (non-exported) — like {@link OAuth2Options}/{@link CookieSessionOptions}, the builder's
  * param type is not part of the package's public export surface (P16: none of the auth option
@@ -213,7 +216,7 @@ interface ApiKeyOptions {
      */
     name?: string;
     /** The key itself — a {@link Secret} resolved at call time; the caller never sees it. */
-    value: Secret;
+    secret: Secret;
 }
 
 /**
@@ -260,8 +263,17 @@ function setCookiePair(
  * and `cookie` arms write header names already on the trace denylist (`cookie` / `x-api-key`); and
  * the `query` arm registers its `name` with the URL-credential scrubber, so if the key surfaces in a
  * sink (an OTLP `url.full`, the structured `input.query`) it is REDACTED, like `api_key`/… are.
+ *
+ * `secret` is the envelope's one required field, so it names its own scalar shorthand
+ * (CONTRACT.md P15), matching {@link bearer}'s positional secret:
+ * `apiKey(env('API_KEY'))` ≡ `apiKey({ secret: env('API_KEY') })`.
  */
-export function apiKey(opts: ApiKeyOptions): AuthStrategy {
+export function apiKey(optsOrSecret: ApiKeyOptions | Secret): AuthStrategy {
+    // A `Secret` is a string or a thunk; the envelope is the one non-callable object form.
+    const opts: ApiKeyOptions =
+        typeof optsOrSecret === 'string' || typeof optsOrSecret === 'function'
+            ? { secret: optsOrSecret }
+            : optsOrSecret;
     if (opts.in === 'query') {
         const name = opts.name ?? 'api_key';
         // Teach the trace scrubber this param name carries a secret, so the key never reaches a
@@ -276,7 +288,7 @@ export function apiKey(opts: ApiKeyOptions): AuthStrategy {
                 // switches the leading `?` to `&` and preserves any trailing `#fragment`.
                 req.url = appendQueryString(
                     req.url,
-                    buildQuery({ [name]: resolve(opts.value) }),
+                    buildQuery({ [name]: resolve(opts.secret) }),
                 );
             },
         };
@@ -295,7 +307,7 @@ export function apiKey(opts: ApiKeyOptions): AuthStrategy {
                 req.headers['cookie'] = setCookiePair(
                     req.headers['cookie'],
                     name,
-                    resolve(opts.value),
+                    resolve(opts.secret),
                 );
             },
         };
@@ -306,7 +318,7 @@ export function apiKey(opts: ApiKeyOptions): AuthStrategy {
         name: 'apiKey',
         scheme: { type: 'apiKey', in: 'header', name: headerName },
         apply(req) {
-            req.headers[header] = resolve(opts.value);
+            req.headers[header] = resolve(opts.secret);
         },
     };
 }

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -488,7 +488,7 @@ from-curl:
   Deterministically turns ONE example into a ready-to-paste \`export const … = stitch({…})\` plus a
   matching call. URL origin → baseUrl, the rest → path with id-like segments lifted into {param}
   slots (each lift is warned). A captured credential is NEVER emitted — recognised auth becomes
-  \`bearer(env('API_TOKEN'))\` / \`apiKey({ value: env('API_KEY') })\` / \`basic({ … })\`. Without --zod
+  \`bearer(env('API_TOKEN'))\` / \`apiKey({ secret: env('API_KEY') })\` / \`basic({ … })\`. Without --zod
   no output schema is emitted, just a comment to add one.
 
 init (alias: rules):

--- a/packages/core/src/config-anatomy.ts
+++ b/packages/core/src/config-anatomy.ts
@@ -19,10 +19,10 @@ import type {
     InputSchemas,
     MultipartOptions,
     ResolvedCacheOptions,
+    ResolvedStreamOptions,
     RetryOptions,
     SseOptions,
     StitchConfig,
-    StreamOptions,
     ThrottleOptions,
     TimeoutOptions,
 } from './types';
@@ -235,7 +235,7 @@ export interface ResolvedNormalizations {
     idempotency?: IdempotencyOptions;
     throttle?: ThrottleOptions;
     circuit?: CircuitOptions;
-    stream?: StreamOptions;
+    stream?: ResolvedStreamOptions;
     multipart?: MultipartOptions;
     sse?: SseOptions;
     hooks?: Hooks;

--- a/packages/core/src/from-curl.ts
+++ b/packages/core/src/from-curl.ts
@@ -21,7 +21,7 @@ export interface ParsedRequest {
     /** Raw request body (already a string); `bodyType` says how to read it. */
     body?: string;
     /** How the body was supplied: a JSON document, a urlencoded form, or unknown. */
-    bodyKind?: 'json' | 'form';
+    bodyType?: 'json' | 'form';
     /** `-G`/`--get`: fold `-d` data into the query string instead of the body. */
     asQuery?: boolean;
     /** Anything we recognised but could not faithfully map — surfaced, never swallowed. */
@@ -267,7 +267,7 @@ function finalizeRequest(acc: CurlAcc): ParsedRequest {
         const joined = acc.dataParts.map((p) => p.value).join('&');
         req.body = joined;
         const anyUrlencode = acc.dataParts.some((p) => p.urlencode);
-        req.bodyKind = anyUrlencode ? 'form' : sniffBodyKind(joined);
+        req.bodyType = anyUrlencode ? 'form' : sniffBodyType(joined);
     }
     return req;
 }
@@ -303,7 +303,7 @@ export function parseCurl(curl: string | string[]): ParsedRequest {
 
 // Classify a raw `-d` payload: a JSON-parseable document → 'json', else (k=v&… or anything else)
 // → 'form'. Conservative — only valid JSON is treated as JSON.
-function sniffBodyKind(raw: string): 'json' | 'form' {
+function sniffBodyType(raw: string): 'json' | 'form' {
     const trimmed = raw.trim();
     if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
         try {
@@ -380,11 +380,11 @@ export function parseHar(har: unknown, entryIndex = 0): ParsedRequest {
             typeof request.postData?.mimeType === 'string'
                 ? request.postData.mimeType
                 : '';
-        req.bodyKind = mime.includes('x-www-form-urlencoded')
+        req.bodyType = mime.includes('x-www-form-urlencoded')
             ? 'form'
             : mime.includes('json')
               ? 'json'
-              : sniffBodyKind(text);
+              : sniffBodyType(text);
     }
     return req;
 }
@@ -760,7 +760,7 @@ function analyzeRequest(req: ParsedRequest): AnalyzedRequest {
     // Static headers: drop auth/transport/implied-content-type noise.
     const bodyType: StitchConfig['bodyType'] | undefined =
         !req.asQuery && req.body
-            ? req.bodyKind === 'form'
+            ? req.bodyType === 'form'
                 ? 'form'
                 : 'json'
             : undefined;
@@ -939,10 +939,10 @@ function renderAuth(auth: AuthEmit): string {
             return `bearer(env('${auth.envName}'))`;
         case 'apiKey':
             return auth.queryName
-                ? `apiKey({ in: 'query', name: '${auth.queryName}', value: env('${auth.envName}') })`
+                ? `apiKey({ in: 'query', name: '${auth.queryName}', secret: env('${auth.envName}') })`
                 : auth.header && auth.header.toLowerCase() !== 'x-api-key'
-                  ? `apiKey({ name: '${auth.header}', value: env('${auth.envName}') })`
-                  : `apiKey({ value: env('${auth.envName}') })`;
+                  ? `apiKey({ name: '${auth.header}', secret: env('${auth.envName}') })`
+                  : `apiKey({ secret: env('${auth.envName}') })`;
         case 'basic':
             return `basic({ user: env('${auth.userEnv}'), pass: env('${auth.passEnv}') })`;
     }

--- a/packages/core/src/json-stream.ts
+++ b/packages/core/src/json-stream.ts
@@ -21,7 +21,7 @@
  * Default cap on the chars the `'json'` decoder will buffer for a single in-progress value before
  * it throws — characters of the DECODED text (UTF-16 code units), not bytes off the socket. ~8M:
  * generous for real records, but bounded so a malformed / never-closing value (e.g. an unterminated
- * `[`) can't grow the buffer without limit. Overridable per-stream via `stream.maxBufferChars`. The
+ * `[`) can't grow the buffer without limit. Overridable per-stream via `stream.buffer.chars`. The
  * engine (`runStreaming`) turns the throw into an `error` event.
  */
 export const JSON_STREAM_DEFAULT_MAX_BUFFER_CHARS = 8 * 1024 * 1024;
@@ -89,7 +89,7 @@ export async function* jsonStream(
     const guard = (): void => {
         if (buf.length > maxBufferChars) {
             throw new Error(
-                `json decoder: in-progress value exceeded maxBufferChars (${String(
+                `json decoder: in-progress value exceeded the stream.buffer.chars cap (${String(
                     maxBufferChars,
                 )}); a malformed or never-closing value was streamed`,
             );

--- a/packages/core/src/line-reader.ts
+++ b/packages/core/src/line-reader.ts
@@ -18,7 +18,7 @@ import { JSON_STREAM_DEFAULT_MAX_BUFFER_CHARS } from './json-stream';
  * a descriptive Error instead. This mirrors the `'json'` decoder's per-value cap (`json-stream.ts`)
  * — same default (~8M chars), same "the engine turns the throw into an
  * `error` event" contract (`runStreaming`), so an abusive body fails the stream cleanly rather than
- * OOM-ing. Overridable per-stream via `stream.maxBufferChars`.
+ * OOM-ing. Overridable per-stream via `stream.buffer.chars`.
  *
  * On any completion — normal end OR an early generator `.return()` (a consumer `break`s without
  * aborting a signal) — the `finally` proactively `cancel()`s the underlying stream before releasing
@@ -38,7 +38,7 @@ export async function* lineReader(
     const guard = (): void => {
         if (buf.length > maxBufferChars) {
             throw new Error(
-                `line reader: un-terminated line exceeded maxBufferChars (${String(
+                `line reader: un-terminated line exceeded the stream.buffer.chars cap (${String(
                     maxBufferChars,
                 )}); a stream with no newline was sent`,
             );

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -177,7 +177,7 @@ function llmConfig(config: LlmOptions): Partial<StitchConfig> {
  * const chat = llm({
  *     provider: anthropic,
  *     model: 'claude-opus-4-8',
- *     auth: apiKey({ name: 'x-api-key', value: env('ANTHROPIC_API_KEY') }),
+ *     auth: apiKey({ name: 'x-api-key', secret: env('ANTHROPIC_API_KEY') }),
  * });
  * const { text } = await chat({ body: { messages: [{ role: 'user', content: 'hi' }] } });
  * ```

--- a/packages/core/src/serve.ts
+++ b/packages/core/src/serve.ts
@@ -10,7 +10,7 @@
 import { compact } from './compact';
 import { type StitchRegistry, selectStitch } from './registry';
 import { redactEventForTransport } from './trace';
-import type { StitchEvent, StitchInput } from './types';
+import type { AtLeastOne, StitchEvent, StitchInput } from './types';
 import { parseBytes } from './util';
 
 import {
@@ -24,15 +24,29 @@ export interface ServeOptions {
     port?: number; // default 8787; 0 picks an ephemeral port
     host?: string; // default 127.0.0.1
     /**
-     * Reject a request body larger than this many bytes with 413 (see
-     * {@link MAX_REQUEST_BODY_BYTES}). `serve` is unauthenticated (loopback by default, but
-     * `--host` lets an operator bind a wider interface), so this bounds the memory a single
-     * request can buffer. Default {@link MAX_REQUEST_BODY_BYTES}.
-     *
-     * A raw byte count or a size token — `4 * 1024 * 1024` or `'4mb'` (powers of 1024),
-     * parsed by the shared {@link parseBytes}.
+     * How the request body is bounded — {@link ServeBodyOptions}, or its dominant field's scalar
+     * (CONTRACT.md P12): `body: '4mb'` ≡ `body: { max: '4mb' }`. `serve` is unauthenticated
+     * (loopback by default, but `--host` lets an operator bind a wider interface), so this bounds
+     * the memory a single request can buffer. Default {@link MAX_REQUEST_BODY_BYTES}.
      */
-    maxBodyBytes?: number | string;
+    body?: number | string | AtLeastOne<ServeBodyOptions>;
+}
+
+/**
+ * Bounds on what a single request may buffer. An envelope rather than a bare byte-cap key so the
+ * next request-body control lands inside it instead of adding a top-level word (P21). Inside it
+ * `max` needs no unit suffix: bytes are the house size unit (CONTRACT.md P25), and a request body
+ * off the socket is natively bytes — unlike the `chars` caps (`trace.body.chars`,
+ * `stream.buffer.chars`), which count UTF-16 code units of decoded text and take no size token.
+ */
+export interface ServeBodyOptions {
+    /**
+     * Ceiling on the buffered request body; past it the request is rejected with 413. A raw byte
+     * count or a size token — `4 * 1024 * 1024` or `'4mb'` (powers of 1024), parsed by the shared
+     * {@link parseBytes}. An unparseable token falls back to the default cap, never to
+     * "unbounded". Default {@link MAX_REQUEST_BODY_BYTES}.
+     */
+    max?: number | string;
 }
 
 export interface ServeHandle {
@@ -46,9 +60,9 @@ export interface ServeHandle {
 // `cli.ts --host` lets an operator bind a wider interface, so an unbounded body would let a single
 // large/slow POST buffer the whole payload into memory → OOM. A few MB comfortably fits any real
 // stitch input (JSON params/query/headers/variables) while capping that exposure. Unrelated to
-// trace's `DEFAULT_MAX_BODY_CHARS` (2048 code units) — that one truncates what gets *logged*,
-// this one bounds what a single request may *buffer*. Override per server via
-// {@link ServeOptions.maxBodyBytes}, as a byte count or a `'2mb'`-style token.
+// trace's `body.chars` cap (2048 code units) — that one truncates what gets *logged*, this one
+// bounds what a single request may *buffer*. Override per server via {@link ServeOptions.body},
+// as a byte count, a `'2mb'`-style token, or the `{ max }` envelope.
 export const MAX_REQUEST_BODY_BYTES = 2 * 1024 * 1024;
 
 // Thrown by `readBody` when the body exceeds the cap; the handler maps it to 413.
@@ -187,15 +201,17 @@ async function runJson(
 }
 
 // A framework-free request handler. Exposed so it can be mounted in an existing
-// server or driven directly in tests. `maxBodyBytes` caps the request body (413 past it);
-// defaults to {@link MAX_REQUEST_BODY_BYTES}.
+// server or driven directly in tests. `body` caps the request body (413 past it) — the
+// scalar or the `{ max }` envelope; defaults to {@link MAX_REQUEST_BODY_BYTES}.
 export function createServeHandler(
     registry: StitchRegistry,
-    { maxBodyBytes }: { maxBodyBytes?: number | string } = {},
+    { body }: { body?: ServeOptions['body'] } = {},
 ): (req: IncomingMessage, res: ServerResponse) => Promise<void> {
-    // Parse the cap ONCE here, not per request. An unparseable token resolves to `undefined`
-    // and lands on the default cap — a typo can never widen this to "unbounded".
-    const limit = parseBytes(maxBodyBytes) ?? MAX_REQUEST_BODY_BYTES;
+    // Fold the P12 scalar and parse the cap ONCE here, not per request. An unparseable token
+    // resolves to `undefined` and lands on the default cap — a typo can never widen this to
+    // "unbounded".
+    const max = typeof body === 'object' ? body.max : body;
+    const limit = parseBytes(max) ?? MAX_REQUEST_BODY_BYTES;
     return async (req, res) => {
         const url = new URL(req.url ?? '/', 'http://localhost');
         const path = url.pathname;
@@ -269,10 +285,7 @@ export function serve(
     opts: ServeOptions = {},
 ): Promise<ServeHandle> {
     const host = opts.host ?? '127.0.0.1';
-    const handle = createServeHandler(
-        registry,
-        compact({ maxBodyBytes: opts.maxBodyBytes }),
-    );
+    const handle = createServeHandler(registry, compact({ body: opts.body }));
     const server = createServer((req, res) => {
         handle(req, res).catch((e: unknown) => {
             if (!res.headersSent)

--- a/packages/core/src/sse.ts
+++ b/packages/core/src/sse.ts
@@ -107,7 +107,7 @@ function dispatchFrame(frame: SseFrame): SseEvent | undefined {
 // DoS). `lineReader` caps a single un-terminated LINE with the same knob; this caps the frame that
 // spans many terminated lines. Counted in characters of the decoded text, not bytes off the socket.
 // Same default (~8M chars) and thrown-error → `error` event contract as the
-// `'json'` decoder (`json-stream.ts` / `runStreaming`). Overridable per-stream via `stream.maxBufferChars`.
+// `'json'` decoder (`json-stream.ts` / `runStreaming`). Overridable per-stream via `stream.buffer.chars`.
 async function* parseEventStream(
     body: ReadableStream<Uint8Array>,
     maxBufferChars: number = JSON_STREAM_DEFAULT_MAX_BUFFER_CHARS,
@@ -136,7 +136,7 @@ async function* parseEventStream(
                 frameChars += added.length + (before > 0 ? 1 : 0);
                 if (frameChars > maxBufferChars) {
                     throw new Error(
-                        `sse parser: un-dispatched event data exceeded maxBufferChars (${String(
+                        `sse parser: un-dispatched event data exceeded the stream.buffer.chars cap (${String(
                             maxBufferChars,
                         )}); a frame with no terminating blank line was streamed`,
                     );
@@ -159,7 +159,7 @@ export const sseSurface: Surface<StitchInput, SseEvent[]> = {
         if (body instanceof ReadableStream)
             yield* parseEventStream(
                 body as ReadableStream<Uint8Array>,
-                cfg.stream?.maxBufferChars,
+                cfg.stream?.buffer?.chars,
             );
     },
     contractValue: (chunk) => (chunk as SseEvent).data,

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -55,6 +55,7 @@ import {
     type StitchInput,
     type StitchResult,
     type StitchStore,
+    type StreamOptions,
     type TraceSink,
     isStitch,
 } from './types';
@@ -199,6 +200,14 @@ function expandShorthand(cfg: Partial<StitchConfig>): void {
         cfg.retry = {
             ...retry,
             backoff: envelope(retry.backoff, 'curve'),
+        };
+    // Nested fold (P25): `stream.buffer` is a scalar-or-envelope slot too — the bare char count
+    // folds to `{ chars }`, so `__config` never carries the number form (P0).
+    const stream = cfg.stream as StreamOptions | undefined;
+    if (stream?.buffer !== undefined)
+        cfg.stream = {
+            ...stream,
+            buffer: envelope(stream.buffer, 'chars'),
         };
     // P7: the cache's list fields take a bare string as the one-element list. Widened HERE, before
     // the deep-merge, so a string in one layer and a list in another merge as one shape and the
@@ -346,7 +355,7 @@ function fileFromEnv(value: string | undefined): string | false {
     return value;
 }
 
-// `STITCH_TRACE_MAX_BODY` tunes JSONL body/result truncation: unset → the built-in
+// `STITCH_TRACE_MAX_BODY` tunes JSONL body/result truncation (the trace `body` slot): unset → the built-in
 // default cap; `full` → full capture (no truncation); a non-negative integer → that
 // character cap (`0` keeps only the marker). Anything else falls back to the default.
 function maxBodyFromEnv(value: string | undefined): number | false | undefined {
@@ -359,12 +368,15 @@ function maxBodyFromEnv(value: string | undefined): number | false | undefined {
 
 function getTrace(): TraceSink {
     const file = fileFromEnv(readEnv('STITCH_TRACE_FILE'));
-    const maxBodyChars = maxBodyFromEnv(readEnv('STITCH_TRACE_MAX_BODY'));
+    const maxBody = maxBodyFromEnv(readEnv('STITCH_TRACE_MAX_BODY'));
     const base = createTrace(
         compact({
             console: readEnv('STITCH_TRACE_CONSOLE') === '1',
             file,
-            maxBodyChars,
+            // `full` (no truncation) is the deliberate long spelling on the `body` slot —
+            // `body: false` means the opposite (marker only), so the env value maps to the
+            // envelope form, never the bare boolean.
+            body: maxBody === false ? { chars: false as const } : maxBody,
         }),
     );
     if (!exportsFromEnv(readEnv('STITCH_EXPORT')).includes('otlp')) return base;

--- a/packages/core/src/stream.ts
+++ b/packages/core/src/stream.ts
@@ -69,10 +69,10 @@ async function* decodeStream(
     const stream = body as ReadableStream<Uint8Array>;
     const decode = cfg.stream?.decode ?? 'bytes';
 
-    // `maxBufferChars` caps a single un-terminated line for the line-based decoders too (an upstream
-    // that never sends a `\n` would otherwise grow memory without limit); a throw becomes an `error`
-    // event in the engine. Same default (~8 MB) / knob as the `'json'` decoder below.
-    const maxBufferChars = cfg.stream?.maxBufferChars;
+    // `stream.buffer.chars` caps a single un-terminated line for the line-based decoders too (an
+    // upstream that never sends a `\n` would otherwise grow memory without limit); a throw becomes
+    // an `error` event in the engine. Same default (~8 MB) / knob as the `'json'` decoder below.
+    const maxBufferChars = cfg.stream?.buffer?.chars;
     if (decode === 'lines') {
         yield* lineReader(stream, maxBufferChars);
         return;
@@ -87,9 +87,9 @@ async function* decodeStream(
     }
     if (decode === 'json') {
         // Structural, unframed streaming-JSON (issue #111): one delta per complete value / top-level
-        // array element. `maxBufferChars` (if set) bounds a single in-progress value; a throw on
-        // overflow / mid-value EOF becomes an `error` event in the engine.
-        yield* jsonStream(stream, cfg.stream?.maxBufferChars);
+        // array element. `stream.buffer.chars` (if set) bounds a single in-progress value; a throw
+        // on overflow / mid-value EOF becomes an `error` event in the engine.
+        yield* jsonStream(stream, cfg.stream?.buffer?.chars);
         return;
     }
     // 'bytes' (default): hand back raw chunks exactly as they arrive on the wire.

--- a/packages/core/src/trace.ts
+++ b/packages/core/src/trace.ts
@@ -1,7 +1,13 @@
 // Zero-infra observability sink: append every StitchEvent as a JSONL record and,
 // optionally, print a compact colored one-line-per-event summary to stderr. No deps.
 import { compact } from './compact';
-import type { DriftLevel, StitchEvent, TraceContext, TraceSink } from './types';
+import type {
+    AtLeastOne,
+    DriftLevel,
+    StitchEvent,
+    TraceContext,
+    TraceSink,
+} from './types';
 import {
     dirnameOf,
     isSecretKey,
@@ -15,19 +21,38 @@ export interface TraceOptions {
     console?: boolean; // pretty one-line-per-event to stderr (default true)
     file?: string | false; // JSONL path; default `${process.env.HOME}/.stitch/runs/proto.jsonl`; false disables
     /**
-     * Max length (in characters of the JSON encoding) of the request body and the
-     * response value persisted to the JSONL sink. Anything larger is replaced with a
-     * `{ truncated, chars, preview }` marker, so a multi-MB response never bloats the
-     * log or persists a payload in full. Default {@link DEFAULT_MAX_BODY_CHARS}; pass
-     * `false` for full capture (the pre-1.0 behaviour); `0` keeps only the marker.
+     * How much of the request body / response value is persisted to the JSONL sink —
+     * {@link TraceBodyOptions}, or a shorthand (CONTRACT.md P12/P13):
+     *   - `body: 2048` ≡ `body: { chars: 2048 }` — truncate past that many characters; anything
+     *     larger is replaced with a `{ truncated, chars, preview }` marker, so a multi-MB
+     *     response never bloats the log or persists a payload in full;
+     *   - `body: false` — never persist a payload, keep only the marker;
+     *   - `body: { chars: false }` — full capture, no truncation. Deliberately the long
+     *     spelling: unbounded logs are the footgun, so opting in is explicit.
+     * Default {@link DEFAULT_MAX_BODY_CHARS} characters.
      */
-    maxBodyChars?: number | false;
+    body?: number | false | AtLeastOne<TraceBodyOptions>;
     /**
      * Extra header names (case-insensitive) to redact on top of the built-in
      * denylist. Additive — you can widen the denylist but never shrink it, so a
      * custom value can't accidentally un-redact `authorization`/`cookie`/…
      */
     redactHeaders?: readonly string[];
+}
+
+/**
+ * Bounds on what the JSONL sink persists of a body/result. An envelope rather than a bare cap key
+ * so the next persistence control lands inside it instead of adding a top-level word (P21). The
+ * ceiling is `chars`, not an unsuffixed `max`: it counts UTF-16 code units of the JSON encoding —
+ * decoded text, not bytes — so it takes no `'64kb'`-style size token (CONTRACT.md P25; the byte
+ * caps, `serve`'s `body.max` and shell's `buffer.max`, do).
+ */
+export interface TraceBodyOptions {
+    /**
+     * Character cap on a persisted body/result; `false` disables truncation entirely (full
+     * capture, the pre-1.0 behaviour); `0` keeps only the marker.
+     */
+    chars?: number | false;
 }
 
 // Header names whose values are secrets: redacted before any event leaves for a
@@ -97,8 +122,19 @@ export function redactEventForTransport(event: StitchEvent): StitchEvent {
 
 // Default body/result truncation cap: large enough to keep a small JSON response or
 // error body fully readable, small enough to bound on-disk growth and limit how much
-// payload is persisted by default. Opt into full capture with `maxBodyChars: false`.
+// payload is persisted by default. Opt into full capture with `body: { chars: false }`.
 const DEFAULT_MAX_BODY_CHARS = 2048;
+
+// Fold the `body` slot into the internal cap the sink enforces: a bare number is the P12 scalar
+// for `{ chars }`; `body: false` means "marker only" (the cap is 0 — never a payload); and
+// `{ chars: false }` is the deliberate long spelling for full capture (no truncation).
+// `AtLeastOne` over the one-field envelope guarantees `chars` is present in the object form.
+function resolveBodyCap(body: TraceOptions['body']): number | false {
+    if (body === undefined) return DEFAULT_MAX_BODY_CHARS;
+    if (body === false) return 0;
+    if (typeof body === 'number') return body;
+    return body.chars;
+}
 
 // Deep-clone `value`, replacing any object property whose key is in `denylist`
 // (lowercased secret header names) with '[REDACTED]'. Non-mutating: the engine keeps
@@ -449,7 +485,7 @@ export function createTrace(
         ...SECRET_HEADERS,
         ...(opts?.redactHeaders ?? []).map((h) => h.toLowerCase()),
     ]);
-    const maxBody = opts?.maxBodyChars ?? DEFAULT_MAX_BODY_CHARS;
+    const maxBody = resolveBodyCap(opts?.body);
 
     return {
         path,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -147,17 +147,33 @@ export interface StreamOptions {
     /** Decoder for a `stream` surface body. Default `'bytes'` (total + lossless). */
     decode?: StreamDecode;
     /**
-     * Max characters a streaming decoder will buffer for a single un-terminated unit before throwing
-     * (the engine turns the throw into an `error` event). Counts characters of the DECODED text —
-     * UTF-16 code units, so an astral character costs 2 — not bytes off the socket. Guards every
-     * un-framed / never-closing case against growing client memory without limit (an OOM DoS):
+     * How the decoder's working buffer is bounded — {@link StreamBufferOptions}, or its dominant
+     * field's scalar (CONTRACT.md P12): `buffer: 4_000_000` ≡ `buffer: { chars: 4_000_000 }`.
+     * The same envelope word as `@stitchapi/shell`'s `buffer` slot (P16) — there the buffered
+     * thing is subprocess bytes, so its ceiling is `max` (a size); here it is DECODED TEXT, so the
+     * ceiling is `chars` (a count) and no byte token is accepted (P25: a chars cap never reads a
+     * `'1mb'`-style size).
+     */
+    buffer?: number | AtLeastOne<StreamBufferOptions>;
+}
+/**
+ * Bounds on what a streaming decoder may buffer. An envelope rather than a bare cap key so the
+ * next buffering control (an overflow policy, say) lands inside it instead of adding a top-level
+ * word (P21) — the same reasoning as `@stitchapi/shell`'s `ShellBufferOptions`.
+ */
+export interface StreamBufferOptions {
+    /**
+     * Max characters buffered for a single un-terminated unit before throwing (the engine turns
+     * the throw into an `error` event). Counts characters of the DECODED text — UTF-16 code
+     * units, so an astral character costs 2 — not bytes off the socket. Guards every un-framed /
+     * never-closing case against growing client memory without limit (an OOM DoS):
      *   - `'json'` — a single in-progress value (e.g. an unclosed `[`).
      *   - `'lines'` / `'ndjson'` — a single un-terminated line (a run of text with no `\n`).
      *   - the `sse` surface — one un-dispatched event's `data:` payload (a frame with no blank line).
      * Default ~8M characters (see `json-stream.ts`). Not meaningful for `decode: 'bytes'` (raw,
      * unbuffered).
      */
-    maxBufferChars?: number;
+    chars?: number;
 }
 /**
  * Tuning for resumable SSE reconnection (issue #71). When enabled, the engine reopens a dropped
@@ -516,14 +532,20 @@ export type SecurityScheme =
     | { type: 'apiKey'; in: 'header' | 'query' | 'cookie'; name: string }
     | {
           type: 'oauth2';
-          flows: {
-              clientCredentials?: {
-                  tokenUrl: string;
-                  scopes: Record<string, string>;
-                  refreshUrl?: string;
-              };
-          };
+          flows: { clientCredentials?: OAuth2ClientCredentialsFlow };
       };
+/**
+ * The client-credentials arm of a {@link SecurityScheme}'s `flows` — OpenAPI 3.1's "OAuth Flow
+ * Object", spelled exactly as the spec spells it (`tokenUrl`/`scopes`/`refreshUrl`, CONTRACT.md
+ * P22) so `stitch export --openapi` emits it as an identity mapping. Named and exported per P14 —
+ * the shape mirrors the standard, the name is ours. (`flows` itself stays inline: a single
+ * optional member is not a multi-field sub-object.)
+ */
+export interface OAuth2ClientCredentialsFlow {
+    tokenUrl: string;
+    scopes: Record<string, string>;
+    refreshUrl?: string;
+}
 export interface AuthStrategy {
     name?: string;
     /**
@@ -882,6 +904,11 @@ export interface StitchConfig {
 export type ResolvedCacheOptions = Omit<CacheOptions, 'vary' | 'methods'> & {
     vary?: string[];
     methods?: string[];
+};
+
+/** {@link StreamOptions} after {@link compose}: the `buffer` scalar is folded to `{ chars }`. */
+export type ResolvedStreamOptions = Omit<StreamOptions, 'buffer'> & {
+    buffer?: StreamBufferOptions;
 };
 
 /**

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -102,8 +102,8 @@ export function parseDuration(
  * house defaults are written in (`10 * 1024 * 1024`). The IEC spellings `kib` | `mib` |
  * `gib` | `tib` are accepted for the same values, for callers who want the base explicit.
  *
- * Only for fields that count **bytes**. The `Chars` family (`stream.maxBufferChars`,
- * `trace.maxBodyChars`) counts UTF-16 code units of decoded text, where a byte token would
+ * Only for fields that count **bytes**. The `Chars` family (`stream.buffer.chars`,
+ * `trace.body.chars`) counts UTF-16 code units of decoded text, where a byte token would
  * be a category error — that distinction is what the `Bytes`/`Chars` suffixes carry (P1).
  */
 export function parseBytes(s: number | string | undefined): number | undefined {

--- a/packages/core/test/HARNESS-API.md
+++ b/packages/core/test/HARNESS-API.md
@@ -68,7 +68,7 @@ Drift is schema-anchored — no snapshot (ADR 0015). Each call validates the unw
 
 ## Auth
 
-`bearer(secret)`, `apiKey({ name?, in?, value })` (`in: 'header' | 'query' | 'cookie'`, default `header`), `basic({ user, pass })`, `cookieSession({ login: <stitch>, cookie: 'sid', loginInput?: () => StitchInput, refresh?: [401] })`. Secrets: `env('VAR')` / `secretsFile('name')` return `() => string` resolved at call time. `cookieSession` auto-logs-in when no cookie is stored, replays the captured cookie, and re-logs-in when a response status is matched by `refresh`.
+`bearer(secret)`, `apiKey({ name?, in?, secret })` (`in: 'header' | 'query' | 'cookie'`, default `header`), `basic({ user, pass })`, `cookieSession({ login: <stitch>, cookie: 'sid', loginInput?: () => StitchInput, refresh?: [401] })`. Secrets: `env('VAR')` / `secretsFile('name')` return `() => string` resolved at call time. `cookieSession` auto-logs-in when no cookie is stored, replays the captured cookie, and re-logs-in when a response status is matched by `refresh`.
 
 ## Mock server
 

--- a/packages/core/test/apikey-location.spec.ts
+++ b/packages/core/test/apikey-location.spec.ts
@@ -24,7 +24,7 @@ describe('apiKey — location model (header / query / cookie)', () => {
         const s = stitch({
             baseUrl: server.url,
             path: '/thing',
-            auth: apiKey({ name: 'X-My-Key', value: 'tok' }),
+            auth: apiKey({ name: 'X-My-Key', secret: 'tok' }),
         });
         await s();
         expect(server.calls('/thing')[0]?.headers['x-my-key']).toBe('tok');
@@ -35,10 +35,33 @@ describe('apiKey — location model (header / query / cookie)', () => {
         const s = stitch({
             baseUrl: server.url,
             path: '/thing',
-            auth: apiKey({ value: 'tok' }),
+            auth: apiKey({ secret: 'tok' }),
         });
         await s();
         expect(server.calls('/thing')[0]?.headers['x-api-key']).toBe('tok');
+    });
+
+    test('the P15 scalar shorthand: apiKey(secret) ≡ apiKey({ secret })', async () => {
+        server.route('GET', '/thing', { body: { ok: true } });
+        // A bare string and a thunk are both Secrets — the two non-envelope spellings.
+        const literal = stitch({
+            baseUrl: server.url,
+            path: '/thing',
+            auth: apiKey('tok-literal'),
+        });
+        await literal();
+        expect(server.calls('/thing')[0]?.headers['x-api-key']).toBe(
+            'tok-literal',
+        );
+        const thunked = stitch({
+            baseUrl: server.url,
+            path: '/thing',
+            auth: apiKey(() => 'tok-thunk'),
+        });
+        await thunked();
+        expect(server.calls('/thing')[1]?.headers['x-api-key']).toBe(
+            'tok-thunk',
+        );
     });
 
     test("in: 'query' appends the named param to the URL", async () => {
@@ -46,7 +69,7 @@ describe('apiKey — location model (header / query / cookie)', () => {
         const s = stitch({
             baseUrl: server.url,
             path: '/thing',
-            auth: apiKey({ in: 'query', name: 'access_token', value: 'tok' }),
+            auth: apiKey({ in: 'query', name: 'access_token', secret: 'tok' }),
         });
         await s();
         expect(server.calls('/thing')[0]?.query['access_token']).toBe('tok');
@@ -57,7 +80,7 @@ describe('apiKey — location model (header / query / cookie)', () => {
         const s = stitch({
             baseUrl: server.url,
             path: '/thing',
-            auth: apiKey({ in: 'cookie', name: 'sid', value: 'tok' }),
+            auth: apiKey({ in: 'cookie', name: 'sid', secret: 'tok' }),
         });
         await s();
         const call = server.calls('/thing')[0];
@@ -71,7 +94,7 @@ describe('apiKey — location model (header / query / cookie)', () => {
             baseUrl: server.url,
             path: '/thing',
             headers: { cookie: 'theme=dark' },
-            auth: apiKey({ in: 'cookie', name: 'sid', value: 'tok' }),
+            auth: apiKey({ in: 'cookie', name: 'sid', secret: 'tok' }),
         });
         await s();
         const call = server.calls('/thing')[0];
@@ -85,7 +108,7 @@ describe('apiKey — location model (header / query / cookie)', () => {
             baseUrl: server.url,
             path: '/thing',
             headers: { cookie: 'sid=stale; theme=dark' },
-            auth: apiKey({ in: 'cookie', name: 'sid', value: 'fresh' }),
+            auth: apiKey({ in: 'cookie', name: 'sid', secret: 'fresh' }),
         });
         await s();
         const call = server.calls('/thing')[0];

--- a/packages/core/test/composition.spec.ts
+++ b/packages/core/test/composition.spec.ts
@@ -308,6 +308,15 @@ test('retry.backoff folds its bare curve into the envelope', () => {
             .retry,
     ).toEqual({ backoff: { base: 50, max: 500 } });
 
+    // P25: `stream.buffer` is the same nested scalar-or-envelope shape — the bare char count
+    // folds to `{ chars }`, and it must survive the outer `stream` scalar shorthand too.
+    expect(
+        compose({ path: '/x', stream: { decode: 'json', buffer: 64 } }).stream,
+    ).toEqual({ decode: 'json', buffer: { chars: 64 } });
+    expect(
+        compose({ path: '/x', stream: { buffer: { chars: 64 } } }).stream,
+    ).toEqual({ buffer: { chars: 64 } });
+
     // No `backoff` at all → the slot stays absent rather than gaining an empty envelope.
     expect(compose({ path: '/x', retry: 3 }).retry).toEqual({ attempts: 3 });
 });

--- a/packages/core/test/from-curl-edges.spec.ts
+++ b/packages/core/test/from-curl-edges.spec.ts
@@ -34,7 +34,7 @@ describe('toStitchSource — auth recognition (untested strategies)', () => {
         );
         expect(source).not.toContain('secret-123');
         expect(source).toContain(
-            "apiKey({ in: 'query', name: 'api_key', value: env('API_KEY') })",
+            "apiKey({ in: 'query', name: 'api_key', secret: env('API_KEY') })",
         );
         expect(source).toContain(
             "import { stitch } from 'stitchapi';\nimport { apiKey, env } from 'stitchapi/auth'",
@@ -52,7 +52,7 @@ describe('toStitchSource — auth recognition (untested strategies)', () => {
         );
         expect(source).not.toContain('tok-xyz');
         expect(source).toContain(
-            "apiKey({ in: 'query', name: 'access_token', value: env('API_KEY') })",
+            "apiKey({ in: 'query', name: 'access_token', secret: env('API_KEY') })",
         );
     });
 });
@@ -135,7 +135,7 @@ describe('parseHar — body kind and entry selection', () => {
                 },
             }),
         );
-        expect(req.bodyKind).toBe('form');
+        expect(req.bodyType).toBe('form');
         expect(req.body).toBe('a=1&b=2');
     });
 

--- a/packages/core/test/from-curl.spec.ts
+++ b/packages/core/test/from-curl.spec.ts
@@ -54,15 +54,15 @@ describe('parseCurl', () => {
         expect(req.headers).toEqual([{ name: 'X-A', value: 'b' }]);
     });
 
-    test('-d JSON → bodyKind json; --data-urlencode → form', () => {
+    test('-d JSON → bodyType json; --data-urlencode → form', () => {
         const json = parseCurl(
             `curl -d '{"name":"Ada"}' https://api.example.com/users`,
         );
-        expect(json.bodyKind).toBe('json');
+        expect(json.bodyType).toBe('json');
         const form = parseCurl(
             'curl --data-urlencode q=ada https://api.example.com/s',
         );
-        expect(form.bodyKind).toBe('form');
+        expect(form.bodyType).toBe('form');
     });
 
     test('an unknown flag warns and does not crash', () => {
@@ -144,7 +144,7 @@ describe('toStitchSource', () => {
         expect(source).toContain('limit: 10');
     });
 
-    test('an x-api-key header → apiKey({ value: env(API_KEY) }), secret stripped', () => {
+    test('an x-api-key header → apiKey({ secret: env(API_KEY) }), secret stripped', () => {
         const key = 'apikey-zzz-1234567890';
         const { source } = toStitchSource(
             parseCurl(
@@ -152,7 +152,7 @@ describe('toStitchSource', () => {
             ),
         );
         expect(source).not.toContain(key);
-        expect(source).toContain("apiKey({ value: env('API_KEY') })");
+        expect(source).toContain("apiKey({ secret: env('API_KEY') })");
         expect(source).toContain(
             "import { stitch } from 'stitchapi';\nimport { apiKey, env } from 'stitchapi/auth'",
         );
@@ -207,7 +207,7 @@ describe('parseHar', () => {
         expect(req.url).toBe('https://api.example.com/items');
         // The HTTP/2 pseudo-header is dropped.
         expect(req.headers.some((h) => h.name.startsWith(':'))).toBe(false);
-        expect(req.bodyKind).toBe('json');
+        expect(req.bodyType).toBe('json');
         expect(req.body).toBe('{"sku":"abc"}');
     });
 

--- a/packages/core/test/gaps/apikey-query.spec.ts
+++ b/packages/core/test/gaps/apikey-query.spec.ts
@@ -41,7 +41,7 @@ describe("issue #147 — apiKey({ in: 'query' }) placement", () => {
         const call = stitch({
             baseUrl: server.url,
             path: '/q-none',
-            auth: apiKey({ in: 'query', value: 'sk-123' }),
+            auth: apiKey({ in: 'query', secret: 'sk-123' }),
         });
         await expect(call()).resolves.toEqual({ ok: true });
         // The default param name is 'api_key'.
@@ -57,7 +57,7 @@ describe("issue #147 — apiKey({ in: 'query' }) placement", () => {
         const call = stitch({
             baseUrl: server.url,
             path: '/q-some?page=2',
-            auth: apiKey({ in: 'query', name: 'token', value: 'sk-abc' }),
+            auth: apiKey({ in: 'query', name: 'token', secret: 'sk-abc' }),
         });
         await expect(call()).resolves.toEqual({ ok: true });
         const q = server.calls('/q-some')[0]?.query ?? {};
@@ -73,7 +73,7 @@ describe("issue #147 — apiKey({ in: 'query' }) placement", () => {
         const call = stitch({
             baseUrl: server.url,
             path: '/q-thunk',
-            auth: apiKey({ in: 'query', value }),
+            auth: apiKey({ in: 'query', secret: value }),
         });
         // Constructing the stitch must NOT have resolved the thunk yet.
         expect(n).toBe(0);
@@ -94,7 +94,7 @@ describe("issue #147 — apiKey({ in: 'query' }) placement", () => {
         const call = stitch({
             baseUrl: server.url,
             path: '/q-enc',
-            auth: apiKey({ in: 'query', value: raw }),
+            auth: apiKey({ in: 'query', secret: raw }),
         });
         await expect(call()).resolves.toEqual({ ok: true });
         // The server decodes the percent-encoded value back to the exact original — so each
@@ -129,7 +129,7 @@ describe("issue #147 — apiKey({ in: 'query' }) placement", () => {
             auth: apiKey({
                 in: 'query',
                 name: 'appkeyparam',
-                value: 'sk-leak',
+                secret: 'sk-leak',
             }),
             trace: fileSink(traceFile),
         });
@@ -156,7 +156,7 @@ describe("issue #147 — apiKey({ in: 'query' }) placement", () => {
         const call = stitch({
             baseUrl: server.url,
             path: '/hdr',
-            auth: apiKey({ value: 'sk-hdr' }),
+            auth: apiKey({ secret: 'sk-hdr' }),
         });
         await expect(call()).resolves.toEqual({ ok: true });
         const c = server.calls('/hdr')[0];

--- a/packages/core/test/gaps/redirect-credential-leak.spec.ts
+++ b/packages/core/test/gaps/redirect-credential-leak.spec.ts
@@ -128,7 +128,7 @@ describe('fetchAdapter — cross-origin redirect must not forward auth/custom he
         const call = stitch({
             url: 'https://api.trusted.com/thing',
             method: 'GET',
-            auth: apiKey({ value: env('REDIRECT_TEST_KEY') }),
+            auth: apiKey({ secret: env('REDIRECT_TEST_KEY') }),
             adapter: fetchAdapter({ fetch: spy }),
         });
         await call();

--- a/packages/core/test/gaps/trace-controls.spec.ts
+++ b/packages/core/test/gaps/trace-controls.spec.ts
@@ -189,9 +189,9 @@ test('STITCH_TRACE_MAX_BODY=full captures the whole body (no truncation)', async
     expect((result['data'] as { blob: string }).blob).toBe(BIG);
 });
 
-// (f) Opt-in full capture (code): fileSink(path, { maxBodyChars: false }) is the
+// (f) Opt-in full capture (code): fileSink(path, { body: { chars: false } }) is the
 // in-code equivalent of the env switch.
-test('fileSink({ maxBodyChars: false }) captures the whole body', async () => {
+test('fileSink({ body: { chars: false } }) captures the whole body', async () => {
     const traceFile = join(tmpdir(), `stitch-trace-cap-${process.pid}.jsonl`);
     rmSync(traceFile, { force: true });
     cleanupPaths.push(traceFile);
@@ -201,12 +201,35 @@ test('fileSink({ maxBodyChars: false }) captures the whole body', async () => {
         name: 'cap',
         baseUrl: server.url,
         path: '/cap',
-        trace: fileSink(traceFile, { maxBodyChars: false }),
+        trace: fileSink(traceFile, { body: { chars: false } }),
     });
     await expect(call()).resolves.toEqual({ blob: BIG });
 
     const result = readRecords(traceFile).find((r) => r['type'] === 'result')!;
     expect((result['data'] as { blob: string }).blob).toBe(BIG);
+});
+
+// (f2) The other end of the `body` slot: `body: false` means "never persist a payload" —
+// only the `{ truncated, chars, preview }` marker lands, with an empty preview. (Full
+// capture is the deliberate long spelling `{ chars: false }` above; the bare boolean is
+// the safe direction.)
+test('fileSink({ body: false }) persists only the marker, never the payload', async () => {
+    const traceFile = join(tmpdir(), `stitch-trace-off-${process.pid}.jsonl`);
+    rmSync(traceFile, { force: true });
+    cleanupPaths.push(traceFile);
+
+    server.route('GET', '/cap', { body: { blob: BIG } });
+    const call = stitch({
+        name: 'cap-off',
+        baseUrl: server.url,
+        path: '/cap',
+        trace: fileSink(traceFile, { body: false }),
+    });
+    await expect(call()).resolves.toEqual({ blob: BIG });
+
+    const result = readRecords(traceFile).find((r) => r['type'] === 'result')!;
+    expect(result['data']).toMatchObject({ truncated: true });
+    expect(readFileSync(traceFile, 'utf8')).not.toContain(BIG.slice(0, 64));
 });
 
 // (g) URL credential-scrub: a secret-bearing query param is REDACTED in the

--- a/packages/core/test/graphql-and-headers.spec.ts
+++ b/packages/core/test/graphql-and-headers.spec.ts
@@ -39,7 +39,7 @@ describe('GraphQL kind', () => {
         const query = graphql({
             baseUrl: server.url,
             document: 'query($id: ID) { thing(id: $id) { name } }',
-            auth: apiKey({ name: 'apikey', value: env('GQL_KEY') }),
+            auth: apiKey({ name: 'apikey', secret: env('GQL_KEY') }),
         });
 
         const out = await query({ variables: { id: 1 } });

--- a/packages/core/test/integration-patterns.spec.ts
+++ b/packages/core/test/integration-patterns.spec.ts
@@ -70,7 +70,7 @@ describe('GraphQL-over-HTTP API (ApiKey header, 1 req/s bucket, retry on 429/5xx
             method: 'POST',
             baseUrl: server.url,
             path: '/graphql',
-            auth: apiKey({ name: 'apikey', value: env('METADATA_API_KEY') }),
+            auth: apiKey({ name: 'apikey', secret: env('METADATA_API_KEY') }),
             retry: {
                 attempts: 5,
                 on: [429, 500, 502, 503],
@@ -95,7 +95,7 @@ describe('GraphQL-over-HTTP API (ApiKey header, 1 req/s bucket, retry on 429/5xx
             method: 'POST',
             baseUrl: server.url,
             path: '/graphql',
-            auth: apiKey({ name: 'apikey', value: () => 'sk' }),
+            auth: apiKey({ name: 'apikey', secret: () => 'sk' }),
             throttle: { rate: '1/s' },
         });
         const start = Date.now();
@@ -251,7 +251,7 @@ describe('Diverse co-located auth (three providers, three header formats)', () =
             path: '/system',
             auth: apiKey({
                 name: 'authorization',
-                value: () => `MediaToken token="${env('MEDIA_A_TOKEN')()}"`,
+                secret: () => `MediaToken token="${env('MEDIA_A_TOKEN')()}"`,
             }),
         });
         const mediaB = stitch({
@@ -259,7 +259,7 @@ describe('Diverse co-located auth (three providers, three header formats)', () =
             path: '/node',
             auth: apiKey({
                 name: 'x-media-token',
-                value: env('MEDIA_B_TOKEN'),
+                secret: env('MEDIA_B_TOKEN'),
             }),
             hooks: {
                 onRequest: ({ req }) =>

--- a/packages/core/test/json-stream-buffer.spec.ts
+++ b/packages/core/test/json-stream-buffer.spec.ts
@@ -1,6 +1,6 @@
 // Two behaviours of the `'json'` streaming tokenizer (src/json-stream.ts) that json-stream.spec.ts
 // leaves open. That suite proves chunk-split correctness exhaustively and that a *single*
-// never-closing value trips the maxBufferChars guard — but not:
+// never-closing value trips the buffer.chars guard — but not:
 //   1. that the cap is PER-VALUE, not cumulative: the sliding-window compaction drops each emitted
 //      value, so a long run of small complete values whose TOTAL dwarfs the cap streams fine. This
 //      is the whole reason compact()/base exist; without them this stream would false-trip the guard.
@@ -35,7 +35,7 @@ async function decode(
 }
 
 describe('json-stream: the buffer cap bounds a VALUE, not the whole stream', () => {
-    test('many small complete values whose total dwarfs maxBufferChars all stream (compaction works)', async () => {
+    test('many small complete values whose total dwarfs the buffer cap all stream (compaction works)', async () => {
         const COUNT = 500;
         const cap = 1024; // each value is ~12 bytes; the total (~6 KB) is far over the cap.
         // One object per chunk forces cross-read compaction (each read appends, emits, compacts).

--- a/packages/core/test/json-stream.spec.ts
+++ b/packages/core/test/json-stream.spec.ts
@@ -216,13 +216,15 @@ describe('json-stream tokenizer: max-buffer guard + incomplete streams', () => {
         );
     });
 
-    test('a never-closing value throws once the buffer exceeds maxBufferChars', async () => {
+    test('a never-closing value throws once the buffer exceeds the buffer cap', async () => {
         // An open `[` whose content never closes; cap at 64 bytes so it trips quickly.
         const chunks = [
             enc.encode('['),
             ...Array.from({ length: 50 }, () => enc.encode('1234567890')),
         ];
-        await expect(decode(chunks, 64)).rejects.toThrow(/maxBufferChars/);
+        await expect(decode(chunks, 64)).rejects.toThrow(
+            /stream\.buffer\.chars/,
+        );
     });
 
     test('a stream that ends mid-value throws (complete-value semantics)', async () => {

--- a/packages/core/test/openapi.spec.ts
+++ b/packages/core/test/openapi.spec.ts
@@ -349,7 +349,7 @@ describe('toOpenApi security schemes', () => {
             createThing: stitch({
                 method: 'POST',
                 url: 'https://api.example.com/things',
-                auth: apiKey({ name: 'X-My-Key', value: 'zzz-apikey-cred' }),
+                auth: apiKey({ name: 'X-My-Key', secret: 'zzz-apikey-cred' }),
             }),
             grant: stitch({
                 url: 'https://api.example.com/grant',
@@ -443,11 +443,11 @@ describe('toOpenApi security schemes', () => {
         const registry: StitchRegistry = {
             a: stitch({
                 url: 'https://api.example.com/a',
-                auth: apiKey({ name: 'X-Key-A', value: 'k' }),
+                auth: apiKey({ name: 'X-Key-A', secret: 'k' }),
             }),
             b: stitch({
                 url: 'https://api.example.com/b',
-                auth: apiKey({ name: 'X-Key-B', value: 'k' }),
+                auth: apiKey({ name: 'X-Key-B', secret: 'k' }),
             }),
         };
         const { document } = toOpenApi(registry);

--- a/packages/core/test/serve.spec.ts
+++ b/packages/core/test/serve.spec.ts
@@ -259,7 +259,7 @@ describe('serve caps the request body (413), so an unauthenticated server cannot
     let capped: ServeHandle;
     beforeAll(async () => {
         const ping = stitch({ baseUrl: api.url, path: '/ping' });
-        capped = await serve({ ping }, { port: 0, maxBodyBytes: CAP });
+        capped = await serve({ ping }, { port: 0, body: CAP });
     });
     afterAll(async () => {
         await capped.close();
@@ -332,7 +332,7 @@ describe('the body cap also accepts a size token (`parseBytes`)', () => {
     let capped: ServeHandle;
     beforeAll(async () => {
         const ping = stitch({ baseUrl: api.url, path: '/ping' });
-        capped = await serve({ ping }, { port: 0, maxBodyBytes: '1kb' });
+        capped = await serve({ ping }, { port: 0, body: { max: '1kb' } });
     });
     afterAll(async () => {
         await capped.close();

--- a/packages/core/test/sse.spec.ts
+++ b/packages/core/test/sse.spec.ts
@@ -19,14 +19,14 @@ import {
 import { z } from 'zod';
 
 // Run the SSE frame parser over the given chunk boundaries and collect the parsed events. A small
-// `maxBufferChars` cap can be threaded through `stream.maxBufferChars` (unbounded-buffer guard).
+// buffer cap can be threaded through `stream.buffer.chars` (unbounded-buffer guard).
 async function parse(
     chunks: string[],
-    cfg: { stream?: { maxBufferChars?: number } } = {},
+    cfg: { stream?: { buffer?: { chars?: number } } } = {},
 ): Promise<SseEvent[]> {
     const res = { status: 200, headers: {}, body: streamOf(chunks) };
     const out: SseEvent[] = [];
-    // `stream` is defined on a streaming surface; tests may assert non-null. Only `stream.maxBufferChars`
+    // `stream` is defined on a streaming surface; tests may assert non-null. Only `stream.buffer.chars`
     // is read off `cfg`, so this partial config (a resolved config's fields are all optional) suffices.
     for await (const ev of sseSurface.stream!(res, cfg))
         out.push(ev as SseEvent);
@@ -123,8 +123,10 @@ describe('sse buffer cap — an unbounded body fails instead of OOM-ing (securit
         // carry grows past the cap. Without the cap this would buffer the whole (unbounded) body.
         const noNewline = 'data: ' + 'x'.repeat(CAP * 4); // no trailing "\n\n"
         await expect(
-            parse([noNewline], { stream: { maxBufferChars: CAP } }),
-        ).rejects.toThrow(/un-terminated line exceeded maxBufferChars/);
+            parse([noNewline], { stream: { buffer: { chars: CAP } } }),
+        ).rejects.toThrow(
+            /un-terminated line exceeded the stream\.buffer\.chars cap/,
+        );
     });
 
     test('endless data: lines with NO dispatching blank line past the cap throws (frame guard)', async () => {
@@ -134,15 +136,17 @@ describe('sse buffer cap — an unbounded body fails instead of OOM-ing (securit
         const manyDataLines =
             Array.from({ length: 200 }, () => 'data: chunk').join('\n') + '\n'; // no blank line ⇒ never dispatched
         await expect(
-            parse([manyDataLines], { stream: { maxBufferChars: CAP } }),
-        ).rejects.toThrow(/un-dispatched event data exceeded maxBufferChars/);
+            parse([manyDataLines], { stream: { buffer: { chars: CAP } } }),
+        ).rejects.toThrow(
+            /un-dispatched event data exceeded the stream\.buffer\.chars cap/,
+        );
     });
 
     test('a normal stream UNDER the cap still parses (no false positive)', async () => {
         // Well under 64 bytes of data per frame, each properly blank-line terminated.
         expect(
             await parse(['data: {"n":1}\n\ndata: {"n":2}\n\n'], {
-                stream: { maxBufferChars: CAP },
+                stream: { buffer: { chars: CAP } },
             }),
         ).toEqual([{ data: { n: 1 } }, { data: { n: 2 } }]);
     });
@@ -156,9 +160,11 @@ describe('sse buffer cap — an unbounded body fails instead of OOM-ing (securit
         );
         await expect(
             parse([lines.join('\n') + '\n'], {
-                stream: { maxBufferChars: CAP },
+                stream: { buffer: { chars: CAP } },
             }),
-        ).rejects.toThrow(/un-dispatched event data exceeded maxBufferChars/);
+        ).rejects.toThrow(
+            /un-dispatched event data exceeded the stream\.buffer\.chars cap/,
+        );
     });
 });
 
@@ -231,19 +237,19 @@ describe('sse over the engine (event spine + await)', () => {
         expect(ev.done?.ok).toBe(false);
     });
 
-    test('an unbounded body past maxBufferChars fails the stream with error+done (not OOM)', async () => {
+    test('an unbounded body past the buffer.chars cap fails the stream with error+done (not OOM)', async () => {
         // A body that streams a long run with no newline / no dispatching blank line. The parser's
         // buffer cap throws; runStreaming turns the throw into error+done — a clean failure, not an
         // unbounded-memory grow. (This is the engine-spine counterpart to the frame-parser unit tests.)
         const s = sse({
             url: 'https://x.test/flood',
-            stream: { maxBufferChars: 64 },
+            stream: { buffer: { chars: 64 } },
             adapter: streamAdapter(streamOf(['data: ' + 'x'.repeat(4096)])), // no "\n\n" terminator
         });
         const ev = await collectEvents(s.stream());
         expect(ev.deltas).toEqual([]); // nothing was ever dispatched
         expect(ev.types).toContain('error');
-        expect(ev.error?.message).toMatch(/maxBufferChars/);
+        expect(ev.error?.message).toMatch(/stream\.buffer\.chars/);
         expect(ev.done?.ok).toBe(false);
     });
 });
@@ -471,13 +477,15 @@ describe('lineReader teardown + cap (shared streaming plumbing)', () => {
         expect(lines).toEqual(['a', 'b', 'c']);
     });
 
-    test('a single un-terminated line past maxBufferChars throws a descriptive error', async () => {
+    test('a single un-terminated line past the buffer.chars cap throws a descriptive error', async () => {
         // No `\n` ever arrives, so the carry grows unbounded — the cap turns that into a clean throw.
         await expect(async () => {
             for await (const _ of lineReader(streamOf(['x'.repeat(200)]), 64)) {
                 void _;
             }
-        }).rejects.toThrow(/un-terminated line exceeded maxBufferChars/);
+        }).rejects.toThrow(
+            /un-terminated line exceeded the stream\.buffer\.chars cap/,
+        );
     });
 });
 

--- a/packages/core/test/stream.spec.ts
+++ b/packages/core/test/stream.spec.ts
@@ -185,10 +185,10 @@ describe('stream event spine (Decisions 5, 12)', () => {
         expect(ev.done?.ok).toBe(false);
     });
 
-    test('decode "json": a never-closing value past maxBufferChars surfaces an error event', async () => {
+    test('decode "json": a never-closing value past the buffer.chars cap surfaces an error event', async () => {
         const s = stream({
             url: 'https://x.test/overflow',
-            stream: { decode: 'json', maxBufferChars: 64 },
+            stream: { decode: 'json', buffer: { chars: 64 } },
             // an open object whose single string value never closes — the in-progress slice grows
             // without bound (nothing can be emitted/compacted), so the cap trips.
             adapter: streamAdapter(
@@ -198,7 +198,7 @@ describe('stream event spine (Decisions 5, 12)', () => {
 
         const ev = await collectEvents(s.stream());
         expect(ev.types).toContain('error');
-        expect(ev.error?.message).toMatch(/maxBufferChars/);
+        expect(ev.error?.message).toMatch(/stream\.buffer\.chars/);
         expect(ev.done?.ok).toBe(false);
     });
 });

--- a/packages/openapi/src/gen-openapi.ts
+++ b/packages/openapi/src/gen-openapi.ts
@@ -947,7 +947,7 @@ function deriveAuth(
                 : '';
         const nm = scheme.name ? `name: ${q(scheme.name)}, ` : '';
         return {
-            expr: `apiKey({ ${where}${nm}value: env('API_KEY') })`,
+            expr: `apiKey({ ${where}${nm}secret: env('API_KEY') })`,
             authImports: ['apiKey', 'env'],
         };
     }

--- a/packages/openapi/test/gen-openapi.spec.ts
+++ b/packages/openapi/test/gen-openapi.spec.ts
@@ -251,7 +251,7 @@ describe('planGen — naming, typing, auth, notice', () => {
         const r = planGen(apiKeyDoc('header'), { all: true });
         const c = file(r, 'client.ts') ?? '';
         expect(c).toMatch(
-            /auth: apiKey\(\{ name: 'X-API-Key', value: env\('API_KEY'\) \}\)/,
+            /auth: apiKey\(\{ name: 'X-API-Key', secret: env\('API_KEY'\) \}\)/,
         );
         expect(c).not.toMatch(/apiKey\(\{ in:/);
         expect(r.warnings.join('\n')).not.toMatch(/not auto-mapped/);
@@ -260,7 +260,7 @@ describe('planGen — naming, typing, auth, notice', () => {
     test("apiKey in query → `in: 'query'` discriminant emitted", () => {
         const r = planGen(apiKeyDoc('query'), { all: true });
         expect(file(r, 'client.ts') ?? '').toMatch(
-            /auth: apiKey\(\{ in: 'query', name: 'X-API-Key', value: env\('API_KEY'\) \}\)/,
+            /auth: apiKey\(\{ in: 'query', name: 'X-API-Key', secret: env\('API_KEY'\) \}\)/,
         );
     });
 
@@ -270,7 +270,7 @@ describe('planGen — naming, typing, auth, notice', () => {
         const r = planGen(apiKeyDoc('cookie'), { all: true });
         const c = file(r, 'client.ts') ?? '';
         expect(c).toMatch(
-            /auth: apiKey\(\{ in: 'cookie', name: 'X-API-Key', value: env\('API_KEY'\) \}\)/,
+            /auth: apiKey\(\{ in: 'cookie', name: 'X-API-Key', secret: env\('API_KEY'\) \}\)/,
         );
         expect(r.warnings.join('\n')).not.toMatch(/not auto-mapped/);
     });

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -315,7 +315,7 @@ const PREFIX_GROUP_ALLOW = new Map([
     // Off the published surface, or a derived/internal read-view rather than an authored config:
     [
         'ParsedRequest.body',
-        'body/bodyType is the CLI-internal from-curl parser type — CONTRACT.md P1 records it as explicitly off the published surface',
+        'body/bodyType (payload + discriminator tag, carve-out (b)) on the CLI-internal from-curl parser type — off the published surface; the P1 bodyKind→bodyType rename landed 2026-08-01',
     ],
     [
         'FingerprintInput.transform',


### PR DESCRIPTION
Closes out the 2026-08-01 pre-GA field-naming audit: every multi-word public field name was verified against CONTRACT.md, and everything that audit left open lands here as pre-GA hard breaks (P19, rc channel — no aliases).

## 1. `apiKey({ value })` → `apiKey({ secret })` + scalar shorthand (P5/P15)

`ApiKeyOptions` is inlined into `apiKey`'s emitted `.d.ts`, so its `value` field was published surface — and P5 reserves `value` for the Standard-Schema success payload (the `SchemaFingerprint.value`→`token` precedent). OpenAPI's `apiKey` scheme carries no credential field, so no upstream spelling was owed (P22 covers only `name`/`in`).

Per P15 the one required field names its scalar shorthand, matching `bearer`'s positional secret:

```ts
auth: apiKey(env('API_KEY'))            // ≡ apiKey({ secret: env('API_KEY') })
auth: apiKey({ in: 'query', name: 'api_key', secret: env('API_KEY') })
```

The from-curl and OpenAPI scaffolders emit the new spelling; docs, README, and tests move with it.

## 2. Size caps: flat suffixed fields → subject envelopes (P25 amended)

| Before | After | Shorthand |
| --- | --- | --- |
| `ServeOptions.maxBodyBytes` | `body: AtLeastOne<ServeBodyOptions>` (`{ max }`) | `body: '2mb'` |
| `TraceOptions.maxBodyChars` | `body: AtLeastOne<TraceBodyOptions>` (`{ chars }`) | `body: 2048` |
| `StreamOptions.maxBufferChars` | `buffer: AtLeastOne<StreamBufferOptions>` (`{ chars }`) | `buffer: 4_000_000` |

The Bytes/Chars contrast the suffixes carried is **not deleted — it is strengthened**: byte ceilings are a bare `max` and accept `number | string` size tokens; char-count ceilings are `chars` and accept `number` only, so a `'64kb'` on decoded text is now a **compile error**, not a misreading. `stream`'s envelope word matches `@stitchapi/shell`'s `buffer` (P16); the scalar folds in `expandShorthand` like `retry.backoff`, so `__config` never carries the number form (P0), pinned in `composition.spec`.

The trace fold also closes a latent trap: full capture was the too-easy `maxBodyChars: false`. Now `body: false` means the intuitive "never persist a payload" (marker only), and unbounded capture is the deliberate long spelling `body: { chars: false }`. `STITCH_TRACE_MAX_BODY` env semantics are unchanged.

CONTRACT.md P25 is rewritten accordingly (with the old clause kept as history).

## 3. `SecurityScheme` oauth2 flow shape named (P14)

The anonymous inline `flows.clientCredentials` object is the named, exported `OAuth2ClientCredentialsFlow`. Fields keep the OpenAPI/RFC spellings (P22) — the shape mirrors the standard, the name is ours.

## 4. `bodyKind` → `bodyType` (P1, CLI-internal)

The last §6 table row: the from-curl parser's `bodyKind` (and its sniff helper) now uses the one spelling every published field already had. No consumer impact (`from-curl.ts` is behind `bin/stitch` only). The R8 allow-list rationale for `ParsedRequest.body` is updated to match.

## 5. CONTRACT.md §6: the open set is empty

Records all of the above, plus the two stale "Open" rows that were actually fixed earlier — nest's SSE envelope (#574) and solid/svelte's phantom `streaming` (#573).

## Verification

- core: typecheck (src + tests) clean, **1308 tests pass**, ESLint clean
- openapi: typecheck + 26 tests pass
- repo-wide `check:types` clean; `check:contract` green (baseline 0); companion-exports/attw clean
- apps/docs: 59 tests pass (twoslash re-validated every edited snippet against the rebuilt core)
- bundle-size budget holds — note only **0.08 KB headroom** on the whole entry now

🤖 Generated with [Claude Code](https://claude.com/claude-code)
