### PR TITLE
fix(core)!: reject `kind` on the `download` preset instead of overwriting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,43 @@ npm release are grouped under the in-development version that introduced them.
     `stitch({ method: 'POST', wire: { response: 'blob' } })`; the only thing it gives up is the
     `Content-Disposition` filename parsing.
 
+- **BREAKING — `kind` on a `download()` preset stitch is now a compile error.** The last field
+  in the same class, and the one the sweep above left behind. Both preset paths build their
+  config as `{ ...config, kind: downloadSurface }` — spreading the caller's `kind` in, then
+  overwriting it on the next line — so authoring one selected nothing:
+
+    ```ts
+    download({ url, kind: graphqlSurface });
+    //              ^ the `download` preset always selects the download surface — `kind` is
+    //                ignored. Before: compiled, and quietly returned a DOWNLOAD stitch.
+    ```
+
+    The guard binds `download()`, `download.stitch`, and `download.bind(…).stitch`, and
+    deliberately **not** `stitch({ kind: downloadSurface })` — on the generic path `kind` is not
+    dead config, it is the only thing selecting the surface, so guarding it there would reject
+    correct code. That is why this is a separate `NoKindOnDownload` rather than a third arm of
+    the `method` / `wire.response` guard, which the generic path shares.
+
+    The redundant `kind: downloadSurface` is rejected on the preset too, for the same reason
+    `method: 'GET'` is: the slot is never read, and letting through the exact value the preset
+    forces would imply that it is.
+
+    This closes on `download` the hole `llm` never had — `LlmOptions` is
+    `Partial<Omit<StitchConfig, 'kind'>>`, and that structural spelling works there only because
+    `llm()`'s parameter is non-generic, so excess-property checking catches a stray `kind`. The
+    preset captures a `const C` to infer its call argument from `config.input`, and a generic
+    constraint does no excess-property checking (the same migration gotcha the `wire` envelope
+    documents above), so `Omit` would be satisfied by a config carrying the extra key. Hence a
+    `ConfigError` guard here and a structural `Omit` there, for one rule.
+
+    Reads the **composed** config like its siblings, and fails **open**: `kind` is the offending
+    slot rather than an enabler here, so a layer the flattener cannot see costs a missed
+    rejection, never a false one. A `kind` supplied only through an `extends` fragment still
+    compiles; the literal spelling errors precisely. Pinned as tsd expectations.
+
+    **Migration:** delete the field. No runtime behaviour changed — the stitch was already a
+    download. To actually get another surface, use a plain `stitch({ kind })`.
+
 ### Added
 
 - **`throttle.rate`'s denominator is now a full duration token — `'1000/h'`, `'100/15m'`,

--- a/packages/core/src/download.ts
+++ b/packages/core/src/download.ts
@@ -14,6 +14,7 @@ import { makeStitch } from './stitch';
 import { verdictOf } from './surface';
 import type { Surface, SurfaceOutcome } from './surface';
 import {
+    type NoKindOnDownload,
     type NoRequestShapeOnDownload,
     type NoUnknownConfigKeys,
     type NoUnknownNestedKeys,
@@ -137,7 +138,8 @@ export interface DownloadSeamApi {
         config: C &
             NoUnknownConfigKeys<C> &
             NoUnknownNestedKeys<C> &
-            NoRequestShapeOnDownload<C>,
+            NoRequestShapeOnDownload<C> &
+            NoKindOnDownload<C>,
     ) => Stitch<DownloadResult, InputOf<C>>;
     readonly seam: Seam;
 }
