### PR TITLE
fix(core)!: reject unknown keys on every generic-inferred option bag

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -71,6 +71,12 @@ jobs:
             # shorthand/duration violation in the published surface, baselined against
             # scripts/contract-violations.baseline.json. Tool-free source scan — no build.
             - run: pnpm check:contract
+            # Unknown-key guard ratchet: every authoring surface that infers `const C` from an
+            # option-bag argument must intersect `NoUnknownKeys`, or be baselined with a reason
+            # in scripts/unknown-keys.baseline.json. Without the guard, that inference suppresses
+            # excess-property checking, so a misspelled or REMOVED slot typechecks and is
+            # silently dropped — which is what makes a slot rename unsafe. Source scan — no build.
+            - run: pnpm check:unknown-keys
             # Release coherence: version lockstep + prerelease-aware peer ranges +
             # scoped publishConfig.access, LICENSE/README presence, so a bad bump fails
             # the PR, not the publish.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,11 +75,12 @@ npm release are grouped under the in-development version that introduced them.
     says to follow the standard that governs each layer and convert at the edge. Custom
     adapters need no changes.
 
-    **Migration gotcha:** a stale `bodyType:` at a call site does **not** produce a compile
-    error — `stitch`'s `const C extends Partial<StitchConfig>` generic captures the argument
-    type, which suppresses excess-property checking, so the field is silently ignored and the
-    body falls back to JSON. Grep for `bodyType:`, `responseType:`, and `arrayFormat:` rather
-    than relying on the typechecker.
+    **Migration:** a stale `bodyType:` / `responseType:` / `arrayFormat:` at a call site is a
+    compile error naming the key, so `tsc` finds every one. That was not true when this entry
+    was first written — `stitch`'s `const C extends Partial<StitchConfig>` generic captures the
+    argument type, which suppressed excess-property checking, so the field was silently ignored
+    and the body fell back to JSON. The `NoUnknownConfigKeys` guard (see **Fixed**) closed that
+    gap; grepping for the old spellings is no longer necessary.
 
 - **`wire.multipart` now requires `wire.body: 'multipart'` at compile time.** The slot is read
   only on a multipart body, so pairing it with `'json'`/`'form'` — or with no body encoding at
@@ -166,6 +167,108 @@ npm release are grouped under the in-development version that introduced them.
     `Content-Disposition` filename parsing.
 
 ### Fixed
+
+- **An unknown config key is now a type error, so removing or renaming a slot has a compile-time
+  safety net.** The authoring overloads infer `const C` from the config argument — that is what lets
+  `InputOf` read RFC 6570 path vars off the literal — and that same inference SUPPRESSES TypeScript's
+  excess-property check: the literal is compared against a `C` just inferred from it, so no property
+  is ever "excess", and the `C extends Partial<StitchConfig>` constraint is then verified by ordinary
+  assignability, which ignores freshness. A misspelled or dead slot therefore typechecked and was
+  silently dropped at runtime:
+
+    ```ts
+    // before: typechecked, and the timeout was never applied
+    stitch({ path: '/things', timeut: 500 });
+    ```
+
+    It is now a type error naming the key, via the same `ConfigError` brand as the sibling guards, so
+    the message lands on the offending property instead of collapsing the config to `never`:
+
+    ```
+    `timeut` is not a StitchConfig slot — check the spelling
+    ```
+
+    The decisive consequence is for **migrations**: folding a flat slot into an envelope (ADR 0022's
+    `acceptStatus` → `verdict.accept`) previously left every call site that still authored the old
+    spelling typechecking. `#591` hit exactly this — 2 files found by typechecking, 30 by running the
+    suite. Such a rename is now mechanical, and `tsc` finds the stragglers.
+
+    Applied to **every** authoring surface that reaches an option bag through an inferred generic
+    (P16), swept for rather than patched case by case: `stitch`, `Seam.stitch`, `Seam.graphql`,
+    `graphql`, `download`, `sse`, `stream` and the `.bind(...)` binders (against `StitchConfig`);
+    `llm` (against `LlmOptions`); and `postmessage`'s `request` / `emit` / `events` (against
+    `RequestOptions` / `EmitOptions` / `EventsOptions`). Each names its own bag in the message, so
+    `reply` — a `RequestOptions` member — is correctly rejected on `emit` and `events`.
+
+    Deliberately **cheaper** than the sibling guards — one `keyof` and one `Exclude` per call site,
+    with no `Layers` walk — because unknown keys are a per-layer spelling concern, and an inline
+    `extends` fragment or a nested envelope is checked against its declared type, so it keeps
+    ordinary excess-property checking.
+
+    Ruled out by the same sweep, verified rather than assumed: the framework hooks
+    (`react`/`vue`/`solid`/`svelte`/`angular`/`swr`/`query-core`/`rtk-query`/`vercel-ai`) bind their
+    generic to the **stitch argument**, not to an option literal, and their options bags are
+    non-generic — so those keep ordinary excess-property checking already. `all()`'s named-bag form
+    takes caller-chosen keys, so it has no fixed vocabulary to misspell.
+
+    **Partial cover that already existed, and why the tests look the way they do:** these bags are
+    all-optional, so TypeScript's weak-type detection rejects a literal sharing _no_ property with
+    the target. That is only partial — add one valid sibling key and the unknown one rides along. So
+    every `expectError` in the type tests carries a valid sibling; without one the rejection would be
+    attributable to weak-type detection rather than to the guard.
+
+    **Stronger than excess-property checking** in one respect, and the reason the net holds
+    repo-wide: EPC only fires on a fresh literal, so a config hoisted into a `const` escapes it
+    entirely. Reading `keyof C` sees the binding's inferred type, so the hoisted spelling is rejected
+    too.
+
+    **Known limits,** both pinned as tsd expectations alongside the loose
+    `string | Partial<StitchConfig>` escape hatch, which is unchanged:
+
+    - An unknown key inside an `extends` fragment that is a `const` binding _and_ carries at least
+      one real slot is not reported — the binding is not fresh, so EPC does not fire, and the real
+      slot satisfies weak-type detection. A bound fragment of only unknown keys is still rejected.
+    - `Stitch.with(partial)` is the one surface left **unguarded**, and the exception is structural
+      rather than a matter of taste. It is the only signature whose return type reads `keyof P`, and
+      `keyof (P & NoUnknownKeys<P, …>)` does not reduce to `keyof P` while `P` is unresolved.
+      Intersecting the parameter rewrites `RelaxKeys<TIn, keyof P>` into a deferred union that the
+      declaration rollup emits differently than source, so the published `Stitch` stops being
+      structurally identical to the source one and every `S extends Stitch<unknown>` constraint in
+      the package breaks. The F-bounded spelling that would keep the parameter bare is a circular
+      constraint (TS2313). Guarding it would degrade the public `Stitch` type for every consumer,
+      which costs more than the hole it closes.
+
+    The class is now held closed by a **ratchet** rather than by having been swept once —
+    `pnpm check:unknown-keys` ([`scripts/check-unknown-keys.mjs`](scripts/check-unknown-keys.mjs)),
+    wired into `verify.yml` and `lefthook` pre-push beside `check:contract`. Every
+    generic-inferred option bag must either carry the guard or be listed in
+    `scripts/unknown-keys.baseline.json` **with a reason** — a bare `TODO` fails the gate — so a new
+    unguarded surface forces a deliberate decision instead of passing by omission. It currently sees
+    17 guarded surfaces and 4 baselined exceptions (`postmessage`'s three `channel()`-local impls,
+    whose consumer-facing declarations are guarded, and `Stitch.with`). Documented in
+    [docs/CONTRACT.md §7](docs/CONTRACT.md).
+
+- **BREAKING (types only) — `llm()` is now generic, so it infers its call argument.** Its parameter
+  was non-generic on purpose: excess-property checking was the only thing rejecting the removed
+  `maxTokens` spelling (P4), and keeping it meant giving up `const C` inference entirely. Now that
+  `NoUnknownKeys` supplies the rejection, the trade is gone and `llm` gets what every other surface
+  has — `InputOf<C>` call-argument inference:
+
+    ```ts
+    const chat = llm({
+        provider: anthropic,
+        url: 'https://llm.example.com/{version}/messages',
+    });
+    chat(); // now a type error: the path template requires `params`
+    chat({ params: { version: 'v1' } });
+    ```
+
+    Runtime behaviour is unchanged — the stitch is byte-identical. Breaking only in that a call
+    argument that was previously the loose `StitchInput` is now checked against the config's `input`
+    schemas and path template, so a call site that was silently under-specified now fails to compile.
+    `llm.stitch` and `llm.bind(...).stitch` inherit it; the binder moves to the loose-impl-plus-cast
+    idiom `download` already uses, because a generic impl cannot be checked against a member of its
+    own guarded shape.
 
 - **The config guards now read the composed config, so `extends` counts.** `wire.multipart` and
   `document`/`operationName` are gated on an enabler — a multipart body, the graphql surface — and

