### PR TITLE
fix(sandbox): define `__PKG_VERSION__` in the MCP build so the `stitch-sandbox` bin imports

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -153,6 +153,14 @@ jobs:
             - run: pnpm install --frozen-lockfile
             - run: pnpm --filter stitchapi build
             - run: pnpm --filter @stitchapi/sandbox test:smoke
+            # The `stitch-sandbox` bin (docs/sandbox/package.json #/bin): `test:mcp` runs
+            # `build:mcp` and then spawns the BUILT dist/mcp.mjs over stdio JSON-RPC, so it
+            # is the only check that proves the bundle actually IMPORTS. Nothing else covers
+            # it — the bundle is git-ignored and built by no other job — which is how it
+            # shipped broken: the build had no `__PKG_VERSION__` define, so core's src/mcp.ts
+            # kept the placeholder and the bin died at import. Its own build step; does not
+            # need the `stitchapi build` above (it aliases `stitchapi` → core src).
+            - run: pnpm --filter @stitchapi/sandbox test:mcp
 
     # `stitch mcp` over a real subprocess (packages/core/test/mcp-e2e.spec.ts): spawns the built
     # `bin/stitch mcp` and drives a full agent conversation (initialize → tools/list → run_stitch)

--- a/docs/sandbox/mcp/smoke.mjs
+++ b/docs/sandbox/mcp/smoke.mjs
@@ -1,9 +1,10 @@
 // Smoke test for the sandbox MCP server (stdio). Spawns the BUILT server
 // (dist/mcp.mjs — run `build:mcp` first), drives it over JSON-RPC, and asserts
-// the three tools work end-to-end against the simulator. Exits non-zero on
-// failure so it is CI-usable: `pnpm --filter @stitchapi/sandbox run test:mcp`.
+// the three tools work end-to-end against the simulator plus the version it
+// reports. Exits non-zero on failure so it is CI-usable:
+// `pnpm --filter @stitchapi/sandbox run test:mcp`.
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -13,6 +14,18 @@ if (!existsSync(server)) {
     console.error(`missing ${server} — run \`build:mcp\` first.`);
     process.exit(2);
 }
+
+// The canonical version, read straight from packages/core/package.json on disk — the
+// same trick as packages/core/test/mcp.spec.ts, and for the same reason: reading the
+// manifest rather than the build-time `__PKG_VERSION__` define asserts the reported
+// version actually TRACKS the release, instead of testing the define against itself.
+// It is core's version because `createSandboxMcp` overrides only `name`, so the
+// version reaching the wire is core's `SERVER_VERSION` — the define that
+// build-sandbox-mcp.mjs substitutes. Un-substituted, this whole bundle fails to
+// import; substituted with the WRONG value, only this check catches it.
+const CORE_VERSION = JSON.parse(
+    readFileSync(resolve(here, '../../../packages/core/package.json'), 'utf8'),
+).version;
 
 const child = spawn('node', [server], { stdio: ['pipe', 'pipe', 'pipe'] });
 let out = '';
@@ -95,6 +108,13 @@ function finish(got) {
         byId[1]?.result?.serverInfo?.name === 'stitchapi-sandbox',
         'initialize serverInfo.name',
     );
+    const reportedVersion = byId[1]?.result?.serverInfo?.version;
+    check(
+        reportedVersion === CORE_VERSION,
+        `initialize serverInfo.version: reported ${JSON.stringify(reportedVersion)}, ` +
+            `packages/core/package.json says ${JSON.stringify(CORE_VERSION)} — the ` +
+            `build's __PKG_VERSION__ define has drifted from the manifest`,
+    );
     const tools = (byId[2]?.result?.tools ?? []).map((t) => t.name);
     for (const t of ['run_in_sandbox', 'run_stitch', 'list_stitches'])
         check(tools.includes(t), `tools/list missing ${t}`);
