### PR TITLE
fix(docs): name `linked()`, not a nonexistent `pipe()`, in the trace tree

### DIFF
--- a/apps/docs/content/docs/concepts/run-identity.mdx
+++ b/apps/docs/content/docs/concepts/run-identity.mdx
@@ -23,15 +23,15 @@ once, and one id can't:
 The tree comes from **composition**, not configuration. When a stitch spawns another
 run, the child **inherits** the `traceId` and points its `parentSpanId` at the parent's
 `spanId`. Two paths do this today: a `cookieSession` login runs as a child of the call
-that triggered it, and each step of a `pipe()` is a child of the step before it.
+that triggered it, and each call in a `linked()` scope is a child of the call before it.
 
 ```
 traceId = abc…   (shared by every node below)
 
 [spanId A]                         ← root: a getUser call. parentSpanId = none
    └─ [spanId B]  parentSpanId = A     ← the cookieSession login it triggered
-[spanId C]                         ← a pipe(): step 1. parentSpanId = none
-   └─ [spanId D]  parentSpanId = C     ← step 2, a child of step 1
+[spanId C]                         ← a linked() scope: call 1. parentSpanId = none
+   └─ [spanId D]  parentSpanId = C     ← call 2, a child of call 1
 ```
 
 A single flat per-call id could say "these are different calls" but never "this login


### PR DESCRIPTION
## What

[Run identity & the trace tree](apps/docs/content/docs/concepts/run-identity.mdx) named a `pipe()` combinator twice — once in prose, once in the ASCII trace-tree diagram — as the thing whose steps parent each other. **There is no `pipe()` export.**

The `stitchapi/pipe` *subpath* ships exactly four things:

```
Object.keys(await import('stitchapi/pipe'))
// → ["all", "any", "linked", "race"]
```

The subpath is named `pipe`; nothing inside it is. A reader following that page would import a name that doesn't resolve.

## Why `linked()`

`linked()` is the combinator those lines were actually describing. Per [pipe.ts:357-369](packages/core/src/pipe.ts#L357-L369), it threads `prev` through the run scope so `newRunContext(prev)` parents every call under the one before it — and the first call, where `prev === undefined`, becomes the scope's root run. That is precisely the shape the diagram already claimed: a first node with `parentSpanId = none`, and a second node parented to it.

So this is a naming fix, not a behavioural correction — the described semantics were right all along, only attributed to a name that doesn't exist.

## Changes

Three lines in one file:

| Line | Before | After |
| --- | --- | --- |
| 26 | each step of a `pipe()` is a child of the step before it | each call in a `linked()` scope is a child of the call before it |
| 33 | `← a pipe(): step 1` | `← a linked() scope: call 1` |
| 34 | `← step 2, a child of step 1` | `← call 2, a child of call 1` |

Line 34 wasn't strictly wrong on its own, but it's the second half of line 33's sentence — leaving it would have read as "call 1" parenting "step 2".

## Notes for the reviewer

- **Terminology.** I moved from "step" to "scope"/"call" to match how `linked` is described everywhere else: its own doc comment ("Open a run SCOPE and run a body of plain `await`s inside it") and [compose-api-calls-into-a-pipeline.mdx](apps/docs/content/blog/compose-api-calls-into-a-pipeline.mdx#L50) ("it opens a run **scope**").
- **Diagram alignment is intact.** Only text to the right of the `←` changed; the prefixes that set the column are untouched.
- **No other bad references.** Grepping all of `apps/docs/content` for `pipe` turned up nine other hits, all legitimate: `stitchapi/pipe` subpath imports of `all`/`any`/`race` in [run-api-calls-in-parallel.mdx](apps/docs/content/blog/run-api-calls-in-parallel.mdx) (all three exist), Angular's built-in `async` pipe, Unix shell/stdio pipes, and two prose metaphors calling an adapter "a dumb pipe".

Docs-only; no source or type changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)