### PR TITLE
feat(pino): accept pino 10 in the peer range

### DIFF
--- a/packages/pino/README.md
+++ b/packages/pino/README.md
@@ -55,8 +55,8 @@ pinoSink(pino(), { lifecycle: false });
 This package **imports no logger** — it runs on a small structural
 `PinoLoggerLike` surface (`{ error, warn, info, debug, trace }`, plus an optional
 `child`). A real `pino()` instance, a `logger.child({ requestId })`, and a plain
-test double all satisfy it. `pino` is the single (peer) dependency, accepting both
-v8 and v9.
+test double all satisfy it. `pino` is the single (peer) dependency, accepting
+v8, v9, and v10.
 
 ## Security — metadata only, by design
 

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "stitchapi": "^1.0.0-rc.1",
-        "pino": "^8.0.0 || ^9.0.0"
+        "pino": "^8.0.0 || ^9.0.0 || ^10.0.0"
     },
     "devDependencies": {
         "@types/node": "^22.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -790,7 +790,7 @@ importers:
   packages/pino:
     dependencies:
       pino:
-        specifier: ^8.0.0 || ^9.0.0
+        specifier: ^8.0.0 || ^9.0.0 || ^10.0.0
         version: 9.14.0
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## What

Adds `^10.0.0` to `@stitchapi/pino`'s `pino` peer range, and updates the README line that spelled out "v8 and v9".

## Why this is safe

The package **imports no logger**. It runs entirely on a structural `PinoLoggerLike` — `{ error, warn, info, debug, trace }` plus an optional `child` — so the peer range is a support *declaration*, not a coupling. Nothing under `src/` touches a pino internal, and the test suite runs on plain doubles.

I checked pino 10.3.1 against that surface directly:

```
methods: error=function warn=function info=function debug=function trace=function
child: function
child methods: true
structured (obj,msg) accepted: true
string-only accepted: true
```

Both call forms this sink relies on still work. pino declares no `engines` in either 9 or 10, so the package's own `node >=18.18.0` floor is unaffected.

## Why it's needed

#588 moves `apps/docs` to pino 10. `apps/docs` depends on **both** `@stitchapi/pino` and `pino` directly, so without this the workspace installs a pino the adapter claims not to support and carries a standing unmet-peer warning on every install.

## Verified

- `pnpm check:format` / `check:contract` / `check:exports` — pass
- `@stitchapi/pino` tests — 13/13
- pre-commit full workspace typecheck — pass

Unblocks #588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)