### PR TITLE
chore(release): 1.0.0-rc.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ npm release are grouped under the in-development version that introduced them.
 
 ## [Unreleased]
 
+## [1.0.0-rc.7] — 2026-08-01
+
 ### Added
 
 - **`parseDuration` is now exported from `stitchapi`.** The one shared duration parser
@@ -26,39 +28,96 @@ npm release are grouped under the in-development version that introduced them.
   values; parsing is case-insensitive.
 
     ```ts
-    serve(registry, { maxBodyBytes: 4 * 1024 * 1024 }); // still fine
-    serve(registry, { maxBodyBytes: '4mb' }); // now equivalent
+    serve(registry, { body: 4 * 1024 * 1024 }); // a raw byte count
+    serve(registry, { body: '4mb' }); // equivalent
     ```
 
-    `ServeOptions.maxBodyBytes` is widened to `number | string` — purely additive, every
-    existing numeric cap keeps working. An unparseable token resolves to `undefined` and lands
-    on the default cap, so a typo can never widen the bound to "unbounded".
+    Every byte cap accepts `number | string`. An unparseable token resolves to `undefined`
+    and lands on the field's default cap, so a typo can never widen the bound to "unbounded".
 
-    It does **not** apply to the `Chars` family (`stream.maxBufferChars`,
-    `trace.maxBodyChars`): those count UTF-16 code units of decoded text, where a byte token
-    would be a category error. That is the distinction the `Bytes`/`Chars` suffixes carry, so —
-    unlike durations under P17 — a size field keeps its unit suffix.
+    It does **not** apply to the char-count caps (`stream.buffer.chars`,
+    `trace.body.chars`): those count UTF-16 code units of decoded text, where a byte token
+    would be a category error — which is why their type has no string arm at all (see the
+    size-envelope entry below).
+
+- **`apiKey` takes its secret positionally — `apiKey(env('API_KEY'))`.** Per CONTRACT.md
+  P15 the envelope's one required field names its own scalar shorthand, matching
+  `bearer`'s positional secret: `apiKey(env('X'))` ≡ `apiKey({ secret: env('X') })`. The
+  envelope form remains for `in` / `name` customization.
+
+- **`SecurityScheme`'s oauth2 flow shape is named: `OAuth2ClientCredentialsFlow`** (P14).
+  A type-only extraction of the previously anonymous `flows.clientCredentials` object —
+  structurally identical, so nothing breaks; the fields keep the OpenAPI/RFC spellings
+  (`tokenUrl` / `scopes` / `refreshUrl`, P22). The shape is now importable and extendable.
 
 ### Changed
 
-- **BREAKING — `stream.maxBufferBytes` is renamed to `maxBufferChars`.** The cap never
-  counted bytes. Every guard it feeds compares `.length` on a string the `TextDecoder` has
-  already produced (`line-reader.ts`, `json-stream.ts`, `sse.ts`), so it measures characters
-  of the decoded text — UTF-16 code units — not bytes off the socket:
+- **BREAKING — the flat size caps are envelopes: `serve`'s `body`, trace's `body`, and
+  `stream`'s `buffer`** (CONTRACT.md **P25**, amended). Each names its subject once and
+  takes its dominant field's scalar as shorthand (P12):
+
+    ```ts
+    // before                                      // after
+    serve(registry, { maxBodyBytes: '4mb' });      serve(registry, { body: '4mb' });
+    trace: fileSink(path, { maxBodyChars: 4096 })  trace: fileSink(path, { body: 4096 })
+    stream: { maxBufferChars: 8_000_000 }          stream: { buffer: 8_000_000 }
+    ```
+
+    Byte ceilings are a bare `max` inside their envelope and accept `number | string` size
+    tokens; char-count ceilings are `chars` and accept `number` only — the `Bytes`/`Chars`
+    distinction the old suffixes spelled is now carried by the field names and enforced by
+    the type grammar. The envelope word `buffer` matches `@stitchapi/shell`'s existing
+    `buffer` slot (P16). New exported envelopes: `ServeBodyOptions`, `TraceBodyOptions`,
+    `StreamBufferOptions`.
+
+    **Watch the trace `false`.** Full capture (no truncation) was the one-word
+    `maxBodyChars: false`; it is now the deliberate long spelling
+    `body: { chars: false }`. The bare `body: false` means the opposite — never persist a
+    payload, keep only the `{ truncated, chars, preview }` marker. The
+    `STITCH_TRACE_MAX_BODY` env variable's semantics are unchanged (`full` still means
+    full capture). No `@deprecated` aliases (P19, `rc` channel).
+
+- **BREAKING — `apiKey`'s credential field is `secret`, not `value`** (P5). `value` is
+  reserved surface-wide for the Standard-Schema success payload — the same overload that
+  renamed `SchemaFingerprint.value` to `token` — and `ApiKeyOptions` is inlined into
+  `apiKey`'s emitted `.d.ts`, so the field is published surface. OpenAPI's `apiKey`
+  security scheme carries no credential field, so no upstream spelling was owed (P22
+  covers only `name` / `in`):
+
+    ```ts
+    // before
+    auth: apiKey({ in: 'query', name: 'api_key', value: env('API_KEY') });
+    // after
+    auth: apiKey({ in: 'query', name: 'api_key', secret: env('API_KEY') });
+    // header default, with the new positional shorthand:
+    auth: apiKey(env('API_KEY'));
+    ```
+
+    The `stitch gen openapi` and from-curl scaffolders emit the new spelling. No
+    `@deprecated` alias (P19, `rc` channel).
+
+- **BREAKING — `stream.maxBufferBytes` never counted bytes; the cap is now the `buffer`
+  envelope's `chars`.** Every guard it feeds compares `.length` on a string the `TextDecoder`
+  has already produced (`line-reader.ts`, `json-stream.ts`, `sse.ts`), so it measures
+  characters of the decoded text — UTF-16 code units — not bytes off the socket:
 
     ```ts
     // before
     stream: { decode: 'json', maxBufferBytes: 8 * 1024 * 1024 }
     // after
-    stream: { decode: 'json', maxBufferChars: 8 * 1024 * 1024 }
+    stream: { decode: 'json', buffer: { chars: 8 * 1024 * 1024 } }
+    // or the scalar shorthand for the dominant field:
+    stream: { decode: 'json', buffer: 8 * 1024 * 1024 }
     ```
 
     Default and behaviour are unchanged; the name, its JSDoc, and the thrown error text
