### PR TITLE
feat(core)!: `Retry-After` is respected by default — `respectRetryAfter` becomes `retry.respect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,46 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Changed
 
+- **`retry.respectRetryAfter` becomes `retry.respect`, and a `Retry-After` header is now honored by
+  default.** The flag was opt-in, which meant the default retry behaviour ignored a number the
+  server had explicitly provided in favour of a guessed backoff curve — on exactly the statuses the
+  header exists for, since `retry.on` already defaults to `[429, 502, 503, 504]`. Every code example
+  in this repository turned it on; the delegate-backoff path already parsed the header with no flag
+  at all; and the delegate-backoff guide already described honoring it as baseline behaviour. The
+  default was the outlier, not the preference.
+
+    ```ts
+    // before — every example in the docs looked like this
+    retry: { attempts: 4, on: [429, 502, 503], respectRetryAfter: true },
+    // after — that is now the default
+    retry: { attempts: 4, on: [429, 502, 503] },
+    // opt out and force the computed curve
+    retry: { attempts: 4, on: [429, 502, 503], respect: false },
+    ```
+
+    The name loses its suffix because the envelope already supplies it: inside `retry`, the only
+    thing there is to respect is the server's `Retry-After`. It stays a plain boolean, so it can
+    never be misread as carrying a duration — and it is spelled differently from
+    `RateLimitError.retryAfter` on purpose. That field's job is to **carry** the header's parsed
+    value in ms ([P22](docs/CONTRACT.md#p22--a-standards-interop-contract-uses-the-standards-field-names),
+    so it keeps the standard's name); this one is a house policy about whether to obey it. One token
+    for both would put a magnitude and a boolean in one word — the collision
+    [P2](docs/CONTRACT.md#p2--dont-reuse-one-word-for-genuinely-different-concepts--rename-one)
+    renamed `reconnect.backoff` to avoid.
+
+    **`tsc` catches the migration**: `NoUnknownConfigKeys` rejects a stale `respectRetryAfter:` by
+    name. That is why this ships as a rename rather than a silent default flip — a change to how
+    long your process sleeps should fail loudly, not quietly start behaving differently. Per
+    [P19](docs/CONTRACT.md#p19--the-alias-obligation-is-scoped-to-the-ga-channel) this is a hard
+    break on the `rc` channel, with no `@deprecated` alias.
+
+    **There is deliberately no ceiling on an honored `Retry-After`.** `timeout.total` is already the
+    one place a caller declares how long they are willing to wait, and it already bounds every
+    backoff sleep in the attempt loop — a second limit inside `retry` would be two patience budgets
+    for one question. A long `Retry-After` under a total budget fails with the timeout instead of
+    parking the call, and the wait ends early on the request's `AbortSignal`. A stitch with `retry`
+    and no `timeout.total` waits as long as the server asks.
+
 - **`acceptStatus` folds into a `verdict` envelope, and response classification becomes one
   decision.** ([ADR 0022](docs/adr/0022-response-classification-merges-at-interpret.md)) The engine
   used to decide what a response _was_ in two places at two times: a status check inside the attempt

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ The things every `src/api/` folder reinvents are configuration here — uniform 
 const listUsers = stitch({
     baseUrl: 'https://api.example.com',
     path: '/users',
-    retry: { attempts: 4, on: [429, 502, 503], respectRetryAfter: true },
+    retry: { attempts: 4, on: [429, 502, 503] },
     throttle: { rate: '1/s', concurrency: 2, pool: 'host' },
     timeout: { total: '30s', perAttempt: '10s' },
 });

--- a/apps/docs/content/blog/axios-alternatives.mdx
+++ b/apps/docs/content/blog/axios-alternatives.mdx
@@ -34,7 +34,7 @@ const listOrders = stitch({
     baseUrl: 'https://api.example.com',
     path: '/orders',
     output: z.object({ orders: z.array(Order) }),
-    retry: { attempts: 4, on: [429, 502, 503], respectRetryAfter: true },
+    retry: { attempts: 4, on: [429, 502, 503] },
     throttle: { rate: '1/s', concurrency: 2, pool: 'host' },
     timeout: { total: '30s', perAttempt: '10s' },
 });

--- a/apps/docs/content/blog/call-any-llm-as-a-typed-function.mdx
+++ b/apps/docs/content/blog/call-any-llm-as-a-typed-function.mdx
@@ -167,7 +167,6 @@ const chat = llm({
         attempts: 3,
         on: [429, 529],
         backoff: 'expo-jitter',
-        respectRetryAfter: true,
     },
     throttle: { rate: '5/s', concurrency: 2, pool: 'host' },
     timeout: { total: '60s' },

--- a/apps/docs/content/blog/circuit-breakers-and-layered-timeouts.mdx
+++ b/apps/docs/content/blog/circuit-breakers-and-layered-timeouts.mdx
@@ -78,7 +78,7 @@ import { stitch } from 'stitchapi';
 const getQuote = stitch({
     baseUrl: 'https://api.example.com',
     path: '/quote/{symbol}',
-    retry: { attempts: 3, on: [429, 502, 503], respectRetryAfter: true },
+    retry: { attempts: 3, on: [429, 502, 503] },
     timeout: { total: '10s', perAttempt: '3s' },
     circuit: { failures: 5, cooldown: 30_000 },
 });

--- a/apps/docs/content/blog/expose-a-stitch-as-an-ai-sdk-tool.mdx
+++ b/apps/docs/content/blog/expose-a-stitch-as-an-ai-sdk-tool.mdx
@@ -36,7 +36,7 @@ export const getOrder = stitch({
     // The credential resolves at call time and never reaches the caller.
     auth: bearer(env('ORDERS_API_TOKEN')),
     // Resilience is declared once, here — not in the tool, not in the agent.
-    retry: { attempts: 3, on: [429, 503], respectRetryAfter: true },
+    retry: { attempts: 3, on: [429, 503] },
     throttle: { rate: '10/s', concurrency: 4, pool: 'host' },
     timeout: { total: '5s' },
     cache: '30s',

--- a/apps/docs/content/blog/fetch-timeout-typescript.mdx
+++ b/apps/docs/content/blog/fetch-timeout-typescript.mdx
@@ -92,7 +92,7 @@ import { stitch } from 'stitchapi';
 const getQuote = stitch({
     baseUrl: 'https://api.example.com',
     path: '/quote/{symbol}',
-    retry: { attempts: 3, on: [429, 502, 503], respectRetryAfter: true },
+    retry: { attempts: 3, on: [429, 502, 503] },
     timeout: { total: '10s', perAttempt: '3s' },
 });
 ```

