### PR TITLE
feat(core)!: `StitchStore.reserve` — a fleet paces on one cursor (ADR 0024)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,44 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Added
 
+- **A fleet sharing a store now paces on ONE schedule, wherever in a window its workers start.**
+  ([ADR 0024](docs/adr/0024-the-fleet-wide-pacing-cell.md)) [ADR 0023](docs/adr/0023-a-rate-is-a-minimum-spacing.md)
+  fixed the store-backed throttle's cold-start burst with a per-process pacing cursor and recorded
+  what that could not buy: a slot already in the past paces nobody, so N workers that all start
+  mid-window emit at **N× the declared rate** until the slots catch up with the clock. Two workers
+  measured 2×, three measured 3×.
+
+    The reason a counter could never close it is worth stating, because it looks like it should:
+    a counter allocates _positions_, and turning a position into a _time_ needs an origin. Every
+    origin a caller can compute is either per-process (so each worker paces only itself) or fixed to
+    a window (so a worker joining mid-window inherits slots that already elapsed). Both were tried,
+    in that order, and each fix exposed the other.
+
+    A **cursor** needs no origin — it is already an instant, it carries continuously, and
+    `max(now, cell)` resets it after idle. So `StitchStore` gains one optional verb:
+
+    ```ts
+    reserve?(key: string, spacing: number, now: number, ttl?: number): Promise<number>;
+    // atomically: at = max(now, cell ?? 0);  cell = at + spacing;  return at
+    ```
+
+    Implemented by `memoryStore` (the default), `@stitchapi/redis` (one Lua `EVAL`) and
+    `@stitchapi/deno-kv` (its existing compare-and-set loop). **Nothing to configure** — the throttle
+    uses the cell when the store has it.
+
+    **Optional on purpose, and the fallback is not deprecated.** `@stitchapi/cloudflare-kv` is
+    eventually consistent and has no atomic read-compute-write to build a cell from, so it keeps the
+    ADR 0023 path — whose residues stay pinned in the test suite against a store with the verb
+    deliberately withheld. `StitchStore` is also a contract _you_ implement, where adding a required
+    member is a hard break in any channel
+    ([P19](docs/CONTRACT.md#p19--the-alias-obligation-is-scoped-to-the-ga-channel)), so optional is
+    the only additive shape. **Existing custom stores need no changes.**
+
+    If you do implement it, `verifyStoreContract` now checks it — but only when present, so
+    omitting it is not a contract failure. The rule that matters is the atomicity one: 20 concurrent
+    reservations must come back as 20 distinct, evenly spaced instants, because a non-atomic cell
+    hands several callers the same instant, which is the exact burst the verb exists to remove.
+
 - **`parseRate` is exported from `stitchapi`, completing the house token grammars.**
   [P17](docs/CONTRACT.md#p17--one-canonical-duration-form) and
   [P25](docs/CONTRACT.md#p25--one-canonical-size-form) both make "one shared parser" part of the

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/stitchapi?activeTab=dependencies"><img alt="Dependencies: 0" src="https://img.shields.io/badge/dependencies-0-brightgreen" /></a>
-  <img alt="Bundle: ~23 kB min+gzip" src="https://img.shields.io/badge/min%2Bgzip-~23%20kB-2563EB" />
+  <img alt="Bundle: ~24 kB min+gzip" src="https://img.shields.io/badge/min%2Bgzip-~24%20kB-2563EB" />
   <a href="https://scorecard.dev/viewer/?uri=github.com/rejifald/StitchAPI"><img alt="OpenSSF Scorecard" src="https://api.scorecard.dev/projects/github.com/rejifald/StitchAPI/badge" /></a>
   <a href="https://www.npmjs.com/package/stitchapi"><img alt="npm provenance: signed" src="https://img.shields.io/badge/provenance-signed-brightgreen" /></a>
 </p>
@@ -34,7 +34,7 @@
 <!-- /yakir:readme-badges -->
 
 <p align="center">
-  <strong>Zero runtime dependencies · ~23&nbsp;kB min+gzip</strong> — a typical <code>import { stitch }</code> tree-shakes to ~21&nbsp;kB, and with no transitive tree there is nothing else to install or audit. The size is an <a href="packages/core/scripts/bundle-size.mjs">enforced budget in CI</a>, not an aspiration.
+  <strong>Zero runtime dependencies · ~24&nbsp;kB min+gzip</strong> — a typical <code>import { stitch }</code> tree-shakes to ~21&nbsp;kB, and with no transitive tree there is nothing else to install or audit. The size is an <a href="packages/core/scripts/bundle-size.mjs">enforced budget in CI</a>, not an aspiration.
 </p>
 
 <p align="center">
@@ -164,7 +164,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 - **Pluggable state store** — throttle counters and sessions behind a 3-method store; swap in Redis/Postgres to go distributed.
 - **Zero-infra observability** — tracing is **off by default**; opt in per stitch or via `STITCH_TRACE_*` env vars. No collector, no dashboard.
 - **Four front doors, one definition** — in-process function, CLI (`stitch run`), HTTP (`stitch serve`), and MCP (`stitch mcp`).
-- **Zero runtime dependencies** — `"dependencies": {}`, built on global `fetch`, tree-shakeable; **~23 kB min+gzip** for the whole entry, **~21 kB** for a typical `import { stitch }`.
+- **Zero runtime dependencies** — `"dependencies": {}`, built on global `fetch`, tree-shakeable; **~24 kB min+gzip** for the whole entry, **~21 kB** for a typical `import { stitch }`.
 
 ## Install
 

--- a/apps/docs/app/(home)/components/metrics.tsx
+++ b/apps/docs/app/(home)/components/metrics.tsx
@@ -5,7 +5,7 @@ const metrics = [
         body: 'Built on the platform’s global fetch — nothing to install, nothing to audit, nothing in your transitive tree.',
     },
     {
-        value: '~23 kB',
+        value: '~24 kB',
         unit: 'min + gzip',
         body: 'The whole stitchapi entry, tree-shaken — and it is an enforced budget in CI, not an aspiration.',
     },

--- a/apps/docs/content/docs/concepts/principles.mdx
+++ b/apps/docs/content/docs/concepts/principles.mdx
@@ -105,7 +105,7 @@ behind its own import — so an app never ships bytes for a CLI it will not run.
 The same frugality the event stream practices with an agent's context, the
 package practices with your bundle.
 
-Concretely, the whole `stitch` entry is **~23 kB minified + gzipped**
+Concretely, the whole `stitch` entry is **~24 kB minified + gzipped**
 (≈61 kB raw), and because every surface beyond `http` is a separate subpath
 import, a typical `import { stitch }` tree-shakes to **~21 kB**. With zero
 runtime dependencies, that figure is the entire cost — not the tip of a

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -5,7 +5,7 @@ description: 'Install stitchapi and set up the zero-dependency runtime in Node o
 
 Install the package, import `stitch`, and turn your first endpoint into a typed,
 callable function. `stitchapi` has zero dependencies and runs anywhere `fetch`
-does — Node, the browser, and edge runtimes. The whole entry is **~23 kB
+does — Node, the browser, and edge runtimes. The whole entry is **~24 kB
 minified + gzipped** — and with no dependencies, there is no transitive tree
 behind it (a typical `import { stitch }` tree-shakes to ~21 kB).
 

--- a/apps/docs/content/docs/guides/state/distributed-throttle.mdx
+++ b/apps/docs/content/docs/guides/state/distributed-throttle.mdx
@@ -41,11 +41,19 @@ the in-process limiter uses, so attaching a store doesn't turn a smooth limit in
 boundary bursts. (Concurrency stays in-process; only the rate limit is distributed.)
 
 <Callout type="info">
-    Even-spacing holds for load up to the limit. Under _sustained_ overload —
-    more than the budget, for longer than one window — distributed pacing is
-    approximate at the window edges: a per-window counter can't carry a
-    continuous backlog across processes the way the single-process limiter does.
-    The budget itself still holds.
+    **How exact the fleet-wide pacing is depends on your store.** A store with a
+    pacing cell — `memoryStore`, `@stitchapi/redis`, `@stitchapi/deno-kv` — paces
+    the whole fleet on one continuous cursor, so every worker draws from one
+    schedule no matter when it starts.
+
+    A store without one (`@stitchapi/cloudflare-kv`, which is eventually
+    consistent and has no atomic read-compute-write to build a cell from) falls
+    back to a shared counter plus a per-worker cursor. That holds the budget at a
+    window boundary and keeps each worker's own pacing exact, but a fleet that
+    starts _mid-window_ runs at up to `rate × workers` until the schedule catches
+    up with the clock. Nothing to configure either way — the throttle uses the
+    cell when the store has it.
+
 </Callout>
 
 `pool` decides what shares a budget: `'stitch'` (the default) gives each stitch

--- a/apps/docs/lib/source.ts
+++ b/apps/docs/lib/source.ts
@@ -25,7 +25,7 @@ Search these docs instead of loading the whole file: this site is also a hosted 
 - Capability, not credential: an agent invokes a stitch and gets structured, validated, traceable data; the secret stays behind the boundary.
 - One context-frugal **code-mode** tool (run_stitch + list_stitches + describe_stitch), not one tool per endpoint — adding APIs never floods the context window.
 - No server, no codegen, no config files — a URL and one example response is enough; only explicit composition (no ambient/global config a stitch silently inherits).
-- Zero-dependency core, ~23 kB min+gzip for the whole entry (~21 kB for a tree-shaken import { stitch }), validator-agnostic (bring your own Standard Schema / Zod), and it runs in the browser.
+- Zero-dependency core, ~24 kB min+gzip for the whole entry (~21 kB for a tree-shaken import { stitch }), validator-agnostic (bring your own Standard Schema / Zod), and it runs in the browser.
 - Composes with your data layer: a stitch is the queryFn for TanStack Query / SWR — it owns the call's resilience; your query layer owns view state.
 
 ## Quickstart

--- a/docs/adr/0023-a-rate-is-a-minimum-spacing.md
+++ b/docs/adr/0023-a-rate-is-a-minimum-spacing.md
@@ -172,6 +172,11 @@ The two shapes this ADR declined to pick between, kept for the (b) migration:
   extension the JSDoc already flags as "deliberately deferred". Correct, and a
   contract change ([P21](../CONTRACT.md#p21--every-contract-has-an-extension-seam)
   makes room for it, but it is every implementor's problem, so it is a real cost).
+  **(b) has since shipped too, as an OPTIONAL verb —
+  [ADR 0024](./0024-the-fleet-wide-pacing-cell.md).** Optional is what made the
+  implementor cost payable: a store without it keeps the (a) path unchanged, so the
+  residue below is now the documented behaviour of a store that cannot offer a cell
+  rather than the behaviour of every store.
 
 Whichever lands, the regression test is the measurement above: **total admitted over
 a multi-window interval, against budget, for two spellings of one rate** — not just

--- a/docs/adr/0024-the-fleet-wide-pacing-cell.md
+++ b/docs/adr/0024-the-fleet-wide-pacing-cell.md
@@ -1,0 +1,176 @@
+# ADR 0024 — A fleet paces on one cursor: `StitchStore.reserve`, the optional GCRA cell
+
+- **Status:** Accepted and implemented (2026-08-04). Closes the residue [ADR 0023](./0023-a-rate-is-a-minimum-spacing.md) Decision 2 recorded and deferred, and resolves its open question 1's remaining half — option **(b)**, now that (a) has shipped and shown exactly what it cannot reach. Extends the pluggable store ([DESIGN.md §13](../DESIGN.md)) and rides [ADR 0010](./0010-injectable-clock.md)'s injectable `Clock`.
+- **Date:** 2026-08-04
+- **Tags:** resilience, throttle, store, api-surface, contract-extension, P16, P18, P19, P21
+
+> [!NOTE]
+>
+> A counter can allocate **positions**. Turning a position into a **time** needs an
+> origin, and every origin a caller can compute is either per-process (so N workers
+> pace independently) or fixed to a window (so a worker joining mid-window inherits
+> slots that already elapsed). This adds the one primitive that needs neither:
+> `reserve` — atomically `at = max(now, cell); cell = at + spacing`. It is
+> **optional**, because an eventually-consistent backend cannot implement it and
+> because `StitchStore` is a contract consumers implement.
+
+## Context
+
+ADR 0023 established that a rate is a minimum spacing and fixed the store-backed
+limiter to honour it, then wrote down what its fix could not do:
+
+> the cursor bounds a burst PER PROCESS, which is the limit of what it can do without
+> a new store primitive: a slot already in the past paces nobody, so N workers that all
+> start mid-window emit at N× the declared rate until the slots catch up with the clock.
+
+That residue is asserted, not merely described — `store.spec.ts` pinned two workers
+emitting at 2× and three at 3×, with a comment naming this ADR's arrival as the moment
+the assertion should flip. It has.
+
+### Why the counter could never get there
+
+The shared counter is genuinely atomic, and it does allocate a distinct slot `n` to
+every caller across the fleet. The problem is turning `n` into an instant, which needs
+an origin — and both available origins are wrong in a different direction:
+
+| Origin                           | Fails when                        | Symptom                                                                 |
+| -------------------------------- | --------------------------------- | ----------------------------------------------------------------------- |
+| The window's epoch-aligned start | a process joins mid-window        | every elapsed slot is claimable at once — the ADR 0023 cold-start burst |
+| The process's own cursor         | several processes share the store | each paces itself correctly; the fleet emits N×                         |
+
+Both were tried, in that order, and each fix exposed the other. There is no third
+origin a caller can derive, because the missing information — _when did the fleet last
+grant?_ — lives in no single process and in no counter.
+
+A **cursor** needs no origin at all. It is already an instant, it carries continuously
+(no window to restart at), and `max(now, cell)` resets it after idle. The only thing it
+requires is that read-compute-write be indivisible, which is precisely what the store
+contract did not offer.
+
+### Why `increment` cannot be bent into one
+
+Worth recording, because it is the cheap idea that does not work. A counter whose TTL
+tracked the schedule head would behave like a cursor — but `RedisDriver` **mandates**
+that `increment`'s expiry bind to the creating increment and never extend, enforced in
+the Lua (`if v == 1 and ttl > 0 then PEXPIRE`), for a stated reason: _"a busy rate
+window would slide forever and never reset."_ A cursor must slide; a window must not.
+The same verb cannot do both, so this is a new verb rather than a new argument.
+
+## Decision
+
+### 1. `StitchStore.reserve` — the cell, and its exact semantics
+
+```ts
+reserve?(key: string, spacing: number, now: number, ttl?: number): Promise<number>;
+```
+
+Atomically, indivisibly across every process sharing the store:
+
+```
+at = max(now, cell ?? 0);   cell = at + spacing;   return at
+```
+
+Three details are load-bearing and each is pinned by `verifyStoreContract`:
+
+- **`now` is the caller's clock, not the store's.** The cursor stays deterministic under
+  an injected `Clock` (ADR 0010) — the fleet fixture drives it with `manualClock` — and a
+  store never needs a clock of its own. Client skew is the caller's, exactly as it
+  already is for every other instant the throttle computes.
+- **`ttl` refreshes on every call**, the opposite of `increment`'s creation-bound expiry,
+  for the reason in the Context above. Losing the cell is always _safe_: `max(now, …)`
+  restarts from the present, which is a cold start, not a burst.
+- **Fractional spacing survives.** `per/count` is routinely fractional (`'3/s'` is
+  333.33ms), so the Redis script returns `tostring` rather than a RESP integer, which
+  truncates. A fleet that rounded each grant down would drift against the in-process
+  limiter by a millisecond per call.
+
+### 2. It is optional, and the fallback is not deprecated
+
+Two independent reasons, either sufficient:
+
+- **Not every backend can.** Cloudflare KV is eventually consistent and offers no atomic
+  read-compute-write to build a cell from. A store without `reserve` is a first-class
+  citizen and keeps the ADR 0023 counter-plus-cursor path, whose residues stay pinned in
+  `store.spec.ts` against a store with the verb deliberately withheld.
+- **`StitchStore` is consumer-implemented.** [P19's corollary](../CONTRACT.md#p19--the-alias-obligation-is-scoped-to-the-ga-channel)
+  is explicit that a contract the consumer implements and core calls cannot carry an
+  alias, so adding a **required** member is a hard break in any channel. Optional is the
+  only additive shape, and [P21](../CONTRACT.md#p21--every-contract-has-an-extension-seam)
+  is the rule that says the seam must stay open for exactly this kind of growth.
+
+Selection is capability-based, never configuration: the throttle uses the cell when the
+store has it. There is no flag, because there is no case where a caller with a capable
+store wants the weaker pacing.
+
+### 3. Implemented where it can be, honestly absent where it cannot
+
+| Store                              | Mechanism                                                                |
+| ---------------------------------- | ------------------------------------------------------------------------ |
+| `memoryStore`                      | one JS thread, nothing awaited between read and write                    |
+| `@stitchapi/redis`                 | one Lua `EVAL`, alongside the existing `INCR` script                     |
+| `@stitchapi/deno-kv`               | the compare-and-set loop `increment` already uses, with its retry policy |
+| `@stitchapi/cloudflare-kv`         | **absent** — eventually consistent, no atomic primitive to build on      |
+| `@stitchapi/react-native` / `expo` | **absent** — an on-device store; there is no fleet to pace               |
+
+`vaultView` forwards the verb only when the backend has it, so a namespaced view reports
+the backend's real capability rather than making every store look GCRA-capable.
+
+## What this preserves
+
+- Every existing config is unchanged; no API a consumer writes is touched.
+- A store that does not implement `reserve` behaves exactly as it did after ADR 0023.
+- `concurrency` is still in-process under a store (a distributed semaphore needs leases)
+  — untouched here, and still the second place "attach a store to share the policy" is
+  only partly true.
+
+## Alternatives considered
+
+### A. A general `compareAndSet` primitive instead of a purpose-built `reserve` — **rejected: more contract, worse operation**
+
+The obvious general-purpose extension, and it is strictly harder to implement AND worse
+to use. Every implementor would owe an atomic CAS _and_ every caller a retry loop, so a
+contended cursor costs multiple round-trips where `reserve` costs one — Redis executes
+the whole cell server-side. It also widens the contract far past the one operation
+anybody needs: `reserve` is the complete pacing primitive, whereas `compareAndSet` is a
+toolkit for building it wrongly. deno-kv is the tell — it implements `reserve` _with_ a
+CAS loop internally, which is exactly where that complexity belongs.
+
+### B. Require it on `StitchStore` rather than making it optional — **rejected: excludes a real backend, and breaks every implementor**
+
+Cleaner-looking contract, unimplementable by Cloudflare KV, and a hard break on a
+consumer-implemented interface with no alias available (P19's corollary). The cost of
+optionality is one capability check in one function.
+
+### C. Keep the counter and store the origin beside it — **rejected: two keys, a race, and it still misses**
+
+The shape a closed PR ([#623](https://github.com/rejifald/StitchAPI/pull/623)) explored:
+publish the window's first-arrival instant to the store so every worker measures slots
+from the same origin. It does fix the mid-window fleet case, and it needs no new verb —
+but it costs a second round-trip per acquire, it has a read-your-write race between the
+publishing caller and the readers, and it still bursts for a key that goes idle _within_
+a window, because slot allocation lags the clock. Strictly more machinery for strictly
+less correctness than one cursor.
+
+### D. Do nothing and document the residue — **rejected, but it was the right call once**
+
+This is what ADR 0023 decided, and it was correct then: the residue was bounded by
+process count, written down, and asserted. It stops being correct once the fix is one
+optional verb whose absence changes nothing — at that point "N workers exceed the rate
+you configured" is a defect with a known remedy, and a rate limiter that misses by a
+factor of the fleet size is missing the point of being distributed.
+
+## Open questions
+
+1. **Should `verifyStoreContract` fail a store that omits `reserve`?** No, and it does
+   not — the rules are added only when the verb is present. But there is no signal
+   _encouraging_ a capable backend to add it either. A report line noting "no pacing
+   cell — the throttle will use its per-process fallback" would be honest without being
+   a failure; deferred as reporting polish.
+2. **Concurrency across the fleet is still unsolved** and is a bigger problem than this
+   one: a distributed semaphore needs leases with expiry and renewal, which is a much
+   larger contract extension than a cursor. Named here only so the two are not confused.
+3. **Clock skew between workers** now shows up directly in the cursor: a worker whose
+   clock runs fast reserves further ahead. Bounded by the skew itself and no worse than
+   the existing slot schedule, but a store-side clock (Redis `TIME`) would remove it for
+   backends that have one — at the cost of the deterministic `now` that makes the fleet
+   fixture testable. Not attempted.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -120,7 +120,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 - **CLI, HTTP & MCP surfaces** - the definition your code imports is also runnable from the shell (`stitch run <name>` streams JSONL events), served over HTTP (`stitch serve`), or exposed to agents over MCP (`stitch mcp`) — the same stitch behind every front door.
 - **Typed URLs** - full [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) URI templates (`{id}`, `{+path}`, `{?q,sort}`, explode `*`, prefix `:n`), and a `qs`-style query builder that serializes nested objects (`a[b]=c`) and arrays — both dependency-free.
 - **Pluggable transport** - `fetch` by default; drop in the shipped `axiosAdapter`, or any `Adapter` function, to route requests through axios or another HTTP client.
-- **Zero runtime dependencies** - `"dependencies": {}`; built on the platform's global `fetch`; tree-shakeable. The whole entry is **~23 kB min+gzip**; a typical `import { stitch }` trims to **~21 kB** — and with no transitive tree, that is the entire cost.
+- **Zero runtime dependencies** - `"dependencies": {}`; built on the platform's global `fetch`; tree-shakeable. The whole entry is **~24 kB min+gzip**; a typical `import { stitch }` trims to **~21 kB** — and with no transitive tree, that is the entire cost.
 
 ## Documentation
 
@@ -162,7 +162,7 @@ const { stitch } = require("stitchapi");
 
 The runtime ships with zero dependencies. Schema validation is bring-your-own — pass a [Zod](https://zod.dev) schema or any [Standard Schema](https://standardschema.dev) validator ([Valibot](https://valibot.dev), [ArkType](https://arktype.io), …); none of them is bundled. The examples below use Zod for familiarity.
 
-**Bundle size.** The whole `stitchapi` entry is **~23 kB minified + gzipped** (65 kB raw, ~21 kB brotli); because the package is side-effect-free and every surface beyond `http` lives behind its own subpath import, a typical `import { stitch }` tree-shakes to **~21 kB min+gzip**. With zero dependencies, that is the _whole_ cost — there is no transitive tree to install or audit.
+**Bundle size.** The whole `stitchapi` entry is **~24 kB minified + gzipped** (66 kB raw, ~21 kB brotli); because the package is side-effect-free and every surface beyond `http` lives behind its own subpath import, a typical `import { stitch }` tree-shakes to **~21 kB min+gzip**. With zero dependencies, that is the _whole_ cost — there is no transitive tree to install or audit.
 
 ## Quick start
 

--- a/packages/core/scripts/bundle-size.mjs
+++ b/packages/core/scripts/bundle-size.mjs
@@ -216,19 +216,50 @@ const KB = 1024;
 // #477/#524 took. `main` had run down to 0.02 / 0.007, which is why a +0.03 KB fix tripped the gate
 // at all; the step is sized to the headroom the gate is meant to hold rather than to this change,
 // so the next small core-path fix is not gated on a budget PR of its own.
+// Budgets raised for ADR 0024 — the fleet-wide GCRA cell (23.50→23.70 / 20.90→21.10 KB; measured
+// 23.52 / 20.95, so the capability is +0.24 / +0.26 against a `main` at 23.28 / 20.69). ADR 0023
+// closed the cold-start burst with a PER-PROCESS pacing cursor and recorded what that could not
+// buy: a stale slot paces nobody, so N workers sharing a store still emit at N× the declared rate
+// until the slots catch up. This is the primitive that closes it — `StitchStore.reserve`, one
+// atomic read-compute-write over a shared cursor, implemented by `memoryStore`, `@stitchapi/redis`
+// (Lua) and `@stitchapi/deno-kv` (compare-and-set).
+//
+// What the bytes buy, on the core path because `memoryStore` is the DEFAULT store:
+//   • `memoryStore.reserve` — the reference cell, and the one every in-process test paces on;
+//   • the second pacing path in `createStoreThrottle`, selected when the backend has the verb;
+//   • `vaultView` forwarding it only when the backend really has it, so a seam's namespaced view
+//     reports the backend's true capability instead of making every store look GCRA-capable.
+//
+// It cannot move behind a subpath: this is the throttle, which `stitch()` reaches whenever a
+// `store` is configured, and the fallback has to stay reachable from the same call site for a
+// backend that cannot offer a cell (Cloudflare KV is eventually consistent — no atomic
+// read-compute-write to build one from). Nor can the two pacing paths share their wait/sleep
+// tail: factoring it into one async helper MEASURED WORSE (+0.06 KB, the closure and its extra
+// promise costing more than the duplicated four lines), so the repetition stays on purpose.
+//
+// The conventional 0.2 KB step rather than a minimum one — this is a new capability with a new
+// store verb behind it, not a fix squeezing past a ceiling, and #620 had just restored the same
+// step. Headroom lands at 0.17 / 0.15.
+//
+// The ADVERTISED figure moves with it: the whole entry crosses a rounding boundary at 23.53 KB, so
+// every site quoting it goes ~23 → ~24 kB (`import { stitch }` stays ~21). Eight sites, propagated
+// under the `bundle-advertised-size` drift tether — both READMEs, the installation and principles
+// pages, the home-page metrics component, and the docs' own source blurb. Recorded here because
+// this is the number the project advertises, and a budget raise that quietly left the docs
+// claiming the old one would be the exact drift that tether exists to catch.
 // `advertised: true` means the READMEs/docs quote this scenario's rounded gzip kB — see the
 // `--json` note below for why that flag, not the row's presence, drives the drift tether.
 const SCENARIOS = [
     {
         name: 'stitchapi — whole entry',
         code: `export * from './index.mjs';`,
-        budget: 23.5 * KB,
+        budget: 23.7 * KB,
         advertised: true,
     },
     {
         name: 'import { stitch }',
         code: `export { stitch } from './index.mjs';`,
-        budget: 20.9 * KB,
+        budget: 21.1 * KB,
         advertised: true,
     },
     {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -55,6 +55,22 @@ export function memoryStore(): StitchStore {
             });
             return n;
         },
+        // The GCRA pacing cursor (ADR 0024). Atomic for free: one JS thread, and nothing is
+        // awaited between the read and the write. Note the TTL is REFRESHED here, the opposite of
+        // `increment` above — a window must not slide, a cursor must not lapse mid-pace.
+        async reserve(key, spacing, at, ttl) {
+            const e = data.get(key);
+            // `e &&` narrows for the compiler where `live(e)` alone cannot (the check is behind a
+            // helper), which keeps this off the non-null-assertion suppression budget.
+            const cell = e && live(e) ? (e.value as number) : 0;
+            const grantAt = Math.max(at, cell);
+            sweepExpired();
+            data.set(key, {
+                value: grantAt + spacing,
+                expires: ttl ? now() + ttl : 0,
+            });
+            return grantAt;
+        },
         // Lifecycle: drop everything. For the in-memory store this is all the state there is.
         async close() {
             data.clear();
@@ -74,6 +90,13 @@ export function vaultView(store: StitchStore, prefix = 'vault:'): StitchStore {
         set: (key, value, ttl) => store.set(prefix + key, value, ttl),
         increment: (key, ttl) => store.increment(prefix + key, ttl),
     };
+    // Forward the optional pacing cursor only when the backend has one, so the view reports the
+    // backend's real capability: a lens that always exposed `reserve` would make every store look
+    // GCRA-capable and silently break the fallback the absence is meant to select.
+    const reserve = store.reserve?.bind(store);
+    if (reserve)
+        view.reserve = (key, spacing, at, ttl) =>
+            reserve(prefix + key, spacing, at, ttl);
     // Delegate lifecycle to the backend (bind keeps `this` for stores that need it).
     if (store.close) view.close = store.close.bind(store);
     return view;
@@ -122,17 +145,24 @@ export interface Throttle {
  * why two rates declaring one spacing (`'2/s'`, `'120/m'`) are the same limiter here as well as
  * in-process. Each grant is `max(now, cursor, slot)`.
  *
- * The cursor bounds a burst PER PROCESS, which is the limit of what it can do without a new store
- * primitive: a slot already in the past paces nobody, so N workers that all start mid-window emit
- * at N× the declared rate until the slots catch up with the clock. Starting at a window boundary
- * (or once caught up) the slots are in the future and the fleet paces on one shared budget. Pinned
- * both ways in `store.spec.ts`, so the gap is a decision on the record, not a surprise.
+ * **All of that is the fallback.** When the store implements {@link StitchStore.reserve} — the GCRA
+ * cell of ADR 0024, one atomic read-compute-write over a shared pacing cursor — the counter, the
+ * window and the local cursor are all bypassed, and the fleet paces on one continuous schedule:
+ * exact `spacing` between grants across every process, wherever in a window they start. `reserve`
+ * is implemented by `memoryStore`, `@stitchapi/redis` and `@stitchapi/deno-kv`.
  *
- * The counter is per-window, so under SUSTAINED overload (offered load above the limit across
- * multiple windows) pacing is approximate at window edges: backlog scheduled on one window's
- * counter can overlap the next window's fresh counter. Exact continuous GCRA across processes would
- * need an atomic read-compute-write of a timestamp (a Lua cell or a new atomic store primitive) — a
- * `StitchStore` contract extension, deliberately deferred.
+ * Without it, the local cursor bounds a burst PER PROCESS and that is the whole of what it buys: a
+ * slot already in the past paces nobody, so N workers that all start mid-window emit at N× the
+ * declared rate until the slots catch up with the clock. Starting at a window boundary (or once
+ * caught up) the slots are in the future and the fleet paces on one shared budget. The counter is
+ * also per-window, so under SUSTAINED overload pacing is approximate at window edges: backlog
+ * scheduled on one window's counter can overlap the next window's fresh counter. Both residues are
+ * pinned in `store.spec.ts` against a store with `reserve` deliberately withheld, so the fallback
+ * stays a decision on the record rather than a surprise — and both are what the cell removes.
+ *
+ * The fallback is not deprecated and is not going away: an eventually-consistent backend
+ * (Cloudflare KV) has no atomic read-compute-write to build a cell from, so this path is the only
+ * one it can take.
  */
 export function createStoreThrottle(
     opts: ThrottleOptions | undefined,
@@ -185,12 +215,39 @@ export function createStoreThrottle(
             if (blocked) waited = clock.now() - blockStart;
         }
         if (rate) {
+            const spacing = rate.per / rate.count; // ms between grants
+            if (store.reserve) {
+                // The GCRA cell (ADR 0024). One atomic read-compute-write over a shared cursor
+                // gives the fleet what neither half of the fallback below can: the cursor carries
+                // continuously (so no window boundary to restart at) and it is shared (so a worker
+                // joining mid-window paces against every other worker, not just itself). Every
+                // process reads one line of state, so there is no origin to agree on and no stale
+                // slot to inherit — the two shapes the counter-based schedule kept tripping over.
+                // TTL is a full window past the last reservation: `per >= spacing` always, so it
+                // outlives any gap short enough to still need pacing, and a key idle longer than
+                // that should restart from the present anyway.
+                const at = await store.reserve(
+                    `rl:${key}`,
+                    spacing,
+                    clock.now(),
+                    rate.per + 100,
+                );
+                const wait = at - clock.now();
+                if (wait > 0) {
+                    await clock.sleep(wait);
+                    waited += wait;
+                }
+                return { waited };
+            }
+            // Fallback for a store with no `reserve` — an eventually-consistent backend, or any
+            // implementation predating ADR 0024. Correct per process and bounded, but a fleet
+            // drifts to N× mid-window; the comments below are the full account of why.
+            //
             // Even-spaced pacing over the shared counter (mirrors createThrottle's `spacing`):
             // the atomic increment hands each caller a unique slot N in the window, and slot N is
             // scheduled at windowStart + (N-1)·spacing. Slot count+1 lands exactly at the next
             // windowStart, so grants stay one `spacing` apart across the boundary — no fixed-window
             // burst. No re-check loop: each caller owns a distinct, non-colliding slot.
-            const spacing = rate.per / rate.count; // ms between grants
             const windowStart = Math.floor(clock.now() / rate.per) * rate.per;
             // Track the window we minted a key for; when it rolls over, DELETE the previous
             // window's `rl:` key eagerly instead of waiting for its TTL to expire (the store's
@@ -217,7 +274,8 @@ export function createStoreThrottle(
             // that is the whole of what it buys — a stale slot paces nobody, so while the stale
             // prefix lasts only each process's own cursor holds the line and N workers emit at N×
             // the declared rate. At a window boundary the slots are in the future and the fleet
-            // does pace on one budget; closing the mid-window case needs the GCRA cell below.
+            // does pace on one budget. That residue is what `store.reserve` closes above, which is
+            // why this path runs only when the backend cannot offer the cell.
             const at = Math.max(
                 clock.now(),
                 s.nextGrantAt ?? 0,

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -348,6 +348,87 @@ export async function verifyStoreContract(
             },
         ],
     ];
+
+    // `reserve` is OPTIONAL (ADR 0024) — an eventually-consistent backend has no atomic
+    // read-compute-write to build the cell from, and a store without it is fully supported. So
+    // these rules are ADDED only when the store claims the verb: a store that omits it is not
+    // failing the contract, but one that ships it must mean the same thing by it as everyone else,
+    // or the fleet-wide pacing it unlocks is worse than the fallback it replaced.
+    if (store.reserve) {
+        const reserve = store.reserve.bind(store);
+        rules.push(
+            [
+                'reserve: a cold cursor grants at the instant asked for',
+                async () => {
+                    const at = await reserve(k('cold'), 1_000, 10_000, 60_000);
+                    if (at !== 10_000)
+                        throw new Error(
+                            `expected a cold cursor to grant at now (10000), got ${show(at)}`,
+                        );
+                },
+            ],
+            [
+                'reserve: successive grants advance by exactly one spacing',
+                async () => {
+                    const key = k('seq');
+                    const first = await reserve(key, 500, 1_000, 60_000);
+                    const second = await reserve(key, 500, 1_000, 60_000);
+                    const third = await reserve(key, 500, 1_000, 60_000);
+                    expectDeepEqual(
+                        [first, second, third],
+                        [1_000, 1_500, 2_000],
+                        'three grants on one cursor, same `now`',
+                    );
+                },
+            ],
+            [
+                'reserve: a `now` past the cursor moves it forward (idle reset)',
+                async () => {
+                    const key = k('idle');
+                    await reserve(key, 500, 1_000, 60_000); // cell → 1500
+                    const after = await reserve(key, 500, 9_000, 60_000);
+                    if (after !== 9_000)
+                        throw new Error(
+                            `expected max(now, cell) = 9000 after an idle gap, got ${show(after)}`,
+                        );
+                },
+            ],
+            [
+                'reserve: 20 concurrent grants are 20 distinct, evenly spaced instants',
+                async () => {
+                    // The atomicity rule, and the whole reason the verb exists: a non-atomic
+                    // read-compute-write hands several callers the SAME instant, which is exactly
+                    // the fleet-wide burst the cell is meant to remove.
+                    const results = await Promise.all(
+                        Array.from({ length: 20 }, () =>
+                            reserve(k('atomic-cursor'), 100, 5_000, 60_000),
+                        ),
+                    );
+                    const sorted = [...results].sort((a, b) => a - b);
+                    const wanted = Array.from(
+                        { length: 20 },
+                        (_, i) => 5_000 + i * 100,
+                    );
+                    expectDeepEqual(
+                        sorted,
+                        wanted,
+                        'sorted results of 20 concurrent reservations (a non-atomic cell collides)',
+                    );
+                },
+            ],
+            [
+                'reserve: cursors are isolated by key',
+                async () => {
+                    await reserve(k('cur-a'), 500, 1_000, 60_000);
+                    const b = await reserve(k('cur-b'), 500, 1_000, 60_000);
+                    if (b !== 1_000)
+                        throw new Error(
+                            `a reservation on cur-a leaked into cur-b: expected 1000, got ${show(b)}`,
+                        );
+                },
+            ],
+        );
+    }
     return runRules('store', rules);
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1969,6 +1969,44 @@ export interface StitchStore {
     /** Atomically increment a counter. Absent `ttl` means no window — the counter never expires. */
     increment(key: string, ttl?: number): Promise<number>;
     /**
+     * Atomically reserve the next slot on a shared **pacing cursor** and resolve to the instant
+     * reserved (epoch ms). One read-compute-write, indivisible across every process on the store:
+     *
+     * ```
+     * at = max(now, cell ?? 0);   cell = at + spacing;   return at
+     * ```
+     *
+     * This is the GCRA cell (ADR 0024). `increment` can only allocate *positions*; turning a
+     * position into a time needs an origin, and any origin a caller can compute is either
+     * per-process (so N workers each pace independently) or fixed to a window (so a worker joining
+     * mid-window inherits slots that already elapsed). A cursor has neither problem: it carries
+     * continuously, it is shared, and `max(now, …)` resets it after idle.
+     *
+     * **Optional**, and a store is a first-class citizen without it. `createStoreThrottle` falls
+     * back to `increment` plus a per-process cursor, which paces each process correctly and lets a
+     * fleet drift to N× mid-window (ADR 0023). Two reasons it is not required: an
+     * eventually-consistent backend (Cloudflare KV) has no atomic read-compute-write to build it
+     * from, and `StitchStore` is a contract **consumers implement**, where adding a required member
+     * is a hard break in any channel
+     * ([CONTRACT.md P19](../../../docs/CONTRACT.md#p19--the-alias-obligation-is-scoped-to-the-ga-channel)).
+     *
+     * `now` is the CALLER's clock, not the store's, so the cursor stays deterministic under an
+     * injected {@link Clock} (ADR 0010) and a store never needs a clock of its own.
+     *
+     * **`ttl` refreshes on every call**, unlike {@link StitchStore.increment}'s — whose expiry is
+     * bound to the creating increment precisely so a busy fixed window cannot slide forever. The
+     * opposite is right here: a cursor is continuous, so letting it lapse mid-pace would reset the
+     * schedule and allow the burst it exists to prevent. Absent `ttl` means it never expires.
+     * Losing the cell is always *safe* — `max(now, …)` restarts pacing from the present, exactly
+     * like a cold start — it just forgets any grants already queued past `now`.
+     */
+    reserve?(
+        key: string,
+        spacing: number,
+        now: number,
+        ttl?: number,
+    ): Promise<number>;
+    /**
      * Release any resources (connections, timers) the store holds. Optional — the in-memory
      * default clears its map. A seam's `close()` calls this as the last lifecycle step.
      */

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -2,7 +2,7 @@
 // state shared across separate stitches (simulating two workers sharing Redis); the default
 // in-memory store keeps them independent.
 import { memoryStore, stitch } from '../src';
-import type { Clock, Stitch } from '../src';
+import type { Clock, Stitch, StitchStore } from '../src';
 import { cookieSession, env } from '../src/auth';
 import { createThrottle } from '../src/resilience';
 import { createStoreThrottle } from '../src/store';
@@ -326,15 +326,28 @@ describe('Pluggable store — throttle', () => {
     // two workers sharing Redis. The mid-window residue is a known, deferred gap — pinned here so
     // it is a decision on the record rather than a surprise, and so the fleet-wide GCRA cell
     // `createStoreThrottle` defers has a test to break when it lands.
-    test('a fleet over one store: the shared budget holds at a window boundary; mid-window the residue is bounded by process count', async () => {
+    // A store with the ADR 0024 pacing cursor withheld — every other verb intact. The fallback
+    // path is not dead code: an eventually-consistent backend (Cloudflare KV) has no atomic
+    // read-compute-write to build a cell from, so this is the only path it can take, and its
+    // residues stay pinned rather than described.
+    const withoutReserve = (): StitchStore => {
+        const s = memoryStore();
+        return {
+            get: (k) => s.get(k),
+            set: (k, v, ttl) => s.set(k, v, ttl),
+            increment: (k, ttl) => s.increment(k, ttl),
+        };
+    };
+
+    test('a fleet over one store paces on ONE schedule, wherever in a window it starts', async () => {
         const fleet = async (
             rate: string,
             procs: number,
             each: number,
             start: number,
+            store: StitchStore = memoryStore(),
         ): Promise<{ p: number; t: number }[]> => {
             const clock = manualClock(start);
-            const store = memoryStore();
             const ts = Array.from({ length: procs }, () =>
                 createStoreThrottle({ rate }, store, clock),
             );
@@ -353,41 +366,50 @@ describe('Pluggable store — throttle', () => {
             return at;
         };
 
-        // 1. AT a window boundary every slot is still in the future, so the shared counter binds
-        //    and two processes draw from ONE budget: 500ms apart fleet-wide, not 500ms apart each.
-        //    This is what the store is for, and the property a per-process cursor could most
-        //    easily have broken.
-        const atBoundary = await fleet('2/s', 2, 3, 0);
-        expect(atBoundary.map((x) => x.t)).toEqual([
+        // 1. AT a window boundary: two processes draw from ONE budget — 500ms apart fleet-wide,
+        //    not 500ms apart each. This always held; the counter's slots were in the future here,
+        //    so even the fallback paced the fleet correctly.
+        expect((await fleet('2/s', 2, 3, 0)).map((x) => x.t)).toEqual([
             0, 500, 1000, 1500, 2000, 2500,
         ]);
 
-        // 2. MID-window, every slot up to `now` is already stale, and a stale slot cannot pace
-        //    anybody — only each process's own cursor can.
+        // 2. MID-window is the case the counter could not reach: every slot up to `now` is already
+        //    stale, and a stale slot paces nobody. The cursor is not a schedule of positions, so
+        //    there is no "stale prefix" to inherit — `max(now, cell)` starts from the present and
+        //    every process advances the same cell. Same 500ms fleet-wide, from a standing start
+        //    59.5s into a one-minute window.
         const midWindow = await fleet('120/m', 2, 3, 59_500);
+        expect(midWindow.map((x) => x.t)).toEqual([
+            59_500, 60_000, 60_500, 61_000, 61_500, 62_000,
+        ]);
 
-        //    a. Each process still honours the declared spacing internally. That is the invariant
-        //       the cursor buys, and the one that was violated outright before it.
-        for (const p of [0, 1]) {
-            const mine = midWindow.filter((x) => x.p === p).map((x) => x.t);
-            for (let i = 1; i < mine.length; i++)
-                expect((mine[i] ?? 0) - (mine[i - 1] ?? 0)).toBe(500);
-        }
-
-        //    b. So the instantaneous burst is bounded by the PROCESS COUNT rather than by how many
-        //       slots the window had left unclaimed. One process used to drain all of them into a
-        //       single instant; two processes now put exactly two calls there.
+        // 3. No instant carries more than one grant — the fleet-wide invariant, where the fallback
+        //    could only bound a burst by the process count.
         const perInstant = new Map<number, number>();
         for (const { t } of midWindow)
             perInstant.set(t, (perInstant.get(t) ?? 0) + 1);
-        expect(Math.max(...perInstant.values())).toBe(2);
+        expect(Math.max(...perInstant.values())).toBe(1);
 
-        //    c. And here is the residue itself, asserted rather than described: through the stale
-        //       prefix the fleet emits at 2× the declared rate (N× for N workers), recovering only
-        //       once the slots catch up with the clock. Closing this needs the fleet-wide GCRA
-        //       cell — when that lands, THIS is the assertion that should fail.
-        expect(midWindow.map((x) => x.t)).toEqual([
+        // 4. Three workers, same story: the fleet emits every 500ms regardless of how many
+        //    processes share the cell. Under the fallback this was 3× the declared rate.
+        expect((await fleet('120/m', 3, 2, 59_500)).map((x) => x.t)).toEqual([
+            59_500, 60_000, 60_500, 61_000, 61_500, 62_000,
+        ]);
+
+        // 5. And the FALLBACK still behaves as documented, pinned against a store with `reserve`
+        //    withheld — this is the path an eventually-consistent backend takes, so its residue is
+        //    a live property, not history. Mid-window the fleet emits at N× the declared rate,
+        //    recovering once the slots catch up with the clock.
+        const noCell = await fleet('120/m', 2, 3, 59_500, withoutReserve());
+        expect(noCell.map((x) => x.t)).toEqual([
             59_500, 59_500, 60_000, 60_000, 60_500, 60_500,
         ]);
+        // Each process still honours the declared spacing internally — the bound the local cursor
+        // buys, and the reason the residue is N× rather than unbounded.
+        for (const p of [0, 1]) {
+            const mine = noCell.filter((x) => x.p === p).map((x) => x.t);
+            for (let i = 1; i < mine.length; i++)
+                expect((mine[i] ?? 0) - (mine[i - 1] ?? 0)).toBe(500);
+        }
     });
 });

--- a/packages/core/test/stream.spec.ts
+++ b/packages/core/test/stream.spec.ts
@@ -382,14 +382,21 @@ describe('Decision 12 — streaming is concurrency-exempt but rate-charged', () 
         expect(r.waited).toBe(0);
     });
 
-    test('createStoreThrottle: rateOnly skips concurrency but DOES charge the rate window', async () => {
+    test('createStoreThrottle: rateOnly skips concurrency but DOES charge the rate gate', async () => {
         const store = memoryStore();
         const t = createStoreThrottle({ concurrency: 1, rate: '100/s' }, store);
+        // Both opens are charged (Decision 12: the rate gate bills at open). Asserted through the
+        // limiter rather than its bookkeeping: three rate-only acquires must take two full
+        // spacings to get through, which is what "charged" means to a caller. The previous version
+        // read the per-window counter key directly, which pinned the fallback's internal
+        // representation — with a `reserve`-capable store the same charges land on the ADR 0024
+        // cursor and no counter key exists at all, so it broke without the behaviour changing.
+        const start = now();
         await t.acquire('svc', { rateOnly: true });
         await t.acquire('svc', { rateOnly: true });
-        // The per-window rate counter records BOTH opens (Decision 12: charge the rate gate at open).
-        const windowStart = Math.floor(now() / 1000) * 1000;
-        expect(await store.get(`rl:svc:${windowStart}`)).toBe(2);
+        await t.acquire('svc', { rateOnly: true });
+        // spacing is 10ms at 100/s; the first is free, so three acquires span ~20ms.
+        expect(now() - start).toBeGreaterThanOrEqual(15);
     });
 
     test('chainThrottle forwards rateOnly to every gate (seam bucket + member)', async () => {

--- a/packages/deno-kv/src/index.ts
+++ b/packages/deno-kv/src/index.ts
@@ -312,6 +312,38 @@ export function denoKvStore(
                 `@stitchapi/deno-kv: increment(${key}) lost ${attempts} compare-and-set races`,
             );
         },
+        async reserve(key, spacing, at, ttl) {
+            // The GCRA pacing cursor (ADR 0024), on the same compare-and-set loop `increment`
+            // uses: read the cell and its versionstamp, commit `max(now, cell) + spacing` guarded
+            // by a `check` on that versionstamp, retry if another isolate committed first. That
+            // guard is what makes the cell atomic FLEET-wide rather than per-isolate.
+            //
+            // Simpler than `increment` above, and for the reason that made that one complicated:
+            // Deno KV's `set` replaces the whole entry INCLUDING its expiry, which forced the
+            // `{ n, deadline }` envelope there to stop a fixed window sliding on every write.
+            // A cursor is supposed to slide — its TTL refreshes on every reservation — so the
+            // replace-everything behaviour is exactly what is wanted and a bare number suffices.
+            const kk = k(key);
+            for (let attempt = 1; attempt <= attempts; attempt++) {
+                const entry = await kv.get(kk);
+                const cell = typeof entry.value === 'number' ? entry.value : 0;
+                const grantAt = Math.max(at, cell);
+                const options =
+                    ttl != null && ttl > 0 ? { expireIn: ttl } : undefined;
+                const res = await kv
+                    .atomic()
+                    .check({ key: kk, versionstamp: entry.versionstamp })
+                    .set(kk, grantAt + spacing, options)
+                    .commit();
+                if (res.ok) return grantAt;
+                if (backoff && attempt < attempts) {
+                    await sleep(backoffDelay(backoff, attempt, base, max));
+                }
+            }
+            throw new Error(
+                `@stitchapi/deno-kv: reserve(${key}) lost ${attempts} compare-and-set races`,
+            );
+        },
     };
     if (kv.close) {
         const close = kv.close.bind(kv);

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -53,6 +53,21 @@ export interface RedisDriver {
      * `ttl` = no expiry.
      */
     increment(key: string, ttl?: number): Promise<number>;
+    /**
+     * Atomically advance a pacing cursor and resolve to the instant reserved — the GCRA cell
+     * backing {@link StitchStore.reserve} (ADR 0024). `at = max(now, cell); cell = at + spacing`,
+     * in ONE server-side step; `ttl` (ms) refreshes on every call, unlike `increment`'s.
+     *
+     * Optional: the three bundled adapters implement it with a Lua `EVAL`, and a custom driver
+     * that omits it still satisfies this interface — `redisStore` then exposes no `reserve`, and
+     * the throttle takes its per-process fallback.
+     */
+    reserve?(
+        key: string,
+        spacing: number,
+        now: number,
+        ttl?: number,
+    ): Promise<number>;
     /** Release the connection (optional — `redisStore().close()` delegates here). */
     close?(): Promise<void>;
 }
@@ -68,6 +83,27 @@ const INCR_SCRIPT = `local v = redis.call('INCR', KEYS[1])
 local ttl = tonumber(ARGV[1]) or 0
 if v == 1 and ttl > 0 then redis.call('PEXPIRE', KEYS[1], ttl) end
 return v`;
+
+// The GCRA pacing cursor (ADR 0024) as one server-side script, which is what makes it atomic
+// across the whole fleet: read the cell, take the later of it and the caller's `now`, write the
+// next free instant back. Two differences from INCR_SCRIPT above, both deliberate:
+//
+//   • the PEXPIRE is UNconditional — a window must not slide (hence `v == 1` there), but a cursor
+//     must not lapse mid-pace, so every reservation refreshes it;
+//   • it returns a STRING. Lua numbers are doubles, but the RESP integer reply truncates, and a
+//     spacing of `per/count` is routinely fractional (`'3/s'` is 333.33ms). Returning `tostring`
+//     and parsing with `Number` keeps the fraction, so a fleet does not drift a millisecond per
+//     grant against the in-process limiter.
+//
+// `GET` on a missing key is Lua `false`, and `tonumber(false)` is nil, so `or 0` seeds a cold cell.
+const RESERVE_SCRIPT = `local spacing = tonumber(ARGV[1])
+local at = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3]) or 0
+local cell = tonumber(redis.call('GET', KEYS[1])) or 0
+if cell > at then at = cell end
+redis.call('SET', KEYS[1], at + spacing)
+if ttl > 0 then redis.call('PEXPIRE', KEYS[1], ttl) end
+return tostring(at)`;
 
 // ---------------------------------------------------------------------------
 // driver adapters (ioredis / node-redis)
@@ -157,6 +193,18 @@ export function fromIoredis(client: IoredisLike): RedisDriver {
             // ioredis: eval(script, numKeys, ...keysThenArgs). 0 = no window.
             return Number(await client.eval(INCR_SCRIPT, 1, key, ttl ?? 0));
         },
+        async reserve(key, spacing, at, ttl) {
+            return Number(
+                await client.eval(
+                    RESERVE_SCRIPT,
+                    1,
+                    key,
+                    spacing,
+                    at,
+                    ttl ?? 0,
+                ),
+            );
+        },
         async close() {
             await client.quit?.();
         },
@@ -193,6 +241,14 @@ export function fromNodeRedis(client: NodeRedisLike): RedisDriver {
                 await client.eval(INCR_SCRIPT, {
                     keys: [key],
                     arguments: [String(ttl ?? 0)],
+                }),
+            );
+        },
+        async reserve(key, spacing, at, ttl) {
+            return Number(
+                await client.eval(RESERVE_SCRIPT, {
+                    keys: [key],
+                    arguments: [String(spacing), String(at), String(ttl ?? 0)],
                 }),
             );
         },
@@ -244,6 +300,15 @@ export function fromUpstash(client: UpstashLike): RedisDriver {
             // Upstash: eval(script, keys[], args[]); ARGV are strings. '0' = no window.
             return Number(
                 await client.eval(INCR_SCRIPT, [key], [String(ttl ?? 0)]),
+            );
+        },
+        async reserve(key, spacing, at, ttl) {
+            return Number(
+                await client.eval(
+                    RESERVE_SCRIPT,
+                    [key],
+                    [String(spacing), String(at), String(ttl ?? 0)],
+                ),
             );
         },
     };
@@ -309,6 +374,14 @@ export function redisStore(
             return driver.increment(k(key), ttl);
         },
     };
+    // Only when the driver actually has the cell — a custom driver predating ADR 0024 must report
+    // its real capability, so the throttle selects the per-process fallback rather than calling a
+    // method that is not there.
+    if (driver.reserve) {
+        const reserve = driver.reserve.bind(driver);
+        store.reserve = (key, spacing, at, ttl) =>
+            reserve(k(key), spacing, at, ttl);
+    }
     if (driver.close) {
         const close = driver.close.bind(driver);
         store.close = async (): Promise<void> => {

--- a/packages/redis/test/conformance.spec.ts
+++ b/packages/redis/test/conformance.spec.ts
@@ -72,7 +72,36 @@ class FakeRedisEngine {
         this.data.set(key, { value: String(v), expiresAt: e.expiresAt });
         return v;
     }
+
+    // The GCRA pacing-cursor script (ADR 0024), same atomicity argument as `incrScript`: no
+    // await between the read and the write, so nothing can interleave — as on the server.
+    // Mirrors the Lua in two details that matter:
+    //   • the expiry is REWRITTEN every call (the Lua's PEXPIRE is unconditional), where the
+    //     counter above preserves the creating increment's — a window must not slide, a cursor
+    //     must not lapse;
+    //   • it returns a STRING, because the real script does `tostring` to keep a fractional
+    //     spacing off the RESP integer reply's truncation.
+    reserveScript(
+        key: string,
+        spacing: number,
+        at: number,
+        ttlMs: number,
+    ): string {
+        const e = this.live(key);
+        const cell = e ? Number(e.value) : 0;
+        const grantAt = Math.max(at, cell);
+        this.data.set(key, {
+            value: String(grantAt + spacing),
+            expiresAt: ttlMs > 0 ? Date.now() + ttlMs : Infinity,
+        });
+        return String(grantAt);
+    }
 }
+
+// Which script the caller sent. The facades below take the script TEXT, exactly as a real client
+// does, so the fake routes on it rather than assuming every `eval` is the counter — which is what
+// it used to do, and why a second script silently read as an increment.
+const isIncr = (script: unknown): boolean => String(script).includes('INCR');
 
 // --- client-shaped facades over one engine --------------------------------
 
@@ -94,9 +123,18 @@ function ioredisFacade(engine: FakeRedisEngine): IoredisLike {
             engine.del(key);
             return 1;
         },
-        async eval(_script, _numKeys, ...args) {
-            const [key, ttlMs] = args;
-            return engine.incrScript(String(key), Number(ttlMs));
+        async eval(script, _numKeys, ...args) {
+            if (isIncr(script)) {
+                const [key, ttlMs] = args;
+                return engine.incrScript(String(key), Number(ttlMs));
+            }
+            const [key, spacing, at, ttlMs] = args;
+            return engine.reserveScript(
+                String(key),
+                Number(spacing),
+                Number(at),
+                Number(ttlMs),
+            );
         },
         async quit() {
             return 'OK';
@@ -117,10 +155,17 @@ function nodeRedisFacade(engine: FakeRedisEngine): NodeRedisLike {
             engine.del(key);
             return 1;
         },
-        async eval(_script, options) {
+        async eval(script, options) {
             const key = options.keys[0] ?? '';
-            const ttlMs = Number(options.arguments[0]);
-            return engine.incrScript(key, ttlMs);
+            if (isIncr(script))
+                return engine.incrScript(key, Number(options.arguments[0]));
+            const [spacing, at, ttlMs] = options.arguments;
+            return engine.reserveScript(
+                key,
+                Number(spacing),
+                Number(at),
+                Number(ttlMs),
+            );
         },
         async quit() {
             return 'OK';
@@ -152,10 +197,16 @@ function upstashFacade(engine: FakeRedisEngine): UpstashLike {
             engine.del(key);
             return 1;
         },
-        async eval(_script, keys, args) {
+        async eval(script, keys, args) {
             const key = keys[0] ?? '';
-            const ttlMs = Number(args[0]);
-            return engine.incrScript(key, ttlMs);
+            if (isIncr(script)) return engine.incrScript(key, Number(args[0]));
+            const [spacing, at, ttlMs] = args;
+            return engine.reserveScript(
+                key,
+                Number(spacing),
+                Number(at),
+                Number(ttlMs),
+            );
         },
     };
 }


### PR DESCRIPTION
Closes the residue [ADR 0023](https://github.com/rejifald/StitchAPI/blob/main/docs/adr/0023-a-rate-is-a-minimum-spacing.md) recorded and deferred — and that [#620](https://github.com/rejifald/StitchAPI/pull/620) pinned with a test whose comment named this change as the moment it should flip. It has.

## The residue

ADR 0023 fixed the store-backed throttle's cold-start burst with a **per-process** pacing cursor, and wrote down what that could not buy:

> a slot already in the past paces nobody, so N workers that all start mid-window emit at N× the declared rate until the slots catch up with the clock.

Two workers measured 2×, three measured 3×.

## Why a counter could never close it

It looks like it should, so this is worth stating. A counter allocates **positions**. Turning a position into a **time** needs an origin — and every origin a caller can compute is wrong in one of two directions:

| Origin | Fails when | Symptom |
| --- | --- | --- |
| The window's epoch-aligned start | a process joins mid-window | every elapsed slot claimable at once — the ADR 0023 cold-start burst |
| The process's own cursor | several processes share the store | each paces itself correctly; the fleet emits N× |

Both were tried, in that order, and each fix exposed the other. There is no third, because the missing fact — *when did the fleet last grant?* — lives in no process and in no counter.

A **cursor** needs no origin. It is already an instant, it carries continuously, and `max(now, cell)` resets it after idle.

## The primitive

```ts
reserve?(key: string, spacing: number, now: number, ttl?: number): Promise<number>;
// atomically: at = max(now, cell ?? 0);  cell = at + spacing;  return at
```

Three details are load-bearing, each pinned by `verifyStoreContract`:

- **`now` is the caller's clock**, so the cursor stays deterministic under an injected `Clock` and a store never needs one of its own.
- **`ttl` refreshes on every call** — the opposite of `increment`, whose expiry is creation-bound *precisely* so a busy window cannot slide. A cursor must slide and must not lapse mid-pace. That constraint is what priced this out of ADR 0023.
- **Fractional spacing survives.** `per/count` is routinely fractional (`'3/s'` is 333.33ms), so the Lua returns `tostring` rather than a RESP integer, which truncates. A fleet rounding each grant down would drift a millisecond per call against the in-process limiter.

## Optional, and the fallback is not deprecated

Two independent reasons, either sufficient:

- **Cloudflare KV is eventually consistent** — no atomic read-compute-write to build a cell from. It keeps the ADR 0023 path, whose residues are still pinned, now against a store with the verb *deliberately withheld*, so the fallback stays tested rather than described.
- **`StitchStore` is consumer-implemented**, where [P19's corollary](https://github.com/rejifald/StitchAPI/blob/main/docs/CONTRACT.md#p19--the-alias-obligation-is-scoped-to-the-ga-channel) makes a required member a hard break in any channel. Optional is the only additive shape — which is what [P21](https://github.com/rejifald/StitchAPI/blob/main/docs/CONTRACT.md#p21--every-contract-has-an-extension-seam) reserves the seam for.

**Existing custom stores need no changes.** Selection is capability-based, never configuration: there is no case where a caller with a capable store wants the weaker pacing.

| Store | Mechanism |
| --- | --- |
| `memoryStore` | one JS thread, nothing awaited between read and write |
| `@stitchapi/redis` | one Lua `EVAL`, beside the existing `INCR` script |
| `@stitchapi/deno-kv` | the compare-and-set loop `increment` already uses |
| `@stitchapi/cloudflare-kv` | **absent** — eventually consistent |
| `@stitchapi/react-native` / `expo` | **absent** — on-device; there is no fleet to pace |

## For the reviewer

- **Two tests changed shape, not expectation.** The fleet fixture now asserts one schedule across 2 and 3 workers from a standing start 59.5s into a one-minute window, and keeps the old numbers as the fallback's pinned behaviour. `stream.spec.ts`'s `rateOnly` test read the per-window counter key directly — with a cell there is no counter key — so it now asserts through the limiter, which is what "charged" means to a caller.
- **deno-kv's `reserve` is simpler than its `increment`**, for the reason that made that one complicated: its `{ n, deadline }` envelope exists to stop a fixed window sliding, and a cursor is supposed to slide.
- **Bundle budgets raised 23.50→23.70 / 20.90→21.10 KB** (measured 23.53 / 20.95), the conventional 0.2 KB step for a new capability. Factoring the two pacing paths' shared wait/sleep tail into one helper **measured worse** (+0.06 KB — closure plus an extra promise costing more than four duplicated lines), so the repetition stays on purpose.
- **The advertised size moves ~23 → ~24 kB**, crossing a rounding boundary. Propagated to all eight sites under the `bundle-advertised-size` drift tether. `import { stitch }` stays ~21.
- **The ESLint suppression ratchet is unchanged** — both non-null assertions this change introduced were removed rather than baselined.

## Breaking

None for consumers: no API you write changes, and a custom store needs no edits. Flagged only because a store that *does* implement `reserve` changes observable pacing — a fleet that was emitting at N× its configured rate mid-window now holds the rate. A drop in throughput after upgrading means the limiter was over-admitting before.

Gates: 1425/1425 core tests, full workspace suite, and the complete pre-push set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)