### PR TITLE
fix(docs): render `{@link}` targets in playground completion tooltips

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -15,7 +15,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "kind",
             type: "property",
             detail: "Surface",
-            info: "Request style — a  plugin (ADR 0005 Decisions 1-2). Omitted = the built-in `http` surface. The public `__config` exposes only the surface's `id` string (so a stitch's declaration round-trips as JSON — Decision 11); the live object stays on `__rawConfig`.",
+            info: "Request style — a Surface plugin (ADR 0005 Decisions 1-2). Omitted = the built-in `http` surface. The public `__config` exposes only the surface's `id` string (so a stitch's declaration round-trips as JSON — Decision 11); the live object stays on `__rawConfig`.",
         },
         {
             label: "method",
@@ -27,19 +27,19 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "wire",
             type: "property",
             detail: "AtLeastOne<WireOptions>",
-            info: "Wire-format options — request body encoding, response decoding, and urlencoded array serialisation, grouped by category rather than by request/response phase (CONTRACT.md P24). The opaque `wire: {}` is rejected (P20); no field dominates, so there is no scalar shorthand (P14), exactly as with .",
+            info: "Wire-format options — request body encoding, response decoding, and urlencoded array serialisation, grouped by category rather than by request/response phase (CONTRACT.md P24). The opaque `wire: {}` is rejected (P20); no field dominates, so there is no scalar shorthand (P14), exactly as with StitchConfig.input.",
         },
         {
             label: "stream",
             type: "property",
             detail: "StreamDecode | AtLeastOne<StreamOptions>",
-            info: "Streaming options (ADR 0005 Decision 5) — how a `stream` surface decodes the live body (`'bytes'` default / `'lines'` / `'ndjson'` / `'json'`). `'json'` is the structural, unframed streaming-JSON decoder (issue #111): one `delta` per complete value / top-level array element, tolerant of internal newlines and concatenated values. Only meaningful for the `stream` surface. A bare  string is shorthand for the object form — `stream: 'ndjson'` ≡ `stream: { decode: 'ndjson' }` (CONTRACT.md P12); the opaque `stream: {}` is rejected (P20).",
+            info: "Streaming options (ADR 0005 Decision 5) — how a `stream` surface decodes the live body (`'bytes'` default / `'lines'` / `'ndjson'` / `'json'`). `'json'` is the structural, unframed streaming-JSON decoder (issue #111): one `delta` per complete value / top-level array element, tolerant of internal newlines and concatenated values. Only meaningful for the `stream` surface. A bare StreamDecode string is shorthand for the object form — `stream: 'ndjson'` ≡ `stream: { decode: 'ndjson' }` (CONTRACT.md P12); the opaque `stream: {}` is rejected (P20).",
         },
         {
             label: "sse",
             type: "property",
             detail: "boolean | AtLeastOne<SseOptions>",
-            info: "Resumable-SSE options (issue #71) — sibling to , but for the `sse` surface. **Off by default**: with no `sse` block the engine opens the live body once (today's behaviour). When enabled, a dropped stream reconnects, replaying the last `id:` as `Last-Event-ID` and honouring a server `retry:` (else `reconnect.delay` / the `retry` policy), capped at `reconnect.attempts`. Plain JSON (the contract gate). Only the `sse` surface reads it. `true` is shorthand for `{ reconnect: true }` (CONTRACT.md P13); the object form must set at least one field (P20).",
+            info: "Resumable-SSE options (issue #71) — sibling to StitchConfig.stream, but for the `sse` surface. **Off by default**: with no `sse` block the engine opens the live body once (today's behaviour). When enabled, a dropped stream reconnects, replaying the last `id:` as `Last-Event-ID` and honouring a server `retry:` (else `reconnect.delay` / the `retry` policy), capped at `reconnect.attempts`. Plain JSON (the contract gate). Only the `sse` surface reads it. `true` is shorthand for `{ reconnect: true }` (CONTRACT.md P13); the object form must set at least one field (P20).",
         },
         {
             label: "url",
@@ -87,7 +87,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "output",
             type: "property",
             detail: "SchemaLike | DriftSpec",
-            info: "Response schema, or a  for leveled drift detection. Accepts any — a raw Zod schema, any Standard Schema (Valibot, ArkType), or a `(value) => boolean` predicate — directly; the stitch infers its result type from it (see `InferOutput`), so a hand-written generic is rarely needed.",
+            info: "Response schema, or a DriftSpec for leveled drift detection. Accepts any SchemaLike — a raw Zod schema, any Standard Schema (Valibot, ArkType), or a `(value) => boolean` predicate — directly; the stitch infers its result type from it (see `InferOutput`), so a hand-written generic is rarely needed.",
         },
         {
             label: "pick",
@@ -123,7 +123,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "acceptStatus",
             type: "property",
             detail: "StatusMatch",
-            info: "Status(es) that are a NORMAL result rather than an error — a number, a list, or a predicate (CONTRACT.md P7). An accepted non-2xx flows through interpret → transform → pick → validate exactly like a 2xx (the response body becomes the result), instead of throwing a . Use this when an endpoint treats e.g. `404`/`400` as expected control flow (resource-gone → fall back to a broader call) so the happy path no longer runs through a `catch`. `retry.on` still wins while attempts remain: a status listed in BOTH is retried until attempts are exhausted, then accepted (returned) on the final attempt. Orthogonal to `throttle.delegate`, which surfaces a  on rate-limit statuses earlier.",
+            info: "Status(es) that are a NORMAL result rather than an error — a number, a list, or a predicate (CONTRACT.md P7). An accepted non-2xx flows through interpret → transform → pick → validate exactly like a 2xx (the response body becomes the result), instead of throwing a StitchError. Use this when an endpoint treats e.g. `404`/`400` as expected control flow (resource-gone → fall back to a broader call) so the happy path no longer runs through a `catch`. `retry.on` still wins while attempts remain: a status listed in BOTH is retried until attempts are exhausted, then accepted (returned) on the final attempt. Orthogonal to `throttle.delegate`, which surfaces a RateLimitError on rate-limit statuses earlier.",
         },
         {
             label: "throttle",
@@ -195,7 +195,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "trace",
             type: "property",
             detail: "TraceSink | 'console' | false",
-            info: "Observability sink — **off by default**, because a stitch's only effect on the world is its call. Opt in with `'console'` (the colored stderr stream), a sink from `fileSink(path)` / `createTrace(...)` for JSONL on disk, or any custom . `false` forces it off even when the `STITCH_TRACE_*` env vars are set. Unset falls back to the env-driven sink, which is itself silent unless `STITCH_TRACE_CONSOLE` / `STITCH_TRACE_FILE` / `STITCH_EXPORT` opt in.",
+            info: "Observability sink — **off by default**, because a stitch's only effect on the world is its call. Opt in with `'console'` (the colored stderr stream), a sink from `fileSink(path)` / `createTrace(...)` for JSONL on disk, or any custom TraceSink. `false` forces it off even when the `STITCH_TRACE_*` env vars are set. Unset falls back to the env-driven sink, which is itself silent unless `STITCH_TRACE_CONSOLE` / `STITCH_TRACE_FILE` / `STITCH_EXPORT` opt in.",
         },
     ]
 };
