### PR TITLE
fix(docs): make the release-candidate banner opaque

### DIFF
--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -13,6 +13,7 @@
     --color-stitch: var(--stitch);
     --color-stitch-strong: var(--stitch-strong);
     --color-stitch-soft: var(--stitch-soft);
+    --color-stitch-soft-solid: var(--stitch-soft-solid);
     --color-stitch-border: var(--stitch-border);
 
     /* Complementary amber accent — use sparingly. */
@@ -43,6 +44,7 @@
     --stitch: var(--brand);
     --stitch-strong: var(--brand-strong);
     --stitch-soft: var(--brand-soft);
+    --stitch-soft-solid: var(--brand-soft-solid);
     --stitch-border: var(--brand-line);
 }
 

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -159,9 +159,12 @@ export default function Layout({ children }: LayoutProps<'/'>) {
                         options: { api: '/api/search-docs' },
                     }}
                 >
+                    {/* The banner is sticky and docs content scrolls underneath
+                        it, so its fill has to be opaque — the translucent
+                        `bg-stitch-soft` tint let the page show through. */}
                     <Banner
                         variant="normal"
-                        className="gap-2 border-b border-stitch-border bg-stitch-soft text-fd-foreground"
+                        className="gap-2 border-b border-stitch-border bg-stitch-soft-solid text-fd-foreground"
                     >
                         <Construction
                             className="size-4 shrink-0 text-stitch-strong"

--- a/apps/docs/app/tokens.css
+++ b/apps/docs/app/tokens.css
@@ -147,6 +147,13 @@
     --brand-soft: color-mix(in srgb, var(--brand) 14%, transparent);
     --brand-softer: color-mix(in srgb, var(--brand) 7%, transparent);
     --brand-line: color-mix(in srgb, var(--brand) 38%, transparent);
+
+    /* Opaque twin of --brand-soft: the same tint, pre-composited over the page
+       background instead of left translucent. Over --bg the two render the same
+       color, so this is a drop-in for sticky/fixed chrome (the release banner)
+       where a translucent fill would let the content scrolling underneath bleed
+       straight through. Keep the percentage in lockstep with --brand-soft. */
+    --brand-soft-solid: color-mix(in srgb, var(--brand) 14%, var(--bg));
     --accent-soft: color-mix(in srgb, var(--accent) 16%, transparent);
     --accent-line: color-mix(in srgb, var(--accent) 42%, transparent);
     --ok-soft: color-mix(in srgb, var(--ok) 15%, transparent);


### PR DESCRIPTION
## The bug

The release-candidate banner is transparent — docs content scrolls straight through it.

The banner is a fumadocs `<Banner>`, which renders `position: sticky; top: 0; z-index: 40`, and the docs layout reserves `--fd-docs-row-1: var(--fd-banner-height)` for it — so page content scrolls *underneath* the banner by design.

Its fill was `bg-stitch-soft`:

```
bg-stitch-soft → --stitch-soft → --brand-soft
              = color-mix(in srgb, var(--brand) 14%, transparent)
```

That's an **86%-transparent** tint. `--brand-soft` is built for chips and icon wells sitting on a solid parent; on sticky chrome there's nothing solid behind it. Fumadocs' own default for `variant="normal"` is the opaque `bg-fd-secondary` — the override dropped that guarantee.

## The fix

Add `--brand-soft-solid`: the opaque twin of `--brand-soft`, the same 14% brand pre-composited over `--bg` instead of over `transparent`.

Because `0.14·brand + 0.86·bg` is exactly what the translucent fill already composited to over the page, **the banner renders pixel-identical at rest** in both themes — it just no longer lets anything through.

| | before | after |
|---|---|---|
| light | `color(srgb 0.145 0.388 0.922 / 0.14)` | `color(srgb 0.867 0.901 0.982)` |
| dark | `color(srgb 0.298 0.553 1 / 0.14)` | `color(srgb 0.075 0.121 0.204)` |

No alpha channel in either, and both match their pre-fix composite to 6 decimal places.

## Scope

`--brand-soft` itself is **untouched**, so the eight other `bg-stitch-soft` consumers keep their intended translucency — notably the hero pill, which has to stay translucent to show the ripple backdrop behind it. Changing the shared token would have regressed all of them.

The 38%-alpha `border-stitch-border` hairline needs no change either: backgrounds paint under the border box (`background-clip: border-box`), so it now composites over the banner's own opaque fill rather than over the scrolling page — same look, same leak sealed.

## Verification

Measured in the running dev server on `/docs` (where the banner stays pinned and content scrolls under it), light and dark. Lint, typecheck, and the docs suite (59 passed, 1 skipped) are green; lefthook's pre-commit format + full-monorepo typecheck passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)