-    (`… exceeded maxBufferChars (…)`) are all that move. The old name mattered because it
-    understated the guard it exists to be: 8M code units of CJK is ~24 MB of UTF-8 on the wire
-    and ~16 MB of string memory, so an OOM bound that read as "8 MB" was 2–3× looser than it
-    looked. Per P1, `Bytes` already denotes bytes elsewhere on the surface (`ServeOptions.maxBodyBytes`,
-    byte progress) and cannot also denote code units.
+    (`… exceeded the stream.buffer.chars cap (…)`) are all that move. The old name mattered
+    because it understated the guard it exists to be: 8M code units of CJK is ~24 MB of UTF-8
+    on the wire and ~16 MB of string memory, so an OOM bound that read as "8 MB" was 2–3×
+    looser than it looked. Per P1, `Bytes` denotes bytes elsewhere on the surface and cannot
+    also denote code units — and the new type (`number`, no string arm) makes a `'8mb'` token
+    on decoded text a compile error. See the size-envelope entry below for the envelope shape
+    shared with `serve` and `trace`.
 
     No `@deprecated` alias: P19 scopes that obligation to the GA channel and this lands on `rc`.
 
@@ -620,7 +679,8 @@ causality push:
 - **Playground:** the browser Worker runner, handler registration, incremental
   streaming, and the trace → Mermaid DAG wiring.
 
-[Unreleased]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.6...HEAD
+[Unreleased]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.7...HEAD
+[1.0.0-rc.7]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.6...v1.0.0-rc.7
 [1.0.0-rc.6]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.5...v1.0.0-rc.6
 [1.0.0-rc.5]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.4...v1.0.0-rc.5
 [1.0.0-rc.4]: https://github.com/rejifald/StitchAPI/compare/v1.0.0-rc.3...v1.0.0-rc.4

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 
 > [!NOTE]
 >
-> **StitchAPI is at `1.0.0-rc.6`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is welcome.
+> **StitchAPI is at `1.0.0-rc.7`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is welcome.
 
 ---
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -12,22 +12,16 @@ enforcement.
 ## What gets published
 
 `pnpm -r publish` pushes every **non-private** workspace package, in **lockstep**
