### PR TITLE
feat(core)!: `cooldown` is the one open→half-open boundary — remove the redundant `halfOpenAfter` (P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Changed
 
+- **BREAKING CHANGE: `circuit.halfOpenAfter` is removed — `cooldown` is the one open→half-open
+  boundary.** ([CONTRACT.md P1](docs/CONTRACT.md#p1--one-word-one-concept-one-value-space)) The two
+  fields named the same instant: `createCircuit` resolved `halfOpenAfter ?? cooldown` into a single
+  value, and `phase()` — the only place the open/half-open boundary is decided — compared against
+  that one value. So `cooldown` had no effect of its own once `halfOpenAfter` was set, and the
+  "probe on a different clock than the fast-fail window" the docs described was never possible: a
+  call is either rejected or admitted, so there is no third phase for a second timer to gate.
+
+    Migration — fold the value you cared about into `cooldown`:
+
+    ```ts
+    // before
+    circuit: { failures: 5, cooldown: '30s', halfOpenAfter: '60s' },
+    // after — '60s' was the effective boundary, so it is the cooldown
+    circuit: { failures: 5, cooldown: '60s' },
+    ```
+
+    **Check your configs by hand.** This one does not fail the build: `NoUnknownKeys` guards
+    top-level `StitchConfig` keys, and a nested envelope inside an inferred config literal gets no
+    excess-property check, so a leftover `halfOpenAfter` still typechecks — and the breaker silently
+    switches to the `cooldown` boundary, which is a real timing change wherever the two differed.
+    `stitch()` now logs a one-time construction warning naming the stitch and the boundary it
+    actually gets. A direct `const o: CircuitOptions = { … }` annotation does still error.
+
 - **`retry.respectRetryAfter` becomes `retry.respect`, and a `Retry-After` header is now honored by
   default.** The flag was opt-in, which meant the default retry behaviour ignored a number the
   server had explicitly provided in favour of a guessed backoff curve — on exactly the statuses the

--- a/apps/docs/content/blog/circuit-breakers-and-layered-timeouts.mdx
+++ b/apps/docs/content/blog/circuit-breakers-and-layered-timeouts.mdx
@@ -64,7 +64,7 @@ const orders = stitch({
 });
 ```
 
-After five consecutive failures the breaker opens; for the next 30 seconds calls to `orders()` fast-fail instead of hitting the host. Then one trial call decides whether to close it or wait out another cooldown. (`halfOpenAfter` lets you probe on a different clock than the fast-fail window, if you want them decoupled.)
+After five consecutive failures the breaker opens; for the next 30 seconds calls to `orders()` fast-fail instead of hitting the host. Then one trial call decides whether to close it or wait out another cooldown. (The `cooldown` is the whole boundary — fast-fail and probe aren't separate clocks you can stagger, because a call is either rejected or let through.)
 
 When the breaker is open, the call surfaces a `STITCH_CIRCUIT_OPEN` error — a distinct, catchable signal that means "I didn't even try, the dependency is presumed down," which is exactly the case your fallback logic wants to branch on.
 

--- a/apps/docs/content/docs/errors/stitch-circuit-open.mdx
+++ b/apps/docs/content/docs/errors/stitch-circuit-open.mdx
@@ -35,16 +35,15 @@ happened on earlier calls; this one is just being short-circuited.
 Most of the time this is working as intended — a failing dependency is being
 shielded from a stampede. Work through these in order:
 
-- **Wait it out.** After `cooldown` (or `halfOpenAfter`, if set) the breaker
-  goes half-open and lets a single trial through; a success closes it and traffic
-  resumes. If the dependency has recovered, the next call after the window will
-  succeed.
+- **Wait it out.** After `cooldown` the breaker goes half-open and lets a single
+  trial through; a success closes it and traffic resumes. If the dependency has
+  recovered, the next call after the window will succeed.
 - **Fix the underlying dependency.** The breaker is a symptom, not the cause. Find
   and fix the real failures — the earlier errors that incremented the count to
   `failures` — so the half-open trial can close it.
 - **Tune the thresholds.** Raise `failures` if the breaker trips on
-  transient blips; adjust `cooldown` / `halfOpenAfter` to control how long it
-  fast-fails before retesting.
+  transient blips; adjust `cooldown` to control how long it fast-fails before
+  retesting.
 - **Check the `key`.** Breakers are keyed (default: the stitch/host key). If two
   unrelated stitches share a `key`, one failing dependency trips the breaker for
   both — give them distinct keys so they don't share a breaker.

--- a/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
+++ b/apps/docs/content/docs/guides/resilience/circuit-breaker.mdx
@@ -40,8 +40,10 @@ events with phase `circuit`. The positional form names both knobs at once:
 the count of consecutive failures that trips the breaker open, and `cooldown`
 is the fast-fail window after opening, before a half-open trial is allowed.
 
-`halfOpenAfter` controls when the half-open trial is permitted (default
-`cooldown`), letting you fast-fail and probe on different clocks.
+`cooldown` is the **only** knob on that boundary: the instant the fast-fail
+window ends is the instant the trial is admitted. There is no separate probe
+timer, because a call is either rejected or let through — a phase between the
+two would have to behave exactly like one of them.
 
 `key` is a store namespace: give two stitches the same `key` plus a shared
 [`store`](/docs/guides/state/pluggable-store) to share one breaker, so a failing

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -403,9 +403,11 @@ on a field that takes `'5s'` would be a lie). On outputs, one uniform de-suffixe
 vocabulary beats a split convention; the JSDoc carries the unit.
 
 _Resolved (2026-07 sweep, inputs — widened + de-suffixed):_ `RetryOptions.baseDelay`/
-`maxDelay` (were `baseMs`/`maxMs`), `CircuitOptions.cooldown`/`halfOpenAfter`,
-`ReconnectOptions.backoff`, `OAuth2Options.refreshSkew`, `CookieSessionOptions.ttl`,
-store-contract `ttl` — all `number | string` via the one shared `parseDuration`.
+`maxDelay` (were `baseMs`/`maxMs`), `CircuitOptions.cooldown` (its `halfOpenAfter`
+sibling was widened here too, then **removed** in the 2026-08-04 P1 fix below —
+the two named one instant), `ReconnectOptions.backoff`, `OAuth2Options.refreshSkew`,
+`CookieSessionOptions.ttl`, store-contract `ttl` — all `number | string` via the one
+shared `parseDuration`.
 _Resolved (2026-07 sweep, emitted — de-suffixed):_ `StitchEvent` `waited`,
 `retryAfter`, the `done` event's `elapsed` (was `ms`), `MockResponse.delay`;
 `SseEvent.retry` stays (already bare; it mirrors the SSE `retry:` wire field).
@@ -764,6 +766,31 @@ surface — 249 of them — against P1/P4/P17/P18/P22/P24/P25 and closed what it
 - **P1** — the CLI-internal `from-curl` parser's `bodyKind`. **Fixed** (2026-08-01:
   `bodyType`, the one spelling every published field already used; CLI-internal, no
   consumer impact).
+- **P1 (two names, one instant)** — `CircuitOptions.halfOpenAfter` was a second name for
+  `cooldown`. The audits above swept for one word meaning two concepts; this is the
+  converse — one concept wearing two words — and no rule in [§7](#7-enforcement) can see
+  it, because both spellings are individually fine. `createCircuit` resolved
+  `halfOpenAfter ?? cooldown` into a single local and `phase()` — the **only** place the
+  open/half-open boundary is decided — compared against that one value, so `cooldown` had
+  no effect of its own once `halfOpenAfter` was set. **Fixed** (2026-08-04:
+  `halfOpenAfter` removed; `cooldown` is the one boundary. Hard break, no alias
+  ([P19](#p19--the-alias-obligation-is-scoped-to-the-ga-channel), `rc` channel).)
+  `cooldown` is the survivor on three counts: it is the one-word token P1 prefers, it is
+  the spelling [P15](#p15--required-fields-are-deliberate-and-get-a-namedpositional-shorthand--not-silent-defaults)
+  names as required-by-design, and it is the second slot of the `[failures, cooldown]`
+  tuple ([P20](#p20--no-empty-object-config-enable-with-defaults-is-a-scalar)).
+  _They could not have been made independent instead:_ a call is either rejected or
+  admitted, so a phase between "fast-failing" and "probing" would have to behave exactly
+  like `open` or exactly like `closed`. The decoupling the docs advertised had nowhere to
+  live. _Why it survived the sweeps:_ nothing tested the transition — `halfOpenAfter`
+  appeared in no test in `packages/core/test`, so no assertion ever depended on which
+  field moved the boundary. The gap is closed by a millisecond-exact `manualClock` test in
+  `circuit-breaker.spec.ts`. _Not statically enforceable at the slot:_ `NoUnknownKeys`
+  guards top-level `StitchConfig` keys only, and a nested envelope inside an inferred
+  `const C` gets no excess-property check either, so a stale `halfOpenAfter` still
+  typechecks and would silently take the `cooldown` boundary instead — a real timing
+  change. A construction-time nudge in `makeStitch` says so out loud; it is runtime-only
+  (no `@deprecated` tag, so **R7** stays clean) and is deleted at 1.0 GA.
 - **P25** — the flat, suffix-carrying size caps (`ServeOptions.maxBodyBytes`,
   `TraceOptions.maxBodyChars`, `StreamOptions.maxBufferChars`). **Fixed** (2026-08-01:
   folded into subject-named envelopes — `serve`'s `body` (`{ max }`), trace's `body`

--- a/packages/core/src/resilience.ts
+++ b/packages/core/src/resilience.ts
@@ -311,6 +311,12 @@ interface CircuitRecord {
  * a success closes it, another failure re-opens it. State lives in the StitchStore, so a shared
  * store gives a breaker shared across workers (DESIGN.md §13).
  *
+ * `cooldown` is the ONE boundary between open and half-open: the instant the fast-fail window
+ * ends is the instant the trial is admitted. Do not add a second timer to "decouple" them — a
+ * call is either rejected or admitted, so a phase between the two would have to behave exactly
+ * like `open` (reject) or exactly like `closed` (admit freely), and a knob with no observable
+ * effect is the bug, not the feature. (This is why `halfOpenAfter` was removed; CONTRACT.md P1.)
+ *
  * `failures` and `cooldown` are required by design (CONTRACT.md P15); this throws when either is
  * missing.
  */
@@ -330,7 +336,6 @@ export function createCircuit(
         throw new Error(
             'circuit requires `failures` and `cooldown`. Fix: set both, e.g. `circuit: { failures: 5, cooldown: "30s" }` or `circuit: [5, "30s"]`.',
         );
-    const halfOpenAfter = parseDuration(opts.halfOpenAfter) ?? cooldown;
     const nsKey = 'circuit:' + (opts.key ?? fallbackKey);
 
     const read = async (): Promise<CircuitRecord> =>
@@ -344,9 +349,7 @@ export function createCircuit(
         async phase(): Promise<CircuitPhase> {
             const r = await read();
             if (r.openedAt === 0) return 'closed';
-            return clock.now() - r.openedAt >= halfOpenAfter
-                ? 'half-open'
-                : 'open';
+            return clock.now() - r.openedAt >= cooldown ? 'half-open' : 'open';
         },
         // A success closes the breaker and clears the failure count.
         async onSuccess(): Promise<void> {

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -360,6 +360,30 @@ function warnIdempotency(cfg: ResolvedStitchConfig): void {
     );
 }
 
+// Construction-time nudge for the REMOVED `circuit.halfOpenAfter` (CONTRACT.md P1; a P19 hard
+// break on the `rc` channel, so there is no alias to fall back to). It always named the SAME
+// instant as `cooldown`: `phase()` is the one place the open/half-open boundary is decided and it
+// compared against `halfOpenAfter ?? cooldown`, so the two could never run on different clocks the
+// way the docs claimed. Dropping it moves that boundary to `cooldown`, which is a REAL timing
+// change for any config that set the two to different values — and nothing else would say so.
+// `NoUnknownKeys` guards TOP-LEVEL slots only, and a nested envelope inside an inferred `const C`
+// gets no excess-property check either (verified: `retry: { nonsense }` compiles too), so a stale
+// `halfOpenAfter` typechecks clean. This warning is the only signal it gets. Delete at 1.0 GA.
+function warnHalfOpenAfter(cfg: ResolvedStitchConfig): void {
+    // `halfOpenAfter` is off the type now, so it is read back at its former `number | string`
+    // shape — the only values a stale config can be carrying.
+    const circuit = cfg.circuit as
+        | { cooldown?: number | string; halfOpenAfter?: number | string }
+        | undefined;
+    if (circuit?.halfOpenAfter === undefined) return;
+    const name = cfg.name ?? cfg.path ?? 'stitch';
+    console.warn(
+        `stitchapi: \`${name}\` sets \`circuit.halfOpenAfter\`, which was removed — it goes ` +
+            `half-open after \`cooldown\` (${String(circuit.cooldown)}) now. Move the value ` +
+            `you want to \`cooldown\`.`,
+    );
+}
+
 // ---- the trace sink — off by default (a stitch's only effect is its call) ------
 // Nothing is printed or written unless you opt in: STITCH_TRACE_CONSOLE=1 streams a
 // colored line per event to stderr, STITCH_TRACE_FILE=<path> appends JSONL, and
@@ -947,6 +971,7 @@ export function makeStitch<T = unknown>(
 ): Stitch<T> {
     const cfg = compose(config);
     warnIdempotency(cfg);
+    warnHalfOpenAfter(cfg);
     // A seam injects shared instances; a standalone stitch builds its own (unchanged behaviour:
     // a store-backed throttle only when a `store` is configured, else the in-process limiter).
     const store = shared?.store ?? cfg.store ?? memoryStore();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -909,12 +909,12 @@ export interface CircuitOptions {
      */
     failures?: number;
     /**
-     * Fast-fail window after opening, before a half-open trial — `30_000`, `'30s'`. Required by
-     * design (P15); `createCircuit` throws when it is missing.
+     * Fast-fail window after opening — `30_000`, `'30s'`. When it elapses the breaker goes
+     * half-open and admits one trial call, so this is the **single** open→half-open boundary:
+     * fast-fail and probe cannot run on different clocks, because a call is either rejected or
+     * admitted (CONTRACT.md P1). Required by design (P15); `createCircuit` throws when missing.
      */
     cooldown?: number | string;
-    /** When to allow a half-open trial — `60_000`, `'1m'`. Default: `cooldown`. */
-    halfOpenAfter?: number | string;
     /** Store namespace to share a breaker across stitches (default: stitch/host key). */
     key?: string;
 }

--- a/packages/core/test/circuit-breaker.spec.ts
+++ b/packages/core/test/circuit-breaker.spec.ts
@@ -1,8 +1,11 @@
 // Circuit breaker: after N consecutive failures the breaker OPENS and calls fast-fail
 // without touching the network (proven by an unchanged server hit-count) while emitting a
 // `circuit` event; after the cooldown it goes HALF-OPEN and a trial request can recover it.
-import { stitch } from '../src';
+import { memoryStore, stitch } from '../src';
 import type { StitchEvent } from '../src';
+import { createCircuit } from '../src/resilience';
+import { manualClock } from '../src/testing';
+import type { CircuitOptions } from '../src/types';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
 
@@ -134,4 +137,161 @@ test('throws when neither failures nor cooldown is set (required-by-design, P15)
     await expect(call()).rejects.toThrow(
         /circuit requires `failures` and `cooldown`/,
     );
+});
+
+// The open → half-open boundary, pinned to the millisecond on an injected clock (ADR 0010).
+// These were the missing tests: `phase()` is the ONLY place the boundary is decided, and until
+// now nothing asserted *when* it moves — which is how a second, redundant knob (`halfOpenAfter`,
+// removed per CONTRACT.md P1) sat on the surface unnoticed, defaulting to `cooldown` and doing
+// nothing else. Driving time directly (rather than sleeping) is what makes the instant assertable.
+describe('the open → half-open boundary is `cooldown`, and only `cooldown`', () => {
+    // Seeded non-zero on purpose: the stored record uses `openedAt: 0` as its "closed" sentinel,
+    // so a breaker that opened at exactly epoch-ms 0 would read back as closed. Unreachable on the
+    // system clock (epoch 0 is 1970); reachable on a `manualClock()`, which seeds at 0.
+    const at = (seed = 1_000_000) => manualClock(seed);
+
+    test('stays open until `cooldown` elapses, then goes half-open on the exact ms', async () => {
+        const clock = at();
+        const c = createCircuit(
+            { failures: 2, cooldown: '30s' },
+            memoryStore(),
+            'boundary',
+            clock,
+        );
+
+        expect(await c.phase()).toBe('closed');
+        expect(await c.onFailure()).toBe(false); // 1 of 2 — not yet
+        expect(await c.phase()).toBe('closed');
+        expect(await c.onFailure()).toBe(true); // 2 of 2 — newly OPEN
+        expect(await c.phase()).toBe('open');
+
+        await clock.advance(29_999);
+        expect(await c.phase()).toBe('open'); // one ms short — still fast-failing
+
+        await clock.advance(1); // exactly `cooldown`
+        expect(await c.phase()).toBe('half-open'); // the trial is admitted here, not later
+
+        await clock.advance(60_000); // and it stays half-open until the trial settles
+        expect(await c.phase()).toBe('half-open');
+    });
+
+    test('a failed trial re-opens and arms a fresh cooldown from that instant', async () => {
+        const clock = at();
+        const c = createCircuit(
+            { failures: 1, cooldown: 30_000 },
+            memoryStore(),
+            'reopen',
+            clock,
+        );
+
+        expect(await c.onFailure()).toBe(true); // opens immediately (failures: 1)
+        await clock.advance(30_000);
+        expect(await c.phase()).toBe('half-open');
+
+        // The trial fails. Not "newly opened" — it was already open — but the window restarts.
+        expect(await c.onFailure()).toBe(false);
+        expect(await c.phase()).toBe('open');
+
+        await clock.advance(29_999);
+        expect(await c.phase()).toBe('open'); // measured from the re-open, not the first open
+        await clock.advance(1);
+        expect(await c.phase()).toBe('half-open');
+    });
+
+    test('a successful trial closes the breaker and clears the count', async () => {
+        const clock = at();
+        const c = createCircuit(
+            { failures: 1, cooldown: 30_000 },
+            memoryStore(),
+            'recover',
+            clock,
+        );
+
+        await c.onFailure();
+        await clock.advance(30_000);
+        expect(await c.phase()).toBe('half-open');
+
+        await c.onSuccess();
+        expect(await c.phase()).toBe('closed');
+
+        // Count cleared: it takes a full `failures` run to trip again, not one more failure.
+        expect(await c.onFailure()).toBe(true);
+    });
+
+    test('`cooldown` is the one input that moves the boundary', async () => {
+        // Same failure history, same clock, different `cooldown` → different instant. This is the
+        // assertion the old `halfOpenAfter` could never make: it varied while the phase did not.
+        const phaseAt = async (cooldown: number | string, elapsed: number) => {
+            const clock = at();
+            const c = createCircuit(
+                { failures: 1, cooldown },
+                memoryStore(),
+                'sole-knob',
+                clock,
+            );
+            await c.onFailure();
+            await clock.advance(elapsed);
+            return c.phase();
+        };
+
+        expect(await phaseAt('1s', 999)).toBe('open');
+        expect(await phaseAt('1s', 1000)).toBe('half-open');
+        expect(await phaseAt('10m', 999)).toBe('open');
+        expect(await phaseAt('10m', 1000)).toBe('open'); // still open — the knob moved it
+        expect(await phaseAt('10m', 600_000)).toBe('half-open');
+    });
+
+    test('`halfOpenAfter` is off the type surface — one boundary, one name (P1)', () => {
+        const opts: CircuitOptions = {
+            failures: 1,
+            cooldown: '30s',
+            // @ts-expect-error — `halfOpenAfter` is removed; `cooldown` IS the half-open boundary,
+            // so a second knob could only restate it (CONTRACT.md P1, hard break under P19).
+            halfOpenAfter: '60s',
+        };
+        expect(opts.cooldown).toBe('30s');
+    });
+
+    // The removal is NOT caught at the `circuit:` slot, only on a direct annotation as above:
+    // `NoUnknownKeys` guards top-level `StitchConfig` keys, and a nested envelope inside an
+    // inferred `const C` gets no excess-property check (`retry: { nonsense }` compiles too). So a
+    // stale config would silently get a DIFFERENT boundary. The nudge is what makes it loud.
+    test('a stale `halfOpenAfter` warns at construction rather than changing timing in silence', () => {
+        const warn = vi
+            .spyOn(console, 'warn')
+            .mockImplementation(() => undefined);
+        try {
+            stitch({
+                name: 'orders',
+                baseUrl: 'https://api.test',
+                path: '/svc',
+                // No `@ts-expect-error` here on purpose — this compiles CLEAN, which is the gap
+                // the nudge covers. If a future EPC fix makes this line an error, delete the test.
+                circuit: { failures: 1, cooldown: '30s', halfOpenAfter: '60s' },
+            });
+            expect(warn).toHaveBeenCalledTimes(1);
+            const msg = String(warn.mock.calls[0]?.[0]);
+            expect(msg).toContain('`orders`');
+            expect(msg).toContain('halfOpenAfter');
+            expect(msg).toContain('30s'); // the boundary it actually gets now
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    test('a circuit without the removed key stays quiet', () => {
+        const warn = vi
+            .spyOn(console, 'warn')
+            .mockImplementation(() => undefined);
+        try {
+            stitch({
+                baseUrl: 'https://api.test',
+                path: '/svc',
+                circuit: { failures: 1, cooldown: '30s' },
+            });
+            expect(warn).not.toHaveBeenCalled();
+        } finally {
+            warn.mockRestore();
+        }
+    });
 });


### PR DESCRIPTION
## The bug

`CircuitOptions.cooldown` and `CircuitOptions.halfOpenAfter` named the same instant.

`createCircuit` resolved them into a single local:

```ts
const halfOpenAfter = parseDuration(opts.halfOpenAfter) ?? cooldown;
```

and `phase()` — the **only** place the open/half-open boundary is decided — compared against that one value. So once `halfOpenAfter` was set, `cooldown` had no effect on behaviour at all. `{ cooldown: '30s', halfOpenAfter: '60s' }` gave a **60s fast-fail window**, not a 30s window with a delayed probe.

Verified with an injectable fake clock before touching anything: at 31s the breaker was still `open`, going `half-open` only at 61s; and `cooldown: '1s'` vs `cooldown: '10m'` (both with `halfOpenAfter: '60s'`) produced identical phases at every instant.

## Why (a) collapse, not (b) decouple

Making them genuinely independent isn't available, because the state machine has no room for a third phase. A call is either **rejected** or **admitted** — those are the only two behaviours. If `cooldown` ended the fast-fail window at 30s and `halfOpenAfter` gated the probe at 60s, the 30s–60s interval would have to behave either exactly like `open` (keep rejecting) or exactly like `closed` (admit everything, defeating the breaker). A third instant has no third behaviour to gate. Option (b) would have shipped a knob with no observable effect — which is the bug, not the fix.

`cooldown` is the survivor on three counts:

- it is the one-word token **P1** prefers;
- it is the spelling **P15** names as required-by-design;
- it is the second slot of the `[failures, cooldown]` positional tuple **P20** references.

Keeping `halfOpenAfter` instead would have meant rewriting both principles.

## Why it went unnoticed

Nothing tested the transition. `halfOpenAfter` appeared in **no test** under `packages/core/test`, so no assertion ever depended on which field moved the boundary.

`circuit-breaker.spec.ts` goes 5 → 12 tests. The core addition is a millisecond-exact `manualClock` suite (ADR 0010): still `open` at `cooldown - 1`, `half-open` at exactly `cooldown`, a failed trial re-arming a fresh window from the new instant, and `cooldown` proven to be the sole input that moves the boundary.

## ⚠️ Reviewer note — the migration has no compile-time safety net

Same class as #606's `acceptStatus`, but one layer deeper. `NoUnknownKeys` guards **top-level** `StitchConfig` keys only, and a nested envelope inside an inferred `const C` gets no excess-property check either. Verified by probe with the workspace `tsc`:

| probe | result |
|---|---|
| `stitch({ …, timeut: 500 })` | ✅ errors (top-level guard works) |
| `stitch({ …, circuit: { …, totalNonsense: 1 } })` | ❌ **no error** |
| `stitch({ …, retry: { …, nonsenseHere: 1 } })` | ❌ **no error** (pre-existing, general) |
| `const o: CircuitOptions = { …, halfOpenAfter: '60s' }` | ✅ errors |

So a stale `halfOpenAfter` typechecks clean **and** silently switches the breaker to the `cooldown` boundary — a real timing change, not merely an ignored field. That is why this PR adds a construction-time nudge in `makeStitch`, matching the existing `warnIdempotency` idiom: runtime-only, no `@deprecated` tag (ratchet **R7** stays clean), deleted at 1.0 GA.

The broader nested-EPC gap is filed separately rather than fixed here — `NoUnknownKeys`' own JSDoc records the no-`Layers`-walk as a deliberate cost decision, so widening it is a trade-off worth its own change.

## Migration

```ts
// before
circuit: { failures: 5, cooldown: '30s', halfOpenAfter: '60s' },
// after — '60s' was the effective boundary, so it is the cooldown
circuit: { failures: 5, cooldown: '60s' },
```

Hard break, no alias (**P19**, `rc` channel).

## Docs — five sites, not three

The reported three, plus two the grep turned up that carried the same false claim:

- `blog/circuit-breakers-and-layered-timeouts.mdx` — "lets you probe on a different clock than the fast-fail window"
- `types.ts` — `cooldown` and `halfOpenAfter` JSDoc describing the same instant
- **`guides/resilience/circuit-breaker.mdx`** — "letting you fast-fail and probe on different clocks"
- **`errors/stitch-circuit-open.mdx`** — two references
- `docs/CONTRACT.md` — stale entry in P17's normative resolution list, plus a new §6 audit-record bullet

The §6 "Shipped" history is deliberately left alone — the contract states those bullets record what each rename did *at the time*.

## Gates

All pass: 1400/1400 core tests, full workspace suite, `check:types`, `check:types-d`, `check:contract` (baseline still 0), `check:unknown-keys`, `check:lint`, `check:format`, `check:docs-links`, `check:exports`, and all 9 `yakir` tethers. Generated playground completions regenerate byte-identical.

**Bundle budgets unchanged.** The nudge first put `import { stitch }` 0.01 KB over; its message was trimmed rather than the budget raised — 23.30→23.26 and 20.70→20.67 KB gzip, both now under.

🤖 Generated with [Claude Code](https://claude.com/claude-code)