### PR TITLE
refactor(core)!: group the whole ADR 0004 ladder under one cache.fingerprint envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,33 +170,51 @@ npm release are grouped under the in-development version that introduced them.
     Taking it here would have made one word mean both an index and a duration, which is the P1/P2
     collision the rename exists to avoid.
 
-- **BREAKING CHANGE: `cache.transformVersion` + `cache.trustTransform` fold into one
-  `cache.transform` envelope.**
-  ([CONTRACT.md P24](docs/CONTRACT.md#p24--a-shared-field-name-prefix-in-a-house-contract-is-an-envelope))
-  The two fields were the two arms of a single decision — how an opaque `transform` clears
-  [ADR 0004](docs/adr/0004-standard-schema-fingerprint-for-cache-invalidation.md)'s rung 2 — with
-  their precedence (`version` wins; `trust` is then inert) living only in the resolver. They are
-  now one envelope that names its subject once, so the members carry only what distinguishes them
-  and the precedence is a within-envelope rule. A bare tag is the P12 shorthand for the dominant
-  field: `transform: 3` ≡ `transform: { version: 3 }`.
+- **BREAKING CHANGE: the four cache fingerprint fields become one `cache.fingerprint` envelope.**
+  ([CONTRACT.md P24](docs/CONTRACT.md#p24--a-shared-field-name-prefix-in-a-house-contract-is-an-envelope),
+  [P25](docs/CONTRACT.md#p25--one-canonical-size-form)) `version`, `transformVersion`,
+  `trustTransform` and `onUnfingerprintable` were four flat fields sitting among the cache's keying
+  and lifetime options, but they are one capability: the whole of
+  [ADR 0004](docs/adr/0004-standard-schema-fingerprint-for-cache-invalidation.md)'s ladder for
+  detecting that a stored value has gone stale against its contract.
 
-    Migration — move each field into the envelope and drop the redundant prefix:
+    Migration — every field moves into the envelope, and two shed a prefix the envelope now carries:
 
     ```ts
     // before
-    cache: { ttl: '60s', transformVersion: 3 },
-    cache: { ttl: '60s', trustTransform: true },
+    cache: { ttl: '1h', version: 3 },
+    cache: { ttl: '1h', transformVersion: 2 },
+    cache: { ttl: '1h', trustTransform: true },
+    cache: { ttl: '1h', onUnfingerprintable: 'revalidate' },
     // after
-    cache: { ttl: '60s', transform: 3 },              // ≡ { version: 3 }
-    cache: { ttl: '60s', transform: { trust: true } },
+    cache: { ttl: '1h', fingerprint: 3 },                              // ≡ { version: 3 }
+    cache: { ttl: '1h', fingerprint: { transform: 2 } },               // ≡ { transform: { version: 2 } }
+    cache: { ttl: '1h', fingerprint: { transform: { trust: true } } },
+    cache: { ttl: '1h', fingerprint: { fallback: 'revalidate' } },
     ```
 
-    `tsc` catches the migration — `NoUnknownNestedKeys` rejects both old keys by name at the
-    `cache:` slot, and neither had a runtime fallback, so there is no silent path. Behaviour is
-    unchanged end to end: the ladder, the refuse-by-default for an un-versioned transform, and the
-    generation token a given version produces are all exactly as they were. The refusal `reason`
-    surfaced on the cache trace now names the new spelling. `resolveFingerprint`'s read-view keeps
-    the flat shape it always had, with `trustTransform` renamed to `transformTrust` so the
+    Two rules drive it. **P24** for `transformVersion`+`trustTransform`: a shared prefix across two
+    flat fields is an envelope, and these were the two arms of one decision (name a version, or
+    trust it) whose precedence — `version` wins, `trust` is then inert — lived only in the resolver
+    and is now a within-envelope rule. **P25's envelope test** for the grouping: an envelope is
+    licensed where it names an unambiguous subject, and every member here is a staleness-detection
+    choice, so `fingerprint` is exhaustive over its contents the way `wire` is, while `ttl`,
+    `tenancy`, `vary`, `methods`, `entries`, `coalesce` and `keyOf` answer a different question and
+    stay outside.
+
+    `onUnfingerprintable` becomes **`fallback`** because inside the envelope the subject is named
+    once, and `on*` is this surface's handler convention — a policy string wearing it reads as a
+    callback slot. A bare tag is the P12 dominant-field shorthand at **both** depths, so the common
+    cases stay one word longer than before at most, and the manual override is now
+    `cache: { ttl, fingerprint: 3 }`.
+
+    `tsc` catches the whole migration — `NoUnknownNestedKeys` rejects every old key by name at the
+    `cache:` slot, and none had a runtime fallback, so there is no silent path. Behaviour is
+    unchanged end to end: the ladder, its rung order, the refuse-by-default for an un-versioned
+    transform or an un-fingerprintable schema, and the generation token a given version produces are
+    all exactly as they were. The refusal `reason` surfaced on the cache trace names the new
+    spellings. `resolveFingerprint`'s read-view stays flat — it is a derived view, not an authored
+    config — with `trustTransform` → `transformTrust` and `onUnfingerprintable` → `fallback` so the
     published `stitchapi/fingerprint` surface carries one vocabulary.
 
 - **BREAKING CHANGE: `circuit.halfOpenAfter` is removed — `cooldown` is the one open→half-open

--- a/README.md
+++ b/README.md
@@ -304,15 +304,15 @@ const listAnnouncements = stitch({
     pick: 'data',
     cache: {
         ttl: '1h',
-        scope: 'app',
+        tenancy: 'app',
         vary: ['accept-language'],
         entries: 500,
-        version: 1, // pins the shape — cacheable without a fingerprinter
+        fingerprint: 1, // pins the shape — cacheable without a fingerprinter
     },
 });
 ```
 
-Caching is sound by construction: a stitch with an `output` schema caches only when that schema can be fingerprinted or you pin a `version` — otherwise it **refuses to cache** rather than serve a stale shape. Mark sensitive data `sensitive: true` to opt out entirely.
+Caching is sound by construction: a stitch with an `output` schema caches only when that schema can be fingerprinted or you pin a `fingerprint` tag — otherwise it **refuses to cache** rather than serve a stale shape. Mark sensitive data `sensitive: true` to opt out entirely.
 
 ## Auth as a boundary
 

--- a/apps/docs/content/docs/reference/config-types.mdx
+++ b/apps/docs/content/docs/reference/config-types.mdx
@@ -136,13 +136,31 @@ request, so it cannot drift from what it names.
 
 <AutoTypeTable path="../../packages/core/src/types.ts" name="CacheOptions" />
 
+#### CacheFingerprintOptions
+
+The shape behind `cache.fingerprint` — how a stored value is detected as stale against
+its contract (the [ADR 0004](https://github.com/rejifald/StitchAPI/blob/main/docs/adr/0004-standard-schema-fingerprint-for-cache-invalidation.md)
+ladder). Every member is a rung of that ladder; `ttl`, `tenancy`, `vary` and the rest of
+`CacheOptions` answer a different question and stay outside. A bare version tag is the
+shorthand for `{ version }` — `fingerprint: 3` ≡ `fingerprint: { version: 3 }`, the
+always-available manual override.
+
+Unset is the automatic path: a registered `@stitchapi/fingerprint-*` strategy makes
+`output` changes self-invalidate, and an un-fingerprintable schema refuses to cache.
+
+<AutoTypeTable
+    path="../../packages/core/src/types.ts"
+    name="CacheFingerprintOptions"
+/>
+
 #### CacheTransformOptions
 
-The shape behind `cache.transform` — what the cache knows about an opaque `transform`.
-A bare version tag is the shorthand for `{ version }` — `transform: 3` ≡
-`transform: { version: 3 }`. A stitch that has a `transform` and none of this **refuses
-to cache**: the closure cannot be hashed, and re-validation cannot detect a transform
-change, so no policy would be sound. `version` wins when both are set.
+The shape behind `cache.fingerprint.transform` — what the cache knows about an opaque
+`transform`. A bare version tag is the shorthand for `{ version }` here too, one level
+in: `fingerprint: { transform: 3 }` ≡ `fingerprint: { transform: { version: 3 } }`. A
+stitch that has a `transform` and none of this **refuses to cache**: the closure cannot
+be hashed, and re-validation cannot detect a transform change, so no policy would be
+sound. `version` wins when both are set.
 
 <AutoTypeTable
     path="../../packages/core/src/types.ts"

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -1085,6 +1085,24 @@ shape, not as today's surface: nothing on the surface carries an alias.
   under `cache` rather than moving beside the closure it versions because it must round-trip as JSON
   (§1) while `transform` itself is function sugar on `__rawConfig`. Genuine breaking flat→envelope,
   no alias. **R8 never flagged this pair** — see its leading-word gap in §7.
+- **P25 envelope test (cache fingerprint, 2026-08-04)** in the same sweep, the **whole ADR 0004
+  ladder** moves under one `cache.fingerprint` envelope: `version` (rung 1), the `transform` fold
+  above (rung 2), and `onUnfingerprintable` → **`fallback`** (rung 5), typed
+  `fingerprint?: string | number | AtLeastOne<CacheFingerprintOptions>`. The licence is P25's — an
+  envelope is licensed where it **names an unambiguous subject** — and this passes the same test
+  `wire` does: every member is a staleness-detection choice, so the name is exhaustive over its
+  contents, while `ttl`/`tenancy`/`vary`/`methods`/`entries`/`coalesce`/`keyOf` answer a different
+  question (what the key is, how long an entry lives) and stay outside. It is **not** a P24 fold —
+  the four fields never shared a prefix, which is why nothing flagged them.
+
+    `fallback` rather than `onUnfingerprintable`: inside the envelope the subject is named once, so
+    the member carries only the dimension (P25's `max`/`chars` idiom), and `on*` is the handler
+    convention (carve-out (c)) — a policy string wearing it reads as a callback slot. A bare tag is
+    the P12 shorthand at **both** depths (`fingerprint: 3` ≡ `{ version: 3 }`;
+    `fingerprint: { transform: 3 }` ≡ `{ transform: { version: 3 } }`) — the only two-level fold on
+    the surface, and `NestedEnvelopes` carries it to that depth so a misspelling inside either
+    envelope is a compile error. Genuine breaking flat→envelope, no alias.
+
 - **P20/P12/P13 (empty-object rejection)** the five bare all-optional `StitchConfig` slots R6 flagged
   now type their object form so `{}` is a **compile error**: `hooks?: AtLeastOne<Hooks>` and
   `input?: AtLeastOne<InputSchemas>` (no scalar); `multipart?: MultipartNesting | AtLeastOne<MultipartOptions>`

--- a/docs/adr/0003-derived-key-response-cache-and-coalescing.md
+++ b/docs/adr/0003-derived-key-response-cache-and-coalescing.md
@@ -95,7 +95,7 @@ round-trips as JSON; functions are sugar).
     must fold into the generation** (decision 8) so a schema change invalidates the bucket.
     Fingerprinting a Standard Schema is its own hard problem (a schema is a closure graph; no
     universal serialisation), split into its own concern (**ADR 0004**): per-validator strategies
-    behind a contract, a manual `cache.version` as the fail-closed fallback, and **re-validate on
+    behind a contract, a manual `cache.fingerprint` tag as the fail-closed fallback, and **re-validate on
     hit** as the safe default for any stitch whose schema can't be fingerprinted (it forfeits this
     decision's skip for that stitch only, trading speed for correctness).
 
@@ -262,8 +262,8 @@ round-trips as JSON; functions are sugar).
   warn-and-pass-through (decision 3).
 - **Schema-fingerprinting (ADR 0004).** ✅ _Resolved & wired._ A Standard Schema fingerprint folds
   into the generation so an `output`/`unwrap`/versioned-`transform` change invalidates cached
-  values (decision 2): per-validator strategies behind a contract, a manual `cache.version`
-  fallback, refuse-to-cache by default when un-fingerprintable, and `onUnfingerprintable:
+  values (decision 2): per-validator strategies behind a contract, a manual `cache.fingerprint`
+  tag, refuse-to-cache by default when un-fingerprintable, and `fingerprint.fallback:
 'revalidate'` for opt-in re-validate-on-hit. `resolveFingerprint` is computed once per stitch in
   `createCache`; its `policy` drives fast / revalidate / refuse and its `reason` rides the cache
   trace.

--- a/docs/adr/0004-standard-schema-fingerprint-for-cache-invalidation.md
+++ b/docs/adr/0004-standard-schema-fingerprint-for-cache-invalidation.md
@@ -4,12 +4,29 @@
 - **Date:** 2026-06-14
 - **Tags:** caching, validation, schema, standard-schema, contract-not-dependency, runtime
 
-> **Amended 2026-08-04 (spelling only, rung 2 unchanged).** The two ways to clear the transform
-> gate were authored as the flat pair `cache.transformVersion` + `cache.trustTransform`; they are
-> now the one envelope [P24](../CONTRACT.md#p24--a-shared-field-name-prefix-in-a-house-contract-is-an-envelope)
-> asks for — **`cache.transform: string | number | { version?, trust? }`**, where a bare tag is the
-> P12 shorthand for `{ version }`. The ladder, its precedence, and every default below are
-> unchanged; only the authored spelling moved. The prose here uses the new one throughout.
+> **Amended 2026-08-04 (spelling only — every rung, default and precedence below is unchanged).**
+> This ladder was authored as four flat fields on `CacheOptions`, sitting among the keying and
+> lifetime options. It is now **one envelope, `cache.fingerprint`**, whose members are its rungs:
+>
+> ```ts
+> cache: {
+>     ttl: '1h', tenancy: 'app',                    // keying + lifetime — unchanged
+>     fingerprint: {                                // ← the whole of this ADR
+>         version: 3,                               // was cache.version          (rung 1)
+>         transform: { version: 2, trust: false },  // was cache.transformVersion / trustTransform (rung 2)
+>         fallback: 'revalidate',                   // was cache.onUnfingerprintable (rung 5)
+>     },
+> }
+> ```
+>
+> A bare tag is the P12 shorthand at both depths (`fingerprint: 3` ≡ `{ version: 3 }`;
+> `fingerprint: { transform: 3 }` ≡ `{ transform: { version: 3 } }`). Two rules drive it:
+> [P24](../CONTRACT.md#p24--a-shared-field-name-prefix-in-a-house-contract-is-an-envelope) for the
+> `transformVersion`/`trustTransform` pair, and P25's "an envelope is licensed where it names an
+> unambiguous subject" for the grouping — every member is a staleness-detection choice, so the name
+> is exhaustive over its contents the way `wire`'s is. `onUnfingerprintable` became `fallback`
+> because inside the envelope the subject is named once, and `on*` is reserved for handlers.
+> The prose below uses the new spellings throughout.
 
 ## Context
 
@@ -75,7 +92,7 @@ _because_ it is opaque.)
   never per request.
 - **Declarative spelling:** every capability needs a JSON-serialisable spelling.
   `transform` is "sugar, never the only way." The declarative escape hatch here
-  is an explicit `cache.version`, which always round-trips as data.
+  is an explicit `cache.fingerprint` tag, which always round-trips as data.
 
 ## Decisions
 
@@ -162,7 +179,9 @@ whole design is between `S` and `X`:
 // core, at stitch-definition time (sketch)
 function stitchGeneration(cfg: StitchConfig): string {
     const unwrap = cfg.unwrap ?? '';
-    if (cfg.cache?.version != null) return h(['v', cfg.cache.version, unwrap]); // rung 1 — authoritative
+    const fingerprint = cfg.cache?.fingerprint;
+    if (fingerprint?.version != null)
+        return h(['v', fingerprint.version, unwrap]); // rung 1 — authoritative
 
     const vendor = (cfg.output as StandardSchemaV1)?.['~standard']?.vendor;
     const fp = vendor
@@ -171,8 +190,8 @@ function stitchGeneration(cfg: StitchConfig): string {
 
     const xTag = !cfg.transform
         ? 'x:none'
-        : cfg.cache?.transform?.version != null
-          ? `x:${cfg.cache.transform.version}`
+        : fingerprint?.transform?.version != null
+          ? `x:${fingerprint.transform.version}`
           : 'x:OPAQUE';
 
     if (xTag === 'x:OPAQUE') return REFUSE; // un-versioned transform → don't cache
@@ -181,9 +200,7 @@ function stitchGeneration(cfg: StitchConfig): string {
     if (cfg.output == null) return h(['noschema', unwrap, xTag]); // nothing to go stale → fast
 
     // output present but un-fingerprintable → refuse (default) | revalidate (opt-in)
-    return cfg.cache?.onUnfingerprintable === 'revalidate'
-        ? REVALIDATE
-        : REFUSE;
+    return fingerprint?.fallback === 'revalidate' ? REVALIDATE : REFUSE;
 }
 ```
 
@@ -191,15 +208,15 @@ function stitchGeneration(cfg: StitchConfig): string {
 
 Resolved once per stitch, highest precedence first:
 
-1.  **Explicit `cache.version` → authoritative.** The user owns correctness; the
+1.  **Explicit `cache.fingerprint.version` → authoritative.** The user owns correctness; the
     fingerprint is `hash(version, unwrap)`. JSON-serialisable, satisfies the
     declarative-spelling gate, and is the always-available manual override. Fast
     path.
 2.  **Un-versioned `transform` present** → **refuse-to-cache.** Re-validation
     cannot see a transform change (Decision 2 — a stale value still satisfies an
     unchanged schema), so neither fast nor revalidate is sound. Lift it with
-    `cache.transform: '<version>'` (→ a sound fingerprint) or
-    `cache.transform: { trust: true }` (cache anyway, bounded only by TTL).
+    `cache.fingerprint: { transform: '<version>' }` (→ a sound fingerprint) or
+    `{ transform: { trust: true } }` (cache anyway, bounded only by TTL).
 3.  **Sound structural fingerprint** — a compliant strategy is registered for the
     vendor and reports full capture (`value !== null`). Fold `hash(vendor, S, U, X)`
     into the generation. Fast path.
@@ -210,20 +227,20 @@ Resolved once per stitch, highest precedence first:
     non-Standard-Schema validator, or the strategy abstains) → **refuse-to-cache**
     by default. Failing closed is unambiguously sound and a clear, actionable nudge
     to register the vendor's fingerprint package. Opt into **re-validate-on-hit**
-    with `cache.onUnfingerprintable: 'revalidate'` — it catches schema changes that
+    with `cache.fingerprint: { fallback: 'revalidate' }` — it catches schema changes that
     _reject_ the stored value, but only soundly so for pure validators (it assumes
     validation is idempotent; coercing/transforming schemas can break that), which
     is why it is opt-in rather than the default.
 
 **Recommended defaults:**
 
-| Situation                                                     | Default behaviour                           |
-| ------------------------------------------------------------- | ------------------------------------------- |
-| Known vendor + serialisable pipeline (no/versioned transform) | auto-fingerprint, fast path                 |
-| No output schema (and no/sound transform)                     | fast — nothing to go stale                  |
-| Unknown/unregistered vendor, non-Standard-Schema, or abstains | **refuse-to-cache** (`onUnfingerprintable`) |
-| Un-versioned `transform` present                              | refuse-to-cache (re-validate can't see it)  |
-| Anything                                                      | `cache.version` overrides everything        |
+| Situation                                                     | Default behaviour                            |
+| ------------------------------------------------------------- | -------------------------------------------- |
+| Known vendor + serialisable pipeline (no/versioned transform) | auto-fingerprint, fast path                  |
+| No output schema (and no/sound transform)                     | fast — nothing to go stale                   |
+| Unknown/unregistered vendor, non-Standard-Schema, or abstains | **refuse-to-cache** (`fingerprint.fallback`) |
+| Un-versioned `transform` present                              | refuse-to-cache (re-validate can't see it)   |
+| Anything                                                      | `cache.fingerprint` overrides everything     |
 
 Why refuse (not re-validate) is the default for an un-fingerprintable schema:
 re-validate-on-hit is only sound when validation is idempotent, and it silently
@@ -273,7 +290,7 @@ Therefore opaque logic is handled by **abstain-or-version**, never by hashing it
 - If a strategy encounters an opaque `.refine`/`.transform`/`.brand`/predicate
   it cannot represent, it **abstains** (`value: null`) → conservative fallback.
 - `config.transform` is opaque to core. Its provenance enters the fingerprint
-  only as `cache.transform.version` (a user tag); otherwise it forces refuse
+  only as `cache.fingerprint.transform.version` (a user tag); otherwise it forces refuse
   (Decision 4, rung 2).
 
 This is exactly how every prior-art system treats non-serialisable logic:
@@ -391,7 +408,7 @@ assertConformance(
   vendor packages and run once at definition time.
 - Every failure mode degrades safely (re-validate-on-hit or refuse-to-cache);
   the system never silently serves a value bound to an unverifiable shape.
-- `cache.version` is a always-available, JSON-serialisable manual override.
+- `cache.fingerprint` is a always-available, JSON-serialisable manual override.
 
 ### Negative / trade-offs
 
@@ -402,7 +419,7 @@ assertConformance(
   ([zod #4497](https://github.com/colinhacks/zod/issues/4497)).
 - **Transforms are a genuine blind spot.** An un-versioned `transform` forces
   refuse-to-cache; this is correct but costs the cache for transform-heavy
-  stitches until the author adds `cache.transform`.
+  stitches until the author adds `cache.fingerprint.transform`.
 - **Over-invalidation by design.** Strong-by-default fingerprints will bump on
   cosmetic schema refactors (e.g. inlining a sub-schema) unless a weak strategy
   is chosen. We accept refetch cost over staleness risk.
@@ -416,7 +433,7 @@ assertConformance(
   sound (re-validate-on-hit assumes idempotent validation), and a missing
   fingerprint package surfaces as a clear, actionable reason rather than a silent
   perf tax. Re-validate-on-hit is retained as an explicit opt-in
-  (`cache.onUnfingerprintable: 'revalidate'`). A stitch with **no** output schema
+  (`cache.fingerprint: { fallback: 'revalidate' }`). A stitch with **no** output schema
   still caches fast (no shape to go stale). Placement (bare-stitch vs subpath) does
   not change the default — both fail closed.
 
@@ -445,7 +462,7 @@ conformance-tested):
   over-invalidation of the opaque token.
 - **The fold (`stitchapi/cache`)** — `createCache` calls `resolveFingerprint`
   once per stitch from its `output`/`transform`/`unwrap` + the `cache` options
-  (`version`, `transform`, `onUnfingerprintable`). The
+  (the `cache.fingerprint` envelope: `version`, `transform`, `fallback`). The
   `generation` token folds into the cache namespace **alongside** the per-stitch
   generation counter (so a schema/unwrap/versioned-transform change moves the
   bucket while bulk-invalidate still bumps the counter); the `policy` selects

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -386,10 +386,10 @@ export function createCache(opts: CacheControllerOptions): CacheController {
         output: opts.output,
         transform: opts.transform,
         pick: opts.pick,
-        version: config.version,
-        transformVersion: config.transform?.version,
-        transformTrust: config.transform?.trust,
-        onUnfingerprintable: config.onUnfingerprintable,
+        version: config.fingerprint?.version,
+        transformVersion: config.fingerprint?.transform?.version,
+        transformTrust: config.fingerprint?.transform?.trust,
+        fallback: config.fingerprint?.fallback,
     });
     const fpTag = `f${fp.generation}:`;
     // 'cluster' is reserved for the deferred cross-process protocol; v1 degrades it to process.

--- a/packages/core/src/fingerprint.ts
+++ b/packages/core/src/fingerprint.ts
@@ -114,7 +114,7 @@ export function clearFingerprinters(): void {
  * - `fast` — the stored value is bound to a known token (or to nothing — no output
  *   schema); serve it without re-validating, and fold `generation` into the cache
  *   generation.
- * - `revalidate` — opt-in (`onUnfingerprintable: 'revalidate'`): cache despite an
+ * - `revalidate` — opt-in (`cache.fingerprint.fallback: 'revalidate'`): cache despite an
  *   un-fingerprintable schema, but re-validate the stored value against the current
  *   schema on every hit. Catches schema changes that REJECT the stored value;
  *   assumes validation is idempotent (no coercion/transform inside the schema).
@@ -137,21 +137,22 @@ export interface FingerprintInput {
     readonly transform?: ((body: unknown) => unknown) | undefined;
     /** `config.pick` — a dot-path string; serialisable, so always sound. */
     readonly pick?: string | undefined;
-    /** Explicit `cache.version` — authoritative override; always wins. */
+    /** `cache.fingerprint.version` — authoritative override; always wins. */
     readonly version?: string | number | undefined;
-    /** `cache.transform.version` — a user tag making an opaque `transform` sound. */
+    /** `cache.fingerprint.transform.version` — a user tag making an opaque `transform` sound. */
     readonly transformVersion?: string | number | undefined;
-    /** `cache.transform.trust` — cache despite an un-versioned `transform`, bounded only by TTL. */
+    /** `cache.fingerprint.transform.trust` — cache despite an un-versioned `transform`, TTL-bounded. */
     readonly transformTrust?: boolean | undefined;
     /**
-     * Policy when an OUTPUT SCHEMA is present but can't be soundly fingerprinted
-     * (unknown/unregistered vendor, non-Standard-Schema validator, or the strategy
-     * abstained). `'refuse'` (the default) does not cache — fail closed, and a
-     * clear nudge to register the vendor's fingerprint package. `'revalidate'`
-     * caches but re-validates on every hit (network savings, but only sound for
-     * pure validators — see {@link CachePolicy}).
+     * `cache.fingerprint.fallback` — where the ladder lands when an OUTPUT SCHEMA
+     * is present but can't be soundly fingerprinted (unknown/unregistered vendor,
+     * non-Standard-Schema validator, or the strategy abstained). `'refuse'` (the
+     * default) does not cache — fail closed, and a clear nudge to register the
+     * vendor's fingerprint package. `'revalidate'` caches but re-validates on every
+     * hit (network savings, but only sound for pure validators — see
+     * {@link CachePolicy}).
      */
-    readonly onUnfingerprintable?: 'refuse' | 'revalidate' | undefined;
+    readonly fallback?: 'refuse' | 'revalidate' | undefined;
 }
 
 export interface FingerprintResolution {
@@ -176,7 +177,7 @@ function vendorOf(schema: unknown): string | undefined {
  * 3. a registered strategy returns a non-null token → fast path, token folded
  *    into `generation`;
  * 4. no output schema at all → fast (nothing validated, so no shape to go stale);
- * 5. an output schema is present but un-fingerprintable → `onUnfingerprintable`
+ * 5. an output schema is present but un-fingerprintable → `fallback`
  *    (default `refuse`; opt into `revalidate`).
  */
 export function resolveFingerprint(
@@ -184,12 +185,12 @@ export function resolveFingerprint(
 ): FingerprintResolution {
     const pick = input.pick ?? '';
 
-    // rung 1 — explicit cache.version is authoritative.
+    // rung 1 — an explicit cache.fingerprint.version is authoritative.
     if (input.version != null) {
         return {
             generation: hash(`v|${input.version}|u|${pick}`),
             policy: 'fast',
-            reason: 'explicit cache.version',
+            reason: 'explicit cache.fingerprint.version',
         };
     }
 
@@ -224,7 +225,7 @@ export function resolveFingerprint(
         return {
             generation: '',
             policy: 'refuse',
-            reason: 'opaque transform without a cache.transform declaration. Fix: set cache.transform to a version tag you bump when the transform changes, or cache.transform: { trust: true } to opt out.',
+            reason: "opaque transform without a cache.fingerprint.transform declaration. Fix: set cache.fingerprint: { transform: '<version>' } and bump it when the transform changes, or { transform: { trust: true } } to opt out.",
         };
     }
 
@@ -254,15 +255,12 @@ export function resolveFingerprint(
     // Default to refusing (fail closed); a caller may opt into re-validate-on-hit.
     const reason = vendor
         ? fp
-            ? `fingerprint strategy for '${vendor}' abstained. Fix: set cache.version, or onUnfingerprintable: 'revalidate'.`
-            : `no fingerprinter registered for '${vendor}'. Fix: install @stitchapi/fingerprint-${vendor}, set cache.version, or onUnfingerprintable: 'revalidate'.`
-        : "output is not a Standard Schema, so a stale value can't be detected. Fix: set cache.version, pass onUnfingerprintable: 'revalidate', or use a blessed validator with a fingerprint-* vendor pkg.";
+            ? `fingerprint strategy for '${vendor}' abstained. Fix: set cache.fingerprint to a version tag, or cache.fingerprint: { fallback: 'revalidate' }.`
+            : `no fingerprinter registered for '${vendor}'. Fix: install @stitchapi/fingerprint-${vendor}, set cache.fingerprint to a version tag, or cache.fingerprint: { fallback: 'revalidate' }.`
+        : "output is not a Standard Schema, so a stale value can't be detected. Fix: set cache.fingerprint to a version tag, pass cache.fingerprint: { fallback: 'revalidate' }, or use a blessed validator with a fingerprint-* vendor pkg.";
     return {
         generation: '',
-        policy:
-            input.onUnfingerprintable === 'revalidate'
-                ? 'revalidate'
-                : 'refuse',
+        policy: input.fallback === 'revalidate' ? 'revalidate' : 'refuse',
         reason,
     };
 }

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -229,18 +229,28 @@ function expandShorthand(cfg: Partial<StitchConfig>): void {
     // P7: the cache's list fields take a bare string as the one-element list. Widened HERE, before
     // the deep-merge, so a string in one layer and a list in another merge as one shape and the
     // controller reads the settled `ResolvedCacheOptions` — always arrays, never re-normalising.
-    // Nested fold (P12/P24) in the same pass: `cache.transform` is a scalar-or-envelope slot, so a
-    // bare version tag folds to `{ version }` and `__config` never carries the scalar form (P0).
+    // Nested folds (P12/P24) in the same pass: `cache.fingerprint` and the `transform` inside it are
+    // both scalar-or-envelope slots, so a bare version tag at either depth folds to `{ version }`
+    // and `__config` never carries a scalar form (P0). Outermost first — the inner fold reads the
+    // envelope the outer one just produced. Two levels is the deepest nesting on the surface, and
+    // the resolver reads `fingerprint.transform.version` without ever re-normalising.
     const cache = cfg.cache as CacheOptions | undefined;
-    if (cache !== undefined)
+    if (cache !== undefined) {
+        const fingerprint = envelope(cache.fingerprint, 'version');
         cfg.cache = {
             ...cache,
             ...compact({
                 vary: listOf(cache.vary),
                 methods: listOf(cache.methods),
-                transform: envelope(cache.transform, 'version'),
+                fingerprint: fingerprint && {
+                    ...fingerprint,
+                    ...compact({
+                        transform: envelope(fingerprint.transform, 'version'),
+                    }),
+                },
             }),
         };
+    }
     // P13: `sse: true` enables reconnection with defaults; `false`/absent is off (the opaque
     // `sse: {}` is a type error at the slot, so the all-defaults case arrives here as `true`).
     if (cfg.sse === true) cfg.sse = { reconnect: true };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -381,7 +381,19 @@ interface NestedEnvelopes {
     cache: [
         CacheOptions,
         'CacheOptions',
-        { transform: [CacheTransformOptions, 'CacheTransformOptions', object] },
+        {
+            fingerprint: [
+                CacheFingerprintOptions,
+                'CacheFingerprintOptions',
+                {
+                    transform: [
+                        CacheTransformOptions,
+                        'CacheTransformOptions',
+                        object,
+                    ];
+                },
+            ];
+        },
     ];
     hooks: [Hooks, 'Hooks', object];
     paginate: [PaginateOptions, 'PaginateOptions', object];
@@ -1223,6 +1235,43 @@ export interface CacheTransformOptions {
 }
 
 /**
+ * How the cache detects that a stored value has gone stale against its contract — the whole of
+ * [ADR 0004](../../../docs/adr/0004-standard-schema-fingerprint-for-cache-invalidation.md)'s
+ * fallback ladder in one envelope. Every member is a rung of that ladder, so the name is
+ * exhaustive over its contents the way `wire`'s is (CONTRACT.md P24/P25); `ttl`, `tenancy`,
+ * `vary`, `methods` and the rest of {@link CacheOptions} answer a different question — what the
+ * key is and how long an entry lives — and stay outside.
+ *
+ * Nothing here is required: with no `fingerprint` block a registered `@stitchapi/fingerprint-*`
+ * strategy makes `output` changes self-invalidate, and an un-fingerprintable schema refuses to
+ * cache (fail closed). The members are the three ways to override that.
+ */
+export interface CacheFingerprintOptions {
+    /**
+     * Opaque schema/version tag — the **authoritative** rung: setting it pins the contract and
+     * takes the **no-revalidate** fast path (you promise `output`/`transform`/`pick` are unchanged
+     * for this tag). A bare `string | number` at the slot is the P12 shorthand for this field.
+     */
+    version?: string | number;
+    /**
+     * What the cache knows about an opaque `transform` (rung 2). A `transform` is a closure that
+     * cannot be soundly hashed, so a stitch carrying one **refuses to cache** until one of
+     * {@link CacheTransformOptions}' two declarations clears the gate. A bare `string | number` is
+     * the P12 shorthand for the dominant field — `transform: 3` ≡ `transform: { version: 3 }`.
+     */
+    transform?: string | number | AtLeastOne<CacheTransformOptions>;
+    /**
+     * Where the ladder lands when an `output` schema is present but cannot be soundly fingerprinted
+     * (no `@stitchapi/fingerprint-*` registered for its vendor, a non-Standard-Schema validator, or
+     * the strategy abstained). `'refuse'` (default, **fail-closed**) does not cache — and nudges you
+     * to register the vendor package or set `version`. `'revalidate'` caches but **re-validates the
+     * stored value on every hit** against the current schema (saves the network, still safe; sound
+     * only for pure validators with no coercion/transform inside the schema).
+     */
+    fallback?: 'refuse' | 'revalidate';
+}
+
+/**
  * Transport-level response cache + in-process request coalescing (ADR 0003). The key is
  * **derived** from the resolved request — no caller-authored keys — so it cannot drift from
  * what it names. Off by default: no `cache` block ⇒ no caching and no hot-path cost. The engine
@@ -1268,31 +1317,14 @@ export interface CacheOptions {
      */
     coalesce?: 'process' | 'cluster' | false;
     /**
-     * Opaque schema/version tag — the **authoritative** rung of the fingerprint ladder (ADR 0004):
-     * setting it pins the contract and takes the **no-revalidate** fast path (you promise the
-     * `output`/`transform`/`pick` are unchanged for this tag). Leaving it unset hands off to the
-     * automatic fingerprint: a registered `@stitchapi/fingerprint-*` strategy makes `output`
-     * changes self-invalidate on the fast path; an un-fingerprintable schema falls to
-     * {@link CacheOptions.onUnfingerprintable} (default **refuse-to-cache**, fail-closed).
+     * How a stored value is detected as stale against its contract — the ADR 0004 ladder, whose
+     * rungs are {@link CacheFingerprintOptions}' three members. Unset is the automatic path: a
+     * registered `@stitchapi/fingerprint-*` strategy makes `output` changes self-invalidate, and an
+     * un-fingerprintable schema refuses to cache (fail-closed). A bare `string | number` is the P12
+     * shorthand for the dominant field — `fingerprint: 3` ≡ `fingerprint: { version: 3 }`, the
+     * always-available manual override.
      */
-    version?: string | number;
-    /**
-     * What the cache knows about an opaque `transform` (ADR 0004 rung 2). A `transform` is a
-     * closure that cannot be soundly hashed, so a stitch carrying one **refuses to cache** until
-     * one of {@link CacheTransformOptions}' two declarations clears the gate. A bare
-     * `string | number` is the P12 shorthand for the dominant field — `transform: 3` ≡
-     * `transform: { version: 3 }`.
-     */
-    transform?: string | number | AtLeastOne<CacheTransformOptions>;
-    /**
-     * Policy when an `output` schema is present but cannot be soundly fingerprinted (no
-     * `@stitchapi/fingerprint-*` registered for its vendor, a non-Standard-Schema validator, or the
-     * strategy abstained). `'refuse'` (default, **fail-closed**) does not cache — and nudges you to
-     * register the vendor package or set `version`. `'revalidate'` caches but **re-validates the
-     * stored value on every hit** against the current schema (saves the network, still safe; sound
-     * only for pure validators with no coercion/transform inside the schema).
-     */
-    onUnfingerprintable?: 'refuse' | 'revalidate';
+    fingerprint?: string | number | AtLeastOne<CacheFingerprintOptions>;
     /** Sugar: author the key seed from the input instead of deriving it from the request (CONTRACT.md P6). */
     keyOf?: (input: StitchInput) => string;
 }
@@ -1690,16 +1722,27 @@ export interface StitchConfig {
 }
 
 /**
+ * {@link CacheFingerprintOptions} after {@link compose}: the nested `transform` scalar is folded to
+ * `{ version }`, so the resolver reads one shape.
+ */
+export type ResolvedCacheFingerprintOptions = Omit<
+    CacheFingerprintOptions,
+    'transform'
+> & {
+    transform?: CacheTransformOptions;
+};
+
+/**
  * {@link CacheOptions} after {@link compose}: the `T | T[]` list fields are always arrays and the
- * `transform` scalar is folded to `{ version }`.
+ * `fingerprint` scalar is folded to `{ version }` (with its own nested fold applied).
  */
 export type ResolvedCacheOptions = Omit<
     CacheOptions,
-    'vary' | 'methods' | 'transform'
+    'vary' | 'methods' | 'fingerprint'
 > & {
     vary?: string[];
     methods?: string[];
-    transform?: CacheTransformOptions;
+    fingerprint?: ResolvedCacheFingerprintOptions;
 };
 
 /** {@link StreamOptions} after {@link compose}: the `buffer` scalar is folded to `{ chars }`. */

--- a/packages/core/test/cache.spec.ts
+++ b/packages/core/test/cache.spec.ts
@@ -423,11 +423,11 @@ describe('cache — scope isolation', () => {
 });
 
 describe('cache — re-validate on hit vs version fast path', () => {
-    test('onUnfingerprintable:"revalidate" self-heals a stale-shaped hit', async () => {
+    test('fingerprint.fallback:"revalidate" self-heals a stale-shaped hit', async () => {
         // First origin call returns a string `n`; later calls return a number. A loose writer
         // (accept-anything predicate) caches the string; a strict reader (number predicate) sharing
         // the store + key re-validates on hit, finds it stale, evicts, and refetches a conforming
-        // value. Both outputs are predicates — un-fingerprintable — so with onUnfingerprintable:
+        // value. Both outputs are predicates — un-fingerprintable — so with fallback:
         // 'revalidate' both take policy 'revalidate' and share one (empty-fingerprint) bucket.
         const { adapter, calls } = counting({
             body: (n) => ({ n: n === 1 ? 'oops' : 7 }),
@@ -442,7 +442,7 @@ describe('cache — re-validate on hit vs version fast path', () => {
             cache: {
                 ttl: '60s',
                 tenancy: 'app' as const,
-                onUnfingerprintable: 'revalidate' as const,
+                fingerprint: { fallback: 'revalidate' as const },
             },
         };
         const writer = stitch({
@@ -460,7 +460,7 @@ describe('cache — re-validate on hit vs version fast path', () => {
         expect(calls()).toBe(2);
     });
 
-    test('cache.version pins the schema — a hit is trusted, not re-validated', async () => {
+    test('a bare cache.fingerprint pins the schema — a hit is trusted, not re-validated', async () => {
         const { adapter, calls } = counting({
             body: (n) => ({ n: n === 1 ? 'oops' : 7 }),
         });
@@ -471,7 +471,8 @@ describe('cache — re-validate on hit vs version fast path', () => {
             adapter,
             store,
             trace: false as const,
-            cache: { ttl: '60s', tenancy: 'app' as const, version: '1' },
+            // P12 scalar at the outer slot ≡ `fingerprint: { version: '1' }`.
+            cache: { ttl: '60s', tenancy: 'app' as const, fingerprint: '1' },
         };
         const writer = stitch(base);
         const reader = stitch({
@@ -551,7 +552,7 @@ describe('cache — schema fingerprint fold (ADR 0004)', () => {
         expect(calls()).toBe(2); // never cached — each call is live
     });
 
-    test('onUnfingerprintable:"revalidate" caches and re-validates the stored value on each hit', async () => {
+    test('fingerprint.fallback:"revalidate" caches and re-validates the stored value on each hit', async () => {
         registerFingerprinter(testFingerprinter);
         const { adapter, calls } = counting();
         const s = stitch({
@@ -561,7 +562,7 @@ describe('cache — schema fingerprint fold (ADR 0004)', () => {
             cache: {
                 ttl: '60s',
                 tenancy: 'app',
-                onUnfingerprintable: 'revalidate',
+                fingerprint: { fallback: 'revalidate' },
             },
             output: fpSchema({ opaque: true }), // abstains → policy 'revalidate'
         });
@@ -571,7 +572,7 @@ describe('cache — schema fingerprint fold (ADR 0004)', () => {
         expect(calls()).toBe(1); // value re-validates fine → still cached
     });
 
-    test('an opaque transform refuses to cache unless cache.transform makes it sound', async () => {
+    test('an opaque transform refuses to cache unless fingerprint.transform makes it sound', async () => {
         const refused = counting();
         const r = stitch({
             url: URL,
@@ -579,7 +580,7 @@ describe('cache — schema fingerprint fold (ADR 0004)', () => {
             adapter: refused.adapter,
             trace: false,
             cache: { ttl: '60s', tenancy: 'app' },
-            transform: (b) => b, // opaque closure, no cache.transform declaration → refuse
+            transform: (b) => b, // opaque closure, no transform declaration → refuse
         });
         const trace = await cacheTrace(r.stream());
         expect(trace.some((d) => d.startsWith('bypass:'))).toBe(true);
@@ -593,7 +594,12 @@ describe('cache — schema fingerprint fold (ADR 0004)', () => {
             name: 'txv',
             adapter: versioned.adapter,
             trace: false,
-            cache: { ttl: '60s', tenancy: 'app', transform: '1' }, // P12 scalar ≡ { version: '1' }
+            // P12 scalar one level in ≡ `fingerprint: { transform: { version: '1' } }`.
+            cache: {
+                ttl: '60s',
+                tenancy: 'app',
+                fingerprint: { transform: '1' },
+            },
             transform: (b) => b, // now sound (version named) → fast
         });
         await v();
@@ -601,34 +607,53 @@ describe('cache — schema fingerprint fold (ADR 0004)', () => {
         expect(versioned.calls()).toBe(1); // second call is a hit
     });
 
-    test('the bare version tag folds to `{ version }` in __config (P0/P12)', () => {
-        const s = stitch({
+    test('both bare version tags fold to `{ version }` in __config (P0/P12)', () => {
+        const outer = stitch({
             url: URL,
             trace: false,
-            cache: { ttl: '60s', transform: 3 },
+            cache: { ttl: '60s', fingerprint: 3 },
+        });
+        const inner = stitch({
+            url: URL,
+            trace: false,
+            cache: { ttl: '60s', fingerprint: { transform: 3 } },
             transform: (b) => b,
         });
-        // The engine only ever sees the object form, so the scalar never reaches the store key or
-        // a serialized config — the same fold `retry.backoff` and `wire.multipart` get.
-        expect(s.__config.cache?.transform).toEqual({ version: 3 });
+        // The engine only ever sees the object form, so a scalar never reaches the store key or a
+        // serialized config — the same fold `retry.backoff` and `wire.multipart` get, applied at
+        // both depths of the only two-level slot on the surface.
+        expect(outer.__config.cache?.fingerprint).toEqual({ version: 3 });
+        expect(inner.__config.cache?.fingerprint).toEqual({
+            transform: { version: 3 },
+        });
     });
 
-    test('the flat `transformVersion`/`trustTransform` pair is off the type surface (P24)', () => {
+    test('the ladder`s flat spellings are off the type surface (P24)', () => {
         // One literal per key: excess-property checking reports only the FIRST unknown key, so a
         // second directive in the same object would be unused (and `check:types` fails on that).
         const versioned: CacheOptions = {
             ttl: '60s',
-            // @ts-expect-error — folded into `cache.transform`, whose bare tag IS the version;
-            // the envelope names the subject once (CONTRACT.md P24, hard break under P19).
+            // @ts-expect-error — `version` moved into the `fingerprint` envelope, whose bare tag IS
+            // the version (CONTRACT.md P24, hard break under P19).
+            version: 3,
+        };
+        const transformed: CacheOptions = {
+            ttl: '60s',
+            // @ts-expect-error — the transform declaration is `fingerprint.transform` now; the flat
+            // `transformVersion`/`trustTransform` pair folded into it one commit earlier.
             transformVersion: 3,
         };
-        const trusted: CacheOptions = {
+        const revalidating: CacheOptions = {
             ttl: '60s',
-            // @ts-expect-error — `cache.transform: { trust: true }` is the weak arm of that same
-            // envelope, one word shorter for having dropped the subject from the field name.
-            trustTransform: true,
+            // @ts-expect-error — `onUnfingerprintable` is `fingerprint.fallback`: inside the
+            // envelope the subject is named once, and `on*` is reserved for handlers.
+            onUnfingerprintable: 'revalidate',
         };
-        expect([versioned.ttl, trusted.ttl]).toEqual(['60s', '60s']);
+        expect([versioned.ttl, transformed.ttl, revalidating.ttl]).toEqual([
+            '60s',
+            '60s',
+            '60s',
+        ]);
     });
 });
 

--- a/packages/core/test/config-at-least-one.spec.ts
+++ b/packages/core/test/config-at-least-one.spec.ts
@@ -87,9 +87,16 @@ test('the opaque `{}` is rejected at each Scalar|AtLeastOne slot (P20)', () => {
         stitch({
             baseUrl: 'https://x',
             path: '/y',
+            // @ts-expect-error — `cache.fingerprint: {}` is rejected; use a version tag or set a field.
+            cache: { ttl: '60s', fingerprint: {} },
+        }),
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
             transform: (b) => b,
-            // @ts-expect-error — `cache.transform: {}` is rejected; name a version or set `trust`.
-            cache: { ttl: '60s', transform: {} },
+            // @ts-expect-error — the nested `fingerprint.transform: {}` is rejected too; name a
+            // version or set `trust`. P20 holds at both depths of the two-level slot.
+            cache: { ttl: '60s', fingerprint: { transform: {} } },
         }),
     ];
     // The assertions that matter are the @ts-expect-error directives above (checked by `check:types`).
@@ -130,18 +137,29 @@ test('the scalar / ≥1-field forms are accepted at each slot (P12/P13/P20)', ()
             path: '/y',
             retry: { backoff: { base: 5 } },
         }),
-        // P24/P12: `cache.transform` takes the bare version tag or a ≥1-field envelope.
+        // P24/P12: `cache.fingerprint` and the `transform` inside it each take the bare version tag
+        // or a ≥1-field envelope — the same shorthand, one level apart.
         stitch({
             baseUrl: 'https://x',
             path: '/y',
-            transform: (b) => b,
-            cache: { ttl: '60s', transform: 3 },
+            cache: { ttl: '60s', fingerprint: 3 },
         }),
         stitch({
             baseUrl: 'https://x',
             path: '/y',
             transform: (b) => b,
-            cache: { ttl: '60s', transform: { trust: true } },
+            cache: { ttl: '60s', fingerprint: { transform: 3 } },
+        }),
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
+            transform: (b) => b,
+            cache: { ttl: '60s', fingerprint: { transform: { trust: true } } },
+        }),
+        stitch({
+            baseUrl: 'https://x',
+            path: '/y',
+            cache: { ttl: '60s', fingerprint: { fallback: 'revalidate' } },
         }),
     ];
     expect(typeof accepted).toBe('function');