--- a/apps/docs/content/blog/migrate-from-axios-to-stitchapi.mdx
+++ b/apps/docs/content/blog/migrate-from-axios-to-stitchapi.mdx
@@ -86,7 +86,6 @@ const getUser = stitch({
         attempts: 4,
         on: [429, 502, 503, 504],
         backoff: 'expo-jitter',
-        respectRetryAfter: true,
     },
     timeout: { total: '30s', perAttempt: '10s' },
     pick: 'data', // the API wraps payloads in { data }
@@ -104,7 +103,7 @@ const user = await getUser({ params: { id } }); // typed · validated · retried
 | ------------------------------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | request interceptor adding `Authorization`  | attaches a token per request  | `auth: bearer(env('API_TOKEN'))` — secret resolves at call time, caller never holds it ([bearer](/docs/guides/auth/bearer))       |
 | 401 response interceptor → refresh + replay | re-login on expiry            | `auth: oauth2(...)` or `cookieSession(...)` — auto re-login on expiry, no hand-rolled replay ([oauth2](/docs/guides/auth/oauth2)) |
-| retry interceptor with backoff              | re-issues on 429/502/503/504  | `retry: { attempts, on, backoff: 'expo-jitter', respectRetryAfter: true }` ([retry](/docs/guides/resilience/retry))               |
+| retry interceptor with backoff              | re-issues on 429/502/503/504  | `retry: { attempts, on, backoff: 'expo-jitter' }` ([retry](/docs/guides/resilience/retry))                                        |
 | `baseURL`                                   | one host for many calls       | `baseUrl` on the stitch, or once on a `seam()` ([seam](/docs/guides/authoring/seam))                                              |
 | `validateStatus`                            | decide what status throws     | the engine never throws on a non-2xx by itself — you declare which statuses `retry`, and a `StitchError` carries the rest         |
 | `transformResponse` + `as User`             | reshape, then assert the type | `pick` plus an `output` schema (wrap in `drift()` to flag shape changes) ([drift](/docs/guides/validation/drift))                 |
@@ -128,7 +127,7 @@ const getUser = stitch({
     path: '/users/{id}',
     adapter: axiosAdapter(client, { timeout: 10_000 }), // defaults merge under every request
     auth: bearer(env('API_TOKEN')),
-    retry: { attempts: 4, on: [429, 502, 503, 504], respectRetryAfter: true },
+    retry: { attempts: 4, on: [429, 502, 503, 504] },
     output: User,
 });
 ```
@@ -151,7 +150,7 @@ const getUser = stitch({
     baseUrl: 'https://api.example.com',
     path: '/users/{id}',
     auth: bearer(env('API_TOKEN')),
-    retry: { attempts: 4, on: [429, 502, 503, 504], respectRetryAfter: true },
+    retry: { attempts: 4, on: [429, 502, 503, 504] },
     output: User,
 }); // no adapter → fetchAdapter() · zero runtime deps
 ```
@@ -178,7 +177,7 @@ const api = seam({
         clientId: env('CLIENT_ID'),
         clientSecret: env('CLIENT_SECRET'),
     }),
-    retry: { attempts: 4, on: [429, 502, 503, 504], respectRetryAfter: true },
+    retry: { attempts: 4, on: [429, 502, 503, 504] },
 });
 
 const getUser = api.stitch({ path: '/users/{id}', output: User });

