### PR TITLE
feat(core)!: fleet-wide `concurrency` by lease (ADR 0025)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,45 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Added
 
+- **`throttle.concurrency` goes fleet-wide too, by lease.** ([ADR 0025](docs/adr/0025-fleet-wide-concurrency-by-lease.md))
+  [ADR 0024](docs/adr/0024-the-fleet-wide-pacing-cell.md) made the rate budget fleet-wide and left
+  the concurrency cap per-process, so `concurrency: 10` across eight workers was really a fleet cap
+  of eighty — "attach a store to share the policy" was true of one of the two limits. With a store
+  that leases, `concurrency: 10` now means ten calls in flight across every worker on it. Nothing
+  to configure; the throttle uses the verbs when the store has them.
+
+    **Why a counter could not do it.** A rate is a schedule — a function of time, which is why one
+    shared cursor settled it. A concurrency slot is _ownership_: held for an unknown interval, by a
+    specific holder, freed by news rather than by a clock. A holder that crashes never decrements, so
+    a shared counter decays monotonically toward zero — a limiter that gets stricter every time
+    something breaks, silently. A lease returns the slot when its holder stops renewing, alive or not.
+
+    `StitchStore` gains a paired pair of optional verbs, implemented by `memoryStore`,
+    `@stitchapi/redis` (a sorted set) and `@stitchapi/deno-kv` (compare-and-set):
+
+    ```ts
+    lease ? (key, token, limit, ttl, now) : Promise<boolean>; // take, renew, or refuse
+    release ? (key, token) : Promise<void>; // idempotent
+    ```
+
+    The caller mints the token, so `lease` doubles as renewal and is idempotent — a retry extends
+    a slot rather than silently consuming a second one. **Existing custom stores need no changes**;
+    without the pair, `concurrency` stays per-process exactly as before, which is the path an
+    eventually-consistent backend (`@stitchapi/cloudflare-kv`) takes, and which stays pinned in the
+    test suite against a store with the verbs deliberately withheld.
+
+    **One new knob, `throttle.lease`** (default 30s, `number | string`): how long a slot is held
+    before it lapses. Think crash timer, not call timer. Too long strands a dead worker's slots; too
+    short and a call still running has already lost its slot, so the fleet briefly exceeds the cap.
+    Streaming holds no slot at all ([ADR 0005](docs/adr/0005-surfaces-and-the-authoring-model.md)
+    Decision 12), so a `lease` above `timeout.total` cannot be outlived.
+
+    **Two behaviours differ from the in-process limiter, inherently.** A blocked caller **polls**
+    with full jitter instead of being handed the slot — no worker can be woken by another worker's
+    release — so strict FIFO fairness is gone and contention costs store round-trips. And a release
+    is fire-and-forget: a lost one costs the fleet a slot for at most `lease`, the same guarantee
+    that already covers a crash, so awaiting it would buy promptness rather than correctness.
+
 - **A fleet sharing a store now paces on ONE schedule, wherever in a window its workers start.**
   ([ADR 0024](docs/adr/0024-the-fleet-wide-pacing-cell.md)) [ADR 0023](docs/adr/0023-a-rate-is-a-minimum-spacing.md)
   fixed the store-backed throttle's cold-start burst with a per-process pacing cursor and recorded

--- a/apps/docs/content/docs/guides/state/distributed-throttle.mdx
+++ b/apps/docs/content/docs/guides/state/distributed-throttle.mdx
@@ -38,7 +38,29 @@ runs at `10/s × workers`. A shared store holds the rate counter every worker
 increments, so the whole fleet shares one `10/s` budget — and grants are
 **even-spaced** (about one every 100ms, i.e. `window / limit`), the same pacing
 the in-process limiter uses, so attaching a store doesn't turn a smooth limit into
-boundary bursts. (Concurrency stays in-process; only the rate limit is distributed.)
+boundary bursts.
+
+`concurrency` goes fleet-wide with it: `concurrency: 5` over a shared store means
+five calls in flight across every worker, not five each. Nothing extra to
+configure — a store that supports it just does it.
+
+<Callout type="info">
+    **A fleet-wide slot is a lease, so it has an expiry.** A worker that crashes
+    mid-call never gives its slot back, and `throttle.lease` (default 30s) is how
+    long the fleet waits before reclaiming it. Size it above your slowest call:
+    too long strands a dead worker's slots, too short and a call still running
+    loses its slot to the next caller, briefly putting the fleet over the cap.
+    Streaming never holds a slot at all, so this only bounds buffered calls — a
+    `lease` comfortably above `timeout.total` can't be outlived.
+
+    Two behaviours differ from the in-process limiter, inherently: a blocked call
+    **polls** rather than being handed the slot (no worker can wake another), so
+    strict FIFO fairness is gone; and a release is fire-and-forget, because the
+    expiry already covers a lost one. Backed by `memoryStore`,
+    `@stitchapi/redis` and `@stitchapi/deno-kv`; a store without leases keeps
+    per-process concurrency.
+
+</Callout>
 
 <Callout type="info">
     **How exact the fleet-wide pacing is depends on your store.** A store with a

