### PR TITLE
refactor(core)!: fold cache.transformVersion + trustTransform into one cache.transform envelope (P24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,35 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Changed
 
+- **BREAKING CHANGE: `cache.transformVersion` + `cache.trustTransform` fold into one
+  `cache.transform` envelope.**
+  ([CONTRACT.md P24](docs/CONTRACT.md#p24--a-shared-field-name-prefix-in-a-house-contract-is-an-envelope))
+  The two fields were the two arms of a single decision — how an opaque `transform` clears
+  [ADR 0004](docs/adr/0004-standard-schema-fingerprint-for-cache-invalidation.md)'s rung 2 — with
+  their precedence (`version` wins; `trust` is then inert) living only in the resolver. They are
+  now one envelope that names its subject once, so the members carry only what distinguishes them
+  and the precedence is a within-envelope rule. A bare tag is the P12 shorthand for the dominant
+  field: `transform: 3` ≡ `transform: { version: 3 }`.
+
+    Migration — move each field into the envelope and drop the redundant prefix:
+
+    ```ts
+    // before
+    cache: { ttl: '60s', transformVersion: 3 },
+    cache: { ttl: '60s', trustTransform: true },
+    // after
+    cache: { ttl: '60s', transform: 3 },              // ≡ { version: 3 }
+    cache: { ttl: '60s', transform: { trust: true } },
+    ```
+
+    `tsc` catches the migration — `NoUnknownNestedKeys` rejects both old keys by name at the
+    `cache:` slot, and neither had a runtime fallback, so there is no silent path. Behaviour is
+    unchanged end to end: the ladder, the refuse-by-default for an un-versioned transform, and the
+    generation token a given version produces are all exactly as they were. The refusal `reason`
+    surfaced on the cache trace now names the new spelling. `resolveFingerprint`'s read-view keeps
+    the flat shape it always had, with `trustTransform` renamed to `transformTrust` so the
+    published `stitchapi/fingerprint` surface carries one vocabulary.
+
 - **BREAKING CHANGE: `circuit.halfOpenAfter` is removed — `cooldown` is the one open→half-open
   boundary.** ([CONTRACT.md P1](docs/CONTRACT.md#p1--one-word-one-concept-one-value-space)) The two
   fields named the same instant: `createCircuit` resolved `halfOpenAfter ?? cooldown` into a single

--- a/apps/docs/content/docs/reference/config-types.mdx
+++ b/apps/docs/content/docs/reference/config-types.mdx
@@ -136,6 +136,19 @@ request, so it cannot drift from what it names.
 
 <AutoTypeTable path="../../packages/core/src/types.ts" name="CacheOptions" />
 
+#### CacheTransformOptions
+
+The shape behind `cache.transform` — what the cache knows about an opaque `transform`.
+A bare version tag is the shorthand for `{ version }` — `transform: 3` ≡
+`transform: { version: 3 }`. A stitch that has a `transform` and none of this **refuses
+to cache**: the closure cannot be hashed, and re-validation cannot detect a transform
+change, so no policy would be sound. `version` wins when both are set.
+
+<AutoTypeTable
+    path="../../packages/core/src/types.ts"
+    name="CacheTransformOptions"
+/>
+
 ### PaginateOptions
 
 The shape behind `paginate`. `next` drives the loop; auth, retry, and throttle apply to

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -1053,6 +1053,16 @@ shape, not as today's surface: nothing on the surface carries an alias.
   `seam?: AtLeastOne<NestFeatureSeamOptions>` (`{ config?: AtLeastOne<SeamConfig>, token? }`).
   `forFeature`/`forFeatureScoped` read `seam.config` / `seam.token`. Genuine breaking
   flat→envelope, no alias.
+- **P24 (cache transform, 2026-08-04)** `CacheOptions.transformVersion`+`trustTransform` — the two
+  ways an opaque `transform` clears [ADR 0004](adr/0004-standard-schema-fingerprint-for-cache-invalidation.md)'s
+  rung 2 — fold into `transform?: string | number | AtLeastOne<CacheTransformOptions>`
+  (`{ version?, trust? }`). A bare tag is the P12 dominant-field shorthand
+  (`transform: 3` ≡ `{ version: 3 }`), folded by `expandShorthand` like the other nested scalars, so
+  `__config` only ever carries the object form (P0). The precedence that lived only in the resolver
+  — `version` wins, and `trust` is then inert — is now a within-envelope rule. The version tag stays
+  under `cache` rather than moving beside the closure it versions because it must round-trip as JSON
+  (§1) while `transform` itself is function sugar on `__rawConfig`. Genuine breaking flat→envelope,
+  no alias. **R8 never flagged this pair** — see its leading-word gap in §7.
 - **P20/P12/P13 (empty-object rejection)** the five bare all-optional `StitchConfig` slots R6 flagged
   now type their object form so `{}` is a **compile error**: `hooks?: AtLeastOne<Hooks>` and
   `input?: AtLeastOne<InputSchemas>` (no scalar); `multipart?: MultipartNesting | AtLeastOne<MultipartOptions>`
@@ -1126,6 +1136,13 @@ shape, not as today's surface: nothing on the surface carries an alias.
   not `type`-literal object shapes or class fields, which is why `SurfaceOutcome.after`
   (a union member) sits outside R9's reach; no R8 group was found in either at the
   2026-07-08 audit, but a future one wouldn't be caught until it grows an `interface`.
+- **R8's known gap: the shared subject must lead.** R8 buckets by **leading** word, so a pair that
+  names its subject in the **trailing** position never groups. `CacheOptions.transformVersion` +
+  `trustTransform` — one capability by any reading, folded 2026-08-04 (§6) — bucketed under
+  "transform" and "trust" and survived every audit clean. Grouping by trailing word instead would
+  collapse unrelated members (`clientId`/`stitchId`, every `*Options` field) and is exactly the
+  guess this ratchet refuses, so the rule stays leading-word and this class is found by **reading**,
+  not by lint. When you find one, the fix is the same fold and a §6 entry saying R8 could not see it.
 
 ### The unknown-key ratchet
 

--- a/docs/adr/0004-standard-schema-fingerprint-for-cache-invalidation.md
+++ b/docs/adr/0004-standard-schema-fingerprint-for-cache-invalidation.md
@@ -4,6 +4,13 @@
 - **Date:** 2026-06-14
 - **Tags:** caching, validation, schema, standard-schema, contract-not-dependency, runtime
 
+> **Amended 2026-08-04 (spelling only, rung 2 unchanged).** The two ways to clear the transform
+> gate were authored as the flat pair `cache.transformVersion` + `cache.trustTransform`; they are
+> now the one envelope [P24](../CONTRACT.md#p24--a-shared-field-name-prefix-in-a-house-contract-is-an-envelope)
+> asks for — **`cache.transform: string | number | { version?, trust? }`**, where a bare tag is the
+> P12 shorthand for `{ version }`. The ladder, its precedence, and every default below are
+> unchanged; only the authored spelling moved. The prose here uses the new one throughout.
+
 ## Context
 
 [ADR 0003](0003-derived-key-response-cache-and-coalescing.md) makes one decision
@@ -164,8 +171,8 @@ function stitchGeneration(cfg: StitchConfig): string {
 
     const xTag = !cfg.transform
         ? 'x:none'
-        : cfg.cache?.transformVersion != null
-          ? `x:${cfg.cache.transformVersion}`
+        : cfg.cache?.transform?.version != null
+          ? `x:${cfg.cache.transform.version}`
           : 'x:OPAQUE';
 
     if (xTag === 'x:OPAQUE') return REFUSE; // un-versioned transform → don't cache
@@ -191,8 +198,8 @@ Resolved once per stitch, highest precedence first:
 2.  **Un-versioned `transform` present** → **refuse-to-cache.** Re-validation
     cannot see a transform change (Decision 2 — a stale value still satisfies an
     unchanged schema), so neither fast nor revalidate is sound. Lift it with
-    `cache.transformVersion` (→ a sound fingerprint) or `cache.trustTransform:
-true` (cache anyway, bounded only by TTL).
+    `cache.transform: '<version>'` (→ a sound fingerprint) or
+    `cache.transform: { trust: true }` (cache anyway, bounded only by TTL).
 3.  **Sound structural fingerprint** — a compliant strategy is registered for the
     vendor and reports full capture (`value !== null`). Fold `hash(vendor, S, U, X)`
     into the generation. Fast path.
@@ -266,7 +273,7 @@ Therefore opaque logic is handled by **abstain-or-version**, never by hashing it
 - If a strategy encounters an opaque `.refine`/`.transform`/`.brand`/predicate
   it cannot represent, it **abstains** (`value: null`) → conservative fallback.
 - `config.transform` is opaque to core. Its provenance enters the fingerprint
-  only as `cache.transformVersion` (a user tag); otherwise it forces refuse
+  only as `cache.transform.version` (a user tag); otherwise it forces refuse
   (Decision 4, rung 2).
 
 This is exactly how every prior-art system treats non-serialisable logic:
@@ -395,7 +402,7 @@ assertConformance(
   ([zod #4497](https://github.com/colinhacks/zod/issues/4497)).
 - **Transforms are a genuine blind spot.** An un-versioned `transform` forces
   refuse-to-cache; this is correct but costs the cache for transform-heavy
-  stitches until the author adds `cache.transformVersion`.
+  stitches until the author adds `cache.transform`.
 - **Over-invalidation by design.** Strong-by-default fingerprints will bump on
   cosmetic schema refactors (e.g. inlining a sub-schema) unless a weak strategy
   is chosen. We accept refetch cost over staleness risk.
@@ -438,7 +445,7 @@ conformance-tested):
   over-invalidation of the opaque token.
 - **The fold (`stitchapi/cache`)** — `createCache` calls `resolveFingerprint`
   once per stitch from its `output`/`transform`/`unwrap` + the `cache` options
-  (`version`, `transformVersion`, `trustTransform`, `onUnfingerprintable`). The
+  (`version`, `transform`, `onUnfingerprintable`). The
   `generation` token folds into the cache namespace **alongside** the per-stitch
   generation counter (so a schema/unwrap/versioned-transform change moves the
   bucket while bulk-invalidate still bumps the counter); the `policy` selects

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -387,8 +387,8 @@ export function createCache(opts: CacheControllerOptions): CacheController {
         transform: opts.transform,
         pick: opts.pick,
         version: config.version,
-        transformVersion: config.transformVersion,
-        trustTransform: config.trustTransform,
+        transformVersion: config.transform?.version,
+        transformTrust: config.transform?.trust,
         onUnfingerprintable: config.onUnfingerprintable,
     });
     const fpTag = `f${fp.generation}:`;

--- a/packages/core/src/fingerprint.ts
+++ b/packages/core/src/fingerprint.ts
@@ -139,10 +139,10 @@ export interface FingerprintInput {
     readonly pick?: string | undefined;
     /** Explicit `cache.version` — authoritative override; always wins. */
     readonly version?: string | number | undefined;
-    /** A user tag making an opaque `transform` sound. */
+    /** `cache.transform.version` — a user tag making an opaque `transform` sound. */
     readonly transformVersion?: string | number | undefined;
-    /** Opt-in: cache despite an un-versioned `transform`, bounded only by TTL. */
-    readonly trustTransform?: boolean | undefined;
+    /** `cache.transform.trust` — cache despite an un-versioned `transform`, bounded only by TTL. */
+    readonly transformTrust?: boolean | undefined;
     /**
      * Policy when an OUTPUT SCHEMA is present but can't be soundly fingerprinted
      * (unknown/unregistered vendor, non-Standard-Schema validator, or the strategy
@@ -202,7 +202,7 @@ export function resolveFingerprint(
     } else if (input.transformVersion != null) {
         xTag = `x:v:${input.transformVersion}`;
         xSound = true;
-    } else if (input.trustTransform) {
+    } else if (input.transformTrust) {
         xTag = 'x:trusted';
         xSound = true;
     } else {
@@ -224,7 +224,7 @@ export function resolveFingerprint(
         return {
             generation: '',
             policy: 'refuse',
-            reason: 'opaque transform without cache.transformVersion or trustTransform. Fix: set cache.transformVersion when you change the transform, or cache.trustTransform: true to opt out.',
+            reason: 'opaque transform without a cache.transform declaration. Fix: set cache.transform to a version tag you bump when the transform changes, or cache.transform: { trust: true } to opt out.',
         };
     }
 

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -229,6 +229,8 @@ function expandShorthand(cfg: Partial<StitchConfig>): void {
     // P7: the cache's list fields take a bare string as the one-element list. Widened HERE, before
     // the deep-merge, so a string in one layer and a list in another merge as one shape and the
     // controller reads the settled `ResolvedCacheOptions` — always arrays, never re-normalising.
+    // Nested fold (P12/P24) in the same pass: `cache.transform` is a scalar-or-envelope slot, so a
+    // bare version tag folds to `{ version }` and `__config` never carries the scalar form (P0).
     const cache = cfg.cache as CacheOptions | undefined;
     if (cache !== undefined)
         cfg.cache = {
@@ -236,6 +238,7 @@ function expandShorthand(cfg: Partial<StitchConfig>): void {
             ...compact({
                 vary: listOf(cache.vary),
                 methods: listOf(cache.methods),
+                transform: envelope(cache.transform, 'version'),
             }),
         };
     // P13: `sse: true` enables reconnection with defaults; `false`/absent is off (the opaque

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -378,7 +378,11 @@ interface NestedEnvelopes {
     timeout: [TimeoutOptions, 'TimeoutOptions', object];
     circuit: [CircuitOptions, 'CircuitOptions', object];
     idempotency: [IdempotencyOptions, 'IdempotencyOptions', object];
-    cache: [CacheOptions, 'CacheOptions', object];
+    cache: [
+        CacheOptions,
+        'CacheOptions',
+        { transform: [CacheTransformOptions, 'CacheTransformOptions', object] },
+    ];
     hooks: [Hooks, 'Hooks', object];
     paginate: [PaginateOptions, 'PaginateOptions', object];
 }
@@ -1123,6 +1127,33 @@ export interface IdempotencyOptions {
 
 // ---- Cache (ADR 0003) -----------------------------------------------------
 /**
+ * The cache's stance on a `transform` (ADR 0004 rung 2) — one envelope for the two ways to clear
+ * the transform gate, because a `transform` is a closure core cannot soundly hash: by default a
+ * stitch that has one refuses to cache, since re-validation cannot detect a transform change (a
+ * stale value still satisfies an unchanged schema).
+ *
+ * The version tag lives here rather than beside the closure it versions because it must round-trip
+ * as JSON (CONTRACT.md P0) while `transform` itself is function sugar on `__rawConfig`.
+ *
+ * `version` is the strong form and **wins when both are set** — once the tag is sound, `trust`
+ * has nothing left to relax.
+ */
+export interface CacheTransformOptions {
+    /**
+     * Version tag for the transform — the sound form. It folds into the fingerprint, so bumping it
+     * whenever the transform's behaviour changes moves the cache generation and makes every entry
+     * written by the old transform unreachable.
+     */
+    version?: string | number;
+    /**
+     * Cache despite an un-versioned transform, trusting its output is stable for the `ttl`. Weaker
+     * than {@link CacheTransformOptions.version} — a transform change is invisible, bounded only by
+     * TTL — so prefer naming a version whenever you can.
+     */
+    trust?: boolean;
+}
+
+/**
  * Transport-level response cache + in-process request coalescing (ADR 0003). The key is
  * **derived** from the resolved request — no caller-authored keys — so it cannot drift from
  * what it names. Off by default: no `cache` block ⇒ no caching and no hot-path cost. The engine
@@ -1177,18 +1208,13 @@ export interface CacheOptions {
      */
     version?: string | number;
     /**
-     * Version tag for an opaque `transform` (ADR 0004). A `transform` is a closure that cannot be
-     * soundly hashed, so by default a stitch that has one **refuses to cache** (re-validation can't
-     * detect a transform change). Set this to make the transform sound and re-enable caching; bump
-     * it whenever the transform's behaviour changes. See also {@link CacheOptions.trustTransform}.
+     * What the cache knows about an opaque `transform` (ADR 0004 rung 2). A `transform` is a
+     * closure that cannot be soundly hashed, so a stitch carrying one **refuses to cache** until
+     * one of {@link CacheTransformOptions}' two declarations clears the gate. A bare
+     * `string | number` is the P12 shorthand for the dominant field — `transform: 3` ≡
+     * `transform: { version: 3 }`.
      */
-    transformVersion?: string | number;
-    /**
-     * Opt in to caching despite an un-versioned `transform`, trusting that its output is stable for
-     * the `ttl`. Weaker than {@link CacheOptions.transformVersion} (a transform change is invisible,
-     * bounded only by TTL); prefer `transformVersion` when you can name a version.
-     */
-    trustTransform?: boolean;
+    transform?: string | number | AtLeastOne<CacheTransformOptions>;
     /**
      * Policy when an `output` schema is present but cannot be soundly fingerprinted (no
      * `@stitchapi/fingerprint-*` registered for its vendor, a non-Standard-Schema validator, or the
@@ -1594,10 +1620,17 @@ export interface StitchConfig {
     trace?: TraceSink | 'console' | false;
 }
 
-/** {@link CacheOptions} after {@link compose}: the `T | T[]` list fields are always arrays. */
-export type ResolvedCacheOptions = Omit<CacheOptions, 'vary' | 'methods'> & {
+/**
+ * {@link CacheOptions} after {@link compose}: the `T | T[]` list fields are always arrays and the
+ * `transform` scalar is folded to `{ version }`.
+ */
+export type ResolvedCacheOptions = Omit<
+    CacheOptions,
+    'vary' | 'methods' | 'transform'
+> & {
     vary?: string[];
     methods?: string[];
+    transform?: CacheTransformOptions;
 };
 
 /** {@link StreamOptions} after {@link compose}: the `buffer` scalar is folded to `{ chars }`. */

--- a/packages/core/test/cache.spec.ts
+++ b/packages/core/test/cache.spec.ts
@@ -4,7 +4,7 @@
 // eviction, the `sensitive` bypass, principal scope isolation, re-validate-on-hit + the
 // `version` fast path, and the cacheable-method gate (GraphQL opt-in).
 import { graphql, memoryStore, seam, stitch } from '../src';
-import type { Adapter } from '../src';
+import type { Adapter, CacheOptions } from '../src';
 import { clearFingerprinters, registerFingerprinter } from '../src/fingerprint';
 import type { SchemaFingerprinter } from '../src/fingerprint';
 import type { StandardSchemaV1 } from '../src/standard-schema';
@@ -571,7 +571,7 @@ describe('cache — schema fingerprint fold (ADR 0004)', () => {
         expect(calls()).toBe(1); // value re-validates fine → still cached
     });
 
-    test('an opaque transform refuses to cache unless a transformVersion makes it sound', async () => {
+    test('an opaque transform refuses to cache unless cache.transform makes it sound', async () => {
         const refused = counting();
         const r = stitch({
             url: URL,
@@ -579,7 +579,7 @@ describe('cache — schema fingerprint fold (ADR 0004)', () => {
             adapter: refused.adapter,
             trace: false,
             cache: { ttl: '60s', tenancy: 'app' },
-            transform: (b) => b, // opaque closure, no transformVersion/trustTransform → refuse
+            transform: (b) => b, // opaque closure, no cache.transform declaration → refuse
         });
         const trace = await cacheTrace(r.stream());
         expect(trace.some((d) => d.startsWith('bypass:'))).toBe(true);
@@ -593,12 +593,42 @@ describe('cache — schema fingerprint fold (ADR 0004)', () => {
             name: 'txv',
             adapter: versioned.adapter,
             trace: false,
-            cache: { ttl: '60s', tenancy: 'app', transformVersion: '1' },
+            cache: { ttl: '60s', tenancy: 'app', transform: '1' }, // P12 scalar ≡ { version: '1' }
             transform: (b) => b, // now sound (version named) → fast
         });
         await v();
         await v();
         expect(versioned.calls()).toBe(1); // second call is a hit
+    });
+
+    test('the bare version tag folds to `{ version }` in __config (P0/P12)', () => {
+        const s = stitch({
+            url: URL,
+            trace: false,
+            cache: { ttl: '60s', transform: 3 },
+            transform: (b) => b,
+        });
+        // The engine only ever sees the object form, so the scalar never reaches the store key or
+        // a serialized config — the same fold `retry.backoff` and `wire.multipart` get.
+        expect(s.__config.cache?.transform).toEqual({ version: 3 });
+    });
+
+    test('the flat `transformVersion`/`trustTransform` pair is off the type surface (P24)', () => {
+        // One literal per key: excess-property checking reports only the FIRST unknown key, so a
+        // second directive in the same object would be unused (and `check:types` fails on that).
+        const versioned: CacheOptions = {
+            ttl: '60s',
+            // @ts-expect-error — folded into `cache.transform`, whose bare tag IS the version;
+            // the envelope names the subject once (CONTRACT.md P24, hard break under P19).
+            transformVersion: 3,
+        };
+        const trusted: CacheOptions = {
+            ttl: '60s',
+            // @ts-expect-error — `cache.transform: { trust: true }` is the weak arm of that same
+            // envelope, one word shorter for having dropped the subject from the field name.
+            trustTransform: true,
+        };
+        expect([versioned.ttl, trusted.ttl]).toEqual(['60s', '60s']);
     });
 });
 

--- a/packages/core/test/config-at-least-one.spec.ts
+++ b/packages/core/test/config-at-least-one.spec.ts
@@ -84,6 +84,13 @@ test('the opaque `{}` is rejected at each Scalar|AtLeastOne slot (P20)', () => {
             // @ts-expect-error — `circuit: {}` is rejected; both fields are required (P15).
             circuit: {},
         }),
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
+            transform: (b) => b,
+            // @ts-expect-error — `cache.transform: {}` is rejected; name a version or set `trust`.
+            cache: { ttl: '60s', transform: {} },
+        }),
     ];
     // The assertions that matter are the @ts-expect-error directives above (checked by `check:types`).
     expect(typeof rejected).toBe('function');
@@ -122,6 +129,19 @@ test('the scalar / ≥1-field forms are accepted at each slot (P12/P13/P20)', ()
             baseUrl: 'https://x',
             path: '/y',
             retry: { backoff: { base: 5 } },
+        }),
+        // P24/P12: `cache.transform` takes the bare version tag or a ≥1-field envelope.
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
+            transform: (b) => b,
+            cache: { ttl: '60s', transform: 3 },
+        }),
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
+            transform: (b) => b,
+            cache: { ttl: '60s', transform: { trust: true } },
         }),
     ];
     expect(typeof accepted).toBe('function');

--- a/packages/core/test/fingerprint-resolve-edges.spec.ts
+++ b/packages/core/test/fingerprint-resolve-edges.spec.ts
@@ -5,7 +5,7 @@
 //     test only checks the policy is fast + the generation is non-empty);
 //   - an opaque transform with no output still REFUSES — the transform gate (rung 2) outranks the
 //     no-schema fast path (rung 4);
-//   - `trustTransform` clears the transform gate but does NOT rescue an un-fingerprintable schema:
+//   - `transformTrust` clears the transform gate but does NOT rescue an un-fingerprintable schema:
 //     it still refuses (rung 5), and only `onUnfingerprintable: 'revalidate'` caches it.
 import { clearFingerprinters, resolveFingerprint } from '../src/fingerprint';
 import type { StandardSchemaV1 } from '../src/standard-schema';
@@ -56,12 +56,12 @@ describe('resolveFingerprint: the transform gate outranks the no-schema fast pat
     });
 });
 
