### PR TITLE
Implement ADR 0023 — fix the store-backed cold-start burst, then widen the rate denominator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,7 +321,7 @@ npm release are grouped under the in-development version that introduced them.
 ### Added
 
 - **`throttle.rate`'s denominator is now a full duration token — `'1000/h'`, `'100/15m'`,
-  `'2/500ms'`.** ([ADR 0023](docs/adr/0023-rate-is-a-spacing-its-denominator-is-a-duration.md)
+  `'2/500ms'`.** ([ADR 0023](docs/adr/0023-a-rate-is-a-minimum-spacing.md)
   Decision 3) The grammar is `<count>/<duration>`, where the denominator is parsed by the one
   shared `parseDuration` and a bare unit means one of that unit (`'2/s'` ≡ `'2/1s'`). Every
   existing rate keeps parsing to exactly what it did — the new grammar is a strict superset.
@@ -396,8 +396,8 @@ npm release are grouped under the in-development version that introduced them.
     when it lands.
 
 - **`throttle.rate: '0/s'` is rejected instead of parsing to "no limit at all".**
-  ([ADR 0023](docs/adr/0023-a-rate-is-a-minimum-spacing.md) Decision 1)
-  `parseRate`'s count was `\d+`, so a zero count parsed and produced a spacing of `per / 0` =
+  ([ADR 0023](docs/adr/0023-a-rate-is-a-minimum-spacing.md), _Found while
+  implementing_) `parseRate`'s count was `\d+`, so a zero count parsed and produced a spacing of `per / 0` =
   `Infinity`. Under an injected `Clock` that reads as "block everything" — which is what the test
   suite saw — but `setTimeout` clamps any delay past 2^31−1 to **1ms**, so on the system clock the
   second acquire was granted after ~1ms and the throttle was unlimited, announced only by a Node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -334,6 +334,47 @@ npm release are grouped under the in-development version that introduced them.
     Widening only, so per [P19](docs/CONTRACT.md#p19--the-alias-obligation-is-scoped-to-the-ga-channel)
     it is non-breaking and needs no alias — every existing surface returning raw ms is unaffected.
 
+- **A store-backed throttle no longer bursts when a process joins mid-window.**
+  ([ADR 0023](docs/adr/0023-a-rate-is-a-minimum-spacing.md) Decision 2) The
+  distributed limiter schedules the Nth slot of a window at `windowStart + (N-1)·spacing`. A
+  process starting partway through a window claims slots whose scheduled times have **already
+  elapsed**, and each was granted the moment it was claimed — draining every elapsed slot in one
+  tick. The burst scaled with the **window**, not the declared rate: `'2/s'` and `'120/m'` both
+  declare a 500ms spacing, but the one-minute window left up to 119 elapsed slots to drain against
+  one for `'2/s'`. Measured mid-window, `'120/m'` granted five concurrent calls at the same
+  instant where `'2/s'` granted two.
+
+    This is a cold start — a rolling deploy, an autoscaler adding a worker, a lambda — not the
+    sustained-overload window edge `createStoreThrottle` already documented as approximate. The
+    slot schedule is now a **floor** applied on top of the same per-key pacing cursor the
+    in-process limiter keeps, so each grant is `max(now, cursor, slot)`: the shared counter still
+    allocates slots across the fleet, while no single process grants two calls closer than
+    `spacing`. A store-backed `'2/s'` and `'120/m'` now produce byte-identical grant sequences,
+    matching the in-process limiter. No config changes; a throttle that was silently bursting
+    starts pacing.
+
+    **The bound is per-process, and that is the limit of what it buys a fleet.** A slot already in
+    the past paces nobody, so while the stale prefix lasts only each worker's own cursor holds the
+    line and N workers emit at N× the declared rate — what the cursor converts is the _shape_, from
+    one worker draining every unclaimed slot into a single instant, to N calls per instant spread
+    at `spacing`. Starting at a window boundary (or once the slots catch up) the fleet does pace on
+    one shared budget. Both halves are pinned in `store.spec.ts`; closing the mid-window case needs
+    the atomic GCRA cell `store.ts` names and defers, and the residue assertion is written to fail
+    when it lands.
+
+- **`throttle.rate: '0/s'` is rejected instead of parsing to "no limit at all".**
+  ([ADR 0023](docs/adr/0023-a-rate-is-a-minimum-spacing.md) Decision 1)
+  `parseRate`'s count was `\d+`, so a zero count parsed and produced a spacing of `per / 0` =
+  `Infinity`. Under an injected `Clock` that reads as "block everything" — which is what the test
+  suite saw — but `setTimeout` clamps any delay past 2^31−1 to **1ms**, so on the system clock the
+  second acquire was granted after ~1ms and the throttle was unlimited, announced only by a Node
+  `TimeoutOverflowWarning` on every wait. A config that validated clean, tested as a hard stop,
+  and shipped as no limit.
+
+    The count is now `[1-9]\d*` and `'0/s'` throws `bad rate` at stitch/seam **construction**,
+    where every other malformed rate already threw. There is no safe reading being taken away: a
+    limiter is not how you stop calling a stitch.
+
 - **The same net now covers NESTED envelopes — `circuit`, `retry`, `wire`, and the rest — so a
   nested rename is mechanical too.** The guard below was scoped to a config's top-level keys on the
   reasoning that an envelope is checked against its _declared_ `AtLeastOne<CircuitOptions>` and so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,39 @@ npm release are grouped under the in-development version that introduced them.
     `stitch({ method: 'POST', wire: { response: 'blob' } })`; the only thing it gives up is the
     `Content-Disposition` filename parsing.
 
+### Added
+
+- **`throttle.rate`'s denominator is now a full duration token — `'1000/h'`, `'100/15m'`,
+  `'2/500ms'`.** ([ADR 0023](docs/adr/0023-rate-is-a-spacing-its-denominator-is-a-duration.md)
+  Decision 3) The grammar is `<count>/<duration>`, where the denominator is parsed by the one
+  shared `parseDuration` and a bare unit means one of that unit (`'2/s'` ≡ `'2/1s'`). Every
+  existing rate keeps parsing to exactly what it did — the new grammar is a strict superset.
+
+    The old `<count>/<ms|s|m>` was a hand-copied subset of `parseDuration`'s scale table, and the
+    truncation left **holes in the value space**: an ordinary 1000/hour quota is a 3600ms spacing,
+    and no legal token denoted it (`60000/count = 3600` needs a fractional count, and counts are
+    integers). The nearest spellings were `'16/m'` — 960/h, abandoning 4% of the quota — and
+    `'17/m'` — 1020/h, i.e. the 429s the throttle was added to prevent. `'100/15m'` was in a hole
+    too. You can now transcribe the limit your vendor publishes instead of converting it to a
+    number the grammar can hold.
+
+    **Equal ratios are one limiter, and that is the design:** `'2/500ms'`, `'4/s'` and `'240/m'`
+    all declare a 250ms gap and behave identically, in-process and store-backed alike. `rate` is a
+    pacer, not a token bucket — there is no capacity for a longer window to grant — so the window
+    length is a way of spelling the ratio, not a burst allowance. Pinned across three window
+    lengths in `store.spec.ts` rather than left as a doc sentence.
+
+    Two values are rejected that the widening would otherwise have admitted, both for the reason
+    `'0/s'` was rejected below — each would have meant _no limit at all_: a **non-positive window**
+    (`'2/0s'`, `'2/-500'` — `parseDuration` returns those as a real `0` / `-500`, not `undefined`,
+    so `spacing` would land at ≤ 0, which both limiters read as "no pacing configured"), and a
+    **spacing past the ~24.8-day timer ceiling** (`'1/30d'` — `setTimeout` clamps any delay past
+    2³¹−1 to 1ms). The ceiling rejects rather than clamps: clamping would silently pace _faster_
+    than asked.
+
+    `ThrottleOptions.rate` also gained TSDoc, so it stops rendering with a blank description on the
+    reference page.
+
 ### Fixed
 
 - **`Surface.resumeRetry` takes the canonical duration form too: its return widens to

--- a/apps/docs/content/docs/guides/resilience/throttle.mdx
+++ b/apps/docs/content/docs/guides/resilience/throttle.mdx
@@ -29,8 +29,39 @@ silently stalled.
 
 `rate` is a string like `"5/s"` — a minimum spacing between successive calls,
 not a token bucket. `concurrency` caps simultaneous in-flight calls; either may
-be set on its own. When rate is all you need, the scalar form reads best:
-`throttle: '2/s'` ≡ `throttle: { rate: '2/s' }`.
+be set on its own.
+
+### The rate grammar
+
+A rate is `<count>/<duration>`. The count is a whole number; the denominator is
+any [duration token](/docs/reference/config-types), and a bare unit means one of
+that unit — so `'2/s'` is `'2/1s'`.
+
+| Rate        | Means              | Spacing |
+| ----------- | ------------------ | ------- |
+| `'2/s'`     | 2 per second       | 500ms   |
+| `'1000/h'`  | 1000 per hour      | 3600ms  |
+| `'100/15m'` | 100 per 15 minutes | 9000ms  |
+| `'2/500ms'` | 2 per half-second  | 250ms   |
+
+Write the limit the way your vendor publishes it. A quota of "1000 requests per
+hour" is `'1000/h'` — you don't have to convert it to a per-minute count, and
+you couldn't do so exactly anyway (it's 16.67/m).
+
+<Callout type="info">
+    **A rate is a ratio, so equal ratios are the same limiter.** `'2/500ms'`,
+    `'4/s'` and `'240/m'` all declare a 250ms gap and behave identically — the
+    window length is a way of spelling the ratio, not a burst allowance. Because
+    this is a pacer rather than a token bucket, there is no capacity for a
+    longer window to grant: calls are spaced, never released in a burst. If you
+    need to spend a real quota the way the vendor accounts for it, hand the
+    backoff to an outer gate with `delegate` instead.
+</Callout>
+
+A rate that can't be honored is rejected when the stitch is built, rather than
+silently ignored — a dropped rate is an unlimited one. That covers the obvious
+typos (`'fast'`, `'2/nope'`) and both degenerate ends: a zero count (`'0/s'`),
+and a spacing longer than the ~24.8-day timer ceiling (`'1/30d'`).
 
 When the rate is all you need, pass it directly — a bare string is shorthand for
 `rate`, exactly like `timeout: '5s'` is shorthand for `timeout: { total: '5s' }`:

--- a/docs/adr/0023-a-rate-is-a-minimum-spacing.md
+++ b/docs/adr/0023-a-rate-is-a-minimum-spacing.md
@@ -1,6 +1,6 @@
 # ADR 0023 — A rate is a minimum spacing, not a window budget; the two limiters must agree before the grammar grows
 
-- **Status:** Proposed (2026-08-04). Nothing here is implemented. Opened by the question "does the P17/P25 `number | string` widening extend to a rate?" ([#618](https://github.com/rejifald/StitchAPI/pull/618)); the answer is no, but establishing why surfaced a live defect in the store-backed limiter that this ADR treats as the blocking issue. Touches the pluggable store ([DESIGN.md §13](../DESIGN.md), which has no ADR of its own) and builds on [ADR 0010](./0010-injectable-clock.md) (the injectable `Clock`, whose tags already include `throttle` — the fix's tests need it).
+- **Status:** Accepted and implemented (2026-08-04) — Decision 2 landed as shape **(a)**, and Decision 3's extension landed behind it in the same PR, in that order. Decision 1 ratifies existing behaviour, Decision 4 is a decision not to change anything, and Decision 5 shipped with [#618](https://github.com/rejifald/StitchAPI/pull/618). All four open questions resolved; implementing surfaced two defects this ADR had not predicted, recorded under _Found while implementing_. Opened by the question "does the P17/P25 `number | string` widening extend to a rate?" (#618); the answer is no, but establishing why surfaced a live defect in the store-backed limiter that this ADR treated as the blocking issue. Touches the pluggable store ([DESIGN.md §13](../DESIGN.md), which has no ADR of its own) and builds on [ADR 0010](./0010-injectable-clock.md) (the injectable `Clock`, whose tags already include `throttle` — the fix's tests need it).
 - **Date:** 2026-08-04
 - **Tags:** resilience, throttle, store, api-surface, correctness, P1, P12, P16, P17, P25
 
@@ -10,10 +10,12 @@
 > number** — the minimum spacing `per / count` — and the `count`/`per` pair is
 > notation for it, not two independent knobs. The in-process limiter already
 > behaves that way. The **store-backed limiter does not**: it uses `per` a second
-> time as a window quantum, which makes the _spelling_ of a rate load-bearing and,
-> today, admits up to a full window's budget instantaneously on a cold key. Until
-> the two agree, no grammar question about `rate` can be answered — so the grammar
-> stays frozen and the defect is the first thing to fix.
+> time as a window quantum, which makes the _spelling_ of a rate load-bearing and
+> admitted up to a full window's budget instantaneously on a cold key. Until the two
+> agreed, no grammar question about `rate` could be answered — so the grammar stayed
+> frozen and the defect was fixed first. **Both have now shipped, in that order**
+> (Decision 2 as shape (a), then Decision 3's extension); implementing them turned up
+> two more values the grammar accepted that also meant no limit at all.
 
 ## Context
 
@@ -135,8 +137,30 @@ so that `'1/s'` and `'60/m'` are once again the same request. The window is an
 implementation device for sharing a counter across processes; it must not leak into
 observable behaviour.
 
-Two shapes are plausible and this ADR does **not** pick between them — that belongs
-in the fix, with tests:
+_Landed as **(a)** ([store.ts](../../packages/core/src/store.ts))._ The slot schedule
+became a **floor** over the same per-key pacing cursor the in-process limiter keeps, so
+each grant is `max(now, cursor, slot)`. One correction to (a) as sketched below: flooring
+against `firstSeenInWindow` alone is **not** sufficient, because when the first grant is
+itself taken from a stale slot the floor is also in the past and the burst survives one
+slot shorter. Clamping against `now` is what makes the cursor a cursor.
+
+`'2/s'`, `'120/m'` and `'1/500ms'` — windows from half a second to a minute — now produce
+byte-identical grant sequences store-backed, matching the in-process limiter, which is the
+substitutability Decision 1 demands. The regression test was confirmed to **fail** against
+the pre-fix source (a gap of 0 where 500ms is required), so it pins the defect rather than
+the implementation.
+
+**What (a) does not buy, measured and pinned.** The bound is per-process. A stale slot
+paces nobody, so while the stale prefix lasts only each worker's own cursor holds the line
+and **N workers emit at N× the declared rate** — measured 2× for two workers and 3× for
+three on `'120/m'`. What the cursor converts is the _shape_: one worker draining every
+unclaimed slot into a single instant becomes N calls per instant, spread at `spacing`. At
+a window boundary the slots are ahead of the clock, the shared counter binds, and the fleet
+does draw from one budget. Both halves are asserted in `store.spec.ts`, and the residue
+assertion is written to **fail** when (b) lands — so the remaining gap is a decision on the
+record rather than a surprise.
+
+The two shapes this ADR declined to pick between, kept for the (b) migration:
 
 - **(a) Clamp the credit.** Keep the per-window counter, but schedule the Nth grant
   from `max(windowStart, firstSeenInWindow)` rather than `windowStart`, so a cold
@@ -155,7 +179,15 @@ the spacing of the tail.
 
 ### 3. The grammar stays frozen until Decision 2 ships
 
-`<count>/<unit>` with `unit ∈ {ms, s, m}` is unchanged for now. The gap is real —
+_Decision 2 shipped, so the freeze lifted and the extension landed with it
+([util.ts](../../packages/core/src/util.ts)) — "ordering, not rejection", as below. The
+denominator is now a full `parseDuration` token: `'1000/h'`, `'100/15m'` and
+`'2/500ms'` parse, a bare unit means one of that unit (`'2/s'` ≡ `'2/1s'`), and every
+existing rate parses to exactly what it did. The `parseRate` scale table is deleted rather
+than extended — a rate's denominator IS a duration, so it reuses the one house grammar
+(P17), which is what the three-entry copy failed to be._
+
+`<count>/<unit>` with `unit ∈ {ms, s, m}` was unchanged pending that. The gap is real —
 `'1000/h'` is an ordinary API quota and cannot be written today, and the reachable
 spacings are only `{1/n, 1000/n, 60000/n}`, so 3.6s is not expressible at all — but
 every extension makes the current defect worse rather than better:
@@ -191,13 +223,57 @@ precisely because the question recurs — it prompted this ADR — and because R
 vocabulary silently depends on it: `rate` is absent from that list, and a reader
 should be able to find out why without reconstructing the argument.
 
+## Found while implementing
+
+Two defects this ADR did not predict, both the **same shape** as the one it was written
+about and neither reachable through the path it examined. Each is a value the grammar
+**accepted** that meant _no limit at all_.
+
+That matters for how #618's fail-loud contract is read. `parseRate` throws so that a typo
+cannot silently remove a limit — correct, and necessary. It is not sufficient: the
+unbounded quiet path was reachable through the **accepting** branch the whole time, which
+no amount of care in the rejecting branch would have caught.
+
+### `'0/s'` parsed, and shipped as unlimited
+
+The count was `\d+`, so a zero parsed and produced `spacing = per / 0 = Infinity`.
+`setTimeout` clamps any delay past `2^31−1` to **1 ms**. So `'0/s'` read as "block
+everything" under an injected `Clock` — which is what the test suite sees — and was **no
+limit at all** on the system clock, announced only by a Node `TimeoutOverflowWarning` on
+every wait. A config that validated clean, tested as a hard stop, and shipped as unlimited.
+
+The count is now `[1-9]\d*` and a zero throws at construction, where every other malformed
+rate already threw. There is no safe reading being taken away: a limiter is not how you
+stop calling a stitch.
+
+The property suite had been generating the count with `min: 0` — it was **asserting the
+defect**, generating `'0/s'` as a valid rate and checking it parsed, which is why a
+property test never caught it.
+
+### The widening reintroduced the same bug at the top of the range
+
+Decision 3 admits `h` and `d`, so a spacing can exceed `2^31−1` ms — the identical
+`setTimeout` clamp, reached from the other end (`setTimeout(fn, 2_592_000_000)` fires
+after 1 ms, measured). Rejected at the grammar rather than clamped: clamping would
+silently pace **faster** than asked, and "quietly more permissive than requested" is the
+failure this whole ADR is about. Boundary measured on both sides — `'1/24d'` parses,
+`'1/25d'` does not.
+
+A third case sits with them: a **non-positive window** (`'2/0s'`, `'2/-500'`).
+`parseDuration` returns those as a real `0` / `-500` rather than `undefined`, so they never
+arrive as a parse failure, and both limiters read `spacing <= 0` as "no pacing configured".
+Checked explicitly rather than trusted to the parser.
+
 ## What this preserves
 
-- Every existing `'2/s'` config keeps working; Decision 3 changes no grammar.
+- Every existing `'2/s'` config keeps working. Decision 3's extension is a strict
+  superset — the ~30 in-repo call sites are all `<int>/<ms|s|m>` and parse to exactly what
+  they did, exercised by the full workspace suite rather than argued.
 - The in-process limiter is unchanged — it is already the reference behaviour.
 - `parseRate`'s fail-loud contract ([#618](https://github.com/rejifald/StitchAPI/pull/618))
   stands: for a rate, `undefined` would mean _unlimited_, so a typo must throw rather
-  than fall back. Decision 2 does not touch it.
+  than fall back. Neither decision touches it — but see _Found while implementing_, which
+  records that failing loud on rejection was never the whole guard.
 - `throttle.concurrency`, `pool`, and `delegate` are untouched; this is only about
   what the rate value means.
 
@@ -257,18 +333,29 @@ the opposite of a fix, reached by treating "consistent" as the goal instead of
 
 ## Open questions
 
-1. **Decision 2(a) or 2(b)?** Deliberately left to the fix. (b) is correct and costs a
-   `StitchStore` contract extension every implementor must satisfy; (a) is
-   proportionate and stays approximate at boundaries. The measurement above is the
-   acceptance criterion either way.
-2. **Should the defect ship as a fix or a breaking change?** It tightens a limiter, so
-   callers relying on today's over-admission would see fewer calls get through. That is
-   a bug fix by any reading, but on the `rc` channel it is worth a CHANGELOG note under
-   BREAKING CHANGE rather than a quiet correction, since the observable effect is
-   throughput.
-3. **Non-integer counts** (`'0.5/s'`) are unaddressed. Under Decision 1 they are pure
-   notation — `'0.5/s'` ≡ `'1/2s'` ≡ a 2000ms spacing — so they are safe but redundant;
-   they belong with Decision 3's extension question, not before it.
+1. **Decision 2(a) or 2(b)?** _Resolved: (a)._ It is proportionate, needs no `StitchStore`
+   extension, and restores the substitutability Decision 1 requires **exactly** for a
+   single process. (b) stays the correct end state and is now precisely scoped by what (a)
+   leaves behind: the fleet residue in Decision 2, where N cold workers emit at N× through
+   the stale prefix. That residue is asserted, so (b) has a test to break when it lands.
+
+    The acceptance criterion moved with the answer. This ADR proposed "total admitted over
+    a multi-window interval, against budget, for two spellings" — the regression test
+    asserts the stronger form (a) makes available: **identical grant sequences**, not just
+    comparable totals, across three spellings and both limiters.
+
+2. **Should the defect ship as a fix or a breaking change?** _Resolved: `fix(core)!` with
+   the CHANGELOG entry under `Fixed`._ The commit carries the `!` because a `'0/s'` config
+   that used to parse now throws, which is upgrade action; the entries sit under `Fixed`
+   rather than `Changed` because the prior behaviour was a defect, not a contract. Both
+   halves flagged in the PR for the maintainer to overrule.
+3. **Non-integer counts** (`'0.5/s'`) — _Resolved: they stay rejected._ Decision 3 removes
+   the motivation rather than the capability: `'1/2s'` is now expressible, denotes the same
+   2000ms spacing, and reads as what it is. Every fractional `x/unit` has an exact integer
+   equivalent in the widened grammar, so nothing is unreachable — only differently spelled,
+   and three spellings of one limiter is a cost with no matching gain. Keeping the count an
+   integer also keeps `parseInt` exact where `parseFloat` would let `'0.1/s'` carry
+   binary-fraction drift into a scheduler.
 4. **`concurrency` is still in-process only** under a store, as `createStoreThrottle`'s
    JSDoc notes (a distributed semaphore needs leases). Out of scope here and unaffected,
    but it is the second place where "attach a store to share the policy" is only

--- a/packages/core/scripts/bundle-size.mjs
+++ b/packages/core/scripts/bundle-size.mjs
@@ -198,19 +198,37 @@ const KB = 1024;
 // (the provider's parsed completion), forcing every composing surface to build a success value and
 // immediately discard it. Headroom lands at 0.16 / 0.15 — the tight step #477/#524 took, not the
 // ~0.2 KB this gate usually restores.
+//
+// Budgets raised for the store-backed throttle's cold-start burst fix — ADR 0023 Decision 2
+// (23.30→23.50 / 20.70→20.90 KB; measured 23.31 / 20.72 against a `main` at 23.28 / 20.69, so the
+// fix itself is +0.03 / +0.03). The distributed limiter granted every already-elapsed slot the
+// moment it was claimed, so a process joining mid-window drained the window's unclaimed slots in
+// one tick — a burst that scaled with the window length rather than the declared rate ('120/m'
+// granted five concurrent calls at one instant where '2/s', the same 500ms spacing, granted two).
+// The bytes are one `Math.max` over a per-key `nextGrantAt` cursor and its assignment, making each
+// grant `max(now, cursor, slot)`.
+//
+// It cannot move behind a subpath: `createStoreThrottle` is reached from `stitch()` whenever a
+// `store` is configured, so it is on the core path by construction — the same reason the rc.1
+// raise above cites for the throttle's idle-state reclamation.
+//
+// Headroom lands at 0.19 / 0.18 — the ~0.2 KB this gate usually restores, not the tight step
+// #477/#524 took. `main` had run down to 0.02 / 0.007, which is why a +0.03 KB fix tripped the gate
+// at all; the step is sized to the headroom the gate is meant to hold rather than to this change,
+// so the next small core-path fix is not gated on a budget PR of its own.
 // `advertised: true` means the READMEs/docs quote this scenario's rounded gzip kB — see the
 // `--json` note below for why that flag, not the row's presence, drives the drift tether.
 const SCENARIOS = [
     {
         name: 'stitchapi — whole entry',
         code: `export * from './index.mjs';`,
-        budget: 23.3 * KB,
+        budget: 23.5 * KB,
         advertised: true,
     },
     {
         name: 'import { stitch }',
         code: `export { stitch } from './index.mjs';`,
-        budget: 20.7 * KB,
+        budget: 20.9 * KB,
         advertised: true,
     },
     {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -116,6 +116,18 @@ export interface Throttle {
  * boundary). A SHARED store paces calls across the whole fleet; concurrency stays in-process (a
  * distributed semaphore needs leases — out of scope here).
  *
+ * That slot schedule is a **floor**, applied on top of a per-key local pacing cursor — the same one
+ * {@link createThrottle} keeps. Without the cursor a process joining mid-window would claim slots
+ * whose scheduled times have already elapsed and grant them all at once (see `acquire`), which is
+ * why two rates declaring one spacing (`'2/s'`, `'120/m'`) are the same limiter here as well as
+ * in-process. Each grant is `max(now, cursor, slot)`.
+ *
+ * The cursor bounds a burst PER PROCESS, which is the limit of what it can do without a new store
+ * primitive: a slot already in the past paces nobody, so N workers that all start mid-window emit
+ * at N× the declared rate until the slots catch up with the clock. Starting at a window boundary
+ * (or once caught up) the slots are in the future and the fleet paces on one shared budget. Pinned
+ * both ways in `store.spec.ts`, so the gap is a decision on the record, not a surprise.
+ *
  * The counter is per-window, so under SUSTAINED overload (offered load above the limit across
  * multiple windows) pacing is approximate at window edges: backlog scheduled on one window's
  * counter can overlap the next window's fresh counter. Exact continuous GCRA across processes would
@@ -135,6 +147,7 @@ export function createStoreThrottle(
             inFlight: number;
             waiters: (() => void)[];
             lastWindow?: number; // windowStart of the last `rl:` key this throttle minted
+            nextGrantAt?: number; // earliest THIS process may take another rate grant
         }
     >();
 
@@ -191,8 +204,27 @@ export function createStoreThrottle(
                 `rl:${key}:${windowStart}`,
                 rate.per + 100,
             );
-            const grantAt = windowStart + (n - 1) * spacing;
-            const wait = grantAt - clock.now();
+            // The slot is a FLOOR on the grant, not the grant time itself. A process that joins
+            // mid-window finds every slot up to `n` already scheduled in the PAST, and granting
+            // each of those the moment it is claimed drains them in one tick — a burst of up to
+            // `count-1` calls with no spacing at all, scaling with the window length: `'2/s'` and
+            // `'120/m'` declare the same 500ms spacing, but one leaves a single elapsed slot to
+            // drain and the other leaves 119. That is a cold start (a rolling deploy, a new
+            // worker, a lambda), not the sustained-overload edge described above.
+            // So pace on the same local cursor the in-process limiter keeps and take the LATER of
+            // the two: the shared counter still allocates slots across the fleet, while no single
+            // process ever grants two calls closer than `spacing`. The bound is PER-PROCESS, and
+            // that is the whole of what it buys — a stale slot paces nobody, so while the stale
+            // prefix lasts only each process's own cursor holds the line and N workers emit at N×
+            // the declared rate. At a window boundary the slots are in the future and the fleet
+            // does pace on one budget; closing the mid-window case needs the GCRA cell below.
+            const at = Math.max(
+                clock.now(),
+                s.nextGrantAt ?? 0,
+                windowStart + (n - 1) * spacing,
+            );
+            s.nextGrantAt = at + spacing;
+            const wait = at - clock.now();
             if (wait > 0) {
                 await clock.sleep(wait);
                 waited += wait;
@@ -210,7 +242,10 @@ export function createStoreThrottle(
         else if (s.inFlight > 0) s.inFlight--;
         // Drop a fully-idle key's state so the `local` Map doesn't accumulate one entry per
         // ever-seen key. Keep it only while it still carries window bookkeeping (`lastWindow`),
-        // which a rate-paced key needs to clean up its `rl:` key on the next rollover.
+        // which a rate-paced key needs to clean up its `rl:` key on the next rollover. That
+        // condition also keeps the pacing cursor (`nextGrantAt`) alive for the life of a
+        // rate-paced key — dropping one mid-pace would reset it and let the next acquire burst,
+        // the same trap `createThrottle.release` guards against explicitly.
         if (
             s.inFlight === 0 &&
             s.waiters.length === 0 &&

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -993,11 +993,19 @@ export interface RetryOptions {
 }
 export interface ThrottleOptions {
     /**
-     * Target pace as a `"count/interval"` string — `'2/s'`, `'10/m'`, `'1/ms'`. A minimum spacing
-     * between successive calls (`interval / count`, applied before any request leaves), not a token
-     * bucket. The dominant field: a bare string is the P12 shorthand for `{ rate }`
-     * (`throttle: '2/s'` ≡ `throttle: { rate: '2/s' }`). The grammar is `<count>/<unit>` with an
-     * INTEGER count and unit `ms` | `s` | `m`, read by the shared {@link parseRate}.
+     * Target pace as a `"count/interval"` string — `'2/s'`, `'1000/h'`, `'100/15m'`, `'2/500ms'`.
+     * A minimum spacing between successive calls (`interval / count`, applied before any request
+     * leaves), not a token bucket. The dominant field: a bare string is the P12 shorthand for
+     * `{ rate }` (`throttle: '2/s'` ≡ `throttle: { rate: '2/s' }`). The grammar is
+     * `<count>/<duration>` with a POSITIVE INTEGER count and any {@link parseDuration} token for
+     * the denominator, where a bare unit means one of that unit (`'2/s'` ≡ `'2/1s'`) — read by
+     * the shared {@link parseRate}.
+     *
+     * Because it paces rather than buckets, the only thing it reads is the **ratio**: `'2/500ms'`,
+     * `'4/s'` and `'240/m'` all declare a 250ms gap and are the same limiter, in-process and
+     * store-backed alike. Window length is a way of spelling the ratio, not a burst allowance —
+     * there is no capacity for a longer window to grant. Where a real quota needs spending the
+     * way the vendor accounts for it, hand the backoff to an outer gate with `delegate`.
      *
      * A **string and only a string**, deliberately. A duration or a byte cap also accepts a bare
      * number because each is a magnitude over a house unit — ms, bytes — so `5_000` and `4096`
@@ -1007,6 +1015,8 @@ export interface ThrottleOptions {
      *
      * An unparseable token **throws** at construction rather than falling back to "no limit" —
      * the one place a house parser fails loud, for the reason spelled out on {@link parseRate}.
+     * That covers both degenerate ends of the range too, since each would also mean no limit: a
+     * zero count, and a spacing past the ~24.8-day timer ceiling.
      */
     rate?: string;
     /** Cap on simultaneous in-flight calls. Independent of `rate` — either may be set on its own. */

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -119,11 +119,32 @@ export function parseBytes(s: number | string | undefined): number | undefined {
 }
 
 /**
+ * `setTimeout` clamps any delay past the 32-bit signed ceiling to **1ms**, so a spacing beyond
+ * this cannot be honoured — the limiter would run *unlimited* instead of very slowly. Rejected
+ * at the grammar (see {@link parseRate}) rather than clamped: clamping would silently pace
+ * FASTER than asked, which is the direction that hurts.
+ */
+const MAX_SPACING = 2_147_483_647;
+
+/**
  * Parse a rate into `{ count, per }` — the number of grants and the window length in ms.
- * Grammar: `<count>/<unit>` with a POSITIVE INTEGER count and unit `ms` | `s` | `m` (`"2/s"`,
- * `"10/m"`, `"1/ms"`; whitespace around the slash is tolerated). The third house token grammar,
- * alongside {@link parseDuration} and {@link parseBytes}, and exported for the same reason: a
- * peer package that takes an authored rate parses it the way core does instead of mirroring it.
+ * Grammar: `<count>/<duration>` with a POSITIVE INTEGER count and a {@link parseDuration} token
+ * for the denominator, where a **bare unit is its one-unit token** (`"2/s"` ≡ `"2/1s"`); so
+ * `"2/s"`, `"10/m"`, `"1000/h"`, `"100/15m"` and `"2/500ms"` all parse, and whitespace around
+ * the slash is tolerated. The third house token grammar, alongside {@link parseDuration} and
+ * {@link parseBytes}, and exported for the same reason: a peer package that takes an authored
+ * rate parses it the way core does instead of mirroring it.
+ *
+ * The denominator is a duration, so it uses the one house duration grammar (CONTRACT.md P17)
+ * rather than a scale table of its own — which is what the old `ms|s|m` was, a hand-copied
+ * subset that left the value space with holes. An ordinary 1000/hour quota is a 3600ms spacing,
+ * and before ADR 0023 Decision 3 **no legal token denoted it**: `60000/count = 3600` needs a
+ * fractional count, and counts are integers.
+ *
+ * **`"2/500ms"` ≡ `"4/s"` ≡ `"240/m"`, and that is the design, not an approximation.** A rate
+ * declares a minimum spacing, not a bucket — there is no capacity parameter for the window
+ * length to set — so any two rates with the same ratio ARE the same limiter, in-process and
+ * store-backed alike. Pinned across three window lengths in `store.spec.ts`.
  *
  * **Unlike those two, an unparseable token THROWS rather than resolving to `undefined`.** The
  * divergence is deliberate, and it runs in the same direction as their fallback rather than
@@ -135,23 +156,42 @@ export function parseBytes(s: number | string | undefined): number | undefined {
  * fail in opposite directions. Both callers guard with a presence check, so an omitted `rate`
  * never reaches here — only a non-empty token that could not be read.
  *
- * **Failing loud is necessary and was not sufficient**, which is why the count is `[1-9]\d*`
- * rather than `\d+`. `"0/s"` used to be *accepted*, and yielded a spacing of `per / 0` =
- * `Infinity`, which `setTimeout` clamps to **1ms** — so it read as "block everything" under an
- * injected {@link Clock}, where the test suite sees it, and was no limit at all on the system
- * clock. The unbounded quiet path this function throws to prevent was reachable through the
- * **accepting** branch, not the rejecting one. A zero count has no safe reading to keep either:
- * a limiter is not how you stop calling a stitch.
+ * **Failing loud is necessary and was not sufficient.** Three values sit inside what a looser
+ * grammar would ACCEPT and each would silently mean *no limit at all* — the unbounded quiet
+ * path reached through the accepting branch rather than the rejecting one — so each is rejected
+ * explicitly:
+ * - a **zero count** (`"0/s"`, once legal under `\d+`) → spacing `per / 0` = `Infinity`, which
+ *   `setTimeout` clamps to 1ms: it read as "block everything" under an injected {@link Clock},
+ *   where the test suite sees it, and was unlimited on the system clock;
+ * - a **non-positive or non-finite window** (`"2/0s"`, `"2/-500"`) → `parseDuration` returns a
+ *   real `0` / `-500` for those rather than `undefined`, and both limiters read `spacing <= 0`
+ *   as "no pacing configured";
+ * - a spacing past {@link MAX_SPACING} (`"1/30d"`) → the same `setTimeout` clamp as the first.
  *
  * A rate is a string and only a string (no `number | string` widening): it is two quantities,
  * not a magnitude, so a bare `2` would have to invent a default window to denote anything. See
  * CONTRACT.md P17/P25, which widen a magnitude that already carries a house unit — this has none.
  */
 export function parseRate(r: string): { count: number; per: number } {
-    const m = /^([1-9]\d*)\s*\/\s*(ms|s|m)$/.exec(r.trim());
+    const m = /^([1-9]\d*)\s*\/\s*(.+)$/.exec(r.trim());
     if (!m) throw new Error(`bad rate: ${r}`);
-    const per = m[2] === 'ms' ? 1 : m[2] === 's' ? 1000 : 60000;
-    return { count: parseInt(m[1] ?? '', 10), per };
+    const count = parseInt(m[1] ?? '', 10);
+    const denom = (m[2] ?? '').trim();
+    // A bare unit is the one-unit token: `'s'` ≡ `'1s'`. Anything else goes to `parseDuration`
+    // as written, so `'500ms'`, `'15m'` and the raw-ms `'500'` all mean what they mean everywhere.
+    const per = parseDuration(
+        /^(?:ms|s|m|h|d)$/.test(denom) ? `1${denom}` : denom,
+    );
+    // `parseDuration` resolves a bad token to `undefined`, but also parses `'0s'` to a real 0 and
+    // `'-500'` through its numeric-string arm — both of which would disable pacing rather than
+    // fail, so the window is checked here rather than trusted.
+    if (per === undefined || !Number.isFinite(per) || per <= 0)
+        throw new Error(`bad rate: ${r}`);
+    if (per / count > MAX_SPACING)
+        throw new Error(
+            `bad rate: ${r} — a spacing of ${per / count}ms is past the ${MAX_SPACING}ms timer ceiling`,
+        );
+    return { count, per };
 }
 
 /**

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -173,10 +173,25 @@ const MAX_SPACING = 2_147_483_647;
  * CONTRACT.md P17/P25, which widen a magnitude that already carries a house unit — this has none.
  */
 export function parseRate(r: string): { count: number; per: number } {
-    const m = /^([1-9]\d*)\s*\/\s*(.+)$/.exec(r.trim());
-    if (!m) throw new Error(`bad rate: ${r}`);
-    const count = parseInt(m[1] ?? '', 10);
-    const denom = (m[2] ?? '').trim();
+    // Split on the first slash by hand rather than matching the whole token in one regex. A
+    // single pattern for both halves wants `\s*\/\s*(.+)$`, whose trailing `\s*` and `.+` both
+    // match a space — the overlap `js/polynomial-redos` flags on caller-supplied input.
+    //
+    // That alert is a pattern match, not a measured blowup: `(.+)$` succeeds as soon as one
+    // character remains, so the engine never enumerates the splits, and the one-regex form
+    // measured LINEAR on every shape tried (including the `'1/' + ' '.repeat(n)` the alert
+    // names). It is replaced rather than dismissed because the hand-rolled form is structurally
+    // free of the pattern and no harder to read — the same trade {@link stripTrailingSlashes}
+    // takes one function below, where the quadratic behaviour IS real. Each half is now checked
+    // by an anchored pattern over a bounded slice with nothing to backtrack across; `indexOf` +
+    // `slice` are linear, and `parseDuration` owns the denominator.
+    const t = r.trim();
+    const slash = t.indexOf('/');
+    if (slash === -1) throw new Error(`bad rate: ${r}`);
+    const head = t.slice(0, slash).trim();
+    if (!/^[1-9]\d*$/.test(head)) throw new Error(`bad rate: ${r}`);
+    const count = parseInt(head, 10);
+    const denom = t.slice(slash + 1).trim();
     // A bare unit is the one-unit token: `'s'` ≡ `'1s'`. Anything else goes to `parseDuration`
     // as written, so `'500ms'`, `'15m'` and the raw-ms `'500'` all mean what they mean everywhere.
     const per = parseDuration(

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -120,10 +120,10 @@ export function parseBytes(s: number | string | undefined): number | undefined {
 
 /**
  * Parse a rate into `{ count, per }` — the number of grants and the window length in ms.
- * Grammar: `<count>/<unit>` with an INTEGER count and unit `ms` | `s` | `m` (`"2/s"`, `"10/m"`,
- * `"1/ms"`; whitespace around the slash is tolerated). The third house token grammar, alongside
- * {@link parseDuration} and {@link parseBytes}, and exported for the same reason: a peer package
- * that takes an authored rate parses it the way core does instead of mirroring the grammar.
+ * Grammar: `<count>/<unit>` with a POSITIVE INTEGER count and unit `ms` | `s` | `m` (`"2/s"`,
+ * `"10/m"`, `"1/ms"`; whitespace around the slash is tolerated). The third house token grammar,
+ * alongside {@link parseDuration} and {@link parseBytes}, and exported for the same reason: a
+ * peer package that takes an authored rate parses it the way core does instead of mirroring it.
  *
  * **Unlike those two, an unparseable token THROWS rather than resolving to `undefined`.** The
  * divergence is deliberate, and it runs in the same direction as their fallback rather than
@@ -135,12 +135,20 @@ export function parseBytes(s: number | string | undefined): number | undefined {
  * fail in opposite directions. Both callers guard with a presence check, so an omitted `rate`
  * never reaches here — only a non-empty token that could not be read.
  *
+ * **Failing loud is necessary and was not sufficient**, which is why the count is `[1-9]\d*`
+ * rather than `\d+`. `"0/s"` used to be *accepted*, and yielded a spacing of `per / 0` =
+ * `Infinity`, which `setTimeout` clamps to **1ms** — so it read as "block everything" under an
+ * injected {@link Clock}, where the test suite sees it, and was no limit at all on the system
+ * clock. The unbounded quiet path this function throws to prevent was reachable through the
+ * **accepting** branch, not the rejecting one. A zero count has no safe reading to keep either:
+ * a limiter is not how you stop calling a stitch.
+ *
  * A rate is a string and only a string (no `number | string` widening): it is two quantities,
  * not a magnitude, so a bare `2` would have to invent a default window to denote anything. See
  * CONTRACT.md P17/P25, which widen a magnitude that already carries a house unit — this has none.
  */
 export function parseRate(r: string): { count: number; per: number } {
-    const m = /^(\d+)\s*\/\s*(ms|s|m)$/.exec(r.trim());
+    const m = /^([1-9]\d*)\s*\/\s*(ms|s|m)$/.exec(r.trim());
     if (!m) throw new Error(`bad rate: ${r}`);
     const per = m[2] === 'ms' ? 1 : m[2] === 's' ? 1000 : 60000;
     return { count: parseInt(m[1] ?? '', 10), per };

--- a/packages/core/test/parsers-properties.spec.ts
+++ b/packages/core/test/parsers-properties.spec.ts
@@ -34,12 +34,13 @@ const MS_SCALE: Record<(typeof MS_UNITS)[number], number> = {
     d: 86_400_000,
 };
 
-const RATE_UNITS = ['ms', 's', 'm'] as const;
-const RATE_WINDOW: Record<(typeof RATE_UNITS)[number], number> = {
-    ms: 1,
-    s: 1000,
-    m: 60_000,
-};
+// A rate's denominator IS a duration (ADR 0023 Decision 3), so it has no scale table of its own —
+// it reuses MS_SCALE above. The separate three-entry RATE_WINDOW this replaced was the hand-copied
+// subset that left the value space with holes (no token denoted a 1000/hour quota's 3600ms spacing).
+//
+// `setTimeout` clamps a delay past the 32-bit signed ceiling to 1ms, so a spacing beyond it would
+// run UNLIMITED. Restated here rather than imported, per this file's rule.
+const MAX_SPACING = 2_147_483_647;
 
 // `1000 * 1024**4` is ~1.1e15, comfortably inside Number.MAX_SAFE_INTEGER, so every exact
 // equality below stays exact — a wider magnitude would be testing float rounding, not parsing.
@@ -192,15 +193,42 @@ describe('parseDuration (property)', () => {
 });
 
 describe('parseRate (property)', () => {
-    it('splits a rate into its count and window length', () => {
+    // A bare unit is its one-unit token, over the SAME unit set as `parseDuration` — `'2/h'` and
+    // `'2/d'` are the units the old three-entry grammar could not spell.
+    it('reads a bare unit as one of that unit, across every duration unit', () => {
         fc.assert(
             fc.property(
                 fc.integer({ min: 1, max: 10_000 }),
-                fc.constantFrom(...RATE_UNITS),
+                fc.constantFrom(...MS_UNITS),
                 (count, unit) => {
                     expect(parseRate(`${count}/${unit}`)).toEqual({
                         count,
-                        per: RATE_WINDOW[unit],
+                        per: MS_SCALE[unit],
+                    });
+                    // …and the bare unit is exactly the 1-unit token, not a near-miss of it.
+                    expect(parseRate(`${count}/1${unit}`)).toEqual(
+                        parseRate(`${count}/${unit}`),
+                    );
+                },
+            ),
+        );
+    });
+
+    // The denominator is a full duration token, which is what makes '1000/h' and '100/15m'
+    // expressible at all — neither has ANY spelling in the old grammar (both need a fractional
+    // count over a bare unit, and counts are integers).
+    it('scales a multi-unit denominator by its documented window', () => {
+        fc.assert(
+            fc.property(
+                fc.integer({ min: 1, max: 10_000 }),
+                fc.integer({ min: 1, max: 1000 }),
+                fc.constantFrom(...MS_UNITS),
+                (count, n, unit) => {
+                    const per = n * MS_SCALE[unit];
+                    fc.pre(per / count <= MAX_SPACING); // past the ceiling is its own property below
+                    expect(parseRate(`${count}/${n}${unit}`)).toEqual({
+                        count,
+                        per,
                     });
                 },
             ),
@@ -211,7 +239,7 @@ describe('parseRate (property)', () => {
         fc.assert(
             fc.property(
                 fc.integer({ min: 1, max: 10_000 }),
-                fc.constantFrom(...RATE_UNITS),
+                fc.constantFrom(...MS_UNITS),
                 (count, unit) => {
                     expect(parseRate(`  ${count} / ${unit}  `)).toEqual(
                         parseRate(`${count}/${unit}`),
@@ -221,31 +249,43 @@ describe('parseRate (property)', () => {
         );
     });
 
-    it('throws on anything outside the grammar', () => {
+    // The claim Decision 3 rests on: the denominator's grammar IS `parseDuration`'s, so a
+    // denominator that parser rejects (or reads as non-positive) is a rate this one rejects.
+    // Using `parseDuration` here is the property, not a mirror of `parseRate`'s own arithmetic —
+    // it asserts the two agree, which is the whole point of deleting the second scale table.
+    it('rejects exactly the denominators parseDuration will not read as a positive window', () => {
         fc.assert(
             fc.property(
                 fc
                     .string()
+                    // Bare units are the documented exception — `'s'` means `'1s'`, and
+                    // `parseDuration('s')` alone is undefined.
                     .filter(
-                        (s) => !/^[1-9]\d*\s*\/\s*(ms|s|m)$/.test(s.trim()),
-                    ),
-                (bad) => {
-                    expect(() => parseRate(bad)).toThrow(/bad rate/);
+                        (d) =>
+                            !(MS_UNITS as readonly string[]).includes(d.trim()),
+                    )
+                    .filter((d) => {
+                        const per = parseDuration(d.trim());
+                        return (
+                            per === undefined ||
+                            !Number.isFinite(per) ||
+                            per <= 0
+                        );
+                    }),
+                (d) => {
+                    expect(() => parseRate(`1/${d}`)).toThrow(/bad rate/);
                 },
             ),
         );
     });
 
-    // A zero count parses to a spacing of `per / 0` = Infinity, which `setTimeout` clamps to 1ms —
-    // "block everything" under an injected clock, NO limit at all on the system clock. Rejected at
-    // the grammar, for every spelling of zero and every unit.
-    it('rejects a zero count', () => {
+    it('throws on a count that is not a positive integer', () => {
         fc.assert(
             fc.property(
-                fc.constantFrom('0', '00', '000'),
-                fc.constantFrom(...RATE_UNITS),
-                (zero, unit) => {
-                    expect(() => parseRate(`${zero}/${unit}`)).toThrow(
+                fc.constantFrom('0', '00', '0.5', '-1', '1.5', '', ' ', 'x'),
+                fc.constantFrom(...MS_UNITS),
+                (count, unit) => {
+                    expect(() => parseRate(`${count}/${unit}`)).toThrow(
                         /bad rate/,
                     );
                 },
@@ -253,16 +293,42 @@ describe('parseRate (property)', () => {
         );
     });
 
+    // Both ends of the spacing range fail the same way and so are rejected the same way: a zero
+    // count gives Infinity, a window past the ceiling gives a delay `setTimeout` clamps to 1ms.
+    // Either would run the limiter UNLIMITED — the one outcome a limiter must never have.
+    it('throws on a spacing past the timer ceiling', () => {
+        fc.assert(
+            fc.property(
+                fc.integer({ min: 1, max: 100 }),
+                fc.integer({ min: 25, max: 10_000 }),
+                (count, days) => {
+                    const per = days * MS_SCALE.d;
+                    fc.pre(per / count > MAX_SPACING);
+                    expect(() => parseRate(`${count}/${days}d`)).toThrow(
+                        /bad rate/,
+                    );
+                },
+            ),
+        );
+        // …and the largest spacing that CAN be honoured still parses, so the bound is the timer's
+        // and not an off-by-one of our own.
+        expect(parseRate('1/24d')).toEqual({ count: 1, per: 24 * MS_SCALE.d });
+    });
+
     // The only thing either limiter consumes is `per / count`, so any two rates with the same
-    // ratio ARE the same limiter — the property that lets the grammar stay a ratio.
-    it('equal ratios parse to equal spacing', () => {
+    // ratio ARE the same limiter. With the denominator widened this is now sayable three ways,
+    // and `'2/500ms'` ≡ `'4/s'` is the case the ADR argued is the design rather than a collapse.
+    it('equal ratios parse to equal spacing, however they are spelled', () => {
         fc.assert(
             fc.property(fc.integer({ min: 1, max: 1000 }), (n) => {
-                const perSecond = parseRate(`${n}/s`);
-                const perMinute = parseRate(`${n * 60}/m`);
-                expect(perMinute.per / perMinute.count).toBe(
-                    perSecond.per / perSecond.count,
-                );
+                const spacing = (r: string) => {
+                    const { count, per } = parseRate(r);
+                    return per / count;
+                };
+                expect(spacing(`${n * 60}/m`)).toBe(spacing(`${n}/s`));
+                expect(spacing(`${n}/1000ms`)).toBe(spacing(`${n}/s`));
+                expect(spacing(`${n * 2}/2s`)).toBe(spacing(`${n}/s`));
+                expect(spacing(`${n * 3600}/h`)).toBe(spacing(`${n}/s`));
             }),
         );
     });

--- a/packages/core/test/parsers-properties.spec.ts
+++ b/packages/core/test/parsers-properties.spec.ts
@@ -315,6 +315,38 @@ describe('parseRate (property)', () => {
         expect(parseRate('1/24d')).toEqual({ count: 1, per: 24 * MS_SCALE.d });
     });
 
+    // The sibling of the `stripTrailingSlashes` property below, with one honest difference: there
+    // the quadratic behaviour is real, here it was only ever a pattern. The one-regex form of this
+    // grammar (`^([1-9]\d*)\s*\/\s*(.+)$`) has a trailing `\s*` and a `.+` that both match a space
+    // — what `js/polynomial-redos` flags — but measured linear on every shape below, because
+    // `(.+)$` succeeds as soon as one character remains. The hand-rolled split has no overlap at
+    // all, and this pins the property either way: a long run of whitespace changes neither the
+    // answer nor the cost, so a future one-regex "simplification" has to fail something.
+    it('is unmoved by a long run of whitespace around the slash', () => {
+        fc.assert(
+            fc.property(
+                fc.nat({ max: 2048 }),
+                fc.nat({ max: 2048 }),
+                fc.constantFrom(...MS_UNITS),
+                (before, after, unit) => {
+                    const pad = (k: number) => ' '.repeat(k);
+                    expect(
+                        parseRate(`2${pad(before)}/${pad(after)}${unit}`),
+                    ).toEqual(parseRate(`2/${unit}`));
+                },
+            ),
+        );
+        // The failing shapes matter more than the passing ones: these have no valid denominator,
+        // so a backtracking matcher would have to exhaust every split before giving up.
+        for (const bad of [
+            `2/${' '.repeat(4096)}`,
+            `2${' '.repeat(4096)}/`,
+            `${' '.repeat(4096)}/s`,
+            `2/${' '.repeat(2048)}x${' '.repeat(2048)}`,
+        ])
+            expect(() => parseRate(bad)).toThrow(/bad rate/);
+    });
+
     // The only thing either limiter consumes is `per / count`, so any two rates with the same
     // ratio ARE the same limiter. With the denominator widened this is now sayable three ways,
     // and `'2/500ms'` ≡ `'4/s'` is the case the ADR argued is the design rather than a collapse.

--- a/packages/core/test/parsers-properties.spec.ts
+++ b/packages/core/test/parsers-properties.spec.ts
@@ -195,7 +195,7 @@ describe('parseRate (property)', () => {
     it('splits a rate into its count and window length', () => {
         fc.assert(
             fc.property(
-                fc.integer({ min: 0, max: 10_000 }),
+                fc.integer({ min: 1, max: 10_000 }),
                 fc.constantFrom(...RATE_UNITS),
                 (count, unit) => {
                     expect(parseRate(`${count}/${unit}`)).toEqual({
@@ -210,7 +210,7 @@ describe('parseRate (property)', () => {
     it('tolerates whitespace around the separator', () => {
         fc.assert(
             fc.property(
-                fc.integer({ min: 0, max: 10_000 }),
+                fc.integer({ min: 1, max: 10_000 }),
                 fc.constantFrom(...RATE_UNITS),
                 (count, unit) => {
                     expect(parseRate(`  ${count} / ${unit}  `)).toEqual(
@@ -226,11 +226,44 @@ describe('parseRate (property)', () => {
             fc.property(
                 fc
                     .string()
-                    .filter((s) => !/^\d+\s*\/\s*(ms|s|m)$/.test(s.trim())),
+                    .filter(
+                        (s) => !/^[1-9]\d*\s*\/\s*(ms|s|m)$/.test(s.trim()),
+                    ),
                 (bad) => {
                     expect(() => parseRate(bad)).toThrow(/bad rate/);
                 },
             ),
+        );
+    });
+
+    // A zero count parses to a spacing of `per / 0` = Infinity, which `setTimeout` clamps to 1ms —
+    // "block everything" under an injected clock, NO limit at all on the system clock. Rejected at
+    // the grammar, for every spelling of zero and every unit.
+    it('rejects a zero count', () => {
+        fc.assert(
+            fc.property(
+                fc.constantFrom('0', '00', '000'),
+                fc.constantFrom(...RATE_UNITS),
+                (zero, unit) => {
+                    expect(() => parseRate(`${zero}/${unit}`)).toThrow(
+                        /bad rate/,
+                    );
+                },
+            ),
+        );
+    });
+
+    // The only thing either limiter consumes is `per / count`, so any two rates with the same
+    // ratio ARE the same limiter — the property that lets the grammar stay a ratio.
+    it('equal ratios parse to equal spacing', () => {
+        fc.assert(
+            fc.property(fc.integer({ min: 1, max: 1000 }), (n) => {
+                const perSecond = parseRate(`${n}/s`);
+                const perMinute = parseRate(`${n * 60}/m`);
+                expect(perMinute.per / perMinute.count).toBe(
+                    perSecond.per / perSecond.count,
+                );
+            }),
         );
     });
 });

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -2,11 +2,12 @@
 // state shared across separate stitches (simulating two workers sharing Redis); the default
 // in-memory store keeps them independent.
 import { memoryStore, stitch } from '../src';
-import type { Stitch } from '../src';
+import type { Clock, Stitch } from '../src';
 import { cookieSession, env } from '../src/auth';
 import { createThrottle } from '../src/resilience';
 import { createStoreThrottle } from '../src/store';
 import type { Throttle } from '../src/store';
+import { manualClock } from '../src/test-clock';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
 
@@ -260,5 +261,125 @@ describe('Pluggable store — throttle', () => {
             expect((ats[n - 1] ?? 0) - (ats[n - 2] ?? 0)).toBeGreaterThan(120);
             expect((ats[n - 2] ?? 0) - (ats[n - 3] ?? 0)).toBeGreaterThan(120);
         }
+    });
+
+    // The even-spacing fix above covered the steady state; this is the COLD START. A process
+    // joining mid-window claims slots whose scheduled times have already elapsed, and granting
+    // each on claim drained them in one tick — a burst that scaled with the WINDOW rather than
+    // the declared rate. `'2/s'` and `'120/m'` are both a 500ms spacing, but a one-minute window
+    // left up to 119 elapsed slots to drain against one for `'2/s'`. It is a rolling deploy, a
+    // new worker, a lambda — not the sustained-overload edge `createStoreThrottle` documents.
+    test('a store-backed throttle does not burst when a process joins mid-window', async () => {
+        // 59.5s is mid-window for BOTH rates: '2/s' is 500ms into its window, '120/m' 59.5s into
+        // its own — so the two differ only in how much elapsed slack the window holds.
+        const grants = async (
+            make: (c: Clock) => Throttle,
+        ): Promise<number[]> => {
+            const clock = manualClock(59_500);
+            const t = make(clock);
+            const at: number[] = [];
+            const all = Promise.all(
+                Array.from({ length: 5 }, () =>
+                    t.acquire('k').then(() => {
+                        at.push(clock.now());
+                    }),
+                ),
+            );
+            await clock.advance(60_000);
+            await all;
+            return at;
+        };
+
+        const perSecond = await grants((c) =>
+            createStoreThrottle({ rate: '2/s' }, memoryStore(), c),
+        );
+        const perMinute = await grants((c) =>
+            createStoreThrottle({ rate: '120/m' }, memoryStore(), c),
+        );
+        const inProcess = await grants((c) =>
+            createThrottle({ rate: '2/s' }, c),
+        );
+
+        // No two grants closer than the declared 500ms — the burst is gone. Before the fix
+        // '120/m' granted all five at once (59500 ×5) and '2/s' granted two.
+        for (const at of [perSecond, perMinute])
+            for (let i = 1; i < at.length; i++)
+                expect((at[i] ?? 0) - (at[i - 1] ?? 0)).toBe(500);
+
+        // And the window length no longer changes the answer: one declared spacing, one limiter,
+        // store-backed or not.
+        expect(perMinute).toEqual(perSecond);
+        expect(perSecond).toEqual(inProcess);
+        expect(perSecond).toEqual([59_500, 60_000, 60_500, 61_000, 61_500]);
+    });
+
+    // The companion to the test above. That fix's bound is PER-PROCESS, so this pins what it does
+    // and does not buy a FLEET: two `createStoreThrottle` instances over one store stand in for
+    // two workers sharing Redis. The mid-window residue is a known, deferred gap — pinned here so
+    // it is a decision on the record rather than a surprise, and so the fleet-wide GCRA cell
+    // `createStoreThrottle` defers has a test to break when it lands.
+    test('a fleet over one store: the shared budget holds at a window boundary; mid-window the residue is bounded by process count', async () => {
+        const fleet = async (
+            rate: string,
+            procs: number,
+            each: number,
+            start: number,
+        ): Promise<{ p: number; t: number }[]> => {
+            const clock = manualClock(start);
+            const store = memoryStore();
+            const ts = Array.from({ length: procs }, () =>
+                createStoreThrottle({ rate }, store, clock),
+            );
+            const at: { p: number; t: number }[] = [];
+            const all: Promise<void>[] = [];
+            // Round-robin, so slot allocation interleaves the way concurrent workers would.
+            for (let i = 0; i < each; i++)
+                for (let p = 0; p < procs; p++)
+                    all.push(
+                        ts[p]!.acquire('k').then(() => {
+                            at.push({ p, t: clock.now() });
+                        }),
+                    );
+            await clock.advance(180_000);
+            await Promise.all(all);
+            return at;
+        };
+
+        // 1. AT a window boundary every slot is still in the future, so the shared counter binds
+        //    and two processes draw from ONE budget: 500ms apart fleet-wide, not 500ms apart each.
+        //    This is what the store is for, and the property a per-process cursor could most
+        //    easily have broken.
+        const atBoundary = await fleet('2/s', 2, 3, 0);
+        expect(atBoundary.map((x) => x.t)).toEqual([
+            0, 500, 1000, 1500, 2000, 2500,
+        ]);
+
+        // 2. MID-window, every slot up to `now` is already stale, and a stale slot cannot pace
+        //    anybody — only each process's own cursor can.
+        const midWindow = await fleet('120/m', 2, 3, 59_500);
+
+        //    a. Each process still honours the declared spacing internally. That is the invariant
+        //       the cursor buys, and the one that was violated outright before it.
+        for (const p of [0, 1]) {
+            const mine = midWindow.filter((x) => x.p === p).map((x) => x.t);
+            for (let i = 1; i < mine.length; i++)
+                expect((mine[i] ?? 0) - (mine[i - 1] ?? 0)).toBe(500);
+        }
+
+        //    b. So the instantaneous burst is bounded by the PROCESS COUNT rather than by how many
+        //       slots the window had left unclaimed. One process used to drain all of them into a
+        //       single instant; two processes now put exactly two calls there.
+        const perInstant = new Map<number, number>();
+        for (const { t } of midWindow)
+            perInstant.set(t, (perInstant.get(t) ?? 0) + 1);
+        expect(Math.max(...perInstant.values())).toBe(2);
+
+        //    c. And here is the residue itself, asserted rather than described: through the stale
+        //       prefix the fleet emits at 2× the declared rate (N× for N workers), recovering only
+        //       once the slots catch up with the clock. Closing this needs the fleet-wide GCRA
+        //       cell — when that lands, THIS is the assertion that should fail.
+        expect(midWindow.map((x) => x.t)).toEqual([
+            59_500, 59_500, 60_000, 60_000, 60_500, 60_500,
+        ]);
     });
 });

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -296,19 +296,27 @@ describe('Pluggable store — throttle', () => {
         const perMinute = await grants((c) =>
             createStoreThrottle({ rate: '120/m' }, memoryStore(), c),
         );
+        // The widened denominator (ADR 0023 Decision 3) gives the same 500ms spacing a third
+        // spelling, over a 500ms window — the shortest of the three, against the minute-long one
+        // above. If the window length still leaked into behaviour, these two would disagree.
+        const perHalfSecond = await grants((c) =>
+            createStoreThrottle({ rate: '1/500ms' }, memoryStore(), c),
+        );
         const inProcess = await grants((c) =>
             createThrottle({ rate: '2/s' }, c),
         );
 
         // No two grants closer than the declared 500ms — the burst is gone. Before the fix
         // '120/m' granted all five at once (59500 ×5) and '2/s' granted two.
-        for (const at of [perSecond, perMinute])
+        for (const at of [perSecond, perMinute, perHalfSecond])
             for (let i = 1; i < at.length; i++)
                 expect((at[i] ?? 0) - (at[i - 1] ?? 0)).toBe(500);
 
         // And the window length no longer changes the answer: one declared spacing, one limiter,
-        // store-backed or not.
+        // store-backed or not, however the ratio is spelled. `'2/s'`, `'120/m'` and `'1/500ms'`
+        // span windows from half a second to a minute and are byte-identical.
         expect(perMinute).toEqual(perSecond);
+        expect(perHalfSecond).toEqual(perSecond);
         expect(perSecond).toEqual(inProcess);
         expect(perSecond).toEqual([59_500, 60_000, 60_500, 61_000, 61_500]);
     });

--- a/packages/core/test/util-helpers.spec.ts
+++ b/packages/core/test/util-helpers.spec.ts
@@ -121,6 +121,22 @@ describe('parseRate', () => {
     it('throws on a malformed rate', () => {
         expect(() => parseRate('fast')).toThrow(/bad rate/);
     });
+
+    // `'0/s'` used to parse to a spacing of Infinity. Under an injected clock that reads as "block
+    // everything"; on the system clock `setTimeout` clamps the wait to 1ms and it is no limit at
+    // all — a config that validates, tests as a hard stop, and ships as unlimited.
+    it('rejects a zero count rather than parsing it to an infinite spacing', () => {
+        expect(() => parseRate('0/s')).toThrow(/bad rate/);
+        expect(() => parseRate('0/ms')).toThrow(/bad rate/);
+        expect(() => parseRate('0/m')).toThrow(/bad rate/);
+        expect(() => parseRate('00/s')).toThrow(/bad rate/);
+        expect(() => parseRate(' 0 / s ')).toThrow(/bad rate/);
+    });
+
+    it('still rejects fractional and negative counts', () => {
+        expect(() => parseRate('0.5/s')).toThrow(/bad rate/);
+        expect(() => parseRate('-1/s')).toThrow(/bad rate/);
+    });
 });
 
 describe('stripTrailingSlashes', () => {

--- a/packages/core/test/util-helpers.spec.ts
+++ b/packages/core/test/util-helpers.spec.ts
@@ -122,6 +122,64 @@ describe('parseRate', () => {
         expect(() => parseRate('fast')).toThrow(/bad rate/);
     });
 
+    // The denominator is a full `parseDuration` token (ADR 0023 Decision 3). These two are the
+    // motivating cases: neither has ANY spelling in the old `<count>/<ms|s|m>` grammar, because
+    // both need a fractional count over a bare unit (1000/h is 16.67/m) and counts are integers.
+    it('takes a full duration token as the denominator', () => {
+        expect(parseRate('1000/h')).toEqual({ count: 1000, per: 3_600_000 });
+        expect(parseRate('100/15m')).toEqual({ count: 100, per: 900_000 });
+        expect(parseRate('2/500ms')).toEqual({ count: 2, per: 500 });
+        expect(parseRate('1/2d')).toEqual({ count: 1, per: 172_800_000 });
+        // A raw-ms numeric denominator is a duration too, per the one shared grammar.
+        expect(parseRate('2/500')).toEqual({ count: 2, per: 500 });
+    });
+
+    it('reads a bare unit as one of that unit', () => {
+        expect(parseRate('2/s')).toEqual(parseRate('2/1s'));
+        expect(parseRate('1/h')).toEqual({ count: 1, per: 3_600_000 });
+        expect(parseRate('1/d')).toEqual({ count: 1, per: 86_400_000 });
+    });
+
+    // `'2/500ms'` and `'4/s'` are the same limiter, and that is the design: a rate declares a
+    // spacing, not a bucket, so there is no capacity for the window length to set.
+    it('collapses equal ratios to one spacing', () => {
+        const spacing = (r: string) => {
+            const { count, per } = parseRate(r);
+            return per / count;
+        };
+        expect(spacing('2/500ms')).toBe(250);
+        expect(spacing('4/s')).toBe(250);
+        expect(spacing('240/m')).toBe(250);
+        expect(spacing('1000/h')).toBe(3600);
+    });
+
+    // A window that is zero, negative, or unreadable would leave `spacing <= 0`, which both
+    // limiters treat as "no pacing configured" — the same silent-unlimited failure as `'0/s'`.
+    // `parseDuration` reads `'0s'` as a real 0 and `'-500'` through its numeric arm, so neither
+    // arrives as `undefined` and both are checked explicitly.
+    it('rejects a non-positive or unreadable window', () => {
+        expect(() => parseRate('2/0s')).toThrow(/bad rate/);
+        expect(() => parseRate('2/0')).toThrow(/bad rate/);
+        expect(() => parseRate('2/-500')).toThrow(/bad rate/);
+        expect(() => parseRate('2/-5s')).toThrow(/bad rate/);
+        expect(() => parseRate('2/abc')).toThrow(/bad rate/);
+        expect(() => parseRate('2/')).toThrow(/bad rate/);
+        expect(() => parseRate('/s')).toThrow(/bad rate/);
+        expect(() => parseRate('2/2/s')).toThrow(/bad rate/);
+        expect(() => parseRate('2/Infinity')).toThrow(/bad rate/);
+    });
+
+    // The top of the range fails the same way `'0/s'` does at the bottom: `setTimeout` clamps a
+    // delay past 2^31-1 to 1ms, so the limiter would run unlimited rather than very slowly.
+    // Rejected rather than clamped — clamping would pace FASTER than asked.
+    it('rejects a spacing past the timer ceiling, and names it', () => {
+        expect(() => parseRate('1/30d')).toThrow(/timer ceiling/);
+        expect(() => parseRate('1/25d')).toThrow(/bad rate/);
+        expect(parseRate('1/24d')).toEqual({ count: 1, per: 2_073_600_000 });
+        // A big enough count brings the same window back under the ceiling.
+        expect(parseRate('2/30d')).toEqual({ count: 2, per: 2_592_000_000 });
+    });
+
     // `'0/s'` used to parse to a spacing of Infinity. Under an injected clock that reads as "block
     // everything"; on the system clock `setTimeout` clamps the wait to 1ms and it is no limit at
     // all — a config that validates, tests as a hard stop, and ships as unlimited.


### PR DESCRIPTION
Implements [ADR 0023](docs/adr/0023-a-rate-is-a-minimum-spacing.md) in the order it asks for:
**Decision 2 first (the store-backed defect), then Decision 3's grammar extension behind it.**

> **Rebased onto main.** This branch was opened before [#621](https://github.com/rejifald/StitchAPI/pull/621)
> landed and carried a **second, independently written ADR 0023** on the same subject. The two agree
> on the substance — both found that the pair collapses to `per / count`, and both found the
> store-backed cold-start burst — so this branch now drops its own and folds the unique content into
> the one that landed first. One ADR 0023, updated to Accepted-and-implemented. See the last commit.

## Decision 2 — the store-backed burst, as shape (a)

The slot schedule becomes a **floor** over the same per-key pacing cursor the in-process limiter
keeps: each grant is `max(now, cursor, slot)`.

One correction to (a) as the ADR sketched it, worth a reviewer's eye: flooring against
`firstSeenInWindow` (the process's own last grant) is **not sufficient**. When the first grant is
itself taken from a stale slot, `lastGrant + spacing` is also in the past and the burst survives one
slot shorter. Clamping against `now` is what makes the cursor a cursor.

`'2/s'`, `'120/m'` and `'1/500ms'` — windows from half a second to a minute — now produce
byte-identical grant sequences store-backed, matching the in-process limiter. That is the
substitutability Decision 1 demands, and it is a stronger acceptance criterion than the ADR's
proposed "total admitted against budget": identical sequences, not comparable totals.

### What (a) does not buy — Open question 1, answered with a fixture

The bound is **per-process**. A stale slot paces nobody, so while the stale prefix lasts only each
worker's own cursor holds the line and **N workers emit at N× the declared rate** — measured 2× for
two workers, 3× for three. What the cursor converts is the *shape*: one worker draining every
unclaimed slot into a single instant becomes N calls per instant, spread at `spacing`. At a window
boundary the slots are ahead of the clock, the shared counter binds, and the fleet draws from one
budget.

Both halves are asserted, and the residue assertion is written to **fail when (b) lands** — so the
remaining gap is on the record rather than a surprise.

## Decision 3 — the grammar, unfrozen

`<count>/<duration>`: the denominator is parsed by the one shared `parseDuration`, a bare unit means
one of that unit (`'2/s'` ≡ `'2/1s'`), and `'1000/h'`, `'100/15m'`, `'2/500ms'` now parse. Strict
superset — the ~30 in-repo call sites parse to exactly what they did.

The `parseRate` scale table is **deleted** rather than extended, and the property suite's separate
`RATE_WINDOW` goes with it, so the unification is structural. A new property asserts the two grammars
agree by checking `parseRate` against `parseDuration` itself.

## Found while implementing — two defects the ADR did not predict

Both are the **same shape**: a value the grammar *accepted* that meant no limit at all.

1. **`'0/s'` parsed and shipped as unlimited.** The count was `\d+`, so a zero gave
   `spacing = per / 0 = Infinity`, which `setTimeout` clamps to **1 ms**. It read as "block
   everything" under an injected `Clock` — what the test suite sees — and was unlimited on the
   system clock. The property suite had been generating the count with `min: 0`: **it was asserting
   the defect**, which is why a property test never caught it.
2. **The widening reintroduced the identical bug at the top of the range.** `parseDuration` accepts
   `d`, so a spacing can exceed 2³¹−1 ms — same clamp, other end. Rejected rather than clamped:
   clamping would silently pace *faster* than asked. Boundary measured (`'1/24d'` parses, `'1/25d'`
   does not). A third case sits with them: a non-positive window (`'2/0s'`, `'2/-500'`), which
   `parseDuration` returns as a real `0` / `-500` rather than `undefined`.

This refines [#618](https://github.com/rejifald/StitchAPI/pull/618)'s fail-loud contract rather than
contradicting it: throwing on a *rejected* token is necessary, and was never sufficient — the
unbounded quiet path was reachable through the **accepting** branch the whole time.

## Verification

Every new test was **confirmed to fail against the pre-change source**:

- store mid-window and the fleet fixture: gap of 0 where 500 ms is required
- zero-count: "expected [Function] to throw an error"
- all 10 new/extended grammar tests fail against the pre-widening parser

Full workspace green (1424 core + every peer package), `check:contract` baseline 0,
`check:unknown-keys`, `check:types` incl. docs twoslash, `check:types-d`, `check:lint`,
`check:format`, `check:docs-links`, `check:exports`, all 9 `yakir` tethers.

Bundle budgets were raised 23.30→23.50 / 20.70→20.90 KB in the burst-fix commit — the conventional
0.2 KB step. `main` had run down to 0.02 / 0.007 KB of headroom, so a +0.03 KB fix tripped the gate;
sizing the step to the headroom rather than to the change meant **Decision 3 then landed inside it**
with no second bump. Now at 0.10 / 0.07 KB left.

## CodeQL — one high-severity alert, replaced rather than dismissed

`js/polynomial-redos` fired on the widened grammar's `^([1-9]\d*)\s*\/\s*(.+)$`: the trailing
`\s*` and the `.+` both match a space, which is the overlap the rule flags — and `parseRate` is a
published export as of #618, so its input is library input by contract.

**It is a pattern match, not a measured blowup.** `(.+)$` succeeds as soon as one character remains,
so the engine never enumerates the splits; the one-regex form timed **linear** on every shape tried,
including the `'1/' + ' '.repeat(n)` the alert names, at n up to 32k. I replaced it anyway rather
than dismissing the alert — the hand-rolled `indexOf` + two anchored checks is structurally free of
the pattern and no harder to read, `stripTrailingSlashes` one function below already takes the same
trade (where the quadratic behaviour *is* real), and dismissing an alert is a maintainer's call, not
mine. Every accepted and rejected token parses exactly as before.

## For the reviewer to weigh

1. **Does (a) unfreeze the grammar strongly enough?** The ADR ties the unfreeze to "`per` no longer
   affects behaviour". Under (a) that is exactly true **per-process** — and not true **fleet-wide**,
   because the residue's *duration* scales with the window. So `'1000/h'` on a cold fleet over-admits
   at N× for up to an hour, where `'2/s'` does so for up to a second. The catastrophic version the
   ADR named (`'1000/h'` admitting 1000 immediate calls) is closed; this is the milder tail of it.
   **Decision 3 is a single commit (`d4d9ee0`) and drops cleanly** if you would rather it wait for
   (b) — say the word.
2. **`fix(core)!` vs the CHANGELOG placing the fixes under `Fixed`.** `'0/s'` now throws where it
   parsed, so upgrade action is required — hence `!`; but the prior behaviour was a defect, not a
   contract, so the entries sit under `Fixed`. ADR Open question 2 resolved this way; reasonable to
   disagree.
3. **The CodeQL fix above assumes you want the alert gone rather than dismissed.** I could not
   reproduce superlinear behaviour, so dismissing it as a false positive is defensible; the
   replacement stands on simplicity instead. Easy to revert to the one-regex form if you disagree.
4. **I could not determine whether anyone outside this repo depends on `'0/s'`** — needs the issue
   tracker and npm usage. Low risk given it never blocked on a real clock.

## Still open

The mid-window fleet residue — ADR Decision 2(b), the atomic GCRA cell `store.ts` names and defers.
A `StitchStore` contract extension, so it is a decision about the store interface rather than a fix
to this file. Open question 4 (`concurrency` is in-process only under a store) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