-at a single version:
-
-| Package                          | Notes                            |
-| -------------------------------- | -------------------------------- |
-| `stitchapi`                      | core library (unscoped, public)  |
-| `@stitchapi/fingerprint-arktype` | cache-fingerprint vendor adapter |
-| `@stitchapi/fingerprint-effect`  | cache-fingerprint vendor adapter |
-| `@stitchapi/fingerprint-typebox` | cache-fingerprint vendor adapter |
-| `@stitchapi/fingerprint-valibot` | cache-fingerprint vendor adapter |
-| `@stitchapi/fingerprint-zod`     | cache-fingerprint vendor adapter |
-| `@stitchapi/nest`                | NestJS integration               |
-| `@stitchapi/redis`               | Redis-backed store               |
-| `@stitchapi/shell`               | shell surface                    |
+at a single version — **33 packages** at the time of writing: `stitchapi` (the
+core library, unscoped) plus the `@stitchapi/*` companions (framework and host
+integrations, stores, fingerprint vendor adapters, the shell surface, tooling
+like `@stitchapi/openapi` and `@stitchapi/docs-mcp`). The authoritative list is
+the manifest set itself — every `packages/*/package.json` without
+`"private": true` — which is exactly what `check:release` walks, so a package
+added tomorrow is covered without editing this page.
 
 **Never published** (`"private": true`): `@stitchapi/completions-plugin`,
-`@stitchapi/sandbox-sim`, `@stitchapi/docs`.
+`@stitchapi/sandbox-sim`, `@stitchapi/eval-harness`, `@stitchapi/docs`.
 
 ## Versioning
 
@@ -77,9 +71,10 @@ Flags: `--print-tag` (print the derived dist-tag and exit), `--changelog`,
 ## Cut a release — checklist
 
 1. [ ] Branch off `main` (a fresh worktree, per [`CLAUDE.md`](../CLAUDE.md)).
-2. [ ] Set the new `version` in **all 9** publishable `packages/*/package.json`
-       (lockstep). For a **major** bump, also widen each companion's `stitchapi`
-       peer range to `^<new-major>.0.0`.
+2. [ ] Set the new `version` in **every** publishable `packages/*/package.json`
+       (lockstep — 33 packages at the time of writing; `check:release` fails if
+       one is missed). For a **major** bump, also widen each companion's
+       `stitchapi` peer range to `^<new-major>.0.0`.
 3. [ ] Update [`CHANGELOG.md`](../CHANGELOG.md): rename `## [Unreleased]` to
        `## [X.Y.Z] — <YYYY-MM-DD>`, add a fresh empty `## [Unreleased]` above it,
        and update the compare links at the bottom.

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/angular",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Angular bindings for StitchAPI — injectStitch/injectStitchStream expose a stitch's lifecycle as both signals and an RxJS observable over @stitchapi/query-core. Streaming-first: re-render as `delta` chunks arrive. Plus an optional TanStack Query stitchQueryOptions helper.",
     "main": "lib/index.js",

--- a/packages/aws-sigv4/package.json
+++ b/packages/aws-sigv4/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/aws-sigv4",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "AWS Signature V4 request signing for StitchAPI — an AuthStrategy that signs each request with SigV4 (Web Crypto, edge-safe), for AWS APIs, S3-compatible stores, and any SigV4-protected endpoint.",
     "main": "lib/index.js",

--- a/packages/cloudflare-kv/package.json
+++ b/packages/cloudflare-kv/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/cloudflare-kv",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Cloudflare Workers KV-backed StitchStore for StitchAPI — edge cache + shared sessions/tokens. Bring your own KV namespace binding. (increment → use a Durable Object store.)",
     "main": "lib/index.js",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,7 +4,7 @@
 
 > [!NOTE]
 >
-> **StitchAPI is at `1.0.0-rc.6`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is welcome.
+> **StitchAPI is at `1.0.0-rc.7`.** The core runtime is feature-complete, zero-dependency, covered by a green test gate, and already running in production in two projects. We're validating in the wild before stamping a stable `1.0.0` — pin an exact version and expect only small, documented changes. Feedback is welcome.
 
 **Turn any REST, GraphQL, SSE, or LLM API into a typed, resilient function.** Its one primitive — a **stitch** — takes a single endpoint and hands you back a callable: declare the endpoint's contract once (input, output, auth, resilience) and call it like a local function. No server, no codegen, no config files — only explicit composition. The same definition your code calls, the CLI runs and an AI agent can invoke without ever touching a credential.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "stitchapi",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Turn any API into a typed, resilient function. A declarative stitch takes one endpoint — HTTP, GraphQL, SSE, LLM, even a shell command — and hands back a callable with auth, retries, validation, and drift built in. No server, no codegen, no config files. Callable from code, the CLI, or an AI agent over MCP — agents get a capability, not your credentials. Zero deps.",
     "main": "lib/index.js",

--- a/packages/deno-kv/package.json
+++ b/packages/deno-kv/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/deno-kv",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Deno KV-backed StitchStore for StitchAPI — distributed throttle + shared sessions/tokens with atomic increment. Bring your own Deno.Kv handle.",
     "main": "lib/index.js",