-describe('resolveFingerprint: trustTransform does not rescue an un-fingerprintable schema', () => {
-    it('trustTransform clears the transform gate but an un-fingerprintable schema still refuses', () => {
+describe('resolveFingerprint: transformTrust does not rescue an un-fingerprintable schema', () => {
+    it('transformTrust clears the transform gate but an un-fingerprintable schema still refuses', () => {
         const r = resolveFingerprint({
             output: unregisteredSchema(),
             transform: (x: unknown) => x,
-            trustTransform: true,
+            transformTrust: true,
         });
         expect(r.policy).toBe('refuse');
         // The refusal is about the SCHEMA (rung 5), not the transform (rung 2) — it cleared the gate.
@@ -73,7 +73,7 @@ describe('resolveFingerprint: trustTransform does not rescue an un-fingerprintab
         const r = resolveFingerprint({
             output: unregisteredSchema(),
             transform: (x: unknown) => x,
-            trustTransform: true,
+            transformTrust: true,
             onUnfingerprintable: 'revalidate',
         });
         expect(r.policy).toBe('revalidate');

--- a/packages/core/test/fingerprint.spec.ts
+++ b/packages/core/test/fingerprint.spec.ts
@@ -167,11 +167,11 @@ describe('resolveFingerprint — the fallback ladder', () => {
         expect(a.generation).not.toBe(b.generation);
     });
 
-    it('rung 2: trustTransform + sound schema → fast', () => {
+    it('rung 2: transformTrust + sound schema → fast', () => {
         const r = resolveFingerprint({
             output: userSchema(),
             transform: (b) => b,
-            trustTransform: true,
+            transformTrust: true,
         });
         expect(r.policy).toBe('fast');
     });

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -327,7 +327,7 @@ const PREFIX_GROUP_ALLOW = new Map([
     ],
     [
         'FingerprintInput.transform',
-        'transform/transformVersion is a derived read-view combining StitchConfig.transform (top-level sugar) and CacheOptions.transformVersion (nested) for the hash — the two are not co-located in any authored config',
+        'transform/transformVersion/transformTrust is a derived read-view that FLATTENS the authored CacheOptions.transform envelope (version/trust) back alongside the top-level StitchConfig.transform closure for the hash — the envelope P24 asks for is the authored one; re-nesting it here would only re-wrap what the resolver reads flat',
     ],
     [
         'CliIO.write',


### PR DESCRIPTION
`cache.transformVersion` and `cache.trustTransform` are the two arms of a single decision — how an opaque `transform` clears [ADR 0004](docs/adr/0004-standard-schema-fingerprint-for-cache-invalidation.md)'s rung 2 — so [P24](docs/CONTRACT.md#p24--a-shared-field-name-prefix-in-a-house-contract-is-an-envelope) says they are an envelope. This folds them.

```ts
// before
cache: { ttl: '60s', transformVersion: 3 },
cache: { ttl: '60s', trustTransform: true },
// after
cache: { ttl: '60s', transform: 3 },              // ≡ { version: 3 }
cache: { ttl: '60s', transform: { trust: true } },
```

## What

### 1. The fold

`CacheOptions.transform?: string | number | AtLeastOne<CacheTransformOptions>` where `CacheTransformOptions` is `{ version?, trust? }`. Both members shed the prefix the envelope now carries, and the precedence that lived only in the resolver — `version` wins, `trust` is then inert — is a within-envelope rule stated on the type.

A bare tag is the P12 dominant-field shorthand, folded by `expandShorthand` beside the other nested scalars (`wire.multipart`, `retry.backoff`, `stream.buffer`), so `__config` only ever carries the object form (P0) and the controller reads a settled `ResolvedCacheOptions.transform`.

**Why the tag stays under `cache`** rather than moving beside the closure it versions: it must round-trip as JSON (§1, the serialization gate) while `transform` itself is function sugar on `__rawConfig`. Co-locating them would drag a serialisable tag off the serialisable config.

### 2. Why the lint never caught it

R8 buckets by **leading** word. `transformVersion` grouped under "transform", `trustTransform` under "trust" — the pair names its shared subject in the *trailing* position, so it never grouped and survived every audit clean. The allow-list entry that mentions these fields is for `FingerprintInput`, a derived read-view, not this pair.

I recorded the gap in CONTRACT.md §7 rather than widening the rule: grouping by trailing word would collapse unrelated members (`clientId`/`stitchId`, every `*Options` field), which is exactly the guess §7 says the ratchet refuses. This class is found by reading, and the note tells the next reader what to do when they find one.

### 3. Behaviour: unchanged

Same ladder, same refuse-by-default for an un-versioned transform, same generation token for a given version. `resolveFingerprint`'s flat read-view keeps the shape it always had, with `trustTransform` renamed `transformTrust` so the published `stitchapi/fingerprint` surface carries one vocabulary. The refusal `reason` on the cache trace now names the new spelling.

## Reviewer notes

- **Hard break, no alias** — P19, `rc` channel. `NoUnknownNestedKeys` rejects both old keys by name at the `cache:` slot, and neither had a runtime fallback, so there is no silent path. I verified that with a throwaway spec before writing the migration claim; the surviving version is pinned in `cache.spec.ts`.
- **`NestedEnvelopes` gained the nested entry** (`transform: [CacheTransformOptions, …]`), so a misspelling *inside* the envelope is a compile error too. `check:unknown-keys` caught that omission before I did — it is the gate that makes a new house envelope declare itself.
- **Narrow fold, deliberately.** `cache.version` and `onUnfingerprintable` stay put. A wider `cache.fingerprint` envelope would group all four ladder fields, but it moves `cache.version` — the always-available manual override ADR 0004 leans on — and re-opens a settled decision. Happy to do it as a follow-up if you'd rather.
- **`CacheTransformOptions` gets its own `AutoTypeTable`** — `AutoTypeTable` renders one level deep, so a nested shape without its own table shows nothing (the #622 lesson).
- ADR 0004 carries a spelling-only amendment note; the decision text is untouched. CONTRACT.md §6 has the migration entry, in the style of the nest-seam fold.

## Verification

- `check:types` across the workspace (including `check:types-d`/tsd), `check:lint`, `check:format`, `check:contract` (**0 violations, baseline still empty**), `check:unknown-keys`, `check:docs-links` — all green.
- Tests: **1427 core** + every peer suite passing.
- Docs checked against the running dev server: the `CacheTransformOptions` heading, prose, and both rows render, and `CacheOptions.transform` shows the full union. No console errors.
- New coverage: the scalar→`{ version }` fold in `__config`, `cache.transform: {}` rejected (P20), both scalar and envelope forms accepted, and the two removed keys pinned off the type surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
