### PR TITLE
fix(core): both config guards walk `extends` instead of reading the literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ npm release are grouped under the in-development version that introduced them.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The config guards now read the composed config, so `extends` counts.** `wire.multipart` and
+  `document`/`operationName` are gated on an enabler — a multipart body, the graphql surface — and
+  both guards previously inspected only the config LITERAL. A config that inherited its enabler
+  through `extends` was therefore rejected outright:
+
+    ```ts
+    const gqlBase = { kind: graphqlSurface, baseUrl };
+    stitch({ extends: [gqlBase], document: `query { me { id } }` }); // was a type error
+    ```
+
+    Both now walk the same layer list `InputOf` uses (`Layers`), so an enabler from any layer
+    counts. There is deliberately one flattener rather than a second copy — a private one would
+    drift on depth budget and fragment normalisation, and the guards would disagree with `InputOf`
+    about what a config is.
+
+    The scan is **existential** ("is the enabler set anywhere?") rather than last-wins. Resolving an
+    override chain at the type level is easy to get subtly wrong, and the two failure directions are
+    not symmetric: a false positive rejects working code loudly, a false negative merely fails to
+    catch something the compiler never caught before. Scanning existentially can only produce the
+    second.
+
+    Two limits are inherited from `Layers` and unchanged: an `extends` list widened to `Frag[]` (a
+    `const` binding without `as const`) and the P7 single-fragment spelling (`extends: frag`) both
+    read as empty, because the flattener destructures a tuple. `InputOf` has read `extends` that way
+    since #76. Both are pinned as tsd expectations.
+
 ### Changed
 
 - **`document` and `operationName` now require the graphql surface at compile time.** Both are

--- a/packages/core/src/infer.ts
+++ b/packages/core/src/infer.ts
@@ -145,8 +145,33 @@ type Flatten<
  * The full ordered layer list for a config `C` (the config itself last). `C` is fed through the
  * same `ExpandFrag` so its own `extends` is expanded ahead of it — identical to `flatten([config])`
  * at runtime. The result is base→child, so a left-to-right fold gives last-wins semantics.
+ *
+ * Exported so the config GUARDS in `types.ts` read the composed config rather than the literal —
+ * without them, a slot supplied through `extends` is invisible and a valid config is rejected.
+ * There is deliberately one flattener: a second copy would drift from this one's depth budget and
+ * `AsFrag` normalisation, and the guards would disagree with `InputOf` about what a config even is.
  */
