### PR TITLE
fix(core): finish the `wire` sweep — seven config sites #591 left behind

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -349,8 +349,8 @@ export interface AdapterRequest {
     /**
      * Array serialisation for the urlencoded body; only read when `bodyType: 'form'` (the query
      * string is already serialised into `url` by the time a request reaches the transport).
-     * Defaults to `'indices'` — the same default the query string uses, so one
-     * {@link StitchConfig.arrayFormat} means one thing on both urlencoded surfaces.
+     * Defaults to `'indices'` — the same default the query string uses, so one authored
+     * {@link WireOptions.array} means one thing on both urlencoded surfaces.
      */
     arrayFormat?: ArrayFormat;
     responseType?: ResponseType;
@@ -1365,7 +1365,7 @@ export interface StitchStore {
  * that are intrinsically **per-endpoint**: the address (`path` / `url` / `method` / `document`)
  * and the request/response shape (`name` / `input` / `output` / `kind`). Everything cross-cutting
  * — `baseUrl`, `headers`, `auth`, `retry`, `throttle`, `timeout`, `circuit`, `idempotency`,
- * `paginate`, `pick`, `transform`, `arrayFormat`, `hooks`, `trace`, `store`, `cache`, `adapter`
+ * `paginate`, `pick`, `transform`, `wire`, `hooks`, `trace`, `store`, `cache`, `adapter`
  * — belongs here, so the type itself answers "what belongs at the seam". Members set the endpoint
  * keys.
  */

--- a/packages/core/test/config-at-least-one.spec.ts
+++ b/packages/core/test/config-at-least-one.spec.ts
@@ -91,14 +91,13 @@ test('the opaque `{}` is rejected at each Scalar|AtLeastOne slot (P20)', () => {
 
 test('the scalar / ≥1-field forms are accepted at each slot (P12/P13/P20)', () => {
     const accepted = () => [
-        // `bodyType: 'multipart'` is required alongside `multipart` — the slot is read only on a
+        // `wire.body: 'multipart'` is required alongside `wire.multipart` — the slot is read only on a
         // multipart body, so the pairing is enforced statically. The shorthand under test is the
         // bare `'dot'` string standing in for `{ nesting: 'dot' }` (P12).
         stitch({
             baseUrl: 'https://x',
             path: '/y',
-            bodyType: 'multipart',
-            multipart: 'dot',
+            wire: { body: 'multipart', multipart: 'dot' },
         }),
         stitch({ baseUrl: 'https://x', path: '/y', stream: 'ndjson' }),
         stitch({ baseUrl: 'https://x', path: '/y', sse: true }),

--- a/packages/core/test/cookie-jar.spec.ts
+++ b/packages/core/test/cookie-jar.spec.ts
@@ -39,7 +39,7 @@ const loginStitch = () =>
         method: 'POST',
         baseUrl: server.url,
         path: '/login',
-        bodyType: 'form',
+        wire: { body: 'form' },
     });
 
 test('cookie: "*" captures and replays every cookie the login set', async () => {

--- a/packages/core/test/gaps/cookie-session-hooks.spec.ts
+++ b/packages/core/test/gaps/cookie-session-hooks.spec.ts
@@ -50,8 +50,43 @@ const loginStitch = (baseUrl: string) =>
         method: 'POST',
         baseUrl,
         path: '/login',
-        bodyType: 'form',
+        wire: { body: 'form' },
     });
+
+// REGRESSION GUARD. Every cookie-session login stitch in the suite declares a urlencoded body, and
+// none of them asserted the content-type — so when the `wire` fold left these `bodyType: 'form'`
+// spellings behind, the field was silently ignored, the logins started POSTing JSON, and the whole
+// suite stayed green. `stitch`'s `const C` generic suppresses excess-property checking, so nothing
+// in `tsc` could catch it either. One assertion on the login's actual content-type makes the next
+// such rename fail loudly instead of quietly.
+test('a cookie-session login really posts urlencoded, not JSON', async () => {
+    server.route('POST', '/login', {
+        setCookie: { name: 'sid', value: 'ABC' },
+        body: { ok: true },
+    });
+    server.route('GET', '/data', {
+        requireCookie: { name: 'sid' },
+        body: { ok: true },
+    });
+
+    await stitch({
+        baseUrl: server.url,
+        path: '/data',
+        auth: cookieSession({
+            login: loginStitch(server.url),
+            cookie: 'sid',
+            loginInput,
+            key: 'csh-contenttype',
+            tenancy: 'app', // standalone shared session; no principal to bind here
+        }),
+    })();
+
+    const login = server.calls('/login')[0];
+    expect(login?.headers['content-type']).toMatch(
+        /application\/x-www-form-urlencoded/,
+    );
+    expect(String(login?.body)).not.toContain('{');
+});
 
 test('onRefresh fires with { ok: true, status: 200 } after a successful cold login', async () => {
     server.route('POST', '/login', {

--- a/packages/core/test/integration-patterns.spec.ts
+++ b/packages/core/test/integration-patterns.spec.ts
@@ -124,7 +124,7 @@ describe('Session-cookie admin API (auto re-login on 403)', () => {
             method: 'POST',
             baseUrl: server.url,
             path: '/auth/login',
-            bodyType: 'form',
+            wire: { body: 'form' },
         });
         const resources = stitch({
             baseUrl: server.url,
@@ -176,7 +176,7 @@ describe('HTML scrape provider — silent markup breakage becomes a loud drift e
             method: 'POST',
             baseUrl: server.url,
             path: '/login',
-            bodyType: 'form',
+            wire: { body: 'form' },
         });
         const search = stitch({
             baseUrl: server.url,

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -66,7 +66,7 @@ describe('Pluggable store — sessions', () => {
             method: 'POST',
             baseUrl: server.url,
             path: '/login',
-            bodyType: 'form',
+            wire: { body: 'form' },
         });
         const store = memoryStore();
 
@@ -119,7 +119,7 @@ describe('Pluggable store — sessions', () => {
             method: 'POST',
             baseUrl: server.url,
             path: '/login',
-            bodyType: 'form',
+            wire: { body: 'form' },
         });
 
         const a = stitch({


### PR DESCRIPTION
#591 shipped with an incomplete sweep. Its own commit message warned why this was possible — a stale `bodyType:` produces **no compile error**, because `stitch`'s `const C extends Partial<StitchConfig>` generic captures the argument type and suppresses excess-property checking — and then seven sites proved the point by being missed.

| file | sites |
|---|---|
| `test/store.spec.ts` | 2 |
| `test/integration-patterns.spec.ts` | 2 |
| `test/cookie-jar.spec.ts` | 1 |
| `test/gaps/cookie-session-hooks.spec.ts` | 1 |
| `test/config-at-least-one.spec.ts` | 1 |

## What was actually broken

The first six are cookie-session **login stitches declaring a urlencoded body**. With the field silently ignored they had been POSTing JSON since #591 — and the suite stayed green, because not one of them asserted the content-type. The urlencoded form-login path had no effective coverage at all.

The seventh is worse in kind. `config-at-least-one.spec.ts` exists to pin the P12 scalar shorthand, and #591 migrated lines 27–37 of that very file while leaving line 100. A test whose stated purpose is pinning `multipart: 'dot'` was asserting nothing.

## The regression guard

Restoring the spelling restores intent, but nothing stopped it recurring — so this adds one assertion that the login's actual content-type is `application/x-www-form-urlencoded` and its body isn't JSON.

I verified it is a real guard rather than decoration: putting the old `bodyType: 'form'` spelling back makes it **fail**, and restoring `wire: { body: 'form' }` makes it pass. That assertion is what would have caught this in #591.

## Also included

Two stale doc references from #591, both doc-comment only:

- `AdapterRequest.arrayFormat` pointed at `{@link StitchConfig.arrayFormat}` — a target that slot's own fold deleted. A dead `{@link}` is invisible to `check:types` and to `check:docs-links` (which only walks `/docs/...` links in MDX). The neighbouring `bodyType: 'form'` in the same comment is **correct** and stays: that doc describes the transport contract, where the flat spelling survives.
- `SeamConfig`'s "everything cross-cutting" list still named `arrayFormat`; the seam shares the whole `wire` envelope now.

## Deliberately left flat

`http-codec.spec.ts`, `aws-sigv4/test/sigv4.spec.ts`, and the adapter specs all build `AdapterRequest` literals. That contract didn't move in #591, so those stay flat — I classified each of the 46 repo-wide hits by its enclosing call before touching anything.

## How this was found

By review, not by any check — credit to the agent updating #585. Worth noting for the next rename of this shape: `tsc` cannot see these, and the runtime suite passed either way. Grep is the only tool that finds them, and my own first grep was wrong (`\s` isn't valid in git grep's POSIX regex, so it silently matched nothing and looked clean).

## Verification

`check:types`, `check:types-d`, `check:lint`, `check:contract`, `check:docs-links`, `check:format` all pass; workspace suite green across 34 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)