### PR TITLE
fix(core): `sse.reconnect` stops replaying a stream that already finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,6 +521,36 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Fixed
 
+- **`sse.reconnect` no longer replays a stream that already finished.** ([#640](https://github.com/rejifald/StitchAPI/issues/640))
+  Measured against an OpenAI-shaped completion — `data: {…}` frames with no `id:`, terminated by
+  `[DONE]` — `sse: { reconnect: true }` opened the body **4×**, delivered 24 deltas where 6 were
+  sent, handed the consumer `ABCDEABCDEABCDEABCDE` instead of `ABCDE`, and still ended
+  `done(ok: true)`. Against a real model API those are three billed completions nobody asked for.
+  It is now 1 open, 6 deltas, `ABCDE`. Two independent defects composed:
+
+    **Resumability was read off surface _capability_, before a single frame arrived.** The engine
+    asked "does this surface expose `resumeToken`/`applyResume`", and `sseSurface` exposes both
+    unconditionally — so an id-less body qualified as resumable. At reopen there was no token to
+    replay, the `applyResume` guard was skipped, and the request went out with **no
+    `Last-Event-ID`**: a request for the entire completion, not a resumption. Capability is now
+    necessary but not sufficient; the reconnect decision tests the token the stream actually
+    produced, since whether a body carries `id:` is a property of the body, not of the surface.
+
+    **A clean close was treated as a drop.** `'closed'` and `'error'` shared one path, so a body
+    that simply ran out spent the whole reconnect budget — which is why a stream that never failed
+    was reopened at all, and why a well-behaved id-carrying feed also opened 4× and replayed its
+    last id each time. A body that ends is now the stream _finishing_: it finalizes with what it
+    collected. Only a transport failure mid-flight reconnects, which is what
+    [the docs](https://stitchapi.dev/docs/reference/surfaces#resumable-sse--ssereconnect) always
+    said this option did.
+
+    `sse: true` is shorthand for `{ reconnect: true }`, so the shorthand carried both and is fixed
+    by the same change. Genuine drops are untouched: a mid-flight failure on an id-carrying feed
+    still reconnects and still sends `Last-Event-ID`, server `retry:` pacing still wins over the
+    fallback delay, and a drop before any delta was delivered still reconnects — nothing has been
+    handed over yet, so there is nothing to duplicate. The surfaces reference now states both
+    requirements, which it never did: the feed must emit `id:`, and the body must have dropped.
+
 - **An uncontended fleet-wide acquire no longer reports a phantom wait.** Under
   [ADR 0025](docs/adr/0025-fleet-wide-concurrency-by-lease.md) leases, `acquire` set
   `waited = clock.now() - blockStart` whenever that difference was non-zero — but `blockStart` is

--- a/apps/docs/content/docs/reference/surfaces.mdx
+++ b/apps/docs/content/docs/reference/surfaces.mdx
@@ -103,6 +103,22 @@ fallback delay. A server-sent `retry:` on the dropped connection always wins ove
     name="ReconnectOptions"
 />
 
+#### It needs a feed that emits `id:`
+
+Two things must hold before a body is reopened, and both are properties of the stream
+rather than of the flag:
+
+- **It has to have dropped.** A body that ran out is a stream that _finished_ — it is
+  never reopened. Only a transport failure mid-flight counts.
+- **It has to be resumable.** The reconnect replays the last `id:` as `Last-Event-ID`, so
+  a feed that never sends `id:` has no resume point. Reopening it could only re-request
+  the whole body, so it is not reopened either.
+
+That second point rules out OpenAI-shaped completions — `data: {…}` frames with no `id:`,
+terminated by a `[DONE]` sentinel. Turning `reconnect` on for one of those does nothing;
+it will not replay the completion. Use it for feeds that emit `id:` and honour
+`Last-Event-ID` — ticks, change feeds, event logs.
+
 ## stream
 
 `stream` is the raw streaming sibling — it hands back the response body decoded

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -1233,8 +1233,10 @@ async function* runFrom(
 // surface's `stream` hook (ADR 0005 Decisions 4-5). Still lean — no circuit/cache (streaming bypasses
 // the cache), but resumable when the surface opts in: a surface that exposes the resume hooks
 // (`resumeToken`/`applyResume`) AND a stitch that set `sse.reconnect` (off by default — issue #71)
-// reconnect a dropped body, replaying the last resume token (sse → `Last-Event-ID`) and honouring a
-// server-sent backoff (sse → the `retry:` field), capped at `reconnect.attempts`. The engine stays
+// reconnect a DROPPED body, replaying the last resume token (sse → `Last-Event-ID`) and honouring a
+// server-sent backoff (sse → the `retry:` field), capped at `reconnect.attempts`. Only a drop — a
+// body that ran out has finished, and a stream with no resume token to replay is not reopened at
+// all, since the reopened request could only ask for the whole body again (issue #640). The engine stays
 // surface-agnostic: it never branches on `kind.id === 'sse'`; it reads the resume token / server
 // backoff through the surface's generic hooks and the reconnect policy through one config accessor.
 // It charges the rate gate at every open (each reconnect is a fresh request) but takes NO concurrency
@@ -1280,12 +1282,18 @@ async function* runStreaming(
     state.attempts = 1;
 
     // Resumability is a GENERIC decision the engine makes from surface capability + config — never
-    // by sniffing `kind.id === 'sse'`. A surface is resumable when it can both read a resume token
+    // by sniffing `kind.id === 'sse'`. A surface CAN resume when it can both read a resume token
     // off a delta and inject it into the next request; the stitch enables it with `sse.reconnect`
     // (off by default — issue #71). `resolveReconnect` is the lone touch point for the `sse` config
     // slot, so no SSE-ism leaks into the loop below.
+    //
+    // Capability is necessary but NOT sufficient (issue #640). A surface exposes these hooks
+    // unconditionally — `sseSurface` does — so this flag says "an id-carrying body could be
+    // resumed here", not "this body carries ids". Whether THIS stream has a resume point is only
+    // known once a token has actually been read off a delta, which is why the reconnect decision
+    // below tests `lastToken` and not this flag alone.
     const policy = resolveReconnect(cfg);
-    const resumable = policy.enabled && !!resumeToken && !!applyResume;
+    const canResume = policy.enabled && !!resumeToken && !!applyResume;
 
     // State carried ACROSS reconnects: the await/`.stream()` result is the whole delta spine, and a
     // reconnect inherits the prior connection's last resume token (sse → the `Last-Event-ID` to
@@ -1300,10 +1308,10 @@ async function* runStreaming(
     let attempt = 0; // open count: 1 = first connection, 2+ = a reconnect
 
     // Open the live body and decode it into `delta` chunks. Returns how the connection ENDED so the
-    // reconnect loop can decide what to do: `'closed'` (the body ran out — for a resumable surface a
-    // normal SSE close the server may want us back from), `'error'` (the body threw mid-stream — a
-    // reconnectable drop), or `'fail'` (a terminal failure that already emitted its `error`+`done`,
-    // stop). It emits the per-open spine (throttle/request progress, deltas, drift) inline via `yield*`.
+    // reconnect loop can decide what to do: `'closed'` (the body ran out — the stream finished, and
+    // is never reopened), `'error'` (the body threw mid-stream, or never opened — a reconnectable
+    // drop), or `'fail'` (a terminal failure that already emitted its `error`+`done`, stop). It
+    // emits the per-open spine (throttle/request progress, deltas, drift) inline via `yield*`.
     async function* openAndDecode(): AsyncGenerator<
         StitchEvent,
         'closed' | 'error' | 'fail'
@@ -1447,23 +1455,37 @@ async function* runStreaming(
             lastError = e; // the body threw mid-stream — a reconnectable drop; keep the live error
             return 'error';
         }
-        // The body ran out. A clean close — for a resumable surface this is the SSE "reconnect"
-        // signal; for a non-resumable one (or reconnect off) the loop's `!resumable` guard finalizes.
+        // The body ran out. A clean close is the stream saying it is DONE, not a failure to paper
+        // over: the loop finalizes with what we collected rather than asking for it again (#640).
         return 'closed';
     }
 
-    // The reconnect loop. The first open is mandatory; each subsequent open is gated on a drop
-    // (`'closed'`/`'error'`) AND remaining attempts. On a drop we emit a `reconnect` progress event
-    // (reusing the `progress` spine — Decision: no new StitchEvent type), wait the backoff (the
-    // server `retry:` seen this run, else `reconnect.backoff`, else the `retry` policy), then loop
-    // — `openAndDecode` reapplies auth + injects the resume token on the reopened request.
+    // The reconnect loop. The first open is mandatory; each subsequent open is gated on a genuine
+    // DROP (`'error'`) that this stream can pick up from, AND remaining attempts. On such a drop we
+    // emit a `reconnect` progress event (reusing the `progress` spine — Decision: no new
+    // StitchEvent type), wait the backoff (the server `retry:` seen this run, else
+    // `reconnect.backoff`, else the `retry` policy), then loop — `openAndDecode` reapplies auth +
+    // injects the resume token on the reopened request.
     for (;;) {
         const ended = yield* openAndDecode();
         if (ended === 'fail') return; // terminal failure already emitted error + done
-        // A drop (`'closed'` or `'error'`). Reconnect only when resumable AND attempts remain;
-        // otherwise behave exactly as today — a clean close finalizes, a mid-stream error surfaces
-        // as error + done.
-        if (!resumable || attempt > policy.maxAttempts) {
+        // Reopening is only ever safe when the reopened body cannot re-deliver what the consumer
+        // already holds: either this stream carried a resume point (replayed as sse's
+        // `Last-Event-ID`, so the server continues from there), or nothing has been delivered yet
+        // — a connect-phase or first-frame failure, where there is nothing to duplicate. Without
+        // this an id-less body replayed itself in full on every reopen (issue #640).
+        const recoverable = lastToken !== undefined || chunks.length === 0;
+        // Reconnect only a recoverable drop, while attempts remain. `'closed'` is NOT a drop: the
+        // body ran out, which is the stream FINISHING — reopening it re-requests a body that
+        // already arrived in full (issue #640). Otherwise behave exactly as the reconnect-off path
+        // does — a clean close finalizes with what we collected, a mid-stream error surfaces as
+        // error + done.
+        if (
+            !canResume ||
+            ended === 'closed' ||
+            !recoverable ||
+            attempt > policy.maxAttempts
+        ) {
             if (ended === 'error') {
                 // Surface the REAL drop error (its message/status/`.response`), matching today's
                 // mid-stream-error behaviour, rather than a synthetic placeholder.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -864,7 +864,8 @@ export interface StreamBufferOptions {
 export interface ReconnectOptions {
     /**
      * Total reconnect attempts after the first connection drops, before the stream gives up and
-     * ends/errors exactly as today. Default 3.
+     * ends/errors exactly as today. Default 3. A ceiling, not a quota: a stream that finishes
+     * cleanly, or that has no `id:` to resume from, spends none of it.
      */
     attempts?: number;
     /**
@@ -887,12 +888,21 @@ export interface ReconnectOptions {
  * `true` = enabled with sane defaults; the object form tunes the cap / fallback backoff (the opaque
  * `{}` is rejected — CONTRACT.md P20). Plain JSON (the contract gate). Only the `sse` surface acts
  * on this; other surfaces ignore it.
+ *
+ * It reopens a **dropped** body only, and only one it can resume: a stream that ran out cleanly has
+ * finished, and a stream whose frames carry no `id:` has no resume point, so neither is reopened
+ * (issue #640). That matters for OpenAI-shaped completions — `data: {…}` frames with no `id:`,
+ * terminated by `[DONE]` — where a reopened request could only ask for the whole completion again.
+ * Turning this on for such a feed is a no-op, not a replay.
  */
 export interface SseOptions {
     /**
      * Reopen a dropped `text/event-stream` body and resume from the last seen `id:`. `true` enables
      * it with defaults; the object form tunes the attempt cap and fallback delay (the opaque `{}` is
      * rejected — P20). Omitted means off: the engine opens the body exactly once.
+     *
+     * Needs a server that emits `id:` and honours `Last-Event-ID`; without one there is nothing to
+     * resume from and the body is never reopened. A body that ends cleanly is never reopened either.
      */
     reconnect?: boolean | AtLeastOne<ReconnectOptions>;
 }

--- a/packages/core/test/sse-reconnect.spec.ts
+++ b/packages/core/test/sse-reconnect.spec.ts
@@ -6,7 +6,7 @@
 // (no fake timers anywhere in this package).
 import { stitch } from '../src';
 import type { Surface } from '../src';
-import { sse, sseSurface } from '../src/sse';
+import { type SseEvent, sse, sseSurface } from '../src/sse';
 import type { Adapter, AdapterRequest, StitchEvent } from '../src/types';
 import { asValidator } from './support/schema';
 import { streamOf, streamThenError } from './support/streams';
@@ -118,11 +118,11 @@ describe('sse reconnect is OFF by default (issue #71)', () => {
 
 describe('sse reconnect replays Last-Event-ID (issue #71)', () => {
     test('the SECOND open carries Last-Event-ID: 2 and its events continue to flow', async () => {
-        // First body: id 1, id 2 then closes. Second body: id 3, id 4 then closes. The third open
-        // (an empty tail) closes immediately; cap at attempts so it terminates deterministically.
+        // First body: id 1, id 2 then DROPS. Second body: id 3, id 4 then drops too. The third open
+        // (an empty tail) closes cleanly, which ends the stream (#640).
         const { adapter, requests } = scriptedAdapter([
-            () => streamOf(['id: 1\ndata: a\n\n', 'id: 2\ndata: b\n\n']),
-            () => streamOf(['id: 3\ndata: c\n\n', 'id: 4\ndata: d\n\n']),
+            () => streamThenError(['id: 1\ndata: a\n\n', 'id: 2\ndata: b\n\n']),
+            () => streamThenError(['id: 3\ndata: c\n\n', 'id: 4\ndata: d\n\n']),
         ]);
         const s = sse({
             url: 'https://x.test/e',
@@ -154,7 +154,7 @@ describe('sse reconnect delay: server retry: vs fallback (issue #71)', () => {
         // The event carries retry: 120 (ms). With a 1ms fallback, only the server value can produce
         // a ≥100ms wait — proving the server `retry:` won. One reconnect, then stop.
         const { adapter } = scriptedAdapter([
-            () => streamOf(['retry: 120\nid: 1\ndata: a\n\n']),
+            () => streamThenError(['retry: 120\nid: 1\ndata: a\n\n']),
         ]);
         const s = sse({
             url: 'https://x.test/e',
@@ -172,7 +172,7 @@ describe('sse reconnect delay: server retry: vs fallback (issue #71)', () => {
 
     test('with no server retry:, the configured reconnect.delay is used', async () => {
         const { adapter } = scriptedAdapter([
-            () => streamOf(['id: 1\ndata: a\n\n']),
+            () => streamThenError(['id: 1\ndata: a\n\n']),
         ]);
         const s = sse({
             url: 'https://x.test/e',
@@ -191,7 +191,7 @@ describe('sse reconnect delay: server retry: vs fallback (issue #71)', () => {
     test('with neither, the stitch retry backoff (fixed backoff.base) supplies the delay', async () => {
         // No server retry:, no reconnect.delay → fall back to the `retry` policy: fixed 70ms.
         const { adapter } = scriptedAdapter([
-            () => streamOf(['id: 1\ndata: a\n\n']),
+            () => streamThenError(['id: 1\ndata: a\n\n']),
         ]);
         const s = sse({
             url: 'https://x.test/e',
@@ -221,7 +221,7 @@ describe('a surface may return the canonical duration form from resumeRetry (P17
 
     test('a duration token paces the reconnect exactly as the raw ms does', async () => {
         const { adapter } = scriptedAdapter([
-            () => streamOf(['id: 1\ndata: a\n\n']),
+            () => streamThenError(['id: 1\ndata: a\n\n']),
         ]);
         const s = stitch({
             kind: returning('120ms'),
@@ -241,7 +241,7 @@ describe('a surface may return the canonical duration form from resumeRetry (P17
 
     test('an unparseable token falls through to the fallback instead of collapsing the wait', async () => {
         const { adapter } = scriptedAdapter([
-            () => streamOf(['id: 1\ndata: a\n\n']),
+            () => streamThenError(['id: 1\ndata: a\n\n']),
         ]);
         const s = stitch({
             kind: returning('soon'),
@@ -260,11 +260,12 @@ describe('a surface may return the canonical duration form from resumeRetry (P17
 });
 
 describe('sse reconnect respects the attempts cap (issue #71)', () => {
-    test('reconnects stop after N attempts; the stream ends with what it collected', async () => {
-        // Every body is a single event then closes — a resumable surface treats each close as a
-        // reconnect signal, so this would loop forever without the cap. attempts: 2 ⇒ 3 opens.
+    test('reconnects stop after N attempts, then the last drop surfaces', async () => {
+        // Every body emits one id-carrying event then DROPS, so the stream stays resumable and
+        // would reconnect forever without the cap. attempts: 2 ⇒ 3 opens, then the third drop is
+        // terminal and its real error surfaces with the deltas collected so far preserved.
         const { adapter, requests } = scriptedAdapter([], {
-            tail: () => streamOf(['data: tick\n\n']),
+            tail: () => streamThenError(['id: t\ndata: tick\n\n']),
         });
         const s = sse({
             url: 'https://x.test/e',
@@ -276,16 +277,17 @@ describe('sse reconnect respects the attempts cap (issue #71)', () => {
         expect(requests).toHaveLength(3); // first open + 2 reconnects
         expect(out.reconnects.map((r) => r.attempt)).toEqual([1, 2]);
         expect(out.deltas).toEqual([
-            { data: 'tick' },
-            { data: 'tick' },
-            { data: 'tick' },
+            { id: 't', data: 'tick' },
+            { id: 't', data: 'tick' },
+            { id: 't', data: 'tick' },
         ]);
-        expect(out.doneOk).toBe(true); // a clean close after the cap finalizes successfully
+        expect(out.error?.message).toBe('stream broke mid-flight');
+        expect(out.doneOk).toBe(false);
     });
 
     test('true means enabled with sane defaults (3 reconnects) and no fallback backoff override', async () => {
         const { adapter, requests } = scriptedAdapter([], {
-            tail: () => streamOf(['data: x\n\n']),
+            tail: () => streamThenError(['id: x\ndata: x\n\n']),
         });
         const s = sse({
             url: 'https://x.test/e',
@@ -351,7 +353,7 @@ describe('sse reconnect resumes from the last id after a mid-stream ERROR (issue
 describe('sse per-delta output validation keeps firing across a reconnect (issue #71)', () => {
     test('a bad payload on the SECOND connection still fails the stream', async () => {
         const { adapter } = scriptedAdapter([
-            () => streamOf(['id: 1\ndata: {"tok":"hi"}\n\n']),
+            () => streamThenError(['id: 1\ndata: {"tok":"hi"}\n\n']),
             () => streamOf(['id: 2\ndata: {"nope":1}\n\n']),
         ]);
         const s = sse({
@@ -390,6 +392,132 @@ describe('sse reconnect config round-trips as JSON (contract-not-dependency gate
             sse?: { reconnect?: { attempts?: number; delay?: number } };
         };
         expect(json.sse?.reconnect).toEqual({ attempts: 5, delay: 250 });
+    });
+});
+
+describe('sse reconnect never replays a stream that FINISHED (issue #640)', () => {
+    // The OpenAI shape: `data: {…}` frames with NO `id:` on any of them, terminated by a `[DONE]`
+    // sentinel. Nothing in it is resumable — a reopened request carries no `Last-Event-ID`, so it
+    // can only ask for the WHOLE completion again. Before #640 this opened 4×, delivered
+    // `ABCDEABCDEABCDEABCDE`, and still ended `done(ok: true)`.
+    const completion = (): ReadableStream<Uint8Array> =>
+        streamOf([
+            ...['A', 'B', 'C', 'D', 'E'].map(
+                (tok) => `data: {"delta":"${tok}"}\n\n`,
+            ),
+            'data: [DONE]\n\n',
+        ]);
+
+    // The text a consumer assembles off the `delta` spine; the `[DONE]` sentinel parses to a bare
+    // string and contributes nothing.
+    const textOf = (deltas: unknown[]): string =>
+        deltas
+            .map((ev) => (ev as SseEvent<{ delta?: string }>).data)
+            .map((d) => (typeof d === 'string' ? '' : (d.delta ?? '')))
+            .join('');
+
+    test('an id-less completion is opened ONCE and delivered ONCE', async () => {
+        // Every open serves the whole completion, exactly as a model API would.
+        const { adapter, requests } = scriptedAdapter([], { tail: completion });
+        const s = sse({
+            url: 'https://api.vendor.test/v1/chat',
+            sse: { reconnect: true },
+            retry: { backoff: { curve: 'fixed', base: 1 } }, // a fast curve, if it were ever used
+            adapter,
+        });
+
+        const out = await drainAll(s.stream());
+        expect(requests).toHaveLength(1); // was 4
+        expect(textOf(out.deltas)).toBe('ABCDE'); // was ABCDEABCDEABCDEABCDE
+        expect(out.deltas).toHaveLength(6); // 5 tokens + [DONE]; was 24
+        expect(out.reconnects).toEqual([]);
+        expect(out.doneOk).toBe(true); // a finished stream is still a SUCCESS
+    });
+
+    test('the `sse: true` shorthand carries the same fix', async () => {
+        // `sse: true` normalizes to `{ reconnect: true }`, so it reaches the identical policy.
+        const { adapter, requests } = scriptedAdapter([], { tail: completion });
+        const s = sse({
+            url: 'https://api.vendor.test/v1/chat',
+            sse: true,
+            retry: { backoff: { curve: 'fixed', base: 1 } },
+            adapter,
+        });
+
+        const out = await drainAll(s.stream());
+        expect(requests).toHaveLength(1);
+        expect(textOf(out.deltas)).toBe('ABCDE');
+        expect(out.doneOk).toBe(true);
+    });
+
+    test('an id-CARRYING feed that ends cleanly is not reopened either', async () => {
+        // Defect 2 on its own: the body ran out with nothing to resume from. Reopening would only
+        // replay `Last-Event-ID: 2` for a stream that already said everything it had.
+        const { adapter, requests } = scriptedAdapter([
+            () => streamOf(['id: 1\ndata: a\n\n', 'id: 2\ndata: b\n\n']),
+        ]);
+        const s = sse({
+            url: 'https://x.test/e',
+            sse: { reconnect: { attempts: 3, delay: 1 } },
+            adapter,
+        });
+
+        const out = await drainAll(s.stream());
+        expect(requests).toHaveLength(1);
+        expect(out.deltas).toEqual([
+            { id: '1', data: 'a' },
+            { id: '2', data: 'b' },
+        ]);
+        expect(out.reconnects).toEqual([]);
+        expect(out.doneOk).toBe(true);
+    });
+
+    test('an id-less stream that genuinely DROPS surfaces error+done, never a replay', async () => {
+        // Defect 1 on its own: a real drop, but no resume token was ever seen, so a reopen would
+        // re-deliver the two events already in the consumer's hands. Refuse, and report the drop —
+        // exactly what the same stitch does with `reconnect` off.
+        const { adapter, requests } = scriptedAdapter([
+            () => streamThenError(['data: a\n\n', 'data: b\n\n']),
+        ]);
+        const s = sse({
+            url: 'https://x.test/e',
+            sse: { reconnect: { attempts: 3, delay: 1 } },
+            adapter,
+        });
+
+        const out = await drainAll(s.stream());
+        expect(requests).toHaveLength(1);
+        expect(out.deltas).toEqual([{ data: 'a' }, { data: 'b' }]);
+        expect(out.error?.message).toBe('stream broke mid-flight');
+        expect(out.doneOk).toBe(false);
+    });
+
+    test('a drop before ANY delta still reconnects — there is nothing to duplicate', async () => {
+        // The token gate is about not re-delivering what the consumer already has. A connection
+        // that never handed over a chunk has nothing to duplicate, so the id-less connect-phase
+        // failure keeps reconnecting exactly as before — this fix is not "reconnect off".
+        const requests: AdapterRequest[] = [];
+        let n = 0;
+        const adapter: Adapter = (req) => {
+            requests.push(req);
+            if (n++ === 0) return Promise.reject(new Error('ECONNRESET'));
+            return Promise.resolve({
+                status: 200,
+                headers: {},
+                body: streamOf(['data: a\n\n']),
+            });
+        };
+        const s = sse({
+            url: 'https://x.test/e',
+            sse: { reconnect: { attempts: 2, delay: 1 } },
+            adapter,
+        });
+
+        const out = await drainAll(s.stream());
+        expect(requests).toHaveLength(2); // the failed connect, then a successful one
+        expect(out.reconnects.map((r) => r.attempt)).toEqual([1]);
+        expect(out.deltas).toEqual([{ data: 'a' }]); // delivered once, not twice
+        expect(out.doneOk).toBe(true);
     });
 });
 


### PR DESCRIPTION
Closes #640.

`sse: { reconnect: true }` reopened a stream that **completed cleanly** and delivered the whole body again — four times — ending `done(ok: true)`. Two independent defects composed; both are fixed here.

## Defect 1 — resumability was decided from surface *capability*, before any frame was read

`engine.ts` asked whether the **surface** exposes the resume hooks:

```ts
const resumable = policy.enabled && !!resumeToken && !!applyResume;
```

`sseSurface` exposes `resumeToken`/`applyResume` unconditionally, so an **id-less** body — every OpenAI-shaped completion — was classified resumable before a single byte arrived. At reopen `lastToken` was `undefined`, the `applyResume` guard was skipped, and the request went out with **no `Last-Event-ID`**: a request for the entire completion, not a resumption.

**Fix.** Whether a body carries `id:` is a property of the *body*, not of the surface. Capability is still necessary (the flag is now named `canResume`, which is what it actually means), but the reconnect decision tests the token the stream really produced:

```ts
const recoverable = lastToken !== undefined || chunks.length === 0;
```

The second clause is deliberate and is what keeps this from being "reconnect off": a connection that never handed over a chunk has nothing to duplicate, so a connect-phase failure still reconnects exactly as before.

## Defect 2 — a clean close was treated as a drop

`'closed'` and `'error'` shared one path, so there was no "this stream is complete" signal: `[DONE]` terminated nothing and the reconnect budget was always spent in full. That is why a stream which never failed was reopened at all — and why the issue also measured a well-behaved id-carrying feed opening 4×, replaying `Last-Event-ID: t5` each time.

**Fix.** `'closed'` is the stream *finishing*: the loop finalizes with what it collected. Only `'error'` — a transport failure mid-flight, or a connection that never opened — reconnects. This is what the option always **documented** ("Reopen a **dropped** `text/event-stream` body", "attempts after the first connection **drops**"); reopening a finished stream was never part of the contract.

## Before / after, measured

Same fake adapter, same fixture: an OpenAI-shaped `text/event-stream` — `data: {…}` frames with no `id:` on any of them, terminated by `data: [DONE]`, served in full on every open.

| | before | after |
| --- | --- | --- |
| opens | **4** | **1** |
| `[DONE]` sentinels seen | 4 | 1 |
| deltas delivered | **24** | **6** (5 tokens + `[DONE]`) |
| text the consumer received | **`ABCDEABCDEABCDEABCDE`** | **`ABCDE`** |
| terminal event | `done(ok: true)` | `done(ok: true)` |
| `Last-Event-ID` sent | `[(none), (none), (none), (none)]` | `[(none)]` |

A finished stream is still a **success** — the fix removes the replay, not the result.

## The neighbours

- **`sse: true` shorthand** — normalizes to `{ reconnect: true }` in `stitch.ts` before the engine sees it, so it reaches the identical policy and is fixed by the same change. Pinned by its own test.
- **Other resumable surfaces** — `sse` is the only surface in the repo that defines `resumeToken`/`applyResume` (grepped across `packages/` and `apps/`); nothing else was misclassified. The misclassification was never SSE-specific though: `runStreaming` never branches on `kind.id`, so a **user-authored** custom surface exposing the same hooks had the identical defect and is fixed by the identical change. No surface-specific code was added.

## Tests

**Added** (`packages/core/test/sse-reconnect.spec.ts`, new describe block for #640) — all five fail against the unfixed engine except the last, which guards the fix from over-reaching:

1. `an id-less completion is opened ONCE and delivered ONCE` — the issue's repro, asserting opens, delta count, assembled text and `done(ok: true)`.
2. `the sse: true shorthand carries the same fix`.
3. `an id-CARRYING feed that ends cleanly is not reopened either` — defect 2 alone.
4. `an id-less stream that genuinely DROPS surfaces error+done, never a replay` — defect 1 alone: a real drop with no resume point is reported, not silently replayed.
5. `a drop before ANY delta still reconnects — there is nothing to duplicate` — the no-regression pin for the connect-phase case.

**Legitimate reconnection still works, and is still pinned.** Nine existing #71 specs failed after the fix — every one of them drove its reconnect from a *cleanly closing* body, i.e. they were pinning the defect. They are re-fixtured to genuine drops (`streamThenError`) and all pass:

- `the SECOND open carries Last-Event-ID: 2 and its events continue to flow` — a mid-flight drop still resumes; opens 2 and 3 carry `Last-Event-ID: 2` and `4`.
- the three delay specs — server `retry:` still dominates, `reconnect.delay` still applies, the `retry.backoff` curve is still the last resort (real elapsed bounds, unchanged).
- both `resumeRetry` P17 duration specs.
- the two attempts-cap specs — `attempts: 2` ⇒ 3 opens, `reconnect: true` ⇒ 4 opens.
- per-delta `output` validation still fires across a reconnect.

Two specs needed a behavioural update beyond the fixture: the cap test now ends `done(ok: false)` with the real drop error, because with the fix an exhausted cap is only ever reached via a drop — a clean close finalizes successfully the moment it happens, cap or no cap.

## Also updated

- `SseOptions` / `ReconnectOptions` doc comments: the feed must emit `id:`, and a body that ends cleanly is never reopened.
- `apps/docs/content/docs/reference/surfaces.mdx`: a new subsection stating both requirements and calling out that `reconnect` is a no-op for OpenAI-shaped completions. The issue notes the reference gave a reader with such a stream every reason to turn it on.
- `CHANGELOG.md` under `[Unreleased] → Fixed`.

## Verification

Run from the repo root on this branch:

| command | result |
| --- | --- |
| `pnpm check:lint` | pass |
| `pnpm check:types` | pass |
| `pnpm test` | pass — 38 projects, core 1439/1439 |
| `pnpm check:format` | pass (after `pnpm format` reflowed the new mdx) |
| `pnpm check:contract` | pass — 0 new violations |
| `pnpm check:unknown-keys` | pass |
| `pnpm check:size` | pass — whole entry 23.95 KB gzip vs 24.10 KB budget (0.15 KB left) |
| `pnpm check:types-d` | pass |
| `pnpm check:changelog` | pass |
| `pnpm check:docs-links` | pass |
| `pnpm check:exports` | pass |
| `pnpm check:media-fresh` | pass |
| `pnpm --filter @stitchapi/docs build` | pass (the AutoTypeTable render gate) |
| `npx ./tools/yakir.tgz check` | pass — 9 tethers ok, 0 drift |
| `pnpm --filter stitchapi test:coverage` | pass — thresholds met |

Nothing was baselined, no `eslint-disable` added, and no unrelated file touched. `check:size` is tight but green; the change is a few bytes of logic in an already-reachable path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
