### PR TITLE
test(core): tolerate the measured `waited` on an uncontended lease acquire

### DIFF
--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -500,12 +500,16 @@ describe('Pluggable store — throttle', () => {
         // `waited` drives the `progress.throttled` event. Under leases the store owns the count,
         // so a blocked caller's wait is measured rather than predicted — this pins that it is
         // still reported, and that an uncontended acquire reports nothing.
+        //
+        // Measured means an uncontended acquire is near-zero, not exactly zero: one that straddles
+        // a millisecond boundary reports 1. The tolerance is what separates "walked straight in"
+        // from a real block, which below is ~60ms — the two cases are nowhere near each other.
         const store = memoryStore();
         const a = createStoreThrottle({ concurrency: 1 }, store);
         const b = createStoreThrottle({ concurrency: 1 }, store);
 
         const first = await a.acquire('svc');
-        expect(first.waited).toBe(0); // uncontended
+        expect(first.waited).toBeLessThan(5); // uncontended
 
         const blocked = b.acquire('svc');
         await new Promise((r) => setTimeout(r, 60));
@@ -521,8 +525,11 @@ describe('Pluggable store — throttle', () => {
         const t = createStoreThrottle({ concurrency: 1 }, store);
         await t.acquire('svc', { rateOnly: true });
         await t.acquire('svc', { rateOnly: true });
-        // Neither took the single slot, so a normal acquire still walks straight in.
+        // Neither took the single slot, so a normal acquire still walks straight in. Tolerance,
+        // not exact zero, for the same reason as the sibling test above: `waited` is measured, so
+        // an uncontended acquire across a millisecond boundary reports 1. Had a stream pinned the
+        // slot, this acquire would have blocked for the whole lease — orders of magnitude away.
         const normal = await t.acquire('svc');
-        expect(normal.waited).toBe(0);
+        expect(normal.waited).toBeLessThan(5);
     });
 });


### PR DESCRIPTION
## What

Two assertions in the `Pluggable store — throttle` suite pinned `waited` to exactly `0` on an uncontended acquire. Both now assert a small tolerance instead.

```diff
-        expect(first.waited).toBe(0); // uncontended
+        expect(first.waited).toBeLessThan(5); // uncontended
```

## Why

Under the ADR 0025 lease accounting landed in faae1e7, `waited` stopped being a value the code predicts. `createStoreThrottle` measures it (`packages/core/src/store.ts:297`):

```ts
const blockStart = clock.now();
if (leases) {
    await takeLease(key);
    const spent = clock.now() - blockStart;
    if (spent > 0) waited = spent;
}
```

So a lease granted on the **first attempt** — one that blocked nobody — still reports `1` whenever it happens to straddle a millisecond boundary. The `rateOnly` test failed roughly **1 run in 4** with `expected 1 to be +0`.

The sibling test at the top of the same block had the identical latent bug and only flaked less often for running earlier, so both are fixed in one pass.

Note the `else` branch immediately below keeps the older *predicted* `blocked` check, which is why only the store-throttle tests are affected and the in-process `createThrottle` equivalents are not.

## Why a tolerance is still a real assertion

Both cases stay far from what they are meant to exclude, so the bound distinguishes "walked straight in" from a genuine wait with a wide margin:

| assertion | uncontended | what it excludes |
| --- | --- | --- |
| fleet-wide slot | 0–1ms | contended sibling waits ~60ms |
| `rateOnly` | 0–1ms | a stream pinning the slot would block for a whole lease |

The existing comments explaining what each assertion pins are kept and extended to say *why* the bound is a tolerance rather than an equality, so it doesn't get "tidied" back to `toBe(0)` later.

## Verification

- 30 consecutive runs of the two tests: 30 passed, 0 failed.
- 16 full-file runs of `store.spec.ts`: neither assertion failed.
- Against a ~1-in-4 baseline, so 46 clean runs is well past coincidence.
- `check:types`, `check:lint`, and the full pre-push CI sequence pass.

Test-only change, so no CHANGELOG entry — matching the precedent set by #615.

## One thing for the reviewer

`store.spec.ts` has a **second, unrelated flake** that this PR deliberately does not touch: `a SHARED store shares the rate budget across two stitches` (line 161) fails about **1 run in 12** with `expected 2 to be 1` — both concurrent calls report a throttled event when exactly one should.

I confirmed it is pre-existing by reproducing it with this change stashed. It is not the same clock-precision class of bug: `memoryStore().reserve` returns `Math.max(at, cell)` and the caller recomputes `wait` against a *fresh* `clock.now()`, so the first caller's wait is always `<= 0` and the store path alone should yield exactly `1`. Something else is emitting the extra event.

If both calls genuinely are being paced under some interleaving, that is a real bug in shared rate budgeting and belongs in `src` — loosening the assertion would bury it. Tracked separately.

**So this does not fully un-block pushes**: the pre-push `test` job can still reject a push roughly 1 run in 12 until that one is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)