### PR TITLE
docs(changelog): one `Added` section in Unreleased — and a guard so it stops recurring

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -77,6 +77,12 @@ jobs:
             # excess-property checking, so a misspelled or REMOVED slot typechecks and is
             # silently dropped — which is what makes a slot rename unsafe. Source scan — no build.
             - run: pnpm check:unknown-keys
+            # CHANGELOG shape: one `###` section per kind per release block, and the
+            # Keep a Changelog order within [Unreleased]. A branch cut from an older
+            # `main` re-adds a heading its base lacked; git merges both cleanly because
+            # they sit at different offsets, and Unreleased ends up with two `Added`s
+            # (#620) or two `Fixed`s (#597). Text-only scan — no build.
+            - run: pnpm check:changelog
             # Release coherence: version lockstep + prerelease-aware peer ranges +
             # scoped publishConfig.access, LICENSE/README presence, so a bad bump fails
             # the PR, not the publish.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,37 @@ npm release are grouped under the in-development version that introduced them.
     reservations must come back as 20 distinct, evenly spaced instants, because a non-atomic cell
     hands several callers the same instant, which is the exact burst the verb exists to remove.
 
+- **`throttle.rate`'s denominator is now a full duration token — `'1000/h'`, `'100/15m'`,
+  `'2/500ms'`.** ([ADR 0023](docs/adr/0023-a-rate-is-a-minimum-spacing.md)
+  Decision 3) The grammar is `<count>/<duration>`, where the denominator is parsed by the one
+  shared `parseDuration` and a bare unit means one of that unit (`'2/s'` ≡ `'2/1s'`). Every
+  existing rate keeps parsing to exactly what it did — the new grammar is a strict superset.
+
+    The old `<count>/<ms|s|m>` was a hand-copied subset of `parseDuration`'s scale table, and the
+    truncation left **holes in the value space**: an ordinary 1000/hour quota is a 3600ms spacing,
+    and no legal token denoted it (`60000/count = 3600` needs a fractional count, and counts are
+    integers). The nearest spellings were `'16/m'` — 960/h, abandoning 4% of the quota — and
+    `'17/m'` — 1020/h, i.e. the 429s the throttle was added to prevent. `'100/15m'` was in a hole
+    too. You can now transcribe the limit your vendor publishes instead of converting it to a
+    number the grammar can hold.
+
+    **Equal ratios are one limiter, and that is the design:** `'2/500ms'`, `'4/s'` and `'240/m'`
+    all declare a 250ms gap and behave identically, in-process and store-backed alike. `rate` is a
+    pacer, not a token bucket — there is no capacity for a longer window to grant — so the window
+    length is a way of spelling the ratio, not a burst allowance. Pinned across three window
+    lengths in `store.spec.ts` rather than left as a doc sentence.
+
+    Two values are rejected that the widening would otherwise have admitted, both for the reason
+    `'0/s'` was rejected below — each would have meant _no limit at all_: a **non-positive window**
+    (`'2/0s'`, `'2/-500'` — `parseDuration` returns those as a real `0` / `-500`, not `undefined`,
+    so `spacing` would land at ≤ 0, which both limiters read as "no pacing configured"), and a
+    **spacing past the ~24.8-day timer ceiling** (`'1/30d'` — `setTimeout` clamps any delay past
+    2³¹−1 to 1ms). The ceiling rejects rather than clamps: clamping would silently pace _faster_
+    than asked.
+
+    `ThrottleOptions.rate` also gained TSDoc, so it stops rendering with a blank description on the
+    reference page.
+
 - **`parseRate` is exported from `stitchapi`, completing the house token grammars.**
   [P17](docs/CONTRACT.md#p17--one-canonical-duration-form) and
   [P25](docs/CONTRACT.md#p25--one-canonical-size-form) both make "one shared parser" part of the
@@ -460,39 +491,6 @@ npm release are grouped under the in-development version that introduced them.
 
     **Migration:** delete the field. No runtime behaviour changed — the stitch was already a
     download. To actually get another surface, use a plain `stitch({ kind })`.
-
-### Added
-
-- **`throttle.rate`'s denominator is now a full duration token — `'1000/h'`, `'100/15m'`,
-  `'2/500ms'`.** ([ADR 0023](docs/adr/0023-a-rate-is-a-minimum-spacing.md)
-  Decision 3) The grammar is `<count>/<duration>`, where the denominator is parsed by the one
-  shared `parseDuration` and a bare unit means one of that unit (`'2/s'` ≡ `'2/1s'`). Every
-  existing rate keeps parsing to exactly what it did — the new grammar is a strict superset.
-
-    The old `<count>/<ms|s|m>` was a hand-copied subset of `parseDuration`'s scale table, and the
-    truncation left **holes in the value space**: an ordinary 1000/hour quota is a 3600ms spacing,
-    and no legal token denoted it (`60000/count = 3600` needs a fractional count, and counts are
-    integers). The nearest spellings were `'16/m'` — 960/h, abandoning 4% of the quota — and
-    `'17/m'` — 1020/h, i.e. the 429s the throttle was added to prevent. `'100/15m'` was in a hole
-    too. You can now transcribe the limit your vendor publishes instead of converting it to a
-    number the grammar can hold.
-
-    **Equal ratios are one limiter, and that is the design:** `'2/500ms'`, `'4/s'` and `'240/m'`
-    all declare a 250ms gap and behave identically, in-process and store-backed alike. `rate` is a
-    pacer, not a token bucket — there is no capacity for a longer window to grant — so the window
-    length is a way of spelling the ratio, not a burst allowance. Pinned across three window
-    lengths in `store.spec.ts` rather than left as a doc sentence.
-
-    Two values are rejected that the widening would otherwise have admitted, both for the reason
-    `'0/s'` was rejected below — each would have meant _no limit at all_: a **non-positive window**
-    (`'2/0s'`, `'2/-500'` — `parseDuration` returns those as a real `0` / `-500`, not `undefined`,
-    so `spacing` would land at ≤ 0, which both limiters read as "no pacing configured"), and a
-    **spacing past the ~24.8-day timer ceiling** (`'1/30d'` — `setTimeout` clamps any delay past
-    2³¹−1 to 1ms). The ceiling rejects rather than clamps: clamping would silently pace _faster_
-    than asked.
-
-    `ThrottleOptions.rate` also gained TSDoc, so it stops rendering with a blank description on the
-    reference page.
 
 ### Fixed
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -79,6 +79,12 @@ pre-push:
         # Cheap source scan, same tier as the contract ratchet. Mirrors CI's step.
         - name: unknown-keys
           run: '{setup} pnpm check:unknown-keys'
+        # CHANGELOG shape: one `###` section per kind per release block, plus the Keep a
+        # Changelog order within [Unreleased]. Catches the second `Added`/`Fixed` a branch
+        # cut from an older `main` grafts on — git merges both cleanly, so nothing else
+        # notices. Text-only scan. Mirrors CI's step.
+        - name: changelog
+          run: '{setup} pnpm check:changelog'
         # Demo-media drift gate (docs/media/README.md): a branch that edits the
         # demo scene or its generator must also regenerate the committed README
         # webp pair. Cheap path diff; STITCH_MEDIA_STALE_OK=1 defers.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "check:docs-links": "node scripts/check-docs-links.mjs",
         "check:contract": "node scripts/check-contract.mjs",
         "check:unknown-keys": "node scripts/check-unknown-keys.mjs",
+        "check:changelog": "node scripts/check-changelog.mjs",
         "check:format": "prettier --check .",
         "check:media-fresh": "node scripts/check-media-freshness.mjs",
         "check:release": "node scripts/check-release.mjs",

--- a/scripts/check-changelog.mjs
+++ b/scripts/check-changelog.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// Structural guard for CHANGELOG.md.
+//
+// This exists because the same defect has now shipped twice. A branch cut from an
+// older `main` writes its entry under a `### Added` (or `### Fixed`) heading that
+// its base did not have yet; by merge time `main` HAS that heading, but the two
+// live at different offsets, so git merges both cleanly and Unreleased ends up with
+// TWO of the same section. #597 did it to `Fixed` (repaired by #598), and #620 did
+// it to `Added` — grafting a second `### Added` between `Changed` and `Fixed`.
+// Nothing failed either time: the entry text is fine, only its placement is wrong,
+// and no existing check reads the changelog's SHAPE. `check:release` only asserts
+// that a `## [version]` heading exists at publish time.
+//
+// The cost of missing it is a released changelog whose reader has to know to scroll
+// past `Changed` and `Fixed` to find the rest of what was added.
+//
+// Checks:
+//   1. Duplicate subsection — no two `###` headings with the SAME TEXT inside one
+//      `## [...]` release block. Compared verbatim, not by stem, because several
+//      historical releases deliberately carry more than one `Added` split by theme
+//      (`### Added — the integration ecosystem` alongside `### Added — a published
+//      testing story` in 1.0.0-rc.3). Those are distinct headings and stay legal;
+//      two bare `### Added`s are not.
+//   2. Subsection order — the Keep a Changelog order (Added, Changed, Deprecated,
+//      Removed, Fixed, Security) within `## [Unreleased]`. Scoped to Unreleased
+//      because that is the only block PRs still write to; published blocks are
+//      frozen history and several predate the convention. Headings outside the
+//      canonical set (`Notes`, `CI / release hardening`) are not ordered against
+//      anything — they only have to not duplicate.
+//
+// Fenced code blocks are skipped, so a `###` inside a ```ts sample is not a heading.
+//
+// Exit code is 1 if any check fails. Run via `pnpm check:changelog`. Takes an
+// optional path so the rules can be exercised against another revision of the file
+// (`git show <ref>:CHANGELOG.md > /tmp/old.md && node scripts/check-changelog.mjs /tmp/old.md`).
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const target = process.argv[2];
+const PATH = target ? resolve(target) : join(ROOT, 'CHANGELOG.md');
+const FILE = target ?? 'CHANGELOG.md';
+
+/** Keep a Changelog 1.1.0 section order. */
+const CANONICAL = [
+    'Added',
+    'Changed',
+    'Deprecated',
+    'Removed',
+    'Fixed',
+    'Security',
+];
+
+/**
+ * The canonical stem of a heading, so `Added — the integration ecosystem` ranks as
+ * `Added`. Returns null for a heading outside the canonical set.
+ */
+function stemOf(text) {
+    const stem = text.split(' — ')[0].trim();
+    return CANONICAL.includes(stem) ? stem : null;
+}
+
+/**
+ * Parse CHANGELOG.md into release blocks. A block is one `## ` heading and the
+ * `### ` headings under it, each with the 1-based line it sits on. Lines inside a
+ * fenced code block are not headings — entries embed ```ts migration samples, and
+ * the fences are indented under a list item.
+ */
+function parseBlocks(body) {
+    const blocks = [];
+    let fenced = false;
+    body.split('\n').forEach((line, i) => {
+        if (/^\s*```/.test(line)) {
+            fenced = !fenced;
+            return;
+        }
+        if (fenced) return;
+        if (/^##\s/.test(line)) {
+            blocks.push({
+                title: line.replace(/^##\s+/, '').trim(),
+                line: i + 1,
+                sections: [],
+            });
+        } else if (/^###\s/.test(line) && blocks.length) {
+            blocks[blocks.length - 1].sections.push({
+                text: line.replace(/^###\s+/, '').trim(),
+                line: i + 1,
+            });
+        }
+    });
+    return blocks;
+}
+
+const failures = [];
+const fail = (msg) => failures.push(msg);
+
+const body = readFileSync(PATH, 'utf8');
+const blocks = parseBlocks(body);
+
+if (blocks.length === 0) {
+    fail(
+        `${FILE}: no "## [version]" release blocks found — is the file intact?`,
+    );
+}
+
+// 1. Duplicate subsection headings within a release block ----------------------
+let sectionCount = 0;
+for (const block of blocks) {
+    const seen = new Map(); // heading text -> first line it appeared on
+    for (const section of block.sections) {
+        sectionCount++;
+        const first = seen.get(section.text);
+        if (first === undefined) {
+            seen.set(section.text, section.line);
+            continue;
+        }
+        fail(
+            `${FILE}:${section.line}: duplicate "### ${section.text}" under "## ${block.title}" ` +
+                `(already open at ${FILE}:${first}). Merge these entries into the section at ` +
+                `line ${first} and delete this heading — one section per kind, per release.`,
+        );
+    }
+}
+
+// 2. Keep a Changelog subsection order, within [Unreleased] --------------------
+const unreleased = blocks.find((b) => /^\[?Unreleased\]?/i.test(b.title));
+if (unreleased) {
+    let highest = { rank: -1, text: null };
+    for (const section of unreleased.sections) {
+        const stem = stemOf(section.text);
+        if (stem === null) continue; // `Notes` and friends are unordered
+        const rank = CANONICAL.indexOf(stem);
+        if (rank < highest.rank) {
+            fail(
+                `${FILE}:${section.line}: "### ${section.text}" comes after "### ${highest.text}" ` +
+                    `under "## ${unreleased.title}". Keep a Changelog order is ` +
+                    `${CANONICAL.join(' → ')}.`,
+            );
+        } else {
+            highest = { rank, text: section.text };
+        }
+    }
+}
+
+// ---- report ------------------------------------------------------------------
+for (const m of failures) console.error(`  ✗ ${m}`);
+
+if (failures.length) {
+    console.error(
+        `\ncheck:changelog FAILED (${failures.length} problem${failures.length > 1 ? 's' : ''}).`,
+    );
+    process.exit(1);
+}
+console.log(
+    `  ✓ ${FILE}: ${sectionCount} subsection(s) across ${blocks.length} release block(s) — no duplicates, Unreleased in Keep a Changelog order`,
+);
+console.log('\ncheck:changelog passed.');


### PR DESCRIPTION
## What

Two commits:

1. **`docs(changelog)`** — merges the duplicate `### Added` in `## [Unreleased]` back into the real one.
2. **`ci`** — adds `scripts/check-changelog.mjs`, so this stops recurring.

## Why

`## [Unreleased]` has **two** `### Added` subsections — still true on `main` today:

| line (on `main`) | heading | |
|---|---|---|
| 14 | `### Added` | |
| 113 | `### Changed` | |
| 464 | `### Added` | ← duplicate, holding the `throttle.rate` denominator entry from #620 |
| 497 | `### Fixed` | |
| 785 | `### Notes` | |

Same class of defect #598 fixed for `Fixed`. #620 branched from a `main` that predated #618 (which created the first `### Added`), so its entry was grafted on as a second heading between `Changed` and `Fixed`.

The failure mode is **structural, not careless**: the two headings sit at different offsets, so git merges both cleanly and nothing downstream notices. The entry text is fine — only its placement is wrong. Reader-visible cost: part of what was added is stranded below `Changed`.

Worth noting #625, #630 and #626 have all since added entries to `Unreleased` **without** noticing the duplicate — it survived three more PRs.

## The fix

`Unreleased` now reads **Added → Changed → Fixed → Notes**, with one `Added`.

The `throttle.rate` entry moved into `### Added` **directly above** the `parseRate` entry, which is where the section's own ordering puts it: #625 and #630 both prepended, so `Added` reads newest-first. Slotting ADR 0023 there makes the run read **ADR 0025 → ADR 0024 → ADR 0023 → `parseRate`**.

**Pure restructure.** The file is exactly two lines shorter — the redundant heading and its blank line. `### Added` within `Unreleased` goes 2 → 1; the entry appears exactly once; no entry text changed, added, removed, or reworded. Same guarantee #598 made.

## The guard

No changelog-structure check existed — `check:release` only asserts a `## [version]` heading exists at publish time, which is blind to shape. Second occurrence of a structural defect is worth a gate.

`scripts/check-changelog.mjs` adds two rules:

1. **No duplicate `###` heading** within a `## [...]` block. Compared **verbatim, not by stem** — several published releases deliberately carry more than one `Added` split by theme (rc.3 has both `### Added — the integration ecosystem` and `### Added — a published testing story`). Those stay legal; two bare `### Added`s do not.
2. **Keep a Changelog order**, scoped to `[Unreleased]` — the only block PRs still write to. Published blocks are frozen history and several predate the convention. Non-canonical headings (`Notes`, `CI / release hardening`) are exempt from ordering; they only have to not duplicate.

Fenced code blocks are skipped, so a `###` inside a ```ts sample is not read as a heading.

## Verification

Exercised against the **real regressions**, not just synthetic input — it takes an optional path argument so any revision can be checked directly:

| input | result |
|---|---|
| `main` as it stands today (#620's duplicate `Added`) | ✅ fails — duplicate **and** ordering |
| `d687afb^` (#597's duplicate `Fixed`, inverted order) | ✅ fails — duplicate **and** ordering |
| CHANGELOG after this PR | ✅ passes — 22 subsections, 9 release blocks |

Edge cases confirmed: `###` inside a fence ignored, `Notes` unordered, distinct themed headings legal, identical themed headings caught in a released block.

Full pre-push suite green locally against the current base (12/12, `changelog` job 0.19s) — including `test`, `build-docs`, and the yakir tethers against #625/#630/#626's new store and concurrency work.

## Reviewer notes

- **Rebased onto `main`** after #599, #625, #624, #630 and #626 landed. The only conflict was `CHANGELOG.md`, resolved by taking `main`'s content wholesale and re-applying the consolidation on top — so every entry those PRs added is preserved untouched, and the placement follows `main`'s current newest-first ordering rather than the base this branch was cut from.
- Wired into CI next to `check:unknown-keys`, and into pre-push with the other cheap source scans — matching where every other `check:*` scan is layered. Text-only, no build.
- **No CHANGELOG entry for this PR.** It's repo tooling, and the changelog is scoped to the library surface; #598 added none for a pure restructure either.
- Worth a look: whether rule 2 should eventually cover published blocks too. It's scoped off today because several pre-date the convention and would need grandfathering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)