--- a/apps/docs/content/blog/proactive-throttling-vs-reactive-429s.mdx
+++ b/apps/docs/content/blog/proactive-throttling-vs-reactive-429s.mdx
@@ -94,15 +94,15 @@ const search = stitch({
     // Proactive: stay under the limit so most 429s never happen.
     throttle: { rate: '5/s', concurrency: 2, pool: 'host' },
     // Reactive: if one slips through anyway, back off and honor Retry-After.
-    retry: { attempts: 3, on: [429, 503], respectRetryAfter: true },
+    retry: { attempts: 3, on: [429, 503] },
 });
 ```
 
-The two cover different failure shapes. The throttle handles the limit _you know about_ — the documented account ceiling you can pace yourself under. The retry handles the limit _you don't_: a burst from another process sharing the same token, a provider that tightened its limit without telling you, a transient `503` that has nothing to do with rate at all. When a `429` does land, `respectRetryAfter` defers to the server's `Retry-After` header instead of guessing. Throttle reduces how often you reach for the net; the net is still there for when you do.
+The two cover different failure shapes. The throttle handles the limit _you know about_ — the documented account ceiling you can pace yourself under. The retry handles the limit _you don't_: a burst from another process sharing the same token, a provider that tightened its limit without telling you, a transient `503` that has nothing to do with rate at all. When a `429` does land, the retry defers to the server's `Retry-After` header instead of guessing. Throttle reduces how often you reach for the net; the net is still there for when you do.
 
 ## Start reactive — turn on `throttle` when you brush the ceiling
 
-The reactive `429`/retry path is the sensible floor. At low volume you'll never come close to a provider's limit, and `retry` with `respectRetryAfter` handles the occasional burst cleanly. Start there.
+The reactive `429`/retry path is the sensible floor. At low volume you'll never come close to a provider's limit, and `retry` — which honors `Retry-After` out of the box — handles the occasional burst cleanly. Start there.
 
 Flip on `throttle` — a single field on the same stitch — when:
 

--- a/apps/docs/content/blog/retry-fetch-in-typescript.mdx
+++ b/apps/docs/content/blog/retry-fetch-in-typescript.mdx
@@ -112,14 +112,13 @@ const getUser = stitch({
         attempts: 3,
         on: [429, 503],
         backoff: { curve: 'expo-jitter', base: 200 },
-        respectRetryAfter: true,
     },
 });
 
 const user = await getUser({ params: { id: '42' } }); // retried, backed off, Retry-After honored
 ```
 