@@ -122,7 +142,8 @@ function finish(got) {
     }
     console.log(
         'PASS — sandbox MCP: run_in_sandbox + run_stitch (sim) + list_stitches, ' +
-            'error containment, and timeout kill all verified against the simulator.',
+            'error containment, and timeout kill all verified against the simulator; ' +
+            `reported version ${CORE_VERSION} matches packages/core/package.json.`,
     );
     process.exit(0);
 }

--- a/docs/sandbox/runtime/build-sandbox-mcp.mjs
+++ b/docs/sandbox/runtime/build-sandbox-mcp.mjs
@@ -10,14 +10,16 @@
  *                                                    node-runner.ts spawns by path)
  *
  * Knobs (vs the browser build): platform 'node' (real node: builtins, NO shims,
- * NO process define), and alias `stitchapi` → packages/core/src so the bundle
- * resolves WITHOUT a build:core. `@babel/standalone` (transpile's never-taken
+ * NO process define), alias `stitchapi` → packages/core/src so the bundle
+ * resolves WITHOUT a build:core, and the `__PKG_VERSION__` define core's
+ * src/mcp.ts needs (see below). `@babel/standalone` (transpile's never-taken
  * load-failure fallback) is marked external so esbuild doesn't try to resolve it.
  *
  * Usage:  pnpm --filter @stitchapi/sandbox run build:mcp
  */
 import { PLAYGROUND_PACKAGES } from './playground-packages.mjs';
 
+import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -41,6 +43,20 @@ const WORKSPACE_ALIASES = Object.fromEntries(
         resolve(repoRoot, p.src),
     ]),
 );