-type Layers<C> = ExpandFrag<C, FragDepth>;
+export type Layers<C> = ExpandFrag<C, FragDepth>;
+
+/**
+ * True when ANY layer satisfies `Shape`. The guards ask two questions of a composed config — "is
+ * this slot set anywhere?" and "is its enabler set anywhere?" — and both are existential, so a
+ * left-to-right scan is enough; neither needs last-wins resolution.
+ *
+ * Existential rather than last-wins is a deliberate, documented bias. Resolving an override chain
+ * at the type level (a later layer setting `wire.body` back to `'json'`) is both hard and easy to
+ * get subtly wrong, and the two failure directions are not symmetric: a false POSITIVE rejects
+ * working code loudly, a false NEGATIVE merely fails to catch something the compiler never caught
+ * before. Scanning existentially can only ever produce the second.
+ */
+export type AnyLayer<
+    Ls extends readonly unknown[],
+    Shape,
+> = Ls extends readonly [infer H, ...infer T]
+    ? [H] extends [Shape]
+        ? true
+        : AnyLayer<T, Shape>
+    : false;
 
 /**
  * Fold the layer list to the merged `output` slot: the LAST layer that declares `output` wins the

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,8 +6,10 @@ import type {
     ResolvedNormalizations,
 } from './config-anatomy';
 import type {
+    AnyLayer,
     Args,
     InputOf,
+    Layers,
     RelaxKeys,
     ResolveOutput,
     SchemaLike,
@@ -211,18 +213,32 @@ export interface ConfigError<Message extends string> {
  * has no options at all, and `form` has none of its own, since array serialisation
  * ({@link WireOptions.array}) is shared with the query string — so a three-arm union would carry
  * two empty arms and duplicate a query concern.
+ *
+ * Reads the COMPOSED config via {@link Layers}, so an enabler inherited through `extends` counts —
+ * `stitch({ extends: [{ wire: { body: 'multipart' } }], wire: { multipart: 'dot' } })` is legal.
+ *
+ * RESIDUAL LIMITS, shared with {@link GraphqlOnlyOnGraphqlSurface}:
+ * - Fail-open: the error is surfaced by intersecting onto the config LITERAL, so a violation
+ *   living entirely in a fragment — the offending slot in one layer, no enabler in any — is not
+ *   reported. The literal-level case, which is the one people write, still errors precisely.
+ * - Fail-open: a fragment typed as `Partial<StitchConfig>` rather than inferred from its literal
+ *   has optional properties, which satisfy neither probe, so it reads as supplying nothing.
+ * - Fail-CLOSED, and inherited from {@link Layers} rather than added here: the flattener
+ *   destructures a tuple, so an `extends` list TypeScript widened to `Frag[]` (what a `const`
+ *   binding does without `as const`) reads as empty, as does the P7 single-fragment spelling
+ *   (`extends: frag`). `InputOf` has read `extends` the same way since #76. Widening it is a
+ *   change to call-argument inference for every consumer, not a guard change.
  */
-export type MultipartOnlyOnMultipartBody<C> = C extends {
-    wire: { multipart: unknown };
-}
-    ? C extends { wire: { body: 'multipart' } }
-        ? unknown
-        : {
-              wire?: {
-                  multipart?: ConfigError<'`wire.multipart` requires `wire.body: "multipart"` — it is ignored on a json or form body'>;
-              };
-          }
-    : unknown;
+export type MultipartOnlyOnMultipartBody<C> =
+    AnyLayer<Layers<C>, { wire: { multipart: unknown } }> extends true
+        ? AnyLayer<Layers<C>, { wire: { body: 'multipart' } }> extends true
+            ? unknown
+            : {
+                  wire?: {
+                      multipart?: ConfigError<'`wire.multipart` requires `wire.body: "multipart"` — it is ignored on a json or form body'>;
+                  };
+              }
+        : unknown;
 /**
  * Compile-time guard: `document` and `operationName` are read ONLY by the graphql surface's
  * `buildRequest` (`surface.ts`), so authoring either without selecting that surface is silently
@@ -233,22 +249,24 @@ export type MultipartOnlyOnMultipartBody<C> = C extends {
  * Applied to `stitch` / `Seam.stitch` only. `graphql()` and `Seam.graphql()` select the surface
  * themselves and REQUIRE `document`, so the guard would be wrong there.
  *
- * KNOWN LIMIT — shared with {@link MultipartOnlyOnMultipartBody}: the check reads the config
- * LITERAL, not the composed result, so a surface inherited through `extends` is invisible to it.
- * `stitch({ extends: [gqlBase], document })` is rejected even though `gqlBase` supplies `kind`.
- * Spell the surface on the layer that carries the document, or use `graphql()`. Widening this to
- * walk `extends` means duplicating `InputOf`'s fragment flattening in a second place; the
- * false-positive is loud and has an obvious fix, so it is left stated rather than solved.
+ * Reads the COMPOSED config via {@link Layers}, so a surface inherited through `extends` counts —
+ * `stitch({ extends: [gqlBase], document })` is legal when `gqlBase` supplies `kind`.
  */