-Every pitfall above is now a named field. `attempts` is the **total** number of tries including the first, so `attempts: 3` means up to two retries. `on` lists the status codes that trigger a retry — defaulting to the transient set `[429, 502, 503, 504]`, which is what keeps a dead `4xx` from being retried at all. `backoff: 'expo-jitter'` doubles the delay each attempt and spreads it randomly to break up the herd, paced from `backoff.base` and clamped to `backoff.max`; `'expo'` and `'fixed'` are there when you want a different curve. And `respectRetryAfter: true` uses the server's `Retry-After` header in place of the computed backoff when the response carries one.
+Every pitfall above is now a named field. `attempts` is the **total** number of tries including the first, so `attempts: 3` means up to two retries. `on` lists the status codes that trigger a retry — defaulting to the transient set `[429, 502, 503, 504]`, which is what keeps a dead `4xx` from being retried at all. `backoff: 'expo-jitter'` doubles the delay each attempt and spreads it randomly to break up the herd, paced from `backoff.base` and clamped to `backoff.max`; `'expo'` and `'fixed'` are there when you want a different curve. And when the response carries a `Retry-After` header, the server's number is used in place of the computed backoff — the default, since it beats guessing; `respect: false` turns it off.
 
 The non-idempotent-write pitfall doesn't vanish — nothing can make a blind `POST` retry safe — but it stops being a silent default. Adding `retry` to a write is a deliberate line you write, and the [retry guide](/docs/guides/resilience/retry) flags it: pair it with an idempotency key so the server collapses the duplicate, or leave retry off. The policy is declared where you can see it, not buried in a shared helper three files away.
 

--- a/apps/docs/content/blog/stitch-vs-codegen-api-clients.mdx
+++ b/apps/docs/content/blog/stitch-vs-codegen-api-clients.mdx
@@ -73,7 +73,7 @@ import { stitch } from 'stitchapi';
 const listUsers = stitch({
     baseUrl: 'https://api.example.com',
     path: '/users',
-    retry: { attempts: 4, on: [429, 502, 503], respectRetryAfter: true },
+    retry: { attempts: 4, on: [429, 502, 503] },
     throttle: { rate: '1/s', concurrency: 2, pool: 'host' },
     timeout: { total: '30s', perAttempt: '10s' },
 });

--- a/apps/docs/content/blog/stop-writing-fetch-in-your-agents.mdx
+++ b/apps/docs/content/blog/stop-writing-fetch-in-your-agents.mdx
@@ -55,7 +55,7 @@ export const getOrders = stitch({
     auth: bearer(env('API_TOKEN')), // resolved at call time; the caller never sees it
     output: z.array(z.object({ id: z.number(), total: z.number() })),
     pick: 'data',
-    retry: { attempts: 3, on: [429, 503], respectRetryAfter: true },
+    retry: { attempts: 3, on: [429, 503] },
     throttle: { rate: '10/s', concurrency: 4, pool: 'host' },
     timeout: { total: '10s' },
 });

--- a/apps/docs/content/blog/trace-api-calls-without-leaking-secrets.mdx
+++ b/apps/docs/content/blog/trace-api-calls-without-leaking-secrets.mdx
@@ -58,7 +58,7 @@ const chargeCard = stitch({
     method: 'POST',
     url: 'https://api.payments.com/charges',
     auth: bearer(env('PAYMENTS_TOKEN')),
-    retry: { attempts: 3, on: [429, 503], respectRetryAfter: true },
+    retry: { attempts: 3, on: [429, 503] },
     trace: 'console',
 });
 ```
@@ -73,7 +73,7 @@ const chargeCard = stitch({
     method: 'POST',
     url: 'https://api.payments.com/charges',
     auth: bearer(env('PAYMENTS_TOKEN')),
-    retry: { attempts: 3, on: [429, 503], respectRetryAfter: true },
+    retry: { attempts: 3, on: [429, 503] },
     trace: 'console',
 });
 

--- a/apps/docs/content/blog/typescript-pagination.mdx
+++ b/apps/docs/content/blog/typescript-pagination.mdx
@@ -101,7 +101,6 @@ const mirror = stitch({
         attempts: 4,
         on: [429, 503],
         backoff: 'expo-jitter',
-        respectRetryAfter: true,
     },
     throttle: { rate: '5/s', concurrency: 2, pool: 'host' },
     paginate: {

--- a/apps/docs/content/docs/guides/resilience/retry.mdx
+++ b/apps/docs/content/docs/guides/resilience/retry.mdx
@@ -20,7 +20,6 @@ const getUser = stitch({
         attempts: 3,
         on: [429, 503],
         backoff: { curve: 'expo-jitter', base: 200 },
-        respectRetryAfter: true,
     },
 });
 ```