--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -236,6 +236,7 @@ export const PLAYGROUND_INSTANCE_COMPLETIONS: Record<string, Completion[]> = {
             label: "with",
             type: "method",
             detail: "(partial: P) => Stitch<TOut, RelaxKeys<TIn, keyof P>>",
+            info: "Bind part of the call input, returning a stitch whose remaining input is relaxed by the keys just supplied. Unlike the config surfaces, a MISSPELLED input key here is not a compile error — it binds nothing, silently (`.with({ params, parms })` keeps the `params` and drops the typo). Spell the slots as `StitchInput` declares them.",
         },
         {
             label: "invalidate",

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -989,6 +989,38 @@ shape, not as today's surface: nothing on the surface carries an alias.
   shapes or class fields; no group was found in either at the 2026-07-08 audit, but
   a future one wouldn't be caught until it grows an `interface`.
 
+### The unknown-key ratchet
+
+[`scripts/check-unknown-keys.mjs`](../scripts/check-unknown-keys.mjs) is a **second
+ratchet** with the same wiring — `pnpm check:unknown-keys`, in `lefthook` (pre-push) and
+`verify.yml` — guarding a different failure mode: not what the surface is _named_, but
+whether the compiler can see a **misspelling** of it.
+
+An authoring surface that infers `const C` from its option-bag argument gets no
+excess-property checking, because the literal is compared against a `C` just inferred from
+it — nothing is ever "excess" — and the `C extends …Options` constraint is then verified by
+ordinary assignability, which ignores freshness. So `stitch({ path: '/x', timeut: 500 })`
+type-checks and the value is silently dropped. That is what makes any slot **rename or
+removal** unsafe: every call site still authoring the old spelling keeps compiling. The fix
+is to intersect the parameter with `NoUnknownKeys<C, Allowed, What>`, which maps
+`Exclude<keyof C, keyof Allowed>` onto a `ConfigError` brand naming the key.
+
+- Every generic-inferred option bag must **either** carry the guard **or** be listed in
+  [`scripts/unknown-keys.baseline.json`](../scripts/unknown-keys.baseline.json) with a
+  **reason** — a bare `TODO` fails the gate. A new unguarded surface therefore forces a
+  deliberate decision rather than passing by omission.
+- High-precision, like the rules above: it matches a type-parameter constraint naming a
+  `…Config`/`…Options` type or a `Partial<…>` of one, which is what every authored option
+  bag here looks like. A generic bound to a _stitch argument_ (`S extends StitchLike<…>`,
+  the framework hooks) or to an index-signature bag (`all()`'s named form) is a different
+  shape and is not flagged — those hooks' options are separate non-generic parameters and
+  keep ordinary excess-property checking.
+- One baselined entry is a real instance that **cannot** take the guard: `Stitch.with` is
+  the only signature whose return type reads `keyof P`, and intersecting its parameter
+  degrades the published `Stitch` type. The reasoning is recorded on the signature and in
+  the baseline.
+- `test/` and `test-d/` are skipped — they author bad configs on purpose.
+
 ---
 
 ## 8. References

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -74,6 +74,11 @@ pre-push:
         # the expensive test/build jobs. Mirrors CI's check:contract step.
         - name: contract
           run: '{setup} pnpm check:contract'
+        # Unknown-key guard ratchet: a generic-inferred option bag with no `NoUnknownKeys`
+        # intersection lets a misspelled or removed slot typecheck and be silently dropped.
+        # Cheap source scan, same tier as the contract ratchet. Mirrors CI's step.
+        - name: unknown-keys
+          run: '{setup} pnpm check:unknown-keys'
         # Demo-media drift gate (docs/media/README.md): a branch that edits the
         # demo scene or its generator must also regenerate the committed README
         # webp pair. Cheap path diff; STITCH_MEDIA_STALE_OK=1 defers.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "check:size": "pnpm -r check:size",
         "check:docs-links": "node scripts/check-docs-links.mjs",
         "check:contract": "node scripts/check-contract.mjs",
+        "check:unknown-keys": "node scripts/check-unknown-keys.mjs",
         "check:format": "prettier --check .",
         "check:media-fresh": "node scripts/check-media-freshness.mjs",
         "check:release": "node scripts/check-release.mjs",

--- a/packages/core/src/download.ts
+++ b/packages/core/src/download.ts
@@ -14,6 +14,7 @@ import { makeStitch } from './stitch';
 import type { Surface, SurfaceOutcome } from './surface';
 import {
     type NoRequestShapeOnDownload,
+    type NoUnknownConfigKeys,
     type Seam,
     type SeamOptions,
     type Stitch,
@@ -117,7 +118,7 @@ export interface DownloadSeamApi {
     readonly stitch: <
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
-        config: C & NoRequestShapeOnDownload<C>,
+        config: C & NoUnknownConfigKeys<C> & NoRequestShapeOnDownload<C>,
     ) => Stitch<DownloadResult, InputOf<C>>;
     readonly seam: Seam;
 }
@@ -134,7 +135,7 @@ const downloadStitch = <
 >(
     // The surface is download by construction here, so the guard applies unconditionally rather
     // than keying off `kind` the way `stitch`'s `RequestShapeFixedByDownload` must.
-    config: C & NoRequestShapeOnDownload<C>,
+    config: C & NoUnknownConfigKeys<C> & NoRequestShapeOnDownload<C>,
 ): Stitch<DownloadResult, InputOf<C>> =>
     makeStitch<DownloadResult>({
         ...config,

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -11,11 +11,13 @@
 // onto it yet.) Bundle-frugal: reached only through the `llm` subpath; `import { stitch }` pulls in
 // none of it.
 import { compact } from './compact';
+import type { InputOf } from './infer';
 import { seam as makeSeam } from './seam';
 import { makeStitch } from './stitch';
 import type { Surface, SurfaceOutcome } from './surface';
 import {
     type NoRequestShapeOnLlm,
+    type NoUnknownKeys,
     type Seam,
     type SeamOptions,
     type Stitch,
@@ -192,32 +194,44 @@ function llmConfig(config: LlmOptions): Partial<StitchConfig> {
  * const { text } = await chat({ body: { messages: [{ role: 'user', content: 'hi' }] } });
  * ```
  */
-const llmStitch = (
+const llmStitch = <const C extends LlmOptions = LlmOptions>(
     // The live (overriding) surface is built by construction here, so the guard applies
     // unconditionally — no `kind`-keyed sibling, because the exported `llmSurface` is only the
     // identity and carries no `buildRequest`, so `method` IS live on `stitch({ kind: llmSurface })`.
-    // The parameter stays non-generic on purpose: that is what keeps excess-property checking, which
-    // is what rejects the removed `maxTokens` spelling (P4).
-    config: LlmOptions & NoRequestShapeOnLlm,
-): Stitch<LlmResult> => makeStitch<LlmResult>(llmConfig(config));
+    config: C &
+        NoUnknownKeys<C, LlmOptions, 'LlmOptions'> &
+        NoRequestShapeOnLlm,
+): Stitch<LlmResult, InputOf<C>> =>
+    // The `as` retypes the loose `makeStitch` result to the declared `InputOf<C>` call-arg type —
+    // the same retype `download`/`sse`/`stream` need for the same reason (`InputOf` reads
+    // `extends`-fragment schemas since #76, so it is not a clean supertype of `StitchInput` under an
+    // unresolved `C`). Sound: the runtime stitch is byte-identical.
+    makeStitch<LlmResult>(llmConfig(config)) as unknown as Stitch<
+        LlmResult,
+        InputOf<C>
+    >;
 
 /** llm members bound to a seam. `stitch(config)` creates an llm member of `seam`; `seam` is the
  *  underlying handle for lifecycle/principal (`.as`/`.flush`/`.close`). */
 export interface LlmSeamApi {
-    readonly stitch: (
-        config: LlmOptions & NoRequestShapeOnLlm,
-    ) => Stitch<LlmResult>;
+    readonly stitch: <const C extends LlmOptions = LlmOptions>(
+        config: C &
+            NoUnknownKeys<C, LlmOptions, 'LlmOptions'> &
+            NoRequestShapeOnLlm,
+    ) => Stitch<LlmResult, InputOf<C>>;
     readonly seam: Seam;
 }
 
 // Bind llm members to a seam through the seam's surface-agnostic `stitch({ kind })` (ADR 0005
 // Decision 3) — no per-surface seam method; one shared runtime / principal boundary.
 function bindSeam(s: Seam): LlmSeamApi {
-    return {
-        stitch: (config: LlmOptions & NoRequestShapeOnLlm) =>
-            s.stitch<LlmResult>(llmConfig(config)),
-        seam: s,
-    };
+    // Implemented loose and `as`-cast to the declared member type — the `download.ts` idiom. A
+    // generic impl whose parameter carries `NoUnknownKeys<C, …>` cannot be checked against a member
+    // of that same shape: TypeScript instantiates the impl's `C` with the target's whole
+    // intersection, so the two `InputOf<C>` return types stop matching.
+    const stitch = ((config: LlmOptions) =>
+        s.stitch<LlmResult>(llmConfig(config))) as LlmSeamApi['stitch'];
+    return { stitch, seam: s };
 }
 
 /**

--- a/packages/core/src/postmessage.ts
+++ b/packages/core/src/postmessage.ts
@@ -34,6 +34,7 @@ import type { Surface } from './surface';
 import type {
     AdapterRequest,
     AdapterResponse,
+    NoUnknownKeys,
     Stitch,
     StitchConfig,
 } from './types';
@@ -191,7 +192,7 @@ export interface PostMessageChannel {
      */
     request<const C extends RequestOptions = RequestOptions>(
         type: string,
-        opts?: C,
+        opts?: C & NoUnknownKeys<C, RequestOptions, 'RequestOptions'>,
     ): Stitch<OutputOf<C>, InputOf<C>>;
     /**
      * Fire-and-forget send (no reply awaited): post `{ type, payload }` and resolve immediately. A
@@ -205,7 +206,7 @@ export interface PostMessageChannel {
      */
     emit<const C extends EmitOptions = EmitOptions>(
         type: string,
-        opts?: C,
+        opts?: C & NoUnknownKeys<C, EmitOptions, 'EmitOptions'>,
     ): Stitch<void, InputOf<C>>;
     /**
      * Subscribe to inbound events of `opts.type`. A STREAMING surface (id `'postmessage-event'`):
@@ -218,7 +219,7 @@ export interface PostMessageChannel {
      */
     events<const C extends EventsOptions = EventsOptions>(
         type: string,
-        opts?: C,
+        opts?: C & NoUnknownKeys<C, EventsOptions, 'EventsOptions'>,
     ): Stitch<OutputOf<C>[], InputOf<C>>;
     /**
      * Register a handler that ANSWERS inbound requests of `type` (the receiving side — e.g. an
@@ -761,5 +762,16 @@ function makeChannel(
         return Promise.resolve();
     }
 
-    return { request, emit, events, respond, close };
+    // The three guarded members are `as`-cast to their declared types — the `download.ts` binder
+    // idiom. A generic impl whose parameter carries `NoUnknownKeys<C, …>` cannot be checked against
+    // a member of that same shape: TypeScript instantiates the impl's `C` with the target's whole
+    // intersection, so the two `InputOf<C>` return types stop matching. `respond`/`close` stay
+    // unguarded and fully checked.
+    return {
+        request: request as PostMessageChannel['request'],
+        emit: emit as PostMessageChannel['emit'],
+        events: events as PostMessageChannel['events'],
+        respond,
+        close,
+    };
 }

--- a/packages/core/src/sse.ts
+++ b/packages/core/src/sse.ts
@@ -17,6 +17,7 @@ import { makeStitch } from './stitch';
 import type { Surface } from './surface';
 import {
     type AdapterResponse,
+    type NoUnknownConfigKeys,
     type ResolvedStitchConfig,
     type Seam,
     type SeamOptions,
@@ -180,7 +181,7 @@ export interface SseSeamApi {
     readonly stitch: <
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
-        config: C,
+        config: C & NoUnknownConfigKeys<C>,
     ) => Stitch<SseEvent<OutputOf<C>>[], InputOf<C>>;
     readonly seam: Seam;
 }
@@ -196,7 +197,7 @@ export interface SseSeamApi {
 const sseStitch = <
     const C extends Partial<StitchConfig> = Partial<StitchConfig>,
 >(
-    config: C,
+    config: C & NoUnknownConfigKeys<C>,
 ): Stitch<SseEvent<OutputOf<C>>[], InputOf<C>> =>
     makeStitch<SseEvent[]>({
         ...config,
@@ -206,15 +207,17 @@ const sseStitch = <
 // Bind sse members to a seam through the seam's surface-agnostic `stitch({ kind })` (Decision 3) —
 // no per-surface seam method; one shared runtime / principal boundary.
 function bindSeam(s: Seam): SseSeamApi {
-    const stitch = <
-        const C extends Partial<StitchConfig> = Partial<StitchConfig>,
-    >(
-        config: C,
-    ): Stitch<SseEvent<OutputOf<C>>[], InputOf<C>> =>
+    // Implemented loose and `as`-cast to the declared member type — the same idiom as
+    // `download.ts`'s binder, for the same reason: a generic impl whose parameter is
+    // `C & NoUnknownConfigKeys<C>` cannot be checked against a member of that same shape, because
+    // TypeScript instantiates the impl's `C` with the target's whole intersection and the two
+    // `InputOf<C>` return types stop matching. Sound — the runtime is one `s.stitch` call, and the
+    // type tests pin every concrete config.
+    const stitch = ((config: Partial<StitchConfig>) =>
         s.stitch<SseEvent[]>({
             ...config,
             kind: sseSurface,
-        }) as unknown as Stitch<SseEvent<OutputOf<C>>[], InputOf<C>>;
+        })) as SseSeamApi['stitch'];
     return { stitch, seam: s };
 }
 

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -44,6 +44,7 @@ import {
     type InspectOptions,
     type Inspection,
     type MultipartOnlyOnMultipartBody,
+    type NoUnknownConfigKeys,
     type NoWireBodyOnGraphql,
     type RedactedStitchConfig,
     type RequestShapeFixedByDownload,
@@ -1128,6 +1129,7 @@ export interface StitchFn {
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
         config: C &
+            NoUnknownConfigKeys<C> &
             MultipartOnlyOnMultipartBody<C> &
             GraphqlOnlyOnGraphqlSurface<C> &
             WireBodyFixedByGraphql<C> &
@@ -1139,12 +1141,13 @@ export interface StitchFn {
      * match the inferring overload above, so the result is `Stitch<unknown>` — override with `<T>`.
      *
      * `C` is captured here ONLY to re-apply the dead-config guards
-     * ({@link MultipartOnlyOnMultipartBody}, {@link GraphqlOnlyOnGraphqlSurface},
-     * {@link WireBodyFixedByGraphql}, {@link RequestShapeFixedByDownload}); the result stays
-     * `Stitch<T>`. Without it a config rejected by the inferring overload would silently fall
-     * through to this one and typecheck after all. On a genuinely loose
-     * `string | Partial<StitchConfig>` argument the guards distribute over the union and every arm
-     * resolves to `unknown`, so this stays the same escape hatch it has always been.
+     * ({@link NoUnknownConfigKeys}, {@link MultipartOnlyOnMultipartBody},
+     * {@link GraphqlOnlyOnGraphqlSurface}, {@link WireBodyFixedByGraphql},
+     * {@link RequestShapeFixedByDownload}); the result stays `Stitch<T>`. Without it a config
+     * rejected by the inferring overload would silently fall through to this one and typecheck
+     * after all. On a genuinely loose `string | Partial<StitchConfig>` argument the guards
+     * distribute over the union and every arm resolves to `unknown`, so this stays the same escape
+     * hatch it has always been.
      */
     <
         T = unknown,
@@ -1152,6 +1155,7 @@ export interface StitchFn {
             string | Partial<StitchConfig>,
     >(
         config: C &
+            NoUnknownConfigKeys<C> &
             MultipartOnlyOnMultipartBody<C> &
             GraphqlOnlyOnGraphqlSurface<C> &
             WireBodyFixedByGraphql<C> &
@@ -1193,7 +1197,10 @@ export function graphql<
 >(
     // The surface is graphql by construction here, so the graphql guard applies unconditionally
     // rather than keying off `kind` the way `stitch`'s `WireBodyFixedByGraphql` must.
-    config: C & MultipartOnlyOnMultipartBody<C> & NoWireBodyOnGraphql<C>,
+    config: C &
+        NoUnknownConfigKeys<C> &
+        MultipartOnlyOnMultipartBody<C> &
+        NoWireBodyOnGraphql<C>,
 ): Stitch<ResolveOutput<TExplicit, C>, InputOf<C>> {
     // Default the endpoint to `/graphql` only when neither `url` nor `path` is given (preserves the
     // convenience without clobbering an explicit endpoint). Method/body shaping is the surface's.

--- a/packages/core/src/stream.ts
+++ b/packages/core/src/stream.ts
@@ -20,6 +20,7 @@ import { makeStitch } from './stitch';
 import type { Surface } from './surface';
 import {
     type AdapterResponse,
+    type NoUnknownConfigKeys,
     type ResolvedStitchConfig,
     type Seam,
     type SeamOptions,
@@ -120,7 +121,7 @@ export interface StreamSeamApi {
     readonly stitch: <
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
-        config: C,
+        config: C & NoUnknownConfigKeys<C>,
     ) => Stitch<StreamElement<C>[], InputOf<C>>;
     readonly seam: Seam;
 }
@@ -136,7 +137,7 @@ export interface StreamSeamApi {
 const streamStitch = <
     const C extends Partial<StitchConfig> = Partial<StitchConfig>,
 >(
-    config: C,
+    config: C & NoUnknownConfigKeys<C>,
 ): Stitch<StreamElement<C>[], InputOf<C>> =>
     makeStitch<unknown[]>({
         ...config,
@@ -145,15 +146,17 @@ const streamStitch = <
 
 // Bind stream members to a seam through the seam's surface-agnostic `stitch({ kind })` (Decision 3).
 function bindSeam(s: Seam): StreamSeamApi {
-    const stitch = <
-        const C extends Partial<StitchConfig> = Partial<StitchConfig>,
-    >(
-        config: C,
-    ): Stitch<StreamElement<C>[], InputOf<C>> =>
+    // Implemented loose and `as`-cast to the declared member type — the same idiom as
+    // `download.ts`'s binder, for the same reason: a generic impl whose parameter is
+    // `C & NoUnknownConfigKeys<C>` cannot be checked against a member of that same shape, because
+    // TypeScript instantiates the impl's `C` with the target's whole intersection and the two
+    // `InputOf<C>` return types stop matching. Sound — the runtime is one `s.stitch` call, and the
+    // type tests pin every concrete config.
+    const stitch = ((config: Partial<StitchConfig>) =>
         s.stitch<unknown[]>({
             ...config,
             kind: streamSurface,
-        }) as unknown as Stitch<StreamElement<C>[], InputOf<C>>;
+        })) as StreamSeamApi['stitch'];
     return { stitch, seam: s };
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1546,26 +1546,32 @@ export interface Stitch<TOut = unknown, TIn = StitchInput> {
     report(
         ...args: [...Args<TIn>, opts?: boolean | AtLeastOne<InspectOptions>]
     ): Promise<RunReport<TOut>>;
+    // WHY THIS SLOT IS UNGUARDED — implementer detail, deliberately a line comment rather than
+    // JSDoc: the docs playground surfaces a member's JSDoc verbatim as autocomplete help
+    // (apps/docs/app/(home)/playground/playground-completions.generated.ts), where a wall of
+    // declaration-emit reasoning is noise for the reader hovering `.with`. The user-facing caveat
+    // stays in the JSDoc below; the mechanism lives here.
+    //
+    // `const P` is inferred from the argument exactly as on the config surfaces, so
+    // excess-property checking is suppressed the same way and `NoUnknownKeys` would be the fix —
+    // but this is the only signature whose RETURN type reads `keyof P`, and
+    // `keyof (P & NoUnknownKeys<P, …>)` does not reduce to `keyof P` while `P` is unresolved.
+    // Intersecting the parameter therefore rewrites `RelaxKeys<TIn, keyof P>` into a deferred union
+    // that `tsup`'s declaration rollup emits in a different form than source — so `lib`'s `Stitch`
+    // stops being structurally identical to `src`'s, and every `S extends Stitch<unknown>`
+    // constraint in the package breaks (`streaming-inference.test-d.ts` catches it immediately).
+    //
+    // The F-bounded spelling that would keep the parameter bare —
+    // `P extends Partial<TIn> & NoUnknownKeys<P, TIn, …>` — is a circular constraint (TS2313).
+    // Guarding this slot means degrading the public `Stitch` type for every consumer, which costs
+    // more than the hole it closes; the config surfaces have no such coupling and are all guarded.
     /**
      * Bind part of the call input, returning a stitch whose remaining input is relaxed by the keys
      * just supplied.
      *
-     * KNOWN LIMIT — this is the one authoring surface {@link NoUnknownKeys} deliberately does NOT
-     * guard, and the exception is structural rather than a matter of taste. `const P` is inferred
-     * from the argument here exactly as on the config surfaces, so excess-property checking is
-     * suppressed the same way and `.with({ params, parms })` binds nothing silently (weak-type
-     * detection catches only the case with no valid sibling key). But this signature is the only one
-     * whose RETURN type reads `keyof P`, and `keyof (P & NoUnknownKeys<P, …>)` does not reduce to
-     * `keyof P` while `P` is unresolved. Intersecting the parameter therefore rewrites
-     * `RelaxKeys<TIn, keyof P>` into a deferred union that `tsup`'s declaration rollup emits in a
-     * different form than source — so `lib`'s `Stitch` stops being structurally identical to
-     * `src`'s, and every `S extends Stitch<unknown>` constraint in the package breaks
-     * (`streaming-inference.test-d.ts` catches it immediately).
-     *
-     * The F-bounded spelling that would keep the parameter bare —
-     * `P extends Partial<TIn> & NoUnknownKeys<P, TIn, …>` — is a circular constraint (TS2313).
-     * Guarding this slot means degrading the public `Stitch` type for every consumer, which costs
-     * more than the hole it closes; the config surfaces have no such coupling and are all guarded.
+     * Unlike the config surfaces, a MISSPELLED input key here is not a compile error — it binds
+     * nothing, silently (`.with({ params, parms })` keeps the `params` and drops the typo). Spell
+     * the slots as `StitchInput` declares them.
      */
     with<const P extends Partial<TIn>>(
         partial: P,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -200,6 +200,79 @@ export interface ConfigError<Message extends string> {
     readonly __stitchConfigError: Message;
 }
 /**
+ * Compile-time guard: reject a key on an authored option bag that is not a slot of `Allowed`.
+ * `What` names the bag in the error message, so each surface reports against its own vocabulary.
+ *
+ * Every authoring surface here infers `const C` from its argument so {@link InputOf} can read
+ * path-template vars off the literal (Phase 2c). That inference is also what SUPPRESSES
+ * TypeScript's excess-property check: the literal is compared against `C`, which was just inferred
+ * from it, so it matches exactly and no property is ever "excess". The `C extends …` constraint is
+ * then verified by ordinary assignability, which ignores freshness. Net effect without this guard:
+ * `stitch({ path: '/x', timeut: 500 })` typechecks, and a REMOVED or RENAMED slot keeps typechecking
+ * at every call site that still authors it.
+ *
+ * TypeScript's WEAK-TYPE detection gives partial cover for free, since these bags are all-optional:
+ * a literal sharing NO property with the target is rejected regardless of freshness. It is only
+ * partial — add one valid sibling key and the unknown one rides along, which is the case this guard
+ * exists for and the reason every `expectError` in the type tests carries a valid sibling.
+ *
+ * That gap is why {@link LlmOptions}'s parameter USED to be non-generic: excess-property checking
+ * was the only thing rejecting the removed `maxTokens` spelling (P4), and keeping it meant giving up
+ * `const C` inference entirely. This guard supplies the rejection instead, so `llm` is now generic
+ * and gets call-argument inference too — the trade is gone.
+ *
+ * Mechanism: intersecting the bag with a mapped type over `Exclude<keyof C, keyof Allowed>` makes
+ * exactly the unknown keys unsatisfiable, so the error lands on the offending property with a
+ * {@link ConfigError} brand that NAMES it. Known keys are untouched, and when there are none the
+ * guard is `unknown` and intersects away.
+ *
+ * Cheaper than the sibling guards on purpose: one `keyof` and one `Exclude` per call site, with no
+ * {@link Layers} walk. Unknown keys are a per-layer spelling concern, not a cross-layer pairing, and
+ * an INLINE `extends` fragment is a fresh literal checked against the declared
+ * `Partial<StitchConfig> | Stitch` — so it still gets ordinary excess-property checking and needs no
+ * help from here.
+ *
+ * STRONGER than excess-property checking in one respect, and the reason a rename is now caught
+ * repo-wide: EPC only fires on a fresh literal, so a config hoisted into a `const` binding escapes
+ * it. `keyof C` reads the binding's INFERRED type, so the hoisted spelling is rejected too.
+ *
+ * NOT applied to `Stitch.with` — the one surface whose RETURN type reads `keyof P`, which makes an
+ * intersected parameter degrade the public `Stitch` type. The reasoning is recorded on `with` itself.
+ *
+ * RESIDUAL LIMITS:
+ * - Fail-open: an unknown key inside an `extends` fragment that is a `const` BINDING and also carries
+ *   at least one real slot is not reported — the binding is not fresh so EPC does not fire, the real
+ *   slot satisfies weak-type detection so that does not either, and this guard reads only the
+ *   literal's own keys. A bound fragment of ONLY unknown keys IS still rejected, by weak-type
+ *   detection. Both pinned in `unknown-config-keys.test-d.ts`.
+ * - Fail-open by design: a config whose static type is already `Partial<StitchConfig>` (or the loose
+ *   `string | Partial<StitchConfig>` escape hatch) has no unknown keys to find. Its declaration site
+ *   is where the spelling was checked, and that site had EPC.
+ * - An index-signature config (`Record<string, unknown>`) is rejected, since every key is unknown.
+ *   It never satisfied `Partial<StitchConfig>` usefully; pinned so the behaviour is deliberate.
+ */
+export type NoUnknownKeys<C, Allowed, What extends string> = C extends string
+    ? unknown
+    : [Exclude<keyof C, keyof Allowed>] extends [never]
+      ? unknown
+      : {
+            [
+                K in Exclude<keyof C, keyof Allowed>
+            ]: ConfigError<`\`${Extract<K, string>}\` is not a ${What} slot — check the spelling`>;
+        };
+/**
+ * {@link NoUnknownKeys} bound to {@link StitchConfig} — the `stitch` / `Seam.stitch` /
+ * `Seam.graphql` / `graphql` / `download` / `sse` / `stream` authoring surfaces. The other option
+ * bags reached through an inferred generic bind their own allowed set the same way:
+ * `LlmOptions` (`stitchapi/llm`) and `RequestOptions` / `EmitOptions` / `EventsOptions`
+ * (`stitchapi/postmessage`).
+ */
+export type NoUnknownConfigKeys<C> = NoUnknownKeys<
+    C,
+    StitchConfig,
+    'StitchConfig'
+>;
+/**
  * Compile-time guard: {@link WireOptions.multipart} is read ONLY when `wire.body` is
  * `'multipart'`, so pairing it with a `json`/`form` body (or omitting `body`, which defaults to
  * `json`) is silently dead config. Intersecting a config with this makes the nested `multipart`
@@ -1473,6 +1546,27 @@ export interface Stitch<TOut = unknown, TIn = StitchInput> {
     report(
         ...args: [...Args<TIn>, opts?: boolean | AtLeastOne<InspectOptions>]
     ): Promise<RunReport<TOut>>;
+    /**
+     * Bind part of the call input, returning a stitch whose remaining input is relaxed by the keys
+     * just supplied.
+     *
+     * KNOWN LIMIT — this is the one authoring surface {@link NoUnknownKeys} deliberately does NOT
+     * guard, and the exception is structural rather than a matter of taste. `const P` is inferred
+     * from the argument here exactly as on the config surfaces, so excess-property checking is
+     * suppressed the same way and `.with({ params, parms })` binds nothing silently (weak-type
+     * detection catches only the case with no valid sibling key). But this signature is the only one
+     * whose RETURN type reads `keyof P`, and `keyof (P & NoUnknownKeys<P, …>)` does not reduce to
+     * `keyof P` while `P` is unresolved. Intersecting the parameter therefore rewrites
+     * `RelaxKeys<TIn, keyof P>` into a deferred union that `tsup`'s declaration rollup emits in a
+     * different form than source — so `lib`'s `Stitch` stops being structurally identical to
+     * `src`'s, and every `S extends Stitch<unknown>` constraint in the package breaks
+     * (`streaming-inference.test-d.ts` catches it immediately).
+     *
+     * The F-bounded spelling that would keep the parameter bare —
+     * `P extends Partial<TIn> & NoUnknownKeys<P, TIn, …>` — is a circular constraint (TS2313).
+     * Guarding this slot means degrading the public `Stitch` type for every consumer, which costs
+     * more than the hole it closes; the config surfaces have no such coupling and are all guarded.
+     */
     with<const P extends Partial<TIn>>(
         partial: P,
     ): Stitch<TOut, RelaxKeys<TIn, keyof P>>;
@@ -1628,6 +1722,7 @@ export interface Seam {
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
         config: C &
+            NoUnknownConfigKeys<C> &
             MultipartOnlyOnMultipartBody<C> &
             GraphqlOnlyOnGraphqlSurface<C> &
             WireBodyFixedByGraphql<C> &
@@ -1636,9 +1731,9 @@ export interface Seam {
     /**
      * Non-inferring fallback: a path string or a `string | Partial<StitchConfig>` value (see
      * {@link StitchFn}). `C` is captured only to re-apply the dead-config guards
-     * ({@link MultipartOnlyOnMultipartBody}, {@link GraphqlOnlyOnGraphqlSurface},
-     * {@link WireBodyFixedByGraphql}, {@link RequestShapeFixedByDownload}) — see
-     * {@link StitchFn}'s fallback for why.
+     * ({@link NoUnknownConfigKeys}, {@link MultipartOnlyOnMultipartBody},
+     * {@link GraphqlOnlyOnGraphqlSurface}, {@link WireBodyFixedByGraphql},
+     * {@link RequestShapeFixedByDownload}) — see {@link StitchFn}'s fallback for why.
      */
     stitch<
         T = unknown,
@@ -1646,6 +1741,7 @@ export interface Seam {
             string | Partial<StitchConfig>,
     >(
         config: C &
+            NoUnknownConfigKeys<C> &
             MultipartOnlyOnMultipartBody<C> &
             GraphqlOnlyOnGraphqlSurface<C> &
             WireBodyFixedByGraphql<C> &
@@ -1660,7 +1756,10 @@ export interface Seam {
             document: string;
         },
     >(
-        config: C & MultipartOnlyOnMultipartBody<C> & NoWireBodyOnGraphql<C>,
+        config: C &
+            NoUnknownConfigKeys<C> &
+            MultipartOnlyOnMultipartBody<C> &
+            NoWireBodyOnGraphql<C>,
     ): Stitch<ResolveOutput<TExplicit, C>, InputOf<C>>;
     /**
      * Derive a principal-bound {@link PrincipalSeam} reusing the same shared runtime, but whose

--- a/packages/core/test-d/unknown-config-keys.test-d.ts
+++ b/packages/core/test-d/unknown-config-keys.test-d.ts
@@ -1,0 +1,222 @@
+// A config key that is not a `StitchConfig` slot must not typecheck. Without a guard it does, and
+// the reason is subtle enough to be worth stating: the authoring overloads infer `const C` from the
+// config argument so `InputOf` can read path-template vars off the literal, and that inference is
+// exactly what SUPPRESSES TypeScript's excess-property check — the literal is compared against a `C`
+// just inferred from it, so nothing is ever "excess". The `C extends Partial<StitchConfig>`
+// constraint is then checked by ordinary assignability, which ignores freshness.
+//
+// The consequence is what this file exists to prevent: REMOVING or RENAMING a config slot leaves
+// every call site that still authors the old spelling typechecking silently. That is the trap #591
+// hit (2 files found by typechecking, 30 by running the suite), the reason `LlmOptions`' parameter is
+// deliberately non-generic, and the migration hazard flagged in #600's review notes for folding
+// `acceptStatus` into `verdict`. `NoUnknownConfigKeys` closes it WITHOUT giving up `const C`
+// inference, so the positive controls below assert that inference still works.
+//
+// Every authoring entry point is covered (CONTRACT.md P16 — a guard binds every surface that authors
+// a stitch): `stitch`, `seam.stitch`, `seam.graphql`, `graphql`, `download`, `sse`, `stream`, and the
+// `.bind(...)` binders — plus the three other option bags reached through an inferred generic:
+// `LlmOptions` (`llm`), `RequestOptions`/`EmitOptions`/`EventsOptions` (`postmessage`), and
+// `StitchInput` (`Stitch.with`). All bind `NoUnknownKeys` to their own allowed set.
+//
+// One nuance the cases below depend on: TypeScript's WEAK-TYPE detection gives partial cover for
+// free, because these option bags are all-optional — a literal sharing NO property with the target
+// is rejected regardless of freshness. That is why every `expectError` here includes a VALID sibling
+// key: without one the rejection would be attributable to weak-type detection rather than to the
+// guard, and the guard is what covers the case that actually leaked.
+import { seam, stitch } from '../src';
+import type { Stitch, StitchConfig } from '../src';
+import { download } from '../src/download';
+import { anthropic, llm } from '../src/llm';
+import type { PostMessageChannel } from '../src/postmessage';
+import { sse } from '../src/sse';
+import { graphql } from '../src/stitch';
+import { stream } from '../src/stream';
+
+import { expectError, expectType } from 'tsd';
+
+const URL_ = 'https://api.example.com/things';
+
+// ── Positive controls: every real slot still authors cleanly ─────────────────
+// If the guard were over-eager these would fail, and each rejection below would be unattributable.
+stitch({ path: '/things', timeout: 500, retry: 2, headers: { a: '1' } });
+stitch({ url: URL_, wire: { array: 'repeat' }, cache: '1m' });
+stitch({ path: '/things', acceptStatus: [404] });
+stitch({ extends: [{ baseUrl: 'https://api.example.com' }], path: '/things' });
+
+// ── Illegal: a key that is not a `StitchConfig` slot ────────────────────────
+expectError(stitch({ path: '/things', totallyMadeUpProperty: 123 }));
+
+// A TYPO of a real slot is the same error, and the common one.
+expectError(stitch({ path: '/things', timeut: 500 }));
+expectError(stitch({ path: '/things', retires: 2 }));
+
+// The #600 migration case: a slot folded into an envelope leaves the flat spelling dead. This is the
+// shape that had no compile-time net before — `acceptStatus` stays legal above, so what is pinned
+// here is that ANY not-a-slot spelling is rejected, which is what makes such a rename mechanical.
+expectError(stitch({ path: '/things', acceptStatusOld: [404] }));
+
+// ── STRONGER than excess-property checking: a hoisted config is caught too ──
+// EPC only fires on a FRESH literal, so lifting the same object into a `const` escapes it entirely.
+// The guard reads `keyof C` off the binding's inferred type, so the hoisted spelling is still
+// rejected — this is the case that makes a rename safe repo-wide rather than only at inline sites.
+const hoisted = { path: '/things', totallyMadeUpProperty: 123 };
+expectError(stitch(hoisted));
+
+// Positive control for the same shape minus the unknown key.
+const hoistedOk = { path: '/things', timeout: 500 };
+stitch(hoistedOk);
+
+// ── The guard binds every authoring entry point ─────────────────────────────
+const api = seam({ baseUrl: 'https://api.example.com' });
+
+api.stitch({ path: '/things', timeout: 500 });
+expectError(api.stitch({ path: '/things', totallyMadeUpProperty: 123 }));
+
+api.graphql({ document: 'query { me { id } }' });
+expectError(
+    api.graphql({ document: 'query { me { id } }', totallyMadeUpProperty: 1 }),
+);
+
+graphql({ document: 'query { me { id } }' });
+expectError(
+    graphql({ document: 'query { me { id } }', totallyMadeUpProperty: 1 }),
+);
+
+download({ url: URL_ });
+expectError(download({ url: URL_, totallyMadeUpProperty: 1 }));
+expectError(download.stitch({ url: URL_, totallyMadeUpProperty: 1 }));
+
+sse({ path: '/events' });
+expectError(sse({ path: '/events', totallyMadeUpProperty: 1 }));
+
+stream({ path: '/chunks' });
+expectError(stream({ path: '/chunks', totallyMadeUpProperty: 1 }));
+
+// The `.bind(...)` binders inherit it through their declared member type.
+const boundDl = download.bind(api);
+boundDl.stitch({ path: '/report.pdf' });
+expectError(boundDl.stitch({ path: '/report.pdf', totallyMadeUpProperty: 1 }));
+
+const boundSse = sse.bind(api);
+boundSse.stitch({ path: '/events' });
+expectError(boundSse.stitch({ path: '/events', totallyMadeUpProperty: 1 }));
+
+const boundStream = stream.bind(api);
+boundStream.stitch({ path: '/chunks' });
+expectError(boundStream.stitch({ path: '/chunks', totallyMadeUpProperty: 1 }));
+
+// ── Nested envelopes and inline fragments were already covered by EPC ───────
+// These are checked against their DECLARED types (`AtLeastOne<WireOptions>`,
+// `Partial<StitchConfig> | Stitch`) rather than against the inferred `C`, so freshness survives and
+// ordinary excess-property checking fires. Pinned so it stays true — it is the reason
+// `NoUnknownConfigKeys` deliberately does NOT walk `Layers<C>`, which keeps its `tsc` cost to one
+// `keyof` and one `Exclude` per call site.
+expectError(stitch({ path: '/things', wire: { bogusNested: 1 } }));
+expectError(stitch({ path: '/things', extends: [{ bogusInFragment: 1 }] }));
+
+// A BOUND fragment carrying ONLY unknown keys is rejected too, though by a third mechanism again —
+// TypeScript's weak-type detection. `Partial<StitchConfig>` is all-optional, so a value sharing NO
+// property with it is unassignable regardless of freshness.
+const allBogus = { bogusInFragment: 1 };
+expectError(stitch({ path: '/things', extends: [allBogus] }));
+
+// ── RESIDUAL LIMIT (fail-open): a BOUND fragment mixing real and unknown keys ──
+// This is the one hole. The binding is not fresh, so EPC does not fire at the `extends` position; the
+// real `baseUrl` satisfies weak-type detection, so that does not fire either; and the guard reads
+// only the literal's own keys. Accepted rather than resolved: catching it needs a `Layers<C>` walk on
+// every call site, and the fragment's own declaration site is the natural place to type it
+// (`const frag: Partial<StitchConfig> = { … }` gets EPC there). Deliberate, so NOT `expectError`.
+const mixedFragment = {
+    baseUrl: 'https://api.example.com',
+    bogusInFragment: 1,
+};
+stitch({ path: '/things', extends: [mixedFragment] });
+
+// ── RESIDUAL LIMIT (fail-open by design): an already-typed config ───────────
+// A value whose static type is `Partial<StitchConfig>` has no unknown keys left to find; its
+// declaration site is where the spelling was checked, and that site had EPC.
+declare const typed: Partial<StitchConfig>;
+stitch(typed);
+
+// The loose `string | Partial<StitchConfig>` escape hatch is unchanged — the guard's `C extends
+// string` arm distributes to `unknown` on both arms of the union.
+declare const loose: string | Partial<StitchConfig>;
+expectType<Stitch<unknown>>(stitch(loose));
+expectType<Stitch<unknown>>(stitch('/plain'));
+
+// An index-signature config makes every key unknown, so it is rejected. It never satisfied
+// `Partial<StitchConfig>` usefully; pinned so the behaviour is deliberate rather than latent.
+declare const anyKeys: Record<string, unknown>;
+expectError(stitch(anyKeys));
+
+// ── `const C` inference survives the guard ──────────────────────────────────
+// The whole point of the generic is `InputOf<C>` reading the RFC 6570 template off the literal. If
+// the guard's intersection had collapsed the inferring overload into the loose one, `params` would
+// stop being required and this would silently pass.
+const byId = stitch({ url: 'https://api.example.com/things/{id}' });
+expectError(byId());
+byId({ params: { id: 't-1' } });
+
+// And the result type is still inferred from `output`, not widened by the intersection.
+const plain = stitch({ path: '/things' });
+expectType<Stitch<unknown>>(plain);
+
+// ── `llm` — `LlmOptions`, and the trade it no longer pays ───────────────────
+// `llmStitch`'s parameter used to be NON-GENERIC on purpose: that was the only way to keep
+// excess-property checking, and it is what rejected the removed `maxTokens` spelling (P4). The cost
+// was total: no `const C`, so no `InputOf<C>` call-argument inference at all. Now that the guard
+// supplies the rejection, the parameter is generic and gets BOTH.
+llm({ provider: anthropic, model: 'claude-opus-4-8', tokens: 10, retry: 2 });
+expectError(llm({ provider: anthropic, model: 'm', bogusLlmKey: 1 }));
+
+// The P4 case the non-generic parameter existed to catch — still caught, now by the guard.
+expectError(llm({ provider: anthropic, maxTokens: 10 }));
+
+// What the generic BUYS: a path template now requires its `params`, which was impossible before.
+const versioned = llm({
+    provider: anthropic,
+    url: 'https://llm.example.com/{version}/messages',
+});
+expectError(versioned());
+versioned({ params: { version: 'v1' } });
+
+// `llm.stitch` is the same function as the callable, and the seam binder declares the same member.
+expectError(llm.stitch({ provider: anthropic, model: 'm', bogusLlmKey: 1 }));
+const boundLlm = llm.bind(api);
+boundLlm.stitch({ provider: anthropic, model: 'm' });
+expectError(
+    boundLlm.stitch({ provider: anthropic, model: 'm', bogusLlmKey: 1 }),
+);
+
+// ── RESIDUAL LIMIT: `Stitch.with(partial)` is deliberately UNGUARDED ────────
+// Same bug class — `const P extends Partial<TIn>` suppresses EPC, so a typo'd input key binds
+// nothing — but this is the only signature whose RETURN type reads `keyof P`, and
+// `keyof (P & NoUnknownKeys<P, …>)` does not reduce while `P` is unresolved. Intersecting the
+// parameter rewrites `RelaxKeys<TIn, keyof P>` into a deferred union that `tsup`'s declaration
+// rollup emits differently than source, so `lib`'s `Stitch` stops matching `src`'s and every
+// `S extends Stitch<unknown>` constraint in the package breaks. The F-bounded spelling that would
+// keep the parameter bare is a circular constraint (TS2313). Guarding it would degrade the public
+// `Stitch` type for every consumer, so it stays open — deliberate, hence NOT `expectError`.
+const withable = stitch({ path: '/things/{id}' });
+withable.with({ params: { id: 't-1' } });
+withable.with({ params: { id: 't-1' }, parms: 2 });
+
+// Weak-type detection still covers the no-valid-sibling case here, for free.
+expectError(withable.with({ totallyBogus: 2 }));
+
+// ── `postmessage` — RequestOptions / EmitOptions / EventsOptions ────────────
+declare const ch: PostMessageChannel;
+
+ch.request('ping', { timeout: 100, reply: 'pong' });
+expectError(ch.request('ping', { timeout: 100, bogusPmKey: 1 }));
+
+ch.emit('fire', { retry: 2 });
+expectError(ch.emit('fire', { retry: 2, bogusPmKey: 1 }));
+
+ch.events('tick', { retry: 2 });
+expectError(ch.events('tick', { retry: 2, bogusPmKey: 1 }));
+
+// Each option bag names ITS OWN type in the message, so the three are not interchangeable: `reply`
+// belongs to `RequestOptions` only, and authoring it on `emit`/`events` is dead config.
+expectError(ch.emit('fire', { retry: 2, reply: 'pong' }));
+expectError(ch.events('tick', { retry: 2, reply: 'pong' }));

--- a/packages/core/test/llm.spec.ts
+++ b/packages/core/test/llm.spec.ts
@@ -5,6 +5,7 @@
 import type { Adapter, AdapterRequest } from '../src';
 import { anthropic, llm, openai } from '../src/llm';
 import type { LlmProvider } from '../src/llm';
+import { seam } from '../src/seam';
 
 function captureAdapter(response: unknown): {
     adapter: Adapter;
@@ -144,6 +145,26 @@ test('llm honours an explicit url over the provider default', async () => {
     });
 
     await chat({ body: { messages: [{ role: 'user', content: 'hi' }] } });
+    expect(calls[0]!.url).toBe('https://gateway.internal/llm');
+});
+
+// The binder is implemented loose and `as`-cast to `LlmSeamApi['stitch']` (the `download.ts` idiom,
+// needed once the member carries `NoUnknownKeys<C, …>`), so its declared type cannot vouch for the
+// runtime wiring — the cast is exactly what the compiler stops checking. This pins that a bound
+// member still resolves through the seam's baseUrl and reaches the provider mapping.
+test('llm.bind(existingSeam).stitch(...) creates an llm member of that seam', async () => {
+    const { adapter, calls } = captureAdapter({ content: [{ text: 'bound' }] });
+    const api = seam({ baseUrl: 'https://gateway.internal', adapter });
+    const chat = llm.bind(api).stitch({
+        provider: anthropic,
+        model: 'claude-opus-4-8',
+        path: '/llm',
+    });
+
+    const { text } = await chat({
+        body: { messages: [{ role: 'user', content: 'hi' }] },
+    });
+    expect(text).toBe('bound');
     expect(calls[0]!.url).toBe('https://gateway.internal/llm');
 });
 

--- a/packages/core/test/stream.spec.ts
+++ b/packages/core/test/stream.spec.ts
@@ -5,6 +5,7 @@
 // charges the rate gate at open. Streams are driven by a fake adapter over Web Streams, so chunk
 // boundaries are fully controlled (no socket).
 import { createThrottle } from '../src/resilience';
+import { seam } from '../src/seam';
 import { chainThrottle, createStoreThrottle, memoryStore } from '../src/store';
 import { stream, streamSurface } from '../src/stream';
 import { now } from '../src/util';
@@ -33,6 +34,20 @@ describe('stream surface identity (Decisions 5, 11)', () => {
             kind?: unknown;
         };
         expect(json.kind).toBe('stream');
+    });
+
+    // The binder is implemented loose and `as`-cast to `StreamSeamApi['stitch']` (the `download.ts`
+    // idiom), so its declared member type cannot vouch for the runtime wiring — the cast is exactly
+    // what the compiler stops checking. This pins that a bound member still resolves through the
+    // seam's baseUrl and streams, which is the sse binder's counterpart test.
+    test('stream.bind(existingSeam).stitch(...) creates a stream member of that seam', async () => {
+        const api = seam({ baseUrl: 'https://x.test' });
+        const chunks = stream.bind(api).stitch({
+            path: '/s',
+            stream: 'lines',
+            adapter: streamAdapter(streamOf(['a\nb\n'])),
+        });
+        expect(await chunks()).toEqual(['a', 'b']);
     });
 });
 

--- a/scripts/check-unknown-keys.mjs
+++ b/scripts/check-unknown-keys.mjs
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+// Unknown-key guard gate — the excess-property-check (EPC) suppression bug class.
+//
+// An authoring surface that infers `const C` from its option-bag argument gets NO
+// excess-property checking: the literal is compared against a `C` just inferred from it, so no
+// property is ever "excess", and the `C extends …Options` constraint is then verified by ordinary
+// assignability, which ignores freshness. The result is that a misspelled or REMOVED slot
+// typechecks and is silently dropped at runtime:
+//
+//     stitch({ path: '/x', timeut: 500 })   // no error without a guard
+//
+// That is what makes a slot rename unsafe — every call site still authoring the old spelling keeps
+// compiling (#591: 2 files found by typechecking, 30 by running the suite). The fix is to intersect
+// the parameter with `NoUnknownKeys<C, Allowed, What>` (packages/core/src/types.ts), which maps
+// `Exclude<keyof C, keyof Allowed>` onto a `ConfigError` brand naming the key.
+//
+// This gate is the RATCHET that keeps it closed: every generic-inferred option bag must either
+// carry a guard or be listed in scripts/unknown-keys.baseline.json WITH A REASON. A new unguarded
+// surface fails the build, so the decision is made deliberately rather than by omission — the same
+// shape as the API meta-contract ratchet in check-contract.mjs.
+//
+//   pnpm check:unknown-keys                        # check the working tree (CI/hook mode)
+//   node scripts/check-unknown-keys.mjs --list     # print every site, guarded and not
+//   node scripts/check-unknown-keys.mjs --update   # rewrite the baseline to the current set
+//
+// HIGH-PRECISION by design, like check-contract.mjs's rules: a flagged line is a real
+// generic-inferred option bag, not a guess. The scan matches a type-parameter constraint naming a
+// `…Config`/`…Options` type or a `Partial<…>` of one, which is what every authored option bag in
+// this repo looks like. Deliberately NOT flagged, because they are a different shape and the
+// distinction was verified by probe rather than assumed:
+//
+//   • `S extends StitchLike<…>` (react/vue/solid/svelte/angular/swr/query-core/rtk-query/
+//     vercel-ai) — the generic binds the STITCH argument, a function, not an option literal. Those
+//     hooks' options bags are separate NON-generic parameters, so they keep ordinary EPC.
+//   • `M extends Record<string, Member>` (`all()`'s named-bag form) — an index-signature
+//     constraint whose keys are caller-chosen, so there is no fixed vocabulary to misspell.
+//   • unconstrained/value generics (`T extends NonNullable<unknown>` in util.ts,
+//     `K extends keyof …`, `S extends SchemaLike`) — internal helpers over already-typed values.
+//
+// `test/` and `test-d/` are skipped: they author bad configs on purpose.
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const BASELINE = join(ROOT, 'scripts', 'unknown-keys.baseline.json');
+
+const SCAN_ROOTS = ['packages', 'apps'];
+const SKIP_DIRS = new Set([
+    'node_modules',
+    'lib',
+    'dist',
+    'build',
+    '.next',
+    '.turbo',
+    'test',
+    'test-d',
+    'coverage',
+]);
+const EXTS = ['.ts', '.tsx', '.mts', '.cts'];
+
+// The guards that discharge a site. `NoUnknownConfigKeys` is the `StitchConfig` binding of
+// `NoUnknownKeys`; both count.
+const GUARDS = ['NoUnknownKeys', 'NoUnknownConfigKeys'];
+
+// A constraint naming an authored option bag: a `…Config`/`…Options` type, or a `Partial<…>` of
+// one. `Partial<` also catches `Stitch.with`'s `Partial<TIn>`, which is the same bug class on the
+// call-input side and is baselined with its reason rather than hidden from the scan.
+const OPTION_BAG = /Config\b|Options\b|Partial</;
+
+function walk(dir, out = []) {
+    let entries;
+    try {
+        entries = readdirSync(dir);
+    } catch {
+        return out;
+    }
+    for (const name of entries) {
+        if (SKIP_DIRS.has(name) || name.startsWith('.')) continue;
+        const full = join(dir, name);
+        let st;
+        try {
+            st = statSync(full);
+        } catch {
+            continue;
+        }
+        if (st.isDirectory()) walk(full, out);
+        else if (
+            EXTS.some((e) => name.endsWith(e)) &&
+            !name.endsWith('.d.ts') &&
+            !name.includes('.generated.')
+        )
+            out.push(full);
+    }
+    return out;
+}
+
+// Read a balanced span starting at `pos`, stopping at any char in `stopAt` seen at depth 0.
+function spanTo(text, pos, stopAt, limit = 4000) {
+    let depth = 0;
+    let i = pos;
+    const end = Math.min(text.length, pos + limit);
+    for (; i < end; i++) {
+        const ch = text[i];
+        if ('<([{'.includes(ch)) depth++;
+        else if ('>)]}'.includes(ch)) {
+            if (depth === 0) break;
+            depth--;
+        } else if (depth === 0 && stopAt.includes(ch)) break;
+    }
+    return { text: text.slice(pos, i), end: i };
+}
+
+const norm = (s) => s.replace(/\s+/g, ' ').trim();
+
+function lineOf(text, index) {
+    let line = 1;
+    for (let i = 0; i < index && i < text.length; i++)
+        if (text[i] === '\n') line++;
+    return line;
+}
+
+function collect() {
+    const sites = [];
+    const files = SCAN_ROOTS.flatMap((r) => walk(join(ROOT, r)));
+
+    for (const file of files.sort()) {
+        const text = readFileSync(file, 'utf8');
+        const rel = relative(ROOT, file).split('\\').join('/');
+
+        // Every type parameter declared with an `extends` constraint, in source order.
+        const decls = [];
+        const declRe = /[<,]\s*(?:const\s+)?([A-Z]\w*)\s+extends\s+/g;
+        for (let m; (m = declRe.exec(text));) {
+            const { text: raw } = spanTo(text, m.index + m[0].length, ',=');
+            decls.push({ pos: m.index, name: m[1], constraint: norm(raw) });
+        }
+        if (!decls.length) continue;
+
+        const names = new Set(decls.map((d) => d.name));
+        const seen = new Map(); // key -> occurrence ordinal
+
+        // A parameter whose declared type is that type parameter (bare or intersected).
+        for (const name of names) {
+            const useRe = new RegExp(
+                String.raw`(?:\(|,|^)\s*(\w+)(\??):\s*(` +
+                    name +
+                    String.raw`)\s*(?=[&,)\n])`,
+                'gm',
+            );
+            for (let m; (m = useRe.exec(text));) {
+                // The nearest PRECEDING declaration of this name owns this use.
+                const owner = decls
+                    .filter((d) => d.name === name && d.pos <= m.index)
+                    .pop();
+                if (!owner || !OPTION_BAG.test(owner.constraint)) continue;
+
+                // The parameter's full declared type — up to the `,`/`)` that ends this parameter.
+                const typeStart = m.index + m[0].indexOf(m[3]);
+                const { text: paramType } = spanTo(text, typeStart, ',');
+                const guarded = GUARDS.some((g) => paramType.includes(g));
+
+                const base = `${rel}:${name}:${owner.constraint}:${m[1]}`;
+                const n = (seen.get(base) ?? 0) + 1;
+                seen.set(base, n);
+
+                sites.push({
+                    key: `${base}#${n}`,
+                    file: rel,
+                    line: lineOf(text, m.index),
+                    param: m[1],
+                    typeParam: name,
+                    constraint: owner.constraint,
+                    guarded,
+                });
+            }
+        }
+    }
+    return sites.sort((a, b) => a.key.localeCompare(b.key));
+}
+
+// ---- ratchet --------------------------------------------------------------
+const args = new Set(process.argv.slice(2));
+const sites = collect();
+const unguarded = sites.filter((s) => !s.guarded);
+const guarded = sites.filter((s) => s.guarded);
+
+if (args.has('--list')) {
+    console.log(`\nGUARDED (${guarded.length}):`);
+    for (const s of guarded)
+        console.log(
+            `  ✓ ${s.file}:${s.line}  ${s.param}: <${s.typeParam} extends ${s.constraint}>`,
+        );
+    console.log(`\nUNGUARDED (${unguarded.length}):`);
+    for (const s of unguarded)
+        console.log(
+            `  · ${s.file}:${s.line}  ${s.param}: <${s.typeParam} extends ${s.constraint}>`,
+        );
+    console.log(`\nTotal: ${sites.length} generic-inferred option bags.`);
+    process.exit(0);
+}
+
+if (args.has('--update')) {
+    const prior = existsSync(BASELINE)
+        ? JSON.parse(readFileSync(BASELINE, 'utf8'))
+        : { allowed: [] };
+    const reasons = new Map(
+        (prior.allowed ?? []).map((a) => [a.key, a.reason]),
+    );
+    writeFileSync(
+        BASELINE,
+        JSON.stringify(
+            {
+                generatedBy: 'scripts/check-unknown-keys.mjs --update',
+                note: 'Generic-inferred option bags that are deliberately UNGUARDED. Every entry needs a `reason` — a bare TODO is not one. Guarded surfaces are not listed; they need no exception.',
+                count: unguarded.length,
+                allowed: unguarded.map((s) => ({
+                    key: s.key,
+                    file: s.file,
+                    reason:
+                        reasons.get(s.key) ??
+                        'TODO: state why this bag is safe unguarded, or guard it.',
+                })),
+            },
+            null,
+            4,
+        ) + '\n',
+    );
+    console.log(
+        `✓ Baseline rewritten: ${unguarded.length} allowed unguarded site(s).`,
+    );
+    process.exit(0);
+}
+
+if (!existsSync(BASELINE)) {
+    console.error(
+        '✗ No baseline found. Run `node scripts/check-unknown-keys.mjs --update` to create it.',
+    );
+    process.exit(1);
+}
+
+const baseline = JSON.parse(readFileSync(BASELINE, 'utf8'));
+const allowed = new Map((baseline.allowed ?? []).map((a) => [a.key, a.reason]));
+
+const added = unguarded.filter((s) => !allowed.has(s.key));
+const stale = [...allowed.keys()].filter(
+    (k) => !unguarded.some((s) => s.key === k),
+);
+const unreasoned = [...allowed.entries()].filter(
+    ([, reason]) => !reason || /^TODO/i.test(reason),
+);
+
+if (stale.length) {
+    console.log(
+        `\n✓ ${stale.length} baseline entr(ies) no longer unguarded — shrink the baseline with ` +
+            '`node scripts/check-unknown-keys.mjs --update`:',
+    );
+    for (const k of stale.sort()) console.log(`    ${k}`);
+}
+
+if (unreasoned.length) {
+    console.error(
+        `\n✗ ${unreasoned.length} baseline entr(ies) have no reason recorded:`,
+    );
+    for (const [k] of unreasoned) console.error(`    ${k}`);
+    console.error(
+        '\n  Every allowed exception must say why it is safe unguarded. Fill in `reason`.',
+    );
+    process.exit(1);
+}
+
+if (added.length) {
+    console.error(
+        `\n✗ ${added.length} NEW unguarded generic-inferred option bag(s) — a misspelled or ` +
+            'removed slot there will typecheck and be silently dropped:',
+    );
+    for (const s of added)
+        console.error(
+            `    ${s.file}:${s.line}  ${s.param}: <${s.typeParam} extends ${s.constraint}>`,
+        );
+    console.error(
+        "\n  Intersect the parameter with `NoUnknownKeys<C, YourOptions, 'YourOptions'>` " +
+            '(packages/core/src/types.ts) — or, if the bag is deliberately open, baseline it with ' +
+            '`node scripts/check-unknown-keys.mjs --update` and record a reason.',
+    );
+    process.exit(1);
+}
+
+console.log(
+    `✓ Unknown-key guards: ${guarded.length} guarded, ` +
+        `${allowed.size} allowed unguarded (baselined).`,
+);

--- a/scripts/unknown-keys.baseline.json
+++ b/scripts/unknown-keys.baseline.json
@@ -1,0 +1,27 @@
+{
+    "generatedBy": "scripts/check-unknown-keys.mjs --update",
+    "note": "Generic-inferred option bags that are deliberately UNGUARDED. Every entry needs a `reason` — a bare TODO is not one. Guarded surfaces are not listed; they need no exception.",
+    "count": 4,
+    "allowed": [
+        {
+            "key": "packages/core/src/postmessage.ts:C:EmitOptions:opts#2",
+            "file": "packages/core/src/postmessage.ts",
+            "reason": "The `channel()`-local IMPLEMENTATION of `emit`, not the authoring surface. `PostMessageChannel.emit` is the consumer-facing declaration and IS guarded (occurrence #1); this local function is `as`-cast to that member at the return, because a generic impl whose parameter carries `NoUnknownKeys<C, …>` cannot be checked against a member of the same shape — TypeScript instantiates the impl's `C` with the target's whole intersection, so the two `InputOf<C>` return types stop matching."
+        },
+        {
+            "key": "packages/core/src/postmessage.ts:C:EventsOptions:opts#2",
+            "file": "packages/core/src/postmessage.ts",
+            "reason": "Same as the `emit` entry: the `channel()`-local implementation of `events`. The guarded authoring surface is `PostMessageChannel.events` (occurrence #1)."
+        },
+        {
+            "key": "packages/core/src/postmessage.ts:C:RequestOptions:opts#2",
+            "file": "packages/core/src/postmessage.ts",
+            "reason": "Same as the `emit` entry: the `channel()`-local implementation of `request`. The guarded authoring surface is `PostMessageChannel.request` (occurrence #1)."
+        },
+        {
+            "key": "packages/core/src/types.ts:P:Partial<TIn>:partial#1",
+            "file": "packages/core/src/types.ts",
+            "reason": "`Stitch.with(partial)` — a real instance of the bug class that CANNOT take the guard, for a structural reason recorded on the signature itself. It is the only signature whose RETURN type reads `keyof P`, and `keyof (P & NoUnknownKeys<P, …>)` does not reduce to `keyof P` while `P` is unresolved, so intersecting the parameter rewrites `RelaxKeys<TIn, keyof P>` into a deferred union that tsup's declaration rollup emits differently than source — the published `Stitch` then stops matching the source one and every `S extends Stitch<unknown>` constraint in the package breaks (streaming-inference.test-d.ts catches it immediately). The F-bounded spelling that would keep the parameter bare is a circular constraint (TS2313). Weak-type detection still covers the no-valid-sibling case. Pinned in unknown-config-keys.test-d.ts."
+        }
+    ]
+}


### PR DESCRIPTION
Answers the migration hazard [#600](https://github.com/rejifald/StitchAPI/pull/600)'s review notes flagged: folding `acceptStatus` into `verdict` has **no compile-time safety net**, so a stale spelling is silently ignored. That turned out to be one instance of a class, so this closes the class and adds a ratchet to keep it closed.

## The bug

Every authoring surface infers `const C` from its option argument so `InputOf` can read RFC 6570 path vars off the literal. That inference is also what **suppresses TypeScript's excess-property check**: the literal is compared against a `C` just inferred from it, so no property is ever "excess", and the `C extends …Options` constraint is then verified by ordinary assignability, which ignores freshness.

```ts
stitch({ path: '/x', timeut: 500 }); // typechecked — the timeout was never applied
```

So any slot **rename or removal** left every call site still authoring the old spelling compiling. #591 hit exactly this: 2 files found by typechecking, 30 by running the suite.

I probed the boundaries rather than assuming — the gap is narrower than "unknown props don't error":

| position | before | why |
| --- | --- | --- |
| top level | **silently accepted** | compared against the inferred `C` |
| `wire: { … }` | already errored | checked against declared `AtLeastOne<WireOptions>` |
| inline `extends: [{ … }]` | already errored | checked against declared `Partial<StitchConfig> \| Stitch` |

Wrong *types* on real slots were always caught. Only unknown *keys* leaked.

## The fix

`NoUnknownKeys<C, Allowed, What>` maps `Exclude<keyof C, keyof Allowed>` onto the existing `ConfigError` brand, so the error lands on the offending property rather than collapsing the config to `never`, and each surface reports against its own vocabulary:

```
`timeut` is not a StitchConfig slot — check the spelling
```

Applied to all **17** generic-inferred sites: `stitch`, `Seam.stitch`, `Seam.graphql`, `graphql`, `download`, `sse`, `stream` (`StitchConfig`); `llm` (`LlmOptions`); `postmessage`'s `request`/`emit`/`events` (`RequestOptions`/`EmitOptions`/`EventsOptions`). Because each names its own bag, `reply` — a `RequestOptions` member — is now correctly rejected on `emit` and `events`.

Deliberately **cheaper** than the sibling guards: one `keyof` and one `Exclude` per call site, no `Layers` walk, since unknown keys are a per-layer spelling concern and the nested/inline positions already have EPC. That matters for [#600](https://github.com/rejifald/StitchAPI/pull/600)'s open Q5 on `tsc` cost.

It is also **stronger than EPC**, which is what makes the net hold repo-wide: EPC only fires on a fresh literal, so a config hoisted into a `const` escapes it entirely. Reading `keyof C` sees the binding's inferred type.

**Verified against the actual #600 scenario:** I temporarily folded `acceptStatus` into `verdict: { accept }` and confirmed stale call sites now error by name on both `stitch` and `seam.stitch`, while the new spelling compiles. Reverted.

## BREAKING (types only) — `llm()` is now generic

Its parameter was non-generic *purely* to keep excess-property checking — the only thing rejecting the removed `maxTokens` spelling (P4) — at the cost of no `const C` inference at all. The guard supplies the rejection now, so the trade is gone and `llm` gains what every other surface has:

```ts
const chat = llm({ provider: anthropic, url: 'https://llm.example.com/{version}/messages' });
chat();                              // now a type error: the template requires params
chat({ params: { version: 'v1' } });
```

Runtime behaviour is byte-identical. Breaking only in that a call argument previously typed as the loose `StitchInput` is now checked against the config's `input` schemas and path template, so a silently under-specified call site stops compiling.

## The ratchet

`pnpm check:unknown-keys` ([`scripts/check-unknown-keys.mjs`](scripts/check-unknown-keys.mjs)), wired into `verify.yml` and `lefthook` pre-push beside `check:contract`. Runs in **0.16s**.

Every generic-inferred option bag must **carry the guard or be baselined with a reason** — a bare `TODO` fails the gate — so a new unguarded surface forces a deliberate decision instead of passing by omission. I deliberately did *not* port the exploratory script's heuristic classifier: auto-deciding "benign" from a regex is the wrong failure mode for a gate, since a real hole could be silently classified away. Same philosophy `check-contract.mjs` states as "a ratchet that guesses is a ratchet nobody trusts".

Currently `17 guarded, 4 allowed unguarded (baselined)`. Precision filter matches `…Config`/`…Options`/`Partial<…>` constraints, which yields **21 sites and zero noise** — the 20 `stitch: S` false positives are structurally excluded, not allowlisted. Keys are file+param+constraint+ordinal, not line numbers, so the baseline doesn't churn on unrelated edits.

## Reviewer notes

**`Stitch.with` is deliberately left unguarded, and the exception is structural.** I implemented it and it broke `streaming-inference.test-d.ts`. `with` is the only signature whose *return* type reads `keyof P`, and `keyof (P & NoUnknownKeys<P, …>)` does not reduce while `P` is unresolved — so `tsup`'s declaration rollup emits it differently than source, the published `Stitch` stops matching the source one, and every `S extends Stitch<unknown>` constraint in the package breaks. The F-bounded spelling that would keep the parameter bare is a circular constraint (TS2313). Guarding one slot isn't worth degrading `Stitch`'s public type for every consumer. Recorded on the signature, in the baseline, and pinned as a non-`expectError` case.

**Weak-type detection already gave partial cover,** which shaped the tests. These bags are all-optional, so a literal sharing *no* property with the target was always rejected. It's only partial — add one valid sibling and the unknown key rides along. So every `expectError` in the type tests carries a valid sibling; without one the rejection would prove nothing about the guard.

**Ruled out by the sweep, verified by probe rather than inspection:** the framework hooks (`react`/`vue`/`solid`/`svelte`/`angular`/`swr`/`query-core`/`rtk-query`/`vercel-ai`) bind their generic to the **stitch argument** — a function, not an option literal — and their options bags are separate non-generic parameters, so they keep ordinary EPC (`bogusHookOption` errors). `all()`'s named-bag form takes caller-chosen keys, so there's no fixed vocabulary to misspell.

**A stale CHANGELOG claim is corrected.** The `wire` envelope entry told readers to grep for `bodyType:`/`responseType:`/`arrayFormat:` because the typechecker wouldn't help. It does now — verified all three plus `maxTokens` error by name — so that paragraph is updated.

**Binder refactor + its test debt.** The `sse`/`stream`/`llm` seam binders move to the loose-impl-plus-cast idiom `download` already uses, because a generic impl whose parameter carries the guard can't be checked against a member of that same shape (TypeScript instantiates the impl's `C` with the target's whole intersection). A cast is exactly what stops the compiler checking the wiring — `sse.bind` had runtime coverage, `stream.bind` and `llm.bind` had none, so both get tests rather than leaving the refactors type-only-verified.

**One judgment call:** the gate is in pre-push, not pre-commit, mirroring `check:contract`'s tier. Pre-commit is currently format/lint/typecheck only and I didn't want to expand it unasked — moving it is a one-line change.

## Verification

All green locally (full pre-push suite ran on push):

`check:types` · `check:types-d` · `check:lint` · `test` (1327, +2) · `check:format` · `check:contract` · `check:unknown-keys` · `check:docs-links` · `check:exports` · `check:release` · `build-docs` · `yakir`

The gate itself was tested against a planted regression: removing the guard from `sse.ts` failed with the exact file:line and fix instruction (exit 1); a `TODO` baseline reason also failed; `--update` preserves existing reasons rather than resetting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