@@ -224,19 +224,19 @@ export const PLAYGROUND_INSTANCE_COMPLETIONS: Record<string, Completion[]> = {
             label: "inspect",
             type: "method",
             detail: "(...args: [...Args<TIn>, opts?: boolean | AtLeastOne<InspectOptions>]) => Promise<Inspection<TOut>>",
-            info: "Probe a fresh call and return an  — `{ data, raw, findings, status, error }` — **without throwing** (ADR 0016). Use it after the fact to ask \"the schema coerced/stripped this; what did the server actually send?\": `raw` is the pre-validation body, `findings` the soft + hard drift between it and `data`. `.inspect()` **always hits the network and bypasses the cache by default**, so it is a fresh probe — *not* an observer of what your cached `await` call did. Pass `true` (≡ `{ cache: true }`) to honour the cache policy (then `raw` is `null` on a hit). On a streaming surface `raw` is `null` too (no single buffered body). ⚠️ `raw` is unredacted and non-enumerable — read `wrapper.raw` deliberately; never log the whole wrapper.",
+            info: "Probe a fresh call and return an Inspection — `{ data, raw, findings, status, error }` — **without throwing** (ADR 0016). Use it after the fact to ask \"the schema coerced/stripped this; what did the server actually send?\": `raw` is the pre-validation body, `findings` the soft + hard drift between it and `data`. `.inspect()` **always hits the network and bypasses the cache by default**, so it is a fresh probe — *not* an observer of what your cached `await` call did. Pass `true` (≡ `{ cache: true }`) to honour the cache policy (then `raw` is `null` on a hit). On a streaming surface `raw` is `null` too (no single buffered body). ⚠️ `raw` is unredacted and non-enumerable — read `wrapper.raw` deliberately; never log the whole wrapper.",
         },
         {
             label: "report",
             type: "method",
             detail: "(...args: [...Args<TIn>, opts?: boolean | AtLeastOne<InspectOptions>]) => Promise<RunReport<TOut>>",
-            info: "Probe a fresh call and return a  — an  (`{ data, raw, findings, status, error, source }`) **plus** run diagnostics: `attempts`, `timing` (`{ elapsed, waited? }`), the resolved+redacted `config`, and the fine-grained `cache` outcome (ADR 0019). Like `.inspect()` it **never throws** (a hard contract violation comes back with `error` set and the diagnostics populated) and is a **network probe**: it always hits the network and **bypasses the cache by default** — pass `true` (≡ `{ cache: true }`) to honour the cache policy (then `cache` reports the real `hit`/`miss` and `raw` is `null`/`source` is `'cache'` on a hit). Use `.report()` to ask \"how did this run go?\"; `.inspect()` stays the minimal \"raw + drift\" probe. ⚠️ `raw` is inherited unredacted and non-enumerable — the rest of the report is safe to log.",
+            info: "Probe a fresh call and return a RunReport — an Inspection (`{ data, raw, findings, status, error, source }`) **plus** run diagnostics: `attempts`, `timing` (`{ elapsed, waited? }`), the resolved+redacted `config`, and the fine-grained `cache` outcome (ADR 0019). Like `.inspect()` it **never throws** (a hard contract violation comes back with `error` set and the diagnostics populated) and is a **network probe**: it always hits the network and **bypasses the cache by default** — pass `true` (≡ `{ cache: true }`) to honour the cache policy (then `cache` reports the real `hit`/`miss` and `raw` is `null`/`source` is `'cache'` on a hit). Use `.report()` to ask \"how did this run go?\"; `.inspect()` stays the minimal \"raw + drift\" probe. ⚠️ `raw` is inherited unredacted and non-enumerable — the rest of the report is safe to log.",
         },
         {
             label: "with",
             type: "method",
             detail: "(partial: P) => Stitch<TOut, RelaxKeys<TIn, keyof P>>",
-            info: "Bind part of the call input, returning a stitch whose remaining input is relaxed by the keys just supplied. Unlike the config surfaces, a MISSPELLED input key here is not a compile error — it binds nothing, silently (`.with({ params, parms })` keeps the `params` and drops the typo). Spell the slots as `StitchInput` declares them.",
+            info: "Bind part of the call input, returning a stitch whose remaining input is relaxed by the keys just supplied. Unlike the config surfaces, a MISSPELLED input key here is not a compile error — it binds nothing, silently (`.with({ params, parms })` keeps the `params` and drops the typo). Spell the slots as StitchInput declares them.",
         },
         {
             label: "invalidate",

--- a/packages/completions-plugin/codegen.mjs
+++ b/packages/completions-plugin/codegen.mjs
@@ -84,7 +84,35 @@ function configToFunctionName(interfaceName) {
     return prefix.charAt(0).toLowerCase() + prefix.slice(1);
 }
 
-function jsDocSummary(node) {
+// Render a `{@link …}` target: an Identifier (`Foo`), a QualifiedName (`Foo.bar`), or a
+// JSDocMemberName (`Foo#bar`). The latter two nest as left/right, so this recurses.
+function entityNameText(ts, name) {
+    if (!name) return '';
+    if (ts.isIdentifier(name)) return name.text;
+    if (!name.left || !name.right) return name.text ?? '';
+    const sep = ts.isQualifiedName(name) ? '.' : '#';
+    return `${entityNameText(ts, name.left)}${sep}${entityNameText(ts, name.right)}`;
+}
+
+// One part of a JSDoc comment array. Parts are JSDocText OR one of the three JSDocLink kinds,
+// and the link kinds keep only the trailing LABEL on `.text` — the target itself lives on
+// `.name`. Reading `.text` alone therefore drops the reference entirely and leaves the prose
+// dangling around the gap ("Spell the slots as  declares them"), which is what this exists to
+// prevent. Mirrors how JSDoc renders a link: the label when one is given, else the target.
+function jsDocPartText(ts, part) {
+    const text = part.text ?? '';
+    const isLink =
+        ts.isJSDocLink(part) ||
+        ts.isJSDocLinkCode(part) ||
+        ts.isJSDocLinkPlain(part);
+    if (!isLink) return text;
+    // `{@link Foo}` → `Foo`; `{@link Foo the thing}` → `the thing`; a bare URL has no `.name`,
+    // so its `.text` is all there is.
+    const label = text.trim();
+    return label || entityNameText(ts, part.name);
+}
+
+function jsDocSummary(ts, node) {
     const docs = node.jsDoc;
     if (!docs?.length) return '';
     const last = docs[docs.length - 1];
@@ -92,8 +120,11 @@ function jsDocSummary(node) {
     const text =
         typeof last.comment === 'string'
             ? last.comment
-            : last.comment.map((c) => c.text ?? '').join('');
-    return text.trim().replace(/\s*\n\s*/g, ' ');
+            : last.comment.map((c) => jsDocPartText(ts, c)).join('');
+    // `collapseWhitespace` rather than a bare newline fold: it also squeezes the runs an inline
+    // tag this function does not render (`{@label …}`, `{@inheritDoc}`) would leave behind, so a
+    // future tag degrades to a clean sentence instead of a visible gap.
+    return collapseWhitespace(text);
 }
 
 function collapseWhitespace(s) {
@@ -114,7 +145,7 @@ function extractConfigEntries(ts, iface, sf) {
             detail: member.type
                 ? collapseWhitespace(member.type.getText(sf))
                 : 'unknown',
-            info: jsDocSummary(member),
+            info: jsDocSummary(ts, member),
         });
     }
     return entries;
@@ -133,7 +164,7 @@ function extractInstanceEntries(ts, iface, sf) {
                 detail: member.type
                     ? collapseWhitespace(member.type.getText(sf))
                     : 'unknown',
-                info: jsDocSummary(member),
+                info: jsDocSummary(ts, member),
             });
         } else if (ts.isMethodSignature(member)) {
             const params = member.parameters
@@ -146,7 +177,7 @@ function extractInstanceEntries(ts, iface, sf) {
                 type: 'method',
                 label: member.name.getText(sf),
                 detail: `(${params}) => ${ret}`,
-                info: jsDocSummary(member),
+                info: jsDocSummary(ts, member),
             });
         }
     }