@@ -49,9 +48,21 @@ spreads it randomly up to that exponential value to avoid thundering herds, and
 `'fixed'` waits a constant `base` every time. Every computed delay is clamped to
 `max`.
 
-`respectRetryAfter` honors a `Retry-After` header on the failing response —
-delta-seconds or an HTTP-date — using it in place of the computed backoff when
-the server tells you when to come back.
+`respect` honors a `Retry-After` header on the failing response — delta-seconds
+or an HTTP-date — using it in place of the computed backoff. **It defaults to
+`true`**: the statuses `on` retries by default are the ones RFC 9110 defines the
+header for, so when the server tells you when to come back, guessing at a curve
+instead is strictly worse information. Set `respect: false` to force the computed
+curve regardless.
+
+There is deliberately no ceiling on an honored `Retry-After`. A server asking for
+five minutes gets five minutes, because the place to say how long you're willing
+to wait is [`timeout.total`](/docs/guides/resilience/timeout) — one patience
+budget for the whole call, not a second one hidden in `retry`. It already bounds
+every backoff sleep, so a long `Retry-After` under a total budget fails with the
+timeout rather than parking the call; the wait also ends early if the caller's
+`AbortSignal` fires. A stitch with `retry` and **no** `timeout.total` will wait
+as long as the server asks.
 
 Each retry surfaces as a `progress` event (phase `retry`) on the
 [event stream](/docs/concepts/event-stream), so a trace sees every wait and

--- a/apps/docs/content/docs/recipes/make-a-flaky-call-succeed.mdx
+++ b/apps/docs/content/docs/recipes/make-a-flaky-call-succeed.mdx
@@ -24,7 +24,6 @@ const getUser = stitch({
         attempts: 3,
         on: [429, 503],
         backoff: 'expo-jitter',
-        respectRetryAfter: true,
     },
 });
 
@@ -37,8 +36,9 @@ const user = await getUser({ params: { id: 1 } });
 `attempts` is the **total** number of tries including the first, so `3` means up
 to two retries. `on` is the set of status codes that trigger a retry.
 `backoff: 'expo-jitter'` doubles the wait each attempt and spreads it randomly to
-avoid thundering herds. `respectRetryAfter` honors a `Retry-After` header when the
-server tells you when to come back. Each retry rides the
+avoid thundering herds — though when the server sends a `Retry-After` header, that
+wait wins over the computed one, which is the default (`respect: false` opts out).
+Each retry rides the
 [event stream](/docs/concepts/event-stream) as a `progress` event (phase
 `retry`), so you can [watch it happen](/docs/recipes/watch-a-call-as-it-happens).
 When the dependency is not just flaky but failing, compose retry with a

