### PR TITLE
fix(core)!: a store-backed throttle enforces its rate, and one rate has one behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,6 +320,39 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Fixed
 
+- **A store-backed `throttle` now actually enforces its rate, and two spellings of one rate
+  behave the same.** ([ADR 0023](docs/adr/0023-a-rate-is-a-minimum-spacing.md)) `'2/s'` and
+  `'120/m'` are the same rate — 500ms between calls either way — and under a shared store they
+  were not the same request. Against a budget of 8 calls, the store-backed limiter admitted **24**
+  for `'2/s'` and **79** for `'120/m'`; the in-process limiter admitted exactly 8 for both.
+
+    Two separate defects, with opposite skews. Grants were scheduled from the window's
+    epoch-aligned start, so a key first seen part-way through a window was credited with every slot
+    that had already elapsed — those grants sit in the past and all fire at once, an opening burst
+    of `count`, which is worst for a **long** window (`'120/m'` released a whole batch of 20
+    immediately; `'2/s'` released 1). And a window rollover restarted the schedule at `now`, running
+    the new window's slots through grants still pending past the boundary — worst for a **short**
+    window. Slots are now measured from the window's first arrival, published in the store by
+    whichever caller the atomic increment hands `n === 1`, and the schedule carries across a
+    rollover. Both spellings now sit exactly at budget, and the opening burst is one call.
+
+    This is the fixed-window burst the even-spacing design was introduced to prevent; the claim
+    held _within_ a window, and failed for a key that starts mid-window — which is every key in a
+    freshly started process. The existing test could not see it: it fires every acquire at once and
+    asserts on the tail of the schedule, where the overflow grants genuinely are spaced correctly.
+    The regression test is now total admitted against budget, for both spellings, plus the opening
+    burst — and each of the two fixes was reverted independently to confirm it is load-bearing.
+
+    Still not exact continuous GCRA across processes: the per-window counter reset and the
+    process-local schedule head are both approximations. Closing them needs an atomic
+    read-compute-write of a timestamp in the store, which the `StitchStore` contract does not offer
+    (its `increment` TTL is deliberately bound to the creating increment and never extended), so it
+    stays deferred — now with a clearer price.
+
+    **BREAKING CHANGE:** no API changes, but a store-backed `throttle` that was silently admitting
+    several times its configured rate will now hold the rate you asked for. If throughput drops after
+    upgrading, the limiter was over-admitting before and the new number is the one you configured.
+
 - **`Surface.resumeRetry` takes the canonical duration form too: its return widens to
   `number | string`.** The sibling of the `SurfaceOutcome.after` fix below, found by sweeping the
   surface under the new [P17](docs/CONTRACT.md#p17--one-canonical-duration-form)/[P25](docs/CONTRACT.md#p25--one-canonical-size-form)

--- a/docs/adr/0023-a-rate-is-a-minimum-spacing.md
+++ b/docs/adr/0023-a-rate-is-a-minimum-spacing.md
@@ -1,6 +1,6 @@
 # ADR 0023 — A rate is a minimum spacing, not a window budget; the two limiters must agree before the grammar grows
 
-- **Status:** Proposed (2026-08-04). Nothing here is implemented. Opened by the question "does the P17/P25 `number | string` widening extend to a rate?" ([#618](https://github.com/rejifald/StitchAPI/pull/618)); the answer is no, but establishing why surfaced a live defect in the store-backed limiter that this ADR treats as the blocking issue. Touches the pluggable store ([DESIGN.md §13](../DESIGN.md), which has no ADR of its own) and builds on [ADR 0010](./0010-injectable-clock.md) (the injectable `Clock`, whose tags already include `throttle` — the fix's tests need it).
+- **Status:** Accepted (2026-08-04). **Decisions 1, 2 and 4 are implemented**; Decision 2 resolved to shape (a) once implementing it priced (b) properly, and its two sub-fixes ship with the measurement as their regression test. Decision 3 (the frozen grammar) and Decision 5 (recording the non-widening in P17/P25) are pending and unblocked. Opened by the question "does the P17/P25 `number | string` widening extend to a rate?" ([#618](https://github.com/rejifald/StitchAPI/pull/618)); the answer is no, but establishing why surfaced a live defect in the store-backed limiter that this ADR treats as the blocking issue. Touches the pluggable store ([DESIGN.md §13](../DESIGN.md), which has no ADR of its own) and builds on [ADR 0010](./0010-injectable-clock.md) (the injectable `Clock`, whose tags already include `throttle` — the fix's tests need it).
 - **Date:** 2026-08-04
 - **Tags:** resilience, throttle, store, api-surface, correctness, P1, P12, P16, P17, P25
 
@@ -135,13 +135,11 @@ so that `'1/s'` and `'60/m'` are once again the same request. The window is an
 implementation device for sharing a counter across processes; it must not leak into
 observable behaviour.
 
-Two shapes are plausible and this ADR does **not** pick between them — that belongs
-in the fix, with tests:
+Two shapes were plausible:
 
-- **(a) Clamp the credit.** Keep the per-window counter, but schedule the Nth grant
-  from `max(windowStart, firstSeenInWindow)` rather than `windowStart`, so a cold
-  key cannot claim elapsed time it was not present for. Smallest change; keeps the
-  existing store contract; still approximate across boundaries.
+- **(a) Clamp the credit.** Keep the per-window counter, but stop measuring slots from
+  `windowStart`, so a cold key cannot claim elapsed time it was not present for.
+  Smallest change; keeps the existing store contract.
 - **(b) Store the timestamp.** Hold `nextGrantAt` in the store rather than a counter,
   which is exact GCRA and spelling-independent by construction. This needs an atomic
   read-compute-write the `StitchStore` contract does not currently offer — the
@@ -149,11 +147,52 @@ in the fix, with tests:
   contract change ([P21](../CONTRACT.md#p21--every-contract-has-an-extension-seam)
   makes room for it, but it is every implementor's problem, so it is a real cost).
 
-Whichever lands, the regression test is the measurement above: **total admitted over
-a multi-window interval, against budget, for two spellings of one rate** — not just
-the spacing of the tail.
+**Resolved to (a).** Implementing it turned up a constraint that raises (b)'s price
+beyond what this ADR first estimated: the store contract **requires** `increment`'s
+TTL to be bound to the creating increment and never extended — spelled out on
+`RedisDriver` and enforced in the Lua (`if v == 1 and ttl > 0 then PEXPIRE`), because
+_"a busy rate window would slide forever and never reset"_. So the counter's reset is
+the only idle-reset mechanism available, which rules out the obvious cheap route to
+(b) — a long-lived counter whose TTL tracks the schedule head — and leaves (b) needing a
+genuine new atomic primitive rather than a clever use of the existing one.
 
-### 3. The grammar stays frozen until Decision 2 ships
+(a) landed as two changes, because measurement showed **two** defects, not one, with
+opposite skews:
+
+1. **Slots are measured from the window's first arrival**, published in the store by
+   whichever caller the atomic increment hands `n === 1` — shared, so every caller in
+   the window agrees. (Measuring from a _process-local_ first-seen, as this ADR first
+   sketched, is wrong: a process joining a window late would schedule from its own
+   arrival against a counter the fleet had already advanced, and over-pace badly.)
+   This is the cold-key defect, worst for a **long** window.
+2. **The schedule carries across a rollover** — a new window's origin is
+   `max(now, head)`, where `head` is the latest grant this process has placed.
+   Without it a rollover restarts the slots at `now`, running them through grants
+   still pending past the boundary. This is the residual defect, worst for a **short**
+   window, and it is why fixing only (1) left `'2/s'` still admitting ~3× budget while
+   `'120/m'` became exact. `head` is process-local, which is exact for one process and
+   safe in a fleet — a process knows a subset of the fleet's grants, so its head can
+   only lag, and a lagging carry over-admits slightly rather than over-pacing anyone.
+
+Measured after the fix, same method as above — both spellings, in-process and store,
+now sit at the budget of 8, and the cold-key opening burst is 1 of 20 for both:
+
+| Rate      | Store, before | Store, after |
+| --------- | ------------- | ------------ |
+| `'2/s'`   | 25, 23        | 8, 8         |
+| `'120/m'` | 79, 79        | 8, 8         |
+
+The regression test is that measurement — **total admitted over a multi-window
+interval, against budget, for two spellings of one rate** — plus the opening burst,
+not the spacing of the tail. Each of the two changes was reverted independently with
+the tests in place to confirm each is load-bearing: reverting (1) fails both tests,
+reverting (2) fails the sustained one.
+
+This is **not** exact continuous GCRA across processes. The per-window counter reset
+and the process-local head are both still approximations, and closing them is still
+(b), still deferred, now with a clearer price tag.
+
+### 3. The grammar stayed frozen until Decision 2 shipped — it now has
 
 `<count>/<unit>` with `unit ∈ {ms, s, m}` is unchanged for now. The gap is real —
 `'1000/h'` is an ordinary API quota and cannot be written today, and the reachable
@@ -168,9 +207,10 @@ every extension makes the current defect worse rather than better:
   [P16](../CONTRACT.md#p16--cross-surface--cross-package-parity) parity break
   manufactured on purpose.
 
-Once Decision 2 lands, `per` no longer affects behaviour, and both extensions become
-pure notation over the one scalar — at which point they are cheap and this ADR
-recommends taking them. Ordering, not rejection.
+Both objections above are now **historical**: Decision 2 has landed, `per` no longer
+reaches a grant time, and both extensions are pure notation over the one scalar. This
+ADR recommends taking them — it was ordering, not rejection — as a follow-up that ships
+the grammar and the guides together. The freeze stays only until someone writes it.
 
 ### 4. `rate` stays a flat string; it does not become an envelope
 
@@ -257,10 +297,10 @@ the opposite of a fix, reached by treating "consistent" as the goal instead of
 
 ## Open questions
 
-1. **Decision 2(a) or 2(b)?** Deliberately left to the fix. (b) is correct and costs a
-   `StitchStore` contract extension every implementor must satisfy; (a) is
-   proportionate and stays approximate at boundaries. The measurement above is the
-   acceptance criterion either way.
+1. ~~**Decision 2(a) or 2(b)?**~~ **Resolved: (a)** — see Decision 2. Implementing it
+   also priced (b) properly: the contract's creation-bound `increment` TTL means (b)
+   needs a genuinely new atomic store primitive, not a clever use of the existing one.
+   (b) remains the only route to exact cross-process GCRA and stays deferred.
 2. **Should the defect ship as a fix or a breaking change?** It tightens a limiter, so
    callers relying on today's over-admission would see fewer calls get through. That is
    a bug fix by any reading, but on the `rc` channel it is worth a CHANGELOG note under

--- a/packages/core/scripts/bundle-size.mjs
+++ b/packages/core/scripts/bundle-size.mjs
@@ -198,19 +198,41 @@ const KB = 1024;
 // (the provider's parsed completion), forcing every composing surface to build a success value and
 // immediately discard it. Headroom lands at 0.16 / 0.15 — the tight step #477/#524 took, not the
 // ~0.2 KB this gate usually restores.
+// Budgets raised for ADR 0023 — the store-backed throttle enforces its rate (23.30→23.45 /
+// 20.70→20.85 KB; measured 23.39 / 20.79, so the fix is +0.09 on both). A store-backed `throttle`
+// was admitting several times its configured rate: grants were scheduled from the window's
+// epoch-aligned start, so a key first seen mid-window was credited with every slot that had already
+// elapsed and released them at once. Against a budget of 8 calls it admitted 24 for `'2/s'` and 79
+// for `'120/m'` — the same rate, differing only in how it was spelled.
+//
+// What the bytes buy, none of it movable behind a subpath (`memoryStore` is the DEFAULT store, so
+// this path is in `import { stitch }` whether or not a consumer configures one):
+//   • the shared per-window origin — one store `set` on the caller the atomic increment hands
+//     `n === 1`, one `get` for everyone else — so slots are measured from the window's first
+//     arrival rather than its epoch boundary;
+//   • the schedule carry across a rollover (`max(now, head)` plus the local head it reads), which
+//     is the mirror-image defect: without it a short window restarts its slots on top of grants
+//     still pending past the boundary, and `'2/s'` stayed at ~3x budget while `'120/m'` went exact.
+//
+// Both are load-bearing and were reverted independently to prove it. The alternative is not
+// "smaller" but "a rate limiter that does not limit", which is the one thing this capability is
+// for. Trimming was considered and there is nothing to take: minification renames the locals, so
+// the cost is the logic itself, and dropping either half restores a measured defect. Headroom
+// lands at 0.06 / 0.06 — the tight step #477/#524/#606 took, not the ~0.2 KB this gate usually
+// restores.
 // `advertised: true` means the READMEs/docs quote this scenario's rounded gzip kB — see the
 // `--json` note below for why that flag, not the row's presence, drives the drift tether.
 const SCENARIOS = [
     {
         name: 'stitchapi — whole entry',
         code: `export * from './index.mjs';`,
-        budget: 23.3 * KB,
+        budget: 23.45 * KB,
         advertised: true,
     },
     {
         name: 'import { stitch }',
         code: `export { stitch } from './index.mjs';`,
-        budget: 20.7 * KB,
+        budget: 20.85 * KB,
         advertised: true,
     },
     {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -110,17 +110,29 @@ export interface Throttle {
 
 /**
  * Store-backed throttle. Rate is paced by EVEN-SPACED grants over an atomic per-window counter in
- * the store: the Nth grant in a window is scheduled at `windowStart + (N-1)·(per/count)` — the
- * same cadence as the in-process limiter ({@link createThrottle}), so attaching a store no longer
- * silently switches pacing to bursty fixed-window (the spacing even carries across the window
- * boundary). A SHARED store paces calls across the whole fleet; concurrency stays in-process (a
- * distributed semaphore needs leases — out of scope here).
+ * the store: the Nth grant is scheduled one `per/count` after the (N-1)th — the same cadence as
+ * the in-process limiter ({@link createThrottle}), so attaching a store does not switch pacing to
+ * bursty fixed-window. A SHARED store paces calls across the whole fleet; concurrency stays
+ * in-process (a distributed semaphore needs leases — out of scope here).
  *
- * The counter is per-window, so under SUSTAINED overload (offered load above the limit across
- * multiple windows) pacing is approximate at window edges: backlog scheduled on one window's
- * counter can overlap the next window's fresh counter. Exact continuous GCRA across processes would
- * need an atomic read-compute-write of a timestamp (a Lua cell or a new atomic store primitive) — a
- * `StitchStore` contract extension, deliberately deferred.
+ * Two things keep `per` out of the grant times, so that every spelling of one rate behaves the
+ * same way (ADR 0023 — `'2/s'` and `'120/m'` are the same request, and used not to be):
+ *
+ * - Slots are measured from the window's **first arrival**, published in the store by whichever
+ *   caller the atomic increment hands `n === 1`. Anchoring on the epoch-aligned `windowStart`
+ *   instead gave a cold key every slot that had already elapsed before anyone called — an opening
+ *   burst of `count`, so a long window bursted harder.
+ * - The schedule **carries across a rollover**: a new window's origin is `max(now, head)`, where
+ *   `head` is the latest grant this process has already placed. Restarting at `now` would run the
+ *   new window's slots through grants still pending past the boundary, and the residue scaled with
+ *   how often the counter rolled — worst for a SHORT window, the opposite skew to the first defect.
+ *
+ * `head` is process-local, which is exactly right for the single-process case and safe in a fleet:
+ * a process knows only a subset of the fleet's grants, so its head can only lag the true one, and
+ * a lagging carry over-admits slightly rather than over-pacing anyone. That residue, and the
+ * per-window counter reset behind it, are why this is still not exact continuous GCRA across
+ * processes — which needs an atomic read-compute-write of a timestamp (a Lua cell or a new atomic
+ * store primitive), a `StitchStore` contract extension that stays deliberately deferred.
  */
 export function createStoreThrottle(
     opts: ThrottleOptions | undefined,
@@ -135,6 +147,7 @@ export function createStoreThrottle(
             inFlight: number;
             waiters: (() => void)[];
             lastWindow?: number; // windowStart of the last `rl:` key this throttle minted
+            head?: number; // latest grant time this process has scheduled, + one spacing
         }
     >();
 
@@ -173,25 +186,63 @@ export function createStoreThrottle(
         }
         if (rate) {
             // Even-spaced pacing over the shared counter (mirrors createThrottle's `spacing`):
-            // the atomic increment hands each caller a unique slot N in the window, and slot N is
-            // scheduled at windowStart + (N-1)·spacing. Slot count+1 lands exactly at the next
-            // windowStart, so grants stay one `spacing` apart across the boundary — no fixed-window
-            // burst. No re-check loop: each caller owns a distinct, non-colliding slot.
+            // the atomic increment hands each caller a unique slot N, and slot N is scheduled one
+            // `spacing` after slot N-1. No re-check loop: each caller owns a distinct,
+            // non-colliding slot.
+            //
+            // The slots are measured from the window's FIRST ARRIVAL, not from its epoch-aligned
+            // start (ADR 0023). Anchoring on `windowStart` credited a key with every slot that had
+            // already elapsed before anyone called: those grants sit in the past, so they all fire
+            // at once, and the size of that opening burst is `count` — which scales with `per`. It
+            // made two spellings of ONE rate behave differently (`'120/m'` admitted ~10x what
+            // `'2/s'` did) and let a cold key emit a full window's budget instantly, the exact
+            // fixed-window burst the even spacing exists to prevent. `per` now sets only how often
+            // the shared counter rolls over; it is not an input to any grant time.
             const spacing = rate.per / rate.count; // ms between grants
             const windowStart = Math.floor(clock.now() / rate.per) * rate.per;
+            const counterKey = `rl:${key}:${windowStart}`;
+            const originKey = `${counterKey}:t0`;
             // Track the window we minted a key for; when it rolls over, DELETE the previous
-            // window's `rl:` key eagerly instead of waiting for its TTL to expire (the store's
+            // window's `rl:` keys eagerly instead of waiting for their TTL to expire (the store's
             // own sweep is opportunistic). Without this, a long-lived rate-limited seam leaves a
             // dead key per window in the backend until something else happens to evict it.
             const s = stateFor(key);
-            if (s.lastWindow !== undefined && s.lastWindow < windowStart)
-                await store.set(`rl:${key}:${s.lastWindow}`, undefined);
+            if (s.lastWindow !== undefined && s.lastWindow < windowStart) {
+                const stale = `rl:${key}:${s.lastWindow}`;
+                await store.set(stale, undefined);
+                await store.set(`${stale}:t0`, undefined);
+            }
             s.lastWindow = windowStart;
-            const n = await store.increment(
-                `rl:${key}:${windowStart}`,
-                rate.per + 100,
-            );
-            const grantAt = windowStart + (n - 1) * spacing;
+            const ttl = rate.per + 100;
+            const n = await store.increment(counterKey, ttl);
+            // Slot 1 IS the first arrival, and the atomic increment makes exactly one caller per
+            // window see `n === 1` across the whole fleet — so that caller publishes the origin
+            // every other caller in the window measures from. A reader that misses it (it raced
+            // the write, or the key lapsed) falls back to its own clock: that can only push a
+            // grant LATER than the true schedule, never earlier, so the failure mode is a touch
+            // of over-pacing rather than a burst.
+            const at = clock.now();
+            let origin = at;
+            if (n === 1) {
+                // Rolling over. The counter resets, but the SCHEDULE must not: grants already
+                // placed beyond this boundary are still pending, and restarting from `now` would
+                // run the new window's slots straight through them — the residual over-admission
+                // that survived anchoring on first arrival (it scales with how often the counter
+                // rolls, so it hit a short `per` hardest: `'2/s'` admitted ~3x its budget under
+                // overload while `'120/m'`, the same rate, was exact). Carrying this process's own
+                // schedule head across the boundary makes a single process exact and, in a fleet,
+                // strictly better than not carrying: a process only ever knows a SUBSET of the
+                // fleet's grants, so its head can only lag the true one — the residue shrinks
+                // toward the shared-counter behaviour instead of over-pacing anyone. A head left
+                // over from an idle stretch is already in the past and `max` discards it.
+                origin = Math.max(at, s.head ?? at);
+                await store.set(originKey, origin, ttl);
+            } else {
+                const published = await store.get(originKey);
+                if (typeof published === 'number') origin = published;
+            }
+            const grantAt = origin + (n - 1) * spacing;
+            s.head = Math.max(s.head ?? 0, grantAt + spacing);
             const wait = grantAt - clock.now();
             if (wait > 0) {
                 await clock.sleep(wait);
@@ -210,11 +261,16 @@ export function createStoreThrottle(
         else if (s.inFlight > 0) s.inFlight--;
         // Drop a fully-idle key's state so the `local` Map doesn't accumulate one entry per
         // ever-seen key. Keep it only while it still carries window bookkeeping (`lastWindow`),
-        // which a rate-paced key needs to clean up its `rl:` key on the next rollover.
+        // which a rate-paced key needs to clean up its `rl:` key on the next rollover, or a
+        // schedule head that has not yet lapsed — dropping THAT would forget the grants already
+        // placed past the next boundary and let the following window restart on top of them,
+        // which is the burst the carry exists to prevent. Same rule the in-process limiter
+        // applies to its own `nextGrantAt`: a still-pacing key outlives its last release.
         if (
             s.inFlight === 0 &&
             s.waiters.length === 0 &&
-            s.lastWindow === undefined
+            s.lastWindow === undefined &&
+            (s.head ?? 0) <= clock.now()
         )
             local.delete(key);
     }

--- a/packages/core/test/gaps/resource-leaks.spec.ts
+++ b/packages/core/test/gaps/resource-leaks.spec.ts
@@ -67,9 +67,17 @@ test('store throttle: old rate-window keys do not accumulate over many windows',
     // Many distinct windows were touched over the run...
     const rlSeen = [...seen].filter((k) => k.startsWith('rl:seamA:'));
     expect(rlSeen.length).toBeGreaterThan(1);
-    // ...but only the CURRENT window's key should still be live (the rollover deletes the prior).
-    const rlLive = [...liveKeys].filter((k) => k.startsWith('rl:seamA:'));
-    expect(rlLive.length).toBeLessThanOrEqual(1);
+    // ...but only the CURRENT window should still be live (the rollover deletes the prior).
+    // Counted in WINDOWS, not keys: a window is represented by more than one key — the counter
+    // plus the origin its grants are measured from (ADR 0023) — and the invariant this guards is
+    // that a rolled-over window leaves nothing behind, not how many keys one window happens to
+    // use. Counting keys would have made adding the origin look like a leak.
+    const liveWindows = new Set(
+        [...liveKeys]
+            .filter((k) => k.startsWith('rl:seamA:'))
+            .map((k) => k.replace(/:t0$/, '')),
+    );
+    expect(liveWindows.size).toBeLessThanOrEqual(1);
 });
 
 // ── 1a'. memoryStore sweeps expired entries on write (no unbounded growth) ───

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -261,4 +261,76 @@ describe('Pluggable store — throttle', () => {
             expect((ats[n - 2] ?? 0) - (ats[n - 3] ?? 0)).toBeGreaterThan(120);
         }
     });
+
+    // ADR 0023. The test above fires every acquire AT ONCE and asserts on the TAIL, which is
+    // where the bug it was written for lived. Both defects fixed here hid in what it does not
+    // look at: the head of the schedule, and arrivals spread over more than one window. The
+    // acceptance criterion is therefore total admitted against budget — the only measure that
+    // catches a limiter letting calls through early rather than bunching them late.
+    test('the same rate spelled two ways admits the same number of calls', async () => {
+        // '2/s' and '120/m' are one rate: spacing 500ms either way. They differ only in `per`,
+        // which used to set the counter's window AND the schedule origin — so `'120/m'` admitted
+        // ~10x its budget (a full minute of credit on a cold key) and `'2/s'` ~3x (a fresh
+        // origin every second, run through the previous second's pending grants).
+        const DURATION = 4000;
+        const BUDGET = 8; // 4s at 2/s
+        const admitted = async (rate: string): Promise<number> => {
+            const t = createStoreThrottle({ rate }, memoryStore());
+            const start = Date.now();
+            let granted = 0;
+            const inflight: Promise<void>[] = [];
+            // Spread arrivals so they land across SEVERAL windows — all-at-once puts every
+            // caller on one counter and cannot see a rollover at all.
+            while (Date.now() - start < DURATION) {
+                inflight.push(
+                    t.acquire('k').then(() => {
+                        if (Date.now() - start <= DURATION) granted++;
+                    }),
+                );
+                await new Promise((r) => setTimeout(r, 50));
+            }
+            await Promise.race([
+                Promise.all(inflight),
+                new Promise((r) => setTimeout(r, 50)),
+            ]);
+            return granted;
+        };
+
+        const [short, long] = await Promise.all([
+            admitted('2/s'),
+            admitted('120/m'),
+        ]);
+        // Bounds are deliberately loose against real timers on a loaded CI box, and still nowhere
+        // near the defect: it admitted 24 and 79 against this budget of 8, so a ceiling of 10
+        // catches both with room to spare while absorbing a couple of calls' worth of drift.
+        // A slow machine can only push grants LATER, i.e. below the ceiling, so this edge is safe.
+        expect(short).toBeLessThanOrEqual(BUDGET + 2);
+        expect(long).toBeLessThanOrEqual(BUDGET + 2);
+        // And the two spellings agree, which is the property `per` leaking into grant times broke
+        // — they differed by 55 (24 vs 79) before, so ±2 is a real assertion, not a formality.
+        expect(Math.abs(short - long)).toBeLessThanOrEqual(2);
+    }, 30000);
+
+    test('a cold key does not open with a burst, however long its window', async () => {
+        // The opening burst was `count` slots — every slot already elapsed in the window before
+        // the first call. `count` scales with `per`, so a long window bursted harder: '600/m'
+        // released the whole batch at once while '10/s', the same rate, released 1-3. Both must
+        // now admit exactly one call without waiting. (Spacing 100ms so 20 calls cost ~2s.)
+        const openingBurst = async (rate: string): Promise<number> => {
+            const t = createStoreThrottle({ rate }, memoryStore());
+            const start = Date.now();
+            const at = await Promise.all(
+                Array.from({ length: 20 }, async () => {
+                    await t.acquire('k');
+                    return Date.now() - start;
+                }),
+            );
+            return at.filter((ms) => ms < 50).length; // half a spacing
+        };
+
+        // ≤2 rather than exactly 1, for the same CI-drift reason: the defect released the entire
+        // batch of 20 at once, so this still fails loudly if the anchor regresses.
+        expect(await openingBurst('10/s')).toBeLessThanOrEqual(2);
+        expect(await openingBurst('600/m')).toBeLessThanOrEqual(2);
+    }, 30000);
 });


### PR DESCRIPTION
Implements [ADR 0023](https://github.com/rejifald/StitchAPI/blob/main/docs/adr/0023-a-rate-is-a-minimum-spacing.md) Decision 2, merged in [#621](https://github.com/rejifald/StitchAPI/pull/621).

## The bug

`'2/s'` and `'120/m'` are the same rate — 500ms between calls either way. Under a shared store they were not the same request. Against a budget of **8** calls over 4s:

| Rate | In-process | Store, before | Store, after |
| --- | --- | --- | --- |
| `'2/s'` | 8 | 25, 23 | **8, 8** |
| `'120/m'` | 8 | 79, 79 | **8, 8** |

`'120/m'` admitted 79 of 80 offered calls — effectively no limiting at all.

## Two defects, opposite skews

This is why fixing the obvious one was not enough.

**1. Grants were anchored to the window's epoch-aligned start.** A key first seen part-way through a window was credited with every slot that had already elapsed; those grants sit in the past and all fire at once. The opening burst is `count`, which scales with `per`, so a **long** window bursted hardest — `'600/m'` released a whole batch of 20 immediately where `'10/s'`, the same rate, released 1.

Slots are now measured from the window's **first arrival**, published in the store by whichever caller the atomic increment hands `n === 1`. Shared, not process-local: a process joining a window late would otherwise schedule from its own arrival against a counter the fleet had already advanced, and over-pace badly. A reader that misses the published origin falls back to its own clock, which can only push a grant later, never earlier.

**2. A rollover restarted the schedule at `now`,** running the new window's slots through grants still pending past the boundary — the mirror image, worst for a **short** window. Fixing only (1) made `'120/m'` exact and left `'2/s'` at ~3× budget.

The schedule now **carries across a rollover**: the new origin is `max(now, head)`, where `head` is the latest grant this process has placed. Process-local is exact for one process and safe in a fleet — a process knows only a subset of the fleet's grants, so its head can only lag, and a lagging carry over-admits slightly rather than over-pacing anyone. `release` no longer evicts local state while a head is still pending, matching the rule the in-process limiter already applies to `nextGrantAt`.

## Why the existing test missed it

It fires every acquire at once and asserts on the **tail** of the schedule, where the overflow grants genuinely are spaced correctly. It never varies arrival time, never uses a key that starts mid-window, and never compares total admitted against budget.

The new tests measure exactly that, plus the opening burst. **Each fix was reverted independently with them in place** to confirm both are load-bearing: reverting (1) fails both tests, reverting (2) fails the sustained one. Tolerances are loose against CI timer drift and still nowhere near the defect (a ceiling of 10 against measurements of 24 and 79).

## For the reviewer

- **Bundle budget raised 0.09 KB** (23.30→23.45 / 20.70→20.85), in its own commit so the justification is reviewable alone. Trimming was the first option: minification renames every local, so the cost is the logic, and neither half is padding. It cannot move behind a subpath — `memoryStore` is the *default* store, so this is on the `import { stitch }` path whether or not a consumer configures one. Minimum step, 0.06 KB headroom. Advertised figure unchanged at ~23 kB.
- **The resource-leak test now counts live *windows*, not live keys.** A window is two keys as of this change (counter + origin); the invariant it guards is that a rolled-over window leaves nothing behind, and counting keys made adding the origin look like a leak.
- **ADR 0023 updated**: Decision 2 resolved to shape (a). Implementing it priced (b) properly — the store contract *requires* `increment`'s TTL to be bound to the creating increment and never extended (spelled out on `RedisDriver`, enforced in the Lua), which rules out the cheap route to (b) and leaves it needing a genuinely new atomic primitive. Still deferred, now with a clearer price.
- **Still not exact cross-process GCRA**, and the ADR says so: the per-window counter reset and the process-local head are both approximations.

## Breaking

No API changes, but a store-backed `throttle` that was silently admitting several times its configured rate now holds the rate you asked for. A drop in throughput after upgrading means the limiter was over-admitting before. Flagged under BREAKING CHANGE per ADR 0023 open question 2, since the observable effect is throughput rather than a signature.

Gates: 1413/1413 core tests (3 new), plus the full pre-push suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)