### PR TITLE
fix(sandbox): restore the playground auth surface, and run every preset in CI

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -29,6 +29,15 @@ docs/sandbox/dist/
 # scope. See lefthook.yml's pre-push `format` job.
 .claude/worktrees/
 
+# Playwright run artifacts (apps/docs, written by test:e2e). Already gitignored,
+# so CI checks out clean and never sees them — but `prettier --check .` (the
+# pre-push format gate) walks the working tree, not the index, and Playwright
+# writes `.last-run.json` raw. Running the e2e suite locally would otherwise
+# block the next push on a file that is not even committed. Same reasoning as
+# `.claude/worktrees/` above.
+apps/docs/test-results/
+apps/docs/playwright-report/
+
 # yakir's baseline lockfile is generated (2-space, written by `yakir fix`); leave
 # its formatting to the tool, like any other lockfile.
 yakir.lock

--- a/apps/docs/e2e/playground-examples.spec.ts
+++ b/apps/docs/e2e/playground-examples.spec.ts
@@ -1,0 +1,162 @@
+import { PLAYGROUND_EXAMPLES } from '../app/(home)/playground/playground-examples';
+
+import { expect, test } from '@playwright/test';
+import { PLAYGROUND_SURFACE_NAMES } from '@stitchapi/sandbox/runtime/playground-surface';
+
+/**
+ * Playground preset regression guard — BROWSER tier.
+ *
+ * The presets are the first thing a visitor runs, so "the shipped example still
+ * executes" is a contract. This drives the real page: click each example tab,
+ * press Run, and fail if the output panel shows an error — the full production
+ * path (CodeMirror seed → dispatchRunner → transpile → `/sandbox/sandbox-worker.mjs`
+ * → sandbox-sim), which is exactly what a visitor gets.
+ *
+ * The second test asserts the whole `PLAYGROUND_SURFACE_NAMES` allow-list is
+ * bound in the snippet scope. Running the presets only covers the names those
+ * three snippets touch, and the failure mode is a re-export that silently
+ * resolves to nothing (see docs/sandbox/runtime/playground-surface.ts for why
+ * esbuild can't catch it) — so any name in the surface is at risk, not just the
+ * ones an example happens to use.
+ *
+ * The node tier gets the same two checks against ITS bundle in
+ * docs/sandbox/tests/playground-examples.test.ts. The two Workers are built from
+ * different entries (worker-main.ts → stitch-browser.ts vs worker-main.node.ts),
+ * so neither run substitutes for the other.
+ */
+
+/** The Complete tour retries a deliberately flaky route — give runs headroom. */
+const RUN_TIMEOUT_MS = 25_000;
+
+test.describe('playground examples', () => {
+    for (const example of PLAYGROUND_EXAMPLES) {
+        test(`the '${example.id}' preset runs without an error`, async ({
+            page,
+        }) => {
+            await page.goto('/playground');
+
+            // Switching tabs remounts <StitchPlayground> with this preset's code.
+            await page.getByRole('tab', { name: example.label }).click();
+            await page
+                .getByRole('button', { name: 'Run', exact: true })
+                .click();
+
+            const stopButton = page.getByRole('button', { name: 'Stop' });
+            const errorBlock = page.locator('.stitch-playground__error');
+            // PlaygroundClient renders the log stream through <ConsoleEditor>, so
+            // the whole stream is one block — present iff the run logged anything.
+            const logs = page.locator('.stitch-playground__logs-editor');
+
+            // Wait for the run to SETTLE before asserting anything, so a green
+            // result can't come from checking before the run started. "Not
+            // showing Stop" alone is true in the frame between the click and
+            // React re-rendering, hence the second half: settled means the run
+            // also left something behind — logs, or the error block (which only
+            // renders from the final reconciled result).
+            await expect
+                .poll(
+                    async () => {
+                        if ((await stopButton.count()) > 0) return false;
+                        return (
+                            (await logs.count()) > 0 ||
+                            (await errorBlock.count()) > 0
+                        );
+                    },
+                    {
+                        timeout: RUN_TIMEOUT_MS,
+                        message: `preset '${example.id}' never finished`,
+                    },
+                )
+                .toBe(true);
+
+            // Assert on the error TEXT, not its absence, so a failure says why
+            // the preset broke ("ReferenceError: bearer is not defined").
+            const errorText =
+                (await errorBlock.count()) > 0
+                    ? await errorBlock.innerText()
+                    : null;
+            expect(
+                errorText,
+                `preset '${example.id}' errored in the playground`,
+            ).toBeNull();
+            expect(
+                await logs.count(),
+                `preset '${example.id}' produced no console output`,
+            ).toBeGreaterThan(0);
+        });
+    }
+
+    test('every surface name is bound in the snippet scope', async ({
+        page,
+    }) => {
+        await page.goto('/playground');
+
+        // Drive the real worker bundle directly — the scope is bound as function
+        // parameters inside it, so `typeof <name>` is the only way to see what a
+        // snippet sees. The worker does not transpile (the main thread does), so
+        // the probe is already-runnable JS.
+        const surface = await page.evaluate(
+            async (names: readonly string[]) => {
+                const js = `return { ${names
+                    .map((name) => `${name}: typeof ${name}`)
+                    .join(', ')} };`;
+                const worker = new Worker('/sandbox/sandbox-worker.mjs', {
+                    type: 'module',
+                });
+                try {
+                    return await new Promise<Record<string, string>>(
+                        (resolve, reject) => {
+                            const timer = setTimeout(
+                                () =>
+                                    reject(new Error('worker probe timed out')),
+                                15_000,
+                            );
+                            worker.onmessage = (ev: MessageEvent) => {
+                                const d = ev.data as {
+                                    type: string;
+                                    value?: unknown;
+                                    error?: { message: string };
+                                };
+                                if (d.type !== 'result') return; // progress event
+                                clearTimeout(timer);
+                                if (d.error)
+                                    reject(
+                                        new Error(
+                                            `probe threw: ${d.error.message}`,
+                                        ),
+                                    );
+                                else
+                                    resolve(
+                                        (d.value ?? {}) as Record<
+                                            string,
+                                            string
+                                        >,
+                                    );
+                            };
+                            worker.onerror = (e: ErrorEvent) =>
+                                reject(new Error(e.message || 'worker error'));
+                            worker.postMessage({
+                                type: 'run',
+                                js,
+                                extraScopeNames: [],
+                            });
+                        },
+                    );
+                } finally {
+                    worker.terminate();
+                }
+            },
+            PLAYGROUND_SURFACE_NAMES as readonly string[],
+        );
+
+        const missing = PLAYGROUND_SURFACE_NAMES.filter(
+            (name) => surface[name] !== 'function',
+        ).map((name) => `${name} (${surface[name] ?? 'undefined'})`);
+
+        expect(
+            missing,
+            'names re-exported by stitch-browser.ts that resolved to nothing — ' +
+                'the source module no longer exports them',
+        ).toEqual([]);
+    });
+});