-export type GraphqlOnlyOnGraphqlSurface<C> = C extends
-    { document: unknown } | { operationName: unknown }
-    ? C extends { kind: { id: 'graphql' } }
+export type GraphqlOnlyOnGraphqlSurface<C> =
+    AnyLayer<Layers<C>, { document: unknown }> extends true
+        ? GraphqlSurfaceSomewhere<C>
+        : AnyLayer<Layers<C>, { operationName: unknown }> extends true
+          ? GraphqlSurfaceSomewhere<C>
+          : unknown;
+
+/** Shared tail of {@link GraphqlOnlyOnGraphqlSurface}: allow iff some layer selects the surface. */
+type GraphqlSurfaceSomewhere<C> =
+    AnyLayer<Layers<C>, { kind: { id: 'graphql' } }> extends true
         ? unknown
         : {
               document?: ConfigError<'`document` requires the graphql surface — use `graphql({ … })`, or set `kind: graphqlSurface`. It is ignored on every other surface'>;
               operationName?: ConfigError<'`operationName` requires the graphql surface — use `graphql({ … })`, or set `kind: graphqlSurface`. It is ignored on every other surface'>;
-          }
-    : unknown;
+          };
 /**
  * How the `stream` surface decodes each chunk of a live response body (ADR 0005 Decision 5).
  * - `'bytes'` (default) — raw `Uint8Array` chunks, lossless, no encoding assumed.

--- a/packages/core/test-d/body-encoding.test-d.ts
+++ b/packages/core/test-d/body-encoding.test-d.ts
@@ -108,5 +108,30 @@ expectError(
     }),
 );
 
+// ── The guard reads the COMPOSED config, so `extends` counts ────────────────
+// This used to be a false positive: the body encoding came from a fragment, the guard only saw the
+// literal, and a valid config was rejected. It now walks the layer list.
+const multipartBase = {
+    baseUrl: 'https://api.example.com',
+    wire: { body: 'multipart' as const },
+};
+stitch({ extends: [multipartBase], path: '/u', wire: { multipart: 'dot' } });
+
+// Inherited from `Layers`, not introduced here: the P7 single-fragment spelling is not a tuple, so
+// the flattener reads it as empty and the enabler goes unseen. Fails closed; see
+// `graphql-fields.test-d.ts` for the full note.
+expectError(
+    stitch({ extends: multipartBase, path: '/u', wire: { multipart: 'dot' } }),
+);
+
+// …but a fragment chain that never sets a multipart body is still rejected.
+const jsonBase = {
+    baseUrl: 'https://api.example.com',
+    wire: { body: 'json' as const },
+};
+expectError(
+    stitch({ extends: [jsonBase], path: '/u', wire: { multipart: 'dot' } }),
+);
+
 // A bare path string still reaches the non-inferring fallback unharmed.
 expectType<Stitch<unknown>>(stitch('/plain'));

--- a/packages/core/test-d/graphql-fields.test-d.ts
+++ b/packages/core/test-d/graphql-fields.test-d.ts
@@ -62,9 +62,34 @@ expectError(
 // A member stitch is guarded the same way — only `.graphql()` selects the surface.
 expectError(api.stitch({ path: '/users', document: 'query Me { me { id } }' }));
 
-// ── KNOWN LIMIT: the guard reads the config literal, not the composed result ──
-// A surface inherited through `extends` is invisible to it, so this is a FALSE POSITIVE. Pinned so
-// the limitation is a decision on record rather than a surprise — if `extends` walking is ever
-// added, this expectation flips and the test names the place to update.
+// ── The guard reads the COMPOSED config, so `extends` counts ────────────────
+// This used to be a false positive: the surface came from a fragment, the guard only saw the
+// literal, and a valid config was rejected. It now walks the layer list.
 const gqlBase = { kind: graphqlSurface, baseUrl: 'https://api.example.com' };
-expectError(stitch({ extends: [gqlBase], document: 'query Me { me { id } }' }));
+stitch({ extends: [gqlBase], document: 'query Me { me { id } }' });
+stitch({ extends: [gqlBase], document: 'query A { a }', operationName: 'A' });
+
+// Nested one level down: the flattener recurses, so the surface is still found.
+stitch({
+    extends: [{ extends: [gqlBase], headers: { 'x-a': '1' } }],
+    document: 'query Me { me { id } }',
+});
+
+// ── Inherited from `Layers`, not introduced here ────────────────────────────
+// The flattener destructures a TUPLE (`readonly [H, ...T]`), so an `extends` list that TypeScript
+// widened to `Frag[]` — which is what a `const` binding does without `as const` — reads as empty,
+// and so does the P7 single-fragment spelling (`extends: frag`, not a list). `InputOf` has read
+// `extends` this way since #76; every existing test in `extends-inference.test-d.ts` uses an inline
+// array literal, which stays a tuple. Both cases fail CLOSED here (a valid config is rejected), so
+// they are pinned rather than left to surprise someone. Fixing them means widening `Flatten`, which
+// changes call-argument inference for every consumer — deliberately out of scope for a guard change.
+expectError(stitch({ extends: gqlBase, document: 'query Me { me { id } }' }));
+
+const widened = [gqlBase]; // inferred `Frag[]`, not `[Frag]`
+expectError(stitch({ extends: widened, document: 'query Me { me { id } }' }));
+
+// …but a fragment chain that never selects the surface is still rejected.
+const httpBase = { baseUrl: 'https://api.example.com', path: '/users' };
+expectError(
+    stitch({ extends: [httpBase], document: 'query Me { me { id } }' }),
+);


### PR DESCRIPTION
`MultipartOnlyOnMultipartBody` and `GraphqlOnlyOnGraphqlSurface` each gate a slot on an enabler — a multipart body, the graphql surface — and both inspected only the config **literal**. A config that inherited its enabler through `extends` was rejected outright:

```ts
const gqlBase = { kind: graphqlSurface, baseUrl };
stitch({ extends: [gqlBase], document: `query { me { id } }` });  // was a type error
```

Both now read the composed layer list.

## One flattener, not two

`Layers` and a new `AnyLayer` are exported from `infer.ts` rather than reimplemented. A private copy would drift from this one's depth budget and `AsFrag` normalisation, and the guards would end up disagreeing with `InputOf` about what a config even is.

## Existential, not last-wins — deliberately

The scan asks "is the enabler set on **any** layer?" rather than resolving the override chain. Resolving it in the type system is easy to get subtly wrong, and the two failure directions aren't symmetric:

- a **false positive** rejects working code, loudly
- a **false negative** merely fails to catch something the compiler never caught before

An existential scan can produce the second but never the first. That bias is stated at the type and is the reason this is a small change rather than a fold-and-merge.

## Residual limits — stated at the guard, pinned in tsd

| limit | direction |
|---|---|
| The error intersects onto the literal, so a violation living entirely in a fragment isn't reported | fail-open |
| A fragment typed `Partial<StitchConfig>` has optional properties, which satisfy neither probe | fail-open |
| An `extends` list widened to `Frag[]`, and the P7 single-fragment spelling `extends: frag`, read as empty | fail-**closed** |

The third is **inherited from `Layers`, not introduced here** — the flattener destructures a tuple, and a `const` binding without `as const` widens the array. `InputOf` has read `extends` this way since #76; every test in `extends-inference.test-d.ts` happens to use an inline array literal, which stays a tuple, so it had never surfaced. Widening `Flatten` changes call-argument inference for every consumer, which is not a guard change — so it's pinned rather than fixed here.

I found this by writing the tests first and watching two of them fail, then isolating the cause to tuple widening rather than the guards.

## Note for #584

`WireBodyFixedByGraphql` has the same blind spot, in the fail-negative direction (a graphql surface inherited via `extends` won't have `wire.body` rejected). It should adopt `AnyLayer<Layers<C>, …>` when it lands — the helper is exported and ready.

## Verification

`check:types`, `check:types-d`, `check:lint`, `check:contract`, `check:docs-links`, `check:format` all pass; workspace suite green across 34 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)