### PR TITLE
fix(hooks): match globs with doublestar so `**` stops skipping files

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,6 +2,21 @@
 # Activated by `lefthook install`, run automatically via the root package.json
 # "prepare" script on `pnpm install`.
 
+# Every `glob:` below is matched with doublestar, NOT lefthook's default gobwas
+# engine. Under gobwas, `**/` requires at least one directory, so `**/*.ts` matches
+# `packages/core/src/a/b.ts` but silently skips BOTH root-level files and the first
+# level under a named prefix — `README.md`, `package.json`, and `lefthook.yml` itself
+# were never formatted at commit time, and `packages/core/src/*.ts` (index.ts,
+# stitch.ts, types.ts — the most-edited files in the package) never triggered the
+# completions regen. doublestar gives `**` its standard meaning of zero-or-more
+# directories, so each glob covers what it plainly reads as. Verified by probe on
+# 2.1.10: under gobwas the `format` glob missed all three root files and
+# `completions` saw only the nested `a/b.ts`. The `yakir` glob is unaffected: its
+# only wildcard, `packages/*/package.json`, resolves to the same set under both
+# engines. Applies to `glob:` matching only, so it is safe to read every pattern
+# here as ordinary shell-style globbing.
+glob_matcher: doublestar
+
 # Every `run:` below starts with `{setup}`, which sources tools/hook-env.sh.
 #
 # Git hooks run in a non-interactive shell that reads no shell rc, so a PATH


### PR DESCRIPTION
## What

Sets lefthook's top-level `glob_matcher: doublestar`, so every `glob:` in `lefthook.yml` matches what it plainly reads as.

## Why

Lefthook's default **gobwas** engine requires `**/` to match *at least one* directory. So `**` quietly covered less than intended in two places:

| job | glob | silently skipped under gobwas |
|---|---|---|
| `format` | `**/*.{ts,tsx,…,yml,…}` | all root-level files — `README.md`, `package.json`, `lefthook.yml` itself |
| `completions` | `packages/core/src/**/*.ts` | `packages/core/src/*.ts` — `index.ts`, `stitch.ts`, `types.ts` |

Both gaps matter:

- **`format`** was weaker than CI's whole-tree `prettier --check .`, which is the exact drift the job's own comment says it exists to prevent. Root files were never formatted at commit time.
- **`completions`** never fired for the first level under `packages/core/src` — the most-edited files in the package, and precisely the ones the generator reads. The committed `*.generated.ts` could drift from the types it mirrors without the hook noticing.

## Verification

`glob_matcher` is a documented top-level key in lefthook 2.1.10 (`enum: [gobwas, doublestar]`, default `gobwas`, described as *"standard `**` behavior"*).

Probed against the real 2.1.10 binary on a fixture tree, using these exact globs:

```
── gobwas (default) ──
COMPLETIONS >> packages/core/src/a/b.ts
YAKIR       >> README.md packages/adapters/package.json
FORMAT      >> packages/adapters/package.json packages/core/src/a/b.ts
               packages/core/src/index.ts packages/core/src/stitch.ts

── doublestar ──
COMPLETIONS >> packages/core/src/a/b.ts packages/core/src/index.ts packages/core/src/stitch.ts
YAKIR       >> README.md packages/adapters/package.json
FORMAT      >> README.md lefthook.yml package.json packages/adapters/package.json
               packages/core/src/a/b.ts packages/core/src/index.ts packages/core/src/stitch.ts
```

- `lefthook validate` → `All good`; `lefthook dump` confirms the key parses.
- The **`yakir` glob is unaffected** — its only wildcard, `packages/*/package.json`, resolves to the same set under both engines.
- This commit **self-tested the fix**: `lefthook.yml` is a root-level `.yml`, so the `format` job fired on it here where gobwas would have skipped it. Job selection was otherwise correct (`lint`/`completions`/`yakir` did not match, `typecheck` is unglobbed).

## Blast radius

Affects `glob:` matching only — no job, command, or gate changes. The tree is already clean under the widened patterns (`prettier --check` passes on the newly-covered root files), so this closes the gap going forward rather than reformatting anything now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)