+
+// The MCP bundle pulls in core's src/mcp.ts (mcp/server.ts wraps `createMcpServer`),
+// and that module reads `__PKG_VERSION__` — a build-time constant with NO runtime
+// fallback by design (packages/core/src/version.d.ts). Every other build that
+// compiles that file substitutes it (core's tsup.config.ts and vitest.config.ts);
+// without the same define here the placeholder survives into dist/mcp.mjs and the
+// `stitch-sandbox` bin dies at import with `__PKG_VERSION__ is not defined`.
+// Same convention as those two: the literal `version` of the canonical
+// packages/core/package.json — core's version, because it is core's MCP server
+// reporting it — stringified at build time, so package.json is NOT pulled into
+// the bundle.
+const CORE_VERSION = JSON.parse(
+    readFileSync(resolve(repoRoot, 'packages/core/package.json'), 'utf8'),
+).version;
 
 async function loadEsbuild() {
     try {
@@ -93,6 +109,10 @@ const shared = {
     // @babel/standalone if sucrase fails to LOAD — never on this path. Keep it
     // external so the build doesn't require the heavy Babel bundle.
     external: ['@babel/standalone'],
+    // Shared by both bundles: mcp.mjs needs it (core's src/mcp.ts), and node-worker.mjs
+    // gets it for free — it costs nothing on a bundle that never references the constant,
+    // and keeps the define from going missing if the worker graph ever reaches mcp.ts.
+    define: { __PKG_VERSION__: JSON.stringify(CORE_VERSION) },
     logLevel: 'info',
 };
 


### PR DESCRIPTION
## The bug

`pnpm --filter @stitchapi/sandbox test:mcp` fails on a clean tree. The built `docs/sandbox/dist/mcp.mjs` dies at import:

```
var SERVER_VERSION = __PKG_VERSION__;
ReferenceError: __PKG_VERSION__ is not defined
```

So the `stitch-sandbox` bin (declared in `docs/sandbox/package.json` `#/bin`) is broken for anyone who builds and runs it.

## Where the placeholder actually comes from

Not `docs/sandbox/mcp/` — it comes from [`packages/core/src/mcp.ts`](https://github.com/rejifald/StitchAPI/blob/main/packages/core/src/mcp.ts), which `docs/sandbox/mcp/server.ts` imports directly to wrap `createMcpServer`. It is a build-time constant with **no runtime fallback by design** (`packages/core/src/version.d.ts` says so explicitly).

Every other build that compiles that file substitutes it — core's `tsup.config.ts` and `vitest.config.ts` — but `build-sandbox-mcp.mjs` had no `define`, so the placeholder survived into the bundle.

This mattered for picking the version source: `version.d.ts` documents the constant as *"the `version` field of packages/core/package.json"*, so it is sourced from **core's** manifest (`1.0.0-rc.7`), not `docs/sandbox/package.json` (which is `0.0.0` and `private`). That is also the version on the wire, because `createSandboxMcp` overrides only `name` and never passes `version` — core's `SERVER_VERSION` flows through untouched.

## Changes

**1. `docs/sandbox/runtime/build-sandbox-mcp.mjs`** — add the `define` to the shared esbuild options.

- Version read via `JSON.parse(readFileSync(...))`, the convention the repo's other `.mjs` scripts use (`scripts/check-release.mjs`, `scripts/gen-readme-metrics.mjs`); it also avoids Node's experimental JSON-import warning.
- It sits in `shared` so `node-worker.mjs` gets it too — a no-op on a bundle that never references the constant, and it keeps the define from going missing if that graph ever reaches `mcp.ts`.
- The browser build `build-sandbox-worker.mjs` needs no define and is **untouched**: `mcp.ts` is a subpath-only entry that core's `index.ts` never re-exports, so the worker graph never reaches it.

**2. `docs/sandbox/mcp/smoke.mjs`** — assert the reported version against core's manifest.

The define has two failure modes and the import check only catches one. Un-substituted, the bundle fails to import (loud). Substituted with the *wrong* value, everything passes and the bin quietly reports a version that never tracked the release. `initialize`'s `serverInfo.version` is now checked against `packages/core/package.json` read **from disk** — the same trick, and the same reasoning, as `packages/core/test/mcp.spec.ts`: reading the manifest rather than the define proves the version tracks the release instead of testing the define against itself.

**3. `.github/workflows/verify.yml`** — add `test:mcp` to the existing `sandbox` job.

It is the only check that proves the bundle actually *imports* — the bundle is git-ignored and built by no other job, which is how it shipped broken. It carries its own `build:mcp` and does not need the job's `pnpm --filter stitchapi build` (the bundle aliases `stitchapi` → core src); confirmed by never building core in the verifying worktree.

## Verification

```bash
pnpm --filter @stitchapi/sandbox test:mcp
```

Passes from a clean `dist/` (`rm -rf docs/sandbox/dist` first):

```
PASS — sandbox MCP: run_in_sandbox + run_stitch (sim) + list_stitches, error containment, and timeout kill all verified against the simulator; reported version 1.0.0-rc.7 matches packages/core/package.json.
```

Checked that the substitution actually landed rather than the crash merely disappearing:

- `dist/mcp.mjs` now contains `var SERVER_VERSION = "1.0.0-rc.7";`
- driving the built bin over stdio returns `"serverInfo":{"name":"stitchapi-sandbox","version":"1.0.0-rc.7"}`

**The version assertion was verified in both directions.** Patching the built bundle to a wrong-but-defined `9.9.9-wrong` and re-running the smoke test fails with exit 1:

```
FAIL:
 - initialize serverInfo.version: reported "9.9.9-wrong", packages/core/package.json says "1.0.0-rc.7" — the build's __PKG_VERSION__ define has drifted from the manifest
```

while the bundle still imports and every other check passes — precisely the mode the import test cannot see.

`prettier --check` passes on all three files; the pre-commit `format` + `typecheck` hooks passed on both commits.

## Reviewer note

**No CHANGELOG entry.** The changelog covers the published `stitchapi` library and in-repo peer-dep packages; `@stitchapi/sandbox` is `private` and unpublished, and this changes no published surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)