@@ -152,12 +154,16 @@ export interface DownloadSeamApi {
 const downloadStitch = <
     const C extends Partial<StitchConfig> = Partial<StitchConfig>,
 >(
-    // The surface is download by construction here, so the guard applies unconditionally rather
-    // than keying off `kind` the way `stitch`'s `RequestShapeFixedByDownload` must.
+    // The surface is download by construction here, so the guards apply unconditionally rather
+    // than keying off `kind` the way `stitch`'s `RequestShapeFixedByDownload` must. `kind` is that
+    // construction — spread in from `config` and overwritten on the next line — so authoring one is
+    // dead config, and `NoKindOnDownload` is separate from its sibling precisely because the
+    // `stitch({ kind: downloadSurface })` path that shares the sibling needs `kind` to be legal.
     config: C &
         NoUnknownConfigKeys<C> &
         NoUnknownNestedKeys<C> &
-        NoRequestShapeOnDownload<C>,
+        NoRequestShapeOnDownload<C> &
+        NoKindOnDownload<C>,
 ): Stitch<DownloadResult, InputOf<C>> =>
     makeStitch<DownloadResult>({
         ...config,
@@ -167,10 +173,12 @@ const downloadStitch = <
 // Bind download members to a seam through the seam's surface-agnostic `stitch({ kind })`.
 function bindSeam(s: Seam): DownloadSeamApi {
     // Implemented loose and `as`-cast to the declared member type — the `Seam['graphql']` idiom in
-    // seam.ts. A generic impl whose parameter is `C & NoRequestShapeOnDownload<C>` cannot be checked
+    // seam.ts. A generic impl whose parameter carries the same guard intersection cannot be checked
     // against a member of that same shape: TypeScript instantiates the impl's `C` with the target's
-    // whole intersection, so the two `InputOf<C>` return types stop matching. Sound — the runtime is
-    // one `s.stitch` call, and the type tests pin every concrete config.
+    // whole intersection, so the two `InputOf<C>` return types stop matching. The cast is also what
+    // gives this member the guards for free — they live on `DownloadSeamApi['stitch']`, which is the
+    // type callers see. Sound — the runtime is one `s.stitch` call, and the type tests pin every
+    // concrete config.
     const stitch = ((config: Partial<StitchConfig>) =>
         s.stitch<DownloadResult>({
             ...config,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -715,6 +715,48 @@ export type RequestShapeFixedByDownload<C> =
         ? NoRequestShapeOnDownload<C>
         : unknown;
 /**
+ * Compile-time guard: the `download()` PRESET selects the surface itself — both authoring paths
+ * build their config as `{ ...config, kind: downloadSurface }`, spreading the caller's `kind` in and
+ * overwriting it on the next line. A `kind` authored on the preset is therefore never read: the
+ * stitch is a download either way, and a caller who wrote `kind: graphqlSurface` silently got a
+ * download. Same class as {@link NoRequestShapeOnDownload} (`method`, `wire.response`) and
+ * {@link NoBodyTypeOnGraphql} (`wire.body`) — a field the surface claims, rejected at the authoring
+ * site rather than ignored at runtime.
+ *
+ * DELIBERATELY SEPARATE from {@link NoRequestShapeOnDownload} rather than a third arm of it, and the
+ * split is load-bearing. That type is shared with {@link RequestShapeFixedByDownload}, which guards
+ * the generic `stitch({ kind: downloadSurface, … })` path — and on THAT path `kind` is not dead
+ * config, it is the very thing selecting the surface. Folding this in would make the guard reject
+ * the config that triggers it, so the two must not share a type.
+ *
+ * Applied ONLY where the preset fixes the surface by construction: `download()` / `download.stitch`
+ * and `DownloadSeamApi['stitch']` (which `bindSeam`'s member is cast to, so it inherits this). The
+ * probe is `{ kind: unknown }`, not keyed to a surface id, so even the redundant
+ * `kind: downloadSurface` is rejected — the same reasoning that makes `method: 'GET'` an error on a
+ * surface that sends exactly that. Authoring the slot implies it is read; it is not.
+ *
+ * The asymmetry with `llm` is a difference in parameter shape, not intent. `LlmOptions` (llm.ts)
+ * closes the identical hole structurally — `Partial<Omit<StitchConfig, 'kind'>>` — and that works
+ * because `llm()`'s parameter is deliberately NON-generic, so excess-property checking on the object
+ * literal turns a stray `kind` into an error. This preset captures a `const C` to infer its
+ * call-argument type from `config.input` (`InputOf<C>`), and a generic CONSTRAINT does not do
+ * excess-property checking — `Omit` would simply be satisfied by a config carrying extra keys. Hence
+ * a `ConfigError` guard here and a structural `Omit` there, for one rule.
+ *
+ * Reads the COMPOSED config via {@link Layers}, like every other guard here. The fail direction is
+ * INVERTED relative to {@link GraphqlOnlyOnGraphqlSurface}: `kind` is the OFFENDING slot here, not
+ * the enabler, so a layer the flattener cannot see (an `extends` widened to `Frag[]`, the P7
+ * single-fragment spelling) merely fails to reject dead config rather than rejecting valid code —
+ * fail-OPEN, the direction #597 biases toward. Residual limits are otherwise shared with
+ * {@link MultipartOnlyOnMultipartBody} and documented there.
+ */
+export type NoKindOnDownload<C> =
+    AnyLayer<Layers<C>, { kind: unknown }> extends true
+        ? {
+              kind?: ConfigError<'the `download` preset always selects the download surface — `kind` is ignored (use a plain `stitch({ kind })` to choose another surface)'>;
+          }
+        : unknown;
+/**
  * Compile-time guard: the `llm` surface OWNS how it frames a chat completion. The live surface's
  * `buildRequest` forces `method: 'POST'` and a JSON body unconditionally and replaces the body with
  * `provider.buildBody(...)`, so either field authored on an `llm()` config is never read. Same

--- a/packages/core/test-d/download-request-shape.test-d.ts
+++ b/packages/core/test-d/download-request-shape.test-d.ts
@@ -14,7 +14,15 @@
 // to reject `wire.response` without closing the rest of `wire`, so the envelope's other members are
 // asserted still-authorable below. (`AdapterRequest` keeps the flat `responseType` — that is the
 // transport contract one layer down, and no guard here touches it.)
-import { seam, stitch } from '../src';
+//
+// A THIRD field is claimed by the same surface and pinned here with them: `kind`. The `download()`
+// preset builds `{ ...config, kind: downloadSurface }`, spreading the caller's `kind` in and
+// overwriting it, so authoring one on the preset is dead config in exactly the same way. It gets a
+// SEPARATE guard (`NoKindOnDownload`) rather than a third arm of `NoRequestShapeOnDownload`, because
+// that type is shared with `RequestShapeFixedByDownload` — the generic `stitch({ kind })` path,
+// where `kind` is not dead but is the thing selecting the surface. Both halves of that split are
+// asserted below: rejected on the preset, still legal as the selector.
+import { graphqlSurface, seam, stitch } from '../src';
 import type { Stitch, StitchConfig } from '../src';
 import { download, downloadSurface } from '../src/download';
 import type { DownloadResult } from '../src/download';
@@ -69,15 +77,64 @@ download.stitch({ url: URL_ });
 expectError(download.stitch({ url: URL_, method: 'POST' }));
 expectError(download.stitch({ url: URL_, wire: { response: 'text' } }));
 
+// ── Illegal: `kind` on the `download()` preset ──────────────────────────────
+// Positive control: the preset says nothing about the surface, which is the ordinary spelling and
+// the one every other case in this file uses. Asserted here too so each rejection below is
+// attributable to `NoKindOnDownload` and not to the surrounding config.
+download({ url: URL_ });
+
+// The hole itself: the preset spreads the caller's `kind` in and overwrites it one line later, so
+// this compiled and silently produced a DOWNLOAD, not a graphql stitch.
+expectError(download({ url: URL_, kind: graphqlSurface }));
+
+// Not special to a different surface — the redundant spelling is rejected too. Same reasoning as
+// `method: 'GET'` above: the slot is never read, and letting through the exact value the preset
+// forces would imply that it is.
+expectError(download({ url: URL_, kind: downloadSurface }));
+
+// A legal sibling in the same literal does not launder it.
+expectError(
+    download({
+        url: URL_,
+        headers: { 'x-api-key': 'k' },
+        kind: graphqlSurface,
+    }),
+);
+
+// Both guard families at once — they intersect, so neither masks the other.
+expectError(download({ url: URL_, kind: graphqlSurface, method: 'POST' }));
+
+// `download.stitch` is the same function, so it inherits this guard as well.
+expectError(download.stitch({ url: URL_, kind: graphqlSurface }));
+
+// A config built up as a BINDING, not an inline literal, is still rejected — and that is the one
+// place this guard is strictly stronger than the `Partial<Omit<StitchConfig, 'kind'>>` spelling
+// `LlmOptions` uses. That one leans on excess-property checking, which only fires on a fresh object
+// literal at the call site; a `ConfigError` intersection is a real assignability failure and does
+// not care how the argument was spelled. Worth pinning, because it is the reason the two surfaces
+// close the same hole two different ways rather than by oversight.
+const preBuilt = { url: URL_, kind: graphqlSurface };
+expectError(download(preBuilt));
+
 // ── Illegal: the same config reached through the generic `stitch({ kind })` ──
 // Positive control first: the identical config MINUS the guarded field must typecheck, so each
 // rejection below is attributable to the guard and not to the `kind` pairing itself.
+//
+// These lines are ALSO the load-bearing control for `NoKindOnDownload`. On this path `kind` is not
+// dead config — it is the only thing selecting the surface — so the guard must NOT reach here. That
+// is why it is a separate type from `NoRequestShapeOnDownload` (which IS shared with
+// `RequestShapeFixedByDownload` and so does run on this path). Folding the two together would turn
+// every line below into an error, which is the regression these controls exist to catch.
 stitch({ url: URL_, kind: downloadSurface });
 stitch({ url: URL_, kind: downloadSurface, wire: { array: 'repeat' } });
 expectError(stitch({ url: URL_, kind: downloadSurface, method: 'POST' }));
 expectError(
     stitch({ url: URL_, kind: downloadSurface, wire: { response: 'text' } }),
 );
+
+// And `kind` on the generic path stays live for every OTHER surface too — the preset guard is
+// scoped to the preset, not to the field.
+stitch({ url: URL_, kind: graphqlSurface, document: 'query Q { a }' });
 
 // ── Legal: `method` / `wire.response` on any NON-download surface are untouched ──
 // This is also the documented escape hatch for "POST, then take the bytes as a Blob".
@@ -93,16 +150,21 @@ stitch({ path: '/things', method: 'PUT', wire: { response: 'arrayBuffer' } });
 // ── The guard binds every surface that authors a download stitch (CONTRACT.md P16) ──
 const api = seam({ baseUrl: 'https://files.example.com' });
 
-// `download.bind(seam).stitch` — positive control, then the two rejections.
+// `download.bind(seam).stitch` — positive control, then the rejections. The bound member is
+// implemented loose and `as`-cast to `DownloadSeamApi['stitch']`, so it carries whatever guards that
+// member type declares; these lines are what prove the cast did not drop them.
 const bound = download.bind(api);
 bound.stitch({ path: '/report.pdf' });
 expectError(bound.stitch({ path: '/report.pdf', method: 'POST' }));
 expectError(bound.stitch({ path: '/report.pdf', wire: { response: 'text' } }));
+expectError(bound.stitch({ path: '/report.pdf', kind: graphqlSurface }));
+expectError(bound.stitch({ path: '/report.pdf', kind: downloadSurface }));
 
 // `download.bind(options)` builds its own seam and must guard identically.
 const owned = download.bind({ baseUrl: 'https://files.example.com' });
 owned.stitch({ path: '/report.pdf' });
 expectError(owned.stitch({ path: '/report.pdf', method: 'POST' }));
+expectError(owned.stitch({ path: '/report.pdf', kind: graphqlSurface }));
 
 // A seam member reaching the surface through `kind` is guarded too.
 api.stitch({ path: '/report.pdf', kind: downloadSurface });
@@ -175,6 +237,28 @@ stitch({ extends: widened, method: 'POST' });
 // reported, because the error is surfaced by intersecting onto the config LITERAL. Documented on
 // `MultipartOnlyOnMultipartBody` as the first residual limit; pinned here so it stays deliberate.
 stitch({ extends: [{ method: 'POST' }], kind: downloadSurface, url: URL_ });
+
+// `NoKindOnDownload` fails open the same way and for the same reason. `kind` is the OFFENDING slot
+// on the preset rather than an enabler, so every `Layers` limit costs a missed rejection, never a
+// false one — the direction #597 biases toward. A `kind` supplied only through a fragment therefore
+// still compiles; the literal-level spelling, which is the one people write, errors precisely above.
+const gqlFrag = { kind: graphqlSurface };
+download({ extends: [gqlFrag], url: URL_ });
+
+// The tuple-destructuring limits reach it identically: neither spelling is seen by the flattener.
+download({ extends: gqlFrag, url: URL_ });
+
+const widenedGql = [gqlFrag]; // inferred `Frag[]`, not `[Frag]`
+download({ extends: widenedGql, url: URL_ });
+
+// But a fragment does NOT launder a literal `kind` — the composed read finds the slot on the layer
+// that carries the error, so this is still rejected.
+expectError(
+    download({
+        extends: [{ baseUrl: 'https://f.test' }],
+        kind: graphqlSurface,
+    }),
+);
 
 // ── The non-inferring fallback must not launder a rejected config ───────────
 // A bare path string still reaches the loose overload unharmed.


### PR DESCRIPTION
Was stacked on #585 — same file, same guard family. #585 has since merged, and this is now **rebased onto `main`**: the four already-merged commits were dropped and only the `kind` guard replays, so the branch is a single commit on `main`.

## The hole

Both `download()` preset paths build their config as `{ ...config, kind: downloadSurface }` — the caller's `kind` is spread in and overwritten one line later. Authoring one was silently dead config, the same class #584/#585/#593 closed for `wire.body`, `method`/`wire.response`, and `document`/`operationName`.

Verified against #585's tip (`acb5269`) with tsd before the fix — both compiled with no error:

```ts
download({ url: 'https://f.test/a', kind: graphqlSurface });
download.bind(api).stitch({ path: '/a', kind: graphqlSurface });
```

## Why a separate guard

`NoKindOnDownload` is **not** a third arm of `NoRequestShapeOnDownload`. That type is shared with `RequestShapeFixedByDownload`, which guards the generic `stitch({ kind: downloadSurface, … })` path — and on that path `kind` is not dead config, it is the only thing selecting the surface. Folding them together would reject the config that triggers the guard. Both halves of the split are pinned as tsd cases, including positive controls that would fail loudly if someone merged the two types.

Applied to the two preset signatures: `downloadStitch` and `DownloadSeamApi['stitch']`. Both had since picked up `NoUnknownConfigKeys`/`NoUnknownNestedKeys` on `main`; the rebase intersects `NoKindOnDownload` after `NoRequestShapeOnDownload`, matching the guard order the other surfaces use. Those two do not subsume it — `kind` is a *known* config key — and that is asserted, not assumed: dropping `NoKindOnDownload` from the rebased signatures fails 9 `expectError` cases. `bindSeam`'s member is `as`-cast to the latter, so it inherits the guard — asserted, not assumed.

## Why not the `llm` spelling

`LlmOptions` closes the identical hole structurally with `Partial<Omit<StitchConfig, 'kind'>>`, which works only because `llm()`'s parameter is deliberately non-generic, so excess-property checking fires on the literal. The download preset captures a `const C` to infer its call argument from `config.input` (`InputOf<C>`), and a generic constraint does **no** excess-property checking — the documented migration gotcha from #591 — so `Omit` would simply be satisfied by a config carrying the extra key.

The `ConfigError` route is also strictly stronger: it is a real assignability failure, so it rejects a pre-built config **binding** that excess-property checking never sees. Pinned as a case, since it is the reason the two surfaces close one hole two ways rather than by oversight.

## Behaviour

- The redundant `kind: downloadSurface` is rejected on the preset too — same reasoning that makes `method: 'GET'` an error on a surface that sends exactly that.
- Reads the **composed** config via `AnyLayer`/`Layers`, like every guard after #597.
- Fails **open**: `kind` is the offending slot rather than an enabler, so a layer the flattener cannot see (`Frag[]`-widened `extends`, the P7 single-fragment spelling) costs a missed rejection, never a false one. Pinned alongside the existing fail-open cases.
- No runtime change — the stitch was always a download.

## Verification

`check:types`, `check:types-d`, `check:lint`, `check:format`, and `test` all pass from the repo root (1425 core tests, on the rebased tip). `check:exports`, `check:contract`, and `check:docs-links` also green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