--- a/docs/adr/0025-fleet-wide-concurrency-by-lease.md
+++ b/docs/adr/0025-fleet-wide-concurrency-by-lease.md
@@ -1,0 +1,174 @@
+# ADR 0025 — Fleet-wide `concurrency` by lease: a slot you hold, not a number you decrement
+
+- **Status:** Accepted and implemented (2026-08-05). Closes the second half of "attach a store to share the policy", which [ADR 0024](./0024-the-fleet-wide-pacing-cell.md) open question 2 named as the larger remaining gap. Extends the pluggable store ([DESIGN.md §13](../DESIGN.md)); the slot-free streaming rule is [ADR 0005](./0005-surfaces-and-the-authoring-model.md) Decision 12.
+- **Date:** 2026-08-05
+- **Tags:** resilience, throttle, store, api-surface, contract-extension, P11, P19, P21
+
+> [!NOTE]
+>
+> Rate and concurrency are not the same shape of problem. A rate is a **schedule** —
+> a pure function of time, which is why one shared cursor settles it. Concurrency is
+> **ownership**: a slot is held for an interval nobody can predict, by a process that
+> might die still holding it. A counter cannot express that, because the decrement
+> lives in a process that may never run again. A **lease** can: the slot comes back
+> when its holder stops renewing, whether or not the holder is alive to say so.
+
+## Context
+
+`throttle.concurrency` has always been per-process, and the docs said so. Attach a
+shared store and the rate budget becomes fleet-wide while the concurrency cap quietly
+stays local — so `concurrency: 10` across eight workers is a fleet cap of eighty. ADR
+0024 closed the rate half and named this one:
+
+> `concurrency` is still in-process under a store … a distributed semaphore needs leases
+> with expiry and renewal, which is a much larger contract extension than a cursor.
+
+It is larger, and the reason is not implementation effort. It is that **the cursor's
+trick does not transfer.**
+
+### Why the pacing cell does not generalise
+
+`reserve` works because a rate is a function of time alone: `at = max(now, cell)`
+needs no memory of who was granted what, and a crashed caller leaves nothing behind to
+clean up — its grant simply passed. Every process can compute the same answer from one
+number.
+
+A concurrency slot is the opposite in each respect. It is held for an **unknown
+interval**, it belongs to a **specific holder**, and the event that frees it — the
+holder finishing — is not a time, it is news. A shared counter fails the moment the
+news does not arrive:
+
+| Failure                        | A shared counter                          | A lease                                  |
+| ------------------------------ | ----------------------------------------- | ---------------------------------------- |
+| Holder crashes mid-call        | slot lost forever; the cap decays to zero | expires, slot returns                    |
+| Release lost to a network blip | same, permanently                         | costs one slot for `lease`, then returns |
+| Holder pauses (GC, VM freeze)  | still counted, correctly                  | may lose its slot early — the real cost  |
+
+Only the last row is a regression against a counter, and it is the honest price: a
+lease trades "a slot can be lost forever" for "a slot can be reclaimed early".
+
+## Decision
+
+### 1. Two paired verbs, `lease` and `release`
+
+```ts
+lease?(key: string, token: string, limit: number, ttl: number, now: number): Promise<boolean>;
+release?(key: string, token: string): Promise<void>;
+```
+
+`lease` atomically prunes every holder expired at `now`, then: renews `token` if it
+already holds a slot, else takes one if fewer than `limit` are live, else refuses.
+Pruning persists **even when it refuses** — a failed attempt must not leave dead
+holders for the next caller to re-walk.
+
+Three consequences worth naming:
+
+- **The caller mints the token**, so `lease` doubles as renewal and is idempotent. A
+  caller that leases twice is extending, never taking a second slot — which removes the
+  entire class of bug where a retry silently consumes the semaphore.
+- **`now` is the caller's clock**, as in `reserve`: deterministic under an injected
+  `Clock`, and no store needs one of its own.
+- **The representation is not specified.** `memoryStore` and `@stitchapi/deno-kv` keep a
+  token→expiry map; `@stitchapi/redis` uses a sorted set, where `ZREMRANGEBYSCORE` prunes
+  in one command. Both satisfy the same rules, which is the point of specifying behaviour.
+
+### 2. Optional and paired — implement both or neither
+
+Same two reasons as [`reserve`](./0024-the-fleet-wide-pacing-cell.md), plus one of its
+own: half a lease API is worse than none, because a slot could be taken and never given
+back. Cloudflare KV cannot make this atomic; `StitchStore` is consumer-implemented, so a
+required member is a hard break in any channel
+([P19](../CONTRACT.md#p19--the-alias-obligation-is-scoped-to-the-ga-channel)). Without
+the pair, `concurrency` stays per-process exactly as before — pinned in `store.spec.ts`
+against a store with the verbs deliberately withheld.
+
+### 3. `throttle.lease` — one knob, and it is a crash timer
+
+Default 30s, `number | string` like every authored duration
+([P17](../CONTRACT.md#p17--one-canonical-duration-form)). Read only when `concurrency`
+is set and the store leases.
+
+Sizing it is the one thing a user must get right, and the two directions fail
+differently: too **long** strands a dead worker's slots for that long; too **short** and
+a call still running has already lost its slot, so the fleet exceeds `concurrency`. The
+second is the dangerous one, and what keeps it manageable is
+[ADR 0005](./0005-surfaces-and-the-authoring-model.md) Decision 12 — **streaming takes no
+concurrency slot at all**. The calls this bounds are buffered ones, which `timeout`
+already bounds, so a `lease` above `timeout.total` cannot be outlived.
+
+### 4. Release stays synchronous and fire-and-forget
+
+`Throttle.release(key): void` is unchanged, so
+[P11](../CONTRACT.md#p11--asyncsync-signature-parity) holds: the verb keeps one shape
+across both limiters. The store call is issued and not awaited.
+
+This is not a shortcut around P11, it is the lease design working. A caller never pays a
+store round-trip on its way out, and a release lost to a blip costs the fleet one slot
+for at most `lease` — the _same_ guarantee that already covers a holder crashing. Making
+it async would buy promptness, not correctness, at the cost of a round-trip on every
+call.
+
+### 5. A blocked caller polls, with full jitter
+
+There is no cross-process handoff: a worker cannot be woken by another worker's release.
+So where the in-process limiter parks on a FIFO queue and is handed the slot, the
+fleet-wide one retries on a uniform `[0, 50ms)` delay — full jitter, the same reasoning
+`expo-jitter` uses, so a fleet queued behind one slot does not re-collide in lockstep.
+
+The cost is real and worth stating: FIFO fairness is gone, and contention costs store
+round-trips proportional to how long callers wait. Both are inherent to a shared
+semaphore without a notification channel, not artefacts of this design.
+
+## What this preserves
+
+- Every existing config is unchanged; a store without the verbs behaves exactly as before.
+- Streaming still takes no slot (ADR 0005 Decision 12), pinned under leases too.
+- `waited` is still reported, so `progress.throttled` still fires — measured under leases
+  rather than predicted, since the store owns the count.
+
+## Alternatives considered
+
+### A. A shared counter with `increment`/decrement — **rejected: it cannot survive a crash**
+
+The obvious reuse of a verb that already exists, and it fails at the first failure. A
+holder that dies never decrements, so the cap decays monotonically toward zero and only
+a restart or manual intervention restores it — a limiter that gets _stricter_ every time
+something goes wrong, silently. Every fix for that reintroduces expiry, which is a lease.
+
+### B. Lease renewal on a timer while the slot is held — **rejected for now: cost without a case**
+
+Strictly more correct: a heartbeat would let a slow call keep its slot past `lease`. It
+needs a timer per held slot, wired through the `Clock` seam, cancelled on every exit path
+including aborts — real machinery whose failure mode (a leaked timer holding a slot alive
+after its call is gone) is worse than the problem it solves. And the case is thin, because
+streaming holds no slot: a `lease` above `timeout.total` cannot be outlived. Revisit if
+someone genuinely needs an unbounded buffered call under a fleet cap.
+
+### C. A distributed queue for fairness instead of polling — **rejected: a different system**
+
+FIFO across processes needs a durable ordered queue and a notification channel, which is
+a message broker, not a KV store. It would fix the fairness this design gives up, and it
+would put a broker on the critical path of every throttled call.
+
+### D. Leave it per-process and document harder — **rejected: the documentation was the problem**
+
+The gap was already documented, and the documentation is exactly what made it unsatisfying:
+"attach a store to share the policy" was true of one of the two limits. A caller who reads
+`concurrency: 10` and runs eight workers has not misread the docs so much as been told
+something that stopped being true halfway through.
+
+## Open questions
+
+1. **Poll interval is not configurable.** 50ms with full jitter is a default chosen for a
+   fleet queued behind a slot, not measured against a real workload. It should probably
+   scale with `lease`, or be tunable, once there is evidence about contention shapes.
+2. **`pool: 'host'` and leases share a key namespace** but have never been exercised
+   together across a fleet. Nothing suggests they conflict — the key is just a string — but
+   it is untested territory.
+3. **Clock skew shortens leases** for a worker whose clock runs fast, exactly as it shifts
+   the pacing cursor. Bounded by the skew and no worse than the existing behaviour, but a
+   store-side clock would remove it for backends that have one.
+4. **No visibility into semaphore state.** There is no way to ask "how many slots are held
+   right now", which is the first thing anyone debugging a stuck fleet will want. A
+   read-only `held(key)` would be cheap; it is left out because an unused verb on a
+   consumer-implemented contract is a cost everyone pays.

--- a/packages/core/scripts/bundle-size.mjs
+++ b/packages/core/scripts/bundle-size.mjs
@@ -247,19 +247,45 @@ const KB = 1024;
 // pages, the home-page metrics component, and the docs' own source blurb. Recorded here because
 // this is the number the project advertises, and a budget raise that quietly left the docs
 // claiming the old one would be the exact drift that tether exists to catch.
+// Budgets raised for ADR 0025 — fleet-wide `concurrency` by lease (23.70→24.10 / 21.10→21.50 KB;
+// measured 23.91 / 21.32, so the capability is +0.38 / +0.37 against a `main` at 23.53 / 20.95).
+// ADR 0024 made the RATE fleet-wide and left the concurrency cap per-process, so `concurrency: 10`
+// across eight workers was a fleet cap of eighty. Closing it needs leases rather than a counter: a
+// slot is held for an unknown interval by a specific holder, and a holder that crashes never
+// decrements, so a shared counter decays toward zero instead of failing safe.
+//
+// What the bytes buy, all on the core path because `memoryStore` is the DEFAULT store:
+//   • `memoryStore.lease` / `release` — the reference semaphore, and what every in-process test
+//     runs against;
+//   • the lease-acquire loop in `createStoreThrottle` (poll with full jitter — there is no
+//     cross-process handoff to park on) plus per-key token tracking so `release` frees a slot the
+//     caller actually holds;
+//   • `vaultView` forwarding the pair only when the backend has both.
+//
+// Trimming came first and got some of it back: holding the semaphore in its own `Map<string,
+// Map<string, number>>` rather than serialising a token→expiry record through the shared `data`
+// keyspace removed a helper and two `Object.fromEntries` round-trips, worth 0.07 KB measured
+// (0.29 → 0.22 over). It cannot move behind a subpath — this is the throttle, reached from
+// `stitch()` whenever a `store` is configured, and the per-process fallback has to stay reachable
+// from the same call site for a backend that cannot lease atomically.
+//
+// The conventional ~0.2 KB step, sized so headroom lands at 0.19 / 0.18. The advertised rounded kB
+// are UNCHANGED at 24 / 21 this time — 23.91 still rounds to 24 — so no README or docs figure
+// moves; verified against the `bundle-advertised-size` tether rather than assumed, which is the
+// mistake the ADR 0024 raise made.
 // `advertised: true` means the READMEs/docs quote this scenario's rounded gzip kB — see the
 // `--json` note below for why that flag, not the row's presence, drives the drift tether.
 const SCENARIOS = [
     {
         name: 'stitchapi — whole entry',
         code: `export * from './index.mjs';`,
-        budget: 23.7 * KB,
+        budget: 24.1 * KB,
         advertised: true,
     },
     {
         name: 'import { stitch }',
         code: `export { stitch } from './index.mjs';`,
-        budget: 21.1 * KB,
+        budget: 21.5 * KB,
         advertised: true,
     },
     {

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -7,11 +7,25 @@ import type {
     StitchStore,
     ThrottleOptions,
 } from './types';
-import { now, parseRate, systemClock } from './util';
+import { hex, now, parseDuration, parseRate, systemClock } from './util';
+
+// How long a fleet-wide concurrency slot is held before it lapses, when `throttle.lease` says
+// nothing. Comfortably above a normal buffered call (streaming holds no slot at all — ADR 0005
+// Decision 12), and short enough that a crashed worker's slots come back on a human timescale.
+const DEFAULT_LEASE_MS = 30_000;
+// Ceiling on the wait between attempts when every slot is taken. There is no cross-process
+// handoff to wait on, so a blocked caller polls; the actual delay is uniform in [0, this), which
+// is full jitter — a fleet queued behind one slot must not retry in lockstep.
+const LEASE_POLL_MS = 50;
 
 /** Default store: in-memory, single process, with TTL + atomic increment. */
 export function memoryStore(): StitchStore {
     const data = new Map<string, { value: unknown; expires: number }>();
+    // Semaphores (ADR 0025) live in their own map, token → expiry, the way Redis keeps them in a
+    // sorted set beside its string keyspace. Kept apart from `data` rather than serialised into
+    // it because nothing else ever reads them: no JSON envelope, no key-level TTL to reconcile
+    // against the per-token expiry that already governs every holder.
+    const sems = new Map<string, Map<string, number>>();
     const live = (e?: { expires: number }) =>
         !!e && (e.expires === 0 || e.expires > now());
     // Opportunistic, bounded sweep of expired entries. The store evicts a key lazily on a `get`/
@@ -71,9 +85,29 @@ export function memoryStore(): StitchStore {
             });
             return grantAt;
         },
+        // The counting semaphore (ADR 0025). Atomic for free, like the two verbs above: one JS
+        // thread, nothing awaited between the read and the write.
+        async lease(key, token, limit, ttl, at) {
+            let held = sems.get(key);
+            if (!held) sems.set(key, (held = new Map<string, number>()));
+            // Prune first, ALWAYS — an attempt that goes on to refuse still has to drop the
+            // lapsed holders, or every later caller re-walks the same dead entries.
+            for (const [t, expiresAt] of held)
+                if (expiresAt <= at) held.delete(t);
+            // Already holding it ⇒ a renewal, never a second slot.
+            const got = held.has(token) || held.size < limit;
+            if (got) held.set(token, at + ttl);
+            return got;
+        },
+        async release(key, token) {
+            // Idempotent: a token that already lapsed (or was never held) is a no-op.
+            const held = sems.get(key);
+            if (held?.delete(token) && held.size === 0) sems.delete(key);
+        },
         // Lifecycle: drop everything. For the in-memory store this is all the state there is.
         async close() {
             data.clear();
+            sems.clear();
         },
     };
 }
@@ -97,6 +131,15 @@ export function vaultView(store: StitchStore, prefix = 'vault:'): StitchStore {
     if (reserve)
         view.reserve = (key, spacing, at, ttl) =>
             reserve(prefix + key, spacing, at, ttl);
+    // The lease pair travels together or not at all — forwarding one without the other would
+    // advertise a semaphore that can be taken and never given back.
+    const lease = store.lease?.bind(store);
+    const release = store.release?.bind(store);
+    if (lease && release) {
+        view.lease = (key, token, limit, ttl, at) =>
+            lease(prefix + key, token, limit, ttl, at);
+        view.release = (key, token) => release(prefix + key, token);
+    }
     // Delegate lifecycle to the backend (bind keeps `this` for stores that need it).
     if (store.close) view.close = store.close.bind(store);
     return view;
@@ -136,8 +179,16 @@ export interface Throttle {
  * the store: the Nth grant in a window is scheduled at `windowStart + (N-1)·(per/count)` — the
  * same cadence as the in-process limiter ({@link createThrottle}), so attaching a store no longer
  * silently switches pacing to bursty fixed-window (the spacing even carries across the window
- * boundary). A SHARED store paces calls across the whole fleet; concurrency stays in-process (a
- * distributed semaphore needs leases — out of scope here).
+ * boundary). A SHARED store paces calls across the whole fleet.
+ *
+ * **Concurrency is fleet-wide too when the store leases** ({@link StitchStore.lease} /
+ * {@link StitchStore.release}, ADR 0025): `concurrency: 10` then means ten calls in flight across
+ * every worker on that store rather than ten each, and a worker that crashes holding slots returns
+ * them when its leases lapse (`throttle.lease`, default 30s). Two differences from the in-process
+ * semaphore are inherent rather than incidental: a blocked caller POLLS, because no worker can be
+ * woken by another worker's release, so the FIFO handoff becomes jittered contention; and a
+ * release is fire-and-forget, because the lease expiry already covers a lost one. Without the
+ * verbs `concurrency` stays per-process exactly as before — pinned both ways in `store.spec.ts`.
  *
  * That slot schedule is a **floor**, applied on top of a per-key local pacing cursor — the same one
  * {@link createThrottle} keeps. Without the cursor a process joining mid-window would claim slots
@@ -171,6 +222,15 @@ export function createStoreThrottle(
 ): Throttle {
     const limit = opts?.concurrency;
     const rate = opts?.rate ? parseRate(opts.rate) : undefined;
+    // The lease pair is all-or-nothing (ADR 0025); resolved once so the hot path is one check.
+    const leases =
+        store.lease && store.release
+            ? {
+                  lease: store.lease.bind(store),
+                  free: store.release.bind(store),
+              }
+            : undefined;
+    const leaseTtl = parseDuration(opts?.lease) ?? DEFAULT_LEASE_MS;
     const local = new Map<
         string,
         {
@@ -178,6 +238,7 @@ export function createStoreThrottle(
             waiters: (() => void)[];
             lastWindow?: number; // windowStart of the last `rl:` key this throttle minted
             nextGrantAt?: number; // earliest THIS process may take another rate grant
+            tokens?: string[]; // fleet-wide leases THIS process is holding, newest last
         }
     >();
 
@@ -198,6 +259,28 @@ export function createStoreThrottle(
         }
         return new Promise<void>((resolve) => s.waiters.push(resolve));
     };
+    // Fleet-wide slot (ADR 0025). Where `takeSlot` parks on an in-process queue and is handed the
+    // slot by whoever releases it, there is no cross-process handoff to wait for — a worker cannot
+    // be woken by another worker's release — so a blocked caller POLLS. The interval is fully
+    // jittered so a fleet that piles up behind one slot does not re-collide in lockstep on every
+    // retry, the same full-jitter reasoning `expo-jitter` uses for retry backoff.
+    const takeLease = async (key: string): Promise<void> => {
+        if (limit == null || !leases) return;
+        const token = hex(8);
+        for (;;) {
+            if (await leases.lease(key, token, limit, leaseTtl, clock.now())) {
+                // `stateFor` is resolved HERE, not before the loop. A poller that captured the
+                // state object up front could be holding an orphan: `release` drops a key's entry
+                // once its last token goes, so a caller that was still polling across that moment
+                // would push its token onto an object no longer in `local` — and the next
+                // `release` would look up the live entry, find nothing, and never free the slot.
+                // One leaked slot per occurrence, which under contention is a deadlock.
+                (stateFor(key).tokens ??= []).push(token);
+                return;
+            }
+            await clock.sleep(Math.random() * LEASE_POLL_MS);
+        }
+    };
 
     async function acquire(
         key: string,
@@ -208,11 +291,20 @@ export function createStoreThrottle(
         // slot (and so is never released); it still charges the rate window below.
         if (!acqOpts?.rateOnly) {
             // Only a real concurrency block counts as "waited" — not incidental store or
-            // scheduling time — so waited (and the 'throttled' event) is deterministic.
-            const blocked = limit != null && stateFor(key).inFlight >= limit;
+            // scheduling time — so waited (and the 'throttled' event) is deterministic. With
+            // leases the store owns the count, so "did I have to wait" is measured rather than
+            // predicted: a lease granted on the first attempt blocked nobody.
             const blockStart = clock.now();
-            await takeSlot(key);
-            if (blocked) waited = clock.now() - blockStart;
+            if (leases) {
+                await takeLease(key);
+                const spent = clock.now() - blockStart;
+                if (spent > 0) waited = spent;
+            } else {
+                const blocked =
+                    limit != null && stateFor(key).inFlight >= limit;
+                await takeSlot(key);
+                if (blocked) waited = clock.now() - blockStart;
+            }
         }
         if (rate) {
             const spacing = rate.per / rate.count; // ms between grants
@@ -295,6 +387,18 @@ export function createStoreThrottle(
         if (limit == null) return;
         const s = local.get(key);
         if (!s) return;
+        if (leases) {
+            // Give back the newest lease this process holds. Which one is arbitrary and does not
+            // matter — the slots are interchangeable — but LIFO keeps the pairing obvious when
+            // reading a trace, and every acquire is matched by exactly one release.
+            const token = s.tokens?.pop();
+            // Fire-and-forget on purpose, so a caller never pays a store round-trip on its way
+            // out. Safe because the lease expires anyway: a release lost to a network blip costs
+            // the fleet one slot for at most `lease`, which is the same guarantee that covers a
+            // holder crashing mid-call. Awaiting here would buy promptness, not correctness.
+            if (token) void leases.free(key, token).catch(() => undefined);
+            if (s.tokens?.length === 0) delete s.tokens;
+        }
         const next = s.waiters.shift();
         if (next) next();
         else if (s.inFlight > 0) s.inFlight--;
@@ -307,7 +411,8 @@ export function createStoreThrottle(
         if (
             s.inFlight === 0 &&
             s.waiters.length === 0 &&
-            s.lastWindow === undefined
+            s.lastWindow === undefined &&
+            !s.tokens?.length
         )
             local.delete(key);
     }

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -429,6 +429,116 @@ export async function verifyStoreContract(
             ],
         );
     }
+    // The semaphore pair (ADR 0025) — optional, and checked only when BOTH are present, since the
+    // contract says implement both or neither. A store that leases must mean the same thing by it
+    // as everyone else, or a fleet-wide concurrency cap is worse than the per-process one.
+    if (store.lease && store.release) {
+        const lease = store.lease.bind(store);
+        const free = store.release.bind(store);
+        rules.push(
+            [
+                'lease: fills to the limit, then refuses',
+                async () => {
+                    const key = k('sem');
+                    const got = [];
+                    for (const t of ['a', 'b', 'c'])
+                        got.push(await lease(key, t, 2, 60_000, 1_000));
+                    expectDeepEqual(
+                        got,
+                        [true, true, false],
+                        'three callers against a 2-slot semaphore',
+                    );
+                },
+            ],
+            [
+                'lease: releasing frees a slot for the next caller',
+                async () => {
+                    const key = k('sem-free');
+                    await lease(key, 'a', 1, 60_000, 1_000);
+                    if (await lease(key, 'b', 1, 60_000, 1_000))
+                        throw new Error(
+                            'b took a slot while a held the only one',
+                        );
+                    await free(key, 'a');
+                    if (!(await lease(key, 'b', 1, 60_000, 1_000)))
+                        throw new Error("b did not get a's released slot");
+                },
+            ],
+            [
+                'lease: re-leasing the same token renews, it does not take a second slot',
+                async () => {
+                    const key = k('sem-renew');
+                    await lease(key, 'a', 1, 60_000, 1_000);
+                    if (!(await lease(key, 'a', 1, 60_000, 2_000)))
+                        throw new Error('a could not renew its own lease');
+                    // If the renewal had consumed the second slot, b would be refused below on a
+                    // 2-slot semaphore.
+                    const key2 = k('sem-renew2');
+                    await lease(key2, 'a', 2, 60_000, 1_000);
+                    await lease(key2, 'a', 2, 60_000, 2_000);
+                    if (!(await lease(key2, 'b', 2, 60_000, 2_000)))
+                        throw new Error(
+                            'a renewal consumed a slot: b was refused on a 2-slot semaphore',
+                        );
+                },
+            ],
+            [
+                'lease: a lapsed holder frees its slot without releasing',
+                async () => {
+                    // The reason leases exist: a holder that crashes never calls release, so the
+                    // expiry is what returns its slot. `now` is a parameter, so this needs no
+                    // sleeping — just ask again from a later instant.
+                    const key = k('sem-lapse');
+                    await lease(key, 'a', 1, 1_000, 1_000); // a holds until 2_000
+                    if (await lease(key, 'b', 1, 1_000, 1_500))
+                        throw new Error("b took a's slot before it lapsed");
+                    if (!(await lease(key, 'b', 1, 1_000, 2_500)))
+                        throw new Error("a's lapsed slot was not reclaimed");
+                },
+            ],
+            [
+                'release: releasing an unheld token is a no-op, not an error',
+                async () => {
+                    const key = k('sem-idem');
+                    await free(key, 'never-held');
+                    await lease(key, 'a', 1, 60_000, 1_000);
+                    await free(key, 'a');
+                    await free(key, 'a'); // twice
+                    if (!(await lease(key, 'b', 1, 60_000, 1_000)))
+                        throw new Error(
+                            'a double release corrupted the semaphore',
+                        );
+                },
+            ],
+            [
+                'lease: 20 concurrent callers, 5 slots — exactly 5 win',
+                async () => {
+                    // The atomicity rule. A non-atomic read-compute-write lets several callers
+                    // each see room and all take the last slot, which is precisely the
+                    // over-admission a fleet-wide cap exists to prevent.
+                    const key = k('sem-atomic');
+                    const results = await Promise.all(
+                        Array.from({ length: 20 }, (_, i) =>
+                            lease(key, `t${i}`, 5, 60_000, 1_000),
+                        ),
+                    );
+                    const won = results.filter(Boolean).length;
+                    if (won !== 5)
+                        throw new Error(
+                            `expected exactly 5 of 20 concurrent callers to win a slot, got ${won}`,
+                        );
+                },
+            ],
+            [
+                'lease: semaphores are isolated by key',
+                async () => {
+                    await lease(k('sem-a'), 'a', 1, 60_000, 1_000);
+                    if (!(await lease(k('sem-b'), 'a', 1, 60_000, 1_000)))
+                        throw new Error('a lease on sem-a leaked into sem-b');
+                },
+            ],
+        );
+    }
     return runRules('store', rules);
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1072,8 +1072,31 @@ export interface ThrottleOptions {
      * zero count, and a spacing past the ~24.8-day timer ceiling.
      */
     rate?: string;
-    /** Cap on simultaneous in-flight calls. Independent of `rate` — either may be set on its own. */
+    /**
+     * Cap on simultaneous in-flight calls. Independent of `rate` — either may be set on its own.
+     *
+     * Per-process by default. It becomes **fleet-wide** when the `store` implements the lease
+     * verbs (ADR 0025) — `memoryStore`, `@stitchapi/redis`, `@stitchapi/deno-kv` — with no config
+     * change: `concurrency: 10` then means ten in flight across every worker on that store, not
+     * ten each. See {@link ThrottleOptions.lease} for the one knob that comes with it.
+     */
     concurrency?: number;
+    /**
+     * How long a fleet-wide concurrency slot is held before it lapses — `30_000`, `'30s'`.
+     * Default 30s. Only read when `concurrency` is set AND the store leases (ADR 0025); ignored
+     * by the per-process limiter, which needs no expiry because a process that dies takes its
+     * own bookkeeping with it.
+     *
+     * **Size it above your slowest call, and think of it as a crash timer, not a call timer.** A
+     * holder that crashes or partitions never gives its slot back, so the lease lapsing is what
+     * returns it — set it too long and a dead worker's slots stay stranded that long. Set it too
+     * SHORT and the opposite failure appears, which is the one that actually hurts: a call still
+     * running at `lease` has already lost its slot to the next caller, so the fleet briefly runs
+     * over `concurrency`. Streaming never holds a slot at all (ADR 0005 Decision 12), so the
+     * calls this bounds are the buffered ones, which `timeout` already bounds — a `lease`
+     * comfortably above `timeout.total` cannot be outlived.
+     */
+    lease?: number | string;
     /**
      * Where the limiter's counter is pooled: `'stitch'` (default) keeps a per-stitch
      * budget; `'host'` shares one budget across every stitch hitting the same host.
@@ -2048,6 +2071,51 @@ export interface StitchStore {
         now: number,
         ttl?: number,
     ): Promise<number>;
+    /**
+     * Atomically take (or renew) one slot of a **counting semaphore** with `limit` slots, expiring
+     * `ttl` ms from `now`. Resolves `true` when this caller holds a slot, `false` when all `limit`
+     * are taken by live holders. The fleet-wide half of `throttle.concurrency` (ADR 0025).
+     *
+     * Semantics, atomically as one step — drop every lease whose expiry is at or before `now`,
+     * then:
+     *
+     * - `token` already held ⇒ **renew** it to `now + ttl` and resolve `true`. Idempotent by
+     *   design: a caller that re-leases is extending, never taking a second slot.
+     * - otherwise, fewer than `limit` live ⇒ **take** a slot for `token` until `now + ttl`, `true`.
+     * - otherwise ⇒ take nothing, `false`. The pruning still persists; a failed attempt must not
+     *   leave expired holders in place for the next caller to trip over.
+     *
+     * **The representation is yours.** This specifies behaviour, not storage: `memoryStore` and
+     * `@stitchapi/deno-kv` keep a token→expiry map, `@stitchapi/redis` uses a sorted set, and both
+     * satisfy the same rules. `token` is minted by the caller, so it is also the identity
+     * {@link StitchStore.release} frees.
+     *
+     * **Expiry is the whole point, not a fallback.** A holder that crashes, is paused, or loses
+     * its network never calls `release`; the lease lapsing is what returns its slot. That is also
+     * why the limiter can treat `release` as fire-and-forget: a dropped release costs the fleet one
+     * slot for at most `ttl`, rather than forever. The cost of that design is the converse — a
+     * caller still working past `ttl` has already lost its slot, so the fleet can briefly exceed
+     * `limit`. Size `throttle.lease` above your slowest call.
+     *
+     * **Optional, and paired** with {@link StitchStore.release} — a store MUST implement both or
+     * neither. Without them `concurrency` stays per-process, exactly as it was before ADR 0025.
+     * Same two reasons as {@link StitchStore.reserve}: an eventually-consistent backend cannot make
+     * this atomic, and a required member on a consumer-implemented contract is a hard break in any
+     * channel ([CONTRACT.md P19](../../../docs/CONTRACT.md#p19--the-alias-obligation-is-scoped-to-the-ga-channel)).
+     */
+    lease?(
+        key: string,
+        token: string,
+        limit: number,
+        ttl: number,
+        now: number,
+    ): Promise<boolean>;
+    /**
+     * Give back the slot {@link StitchStore.lease} took for `token` — atomically, and idempotent:
+     * releasing a token that is not held (already expired, already released) is a no-op, never an
+     * error. Paired with `lease`; implement both or neither.
+     */
+    release?(key: string, token: string): Promise<void>;
     /**
      * Release any resources (connections, timers) the store holds. Optional — the in-memory
      * default clears its map. A seam's `close()` calls this as the last lifecycle step.

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -339,6 +339,45 @@ describe('Pluggable store — throttle', () => {
         };
     };
 
+    // Same idea for the ADR 0025 semaphore: every verb intact except the lease pair, so the
+    // per-process fallback stays pinned rather than merely described. Cloudflare KV takes this
+    // path for real.
+    const withoutLeases = (): StitchStore => {
+        const s = memoryStore();
+        return {
+            get: (k) => s.get(k),
+            set: (k, v, ttl) => s.set(k, v, ttl),
+            increment: (k, ttl) => s.increment(k, ttl),
+            reserve: (k, spacing, at, ttl) => s.reserve!(k, spacing, at, ttl),
+        };
+    };
+
+    // Run `calls` acquire/hold/release cycles spread over `procs` throttles sharing one store,
+    // and report the peak number held at once. That peak IS the concurrency cap's meaning.
+    const peakInFlight = async (
+        store: StitchStore,
+        procs: number,
+        calls: number,
+        opts: { concurrency: number; lease?: string },
+    ): Promise<number> => {
+        const ts = Array.from({ length: procs }, () =>
+            createStoreThrottle(opts, store),
+        );
+        let held = 0;
+        let peak = 0;
+        await Promise.all(
+            Array.from({ length: calls }, async (_, i) => {
+                const t = ts[i % procs]!;
+                await t.acquire('svc');
+                peak = Math.max(peak, ++held);
+                await new Promise((r) => setTimeout(r, 25));
+                held--;
+                t.release('svc');
+            }),
+        );
+        return peak;
+    };
+
     test('a fleet over one store paces on ONE schedule, wherever in a window it starts', async () => {
         const fleet = async (
             rate: string,
@@ -411,5 +450,79 @@ describe('Pluggable store — throttle', () => {
             for (let i = 1; i < mine.length; i++)
                 expect((mine[i] ?? 0) - (mine[i - 1] ?? 0)).toBe(500);
         }
+    });
+
+    // ADR 0025 — `concurrency` becomes fleet-wide when the store leases.
+    test('a fleet over one store holds ONE concurrency budget', async () => {
+        // Four workers, twelve calls, cap of 3. Per-process this is a cap of 3 EACH, so the peak
+        // would be up to 12; fleet-wide it is 3 full stop. Nothing is configured to switch — the
+        // throttle uses the lease verbs because `memoryStore` has them.
+        const peak = await peakInFlight(memoryStore(), 4, 12, {
+            concurrency: 3,
+        });
+        expect(peak).toBe(3);
+    });
+
+    test('without the lease verbs, concurrency stays PER-PROCESS', async () => {
+        // The documented fallback, asserted rather than described: the same four workers each
+        // enforce the cap alone, so the fleet runs at up to `concurrency × workers`. This is the
+        // path an eventually-consistent backend takes, so it is a live property.
+        const peak = await peakInFlight(withoutLeases(), 4, 12, {
+            concurrency: 3,
+        });
+        expect(peak).toBeGreaterThan(3);
+        expect(peak).toBeLessThanOrEqual(12);
+    });
+
+    test('a crashed holder frees its slot when the lease lapses', async () => {
+        // The reason leases exist. Acquire and never release — a worker that died mid-call — then
+        // show the slot comes back on its own, without anybody releasing it.
+        const store = memoryStore();
+        const dead = createStoreThrottle(
+            { concurrency: 1, lease: '80ms' },
+            store,
+        );
+        const live = createStoreThrottle(
+            { concurrency: 1, lease: '80ms' },
+            store,
+        );
+        await dead.acquire('svc'); // held, never released
+
+        const start = Date.now();
+        await live.acquire('svc');
+        const waited = Date.now() - start;
+        // It had to wait out the lease — proving the slot really was held — but not forever.
+        expect(waited).toBeGreaterThanOrEqual(50);
+        expect(waited).toBeLessThan(1_000);
+    });
+
+    test('a fleet-wide slot is reported as waited, so the throttled event still fires', async () => {
+        // `waited` drives the `progress.throttled` event. Under leases the store owns the count,
+        // so a blocked caller's wait is measured rather than predicted — this pins that it is
+        // still reported, and that an uncontended acquire reports nothing.
+        const store = memoryStore();
+        const a = createStoreThrottle({ concurrency: 1 }, store);
+        const b = createStoreThrottle({ concurrency: 1 }, store);
+
+        const first = await a.acquire('svc');
+        expect(first.waited).toBe(0); // uncontended
+
+        const blocked = b.acquire('svc');
+        await new Promise((r) => setTimeout(r, 60));
+        a.release('svc');
+        expect((await blocked).waited).toBeGreaterThan(0);
+        b.release('svc');
+    });
+
+    test('a streaming (rateOnly) acquire takes no fleet-wide slot either', async () => {
+        // ADR 0005 Decision 12 holds under leases: a long-lived stream must not pin a slot for
+        // its whole life, which is also what keeps `lease` a crash timer rather than a call timer.
+        const store = memoryStore();
+        const t = createStoreThrottle({ concurrency: 1 }, store);
+        await t.acquire('svc', { rateOnly: true });
+        await t.acquire('svc', { rateOnly: true });
+        // Neither took the single slot, so a normal acquire still walks straight in.
+        const normal = await t.acquire('svc');
+        expect(normal.waited).toBe(0);
     });
 });

--- a/packages/deno-kv/src/index.ts
+++ b/packages/deno-kv/src/index.ts
@@ -104,6 +104,19 @@ interface CounterWindow {
     deadline: number;
 }
 
+/**
+ * Read a stored lease set (ADR 0025) back as a mutable token→expiry record. Anything that is not
+ * a record of numbers — an absent key, a legacy value — reads as empty rather than throwing, so
+ * one malformed entry can never wedge a semaphore shut.
+ */
+function asLeases(value: unknown): Record<string, number> {
+    const out: Record<string, number> = {};
+    if (value && typeof value === 'object')
+        for (const [t, at] of Object.entries(value as Record<string, unknown>))
+            if (typeof at === 'number') out[t] = at;
+    return out;
+}
+
 /** A value is a live {@link CounterWindow} iff it's a `{ n, deadline }` object. */
 function asWindow(value: unknown): CounterWindow | null {
     if (value == null || typeof value !== 'object') return null;
@@ -342,6 +355,57 @@ export function denoKvStore(
             }
             throw new Error(
                 `@stitchapi/deno-kv: reserve(${key}) lost ${attempts} compare-and-set races`,
+            );
+        },
+        async lease(key, token, limit, ttl, at) {
+            // The counting semaphore (ADR 0025), on the same compare-and-set loop as the two verbs
+            // above. Held as a token→expiry record — Redis reaches for a sorted set here, and both
+            // satisfy the contract, which specifies behaviour rather than storage.
+            const kk = k(key);
+            for (let attempt = 1; attempt <= attempts; attempt++) {
+                const entry = await kv.get(kk);
+                const held = asLeases(entry.value);
+                // Prune first and commit the pruning even when the answer is "full", so a failed
+                // attempt never leaves lapsed holders for the next caller to re-walk.
+                for (const [t, expiresAt] of Object.entries(held))
+                    if (expiresAt <= at) delete held[t];
+                const got = token in held || Object.keys(held).length < limit;
+                if (got) held[token] = at + ttl; // already there ⇒ a renewal, not a second slot
+                const res = await kv
+                    .atomic()
+                    .check({ key: kk, versionstamp: entry.versionstamp })
+                    .set(kk, held, { expireIn: ttl * 2 })
+                    .commit();
+                if (res.ok) return got;
+                if (backoff && attempt < attempts) {
+                    await sleep(backoffDelay(backoff, attempt, base, max));
+                }
+            }
+            throw new Error(
+                `@stitchapi/deno-kv: lease(${key}) lost ${attempts} compare-and-set races`,
+            );
+        },
+        async release(key, token) {
+            const kk = k(key);
+            for (let attempt = 1; attempt <= attempts; attempt++) {
+                const entry = await kv.get(kk);
+                const held = asLeases(entry.value);
+                // Idempotent: a token that already lapsed (or was never held) is a no-op, and
+                // needs no commit at all.
+                if (!(token in held)) return;
+                delete held[token];
+                const res = await kv
+                    .atomic()
+                    .check({ key: kk, versionstamp: entry.versionstamp })
+                    .set(kk, held)
+                    .commit();
+                if (res.ok) return;
+                if (backoff && attempt < attempts) {
+                    await sleep(backoffDelay(backoff, attempt, base, max));
+                }
+            }
+            throw new Error(
+                `@stitchapi/deno-kv: release(${key}) lost ${attempts} compare-and-set races`,
             );
         },
     };

--- a/packages/redis/src/index.ts
+++ b/packages/redis/src/index.ts
@@ -68,6 +68,25 @@ export interface RedisDriver {
         now: number,
         ttl?: number,
     ): Promise<number>;
+    /**
+     * Atomically take or renew one slot of a `limit`-slot counting semaphore, expiring `ttl` ms
+     * from `now` — the fleet-wide half of `throttle.concurrency` ({@link StitchStore.lease},
+     * ADR 0025). Resolves `true` when the caller holds a slot. Paired with
+     * {@link RedisDriver.releaseLease}: implement both or neither.
+     */
+    lease?(
+        key: string,
+        token: string,
+        limit: number,
+        ttl: number,
+        now: number,
+    ): Promise<boolean>;
+    /**
+     * Give back the slot {@link RedisDriver.lease} took for `token`; idempotent. Named for the
+     * lease rather than bare `release`, because this interface's `close` already owns the
+     * connection-lifecycle meaning of that word.
+     */
+    releaseLease?(key: string, token: string): Promise<void>;
     /** Release the connection (optional — `redisStore().close()` delegates here). */
     close?(): Promise<void>;
 }
@@ -104,6 +123,35 @@ if cell > at then at = cell end
 redis.call('SET', KEYS[1], at + spacing)
 if ttl > 0 then redis.call('PEXPIRE', KEYS[1], ttl) end
 return tostring(at)`;
+
+// The counting semaphore (ADR 0025) as a SORTED SET: member = token, score = expiry. The store
+// contract specifies behaviour, not storage, and here that pays — `ZREMRANGEBYSCORE` prunes every
+// lapsed holder in one command and `ZCARD` counts what is left, where the map-shaped stores have
+// to walk their entries. Redis drops an emptied zset by itself, so a fully-released semaphore
+// leaves no key behind.
+//
+// The prune runs BEFORE the decision and is therefore persisted even when the answer is "full" —
+// the contract requires that, so a failed attempt never leaves dead holders for the next caller.
+// `ZSCORE` non-nil means this token already holds a slot, which makes the call a renewal: `ZADD`
+// then just moves its score, never adding a second member. The key outlives its longest lease
+// (`ttl * 2`) so a full semaphore cannot evaporate under its own holders.
+const LEASE_SCRIPT = `local token = ARGV[1]
+local limit = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+local at = tonumber(ARGV[4])
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', at)
+if redis.call('ZSCORE', KEYS[1], token) or redis.call('ZCARD', KEYS[1]) < limit then
+  redis.call('ZADD', KEYS[1], at + ttl, token)
+  redis.call('PEXPIRE', KEYS[1], ttl * 2)
+  return 1
+end
+return 0`;
+
+// Giving a slot back is one atomic command on its own; it rides EVAL only so the driver needs no
+// new client surface. `ZREM` on an absent member is a no-op, which is exactly the idempotence the
+// contract asks for — releasing a lease that already lapsed must not be an error.
+const RELEASE_SCRIPT = `redis.call('ZREM', KEYS[1], ARGV[1])
+return 1`;
 
 // ---------------------------------------------------------------------------
 // driver adapters (ioredis / node-redis)
@@ -205,6 +253,24 @@ export function fromIoredis(client: IoredisLike): RedisDriver {
                 ),
             );
         },
+        async lease(key, token, limit, ttl, at) {
+            return (
+                Number(
+                    await client.eval(
+                        LEASE_SCRIPT,
+                        1,
+                        key,
+                        token,
+                        limit,
+                        ttl,
+                        at,
+                    ),
+                ) === 1
+            );
+        },
+        async releaseLease(key, token) {
+            await client.eval(RELEASE_SCRIPT, 1, key, token);
+        },
         async close() {
             await client.quit?.();
         },
@@ -251,6 +317,27 @@ export function fromNodeRedis(client: NodeRedisLike): RedisDriver {
                     arguments: [String(spacing), String(at), String(ttl ?? 0)],
                 }),
             );
+        },
+        async lease(key, token, limit, ttl, at) {
+            return (
+                Number(
+                    await client.eval(LEASE_SCRIPT, {
+                        keys: [key],
+                        arguments: [
+                            token,
+                            String(limit),
+                            String(ttl),
+                            String(at),
+                        ],
+                    }),
+                ) === 1
+            );
+        },
+        async releaseLease(key, token) {
+            await client.eval(RELEASE_SCRIPT, {
+                keys: [key],
+                arguments: [token],
+            });
         },
         async close() {
             await client.quit?.();
@@ -310,6 +397,20 @@ export function fromUpstash(client: UpstashLike): RedisDriver {
                     [String(spacing), String(at), String(ttl ?? 0)],
                 ),
             );
+        },
+        async lease(key, token, limit, ttl, at) {
+            return (
+                Number(
+                    await client.eval(
+                        LEASE_SCRIPT,
+                        [key],
+                        [token, String(limit), String(ttl), String(at)],
+                    ),
+                ) === 1
+            );
+        },
+        async releaseLease(key, token) {
+            await client.eval(RELEASE_SCRIPT, [key], [token]);
         },
     };
 }
@@ -381,6 +482,15 @@ export function redisStore(
         const reserve = driver.reserve.bind(driver);
         store.reserve = (key, spacing, at, ttl) =>
             reserve(k(key), spacing, at, ttl);
+    }
+    // The semaphore pair, forwarded only when the driver has BOTH — half a lease API would let a
+    // slot be taken and never given back.
+    const lease = driver.lease?.bind(driver);
+    const releaseLease = driver.releaseLease?.bind(driver);
+    if (lease && releaseLease) {
+        store.lease = (key, token, limit, ttl, at) =>
+            lease(k(key), token, limit, ttl, at);
+        store.release = (key, token) => releaseLease(k(key), token);
     }
     if (driver.close) {
         const close = driver.close.bind(driver);

--- a/packages/redis/test/conformance.spec.ts
+++ b/packages/redis/test/conformance.spec.ts
@@ -29,6 +29,22 @@ interface Entry {
 /** The handful of Redis operations the store's two adapters depend on. */
 class FakeRedisEngine {
     private readonly data = new Map<string, Entry>();
+    // Sorted sets live beside the string keyspace, as they do in Redis. Member → score; the
+    // lease scripts are the only users, and they never need ordering, just prune + count.
+    private readonly zsets = new Map<
+        string,
+        { members: Map<string, number>; expiresAt: number }
+    >();
+
+    private liveZ(key: string): Map<string, number> | undefined {
+        const z = this.zsets.get(key);
+        if (!z) return undefined;
+        if (z.expiresAt <= Date.now()) {
+            this.zsets.delete(key);
+            return undefined;
+        }
+        return z.members;
+    }
 
     private live(key: string): Entry | undefined {
         const e = this.data.get(key);
@@ -96,12 +112,81 @@ class FakeRedisEngine {
         });
         return String(grantAt);
     }
+
+    // The semaphore script (ADR 0025), mirroring the Lua's sorted-set commands: prune every
+    // member scored at or below `at` (ZREMRANGEBYSCORE), then take a slot if this token already
+    // holds one (ZSCORE — a renewal) or there is room (ZCARD < limit). Same atomicity argument as
+    // the two above. Redis drops an emptied zset, so an all-released semaphore leaves no key.
+    leaseScript(
+        key: string,
+        token: string,
+        limit: number,
+        ttl: number,
+        at: number,
+    ): number {
+        const members = this.liveZ(key) ?? new Map<string, number>();
+        for (const [t, score] of members) if (score <= at) members.delete(t);
+        const got = members.has(token) || members.size < limit;
+        if (got) {
+            members.set(token, at + ttl);
+            this.zsets.set(key, {
+                members,
+                expiresAt: Date.now() + ttl * 2,
+            });
+        } else if (members.size === 0) this.zsets.delete(key);
+        else
+            this.zsets.set(key, {
+                members,
+                expiresAt: this.zsets.get(key)?.expiresAt ?? Infinity,
+            });
+        return got ? 1 : 0;
+    }
+
+    // ZREM; absent member is a no-op, and an emptied set drops its key.
+    releaseScript(key: string, token: string): number {
+        const members = this.liveZ(key);
+        if (!members) return 1;
+        members.delete(token);
+        if (members.size === 0) this.zsets.delete(key);
+        return 1;
+    }
 }
 
 // Which script the caller sent. The facades below take the script TEXT, exactly as a real client
 // does, so the fake routes on it rather than assuming every `eval` is the counter — which is what
 // it used to do, and why a second script silently read as an increment.
-const isIncr = (script: unknown): boolean => String(script).includes('INCR');
+//
+// Order matters: `ZREMRANGEBYSCORE` CONTAINS `ZREM`, so the lease script has to be recognised
+// before the release script or every lease would read as a release.
+type ScriptKind = 'incr' | 'reserve' | 'lease' | 'release';
+const scriptKind = (script: unknown): ScriptKind => {
+    const s = String(script);
+    if (s.includes('ZREMRANGEBYSCORE')) return 'lease';
+    if (s.includes('ZREM')) return 'release';
+    if (s.includes('INCR')) return 'incr';
+    return 'reserve';
+};
+
+// One dispatcher, shared by all three client facades: they differ only in how the client spells
+// `eval`, never in what the scripts mean.
+const runScript = (
+    engine: FakeRedisEngine,
+    script: unknown,
+    key: string,
+    args: unknown[],
+): unknown => {
+    const n = (i: number): number => Number(args[i]);
+    switch (scriptKind(script)) {
+        case 'incr':
+            return engine.incrScript(key, n(0));
+        case 'reserve':
+            return engine.reserveScript(key, n(0), n(1), n(2));
+        case 'lease':
+            return engine.leaseScript(key, String(args[0]), n(1), n(2), n(3));
+        case 'release':
+            return engine.releaseScript(key, String(args[0]));
+    }
+};
 
 // --- client-shaped facades over one engine --------------------------------
 
@@ -124,17 +209,8 @@ function ioredisFacade(engine: FakeRedisEngine): IoredisLike {
             return 1;
         },
         async eval(script, _numKeys, ...args) {
-            if (isIncr(script)) {
-                const [key, ttlMs] = args;
-                return engine.incrScript(String(key), Number(ttlMs));
-            }
-            const [key, spacing, at, ttlMs] = args;
-            return engine.reserveScript(
-                String(key),
-                Number(spacing),
-                Number(at),
-                Number(ttlMs),
-            );
+            const [key, ...rest] = args;
+            return runScript(engine, script, String(key), rest);
         },
         async quit() {
             return 'OK';
@@ -156,15 +232,11 @@ function nodeRedisFacade(engine: FakeRedisEngine): NodeRedisLike {
             return 1;
         },
         async eval(script, options) {
-            const key = options.keys[0] ?? '';
-            if (isIncr(script))
-                return engine.incrScript(key, Number(options.arguments[0]));
-            const [spacing, at, ttlMs] = options.arguments;
-            return engine.reserveScript(
-                key,
-                Number(spacing),
-                Number(at),
-                Number(ttlMs),
+            return runScript(
+                engine,
+                script,
+                options.keys[0] ?? '',
+                options.arguments,
             );
         },
         async quit() {
@@ -198,15 +270,7 @@ function upstashFacade(engine: FakeRedisEngine): UpstashLike {
             return 1;
         },
         async eval(script, keys, args) {
-            const key = keys[0] ?? '';
-            if (isIncr(script)) return engine.incrScript(key, Number(args[0]));
-            const [spacing, at, ttlMs] = args;
-            return engine.reserveScript(
-                key,
-                Number(spacing),
-                Number(at),
-                Number(ttlMs),
-            );
+            return runScript(engine, script, keys[0] ?? '', args);
         },
     };
 }

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -377,6 +377,7 @@ const WIDENED_MEMBER = new Set([
     'cooldown', // CircuitOptions — fast-fail window
     'delay', // ReconnectOptions / MockResponse
     'interval', // any polling cadence
+    'lease', // ThrottleOptions — how long a fleet-wide concurrency slot is held
     'max', // BackoffOptions (delay ceiling) | ServeBodyOptions/ShellBufferOptions (byte cap)
     'perAttempt', // TimeoutOptions
     'resumeRetry', // Surface — the server-suggested reconnect backoff (returned by the seam)


### PR DESCRIPTION
Closes the second half of "attach a store to share the policy", which [ADR 0024](https://github.com/rejifald/StitchAPI/blob/main/docs/adr/0024-the-fleet-wide-pacing-cell.md)'s open question 2 named as the larger remaining gap.

## The gap

ADR 0024 made the **rate** budget fleet-wide and left the **concurrency** cap per-process. So `concurrency: 10` across eight workers was really a fleet cap of eighty — the promise held for one of the two limits.

## Why the pacing cell's trick doesn't transfer

A rate is a **schedule** — a function of time. `at = max(now, cell)` needs no memory of who was granted what, and a crashed caller leaves nothing to clean up.

A concurrency slot is **ownership**: held for an unknown interval, by a specific holder, freed by *news* rather than by a clock. A shared counter fails the moment the news doesn't arrive:

| Failure | Shared counter | Lease |
| --- | --- | --- |
| Holder crashes mid-call | slot lost forever; cap decays to zero | expires, slot returns |
| Release lost to a blip | same, permanently | one slot for `lease`, then returns |
| Holder pauses (GC, VM freeze) | still counted, correctly | may lose its slot early — the real cost |

Only the last row is a regression, and it's the honest price: a lease trades "a slot can be lost forever" for "a slot can be reclaimed early". A counter that decays toward zero is a limiter that gets *stricter* every time something breaks, silently.

## The verbs

```ts
lease?(key, token, limit, ttl, now): Promise<boolean>;  // take, renew, or refuse
release?(key, token): Promise<void>;                    // idempotent
```

The **caller mints the token**, so `lease` doubles as renewal and is idempotent — a retry extends a slot instead of silently consuming a second one. Pruning persists **even when it refuses**, so a failed attempt never leaves dead holders for the next caller.

The representation is deliberately unspecified, and the implementations prove why: `memoryStore` and `@stitchapi/deno-kv` keep a token→expiry map; `@stitchapi/redis` uses a sorted set, where `ZREMRANGEBYSCORE` prunes in one command. Same rules, different storage.

**Optional and paired** — for `reserve`'s two reasons plus one of its own: half a lease API is worse than none, since a slot could be taken and never given back. Without the pair, `concurrency` stays per-process exactly as before. **Existing custom stores need no changes.**

## Two differences that are inherent, not incidental

Both documented rather than smoothed over:

- **A blocked caller polls** (full jitter, `[0, 50ms)`), because no worker can be woken by another worker's release. Strict FIFO fairness is gone, and contention costs store round-trips.
- **Release stays sync and fire-and-forget**, which keeps [P11](https://github.com/rejifald/StitchAPI/blob/main/docs/CONTRACT.md#p11--asyncsync-signature-parity). Not a shortcut around it: a lost release costs one slot for at most `lease` — the same guarantee that already covers a crash — so awaiting would buy promptness, not correctness.

## For the reviewer

- **`throttle.lease`** (default 30s) is the one new knob, and it's a **crash timer, not a call timer**. Too short is the dangerous direction: a call still running has already lost its slot. What keeps that manageable is [ADR 0005](https://github.com/rejifald/StitchAPI/blob/main/docs/adr/0005-surfaces-and-the-authoring-model.md) Decision 12 — streaming holds no slot at all, so this bounds only buffered calls, which `timeout` already bounds.
- **A deadlock I hit and fixed**, worth flagging because the tests caught it and reading wouldn't have. The acquire loop originally captured its per-key state before polling; `release` drops a key's entry once its last token goes, so a caller polling across that moment pushed its token onto an orphan, and the next release found nothing to free. One leaked slot per occurrence — a hang under contention. `stateFor` is now resolved *after* the lease succeeds.
- **Bundle budgets raised 23.70→24.10 / 21.10→21.50 KB.** Trimming came first and recovered 0.07 KB (own `Map` instead of serialising through the shared keyspace). Advertised kB unchanged at 24 / 21 — verified against the tether this time rather than asserted, which is the mistake the ADR 0024 raise made.
- **Seven new conformance rules**, including the atomicity one that matters: 20 concurrent callers against 5 slots must yield exactly 5 winners.
- Three of the four new fleet tests were confirmed to fail with the lease path disabled.

## Breaking

No API changes; a custom store needs no edits. Flagged because a store that *does* lease changes observable behaviour: a fleet running at `concurrency × workers` now holds `concurrency`. Fewer calls in flight after upgrading means the cap was never enforced fleet-wide before.

Gates: 1430/1430 core tests (5 new), full workspace suite, and the complete pre-push set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)