--- a/packages/core/test/fingerprint-resolve-edges.spec.ts
+++ b/packages/core/test/fingerprint-resolve-edges.spec.ts
@@ -6,7 +6,7 @@
 //   - an opaque transform with no output still REFUSES — the transform gate (rung 2) outranks the
 //     no-schema fast path (rung 4);
 //   - `transformTrust` clears the transform gate but does NOT rescue an un-fingerprintable schema:
-//     it still refuses (rung 5), and only `onUnfingerprintable: 'revalidate'` caches it.
+//     it still refuses (rung 5), and only `fallback: 'revalidate'` caches it.
 import { clearFingerprinters, resolveFingerprint } from '../src/fingerprint';
 import type { StandardSchemaV1 } from '../src/standard-schema';
 
@@ -69,12 +69,12 @@ describe('resolveFingerprint: transformTrust does not rescue an un-fingerprintab
         expect(r.reason).not.toContain('opaque transform');
     });
 
-    it('the same case caches under onUnfingerprintable: revalidate', () => {
+    it('the same case caches under fallback: revalidate', () => {
         const r = resolveFingerprint({
             output: unregisteredSchema(),
             transform: (x: unknown) => x,
             transformTrust: true,
-            onUnfingerprintable: 'revalidate',
+            fallback: 'revalidate',
         });
         expect(r.policy).toBe('revalidate');
     });

--- a/packages/core/test/fingerprint.spec.ts
+++ b/packages/core/test/fingerprint.spec.ts
@@ -114,7 +114,7 @@ describe('resolveFingerprint — the fallback ladder', () => {
     it('rung 1: explicit version is authoritative (fast)', () => {
         const r = resolveFingerprint({ output: userSchema(), version: 'v3' });
         expect(r.policy).toBe('fast');
-        expect(r.reason).toBe('explicit cache.version');
+        expect(r.reason).toBe('explicit cache.fingerprint.version');
         expect(r.generation).not.toBe('');
     });
 
@@ -183,11 +183,11 @@ describe('resolveFingerprint — the fallback ladder', () => {
         expect(r.reason).toContain('no fingerprinter registered');
     });
 
-    it('rung 5: opt-in onUnfingerprintable:revalidate', () => {
+    it('rung 5: opt-in fallback:revalidate', () => {
         clearFingerprinters();
         const r = resolveFingerprint({
             output: userSchema(),
-            onUnfingerprintable: 'revalidate',
+            fallback: 'revalidate',
         });
         expect(r.policy).toBe('revalidate');
     });

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -327,7 +327,7 @@ const PREFIX_GROUP_ALLOW = new Map([
     ],
     [
         'FingerprintInput.transform',
-        'transform/transformVersion/transformTrust is a derived read-view that FLATTENS the authored CacheOptions.transform envelope (version/trust) back alongside the top-level StitchConfig.transform closure for the hash — the envelope P24 asks for is the authored one; re-nesting it here would only re-wrap what the resolver reads flat',
+        'transform/transformVersion/transformTrust is a derived read-view that FLATTENS the authored cache.fingerprint.transform envelope (version/trust) back alongside the top-level StitchConfig.transform closure for the hash — the envelope P24 asks for is the authored one; re-nesting it here would only re-wrap what the resolver reads flat',
     ],
     [
         'CliIO.write',


### PR DESCRIPTION
Follow-up to #626, which folded `transformVersion` + `trustTransform` into `cache.transform`. That fold was the narrow one — this takes the rest of the ladder.

`version`, `transform`, and `onUnfingerprintable` were flat fields on `CacheOptions`, sitting among the keying and lifetime options while being **one capability**: [ADR 0004](docs/adr/0004-standard-schema-fingerprint-for-cache-invalidation.md)'s ladder for detecting that a stored value has gone stale against its contract.

```ts
// before                                                // after
cache: { ttl: '1h', version: 3 }                         cache: { ttl: '1h', fingerprint: 3 }
cache: { ttl: '1h', transform: 2 }                       cache: { ttl: '1h', fingerprint: { transform: 2 } }
cache: { ttl: '1h', trustTransform: true }               cache: { ttl: '1h', fingerprint: { transform: { trust: true } } }
cache: { ttl: '1h', onUnfingerprintable: 'revalidate' }  cache: { ttl: '1h', fingerprint: { fallback: 'revalidate' } }
```

## What

### 1. Why this is an envelope

**Not P24.** These four never shared a prefix, which is exactly why no lint ever flagged them — #626's fold was P24's, this one isn't.

The licence is **P25's** test: an envelope is licensed where it **names an unambiguous subject**. `fingerprint` passes the same test `wire` does — every member is a staleness-detection choice, so the name is exhaustive over its contents. `ttl`, `tenancy`, `vary`, `methods`, `entries`, `coalesce` and `keyOf` answer a different question (what the key is, how long an entry lives) and stay outside. The split falls exactly where ADR 0004 ends and ADR 0003 begins.

### 2. `onUnfingerprintable` → `fallback`

Inside the envelope the subject is named once, so the member carries only the dimension — P25's own `max`/`chars` idiom. And `on*` is this surface's handler convention (`onRequest`, `onProgress`, and P24 carve-out (c)); a policy string wearing it reads as a callback slot. The word also matches what ADR 0004 calls the thing: "the fallback ladder".

### 3. A two-level fold

`fingerprint` and the `transform` inside it are both scalar-or-envelope slots, so a bare tag folds to `{ version }` at either depth and `__config` never carries a scalar (P0):

```ts
cache: { ttl: '1h', fingerprint: 3 }                 // ≡ { version: 3 }
cache: { ttl: '1h', fingerprint: { transform: 3 } }  // ≡ { transform: { version: 3 } }
```

`expandShorthand` applies them outermost-first — the inner fold reads the envelope the outer one just produced — and `NestedEnvelopes` carries the guard table to that depth, so a misspelling inside *either* envelope is a compile error. This is the only two-level slot on the surface.

## Reviewer notes

- **The `version` tag moved, and that is the debatable part.** `cache.version` was the always-available manual override ADR 0004 leans on, and it now reads `cache.fingerprint: 3` — one word longer at the slot, but it says what it does (it *is* the fingerprint) and keeps the ladder in one place. If you'd rather keep `version` flat and fold only the other two, say so and I'll re-cut.
- **Behaviour is unchanged end to end** — same rungs, same rung order, same refuse-by-default for an un-versioned transform or an un-fingerprintable schema, same generation token for a given version. Only spellings moved. The refusal `reason` on the cache trace names the new ones.
- **Hard break, no alias** (P19, `rc` channel). `NoUnknownNestedKeys` rejects every old key by name at the `cache:` slot, and none had a runtime fallback, so there is no silent path; `cache.spec.ts` pins all three off the type surface.
- **`resolveFingerprint`'s read-view stays flat** — it is a derived view, not an authored config (its allow-list entry says so) — with `onUnfingerprintable` → `fallback` there too, so the published `stitchapi/fingerprint` surface carries one vocabulary.
- **Docs:** `CacheFingerprintOptions` gets its own `AutoTypeTable` (the #622 lesson — a nested shape without its own table renders nothing), and ADR 0004 carries a spelling-only amendment note with the before/after block. CONTRACT.md §6 records the fold under the P25 test rather than P24.
- Drive-by: the README cache snippet still spelled `tenancy` as the pre-P2 `scope`, in the same block as the `version` line this change touches.

## Verification

- **Bundle: +0.07 / +0.06 KB gzip** (23.93→24.00 whole entry, 21.36→21.42 for `import { stitch }`, measured against this branch's merge base). **Fits the current budgets** with 0.10 / 0.08 left — no raise, and the advertised `~24 kB` / `~21 kB` figures are unchanged. The bytes are the nested fold in `expandShorthand`, which cannot move behind a subpath (it is a rule in `compose`, which every stitch runs). If a later change needs them back, dropping the *inner* scalar shorthand returns ~0.02 KB.
- `check:types` (workspace + tsd), `check:lint`, `check:format`, `check:contract` (**0 violations**), `check:unknown-keys` (19 nested envelopes tabled, 0 un-tabled), `check:docs-links`, `build-docs`, and the full yakir drift set (9/9 ok) — all green, plus **1434 core tests** and every peer suite.
- Docs checked against the running dev server: `CacheOptions.fingerprint` renders the union, and both nested tables render their members. No console errors.
- New coverage: the fold at both depths in `__config`, `{}` rejected at both depths (P20), each accepted form, and the three removed spellings pinned off the type surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
