### PR TITLE
fix: finish the #591 `wire` sweep — 8 dead config sites, and the shell envelope leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ npm release are grouped under the in-development version that introduced them.
   all — was silently inert config that typechecked. It is now a type error naming the offending
   field, on `stitch`, `graphql`, `Seam.stitch`, and `Seam.graphql`.
 
+- **`@stitchapi/shell` omits the whole `wire` envelope from `ShellOptions`.** A subprocess has no
+  HTTP wire format: its `body` is argv rather than an encoded payload, and how stdout becomes a
+  value is spelled `decode`. The surface already omitted the flat `responseType` for that reason,
+  so it omits the envelope that field moved into — dropped whole rather than by its `response`
+  member, since filtering one member would leave the other three inherited, typechecking and
+  doing nothing. `shell({ wire: … })` is now a type error.
+
 ### Fixed
 
 - **A `wire: { body: 'form' }` body no longer mangles nested objects and arrays.** ADR 0005

--- a/packages/core/test/config-at-least-one.spec.ts
+++ b/packages/core/test/config-at-least-one.spec.ts
@@ -91,14 +91,13 @@ test('the opaque `{}` is rejected at each Scalar|AtLeastOne slot (P20)', () => {
 
 test('the scalar / ≥1-field forms are accepted at each slot (P12/P13/P20)', () => {
     const accepted = () => [
-        // `bodyType: 'multipart'` is required alongside `multipart` — the slot is read only on a
-        // multipart body, so the pairing is enforced statically. The shorthand under test is the
-        // bare `'dot'` string standing in for `{ nesting: 'dot' }` (P12).
+        // `wire.body: 'multipart'` is required alongside `wire.multipart` — the slot is read only
+        // on a multipart body, so the pairing is enforced statically. The shorthand under test is
+        // the bare `'dot'` string standing in for `{ nesting: 'dot' }` (P12).
         stitch({
             baseUrl: 'https://x',
             path: '/y',
-            bodyType: 'multipart',
-            multipart: 'dot',
+            wire: { body: 'multipart', multipart: 'dot' },
         }),
         stitch({ baseUrl: 'https://x', path: '/y', stream: 'ndjson' }),
         stitch({ baseUrl: 'https://x', path: '/y', sse: true }),

--- a/packages/core/test/cookie-jar.spec.ts
+++ b/packages/core/test/cookie-jar.spec.ts
@@ -39,7 +39,7 @@ const loginStitch = () =>
         method: 'POST',
         baseUrl: server.url,
         path: '/login',
-        bodyType: 'form',
+        wire: { body: 'form' },
     });
 
 test('cookie: "*" captures and replays every cookie the login set', async () => {
@@ -68,6 +68,11 @@ test('cookie: "*" captures and replays every cookie the login set', async () => 
 
     await expect(data()).resolves.toEqual({ ok: true });
     expect(server.callCount('/login')).toBe(1);
+    // The login posts a urlencoded body — pinned so a lost `wire.body` silently falls back to
+    // JSON without a single test noticing.
+    expect(server.calls('/login')[0]?.headers['content-type']).toMatch(
+        /application\/x-www-form-urlencoded/,
+    );
 
     const req = server.calls('/data')[0]!;
     expect(req.cookies['sid']).toBe('ABC'); // both cookies from the jar replay together

--- a/packages/core/test/gaps/cookie-session-hooks.spec.ts
+++ b/packages/core/test/gaps/cookie-session-hooks.spec.ts
@@ -50,7 +50,7 @@ const loginStitch = (baseUrl: string) =>
         method: 'POST',
         baseUrl,
         path: '/login',
-        bodyType: 'form',
+        wire: { body: 'form' },
     });
 
 test('onRefresh fires with { ok: true, status: 200 } after a successful cold login', async () => {
@@ -87,6 +87,11 @@ test('onRefresh fires with { ok: true, status: 200 } after a successful cold log
 
     expect(refreshes).toEqual([{ ok: true, status: 200 }]);
     expect(failures).toEqual([]); // a successful login never reports a failure
+    // The login posts a urlencoded body — pinned so a lost `wire.body` silently falls back to
+    // JSON without a single test noticing.
+    expect(server.calls('/login')[0]?.headers['content-type']).toMatch(
+        /application\/x-www-form-urlencoded/,
+    );
 });
 
 test('onRefresh fires ONCE (not per-waiter) under concurrent cold callers sharing one login', async () => {

--- a/packages/core/test/integration-patterns.spec.ts
+++ b/packages/core/test/integration-patterns.spec.ts
@@ -124,7 +124,7 @@ describe('Session-cookie admin API (auto re-login on 403)', () => {
             method: 'POST',
             baseUrl: server.url,
             path: '/auth/login',
-            bodyType: 'form',
+            wire: { body: 'form' },
         });
         const resources = stitch({
             baseUrl: server.url,
@@ -146,6 +146,11 @@ describe('Session-cookie admin API (auto re-login on 403)', () => {
         const out = await resources(); // caller passes NO credentials
         expect(out).toEqual([{ id: 'abc', state: 'active' }]);
         expect(server.callCount('/auth/login')).toBe(2); // initial auto-login + refresh after 403
+        // The login posts a urlencoded body — pinned so a lost `wire.body` silently falls back
+        // to JSON without a single test noticing.
+        expect(server.calls('/auth/login')[0]?.headers['content-type']).toMatch(
+            /application\/x-www-form-urlencoded/,
+        );
         expect(server.callCount('/resources')).toBe(2);
         expect(server.calls('/resources').at(-1)?.cookies['SID']).toBe(
             'SID-OK',
@@ -176,7 +181,7 @@ describe('HTML scrape provider — silent markup breakage becomes a loud drift e
             method: 'POST',
             baseUrl: server.url,
             path: '/login',
-            bodyType: 'form',
+            wire: { body: 'form' },
         });
         const search = stitch({
             baseUrl: server.url,

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -66,7 +66,7 @@ describe('Pluggable store — sessions', () => {
             method: 'POST',
             baseUrl: server.url,
             path: '/login',
-            bodyType: 'form',
+            wire: { body: 'form' },
         });
         const store = memoryStore();
 
@@ -98,6 +98,11 @@ describe('Pluggable store — sessions', () => {
         expect(await a()).toEqual({ r: 'a' });
         expect(await b()).toEqual({ r: 'b' });
         expect(server.callCount('/login')).toBe(1); // ONE login, reused via the shared store
+        // The login posts a urlencoded body — pinned so a lost `wire.body` silently falls back
+        // to JSON without a single test noticing.
+        expect(server.calls('/login')[0]?.headers['content-type']).toMatch(
+            /application\/x-www-form-urlencoded/,
+        );
     });
 
     test('default (separate) stores → each stitch logs in independently', async () => {
@@ -119,7 +124,7 @@ describe('Pluggable store — sessions', () => {
             method: 'POST',
             baseUrl: server.url,
             path: '/login',
-            bodyType: 'form',
+            wire: { body: 'form' },
         });
 
         const a = stitch({

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -150,13 +150,19 @@ export interface ShellBufferOptions {
  * `command` is required by design (CONTRACT.md P15) — the positional `shell(command, options?)`
  * shorthand names it, so the options bag there is `Omit<ShellOptions, 'command'>`.
  *
- * `responseType` is omitted from the inherited keys: a subprocess has no HTTP response, so how
- * stdout becomes a value is spelled once, as `decode` — the house word for "turn raw output into
- * values" (core spells the streaming decoder `stream.decode`). Passing the HTTP-shaped slot to a
- * shell used to type-check and do nothing; now it does not type-check.
+ * The whole `wire` envelope is omitted from the inherited keys: it describes the HTTP wire format
+ * — request body encoding, urlencoded array serialisation, multipart nesting, response reading —
+ * and a subprocess has none of it. Its `body` is argv, not an encoded payload, and how stdout
+ * becomes a value is spelled once, as `decode` — the house word for "turn raw output into values"
+ * (core spells the streaming decoder `stream.decode`). Passing an HTTP-shaped slot to a shell used
+ * to type-check and do nothing; now it does not type-check.
+ *
+ * The envelope is dropped whole rather than by its `response` field: once the four flat slots
+ * folded into one word (CONTRACT.md P24), filtering a single field inside it would leave the other
+ * three inherited — type-checking and doing nothing, which is the exact hole this closes.
  */
 export interface ShellOptions extends Partial<
-    Omit<StitchConfig, 'kind' | 'responseType'>
+    Omit<StitchConfig, 'kind' | 'wire'>
 > {
     /** The executable — STATIC, bound at construction, NEVER from call input. An absolute path
      *  needs no `PATH`; a bare name (`'git'`) needs `env: { PATH: process.env.PATH }`. */

--- a/packages/shell/test/shell.spec.ts
+++ b/packages/shell/test/shell.spec.ts
@@ -184,6 +184,11 @@ test('old spellings are DELETED and the empty bags are rejected (compile-time)',
     void shell({ command: NODE, maxBuffer: 4 });
     // @ts-expect-error — the HTTP-shaped slot is off this surface; the shell's word is `decode`
     void shell(NODE, { responseType: 'json' });
+    // The same slot in its CURRENT spelling: `responseType` moved into the `wire` envelope, and
+    // the whole envelope is off this surface — so the rejection has to follow it there, not just
+    // guard the retired flat name above.
+    // @ts-expect-error — `wire` is the HTTP wire format; a subprocess has none of it
+    void shell(NODE, { wire: { response: 'json' } });
     // @ts-expect-error — a subprocess yields text or JSON, nothing else
     void shell(NODE, { decode: 'blob' });
     // @ts-expect-error — the buffer envelope must set a field (P20): pass a scalar or omit it


### PR DESCRIPTION
Follow-up to #591, which folded `bodyType` / `responseType` / `arrayFormat` / `multipart` into the `wire` envelope. Two things it left behind.

## Why `tsc` didn't catch any of this

#591's own commit message says it: a stale `bodyType:` does **not** produce a compile error, because `stitch`'s `const C extends Partial<StitchConfig>` generic captures the argument type and suppresses excess-property checking. The field is silently ignored and the body falls back to JSON. So the sweep is grep-driven, and `check:types` is green on every site below both before and after.

## 1. Eight config-level sites still on the flat spelling

Migrated to `wire: { body: 'form' }` (and `wire: { body: 'multipart', multipart: 'dot' }`). Two groups matter beyond tidiness.

**Four login stitches** — `store.spec.ts` (×2), `cookie-jar.spec.ts`, `integration-patterns.spec.ts` (×2), `gaps/cookie-session-hooks.spec.ts` — were POSTing **JSON** where each test intends `application/x-www-form-urlencoded`. They passed only because the mock servers never assert the content type, so the cookie-session form-login paths had quietly lost their urlencoded coverage.

Confirmed rather than assumed — re-inserting the stale field and running the file gives:

```
AssertionError: expected 'application/json' to match /application\/x-www-form-urlencoded/
```

So each of those four files also gains a **Content-Type assertion** on the login call, in the style already used in `body-encoding.spec.ts`. Without them the same regression re-lands silently the next time a wire field moves. Test count is unchanged at 1320 — these are assertions inside existing tests, not new cases.

**The P12/P13/P20 case** in `config-at-least-one.spec.ts`, whose stated purpose is to pin the bare `multipart: 'dot'` shorthand standing in for `{ nesting: 'dot' }`. With both fields at the top level they were both ignored, so the case asserted nothing at all and stopped exercising the `MultipartOnlyOnMultipartBody` pairing its own comment documents. Lines 27–37 of that same file *were* migrated, so this was a partial migration, not a deliberate exemption.

Every `AdapterRequest`-level site is deliberately untouched — that transport contract keeps the flat fields per CONTRACT.md P22, so `auth.ts`'s direct `adapter({...})` call, the `buildRequest` returns, the engine conversion, and the adapter / sigv4 / from-curl tests all keep `bodyType`.

## 2. `@stitchapi/shell` leaked the envelope back in

Found while sweeping. `ShellOptions` declared `Omit<StitchConfig, 'kind' | 'responseType'>` — #514 put `responseType` there deliberately, with a doc comment stating the intent: *"Passing the HTTP-shaped slot to a shell used to type-check and do nothing; now it does not type-check."*

#591 moved `responseType` inside `wire`, so that omitted key stopped naming anything and the envelope became inherited. On main, `shell(NODE, { wire: { response: 'json' } })` typechecks and does nothing at runtime — exactly the state #514 set out to end. Nothing was red, because the `@ts-expect-error` guarding it names the retired flat spelling and still errors on its own terms.

Fixed to `Omit<StitchConfig, 'kind' | 'wire'>`.

**Reviewer notes on the two judgment calls:**

- *Why the whole envelope, not just `wire.response`?* The other three members are equally meaningless on a subprocess — its `body` is argv, not an encoded payload — so filtering one member leaves three more inherited: the same hole, one field narrower. A surface with no wire format drops the category, not a field inside it (P24).
- *Why `Omit` and not a `ConfigError` brand?* House precedent. The brand appears once, for the `wire.multipart`/`wire.body` **pairing**, where the field is valid but not in that combination. "This slot doesn't exist on this surface" is what `Omit` is for, as postmessage's options already do with `url`. It produces a real error here because `shell()` takes its options unwrapped — no generic capture, so excess-property checking isn't suppressed the way it is on `stitch`.

Verified by reverting only the omit: tsc then reports `Unused '@ts-expect-error' directive` on the new test line, proving the case compiled before and errors now. The test keeps **both** directives — the old one guards the retired flat spelling staying deleted, the new one guards the current spelling.

`wire` is still `[Unreleased]`, so this rides that same unreleased breaking change rather than adding one; rc.7's `ShellOptions` already rejected flat `responseType`, and no published API shifts. CHANGELOG notes it beside the `wire.multipart` entry.

## Verification

`check:types`, `check:types-d`, `check:lint`, `check:format`, `check:exports`, `check:contract`, `check:docs-links`, `check:media-fresh`, `pnpm test`, plus the docs build and yakir drift check — all green via the full pre-push sequence. Core 135 files / 1320 tests, shell 17 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)