### PR TITLE
fix(core): an uncontended fleet-wide acquire reports no phantom wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,22 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Fixed
 
+- **An uncontended fleet-wide acquire no longer reports a phantom wait.** Under
+  [ADR 0025](docs/adr/0025-fleet-wide-concurrency-by-lease.md) leases, `acquire` set
+  `waited = clock.now() - blockStart` whenever that difference was non-zero — but `blockStart` is
+  read before the `lease` call, which is a store round-trip. A grant on the **first** attempt
+  blocked nobody, yet any round-trip that happened to straddle a millisecond reported `waited: 1`
+  and fired a spurious `progress.throttled` event, telling an operator their limiter was pacing
+  calls it never paced. The gate is now "did it have to poll" — `takeLease` reports whether it went
+  round the loop — so store latency alone can never register, which is what the code's own comment
+  ("not incidental store or scheduling time") always claimed. A genuine block still measures its
+  real elapsed wait, unchanged.
+
+    This also fixes a flaky test: `store.spec.ts`'s `expect(first.waited).toBe(0)` failed whenever
+    the machine was slow enough, reliably under `--coverage` (it blocked CI on #632 twice). The new
+    pin injects 5ms of store latency into an uncontended grant, so it fails deterministically
+    against the old behaviour instead of once every few runs.
+
 - **`Surface.resumeRetry` takes the canonical duration form too: its return widens to
   `number | string`.** The sibling of the `SurfaceOutcome.after` fix below, found by sweeping the
   surface under the new [P17](docs/CONTRACT.md#p17--one-canonical-duration-form)/[P25](docs/CONTRACT.md#p25--one-canonical-size-form)

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -264,9 +264,13 @@ export function createStoreThrottle(
     // be woken by another worker's release — so a blocked caller POLLS. The interval is fully
     // jittered so a fleet that piles up behind one slot does not re-collide in lockstep on every
     // retry, the same full-jitter reasoning `expo-jitter` uses for retry backoff.
-    const takeLease = async (key: string): Promise<void> => {
-        if (limit == null || !leases) return;
+    // Resolves to whether the caller was actually BLOCKED — i.e. it went round the poll loop at
+    // least once. The first `lease` call is a store round-trip whose duration is not a wait on
+    // anyone; only a retry means a slot was genuinely held elsewhere.
+    const takeLease = async (key: string): Promise<boolean> => {
+        if (limit == null || !leases) return false;
         const token = hex(8);
+        let polled = false;
         for (;;) {
             if (await leases.lease(key, token, limit, leaseTtl, clock.now())) {
                 // `stateFor` is resolved HERE, not before the loop. A poller that captured the
@@ -276,8 +280,9 @@ export function createStoreThrottle(
                 // `release` would look up the live entry, find nothing, and never free the slot.
                 // One leaked slot per occurrence, which under contention is a deadlock.
                 (stateFor(key).tokens ??= []).push(token);
-                return;
+                return polled;
             }
+            polled = true;
             await clock.sleep(Math.random() * LEASE_POLL_MS);
         }
     };
@@ -296,9 +301,11 @@ export function createStoreThrottle(
             // predicted: a lease granted on the first attempt blocked nobody.
             const blockStart = clock.now();
             if (leases) {
-                await takeLease(key);
-                const spent = clock.now() - blockStart;
-                if (spent > 0) waited = spent;
+                // Gate on "did it poll", not on "did the clock move". `lease` is a store
+                // round-trip, and an uncontended one that happens to straddle a millisecond
+                // boundary would otherwise report `waited: 1` and fire a spurious `throttled`
+                // event — incidental store time, which is exactly what this must not count.
+                if (await takeLease(key)) waited = clock.now() - blockStart;
             } else {
                 const blocked =
                     limit != null && stateFor(key).inFlight >= limit;

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -514,6 +514,33 @@ describe('Pluggable store — throttle', () => {
         b.release('svc');
     });
 
+    test('a SLOW but uncontended lease still reports waited: 0', async () => {
+        // Regression: `waited` used to be `clock.now() - blockStart` whenever it was non-zero, so
+        // a store round-trip that merely straddled a millisecond reported `waited: 1` on an
+        // acquire that blocked nobody — a spurious `throttled` event, and a flaky
+        // `expect(waited).toBe(0)` above whenever CI was slow enough (reliably under --coverage).
+        // The gate is now "did it have to poll", so store latency alone can never register.
+        const inner = memoryStore();
+        const slow: StitchStore = {
+            ...inner,
+            get: inner.get.bind(inner),
+            set: inner.set.bind(inner),
+            lease: async (
+                ...args: Parameters<NonNullable<StitchStore['lease']>>
+            ) => {
+                // 5ms of pure store latency, granted on the FIRST attempt — nobody was blocked.
+                await new Promise((r) => setTimeout(r, 5));
+                return inner.lease!(...args);
+            },
+            release: inner.release!.bind(inner),
+        };
+        const t = createStoreThrottle({ concurrency: 1 }, slow);
+
+        const first = await t.acquire('svc');
+        expect(first.waited).toBe(0);
+        t.release('svc');
+    });
+
     test('a streaming (rateOnly) acquire takes no fleet-wide slot either', async () => {
         // ADR 0005 Decision 12 holds under leases: a long-lived stream must not pin a slot for
         // its whole life, which is also what keeps `lease` a crash timer rather than a call timer.


### PR DESCRIPTION
## The bug

Under [ADR 0025](docs/adr/0025-fleet-wide-concurrency-by-lease.md) leases, `acquire` measured `waited` off the wall clock unconditionally:

```ts
const blockStart = clock.now();
if (leases) {
    await takeLease(key);
    const spent = clock.now() - blockStart;
    if (spent > 0) waited = spent;          // ← any elapsed ms counts
}
```

But `blockStart` is read **before** the `lease` call, and `lease` is a store round-trip. A lease granted on the *first* attempt blocked nobody — yet if that round-trip happened to straddle a millisecond, the call reported `waited: 1` and fired a spurious `progress.throttled` event, telling an operator their limiter paced a call it never paced.

The surrounding comment already stated the intended contract — *"Only a real concurrency block counts as `waited` — not incidental store or scheduling time"* — and the non-lease branch two lines below implements it correctly, computing `blocked` **before** awaiting. Only the lease branch drifted.

## The fix

`takeLease` now reports whether it actually went round the poll loop, and that is the gate:

```ts
if (await takeLease(key)) waited = clock.now() - blockStart;
```

A retry means a slot was genuinely held elsewhere; the first attempt's latency is not a wait on anyone. A real block still measures its true elapsed time — unchanged.

## Why this also unblocked CI

`store.spec.ts`'s `expect(first.waited).toBe(0)` was failing on `main` whenever the machine was slow enough. I reproduced it on plain `main` with coverage **off**: **2 of 5** runs in one batch, **1 of 8** in another. Under `--coverage` the instrumentation widens the window enough that it hit **twice in a row** on #632 — a docs-only PR that changes one markdown file and cannot reach this code.

It presented as a flaky test, but the test was right and the code was wrong: an uncontended acquire really should report `0`.

## The regression pin

Injects 5ms of store latency into a grant that succeeds on the first attempt, so it fails **deterministically** against the old code rather than once every few runs:

```
AssertionError: expected 6 to be +0     ← without the fix
```

## Gates

- `test` **1433/1433** · `test:coverage` **1433/1433** (the job that was failing)
- `check:types`, `check:types-d` (tsd), `check:lint`, `check:exports`, `check:contract`, `check:unknown-keys`, `check:changelog` — all pass
- Stress: **0/10** failures on `store.spec.ts` with the fix, against 1–2 per 5–8 before

🤖 Generated with [Claude Code](https://claude.com/claude-code)