--- a/packages/completions-plugin/test/codegen.test.mjs
+++ b/packages/completions-plugin/test/codegen.test.mjs
@@ -64,6 +64,65 @@ test('emits config + instance completions for a matched primitive', async () => 
     }
 });
 
+test('a `{@link …}` in a doc comment renders its target, not a gap', async () => {
+    // TypeScript models `{@link X}` as a JSDocLink node whose `.text` holds only the trailing
+    // LABEL — the target lives on `.name`. Joining `.text` alone dropped the reference and left
+    // the prose dangling around the hole ("Spell the slots as  declares them"), which shipped
+    // into four real playground tooltips before this was fixed.
+    const pkg = fixturePackage(
+        [
+            'export function stitch() {}',
+            'export interface StitchInput { params?: unknown }',
+            'export interface Other { nested?: unknown }',
+            'export interface StitchConfig {',
+            '    /** Spell it as {@link StitchInput} declares it. */',
+            '    baseUrl: string;',
+            '    /** See {@link Other.nested} for the shape. */',
+            '    path: string;',
+            '    /** Use {@link StitchInput the input bag} instead. */',
+            '    url: string;',
+            '}',
+            '',
+        ].join('\n'),
+    );
+    const out = join(pkg, 'out.generated.ts');
+    try {
+        await generatePlaygroundCompletions({
+            packages: [pkg],
+            outputFile: out,
+        });
+        const content = readFileSync(out, 'utf8');
+
+        // A bare link renders its target.
+        assert.match(
+            content,
+            /Spell it as StitchInput declares it\./,
+            'bare {@link Target} should render the target name',
+        );
+        // A qualified target keeps its dotted path.
+        assert.match(
+            content,
+            /See Other\.nested for the shape\./,
+            'qualified {@link A.b} should render as A.b',
+        );
+        // An explicit label wins over the target, as JSDoc renders it.
+        assert.match(
+            content,
+            /Use the input bag instead\./,
+            '{@link Target label} should render the label',
+        );
+        // The regression itself: no doubled space anywhere in an emitted `info`.
+        for (const [, info] of content.matchAll(/info: "(.*?)",\n/g))
+            assert.doesNotMatch(
+                info,
+                / {2}/,
+                `emitted info should not contain a doubled space: ${info}`,
+            );
+    } finally {
+        rmSync(pkg, { recursive: true, force: true });
+    }
+});
+
 test('emits empty maps for a package with no *Config interface', async () => {
     const pkg = fixturePackage('export const x = 1;\n');
     const out = join(pkg, 'out.generated.ts');

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1571,7 +1571,7 @@ export interface Stitch<TOut = unknown, TIn = StitchInput> {
      *
      * Unlike the config surfaces, a MISSPELLED input key here is not a compile error — it binds
      * nothing, silently (`.with({ params, parms })` keeps the `params` and drops the typo). Spell
-     * the slots as `StitchInput` declares them.
+     * the slots as {@link StitchInput} declares them.
      */
     with<const P extends Partial<TIn>>(
         partial: P,


### PR DESCRIPTION
Follow-up to [#601](https://github.com/rejifald/StitchAPI/pull/601), which surfaced this while regenerating the completions map. Independent of that change — split onto its own branch off `main` rather than bolted onto a PR about type guards.

## The bug

TypeScript models `{@link Target}` as a `JSDocLink` node whose `.text` holds only the trailing **label** — the target itself lives on `.name`. [`jsDocSummary`](packages/completions-plugin/codegen.mjs) joined `.text` across the comment parts, so every link contributed the empty string: the reference vanished and the prose closed over the gap with a doubled space.

Five real playground tooltips read that way:

| member | before | after |
| --- | --- | --- |
| `kind` | "Request style — a&nbsp;&nbsp;plugin" | "a `Surface` plugin" |
| `stream` | "A bare&nbsp;&nbsp;string is shorthand" | "A bare `StreamDecode` string" |
| `output` | "or a&nbsp;&nbsp;for leveled drift detection… Accepts any&nbsp;&nbsp;—" | "or a `DriftSpec`… Accepts any `SchemaLike` —" |
| `acceptStatus` | "surfaces a&nbsp;&nbsp;on rate-limit statuses" | "surfaces a `RateLimitError`" |
| `with` | "Spell the slots as&nbsp;&nbsp;declares them" | "as `StitchInput` declares them" |

These are user-facing: the map feeds autocomplete help in the docs playground, so a reader hovering `.with` or `kind` got a sentence with a hole in it.

## The fix

`jsDocPartText` renders the three `JSDocLink` kinds the way JSDoc itself does:

- `{@link Foo}` → `Foo`
- `{@link Foo.bar}` → `Foo.bar` — qualified targets nest as `left`/`right`, so `entityNameText` recurses (it also handles the `Foo#bar` member form)
- `{@link Foo the thing}` → `the thing` — an explicit label wins over the target
- `{@link https://…}` → the URL, unchanged; a bare URL carries no `.name`, so `.text` is all there is

`jsDocSummary` also switches to the file's existing `collapseWhitespace` helper instead of folding newlines alone. That is belt-and-braces rather than load-bearing: with links rendering there are no doubled spaces left, but any *other* inline tag this function doesn't render (`{@label …}`, `{@inheritDoc}`) would leave the same visible gap, and this degrades it to a clean sentence instead.

`ts` is now threaded into `jsDocSummary` as a parameter, matching how every other helper in the file receives it (the module has no `ts` global — it's `require`d once and passed down).

## Tests

One test covering all three link forms, plus the regression itself as an invariant over the whole emitted map:

```js
for (const [, info] of content.matchAll(/info: "(.*?)",\n/g))
    assert.doesNotMatch(info, / {2}/, …);
```

That assertion is what would have caught this originally — it holds for any future inline tag that renders empty, not just links. `node --test`, no new deps. 5/5 pass.

## Reviewer notes

- `packages/core/src/types.ts` is a **one-line** change: `` `StitchInput` `` back to `{@link StitchInput}`. #601 had to use a backtick reference to avoid adding a sixth mangled tooltip; now that links render, the proper reference is restored.
- The regenerated `playground-completions.generated.ts` is included, and `yakir --tier executable` confirms the `playground-completions` tether is in sync — that tether is what failed on #601's first push, so it's worth checking explicitly here.

## Verification

`check:types` · `check:types-d` · `check:lint` · `test` · `check:format` · `check:contract` · `check:unknown-keys` · `check:docs-links` · `yakir --tier executable` — all pass on a branch based on current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
