### PR TITLE
test(fingerprint-zod): read v3 from `zod/v3`, not the bare `zod` specifier

### DIFF
--- a/packages/fingerprint-zod/test/conformance.spec.ts
+++ b/packages/fingerprint-zod/test/conformance.spec.ts
@@ -1,5 +1,8 @@
 // Conformance proof for the Zod fingerprint strategy, run against BOTH Zod
-// majors: the default `zod` import (v3 `_def`) and `zod/v4` (v4 `_zod.def`).
+// majors: `zod/v3` (v3 `_def`) and `zod/v4` (v4 `_zod.def`). Both subpaths are
+// pinned explicitly rather than reading v3 off the bare `zod` specifier — that
+// one tracks whichever major is installed (v3 on zod 3.25, v4 on zod 4), which
+// would quietly collapse both halves of this suite onto the same major.
 import { zodFingerprinter } from '../src';
 
 import {
@@ -8,7 +11,7 @@ import {
 } from 'stitchapi/testing';
 import type { FingerprintFixtures } from 'stitchapi/testing';
 import { describe, expect, it } from 'vitest';
-import { z } from 'zod';
+import { z } from 'zod/v3';
 import * as z4 from 'zod/v4';
 
 const fixtures: FingerprintFixtures = {


### PR DESCRIPTION
## What

The conformance suite proves the fingerprinter against both Zod majors — `z.*` fixtures for the v3 walker (`_def`/`typeName`), `z4.*` for the v4 one (`_zod.def`/`type`). But the v3 half read its schemas off the bare `zod` specifier, which does not mean "v3". It means "whichever major is installed":

| import | zod@3.25.76 | zod@4.4.3 |
| --- | --- | --- |
| `zod` | **v3** | **v4** |
| `zod/v3` | v3 | v3 |
| `zod/v4` | v4 | v4 |

So the suite covers two majors only by accident of the current devDependency. Move `zod` to 4 — as #589 proposes — and both halves silently become v4: the `v3()` walker goes entirely untested while `peerDependencies` still advertises `^3.24.0 || ^4.0.0`.

The contract does catch it, which is the one bit of luck. With both halves on v4 the fixtures become the same schema, so the `distinct` rule fires:

```
collisions: v4-obj-id collides with v3-obj-id; v4-obj-id-name collides with
v3-obj-id-name; v4-string-min2 collides with v3-string-min2
```

A collision report is a confusing way to learn that an import moved.

## The fix

Pin the subpath so the test states which major it means. `zod/v3` resolves to v3 under both zod 3.25 and zod 4, so this is correct now and stays correct after a v4 bump.

## Verified

- zod 3.25.76 (current): 12/12 pass, `check:types` exit 0
- zod 4.4.3: 12/12 pass, `check:types` exit 0 — versus 1 failure without this change

Worth landing on its own merits; it also unblocks #589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)