--- a/docs/sandbox/package.json
+++ b/docs/sandbox/package.json
@@ -7,14 +7,15 @@
         "./component/StitchPlayground": "./component/StitchPlayground.tsx",
         "./contracts/dispatch": "./contracts/dispatch.ts",
         "./contracts/sim": "./contracts/sim.ts",
-        "./runtime/browser-runner": "./runtime/browser-runner.ts"
+        "./runtime/browser-runner": "./runtime/browser-runner.ts",
+        "./runtime/playground-surface": "./runtime/playground-surface.ts"
     },
     "bin": {
         "stitch-sandbox": "./dist/mcp.mjs"
     },
     "scripts": {
         "build:mcp": "node runtime/gen-sandbox-modules.mjs && node runtime/build-sandbox-mcp.mjs",
-        "test:smoke": "node tests/run-all.mjs",
+        "test:smoke": "pnpm run build:mcp && node tests/run-all.mjs",
         "test:mcp": "pnpm run build:mcp && node mcp/smoke.mjs"
     },
     "dependencies": {

--- a/docs/sandbox/runtime/playground-surface.ts
+++ b/docs/sandbox/runtime/playground-surface.ts
@@ -1,0 +1,70 @@
+/**
+ * The stitch names a playground snippet may rely on finding in scope.
+ *
+ * ─── Why this list exists ──────────────────────────────────────────────────
+ * The snippet scope is an ALLOW-LIST, assembled per tier: the browser Worker
+ * spreads `stitch-browser.ts` (a hand-maintained re-export of the browser-safe
+ * core surface plus shims), the node Worker spreads the real `stitchapi`
+ * namespace (worker-main.node.ts). Both lists are written by hand, and both are
+ * built by esbuild — which does NOT fail a re-export of a name the source module
+ * no longer has, because core's barrel ends in `export * from './types'` and that
+ * makes the missing-export check ambiguous. A name that moves out of core's main
+ * entry therefore resolves to nothing and the snippet dies at runtime with
+ * `<name> is not defined`, with nothing in the build to catch it.
+ *
+ * That has now happened twice: `validate`/`compile` were never added when they
+ * landed (#433), and `bearer`/`apiKey`/`basic`/`oauth2` were left pointing at
+ * `'stitchapi'` when ADR 0021 moved the auth surface to `'stitchapi/auth'`
+ * (#545) — which broke the playground's own Complete example.
+ *
+ * So the surface is asserted, not assumed. This is the INTERSECTION both tiers
+ * must expose, checked against the real built worker bundles:
+ *   - node tier   → docs/sandbox/tests/playground-examples.test.ts
+ *   - browser tier → apps/docs/e2e/playground-examples.spec.ts
+ *
+ * ─── What belongs here ─────────────────────────────────────────────────────
+ * Only names a snippet can use on BOTH tiers. Deliberately excluded:
+ *   - `env` / `cookieSession` — browser-only. They exist there as the shims in
+ *     `./shims/node-surfaces`; the node tier leaves them out on purpose, since
+ *     the real ones read the host environment and the host disk
+ *     (see worker-main.node.ts).
+ *   - `cli` / `serve` / `mcp` — browser-only throwing stubs; on the node tier
+ *     they are simply absent (core exposes them as subpath entries).
+ *   - the `drainNotices` / `emitNotice` notice channel — runner plumbing, not a
+ *     snippet-facing API.
+ *
+ * Adding a core export does NOT require an edit here; this is the floor the
+ * playground promises, not a mirror of core's barrel.
+ */
+
+/**
+ * Names every playground tier binds into the snippet scope. Each MUST be a
+ * function at runtime — a silently-dropped re-export shows up as `undefined`.
+ */
+export const PLAYGROUND_SURFACE_NAMES = [
+    // The call API.
+    'stitch',
+    'seam',
+    'drift',
+    'graphql',
+    // Schema normalisation (#433).
+    'validate',
+    'compile',
+    // Credential strategies — `stitchapi/auth` since ADR 0021 (#545).
+    'bearer',
+    'apiKey',
+    'basic',
+    'oauth2',
+    // Transport + storage.
+    'fetchAdapter',
+    'memoryStore',
+    // Tracing (shimmed on the browser tier, real on node — present on both).
+    'createTrace',
+    'multiplex',
+    'otlpSink',
+    'otlpHttpExporter',
+    'toOtlpJson',
+] as const;
+
+/** Union of the surface-name literals. */
+export type PlaygroundSurfaceName = (typeof PLAYGROUND_SURFACE_NAMES)[number];

--- a/docs/sandbox/runtime/stitch-browser.ts
+++ b/docs/sandbox/runtime/stitch-browser.ts
@@ -21,8 +21,9 @@ import type { TraceSink } from 'stitchapi';
  *   Browser-safe (re-exported verbatim from core):
  *     stitch, seam, drift, graphql,
  *     validate, compile,
- *     bearer, apiKey, basic, oauth2,
  *     fetchAdapter, memoryStore, multiplex, toOtlpJson, + all types
+ *   Browser-safe, from the `stitchapi/auth` entry (ADR 0021):
+ *     bearer, apiKey, basic, oauth2
  *   Node-only, runs SHIMMED here (with a RunNotice):
  *     env                      → ./shims/node-surfaces  (demo values)
  *     cookieSession            → ./shims/node-surfaces  (in-memory jar)
@@ -43,10 +44,6 @@ export {
     // runtime-schema snippets (`compile(JsonSchema.adapt(...))`) run in the playground.
     validate,
     compile,
-    bearer,
-    apiKey,
-    basic,
-    oauth2,
     fetchAdapter,
     memoryStore,
     // `multiplex` is pure JS (B1-SPIKE §5) — safe to re-export verbatim.
@@ -54,6 +51,14 @@ export {
     // `toOtlpJson` is a pure span→JSON mapper (no Node) — safe verbatim.
     toOtlpJson,
 } from 'stitchapi';
+
+/* ---- Browser-safe auth surface (its own entry since ADR 0021) ------------ */
+// The four credential strategies are pure header/query builders — no Node
+// touch-points, safe to re-export verbatim. They live in `stitchapi/auth`, NOT
+// the main barrel (#545); re-exporting them from 'stitchapi' made them resolve
+// to nothing, so `bearer('…')` in a snippet threw `bearer is not defined`.
+// (`env`/`cookieSession` come from the same entry but are shimmed — below.)
+export { bearer, apiKey, basic, oauth2 } from 'stitchapi/auth';
 
 // All public types — none carry runtime Node weight. Core's barrel re-exports
 // `./types` via `export *`, so every public type is reachable from the main entry.

--- a/docs/sandbox/runtime/worker-main.node.ts
+++ b/docs/sandbox/runtime/worker-main.node.ts
@@ -32,6 +32,7 @@ import {
 
 import { parentPort } from 'node:worker_threads';
 import * as stitchBuild from 'stitchapi';
+import { apiKey, basic, bearer, oauth2 } from 'stitchapi/auth';
 
 // Baseline knobs for the current run, mutated by `env.applyKnobs`; the shim
 // reads it on every request. URL-explicit knobs still win (see dispatch).
@@ -55,9 +56,23 @@ const simFetch = createFetchShim(allHandlers, () => currentKnobs);
 // server sandbox makes no real network egress.
 (globalThis as { fetch?: unknown }).fetch = simFetch;
 
+// The four credential strategies live in `stitchapi/auth`, not the main barrel
+// (ADR 0021 / #545), so the namespace above does not carry them. They are pure
+// header/query builders — no ambient authority — and the browser tier exposes
+// them by the same names, so merging them here is what makes a snippet run
+// identically on either tier (a snippet's `bearer('…')` is the case that broke).
+//
+// The rest of that entry stays OUT on purpose: `env` reads the host environment
+// and `secretsFile` reads the host disk, which would defeat the clean `process`
+// shadow below. The browser tier only has them because they are shimmed there.
+const authBuild = { bearer, apiKey, basic, oauth2 };
+
 const env: WorkerEnv = {
     // The whole real `stitchapi` surface, exposed name-by-name into the snippet.
-    stitchBuild: stitchBuild as unknown as Record<string, unknown>,
+    stitchBuild: { ...stitchBuild, ...authBuild } as unknown as Record<
+        string,
+        unknown
+    >,
     // Modules a snippet may `import` beyond 'stitchapi' (rebound via __stitchImport).
     modules: sandboxModules,
     fetch: simFetch as unknown as WorkerEnv['fetch'],

--- a/docs/sandbox/tests/playground-examples.test.ts
+++ b/docs/sandbox/tests/playground-examples.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Playground preset regression guard — NODE tier.
+ *
+ * Runs every preset the playground ships (`PLAYGROUND_EXAMPLES`, the Complete /
+ * Simple / Validated tabs) through the REAL built node Worker — the same bundle
+ * `node-runner.ts` and the `stitch-sandbox` MCP server spawn — and fails if any
+ * of them errors. The presets are the first thing a visitor runs and the surface
+ * an agent gets from `run_in_sandbox`, so "the shipped example still executes"
+ * is a contract, not a nice-to-have.
+ *
+ * It also asserts the whole `PLAYGROUND_SURFACE_NAMES` allow-list is bound in
+ * the snippet scope. Running the presets alone only covers the names those three
+ * snippets happen to touch; the failure mode here is a re-export that silently
+ * resolves to nothing (see playground-surface.ts for why esbuild can't catch it),
+ * and that can hit any name in the surface.
+ *
+ * The browser tier gets the same two checks against ITS bundle in
+ * apps/docs/e2e/playground-examples.spec.ts — the two Workers are built from
+ * different entries (worker-main.node.ts vs worker-main.ts → stitch-browser.ts),
+ * so neither run substitutes for the other.
+ *
+ * Requires `dist/node-worker.mjs` — `pnpm --filter @stitchapi/sandbox test:smoke`
+ * builds it first.
+ *
+ * Run with:  node --import tsx docs/sandbox/tests/playground-examples.test.ts
+ */
+import { PLAYGROUND_EXAMPLES } from '../../../apps/docs/app/(home)/playground/playground-examples';
+import type { RunResult } from '../component/runner';
+import {
+    type WorkerLike,
+    makeBrowserWorkerRunner,
+} from '../runtime/browser-runner';
+import { PLAYGROUND_SURFACE_NAMES } from '../runtime/playground-surface';
+
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Worker as ThreadWorkerImpl } from 'node:worker_threads';
+
+/* -------------------------------------------------------------------------- */
+/*  Tiny assertion harness (mirrors browser-runner.test.ts convention)        */
+/* -------------------------------------------------------------------------- */
+
+let passed = 0;
+let failed = 0;
+
+function assert(label: string, condition: boolean, detail?: unknown): void {
+    if (condition) {
+        console.log(`  PASS  ${label}`);
+        passed++;
+    } else {
+        console.error(`  FAIL  ${label}`, detail ?? '');
+        failed++;
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+/*  The runner: the REAL node worker bundle, a fresh thread per run           */
+/* -------------------------------------------------------------------------- */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const NODE_WORKER_URL = resolve(__dirname, '../dist/node-worker.mjs');
+
+/** `node:worker_threads` Worker as the runner's `WorkerLike` (see node-runner.ts). */
+class ThreadWorker implements WorkerLike {
+    onmessage: ((ev: { data: unknown }) => void) | null = null;
+    onerror: ((err: unknown) => void) | null = null;
+    private readonly w: ThreadWorkerImpl;
+    constructor(url: string) {
+        this.w = new ThreadWorkerImpl(url);
+        this.w.on('message', (data) => this.onmessage?.({ data }));
+        this.w.on('error', (err) => this.onerror?.(err));
+    }
+    postMessage(message: unknown): void {
+        this.w.postMessage(message);
+    }
+    terminate(): void {
+        void this.w.terminate();
+    }
+}
+
+// The presets make several simulated round-trips (the Complete tour retries a
+// deliberately flaky route), so they need more headroom than the 5 s default.
+const TIMEOUT_MS = 20_000;
+
+const runner = makeBrowserWorkerRunner({
+    workerFactory: () => new ThreadWorker(NODE_WORKER_URL),
+    defaultTimeoutMs: TIMEOUT_MS,
+});
+
+const run = (code: string): Promise<RunResult> =>
+    runner.run({ code, timeoutMs: TIMEOUT_MS });
+
+/** Compact one-line failure detail — the whole stack is noise in a smoke log. */
+function describeError(result: RunResult): string {
+    const e = result.error;
+    if (!e) return '(no error)';
+    const where = e.line !== undefined ? ` at line ${e.line}` : '';
+    return `${e.phase}/${e.reason ?? 'unknown'}: ${e.name}: ${e.message}${where}`;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Checks                                                                    */
+/* -------------------------------------------------------------------------- */
+
+async function runTests(): Promise<void> {
+    if (!existsSync(NODE_WORKER_URL)) {
+        console.error(
+            `missing ${NODE_WORKER_URL} — run \`pnpm --filter @stitchapi/sandbox run build:mcp\` first.`,
+        );
+        process.exit(2);
+    }
+
+    console.log('\nPlayground presets — node tier\n');
+
+    /* === 1. Every shipped preset runs clean ================================ */
+
+    assert(
+        'PLAYGROUND_EXAMPLES is non-empty',
+        PLAYGROUND_EXAMPLES.length > 0,
+        PLAYGROUND_EXAMPLES.length,
+    );
+
+    for (const example of PLAYGROUND_EXAMPLES) {
+        const result = await run(example.code);
+
+        assert(
+            `preset '${example.id}' runs without error`,
+            result.error === undefined,
+            describeError(result),
+        );
+
+        // A preset that errors mid-way still returns the logs it managed to
+        // print, so "no error" alone would pass a snippet that silently did
+        // nothing at all. Every preset ends in a console.log.
+        assert(
+            `preset '${example.id}' produced console output`,
+            result.logs.length > 0,
+            result.logs.length,
+        );
+    }
+
+    /* === 2. The whole surface allow-list is bound ========================== */
+
+    // Reported from INSIDE the worker: the scope is bound as function parameters
+    // there, so `typeof <name>` is the only way to see what a snippet sees.
+    const probe = `return { ${PLAYGROUND_SURFACE_NAMES.map(
+        (name) => `${name}: typeof ${name}`,
+    ).join(', ')} };`;
+    const probeResult = await run(probe);
+
+    assert(
+        'surface probe ran',
+        probeResult.error === undefined,
+        describeError(probeResult),
+    );
+
+    const surface = (probeResult.value ?? {}) as Record<string, string>;
+    const missing = PLAYGROUND_SURFACE_NAMES.filter(
+        (name) => surface[name] !== 'function',
+    );
+    assert(
+        `all ${PLAYGROUND_SURFACE_NAMES.length} PLAYGROUND_SURFACE_NAMES are bound in the snippet scope`,
+        missing.length === 0,
+        missing.length > 0
+            ? `not a function: ${missing
+                  .map((n) => `${n} (${surface[n] ?? 'undefined'})`)
+                  .join(', ')}`
+            : '',
+    );
+
+    /* === Summary =========================================================== */
+
+    console.log(`\n${passed} passed, ${failed} failed\n`);
+    if (failed === 0) {
+        console.log('PLAYGROUND PRESETS OK');
+    } else {
+        console.error('PLAYGROUND PRESETS FAILED');
+        process.exit(1);
+    }
+}
+
+runTests().catch((err) => {
+    console.error('Unexpected test runner error:', err);
+    process.exit(1);
+});

--- a/docs/sandbox/tests/run-all.mjs
+++ b/docs/sandbox/tests/run-all.mjs
@@ -4,7 +4,11 @@
  *
  * Exits 0 when all suites pass; exits 1 if any fail.
  *
- * Run with:  node docs/sandbox/tests/run-all.mjs
+ * Run with:  pnpm --filter @stitchapi/sandbox test:smoke
+ *
+ * Prefer that script over calling this file directly — the playground-preset
+ * suite drives the BUILT node Worker (dist/node-worker.mjs) and `test:smoke`
+ * runs `build:mcp` first. (It exits 2 with a build hint if the bundle is absent.)
  */
 import { spawnSync } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
@@ -42,6 +46,9 @@ const SUITES = [
     'docs/sandbox/component/output-format.test.ts',
     // T-α — integration over REAL sim + dispatch
     'docs/sandbox/tests/integration.test.ts',
+    // Playground presets + surface allow-list, over the BUILT node Worker
+    // (dist/node-worker.mjs — `test:smoke` builds it first).
+    'docs/sandbox/tests/playground-examples.test.ts',
 ];
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

The playground's **Complete** preset — the tab that loads by default at `/playground` — died on its first line:

```
ReferenceError: bearer is not defined
```

[`stitch-browser.ts`](docs/sandbox/runtime/stitch-browser.ts) is the curated surface bound into the snippet scope, and it re-exported `bearer`/`apiKey`/`basic`/`oauth2` from `'stitchapi'`. #545 (ADR 0021) moved the auth surface to `'stitchapi/auth'`; that sweep updated the `cookieSession` import in `shims/node-surfaces.ts` but missed this file.

The node tier was broken the same way — `worker-main.node.ts` binds the `stitchapi` namespace, which also lost those names — so an agent calling `run_in_sandbox` on the `stitch-sandbox` MCP server hit the identical wall.

## Why nothing caught it

**esbuild does not fail a re-export of a name the source module no longer has.** Core's barrel ends in `export * from './types'`, which makes the missing-export check ambiguous, so the name silently resolves to nothing and the bundle builds clean. Nothing in the build, the type-check, or the test suite looks at what the playground scope actually contains.

That is the second time this exact mechanism has shipped a broken playground — #433 was `validate`/`compile`, same story.

## The guards

So the surface is asserted now, not assumed. [`playground-surface.ts`](docs/sandbox/runtime/playground-surface.ts) names the 17 symbols both tiers must bind, and two suites check the **real built Workers**:

| Suite | CI job | Time |
|---|---|---|
| [`docs/sandbox/tests/playground-examples.test.ts`](docs/sandbox/tests/playground-examples.test.ts) | existing `sandbox` | 0.6s |
| [`apps/docs/e2e/playground-examples.spec.ts`](apps/docs/e2e/playground-examples.spec.ts) | existing `e2e` | 2.2s |

Each runs **every shipped preset** and probes the **whole allow-list**. Running the presets alone only covers the names those three snippets happen to touch; the surface probe is what catches a dropped `apiKey` or `oauth2` *before* an example comes to depend on it.

The browser spec drives the real page (tab → Run → assert the output panel), so it covers the full production path a visitor gets: CodeMirror seed → `dispatchRunner` → transpile → `/sandbox/sandbox-worker.mjs` → sandbox-sim. The two Workers are built from different entries (`worker-main.ts` → `stitch-browser.ts` vs `worker-main.node.ts`), so neither run substitutes for the other.

**No workflow edits** — both jobs already exist. `test:smoke` now runs `build:mcp` first, since the new suite drives the built node Worker.

## Reviewer notes

- **The node tier gets the four credential strategies only.** `env` and `secretsFile` from that same entry stay out on purpose: they read the host environment and the host disk, which would defeat that Worker's clean `process` shadow. The browser tier only has `env`/`cookieSession` because they are shimmed there.
- **`.prettierignore`** (second commit, independent): `prettier --check .` walks the working tree, not the index, so it descends into the gitignored `apps/docs/test-results/`. Running `test:e2e` locally blocked the next push on a file that isn't even committed. Pre-existing, but the new spec is a reason to actually run that suite.

## Verification

Each fix was **reverted and re-run** to confirm the guards fail on the real bug:

- node suite → `runtime/throw: ReferenceError: bearer is not defined`, plus `not a function: bearer (undefined), apiKey (undefined), basic (undefined), oauth2 (undefined)`
- browser spec → fails in 435ms with `preset 'complete' errored in the playground` / `Received: "ReferenceError: bearer is not defined"`

Restored, then: sandbox smoke **12/12**, full e2e **15/15**, docs vitest **59 passed**, and the complete pre-push gate (format, lint, contract, media-fresh, typecheck, typecheck-d, test, exports, build-docs, yakir) green.

Confirmed in the browser: all four numbered blocks run, `credentialKind: "bearer"` proves the strategy actually applied, and the flaky route recovers on attempt 3.

## Out of scope, flagged

- `pnpm --filter @stitchapi/sandbox test:mcp` fails on a clean tree — `__PKG_VERSION__ is not defined` in `dist/mcp.mjs`; the build script never defines it, so the `stitch-sandbox` bin crashes at import. Unrelated and pre-existing (confirmed by stashing this branch's changes); that script isn't wired into CI.
- The Complete example logs `` `demo-api` sets `idempotency` on a GET, but the key is sent on writes only `` to devtools on every run. Not visible in the playground panel, but the flagship example demonstrates a knob the library nudges against — whether to silence it or drop the field is a call about what the example is teaching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