--- a/apps/docs/content/docs/recipes/mirror-a-paginated-api.mdx
+++ b/apps/docs/content/docs/recipes/mirror-a-paginated-api.mdx
@@ -32,7 +32,6 @@ const mirror = stitch({
         attempts: 4,
         on: [429, 503],
         backoff: 'expo-jitter',
-        respectRetryAfter: true,
     },
     throttle: { rate: '5/s', concurrency: 2, pool: 'host' },
     paginate: {

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -202,7 +202,7 @@ This is a concrete cookie wall (`GET /api/websites` needs a `session_token` cook
 ## 6. Resilience — retry, throttle, timeout
 
 ```ts
-retry:    { attempts: 3, backoff: 'expo-jitter', on: [429, 503], respectRetryAfter: true },
+retry:    { attempts: 3, backoff: 'expo-jitter', on: [429, 503] },
 throttle: { rate: '1/s', concurrency: 2, pool: 'host' },   // proactive limiter
 timeout:  { total: '30s', perAttempt: '10s' },
 ```

--- a/docs/FEATURE-LENSES.md
+++ b/docs/FEATURE-LENSES.md
@@ -30,7 +30,7 @@ existing or proposed — passes through all three before it ships.
 
 - Retry with backoff — `attempts`, retry-on status codes (default `429/502/503/504`),
   `expo` / `expo-jitter` / `fixed` strategies, `baseMs` / `maxMs` clamp — [`src/resilience.ts`](../src/resilience.ts)
-- `Retry-After` respected (delta-seconds **or** HTTP-date) via `respectRetryAfter`
+- `Retry-After` respected (delta-seconds **or** HTTP-date) by default; `retry.respect: false` opts out
 - Timeouts — `total` and `perAttempt`, enforced with a real `AbortSignal`
 - Lifecycle hooks — `onRequest` / `onResponse` / `onError` / `onRetry`, chained across layers
 - Auth auto-refresh on the wall — a `401` (or soft wall) re-runs the attempt with fresh

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -389,14 +389,14 @@ The things every `src/api/` folder reinvents are configuration here — uniform 
 const listUsers = stitch({
     baseUrl: 'https://api.example.com',
     path: '/users',
-    retry: { attempts: 4, on: [429, 502, 503], respectRetryAfter: true },
+    retry: { attempts: 4, on: [429, 502, 503] },
     throttle: { rate: '1/s', concurrency: 2, pool: 'host' },
     timeout: { total: '30s', perAttempt: '10s' },
 });
 ```
 
 - **`throttle` is proactive** - a rate (`'1/s'`) and a concurrency cap that keep you under a vendor's limit before it bites; `pool: 'host'` shares one limiter across every stitch hitting the same host.
-- **`retry` is reactive** - `attempts` is the total including the first; retried statuses default to `[429, 502, 503, 504]`; backoff is `'expo'` / `'expo-jitter'` / `'fixed'`, with `backoff.base` / `backoff.max` bounds; `respectRetryAfter` honors the `Retry-After` header (delta-seconds or HTTP-date).
+- **`retry` is reactive** - `attempts` is the total including the first; retried statuses default to `[429, 502, 503, 504]`; backoff is `'expo'` / `'expo-jitter'` / `'fixed'`, with `backoff.base` / `backoff.max` bounds; a `Retry-After` header (delta-seconds or HTTP-date) is honored over the computed backoff by default, and `respect: false` opts out.
 - **`timeout` aborts** - `total` and/or `perAttempt`, as milliseconds or `'30s'`-style strings, enforced with a real `AbortSignal` instead of a request left hanging.
 
 Throttle waits and retries emit `throttled` / `retry` events on the stream, so the waiting is visible in the trace for free.

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -741,9 +741,14 @@ async function* attemptLoop(
             }
 
             if (retryMatch(res.status) && attempt < max) {
-                const ra = cfg.retry?.respectRetryAfter
-                    ? parseRetryAfter(res.headers['retry-after'], rt.clock)
-                    : undefined;
+                // `!== false`, not a truthy check: `retry.respect` defaults ON. The server's stated
+                // wait beats a curve we guessed, and the default `on` set is exactly the statuses
+                // the header exists for. Only an explicit `false` forces the computed backoff.
+                // Unbounded by design — `sleepWithin` already caps every wait at `timeout.total`.
+                const ra =
+                    cfg.retry?.respect !== false
+                        ? parseRetryAfter(res.headers['retry-after'], rt.clock)
+                        : undefined;
                 yield {
                     type: 'progress',
                     phase: 'retry',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -857,7 +857,18 @@ export interface RetryOptions {
      * (`backoff: 'fixed'` ≡ `backoff: { curve: 'fixed' }`); the envelope adds `base`/`max`.
      */
     backoff?: BackoffCurve | AtLeastOne<BackoffOptions>;
-    respectRetryAfter?: boolean;
+    /**
+     * Respect a `Retry-After` header on the failing response — delta-seconds OR an HTTP-date —
+     * using the server's stated wait in place of the computed `backoff`. **Default `true`**: the
+     * default `on` set (`[429, 502, 503, 504]`) is the statuses RFC 9110 defines the header for, so
+     * ignoring it means guessing at a number the server already told us. Set `false` to force the
+     * computed curve regardless.
+     *
+     * There is deliberately NO ceiling on the honored wait — `timeout.total` already bounds every
+     * sleep in the attempt loop (one patience budget, not two), and the wait aborts with the
+     * request signal. A stitch with no `timeout.total` waits as long as the server asks.
+     */
+    respect?: boolean;
 }
 export interface ThrottleOptions {
     rate?: string; // "2/s"

--- a/packages/core/test/HARNESS-API.md
+++ b/packages/core/test/HARNESS-API.md
@@ -22,7 +22,7 @@ import { z } from 'zod';
 - `output`: a schema **or** `drift(schema, opts)` — validated against the **picked** value
 - `pick`: dot-path string (e.g. `'data'`)
 - `auth`: an AuthStrategy (see below)
-- `retry`: `{ attempts (total incl. first, default 1), on: StatusMatch (default [429,502,503,504]), backoff: BackoffCurve | { curve, base, max }, respectRetryAfter }`
+- `retry`: `{ attempts (total incl. first, default 1), on: StatusMatch (default [429,502,503,504]), backoff: BackoffCurve | { curve, base, max }, respect (honor Retry-After, default true) }`
 - `throttle`: `{ rate: '2/s', concurrency: number, pool: 'stitch'|'host', delegate?: boolean, on?: StatusMatch }`
 - `timeout`: `{ total: number|string, perAttempt: number|string }` (ms or '30s')
 - `hooks`: `{ onRequest, onResponse, onError, onRetry }` — `(ctx) => void|Promise<void>`, `ctx = { name, attempt, req?, res?, error? }`

--- a/packages/core/test/resilience.spec.ts
+++ b/packages/core/test/resilience.spec.ts
@@ -75,8 +75,10 @@ test('rejects with status 503 after exhausting all retry attempts', async () => 
     expect(server.callCount('/down')).toBe(3);
 });
 
-// ── 3. Respects Retry-After ────────────────────────────────────────────────
-test('honors the Retry-After header instead of the short backoff', async () => {
+// ── 3. Respects Retry-After BY DEFAULT ─────────────────────────────────────
+// `retry.respect` defaults ON, so this config never names it. The 5ms backoff is what a
+// non-respecting engine would wait, which is what makes the elapsed assertion discriminating.
+test('honors the Retry-After header with no opt-in, over the short backoff', async () => {
     server.route('GET', '/limited', {
         statuses: [429, 200],
         retryAfterSeconds: 1,
@@ -85,12 +87,7 @@ test('honors the Retry-After header instead of the short backoff', async () => {
     const call = stitch({
         baseUrl: server.url,
         path: '/limited',
-        retry: {
-            attempts: 2,
-            on: [429],
-            respectRetryAfter: true,
-            backoff: { base: 5 },
-        },
+        retry: { attempts: 2, on: [429], backoff: { base: 5 } },
     });
 
     const t0 = Date.now();
@@ -99,6 +96,58 @@ test('honors the Retry-After header instead of the short backoff', async () => {
 
     // Retry-After: 1 (second) must dominate the 5ms backoff.
     expect(elapsed).toBeGreaterThanOrEqual(900);
+}, 15000);
+
+// ── 3b. `respect: false` forces the computed curve ─────────────────────────
+test('respect:false ignores Retry-After and uses the computed backoff', async () => {
+    server.route('GET', '/limited-off', {
+        statuses: [429, 200],
+        retryAfterSeconds: 1,
+        body: { ok: true },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/limited-off',
+        retry: {
+            attempts: 2,
+            on: [429],
+            respect: false,
+            backoff: { curve: 'fixed', base: 5 },
+        },
+    });
+
+    const t0 = Date.now();
+    await expect(call()).resolves.toEqual({ ok: true });
+    const elapsed = Date.now() - t0;
+
+    // The 5ms fixed backoff wins — nowhere near the 1s the server asked for.
+    expect(elapsed).toBeLessThan(500);
+    expect(server.callCount('/limited-off')).toBe(2);
+}, 15000);
+
+// ── 3c. `timeout.total` is the bound on a long Retry-After ─────────────────
+// There is no ceiling ON the honored wait by design (one patience budget, not two). A server
+// asking for 30s does not park the call for 30s when the caller declared a total budget — the
+// shared deadline cuts the sleep short and fails with the timeout, not a 30s stall.
+test('timeout.total bounds a long Retry-After instead of waiting it out', async () => {
+    server.route('GET', '/parked', {
+        statuses: [429, 200],
+        retryAfterSeconds: 30,
+        body: { ok: true },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/parked',
+        retry: { attempts: 2, on: [429], backoff: { base: 5 } },
+        timeout: { total: '300ms' },
+    });
+
+    const t0 = Date.now();
+    await expect(call()).rejects.toThrow(/timed out/);
+    const elapsed = Date.now() - t0;
+
+    expect(elapsed).toBeLessThan(3_000); // NOT the 30s the server asked for
+    expect(server.callCount('/parked')).toBe(1); // never got to the second attempt
 }, 15000);
 
 // ── 4. Throttle rate spacing ───────────────────────────────────────────────


### PR DESCRIPTION
## What

`retry.respectRetryAfter` becomes **`retry.respect`**, and a `Retry-After` header is now honored **by default**.

```ts
// before — what every example in this repo already looked like
retry: { attempts: 4, on: [429, 502, 503], respectRetryAfter: true },
// after — that is the default
retry: { attempts: 4, on: [429, 502, 503] },
// opt out, force the computed curve
retry: { attempts: 4, on: [429, 502, 503], respect: false },
```

## Why

The flag was opt-in, so the default retry behaviour ignored a number the server had explicitly supplied in favour of a guessed backoff curve — on exactly the statuses the header exists for, since `retry.on` already defaults to `[429, 502, 503, 504]`.

Four things in the repo already disagreed with that default:

- **Every code example turned it on** — the READMEs, both recipes, the retry guide and 12 blog posts. Not one left it off. When every example in your own docs sets a flag, the default is wrong.
- **The delegate-backoff path already parsed it with no flag at all** (`engine.ts`), handing it to the host on `RateLimitError.retryAfter`. Half the engine already respected it by default.
- **The delegate-backoff guide already described honoring it as baseline behaviour** — "a `429` listed in `retry.on` is retried with backoff, the `Retry-After` header is consumed to pace that wait." That was not true unless you opted in. This PR makes the sentence true rather than aspirational.
- **RFC 9110 defines the header for 429 and 503** — precisely the statuses `retry.on` retries by default.

## Naming

The suffix goes because the envelope supplies it: inside `retry`, the only thing there is to respect is the server's `Retry-After`. It stays a plain boolean, so it can never be misread as carrying a duration.

It is spelled differently from `RateLimitError.retryAfter` **on purpose**. That field's job is to *carry* the header's parsed value in ms, so [P22](docs/CONTRACT.md) keeps the standard's name; this one is a house policy about whether to obey it. One token for both would put a magnitude and a boolean in one word — the collision [P2](docs/CONTRACT.md) renamed `reconnect.backoff` to avoid. The other `retryAfter` fields in the tree (`resilience.ts`, `auth.ts`) are all the carry-the-value kind and correctly keep the standard's name.

## No ceiling, deliberately

An earlier draft capped the honored wait. That was wrong: `timeout.total` is already the one place a caller declares how long they are willing to wait, and `sleepWithin` already bounds every backoff sleep against it — a second limit inside `retry` would be two patience budgets for one question.

So a long `Retry-After` under a total budget fails with the timeout instead of parking the call, and the wait ends early on the request's `AbortSignal`. **A stitch with `retry` and no `timeout.total` waits as long as the server asks** — documented in the retry guide, not guarded against.

## Breaking change

`NoUnknownConfigKeys` rejects a stale `respectRetryAfter:` by name. That is *why* this ships as a rename rather than a silent default flip — a change to how long your process sleeps should fail loudly rather than quietly start behaving differently. Hard break with no `@deprecated` alias, per P19 on the `rc` channel.

Migration: drop the line to keep the behaviour you already had; add `respect: false` to keep ignoring the header.

## Reviewer notes

- **No ADR.** This is a default flip and a rename, not a new decision shape like 0022's, so the CHANGELOG entry carries the reasoning. Happy to add ADR 0023 if you'd rather it be a numbered decision.
- **Docs sweep is 20 files** and was mostly mechanical — the examples just drop a now-redundant line. The blog posts had to be included because their blocks are `twoslash`, so a stale key would fail the docs build.
- The three new tests are written to fail on regression, not just to pass: the default-on test asserts `>= 900ms` (fails at 5ms if the default flips back), the suppression test asserts `< 500ms` (fails at 1s if `respect: false` stops working), and the budget test asserts the call never waits out the 30s the server asked for.

## Verification

- 1395 core tests pass (3 new)
- `tsc --noEmit` clean on src and test
- `eslint`, `prettier` clean
- `check:contract`, `check:unknown-keys`, `check:docs-links` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