--- a/packages/docs-mcp/package.json
+++ b/packages/docs-mcp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@stitchapi/docs-mcp",
     "mcpName": "dev.stitchapi/docs",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "StitchAPI documentation search, running locally over MCP stdio. Bundled docs, no network calls per query \u2014 the offline/air-gapped counterpart to the hosted stitchapi.dev/api/mcp server.",
     "bin": {

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/elysia",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Elysia plugin for StitchAPI — put a request-scoped seam on the context, stream a stitch's SSE output, and map Stitch errors to HTTP. Web-standard (Fetch-only, no node:*).",
     "main": "lib/index.js",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/expo",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Expo bindings for StitchAPI — expoFetchAdapter (streaming over expo/fetch, no polyfills), an expo-secure-store-backed StitchStore for encrypted tokens, and the re-exported useStitch/useStitchStream hooks, AsyncStorage store, and AppState/NetInfo refetch helpers from @stitchapi/react-native.",
     "main": "lib/index.js",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/express",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Express middleware for StitchAPI — attach a request-scoped seam to req, stream a stitch's SSE output, and map Stitch errors to HTTP. Express 4 & 5.",
     "main": "lib/index.js",

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fastify",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Fastify plugin for StitchAPI — decorate the app/request with a seam, request-scoped principal (AsyncLocalStorage), and SSE + error + Pino-logger bridges.",
     "main": "lib/index.js",

--- a/packages/fingerprint-arktype/package.json
+++ b/packages/fingerprint-arktype/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-arktype",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for ArkType — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-effect/package.json
+++ b/packages/fingerprint-effect/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-effect",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for Effect Schema — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-typebox/package.json
+++ b/packages/fingerprint-typebox/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-typebox",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for TypeBox — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-valibot/package.json
+++ b/packages/fingerprint-valibot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-valibot",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for Valibot — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/fingerprint-zod/package.json
+++ b/packages/fingerprint-zod/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/fingerprint-zod",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Stable Standard Schema fingerprint strategy for Zod — StitchAPI ADR 0004 cache invalidation.",
     "main": "lib/index.js",

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/hono",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Hono middleware + helpers for StitchAPI — put a seam on the request context, stream a stitch's SSE output, and map Stitch errors to HTTP. Edge/multi-runtime (Fetch-only, no node:*).",
     "main": "lib/index.js",

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/json-schema",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Turn a runtime-discovered JSON Schema into a Standard Schema validator StitchAPI accepts — validate against schemas you only obtain at runtime, without codegen.",
     "main": "lib/index.js",

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/nest",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "First-class NestJS integration for StitchAPI — StitchModule.forRoot/forFeature/forFeatureScoped, injectable stitches, Logger + ConfigService bridges, an exception filter and an SSE bridge (ADR 0006).",
     "main": "lib/index.js",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/next",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Next.js helpers for StitchAPI — stream a stitch as an SSE Response and map a StitchError to a Response, for App Router route handlers (and any Web-standard fetch handler).",
     "main": "lib/index.js",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/openapi",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Eject selected operations from an OpenAPI document into ready-to-own StitchAPI source — a build-time code generator, separate from the zero-dep runtime.",
     "main": "lib/index.js",

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/pino",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Pino TraceSink for StitchAPI — bridge the stitch event stream to a Pino logger as structured, metadata-only log records.",
     "main": "lib/index.js",

--- a/packages/query-core/package.json
+++ b/packages/query-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/query-core",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Framework-agnostic reactive query store for StitchAPI — a subscribe/getSnapshot store wrapping a stitch call (unary + streaming deltas). The shared core behind @stitchapi/react and future Vue/Svelte/Solid bindings.",
     "main": "lib/index.js",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/react-native",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "React Native bindings for StitchAPI — a streaming-capable XHR transport adapter (the streaming `fetch` bare RN lacks), an AsyncStorage-backed StitchStore for persistent sessions/tokens, AppState/NetInfo refetch helpers, and the re-exported useStitch/useStitchStream hooks.",
     "main": "lib/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/react",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "React bindings for StitchAPI — tearing-free useStitch/useStitchStream hooks over useSyncExternalStore, plus an optional TanStack Query queryOptions helper. Streaming-first: re-render as `delta` chunks arrive.",
     "main": "lib/index.js",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/redis",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Redis-backed StitchStore for StitchAPI — distributed throttle + shared sessions/tokens. Bring your own ioredis, node-redis, or Upstash (edge HTTP Redis) client.",
     "main": "lib/index.js",

--- a/packages/rtk-query/package.json
+++ b/packages/rtk-query/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/rtk-query",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "RTK Query bindings for StitchAPI — stitchQueryFn turns a stitch into an RTK Query endpoint queryFn (error-normalized), and stitchStreamUpdater folds a streaming stitch into the cache via onCacheEntryAdded.",
     "main": "lib/index.js",

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/sentry",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "A Sentry TraceSink for StitchAPI — maps the stitch event stream to Sentry breadcrumbs, and captures error events with the call's context. Metadata-only, safe on a secret-bearing seam.",
     "main": "lib/index.js",

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/shell",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Run a static local command as a StitchAPI surface — Node-only, injection-proof by construction (static binary + argv array + no shell). ADR 0008.",
     "main": "lib/index.js",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/solid",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Solid bindings for StitchAPI — createStitch/createStitchStream primitives that reconcile a Solid store from the query-core reactive store. Streaming-first: re-render as `delta` chunks arrive. Plus an optional TanStack Query stitchQueryOptions helper.",
     "main": "lib/index.js",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/svelte",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Svelte bindings for StitchAPI — stitchStore/stitchStreamStore Svelte stores over @stitchapi/query-core (unary + streaming deltas), plus an optional TanStack-shaped stitchQueryOptions helper. Works on Svelte 4 and 5.",
     "main": "lib/index.js",

--- a/packages/swr/package.json
+++ b/packages/swr/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/swr",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "SWR bindings for StitchAPI — useStitchSWR runs a stitch as an SWR fetcher, so SWR owns caching and revalidation while the stitch stays typed, validated, and traced.",
     "main": "lib/index.js",

--- a/packages/vercel-ai/package.json
+++ b/packages/vercel-ai/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/vercel-ai",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Vercel AI SDK adapter for StitchAPI — expose a stitch as a tool() the model can call. It runs the typed, validated, traced stitch as the tool's execute; the model gets validated data, never the credential.",
     "main": "lib/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@stitchapi/vue",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "type": "commonjs",
     "description": "Vue 3 bindings for StitchAPI — reactive useStitch/useStitchStream composables over @stitchapi/query-core, plus an optional TanStack Query stitchQueryOptions helper. Streaming-first: re-render as `delta` chunks arrive.",
     "main": "lib/index.js",

--- a/yakir.lock
+++ b/yakir.lock
@@ -2,147 +2,147 @@
   "version": 1,
   "tethers": {
     "release-version": {
-      "baseline": "1.0.0-rc.6",
+      "baseline": "1.0.0-rc.7",
       "sites": {
         "packages/angular/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/aws-sigv4/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/cloudflare-kv/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/core/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/deno-kv/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/docs-mcp/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/elysia/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/expo/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/express/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/fastify/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/fingerprint-arktype/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/fingerprint-effect/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/fingerprint-typebox/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/fingerprint-valibot/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/fingerprint-zod/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/hono/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/json-schema/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/nest/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/next/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/openapi/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/pino/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/query-core/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/react-native/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/react/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/redis/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/rtk-query/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/sentry/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/shell/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/solid/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/svelte/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/swr/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/vercel-ai/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/vue/package.json#/version": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "README.md#pattern:StitchAPI is at `([^`]+)`": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         },
         "packages/core/README.md#pattern:StitchAPI is at `([^`]+)`": {
-          "value": "1.0.0-rc.6",
-          "fp": "sha256:c476058e11e9fce20e4b9440129a545e26ab96c0e73af45ae0b9adfda45e6828"
+          "value": "1.0.0-rc.7",
+          "fp": "sha256:14274e3152e2e8ccf2cc4eed051eace97f51c83ba018d5d5c44f61fa78e2b9ce"
         }
       },
       "accepted": null


### PR DESCRIPTION
Cuts **v1.0.0-rc.7** — the soak candidate for the 1.0.0 GA cut.

- Lockstep bump across all 33 publishable packages (`check:release` green; the yakir release-version tether propagated the version to both READMEs).
- CHANGELOG: `[Unreleased]` (the rc.6→now delta, #572–#580) becomes `[1.0.0-rc.7] — 2026-08-01`; adds the #580 breaking entries (apiKey `secret` + positional shorthand, the serve/trace/stream size envelopes with the trace `body: false` semantics note, `OAuth2ClientCredentialsFlow`) and amends the two entries #580 superseded to the net rc.6→rc.7 state.
- RELEASING.md: the stale 9-package table becomes a description of the manifest set (33 packages, enforced by `check:release`); step 2's "all 9" corrected.

After merge: tag `v1.0.0-rc.7` + GitHub pre-release → `npm-publish.yml` publishes over OIDC. Trusted Publishers for `@stitchapi/json-schema`/`@stitchapi/openapi` are verified working (rc.5 + rc.6 both carry SLSA provenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)