### PR TITLE
fix(core)!: reject unknown keys inside nested envelopes, not just at the top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,12 @@ npm release are grouped under the in-development version that introduced them.
     circuit: { failures: 5, cooldown: '60s' },
     ```
 
-    **Check your configs by hand.** This one does not fail the build: `NoUnknownKeys` guards
-    top-level `StitchConfig` keys, and a nested envelope inside an inferred config literal gets no
-    excess-property check, so a leftover `halfOpenAfter` still typechecks — and the breaker silently
-    switches to the `cooldown` boundary, which is a real timing change wherever the two differed.
-    `stitch()` now logs a one-time construction warning naming the stitch and the boundary it
-    actually gets. A direct `const o: CircuitOptions = { … }` annotation does still error.
+    **`tsc` catches the migration** — but only as of the nested-key fix released alongside this
+    entry. When this change first landed a leftover `halfOpenAfter` still typechecked at the
+    `circuit:` slot, and the breaker silently switched to the `cooldown` boundary; `stitch()`
+    therefore logs a one-time construction warning naming the stitch and the boundary it actually
+    gets. With `NoUnknownNestedKeys` in place the slot rejects the key by name, and that warning is
+    now a backstop for JS callers rather than your only signal.
 
 - **`retry.respectRetryAfter` becomes `retry.respect`, and a `Retry-After` header is now honored by
   default.** The flag was opt-in, which meant the default retry behaviour ignored a number the
@@ -297,6 +297,71 @@ npm release are grouped under the in-development version that introduced them.
     `Content-Disposition` filename parsing.
 
 ### Fixed
+
+- **The same net now covers NESTED envelopes — `circuit`, `retry`, `wire`, and the rest — so a
+  nested rename is mechanical too.** The guard below was scoped to a config's top-level keys on the
+  reasoning that an envelope is checked against its _declared_ `AtLeastOne<CircuitOptions>` and so
+  stays a fresh literal. It does not. `const C` is inferred from the **whole** config object, so
+  excess-property checking is suppressed at every depth, not just at the root:
+
+    ```ts
+    // before: typechecked, and `totalNonsense` was silently dropped
+    stitch({
+        path: '/x',
+        circuit: { failures: 1, cooldown: '30s', totalNonsense: 1 },
+    });
+    // before: typechecked — the `retry.backoff` rename in rc.5 had no compile-time net either
+    stitch({
+        path: '/x',
+        retry: { attempts: 2, backoff: { curve: 'fixed', baseMs: 100 } },
+    });
+    ```
+
+    Both are now type errors naming the key **and the envelope it was misspelled against**, so the
+    report reads against the right vocabulary:
+
+    ```
+    `totalNonsense` is not a CircuitOptions slot — check the spelling
+    ```
+
+    **Why this looked closed for so long.** The type test pinning nested coverage carried _no valid
+    sibling_, so weak-type detection did the rejecting and got the credit — the exact attribution
+    error the same test file's preamble warns about. Add one valid sibling and the rejection
+    vanished. The two assertions are rewritten, and every new one carries a sibling.
+
+    Covers 17 slots across two levels: the 13 envelopes plus `wire.multipart`, `retry.backoff`,
+    `stream.buffer`, `sse.reconnect`. The second level is not hypothetical — rc.5's
+    `baseMs`→`base` / `maxMs`→`max` renames happened there.
+
+    **The table is explicit, not derived, and that is a correctness requirement rather than a cost
+    tweak.** A walk derived from `StitchConfig[K]` descends into `output`, whose `SchemaLike` Zod arm
+    is the phantom `{ _output: unknown }`; a real `z.object(…)` carries dozens of keys beyond it, so
+    every config that validates anything would fail with `safeParse` reported as a misspelling. The
+    same holds for each pluggable seam (`adapter` / `store` / `clock` / `trace` / `kind` / `auth`),
+    where an unknown key _is_ the extension point. Unknown-key rejection is correct only for closed
+    house vocabularies.
+
+    **Cost, measured** on core's 625-call-site typecheck project: +7% types, +12% instantiations,
+    and no measurable check-time change (~1.1s either way). The docs' twoslash build, every
+    downstream package, and the runtime bundle are unchanged. One subtlety is load-bearing: the
+    guard maps over the table's **fixed** key set rather than `keyof C & keyof NestedEnvelopes`.
+    Keying it on `C` makes the parameter type depend on the type being inferred, which costs
+    contextual typing for callback slots (`adapter`, `transform`) and produces spurious
+    `implicitly has an 'any' type` errors.
+
+    **Still fail-open through `extends`,** at every depth — that is the cross-layer `Layers` axis,
+    and a fragment's own declaration site is where its spelling is checked. The `NoUnknownKeys`
+    JSDoc previously claimed an _inline_ fragment was covered by excess-property checking; it is
+    not, for the same reason the root is not, and the limit is now recorded honestly and pinned.
+
+    The ratchet grew a **second rule** to keep the table from going stale by omission: it walks every
+    root bag rule 1 found (`StitchConfig` plus the four that intersect it) and every interface the
+    table covers, failing on any field naming a house `…Options` / `…Schemas` bag with no entry, at
+    any depth. The rest of the class was **swept rather than assumed** — every other
+    envelope-consuming surface takes its bag as a direct annotation and keeps ordinary
+    excess-property checking, verified by probe (with a valid sibling present) on `seam`, `serve`,
+    `createTrace`, `mockAdapter`, `oauth2`, `serveStdio`, `deltaFrame`, and `@stitchapi/shell`'s
+    nested `buffer` envelope.
 
 - **An unknown config key is now a type error, so removing or renaming a slot has a compile-time
   safety net.** The authoring overloads infer `const C` from the config argument — that is what lets

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -785,12 +785,15 @@ surface — 249 of them — against P1/P4/P17/P18/P22/P24/P25 and closed what it
   live. _Why it survived the sweeps:_ nothing tested the transition — `halfOpenAfter`
   appeared in no test in `packages/core/test`, so no assertion ever depended on which
   field moved the boundary. The gap is closed by a millisecond-exact `manualClock` test in
-  `circuit-breaker.spec.ts`. _Not statically enforceable at the slot:_ `NoUnknownKeys`
-  guards top-level `StitchConfig` keys only, and a nested envelope inside an inferred
-  `const C` gets no excess-property check either, so a stale `halfOpenAfter` still
-  typechecks and would silently take the `cooldown` boundary instead — a real timing
-  change. A construction-time nudge in `makeStitch` says so out loud; it is runtime-only
-  (no `@deprecated` tag, so **R7** stays clean) and is deleted at 1.0 GA.
+  `circuit-breaker.spec.ts`. _Not statically enforceable at the slot — at the time:_
+  `NoUnknownKeys` guarded top-level `StitchConfig` keys only, and a nested envelope inside
+  an inferred `const C` got no excess-property check either, so a stale `halfOpenAfter`
+  typechecked clean and would silently take the `cooldown` boundary instead — a real timing
+  change. A construction-time nudge in `makeStitch` was the only signal. **That gap is since
+  closed** — the `NoUnknownNestedKeys` entry below descends into the house envelopes, so
+  `circuit: { …, halfOpenAfter }` is a compile error naming the key, and the nudge is now a
+  second line of defence for JS callers rather than the only one. It stays runtime-only (no
+  `@deprecated` tag, so **R7** stays clean) and is deleted at 1.0 GA.
 - **P25** — the flat, suffix-carrying size caps (`ServeOptions.maxBodyBytes`,
   `TraceOptions.maxBodyChars`, `StreamOptions.maxBufferChars`). **Fixed** (2026-08-01:
   folded into subject-named envelopes — `serve`'s `body` (`{ max }`), trace's `body`
@@ -1047,6 +1050,52 @@ is to intersect the parameter with `NoUnknownKeys<C, Allowed, What>`, which maps
   degrades the published `Stitch` type. The reasoning is recorded on the signature and in
   the baseline.
 - `test/` and `test-d/` are skipped — they author bad configs on purpose.
+
+**Rule 2 — nested envelopes.** The suppression is **depth-independent**: `const C` is
+inferred from the whole config object, so `wire` / `retry` / `circuit` are no more fresh
+literals than the root is, and `stitch({ circuit: { failures: 1, cooldown: '30s',
+totalNonsense: 1 } })` type-checked silently. This was long believed covered — the type test
+pinning it carried **no valid sibling**, so weak-type detection rejected it and the
+rejection was misattributed to excess-property checking. `NoUnknownNestedKeys` closes it,
+and the second rule keeps its table honest.
+
+- The table (`NestedEnvelopes`, in [`types.ts`](../packages/core/src/types.ts)) is
+  **explicit, not derived** — and that is a correctness requirement, not a cost tweak. A
+  walk derived from `StitchConfig[K]` would descend into `output`, whose `SchemaLike` Zod
+  arm is the phantom `{ _output: unknown }`; a real `z.object(…)` carries dozens of keys
+  beyond it, so every schema in every config would fail with `safeParse` reported as a
+  misspelling. The same holds for each pluggable seam ([P21](#p21--every-contract-has-an-extension-seam))
+  — `adapter` / `store` / `clock` / `trace` / `kind` / `auth` — where an unknown key is the
+  extension point. Unknown-key rejection is correct **only** for closed house vocabularies.
+- Because a hand-maintained table goes stale by omission, the rule walks **every root bag
+  rule 1 found** — `StitchConfig` plus the four that intersect it (`LlmOptions`,
+  `RequestOptions`, `EmitOptions`, `EventsOptions`, each of which adds its own fields) — and
+  every interface the table already covers, then fails on any field naming a `…Options` /
+  `…Schemas` bag (plus `Hooks`) that has no entry, at **any** depth. It currently covers 17
+  slots: 13 envelopes plus `wire.multipart`, `retry.backoff`, `stream.buffer`,
+  `sse.reconnect`. That second level is not hypothetical: `retry.backoff`'s `baseMs`→`base`
+  / `maxMs`→`max` renames in [§6](#6-migration-record-2026-07-08-hard-break-sweep) happened
+  there.
+- **The class is confined to those root bags, and that was swept rather than assumed.** Every
+  other envelope-consuming surface in the repo takes its bag as a _direct annotation_, which
+  keeps ordinary excess-property checking at every depth. Verified by probe with a valid
+  sibling present (so each rejection is attributable to EPC, not to weak-type detection) on
+  `seam`, `serve`, `createTrace`, `mockAdapter`, `oauth2`, `serveStdio`, `deltaFrame`, and —
+  outside core — `@stitchapi/shell`'s nested `buffer` envelope. All reject.
+- **Measured cost**, on `packages/core`'s 625-call-site typecheck project: +7% types
+  (73.5k→78.6k), +12% instantiations (241k→270k), and **no measurable check-time change**
+  (~1.1s either way). The docs' twoslash build and every downstream package typecheck
+  unchanged; the runtime bundle is untouched. The guard maps over the table's **fixed** key
+  set rather than
+  `keyof C & keyof NestedEnvelopes`; keying it on `keyof C` makes the parameter type depend
+  on the type being inferred, which costs contextual typing for callback slots (`adapter`,
+  `transform`) and produces spurious `implicitly has an 'any' type` errors.
+- Still **fail-open** for `extends` fragments, at every depth — that is the cross-layer
+  (`Layers`) axis, and closing it needs the walk the guard deliberately declines. A
+  fragment's own declaration site is where its spelling is checked. The `NoUnknownKeys`
+  JSDoc used to claim an _inline_ fragment was covered by excess-property checking; it is
+  not, for the same reason the root is not, and that residual limit is now recorded honestly
+  there and pinned in `unknown-config-keys.test-d.ts`.
 
 ---
 

--- a/packages/core/src/download.ts
+++ b/packages/core/src/download.ts
@@ -16,6 +16,7 @@ import type { Surface, SurfaceOutcome } from './surface';
 import {
     type NoRequestShapeOnDownload,
     type NoUnknownConfigKeys,
+    type NoUnknownNestedKeys,
     type Seam,
     type SeamOptions,
     type Stitch,
@@ -125,7 +126,10 @@ export interface DownloadSeamApi {
     readonly stitch: <
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
-        config: C & NoUnknownConfigKeys<C> & NoRequestShapeOnDownload<C>,
+        config: C &
+            NoUnknownConfigKeys<C> &
+            NoUnknownNestedKeys<C> &
+            NoRequestShapeOnDownload<C>,
     ) => Stitch<DownloadResult, InputOf<C>>;
     readonly seam: Seam;
 }
@@ -142,7 +146,10 @@ const downloadStitch = <
 >(
     // The surface is download by construction here, so the guard applies unconditionally rather
     // than keying off `kind` the way `stitch`'s `RequestShapeFixedByDownload` must.
-    config: C & NoUnknownConfigKeys<C> & NoRequestShapeOnDownload<C>,
+    config: C &
+        NoUnknownConfigKeys<C> &
+        NoUnknownNestedKeys<C> &
+        NoRequestShapeOnDownload<C>,
 ): Stitch<DownloadResult, InputOf<C>> =>
     makeStitch<DownloadResult>({
         ...config,

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -19,6 +19,7 @@ import type { Surface, SurfaceOutcome } from './surface';
 import {
     type NoRequestShapeOnLlm,
     type NoUnknownKeys,
+    type NoUnknownNestedKeys,
     type Seam,
     type SeamOptions,
     type Stitch,
@@ -204,6 +205,7 @@ const llmStitch = <const C extends LlmOptions = LlmOptions>(
     // identity and carries no `buildRequest`, so `method` IS live on `stitch({ kind: llmSurface })`.
     config: C &
         NoUnknownKeys<C, LlmOptions, 'LlmOptions'> &
+        NoUnknownNestedKeys<C> &
         NoRequestShapeOnLlm,
 ): Stitch<LlmResult, InputOf<C>> =>
     // The `as` retypes the loose `makeStitch` result to the declared `InputOf<C>` call-arg type —
@@ -221,6 +223,7 @@ export interface LlmSeamApi {
     readonly stitch: <const C extends LlmOptions = LlmOptions>(
         config: C &
             NoUnknownKeys<C, LlmOptions, 'LlmOptions'> &
+            NoUnknownNestedKeys<C> &
             NoRequestShapeOnLlm,
     ) => Stitch<LlmResult, InputOf<C>>;
     readonly seam: Seam;

--- a/packages/core/src/postmessage.ts
+++ b/packages/core/src/postmessage.ts
@@ -35,6 +35,7 @@ import type {
     AdapterRequest,
     AdapterResponse,
     NoUnknownKeys,
+    NoUnknownNestedKeys,
     Stitch,
     StitchConfig,
 } from './types';
@@ -192,7 +193,9 @@ export interface PostMessageChannel {
      */
     request<const C extends RequestOptions = RequestOptions>(
         type: string,
-        opts?: C & NoUnknownKeys<C, RequestOptions, 'RequestOptions'>,
+        opts?: C &
+            NoUnknownKeys<C, RequestOptions, 'RequestOptions'> &
+            NoUnknownNestedKeys<C>,
     ): Stitch<OutputOf<C>, InputOf<C>>;
     /**
      * Fire-and-forget send (no reply awaited): post `{ type, payload }` and resolve immediately. A
@@ -206,7 +209,9 @@ export interface PostMessageChannel {
      */
     emit<const C extends EmitOptions = EmitOptions>(
         type: string,
-        opts?: C & NoUnknownKeys<C, EmitOptions, 'EmitOptions'>,
+        opts?: C &
+            NoUnknownKeys<C, EmitOptions, 'EmitOptions'> &
+            NoUnknownNestedKeys<C>,
     ): Stitch<void, InputOf<C>>;
     /**
      * Subscribe to inbound events of `opts.type`. A STREAMING surface (id `'postmessage-event'`):
@@ -219,7 +224,9 @@ export interface PostMessageChannel {
      */
     events<const C extends EventsOptions = EventsOptions>(
         type: string,
-        opts?: C & NoUnknownKeys<C, EventsOptions, 'EventsOptions'>,
+        opts?: C &
+            NoUnknownKeys<C, EventsOptions, 'EventsOptions'> &
+            NoUnknownNestedKeys<C>,
     ): Stitch<OutputOf<C>[], InputOf<C>>;
     /**
      * Register a handler that ANSWERS inbound requests of `type` (the receiving side — e.g. an

--- a/packages/core/src/sse.ts
+++ b/packages/core/src/sse.ts
@@ -18,6 +18,7 @@ import type { Surface } from './surface';
 import {
     type AdapterResponse,
     type NoUnknownConfigKeys,
+    type NoUnknownNestedKeys,
     type ResolvedStitchConfig,
     type Seam,
     type SeamOptions,
@@ -181,7 +182,7 @@ export interface SseSeamApi {
     readonly stitch: <
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
-        config: C & NoUnknownConfigKeys<C>,
+        config: C & NoUnknownConfigKeys<C> & NoUnknownNestedKeys<C>,
     ) => Stitch<SseEvent<OutputOf<C>>[], InputOf<C>>;
     readonly seam: Seam;
 }
@@ -197,7 +198,7 @@ export interface SseSeamApi {
 const sseStitch = <
     const C extends Partial<StitchConfig> = Partial<StitchConfig>,
 >(
-    config: C & NoUnknownConfigKeys<C>,
+    config: C & NoUnknownConfigKeys<C> & NoUnknownNestedKeys<C>,
 ): Stitch<SseEvent<OutputOf<C>>[], InputOf<C>> =>
     makeStitch<SseEvent[]>({
         ...config,

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -46,6 +46,7 @@ import {
     type Inspection,
     type MultipartOnlyOnMultipartBody,
     type NoUnknownConfigKeys,
+    type NoUnknownNestedKeys,
     type NoWireBodyOnGraphql,
     type RedactedStitchConfig,
     type RequestShapeFixedByDownload,
@@ -343,9 +344,11 @@ export function compose(config: Fragment): ResolvedStitchConfig {
 // named the SAME instant as `cooldown` — `phase()` compared against `halfOpenAfter ?? cooldown` —
 // so the two could never run on different clocks the way the docs claimed. Dropping it moves the
 // boundary to `cooldown`, a REAL timing change for any config that set the two to different
-// values, and nothing else would say so: `NoUnknownKeys` guards TOP-LEVEL slots only, and a nested
-// envelope inside an inferred `const C` gets no excess-property check either (verified:
-// `retry: { nonsense }` compiles too), so a stale `halfOpenAfter` typechecks clean. Delete at 1.0 GA.
+// values. It shipped because nothing ELSE would say so: `NoUnknownKeys` guarded TOP-LEVEL slots
+// only, so a stale `halfOpenAfter` typechecked clean at the `circuit:` slot. {@link
+// NoUnknownNestedKeys} has since closed that, and the key is now a compile error naming itself —
+// so this is a backstop for callers `tsc` never sees (plain JS, a silenced error), not the only
+// signal. Keep it cheap; delete at 1.0 GA.
 //
 // It shares THIS function rather than declaring its own (it did, in #610) purely to pay for the
 // `tripped` flag this commit adds to `CircuitRecord`: the two changes together put
@@ -1167,6 +1170,7 @@ export interface StitchFn {
     >(
         config: C &
             NoUnknownConfigKeys<C> &
+            NoUnknownNestedKeys<C> &
             MultipartOnlyOnMultipartBody<C> &
             FlagPathInOutput<C> &
             GraphqlOnlyOnGraphqlSurface<C> &
@@ -1194,6 +1198,7 @@ export interface StitchFn {
     >(
         config: C &
             NoUnknownConfigKeys<C> &
+            NoUnknownNestedKeys<C> &
             MultipartOnlyOnMultipartBody<C> &
             FlagPathInOutput<C> &
             GraphqlOnlyOnGraphqlSurface<C> &
@@ -1238,6 +1243,7 @@ export function graphql<
     // rather than keying off `kind` the way `stitch`'s `WireBodyFixedByGraphql` must.
     config: C &
         NoUnknownConfigKeys<C> &
+        NoUnknownNestedKeys<C> &
         MultipartOnlyOnMultipartBody<C> &
         FlagPathInOutput<C> &
         NoWireBodyOnGraphql<C>,

--- a/packages/core/src/stream.ts
+++ b/packages/core/src/stream.ts
@@ -21,6 +21,7 @@ import type { Surface } from './surface';
 import {
     type AdapterResponse,
     type NoUnknownConfigKeys,
+    type NoUnknownNestedKeys,
     type ResolvedStitchConfig,
     type Seam,
     type SeamOptions,
@@ -121,7 +122,7 @@ export interface StreamSeamApi {
     readonly stitch: <
         const C extends Partial<StitchConfig> = Partial<StitchConfig>,
     >(
-        config: C & NoUnknownConfigKeys<C>,
+        config: C & NoUnknownConfigKeys<C> & NoUnknownNestedKeys<C>,
     ) => Stitch<StreamElement<C>[], InputOf<C>>;
     readonly seam: Seam;
 }
@@ -137,7 +138,7 @@ export interface StreamSeamApi {
 const streamStitch = <
     const C extends Partial<StitchConfig> = Partial<StitchConfig>,
 >(
-    config: C & NoUnknownConfigKeys<C>,
+    config: C & NoUnknownConfigKeys<C> & NoUnknownNestedKeys<C>,
 ): Stitch<StreamElement<C>[], InputOf<C>> =>
     makeStitch<unknown[]>({
         ...config,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -290,10 +290,13 @@ export interface ConfigError<Message extends string> {
  * guard is `unknown` and intersects away.
  *
  * Cheaper than the sibling guards on purpose: one `keyof` and one `Exclude` per call site, with no
- * {@link Layers} walk. Unknown keys are a per-layer spelling concern, not a cross-layer pairing, and
- * an INLINE `extends` fragment is a fresh literal checked against the declared
- * `Partial<StitchConfig> | Stitch` — so it still gets ordinary excess-property checking and needs no
- * help from here.
+ * {@link Layers} walk. Unknown keys are a per-layer spelling concern, not a cross-layer pairing, so
+ * a fragment reached through `extends` is not this guard's business — see the residual limit below,
+ * which is the honest version of a claim this comment used to make.
+ *
+ * Scoped to the TOP level. The same suppression applies at every depth — `const C` is inferred from
+ * the whole config object, so a nested envelope is no longer a fresh literal either — and that layer
+ * is {@link NoUnknownNestedKeys}'s job, on the house envelopes it lists.
  *
  * STRONGER than excess-property checking in one respect, and the reason a rename is now caught
  * repo-wide: EPC only fires on a fresh literal, so a config hoisted into a `const` binding escapes
@@ -303,11 +306,13 @@ export interface ConfigError<Message extends string> {
  * intersected parameter degrade the public `Stitch` type. The reasoning is recorded on `with` itself.
  *
  * RESIDUAL LIMITS:
- * - Fail-open: an unknown key inside an `extends` fragment that is a `const` BINDING and also carries
- *   at least one real slot is not reported — the binding is not fresh so EPC does not fire, the real
- *   slot satisfies weak-type detection so that does not either, and this guard reads only the
- *   literal's own keys. A bound fragment of ONLY unknown keys IS still rejected, by weak-type
- *   detection. Both pinned in `unknown-config-keys.test-d.ts`.
+ * - Fail-open: an unknown key inside an `extends` fragment carrying at least one real slot is not
+ *   reported — INLINE or hoisted. This comment used to say the inline case was covered by EPC on the
+ *   declared `Partial<StitchConfig> | Stitch`; it is not, for the same reason the top level is not.
+ *   `C` is inferred from the whole config, so the fragment is not fresh either, and the real slot
+ *   satisfies weak-type detection. A fragment of ONLY unknown keys IS still rejected, by weak-type
+ *   detection. Both pinned in `unknown-config-keys.test-d.ts`. Closing it needs the {@link Layers}
+ *   walk this guard declines; the fragment's own declaration site is the natural place to type it.
  * - Fail-open by design: a config whose static type is already `Partial<StitchConfig>` (or the loose
  *   `string | Partial<StitchConfig>` escape hatch) has no unknown keys to find. Its declaration site
  *   is where the spelling was checked, and that site had EPC.
@@ -335,6 +340,113 @@ export type NoUnknownConfigKeys<C> = NoUnknownKeys<
     StitchConfig,
     'StitchConfig'
 >;
+/**
+ * The HOUSE envelopes {@link NoUnknownNestedKeys} descends into, as
+ * `slot: [bag, its exported name, its own children]`.
+ *
+ * Explicit rather than derived from `StitchConfig[K]`, and that is a CORRECTNESS requirement, not a
+ * cost tweak: several slots hold FOREIGN objects whose extra keys are the point. `output` takes a
+ * `SchemaLike`, whose Zod arm is the phantom `{ _output: unknown }` — a real `z.object(…)` carries
+ * ~40 keys beyond it, so a derived walk reports `safeParse` as a misspelling and every schema in
+ * every config stops compiling. Same for `adapter` / `store` / `clock` / `trace` / `kind` / `auth`:
+ * pluggable seams (P21), where an unknown key is an implementation detail, not a typo.
+ */
+interface NestedEnvelopes {
+    wire: [
+        WireOptions,
+        'WireOptions',
+        { multipart: [MultipartOptions, 'MultipartOptions', object] },
+    ];
+    stream: [
+        StreamOptions,
+        'StreamOptions',
+        { buffer: [StreamBufferOptions, 'StreamBufferOptions', object] },
+    ];
+    sse: [
+        SseOptions,
+        'SseOptions',
+        { reconnect: [ReconnectOptions, 'ReconnectOptions', object] },
+    ];
+    retry: [
+        RetryOptions,
+        'RetryOptions',
+        { backoff: [BackoffOptions, 'BackoffOptions', object] },
+    ];
+    input: [InputSchemas, 'InputSchemas', object];
+    verdict: [VerdictOptions, 'VerdictOptions', object];
+    throttle: [ThrottleOptions, 'ThrottleOptions', object];
+    timeout: [TimeoutOptions, 'TimeoutOptions', object];
+    circuit: [CircuitOptions, 'CircuitOptions', object];
+    idempotency: [IdempotencyOptions, 'IdempotencyOptions', object];
+    cache: [CacheOptions, 'CacheOptions', object];
+    hooks: [Hooks, 'Hooks', object];
+    paginate: [PaginateOptions, 'PaginateOptions', object];
+}
+/**
+ * One envelope's worth of {@link NoUnknownNestedKeys}: brand the unknown keys of `V` against
+ * `Allowed`, then recurse into whichever of `V`'s keys name a child envelope.
+ *
+ * The array/function arm is what keeps the scalar and positional shorthands legal — `retry: 3`
+ * never reaches the object arm, and `circuit: [5, '30s']` is an ARRAY, whose `keyof` is
+ * `length`/`push`/… and would otherwise read as 30-odd unknown keys.
+ */
+type EnvelopeGuard<V, E> = E extends [
+    infer Allowed,
+    infer What extends string,
+    infer Kids,
+]
+    ? V extends readonly unknown[] | ((...args: never[]) => unknown)
+        ? unknown
+        : V extends object
+          ? ([Exclude<keyof V, keyof Allowed>] extends [never]
+                ? unknown
+                : {
+                      [
+                          K in Exclude<keyof V, keyof Allowed>
+                      ]: ConfigError<`\`${Extract<K, string>}\` is not a ${What} slot — check the spelling`>;
+                  }) & {
+                [K in keyof V & keyof Kids]?: EnvelopeGuard<V[K], Kids[K]>;
+            }
+          : unknown
+    : unknown;
+/**
+ * Compile-time guard: the same rejection {@link NoUnknownKeys} gives a config's TOP-LEVEL keys,
+ * one and two layers down, for the house envelopes listed in {@link NestedEnvelopes}.
+ *
+ * Needed for the same reason and by the same mechanism: `const C` is inferred from the WHOLE config
+ * object, so the envelope is no longer a fresh literal by the time it is compared against
+ * `AtLeastOne<CircuitOptions>` — excess-property checking is suppressed at every depth, not just at
+ * the root. `stitch({ circuit: { failures: 1, cooldown: '30s', totalNonsense: 1 } })` type-checks
+ * without this, and so does every call site still authoring a REMOVED nested slot. The gap read as
+ * closed for a long time because the type test pinning it carried no valid sibling, so weak-type
+ * detection did the rejecting and got the credit — see `unknown-config-keys.test-d.ts`.
+ *
+ * The key set is `keyof NestedEnvelopes`, NOT `keyof C & keyof NestedEnvelopes`, and that is
+ * load-bearing rather than stylistic. Keying it on `C` makes the guard's own SHAPE depend on the
+ * type still being inferred, which defers the parameter type past the point where a
+ * context-sensitive argument draws its contextual type: the callback slots — `adapter: (req) => …`,
+ * `transform: (b) => …` — lose theirs and report TS7006 `implicitly has an 'any' type`. Six sites
+ * in the suite caught it. The fixed key set costs one `K extends keyof C` per envelope and keeps
+ * inference intact.
+ *
+ * RESIDUAL LIMITS:
+ * - Scoped to the {@link NestedEnvelopes} table, which is explicit BY NECESSITY: `output` holds a
+ *   {@link SchemaLike}, and a walk derived from `StitchConfig[K]` reports `safeParse` on a real
+ *   `z.object(…)` as a misspelling. Unknown-key rejection is correct only for closed house
+ *   vocabularies, never for the pluggable seams. `scripts/check-unknown-keys.mjs` fails the build
+ *   when a new house envelope is added without a table entry.
+ * - Fail-open through `extends`, exactly as {@link NoUnknownKeys} is: this reads the literal's own
+ *   slots, so a fragment's nested keys are the `Layers` axis and not its business.
+ * - Fail-open on an already-typed envelope: `circuit: someCircuitOptions` has no unknown keys left
+ *   to find, and that binding's declaration site had ordinary excess-property checking.
+ */
+export type NoUnknownNestedKeys<C> = C extends string
+    ? unknown
+    : {
+          [K in keyof NestedEnvelopes]?: K extends keyof C
+              ? EnvelopeGuard<C[K], NestedEnvelopes[K]>
+              : unknown;
+      };
 /**
  * Compile-time guard: {@link WireOptions.multipart} is read ONLY when `wire.body` is
  * `'multipart'`, so pairing it with a `json`/`form` body (or omitting `body`, which defaults to
@@ -1872,6 +1984,7 @@ export interface Seam {
     >(
         config: C &
             NoUnknownConfigKeys<C> &
+            NoUnknownNestedKeys<C> &
             MultipartOnlyOnMultipartBody<C> &
             FlagPathInOutput<C> &
             GraphqlOnlyOnGraphqlSurface<C> &
@@ -1892,6 +2005,7 @@ export interface Seam {
     >(
         config: C &
             NoUnknownConfigKeys<C> &
+            NoUnknownNestedKeys<C> &
             MultipartOnlyOnMultipartBody<C> &
             FlagPathInOutput<C> &
             GraphqlOnlyOnGraphqlSurface<C> &
@@ -1909,6 +2023,7 @@ export interface Seam {
     >(
         config: C &
             NoUnknownConfigKeys<C> &
+            NoUnknownNestedKeys<C> &
             MultipartOnlyOnMultipartBody<C> &
             FlagPathInOutput<C> &
             NoWireBodyOnGraphql<C>,

--- a/packages/core/test-d/unknown-config-keys.test-d.ts
+++ b/packages/core/test-d/unknown-config-keys.test-d.ts
@@ -108,13 +108,120 @@ const boundStream = stream.bind(api);
 boundStream.stitch({ path: '/chunks' });
 expectError(boundStream.stitch({ path: '/chunks', totallyMadeUpProperty: 1 }));
 
-// ── Nested envelopes and inline fragments were already covered by EPC ───────
-// These are checked against their DECLARED types (`AtLeastOne<WireOptions>`,
-// `Partial<StitchConfig> | Stitch`) rather than against the inferred `C`, so freshness survives and
-// ordinary excess-property checking fires. Pinned so it stays true — it is the reason
-// `NoUnknownConfigKeys` deliberately does NOT walk `Layers<C>`, which keeps its `tsc` cost to one
-// `keyof` and one `Exclude` per call site.
+// ── Nested envelopes: `NoUnknownNestedKeys`, and why EPC was never covering them ──
+// This block used to assert that nested envelopes "were already covered by EPC", on the reasoning
+// that `wire` is checked against its DECLARED `AtLeastOne<WireOptions>` and so stays fresh. That
+// reasoning was wrong, and the two cases pinning it were passing for a different reason: NEITHER
+// carried a valid sibling, so both were rejected by weak-type detection (and by `AtLeastOne`, which
+// an all-unknown object cannot satisfy) — exactly the attribution error the preamble above warns
+// about. `const C` is inferred from the WHOLE config object, so the envelope is no longer fresh
+// either; EPC is suppressed at every depth, not just at the root.
+//
+// Add one valid sibling and the pre-guard behaviour was total silence:
+//   stitch({ circuit: { failures: 1, cooldown: '30s', totalNonsense: 1 } })   // no error
+// `NoUnknownNestedKeys` closes that, naming the ENVELOPE's own type in the message so the report
+// reads against the vocabulary the key was misspelled against.
 expectError(stitch({ path: '/things', wire: { bogusNested: 1 } }));
+expectError(
+    stitch({ path: '/things', wire: { array: 'repeat', bogusNested: 1 } }),
+);
+expectError(
+    stitch({
+        path: '/things',
+        circuit: { failures: 1, cooldown: '30s', totalNonsense: 1 },
+    }),
+);
+expectError(stitch({ path: '/things', retry: { attempts: 2, nonsense: 1 } }));
+expectError(
+    stitch({ path: '/things', timeout: { total: '5s', perAttemptMs: 1 } }),
+);
+expectError(stitch({ path: '/things', cache: { ttl: '1m', bogusCache: 1 } }));
+expectError(
+    stitch({ path: '/things', verdict: { accept: [404], bogusVerdict: 1 } }),
+);
+
+// Two levels down — the depth CONTRACT.md §6 actually renamed at (`baseMs`→`base`,
+// `maxMs`→`max` inside `retry.backoff`, P4/P17). A one-level walk would have left those silent.
+expectError(
+    stitch({
+        path: '/things',
+        retry: { attempts: 2, backoff: { curve: 'fixed', baseMs: 100 } },
+    }),
+);
+expectError(
+    stitch({
+        path: '/things',
+        wire: { body: 'multipart', multipart: { nesting: 'dot', bogus: 1 } },
+    }),
+);
+expectError(
+    stitch({ path: '/things', sse: { reconnect: { attempts: 2, bogus: 1 } } }),
+);
+expectError(
+    stitch({
+        path: '/things',
+        stream: { decode: 'lines', buffer: { chars: 10, bogus: 1 } },
+    }),
+);
+
+// HOISTED, one level down — the case EPC could never have caught even in principle, and the one
+// that makes a nested rename safe repo-wide rather than only at inline call sites.
+const hoistedNested = {
+    path: '/things',
+    circuit: { failures: 1, cooldown: '30s', totalNonsense: 1 },
+};
+expectError(stitch(hoistedNested));
+
+// Positive controls — every scalar/positional shorthand must survive the walk. A guard that read
+// `keyof` on these would report `circuit: [5, '30s']` as 30-odd unknown array keys, and reject the
+// `retry: 3` / `stream: 'ndjson'` / `sse: true` spellings outright (P12/P13/P15).
+stitch({ path: '/things', circuit: [5, '30s'] });
+stitch({ path: '/things', retry: 3 });
+stitch({ path: '/things', timeout: '5s' });
+stitch({ path: '/things', throttle: '2/s' });
+stitch({ path: '/things', stream: 'ndjson' });
+stitch({ path: '/things', sse: true });
+stitch({ path: '/things', cache: '1m' });
+stitch({ path: '/things', retry: { attempts: 2, backoff: 'fixed' } });
+stitch({ path: '/things', wire: { body: 'multipart', multipart: 'dot' } });
+stitch({ path: '/things', hooks: { onRequest: () => {} } });
+stitch({ path: '/things', paginate: { next: () => undefined, pages: 3 } });
+
+// And a FOREIGN object in a slot the walk must not descend into: `output` takes a `SchemaLike`,
+// whose Zod arm is the phantom `{ _output: unknown }`. A schema carries dozens of keys beyond it,
+// so a walk derived from `StitchConfig[K]` rather than from the house-envelope table would report
+// `safeParse` as a misspelling and break every config that validates anything.
+stitch({
+    path: '/things',
+    output: (v: unknown): v is string => typeof v === 'string',
+});
+stitch({ path: '/things', input: { body: (v: unknown) => v != null } });
+
+// The nested guard binds every authoring surface, not just `stitch`.
+expectError(
+    api.stitch({ path: '/things', retry: { attempts: 2, nonsense: 1 } }),
+);
+expectError(sse({ path: '/events', retry: { attempts: 2, nonsense: 1 } }));
+expectError(stream({ path: '/chunks', retry: { attempts: 2, nonsense: 1 } }));
+expectError(download({ url: URL_, retry: { attempts: 2, nonsense: 1 } }));
+expectError(
+    llm({
+        provider: anthropic,
+        model: 'm',
+        retry: { attempts: 2, nonsense: 1 },
+    }),
+);
+
+// ── RESIDUAL LIMIT (fail-open): `extends` fragments are still the `Layers` axis ──
+// The guard reads the literal's OWN slots, so a fragment's keys — at any depth — are not its
+// business. An inline fragment carrying a valid sibling is therefore NOT rejected: `C` is inferred
+// from the whole config, so the fragment is not fresh either, and weak-type detection is satisfied
+// by the real key. Deliberate, hence not `expectError` — catching it needs the `Layers<C>` walk
+// `NoUnknownConfigKeys`'s JSDoc declines, and the fragment's declaration site is where it belongs.
+stitch({
+    path: '/things',
+    extends: [{ baseUrl: 'https://api.example.com', bogusInFragment: 1 }],
+});
 expectError(stitch({ path: '/things', extends: [{ bogusInFragment: 1 }] }));
 
 // A BOUND fragment carrying ONLY unknown keys is rejected too, though by a third mechanism again —
@@ -223,3 +330,7 @@ expectError(ch.events('tick', { retry: 2, bogusPmKey: 1 }));
 // belongs to `RequestOptions` only, and authoring it on `emit`/`events` is dead config.
 expectError(ch.emit('fire', { retry: 2, reply: 'pong' }));
 expectError(ch.events('tick', { retry: 2, reply: 'pong' }));
+
+// The three bags embed `Partial<Omit<StitchConfig, …>>`, so they carry the same house envelopes and
+// take the nested guard too.
+expectError(ch.request('ping', { retry: { attempts: 2, nonsense: 1 } }));

--- a/packages/core/test/circuit-breaker.spec.ts
+++ b/packages/core/test/circuit-breaker.spec.ts
@@ -342,10 +342,11 @@ describe('the open → half-open boundary is `cooldown`, and only `cooldown`', (
         expect(opts.cooldown).toBe('30s');
     });
 
-    // The removal is NOT caught at the `circuit:` slot, only on a direct annotation as above:
-    // `NoUnknownKeys` guards top-level `StitchConfig` keys, and a nested envelope inside an
-    // inferred `const C` gets no excess-property check (`retry: { nonsense }` compiles too). So a
-    // stale config would silently get a DIFFERENT boundary. The nudge is what makes it loud.
+    // The `circuit:` slot rejects it too, since `NoUnknownNestedKeys` began descending into the
+    // house envelopes — when this test was written only the direct annotation above was guarded,
+    // and a stale key at the slot compiled clean. The runtime nudge is now the SECOND line of
+    // defence rather than the only one: it still fires for JS callers and for anyone who silences
+    // the error, which is exactly what the suppression below stands in for.
     test('a stale `halfOpenAfter` warns at construction rather than changing timing in silence', () => {
         const warn = vi
             .spyOn(console, 'warn')
@@ -355,8 +356,8 @@ describe('the open → half-open boundary is `cooldown`, and only `cooldown`', (
                 name: 'orders',
                 baseUrl: 'https://api.test',
                 path: '/svc',
-                // No `@ts-expect-error` here on purpose — this compiles CLEAN, which is the gap
-                // the nudge covers. If a future EPC fix makes this line an error, delete the test.
+                // @ts-expect-error — rejected at the slot now; suppressed so the RUNTIME nudge
+                // below is still exercised on the shape a JS caller can still hand us.
                 circuit: { failures: 1, cooldown: '30s', halfOpenAfter: '60s' },
             });
             expect(warn).toHaveBeenCalledTimes(1);

--- a/scripts/check-unknown-keys.mjs
+++ b/scripts/check-unknown-keys.mjs
@@ -14,10 +14,17 @@
 // the parameter with `NoUnknownKeys<C, Allowed, What>` (packages/core/src/types.ts), which maps
 // `Exclude<keyof C, keyof Allowed>` onto a `ConfigError` brand naming the key.
 //
-// This gate is the RATCHET that keeps it closed: every generic-inferred option bag must either
-// carry a guard or be listed in scripts/unknown-keys.baseline.json WITH A REASON. A new unguarded
-// surface fails the build, so the decision is made deliberately rather than by omission — the same
-// shape as the API meta-contract ratchet in check-contract.mjs.
+// This gate is the RATCHET that keeps it closed, in two rules — the same shape as the API
+// meta-contract ratchet in check-contract.mjs, where a decision must be made deliberately rather
+// than by omission. Both record their exceptions in scripts/unknown-keys.baseline.json WITH A
+// REASON:
+//
+//   RULE 1 (surfaces) — every generic-inferred option bag must carry a guard or be baselined.
+//   RULE 2 (nested)   — every house envelope reachable from a guarded bag (`StitchConfig` and
+//                       the four that intersect it) must appear in the `NestedEnvelopes` table in
+//                       packages/core/src/types.ts, or be baselined.
+//                       The suppression is depth-independent, but the FIX cannot be: see the
+//                       rule-2 block below for why the table is explicit rather than derived.
 //
 //   pnpm check:unknown-keys                        # check the working tree (CI/hook mode)
 //   node scripts/check-unknown-keys.mjs --list     # print every site, guarded and not
@@ -180,9 +187,211 @@ function collect() {
     return sites.sort((a, b) => a.key.localeCompare(b.key));
 }
 
+// ---- rule 2: nested house envelopes ---------------------------------------
+// Same bug class, one layer down, and the one that stayed open longest because it LOOKED closed.
+// `const C` is inferred from the whole config object, so a nested envelope is no more a fresh
+// literal than the root is — excess-property checking is suppressed at every depth:
+//
+//     stitch({ circuit: { failures: 1, cooldown: '30s', totalNonsense: 1 } })   // no error
+//
+// (The type test that used to "pin" nested coverage passed only because its case carried no valid
+// sibling, so weak-type detection rejected it — an attribution error, not coverage.)
+//
+// `NoUnknownNestedKeys` closes it over an EXPLICIT table, `NestedEnvelopes` in types.ts. Explicit
+// because a walk derived from `StitchConfig[K]` is not merely more expensive but WRONG: `output`
+// takes a `SchemaLike`, whose Zod arm is the phantom `{ _output: unknown }`, so a derived walk
+// reports `safeParse` on a real `z.object(…)` as a misspelling. Same for the pluggable seams
+// (`adapter`/`store`/`clock`/`trace`/`kind`/`auth`), where unknown keys are the extension point.
+//
+// A hand-maintained table goes stale by omission, which is exactly what a ratchet is for: this rule
+// walks `StitchConfig` and every interface the table already covers, and flags any field that names
+// a house option bag but has no table entry.
+const CORE_TYPES = join(ROOT, 'packages', 'core', 'src', 'types.ts');
+
+// A house envelope by NAME. Deliberately suffix-based, like the rules above: it admits exactly the
+// `…Options` / `…Schemas` bags this repo authors and never matches the duck-typed slots
+// (`SchemaLike`, `Adapter`, `Clock`, `StitchStore`, `TraceSink`, `AuthStrategy`, `Surface`,
+// `DriftSpec`), which must NOT be walked. `Hooks` predates the suffix system and is listed by hand.
+const ENVELOPE_NAME = /\b([A-Z]\w*(?:Options|Schemas))\b/g;
+const EXTRA_ENVELOPES = new Set(['Hooks']);
+
+const stripComments = (s) =>
+    s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+
+// Split `s` on `sep` seen at nesting depth 0. `=>` is masked first: its `>` would otherwise read as
+// a closing bracket and drive the depth negative on every function-valued field (`keyOf`, `next`).
+function splitTop(s, sep) {
+    const text = s.replace(/=>/g, '__');
+    const out = [];
+    let depth = 0;
+    let cur = '';
+    for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        if ('<([{'.includes(ch)) depth++;
+        else if ('>)]}'.includes(ch)) depth--;
+        if (ch === sep && depth === 0) {
+            out.push(cur);
+            cur = '';
+        } else cur += s[i];
+    }
+    out.push(cur);
+    return out.map((p) => p.trim()).filter(Boolean);
+}
+
+function interfaceBody(text, name) {
+    const re = new RegExp(
+        String.raw`(?:export\s+)?interface\s+${name}\s*(?:extends[^{]+)?\{`,
+    );
+    const m = re.exec(text);
+    if (!m) return null;
+    let depth = 1;
+    let i = m.index + m[0].length;
+    for (; i < text.length && depth > 0; i++) {
+        if (text[i] === '{') depth++;
+        else if (text[i] === '}') depth--;
+    }
+    return text.slice(m.index + m[0].length, i - 1);
+}
+
+const fieldsOf = (body, sep = ';') =>
+    splitTop(body, sep)
+        .map((f) => /^(\w+)\??\s*:\s*([\s\S]+)$/.exec(f))
+        .filter(Boolean)
+        .map((m) => ({ name: m[1], type: norm(m[2]) }));
+
+// `[Bag, 'Bag', object]` or `[Bag, 'Bag', { slot: [...] }]` → { type, children }.
+function parseNode(txt) {
+    const parts = splitTop(
+        txt.trim().replace(/^\[/, '').replace(/\]$/, ''),
+        ',',
+    );
+    const kidsTxt = parts.slice(2).join(',').trim();
+    const children = {};
+    if (kidsTxt.startsWith('{'))
+        for (const f of fieldsOf(kidsTxt.slice(1, -1), ','))
+            children[f.name] = parseNode(f.type);
+    return { type: parts[0], children };
+}
+
+// The declared members of `name`, whichever form it takes: an `interface`, or a `type` alias whose
+// right-hand side intersects an object literal (`type LlmOptions = Partial<Omit<StitchConfig, …>> &
+// { provider: … }`). For the alias form only the LITERAL members are returned — the
+// `Partial<StitchConfig>` half is reached by walking `StitchConfig` itself, so returning it again
+// would double-report every envelope against a second owner.
+function declBody(text, name) {
+    const iface = interfaceBody(text, name);
+    if (iface !== null) return iface;
+    const m = new RegExp(String.raw`type\s+${name}\s*=`).exec(text);
+    if (!m) return null;
+    const { text: rhs } = spanTo(text, m.index + m[0].length, ';', 20000);
+    let body = '';
+    for (let i = 0; i < rhs.length; i++) {
+        if (rhs[i] !== '{') continue;
+        let depth = 1;
+        let j = i + 1;
+        for (; j < rhs.length && depth > 0; j++) {
+            if (rhs[j] === '{') depth++;
+            else if (rhs[j] === '}') depth--;
+        }
+        body += rhs.slice(i + 1, j - 1) + ';';
+        i = j - 1;
+    }
+    return body || null;
+}
+
+// The bag types every guarded/baselined surface infers into — `Partial<StitchConfig>`,
+// `LlmOptions`, `RequestOptions`… Each is a ROOT the nested walk must start from: they intersect
+// `Partial<Omit<StitchConfig, …>>` and then ADD their own fields, and a house envelope added there
+// would be just as unguarded as one added to `StitchConfig`, but invisible to a StitchConfig-only
+// walk. Type parameters (`Partial<TIn>`) are not resolvable to a declaration and are skipped.
+function rootBagsFrom(sites) {
+    const names = new Set(['StitchConfig']);
+    for (const s of sites)
+        for (const m of s.constraint.matchAll(
+            /\b([A-Z]\w*(?:Config|Options))\b/g,
+        ))
+            names.add(m[1]);
+    return [...names];
+}
+
+function collectNested(rule1Sites) {
+    const raw = readFileSync(CORE_TYPES, 'utf8');
+    const text = stripComments(raw);
+    const table = interfaceBody(text, 'NestedEnvelopes');
+    if (!table)
+        return {
+            sites: [],
+            error: 'NestedEnvelopes table not found in packages/core/src/types.ts',
+        };
+
+    const root = {};
+    for (const f of fieldsOf(table)) root[f.name] = parseNode(f.type);
+
+    // Every scanned source, so a root bag declared outside types.ts (`LlmOptions` in llm.ts, the
+    // postmessage bags in postmessage.ts) resolves.
+    const corpus = SCAN_ROOTS.flatMap((r) => walk(join(ROOT, r))).map((f) => ({
+        file: relative(ROOT, f).split('\\').join('/'),
+        raw: readFileSync(f, 'utf8'),
+    }));
+    const findDecl = (name) => {
+        for (const c of corpus) {
+            const body = declBody(stripComments(c.raw), name);
+            if (body !== null) return { body, file: c.file, raw: c.raw };
+        }
+        return null;
+    };
+
+    const sites = [];
+    const seen = new Set();
+    // Each root bag against the table, then each covered envelope against its own children.
+    const queue = rootBagsFrom(rule1Sites).map((owner) => ({
+        owner,
+        node: { children: root },
+        path: '',
+    }));
+    while (queue.length) {
+        const { owner, node, path } = queue.shift();
+        if (seen.has(owner)) continue;
+        seen.add(owner);
+        const decl = findDecl(owner);
+        if (!decl) continue;
+        const body = decl.body;
+        for (const field of fieldsOf(body)) {
+            const bags = [...field.type.matchAll(ENVELOPE_NAME)]
+                .map((m) => m[1])
+                .concat(
+                    [...EXTRA_ENVELOPES].filter((n) =>
+                        new RegExp(String.raw`\b${n}\b`).test(field.type),
+                    ),
+                );
+            if (!bags.length) continue;
+            // Key by OWNER too: the same slot name on two roots is two places to keep in sync, and
+            // a baseline entry for one must not silently discharge the other.
+            const at = path
+                ? `${path}.${field.name}`
+                : `${owner}.${field.name}`;
+            const child = node.children[field.name];
+            sites.push({
+                key: at,
+                owner,
+                slot: field.name,
+                bag: bags[0],
+                file: decl.file,
+                line: lineOf(decl.raw, decl.raw.indexOf(owner)),
+                covered: Boolean(child),
+            });
+            if (child) queue.push({ owner: child.type, node: child, path: at });
+        }
+    }
+    return { sites: sites.sort((a, b) => a.key.localeCompare(b.key)) };
+}
+
 // ---- ratchet --------------------------------------------------------------
 const args = new Set(process.argv.slice(2));
 const sites = collect();
+const nested = collectNested(sites);
+const nestedUncovered = (nested.sites ?? []).filter((s) => !s.covered);
+const nestedCovered = (nested.sites ?? []).filter((s) => s.covered);
 const unguarded = sites.filter((s) => !s.guarded);
 const guarded = sites.filter((s) => s.guarded);
 
@@ -198,6 +407,16 @@ if (args.has('--list')) {
             `  · ${s.file}:${s.line}  ${s.param}: <${s.typeParam} extends ${s.constraint}>`,
         );
     console.log(`\nTotal: ${sites.length} generic-inferred option bags.`);
+
+    console.log(`\nNESTED — IN THE TABLE (${nestedCovered.length}):`);
+    for (const s of nestedCovered)
+        console.log(`  ✓ ${s.key}  → ${s.bag}  (on ${s.owner})`);
+    console.log(`\nNESTED — NOT IN THE TABLE (${nestedUncovered.length}):`);
+    for (const s of nestedUncovered)
+        console.log(`  · ${s.key}  → ${s.bag}  (on ${s.owner})`);
+    console.log(
+        `\nTotal: ${(nested.sites ?? []).length} house-envelope slots reachable from a guarded bag.`,
+    );
     process.exit(0);
 }
 
@@ -207,6 +426,9 @@ if (args.has('--update')) {
         : { allowed: [] };
     const reasons = new Map(
         (prior.allowed ?? []).map((a) => [a.key, a.reason]),
+    );
+    const nestedReasons = new Map(
+        (prior.allowedNested ?? []).map((a) => [a.key, a.reason]),
     );
     writeFileSync(
         BASELINE,
@@ -222,13 +444,24 @@ if (args.has('--update')) {
                         reasons.get(s.key) ??
                         'TODO: state why this bag is safe unguarded, or guard it.',
                 })),
+                nestedNote:
+                    'House-envelope slots reachable from a guarded option bag that are deliberately ABSENT from the `NestedEnvelopes` table in packages/core/src/types.ts, and so get no nested unknown-key rejection. Same rule: every entry needs a `reason`.',
+                nestedCount: nestedUncovered.length,
+                allowedNested: nestedUncovered.map((s) => ({
+                    key: s.key,
+                    bag: s.bag,
+                    reason:
+                        nestedReasons.get(s.key) ??
+                        'TODO: add this slot to `NestedEnvelopes`, or state why it must stay open.',
+                })),
             },
             null,
             4,
         ) + '\n',
     );
     console.log(
-        `✓ Baseline rewritten: ${unguarded.length} allowed unguarded site(s).`,
+        `✓ Baseline rewritten: ${unguarded.length} allowed unguarded site(s), ` +
+            `${nestedUncovered.length} allowed un-tabled nested slot(s).`,
     );
     process.exit(0);
 }
@@ -287,7 +520,65 @@ if (added.length) {
     process.exit(1);
 }
 
+// ---- rule 2 gate ----------------------------------------------------------
+if (nested.error) {
+    console.error(`\n✗ ${nested.error}`);
+    console.error(
+        '  The nested rule reads that table to know which envelopes are covered. If it was ' +
+            'renamed, update CORE_TYPES/`NestedEnvelopes` here to match.',
+    );
+    process.exit(1);
+}
+
+const allowedNested = new Map(
+    (baseline.allowedNested ?? []).map((a) => [a.key, a.reason]),
+);
+const nestedAdded = nestedUncovered.filter((s) => !allowedNested.has(s.key));
+const nestedStale = [...allowedNested.keys()].filter(
+    (k) => !nestedUncovered.some((s) => s.key === k),
+);
+const nestedUnreasoned = [...allowedNested.entries()].filter(
+    ([, reason]) => !reason || /^TODO/i.test(reason),
+);
+
+if (nestedStale.length) {
+    console.log(
+        `\n✓ ${nestedStale.length} nested baseline entr(ies) now covered by the table — shrink it ` +
+            'with `node scripts/check-unknown-keys.mjs --update`:',
+    );
+    for (const k of nestedStale.sort()) console.log(`    ${k}`);
+}
+
+if (nestedUnreasoned.length) {
+    console.error(
+        `\n✗ ${nestedUnreasoned.length} nested baseline entr(ies) have no reason recorded:`,
+    );
+    for (const [k] of nestedUnreasoned) console.error(`    ${k}`);
+    process.exit(1);
+}
+
+if (nestedAdded.length) {
+    console.error(
+        `\n✗ ${nestedAdded.length} house-envelope slot(s) reachable from a guarded option bag with no ` +
+            '`NestedEnvelopes` entry — a misspelled or removed key inside them will typecheck and ' +
+            'be silently dropped:',
+    );
+    for (const s of nestedAdded)
+        console.error(`    ${s.key}  → ${s.bag}  (on ${s.owner})`);
+    console.error(
+        '\n  Add the slot to `NestedEnvelopes` (packages/core/src/types.ts) as ' +
+            "`slot: [Bag, 'Bag', object]` — or, if the bag is deliberately open (a pluggable seam, " +
+            'a foreign object), baseline it with `node scripts/check-unknown-keys.mjs --update` and ' +
+            'record a reason.',
+    );
+    process.exit(1);
+}
+
 console.log(
     `✓ Unknown-key guards: ${guarded.length} guarded, ` +
         `${allowed.size} allowed unguarded (baselined).`,
+);
+console.log(
+    `✓ Nested house envelopes: ${nestedCovered.length} in the table, ` +
+        `${allowedNested.size} allowed un-tabled (baselined).`,
 );


### PR DESCRIPTION
## The bug

`NoUnknownConfigKeys` guards a config's **top-level** keys. Nested envelopes were believed covered by excess-property checking. They are not:

```ts
stitch({ path: '/x', circuit: { failures: 1, cooldown: '30s', totalNonsense: 1 } }); // typechecked
stitch({ path: '/x', retry: { attempts: 2, backoff: { curve: 'fixed', baseMs: 100 } } }); // typechecked
```

`const C` is inferred from the **whole** config object, so the envelope is no more a fresh literal than the root is — EPC is suppressed at every depth. Any nested rename or removal was therefore unsafe: every stale call site kept compiling.

## Why it read as closed

[`unknown-config-keys.test-d.ts`](packages/core/test-d/unknown-config-keys.test-d.ts) asserted *"Nested envelopes and inline fragments were already covered by EPC… Pinned so it stays true."* Both pinning cases carried **no valid sibling**, so weak-type detection did the rejecting and got the credit — the exact attribution error that file's own preamble warns about. Add one sibling and the rejection vanishes.

The `NoUnknownKeys` JSDoc's related claim — that an inline `extends` fragment "still gets ordinary excess-property checking" — was wrong for the same reason. Both are corrected.

Note the JSDoc's "deliberate cost decision" was about not walking `Layers` (the cross-layer `extends` axis), which is orthogonal to nesting. This gap was never actually weighed.

## The fix

`NoUnknownNestedKeys` covers **17 slots across two levels** — the 13 envelopes plus `wire.multipart`, `retry.backoff`, `stream.buffer`, `sse.reconnect` — and binds all nine authoring surfaces. Errors name the key *and* the envelope it was misspelled against:

```
`totalNonsense` is not a CircuitOptions slot — check the spelling
```

The second level is not hypothetical: rc.5's `baseMs`→`base` / `maxMs`→`max` renames happened there.

**The table is explicit, not derived — a correctness requirement, not a cost tweak.** A walk derived from `StitchConfig[K]` descends into `output`, whose `SchemaLike` Zod arm is the phantom `{ _output: unknown }`; a real `z.object(…)` carries dozens of keys past it, so every config that validates anything would fail with `safeParse` reported as a misspelling. Same for every pluggable seam (P21), where an unknown key *is* the extension point. Verified by probe before designing around it.

## Cost — measured, not estimated

On core's 625-call-site typecheck project:

| | types | instantiations | check time |
|---|---|---|---|
| before | 73,501 | 240,876 | 1.09–1.25s |
| after | 78,621 | 269,975 | 1.06–1.07s |

+7% types, +12% instantiations, **no measurable check-time change**. Docs twoslash build, all downstream packages, and the runtime bundle unchanged.

One subtlety is load-bearing: the guard maps over the table's **fixed** key set, not `keyof C & keyof NestedEnvelopes`. Keying it on `C` makes the parameter type depend on the type being inferred, costing contextual typing for callback slots — six `TS7006 implicitly has an 'any' type` regressions on `adapter` / `transform`. Documented on the type so it doesn't get "simplified" back.

## Sweep

The class is confined to the generic-inferred surfaces, **swept rather than assumed**. Every other envelope-consuming surface takes its bag as a direct annotation and keeps EPC at nested depth — probed with a valid sibling present (so each rejection is attributable) on `seam`, `serve`, `createTrace`, `mockAdapter`, `oauth2`, `serveStdio`, `deltaFrame`, and `@stitchapi/shell`'s nested `buffer`. All reject.

## Ratchet rule 2

The table would go stale by omission, so `check-unknown-keys.mjs` grew a second rule: it walks **every root bag rule 1 found** — `StitchConfig` plus the four that intersect it (`LlmOptions`, `RequestOptions`, `EmitOptions`, `EventsOptions`, each adding its own fields) — and every interface the table covers, failing on any house `…Options`/`…Schemas` bag with no entry, at any depth. Negative-tested at both levels and on a non-`StitchConfig` root.

## Residual limit

Still fail-open through `extends`, at every depth — that is the cross-layer `Layers` axis, and a fragment's own declaration site is where its spelling is checked. Recorded honestly and pinned rather than closed.

## Verification

`check:format` · `check:lint` · workspace `check:types` · `check:types-d` (tsd) · **1395 tests / 137 files** · `check:exports` (attw) · `check:contract` · `check:unknown-keys` · `check:docs-links` · `check:release` · docs build (twoslash) · `check:size` (within budget) — all green.

15 new `expectError` cases all fire; 13 positive controls (scalar/positional shorthands, foreign schema objects) all compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)