### PR TITLE
fix(docs): render nested surface shapes and document resumable SSE

### DIFF
--- a/apps/docs/content/docs/reference/surfaces.mdx
+++ b/apps/docs/content/docs/reference/surfaces.mdx
@@ -80,6 +80,29 @@ for await (const ev of ticks.stream()) {
 
 <AutoTypeTable path="../../packages/core/src/sse.ts" name="SseEvent" />
 
+### Resumable SSE — sse.reconnect
+
+**Off by default**: with no `sse.reconnect` the engine opens the body exactly once. Turn
+it on and a dropped stream is reopened, replaying the last seen `id:` as the
+`Last-Event-ID` request header so the stream continues from where it broke.
+
+```ts
+const ticks = sse({
+    url: 'https://api.example.com/ticks',
+    sse: { reconnect: { attempts: 5, delay: '2s' } },
+});
+```
+
+<AutoTypeTable path="../../packages/core/src/types.ts" name="SseOptions" />
+
+`reconnect: true` is shorthand for the defaults; the object form tunes the cap and the
+fallback delay. A server-sent `retry:` on the dropped connection always wins over both.
+
+<AutoTypeTable
+    path="../../packages/core/src/types.ts"
+    name="ReconnectOptions"
+/>
+
 ## stream
 
 `stream` is the raw streaming sibling — it hands back the response body decoded
@@ -102,6 +125,21 @@ for await (const ev of logs.stream()) {
 ```
 
 <AutoTypeTable path="../../packages/core/src/types.ts" name="StreamOptions" />
+
+### stream.buffer
+
+Bounds what the decoder may hold for a single un-terminated unit — an unclosed JSON
+value, a line with no `\n`, or an SSE frame with no blank line — so a never-closing
+stream can't grow client memory without limit. The scalar is shorthand for the dominant
+field: `buffer: 4_000_000` ≡ `buffer: { chars: 4_000_000 }`.
+
+<AutoTypeTable
+    path="../../packages/core/src/types.ts"
+    name="StreamBufferOptions"
+/>
+
+The cap counts characters of the **decoded text**, not bytes off the socket, so it is not
+meaningful for `decode: 'bytes'` (raw and unbuffered).
 
 Streaming members open on the same auth/retry/throttle spine, with one twist:
 opening a stream **charges the rate limiter once** but **never holds a
@@ -154,6 +192,16 @@ const { blob, filename } = await getReport({
     path="../../packages/core/src/download.ts"
     name="DownloadResult"
 />
+
+### onProgress
+
+The per-call `onProgress` callback above receives one of these per tick. It is per-call,
+not config — a different bar per download:
+
+<AutoTypeTable path="../../packages/core/src/types.ts" name="AdapterProgress" />
+
+Which phases report depends on the adapter — see
+[Guide → Adapters](/docs/guides/transport/adapters).
 
 The surface owns the request shape, so `method` and `wire.response` are not
 accepted here — setting either is a compile error rather than a silently ignored

--- a/packages/core/src/download.ts
+++ b/packages/core/src/download.ts
@@ -27,7 +27,15 @@ import {
 
 /** What a `download` stitch resolves to: the buffered body and its parsed filename (when known). */
 export interface DownloadResult {
+    /**
+     * The whole response body, buffered. Saving it is the caller's choice — the surface never
+     * writes to disk, which is what keeps it browser-first.
+     */
     blob: Blob;
+    /**
+     * Name parsed from `Content-Disposition` (`filename*` preferred over `filename`), falling back
+     * to the response URL's last path segment. Absent when neither yields one.
+     */
     filename?: string;
 }
 

--- a/packages/core/src/sse.ts
+++ b/packages/core/src/sse.ts
@@ -40,9 +40,16 @@ import {
  * (the `sse` surface's `contractValue` points per-`delta` validation at `.data`).
  */
 export interface SseEvent<T = unknown> {
+    /** The event type, from an `event:` field. Present only when the event carried one. */
     event?: string;
+    /** The `data:` payload — JSON-parsed when it parses, else the raw string. */
     data: T;
+    /**
+     * The last-event id, from an `id:` field. Present only when the event carried one; it is what
+     * the engine replays as `Last-Event-ID` when {@link SseOptions.reconnect} is on.
+     */
     id?: string;
+    /** The server's reconnect hint in ms, from a `retry:` field. Present only when the event carried one. */
     retry?: number;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -843,6 +843,11 @@ export interface ReconnectOptions {
  * on this; other surfaces ignore it.
  */
 export interface SseOptions {
+    /**
+     * Reopen a dropped `text/event-stream` body and resume from the last seen `id:`. `true` enables
+     * it with defaults; the object form tunes the attempt cap and fallback delay (the opaque `{}` is
+     * rejected — P20). Omitted means off: the engine opens the body exactly once.
+     */
     reconnect?: boolean | AtLeastOne<ReconnectOptions>;
 }
 /**
@@ -851,8 +856,14 @@ export interface SseOptions {
  * sent, `'download'` as the response body arrives. `total` is the content length when known.
  */
 export interface AdapterProgress {
+    /**
+     * Which phase this tick reports: `'upload'` as the request body is sent, `'download'` as the
+     * response body arrives. Not every adapter reports both — see the transport guides.
+     */
     direction: 'upload' | 'download';
+    /** Bytes transferred so far in this direction. */
     loaded: number;
+    /** Total bytes, when the content length is known. Absent for a chunked or unknown-length body. */
     total?: number;
 }
 export interface AdapterRequest {


### PR DESCRIPTION
Follow-up to #616, applying the same treatment to **Request surfaces**.

## What

### 1. Four nested shapes were tabled nowhere on the site

`AutoTypeTable` renders only one level deep, so a field whose type is another interface never shows its inner fields. The page reached four shapes that had no table anywhere:

| Missing shape | Reached via | Fields |
| --- | --- | --- |
| `AdapterProgress` | the `onProgress` callback | 3 |
| `ReconnectOptions` | `sse.reconnect` | 2 |
| `StreamBufferOptions` | `stream.buffer` | 1 |
| `SseOptions` | `sse` | 1 |

`AdapterProgress` is the sharpest case: the page's **own** download example already reads `p.loaded` and `p.total` without anything on the site saying what `p` is.

### 2. Resumable SSE was undocumented site-wide

No page mentioned `sse.reconnect`, and the published docs bundle has nothing on it either — despite it being a real config feature (issue #71) with rich TSDoc already in the source. It now has a section under `sse` covering both its shapes, with the precedence rule that a server-sent `retry:` wins over the configured delay.

### 3. Ten fields rendered blank

The generator only reads TSDoc. These interfaces documented their members in **interface-level prose** rather than per-field comments, so every row came out empty: all four of `SseEvent`, both of `DownloadResult`, all three of `AdapterProgress`, and `SseOptions.reconnect`. Written from that existing prose plus the surfaces and transport guides. Comments only — no code change.

The Type column on this page was already fixed by the `preferWrittenType` transform in #616.

## Reviewer notes

- Placement follows the precedent set by `StreamOptions`, which already lives here rather than on Config types: stream/sse option shapes belong with the surface that reads them.
- `SseEvent.id` now carries an `{@link SseOptions.reconnect}` cross-reference, since the id **is** the thing replayed as `Last-Event-ID`.
- `AdapterProgress.direction` notes that not every adapter reports both phases, and links to the adapters guide rather than restating the per-adapter matrix.

## Verification

- **15/15 rows across 7 tables** (was 3 tables) carry a description and a real type name.
- Confirmed in the production build: all 7 tables, all three new headings (`resumable-sse--ssereconnect`, `streambuffer`, `onprogress`), and the new descriptions are present in `surfaces.html`. The only bare kind word left is a `z.object` code sample.
- Core tests (1411), all typechecks, eslint, prettier, production build — green. All 11 pre-push gates passed.

⚠️ **Unrelated pre-existing breakage on `main`:** `next dev` currently returns 500 on every docs page. A twoslash sample in `content/blog/compose-api-calls-into-a-pipeline.mdx` fails to compile (TS2769, `Stitch` missing `__composable`), which looks like fallout from the recent `pipe`/`Composable` work. I reproduced it on clean `main` with none of these changes applied, so it is not from this PR — but it means the dev server is unusable until it is fixed. `next build` is unaffected and passes, which is why CI stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)