### PR TITLE
test(core): re-pin `waited` to exact zero — #634 made it exact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -537,6 +537,14 @@ npm release are grouped under the in-development version that introduced them.
     pin injects 5ms of store latency into an uncontended grant, so it fails deterministically
     against the old behaviour instead of once every few runs.
 
+    It fixes a **second** flake in that file too, which #635 recorded as having a different root
+    cause: the shared-rate-budget test failed ~1 run in 12 with `expected 2 to be 1` because the
+    phantom wait also reaches the path where no `concurrency` is configured at all — `takeLease`
+    no-ops there, but is still `async`, so the microtask hop alone could straddle a millisecond.
+    The **unpaced** caller reported `waited: 1` and fired a `throttled` event beside the paced
+    caller's 1000. Shared rate budgeting was never implicated: `reserve` grants the first caller
+    `at`, so its `wait` is never positive. That path is now pinned deterministically too.
+
 - **`Surface.resumeRetry` takes the canonical duration form too: its return widens to
   `number | string`.** The sibling of the `SurfaceOutcome.after` fix below, found by sweeping the
   surface under the new [P17](docs/CONTRACT.md#p17--one-canonical-duration-form)/[P25](docs/CONTRACT.md#p25--one-canonical-size-form)

--- a/packages/core/test/store.spec.ts
+++ b/packages/core/test/store.spec.ts
@@ -501,15 +501,17 @@ describe('Pluggable store — throttle', () => {
         // so a blocked caller's wait is measured rather than predicted — this pins that it is
         // still reported, and that an uncontended acquire reports nothing.
         //
-        // Measured means an uncontended acquire is near-zero, not exactly zero: one that straddles
-        // a millisecond boundary reports 1. The tolerance is what separates "walked straight in"
-        // from a real block, which below is ~60ms — the two cases are nowhere near each other.
+        // Exactly nothing, not merely near-zero. Measured no longer means timed: the gate is "did
+        // `takeLease` have to poll", so a first-attempt grant reports 0 however long the store
+        // round-trip took — which is what the sibling below proves by injecting 5ms of latency and
+        // still pinning 0. A tolerance here would re-admit the phantom `waited: 1` that this is
+        // meant to exclude, since 1 < 5.
         const store = memoryStore();
         const a = createStoreThrottle({ concurrency: 1 }, store);
         const b = createStoreThrottle({ concurrency: 1 }, store);
 
         const first = await a.acquire('svc');
-        expect(first.waited).toBeLessThan(5); // uncontended
+        expect(first.waited).toBe(0); // uncontended
 
         const blocked = b.acquire('svc');
         await new Promise((r) => setTimeout(r, 60));
@@ -545,6 +547,44 @@ describe('Pluggable store — throttle', () => {
         t.release('svc');
     });
 
+    test('no `concurrency` at all still reports waited: 0, however the clock moves', async () => {
+        // The sibling above pins the `concurrency: 1` path. This pins the one with NO concurrency
+        // configured, where `takeLease` no-ops — but is still an `async` function, so `await` costs
+        // a microtask hop that a `Date.now()` millisecond boundary can straddle. That is the exact
+        // path the shared-rate-budget test at the top of this file runs on, and the reason it
+        // failed ~1 run in 12 with `expected 2 to be 1`: the UNPACED caller reported `waited: 1`
+        // and fired a `throttled` event beside the paced caller's 1000. Same root cause as the
+        // phantom wait above, not a separate bug in shared rate budgeting — the shared budget was
+        // always correct, `reserve` grants the first caller `at` and its `wait` is never positive.
+        //
+        // A clock that advances on every read makes that deterministic instead of a race.
+        const ticking = (): Clock => {
+            let t = 1_000_000;
+            return {
+                now: () => (t += 1),
+                sleep: async () => undefined,
+                setTimer: (fn, ms) => setTimeout(fn, ms),
+                clearTimer: (h) => {
+                    clearTimeout(h as ReturnType<typeof setTimeout>);
+                },
+            };
+        };
+        const store = memoryStore();
+
+        // Nothing to wait for at all: no concurrency, no rate.
+        const bare = createStoreThrottle({}, store, ticking());
+        expect((await bare.acquire('bare')).waited).toBe(0);
+
+        // The shape the shared-rate-budget test runs on, FIRST caller — the one that must stay
+        // silent for `throttled` to mark the one call that really paced.
+        const paced = createStoreThrottle(
+            { rate: '1/s', pool: 'host' },
+            store,
+            ticking(),
+        );
+        expect((await paced.acquire('paced')).waited).toBe(0);
+    });
+
     test('a streaming (rateOnly) acquire takes no fleet-wide slot either', async () => {
         // ADR 0005 Decision 12 holds under leases: a long-lived stream must not pin a slot for
         // its whole life, which is also what keeps `lease` a crash timer rather than a call timer.
@@ -552,11 +592,11 @@ describe('Pluggable store — throttle', () => {
         const t = createStoreThrottle({ concurrency: 1 }, store);
         await t.acquire('svc', { rateOnly: true });
         await t.acquire('svc', { rateOnly: true });
-        // Neither took the single slot, so a normal acquire still walks straight in. Tolerance,
-        // not exact zero, for the same reason as the sibling test above: `waited` is measured, so
-        // an uncontended acquire across a millisecond boundary reports 1. Had a stream pinned the
-        // slot, this acquire would have blocked for the whole lease — orders of magnitude away.
+        // Neither took the single slot, so a normal acquire still walks straight in — reporting
+        // exactly zero, for the same reason as the sibling above: a grant that never polled never
+        // opens the measurement, so no amount of store or scheduling time can leak in. Had a
+        // stream pinned the slot, this acquire would have blocked for the whole lease.
         const normal = await t.acquire('svc');
-        expect(normal.waited).toBeLessThan(5);
+        expect(normal.waited).toBe(0);
     });
 });


### PR DESCRIPTION
Test-only. `src` is untouched.

## Why

#635 loosened two uncontended-acquire assertions from `toBe(0)` to `toBeLessThan(5)`, and its comments say the tolerance exists "so this does not get 'tidied' back to `toBe(0)`". That reasoning was written against the pre-#634 code, which the commit message quotes:

```js
const blockStart = clock.now();
await takeLease(key);
const spent = clock.now() - blockStart;
if (spent > 0) waited = spent;
```

#634 replaced that with `if (await takeLease(key)) waited = ...`. On an uncontended acquire `waited` is now never **assigned** — it stays literally `0`, not approximately `0`. The two commits landed in that order, so the loosening sits on top of the fix that made it unnecessary.

Two consequences:

1. **The tolerance is strictly weaker than the invariant.** A regression of #634 reports `waited: 1`, and `1 < 5` passes silently.
2. **The file contradicts itself.** The `SLOW but uncontended` test #634 added pins `toBe(0)` while *injecting 5ms of store latency*, right beside two siblings tolerating 5ms with no latency injected at all — the hardest case pinned exactly, the easy ones loosened.

## What changed

- Both assertions restored to `toBe(0)`, with the comments rewritten to say **why exact zero holds** (the gate is "did it poll", not "did the clock move") rather than why it cannot.
- A new deterministic pin for the one path with no cover: **no `concurrency` configured at all**, where `takeLease` no-ops but is still `async`, so the microtask hop alone can straddle a millisecond. Uses a clock that ticks on every read.

## The second flake was the same root cause

#635's message recorded `store.spec.ts`'s shared-rate-budget flake (~1 run in 12, `expected 2 to be 1`) as "pre-existing, has a different root cause" and deliberately left it alone. It is the same root cause, and **#634 already fixed it**.

The phantom wait also reaches the no-`concurrency` path, which is what that test runs on. The tell was the magnitudes — captured end-to-end by replaying the scenario 40× in one process:

```
round 0: a=[1] b=[1000]
```

The **unpaced** caller emitted `throttled { waited: 1 }` while the genuinely paced one waited the full 1000ms. Incidental scheduling time, not a second call being paced. Shared rate budgeting was never implicated: `reserve` returns `grantAt = at` for the first caller against an empty cell, so its `wait` is never positive.

That path now has a deterministic pin, so it can't quietly regress again.

## Verification

- 24 consecutive runs of the shared-rate-budget test on current `main` — clean, confirming #634 fixed it
- 25 consecutive runs of the restored assertions — clean
- 3 full-file runs under `--coverage`, the condition #635 named as its reliable reproducer — 15/15 each
- Full core suite: 137 files, 1434 tests
- All 12 CI checks green on `c8cafcc` — including `verify`, `coverage`, `e2e`, and `drift`
- **Reverted #634's gate with the tests in place**: the two deterministic pins fail (`expected 6 to be 0`, `expected 1 to be 0`); the two restored assertions happened to pass that run — which is precisely why the deterministic pins, not the tolerances, are what hold this invariant. Restoring `toBe(0)` is about accuracy and not silently accepting `waited: 1`; the injected-latency and ticking-clock tests are the actual regression detectors.

## Note on this PR's history

This branch first carried an independent rediscovery of the #634 fix — it was cut from `8d045a3`, two commits behind `main`, so neither #634 nor #635 was visible. That duplicate work has been dropped; what remains is the delta that is still useful on top of `main`.
