### PR TITLE
fix(core): `SurfaceOutcome.after` takes the canonical duration form, and is parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,21 @@ npm release are grouped under the in-development version that introduced them.
     parking the call, and the wait ends early on the request's `AbortSignal`. A stitch with `retry`
     and no `timeout.total` waits as long as the server asks.
 
+- **`SurfaceOutcome`'s retry arm takes the canonical duration form: `after` widens to
+  `number | string`.** It was raw ms only, so `after: '5s'` — the spelling every other authored
+  duration in the library accepts — did not typecheck, and the value is now run through the shared
+  `parseDuration` rather than used raw. `after` is authored by a surface, and `Surface` is a public
+  extension seam ([P21](docs/CONTRACT.md)), so
+  [P17](docs/CONTRACT.md#p17--one-canonical-duration-form)'s consumer-authored rule applies to it:
+  raw ms **or** a token like `'5s'`, through the one shared parser.
+
+    Worth knowing if you had cast around the old type: an unparsed token reached `setTimeout`, which
+    coerces it to `NaN` and fires immediately — so the wait collapsed to ~0 instead of failing.
+    Covered now by a test that asserts the elapsed floor, which fails at 14ms without the parse.
+
+    Widening only, so per [P19](docs/CONTRACT.md#p19--the-alias-obligation-is-scoped-to-the-ga-channel)
+    this is non-breaking and needs no alias — every existing `after: 1_000` keeps working unchanged.
+
 - **`acceptStatus` folds into a `verdict` envelope, and response classification becomes one
   decision.** ([ADR 0022](docs/adr/0022-response-classification-merges-at-interpret.md)) The engine
   used to decide what a response _was_ in two places at two times: a status check inside the attempt

--- a/apps/docs/content/docs/guides/resilience/verdict.mdx
+++ b/apps/docs/content/docs/guides/resilience/verdict.mdx
@@ -173,10 +173,14 @@ const poller: Surface = {
     interpret: (res, cfg) =>
         verdictOf(res, cfg) ??
         ((res.body as { status?: string }).status === 'PENDING'
-            ? { ok: false, retry: true, message: 'PENDING', after: 1_000 }
+            ? { ok: false, retry: true, message: 'PENDING', after: '1s' }
             : { ok: true, data: res.body }),
 };
 ```
+
+`after` is how long to wait before the next attempt, in the same duration form as
+every other authored duration — `1_000` or `'1s'`. Omit it and the configured
+`backoff` curve paces the wait instead.
 
 A body-driven retry shares the `retry.attempts` budget and reuses the run's
 `Idempotency-Key`, so replaying a write is as safe as a status-driven retry.

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -792,7 +792,11 @@ async function* attemptLoop(
                 };
                 await cfg.hooks?.onRetry?.({ name: nameOf(cfg), attempt, res });
                 await sleepWithin(
-                    outcome.after ?? backoffDelay(attempt + 1, cfg.retry),
+                    // `parseDuration`, not the raw value: `after` is authored by a surface, so it
+                    // takes the house duration form (`500`, `'5s'`) like every other authored
+                    // duration. An unparseable value falls through to the computed backoff.
+                    parseDuration(outcome.after) ??
+                        backoffDelay(attempt + 1, cfg.retry),
                     budget,
                     baseReq.signal,
                     rt.clock,

--- a/packages/core/src/surface.ts
+++ b/packages/core/src/surface.ts
@@ -27,12 +27,13 @@ import { getPath } from './util';
  * the body can ask for another attempt — a `200` carrying `{ status: 'PENDING' }`, an in-payload
  * rate limit, a `{ ok: false, code: 'TRY_AGAIN' }` envelope. It is expressible only because
  * `interpret` now runs INSIDE the attempt loop (Decision 1); before that there was no loop left to
- * re-enter. It shares the `retry.attempts` budget, and `after` (ms) is honoured the way
- * `Retry-After` is. Exhausting the budget surfaces the outcome as an ordinary failure.
+ * re-enter. It shares the `retry.attempts` budget, and `after` is honoured the way `Retry-After`
+ * is — it takes the one canonical duration form (`500`, `'5s'`; CONTRACT.md P17), since a surface
+ * author writes it. Exhausting the budget surfaces the outcome as an ordinary failure.
  */
 export type SurfaceOutcome<T = unknown> =
     | { ok: true; data: T }
-    | { ok: false; retry: true; message: string; after?: number }
+    | { ok: false; retry: true; message: string; after?: number | string }
     | { ok: false; message: string; status?: number };
 
 /**

--- a/packages/core/test/interpret-in-loop.spec.ts
+++ b/packages/core/test/interpret-in-loop.spec.ts
@@ -226,6 +226,43 @@ describe('the SurfaceOutcome retry arm (Decision 5)', () => {
         expect(server.callCount('/stuck')).toBe(2);
     });
 
+    // `after` is authored by a surface, so it takes the house duration form (P17) — not raw ms
+    // only. The token has to be PARSED, not coerced: an unparsed `'700ms'` reaches `sleepWithin`
+    // as a string and `remaining <= ms` compares false, so the wait silently collapses to ~0.
+    test('after accepts a duration token, not just raw ms', async () => {
+        const slowPoller: Surface = {
+            id: 'slow-poller',
+            interpret: (res) => {
+                const body = res.body as { status?: string };
+                return body.status === 'PENDING'
+                    ? {
+                          ok: false,
+                          retry: true,
+                          message: 'PENDING',
+                          after: '700ms',
+                      }
+                    : { ok: true, data: body };
+            },
+        };
+        server.route('GET', '/slow-job', {
+            statuses: [200, 200],
+            body: [{ status: 'PENDING' }, { status: 'READY' }],
+        });
+        const call = stitch({
+            baseUrl: server.url,
+            path: '/slow-job',
+            kind: slowPoller,
+            // A 1ms fixed backoff is what a NON-parsing engine would fall back to, so the
+            // elapsed floor below fails if `after` is dropped instead of parsed.
+            retry: { attempts: 2, backoff: { curve: 'fixed', base: 1 } },
+        });
+
+        const t0 = Date.now();
+        await expect(call()).resolves.toEqual({ status: 'READY' });
+        expect(Date.now() - t0).toBeGreaterThanOrEqual(600);
+        expect(server.callCount('/slow-job')).toBe(2);
+    }, 15000);
+
     test('with no retry config it is a single attempt and an ordinary failure', async () => {
         server.route('GET', '/once', { body: { status: 'PENDING' } });
         const err = await rejectionOf(


### PR DESCRIPTION
## What

`SurfaceOutcome`'s retry arm — the body-aware retry from [ADR 0022](docs/adr/0022-response-classification-merges-at-interpret.md) Decision 5 — widens `after` from `number` to `number | string`, and runs it through the shared `parseDuration`.

```ts
// now valid, and honored
{ ok: false, retry: true, message: 'PENDING', after: '5s' }
```

## Why

`after` was the one authored duration in the library that didn't speak the house form. Every other one takes `500` or `'5s'` through one shared parser; this took raw ms or nothing.

[P17](docs/CONTRACT.md#p17--one-canonical-duration-form) scopes that rule to *consumer-authored* durations, and `after` is authored by a **surface** — `Surface` being a public extension seam under [P21](docs/CONTRACT.md). Every entry in P17's resolved list is end-user config (`RetryOptions`, `CircuitOptions`, `OAuth2Options`, store `ttl`), which is presumably why the plugin-facing seam was missed in the 2026-07 sweep.

## The part worth fixing

The old shape failed **quietly** rather than loudly. An unparsed `'700ms'` reached `sleepWithin` as a string: `remaining <= ms` compares false against a string, and `setTimeout` coerces it to `NaN` and fires immediately — so the wait collapsed to ~0 with no error anywhere.

Nobody could reach that through the type, which is why there's no BREAKING note. But a cast around it would have, and it would have been near-undiagnosable — a poller that silently hammers instead of pacing.

Verified by reverting the parse with the new test in place: **elapsed 14ms against a 600ms floor**, exactly the silent collapse described. The test is written to fail that way, not merely to pass — its fallback backoff is 1ms fixed, so a dropped `after` can't accidentally satisfy the assertion.

## Also

The verdict guide showed a bare `after: 1_000` with no statement of its unit — a reader had to guess ms vs seconds. It now reads `'1s'`, with a sentence documenting the field.

## Not breaking

Widening only, so per [P19](docs/CONTRACT.md#p19--the-alias-obligation-is-scoped-to-the-ga-channel) this is non-breaking and needs no alias. Every existing `after: 1_000` keeps working — `parseDuration` passes numbers straight through.

## Context

Found while auditing the `retryAfter` name family for #608. `after` is the nearest neighbour to `retryAfter`: the two feed the identical position of the identical `sleepWithin` call, one sourced from the `Retry-After` header and one from a body a surface read. Checking whether they should share a name surfaced that only one of them was being parsed.

This was originally a second commit on #608's branch; that PR merged before it could be pushed, so it's split out here on top of the merged main.

## Verification

- 1396 core tests pass (1 new), run against the post-#608 main
- `tsc --noEmit` clean on src and test
- `eslint`, `prettier`, `check:contract`, `check:docs-links` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
