### PR TITLE
fix(core): a `bigint` path parameter no longer vanishes from the URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -539,6 +539,30 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Fixed
 
+- **A `bigint` path parameter no longer vanishes from the URL.** `stitch({ path: '/v1/things/{id}' })`
+  called with `{ params: { id: 1234567890123456789n } }` built `https://api.test/v1/things/` — the id
+  simply gone, no error, no event, no drift finding. A request meant for one item silently addressed
+  the **collection**; against a `DELETE` that is a different operation than the one the caller wrote.
+
+    `expandTemplateVar` branched on `string | number | boolean`, so a bigint matched none of the
+    scalar arms and fell through to the object arm, where `Object.entries(1n)` is `[]` and nothing was
+    emitted. It hit **every scalar position**, not just the plain `{id}` case measured above: `{/id}`
+    dropped the whole path segment (`/v1{/id}` → `/v1`), and `{+id}`, `{#id}`, `{.id}`, `{;id}`,
+    `{?id}` and the `{id:4}` prefix modifier all rendered empty. Composite values were never affected
+    — `[1n, 2n]` and `{ a: 1n }` route through `String()`/`stringifyLeaf` — so a bigint inside a list
+    expanded correctly while the same bigint on its own disappeared, and the query builder rendered
+    `?since=1234567890123456789` for a value the path builder erased.
+
+    **The type said the same thing twice.** Path-only vars inferred as `string | number`, so the value
+    was rejected at the call site as well as dropped at runtime; fixing either half alone still left
+    the caller stuck. The folded `params` slot is now `string | number | bigint`, which is what
+    `expandPath` has always stringified. A key named by an `input.params` schema still answers to its
+    schema — widening the path-only fold does not punch through a declared shape.
+
+    This lands on the people who had already done the right thing: parsing a 64-bit id into a `BigInt`
+    is the standard repair for JSON's double-precision rounding, and handing that repaired value back
+    to a path parameter was the moment it disappeared.
+
 - **`sse.reconnect` no longer replays a stream that already finished.** ([#640](https://github.com/rejifald/StitchAPI/issues/640))
   Measured against an OpenAI-shaped completion — `data: {…}` frames with no `id:`, terminated by
   `[DONE]` — `sse: { reconnect: true }` opened the body **4×**, delivered 24 deltas where 6 were

--- a/apps/docs/content/docs/getting-started/migration-notes.mdx
+++ b/apps/docs/content/docs/getting-started/migration-notes.mdx
@@ -182,12 +182,11 @@ import { type Stitch, stitch } from 'stitchapi';
 const registry = new Map<string, Stitch>();
 registry.set('item', stitch({ path: '/items/{id}' }) as Stitch);
 
-// Single field you want to keep precise — annotate it with the narrowed type
-// and you keep the required-params check (path vars stringify to `string | number`).
+// Single field you want to keep precise — annotate it with the narrowed type and you keep
+// the required-params check (path vars stringify to `string | number | bigint`).
 class Catalog {
-    getItem: Stitch<unknown, { params: { id: string | number } }> = stitch({
-        path: '/items/{id}',
-    });
+    getItem: Stitch<unknown, { params: { id: string | number | bigint } }> =
+        stitch({ path: '/items/{id}' });
 }
 ```
 

--- a/packages/core/src/infer.ts
+++ b/packages/core/src/infer.ts
@@ -392,14 +392,23 @@ type SchemaParams<C> =
         : Record<never, never>;
 /**
  * The folded `params` slot: the schema-declared shape ({@link SchemaParams}) intersected with the
- * path-only var names typed `string | number` (what `expandPath` ultimately stringifies). Path-only
- * keys are `Exclude`d of the schema's keys, so a key the schema already names KEEPS its schema type —
- * schema wins. Placed as a REQUIRED property, so `HasRequired`/`Args` make the call argument required —
- * the correctness win. {@link Prettify} flattens the intersection for clean errors and tsd identity.
+ * path-only var names typed `string | number | bigint` (what `expandPath` ultimately stringifies).
+ * Path-only keys are `Exclude`d of the schema's keys, so a key the schema already names KEEPS its
+ * schema type — schema wins. Placed as a REQUIRED property, so `HasRequired`/`Args` make the call
+ * argument required — the correctness win. {@link Prettify} flattens the intersection for clean
+ * errors and tsd identity.
+ *
+ * `bigint` is in the set because it is the value a caller holds after parsing a 64-bit id OUT of the
+ * double-precision range JSON would have rounded it into — the standard repair for that precision
+ * loss. `expandPath` stringifies it exactly like a number, so the type admitting it is the type
+ * telling the truth about what the runtime accepts.
  */
 type PathParams<C> = Prettify<
     SchemaParams<C> &
-        Record<Exclude<PathVarsOf<C>, keyof SchemaParams<C>>, string | number>
+        Record<
+            Exclude<PathVarsOf<C>, keyof SchemaParams<C>>,
+            string | number | bigint
+        >
 >;
 
 /**
@@ -456,8 +465,8 @@ type FoldPathParams<C, Base> = [PathVarsOf<C>] extends [never]
  * - **Without input schemas** (`Base = StitchInput`, a CONCRETE interface): build `params` purely from
  *   the path vars via `Omit<StitchInput, 'params'> & { params }`. `Omit` over a concrete type resolves
  *   immediately (no deferral → no boundary break) and DROPS `StitchInput`'s loose
- *   `params?: Record<string, unknown>`, so the slot is exactly `{ id: string | number }` rather than
- *   that intersected with the catch-all index signature.
+ *   `params?: Record<string, unknown>`, so the slot is exactly `{ id: string | number | bigint }`
+ *   rather than that intersected with the catch-all index signature.
  */
 export type InputOf<C> = [C] extends [
     { extends: readonly [unknown, ...unknown[]] },

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -392,8 +392,13 @@ function expandTemplateVar(
         if (
             typeof value === 'string' ||
             typeof value === 'number' ||
-            typeof value === 'boolean'
+            typeof value === 'boolean' ||
+            typeof value === 'bigint'
         ) {
+            // `bigint` belongs with the other scalars, not in the object arm below: it has no
+            // enumerable entries, so `Object.entries(1n)` is `[]` and the var would expand to
+            // NOTHING — `/things/{id}` silently becoming `/things/`, a collection request where
+            // an item was meant. Matches `stringifyLeaf`, which the list/object arms already use.
             let s = String(value);
             if (modifier && modifier !== '*')
                 s = s.substring(0, parseInt(modifier, 10));

--- a/packages/core/test-d/input-inference.test-d.ts
+++ b/packages/core/test-d/input-inference.test-d.ts
@@ -145,7 +145,7 @@ const templated = stitch({
     path: '/users/{id}',
     input: { body: z.object({ name: z.string() }) },
 });
-expectType<Record<string, unknown> & { id: string | number }>(
+expectType<Record<string, unknown> & { id: string | number | bigint }>(
     null as unknown as NonNullable<CallArg<typeof templated>>['params'],
 );
 expectError(templated({ body: { name: 'Ada' } })); // params still required by the path var

--- a/packages/core/test-d/path-vars.test-d.ts
+++ b/packages/core/test-d/path-vars.test-d.ts
@@ -15,9 +15,9 @@ import { type CallArg } from './_util';
 import { expectAssignable, expectError, expectType } from 'tsd';
 import { z } from 'zod';
 
-// 1) bare `{id}`: params is present, required, and typed `string | number`; the arg is required.
+// 1) bare `{id}`: params is present, required, and typed `string | number | bigint`; the arg is required.
 const u = stitch({ path: '/users/{id}' });
-expectType<{ id: string | number }>(
+expectType<{ id: string | number | bigint }>(
     null as unknown as NonNullable<CallArg<typeof u>>['params'],
 );
 expectError(u()); // params required → no-arg call is an error
@@ -25,16 +25,16 @@ expectError(u({})); // params still required
 expectError(u({ query: { page: 1 } })); // params still required
 
 // 2) path var + `input.params` schema for a SHARED key: the schema type wins for `id`, the path adds
-//    the rest (`postId`) as required `string | number`.
+//    the rest (`postId`) as required `string | number | bigint`.
 const post = stitch({
     path: '/u/{id}/p/{postId}',
     input: { params: z.object({ id: z.string() }) },
 });
 expectType<string>(
-    null as unknown as NonNullable<CallArg<typeof post>>['params']['id'], // schema wins (not string|number)
+    null as unknown as NonNullable<CallArg<typeof post>>['params']['id'], // schema wins (not string|number|bigint)
 );
-expectType<string | number>(
-    null as unknown as NonNullable<CallArg<typeof post>>['params']['postId'], // path-only → string|number
+expectType<string | number | bigint>(
+    null as unknown as NonNullable<CallArg<typeof post>>['params']['postId'], // path-only → string|number|bigint
 );
 expectError(post()); // params required
 expectError(post({ params: { id: 'a' } })); // missing the path-only `postId`
@@ -42,15 +42,15 @@ expectError(post({ params: { id: 'a' } })); // missing the path-only `postId`
 // 3) operators and modifiers are stripped to bare names (mirrors `expandPath`'s varspec parse):
 //    `{?q,sort}` → `q | sort`; `{id*}` (explode) → `id`; `{id:2}` (prefix) → `id`.
 const query = stitch({ path: '/search{?q,sort}' });
-expectType<{ q: string | number; sort: string | number }>(
+expectType<{ q: string | number | bigint; sort: string | number | bigint }>(
     null as unknown as NonNullable<CallArg<typeof query>>['params'],
 );
 const explode = stitch({ url: 'https://api.example.com/files/{id*}' });
-expectType<{ id: string | number }>(
+expectType<{ id: string | number | bigint }>(
     null as unknown as NonNullable<CallArg<typeof explode>>['params'],
 );
 const prefix = stitch({ url: 'https://api.example.com/u/{id:2}' });
-expectType<{ id: string | number }>(
+expectType<{ id: string | number | bigint }>(
     null as unknown as NonNullable<CallArg<typeof prefix>>['params'],
 );
 
@@ -74,7 +74,7 @@ expectAssignable<CallArg<typeof bound>>(undefined);
 
 // 7) `url` (host included) is templated too: a `{tenant}` in the host is a required param.
 const host = stitch({ url: 'https://{tenant}.example.com/v1/ping' });
-expectType<{ tenant: string | number }>(
+expectType<{ tenant: string | number | bigint }>(
     null as unknown as NonNullable<CallArg<typeof host>>['params'],
 );
 expectError(host());
@@ -82,7 +82,7 @@ expectError(host());
 // 8) `path` wins the var source when both `path` and `url` are literals (the engine never expands both;
 //    reading `path` first is the stable choice).
 const both = stitch({ path: '/p/{p}', url: 'https://x/u/{u}' });
-expectType<{ p: string | number }>(
+expectType<{ p: string | number | bigint }>(
     null as unknown as NonNullable<CallArg<typeof both>>['params'],
 );
 
@@ -95,7 +95,7 @@ expectAssignable<CallArg<typeof plain>>(undefined);
 //     schema stays required; `params` is added required from the path var. Since a declared sibling slot
 //     (`body`) now leaves `params` with its loose `Record<string, unknown>` passthrough (issue #134), the
 //     folded slot is that passthrough INTERSECTED with the path-only `{ id }` — the required modifier from
-//     the fold wins (still required), and the path-only key keeps `string | number`; extra loose keys are
+//     the fold wins (still required), and the path-only key keeps `string | number | bigint`; extra loose keys are
 //     tolerated. A no-input templated stitch (case 1) stays byte-clean `{ id }` — only a declared sibling
 //     brings the index-signature tail.
 const withBody = stitch({
@@ -105,7 +105,7 @@ const withBody = stitch({
 expectType<{ name: string }>(
     null as unknown as NonNullable<CallArg<typeof withBody>>['body'],
 );
-expectType<Record<string, unknown> & { id: string | number }>(
+expectType<Record<string, unknown> & { id: string | number | bigint }>(
     null as unknown as NonNullable<CallArg<typeof withBody>>['params'],
 );
 expectError(withBody({ body: { name: 'Ada' } })); // params still required
@@ -118,12 +118,12 @@ expectAssignable<CallArg<typeof withBody>>({
 // 11) seam members (root, principal-bound, and graphql) fold path vars identically.
 const api = seam({ baseUrl: 'https://x' });
 const member = api.stitch({ path: '/users/{id}' });
-expectType<{ id: string | number }>(
+expectType<{ id: string | number | bigint }>(
     null as unknown as NonNullable<CallArg<typeof member>>['params'],
 );
 expectError(member());
 const asMember = api.as('u1').stitch({ path: '/orgs/{org}' });
-expectType<{ org: string | number }>(
+expectType<{ org: string | number | bigint }>(
     null as unknown as NonNullable<CallArg<typeof asMember>>['params'],
 );
 expectError(asMember());
@@ -131,7 +131,26 @@ const gqlMember = api.graphql({
     document: 'query { ok }',
     path: '/gql/{region}',
 });
-expectType<{ region: string | number }>(
+expectType<{ region: string | number | bigint }>(
     null as unknown as NonNullable<CallArg<typeof gqlMember>>['params'],
 );
 expectError(gqlMember());
+
+// 12) a `bigint` is accepted where a path var is expected. It is what a caller holds after parsing a
+//     64-bit id out of the range a JSON double would have silently rounded — the standard repair for
+//     that precision loss — and `expandPath` stringifies it exactly like a number. The type used to
+//     say `string | number`, which rejected the repaired value at the call site while the runtime
+//     ALSO dropped it; both halves are fixed, so pin the type half here and the expansion half in
+//     `test/url-query.spec.ts`.
+expectAssignable<CallArg<typeof u>>({ params: { id: 9007199254740993n } });
+expectAssignable<CallArg<typeof member>>({ params: { id: 9007199254740993n } });
+expectAssignable<NonNullable<CallArg<typeof query>>['params']>({
+    q: 1n, // every path-only var takes it, under an operator too
+    sort: 'asc',
+});
+// A schema-named key still answers to its SCHEMA, not the widened path-only type: `id` is `z.string()`
+// in case 2, so a bigint there stays an error. Widening the fold must not punch through a declared shape.
+expectError<NonNullable<CallArg<typeof post>>['params']>({
+    id: 1n,
+    postId: 1n,
+});

--- a/packages/core/test/input-inference.spec.ts
+++ b/packages/core/test/input-inference.spec.ts
@@ -90,8 +90,9 @@ test('params + query schemas validate and the typed call expands them', async ()
 test('an RFC 6570 path var with NO input schema requires params (Phase 2c)', async () => {
     server.route('GET', '/users/7', { body: { id: 7, name: 'Bo' } });
     // No `input.params` schema: the `{id}` template alone makes `params` a required call argument,
-    // typed `string | number`. This call is itself a compile-time assertion (tsconfig.test.json
-    // typechecks this file) — it only compiles because the path var is folded into the argument.
+    // typed `string | number | bigint`. This call is itself a compile-time assertion
+    // (tsconfig.test.json typechecks this file) — it only compiles because the path var is folded
+    // into the argument.
     const getUser = stitch({
         baseUrl: server.url,
         path: '/users/{id}',
@@ -105,6 +106,32 @@ test('an RFC 6570 path var with NO input schema requires params (Phase 2c)', asy
     const bound = getUser.with({ params: { id: 7 } });
     const same = await bound();
     expect(same.name).toBe('Bo');
+});
+
+test('a bigint path var reaches the server intact, digits and all', async () => {
+    // End-to-end guard for the two-sided bug: the folded `params` slot USED TO be typed
+    // `string | number` (so this call did not compile) and `expandPath` USED TO drop a bigint
+    // entirely (so the URL became `/things/`, hitting the COLLECTION instead of the item). Both
+    // sides are fixed; this pins them together, since either one alone still leaves the caller stuck.
+    //
+    // 9007199254740993n is `Number.MAX_SAFE_INTEGER + 2` — a value no JSON double can hold, which is
+    // exactly why a caller parses ids like it into a bigint in the first place.
+    const id = 9007199254740993n;
+    server.route('GET', `/things/${id}`, { body: { id: 7, name: 'Bo' } });
+    const getThing = stitch({
+        baseUrl: server.url,
+        path: '/things/{id}',
+        output: userSchema,
+    });
+
+    // Compiles only because `params` admits a bigint; resolves only because the URL kept every digit.
+    const thing = await getThing({ params: { id } });
+    expect(thing.name).toBe('Bo');
+    expect(server.callCount(`/things/${id}`)).toBe(1);
+    // The lossy `number` form is a DIFFERENT, wrong path — it must never have been requested.
+    expect(server.callCount(`/things/${Number(id)}`)).toBe(0);
+    // And the id must not have vanished into a bare collection request.
+    expect(server.callCount('/things/')).toBe(0);
 });
 
 test('seam members infer and validate input identically', async () => {

--- a/packages/core/test/url-query.spec.ts
+++ b/packages/core/test/url-query.spec.ts
@@ -60,6 +60,74 @@ describe('expandPath (RFC 6570)', () => {
             'https://h.io/x/1',
         );
     });
+
+    // Regression: a `bigint` var used to match none of the scalar `typeof` arms and fell through to
+    // the object arm, where `Object.entries(1n)` is `[]` — so the var expanded to NOTHING and
+    // `/things/{id}` silently became `/things/`, addressing the COLLECTION instead of the item. No
+    // error, no event. This is the exact value 64-bit IDs are parsed into to dodge JSON precision
+    // loss, so the drop hit the people who had already done the right thing.
+    describe('bigint vars (issue: silently dropped path parameter)', () => {
+        const id = 9007199254740993n; // Number.MAX_SAFE_INTEGER + 2 — unrepresentable as a double
+
+        test('a bigint expands in every scalar position, not just some', () => {
+            expect(expandPath('/v1/things/{id}', { id })).toBe(
+                '/v1/things/9007199254740993',
+            );
+            expect(expandPath('/v1/{+id}', { id })).toBe(
+                '/v1/9007199254740993',
+            );
+            expect(expandPath('{#id}', { id })).toBe('#9007199254740993');
+            expect(expandPath('{.id}', { id })).toBe('.9007199254740993');
+            expect(expandPath('/v1{/id}', { id })).toBe('/v1/9007199254740993');
+            expect(expandPath('/v1{;id}', { id })).toBe(
+                '/v1;id=9007199254740993',
+            );
+            expect(expandPath('/v1{?id}', { id })).toBe(
+                '/v1?id=9007199254740993',
+            );
+            expect(expandPath('/v1{?a}{&id}', { a: 1, id })).toBe(
+                '/v1?a=1&id=9007199254740993',
+            );
+        });
+
+        test('every digit survives — the whole reason the caller reached for a bigint', () => {
+            const url = expandPath('/v1/things/{id}', { id });
+            expect(url).toBe(`/v1/things/${id.toString()}`);
+            // The same id through a `number` loses the low digits; that lossy form must NOT appear.
+            expect(url).not.toContain(String(Number(id))); // 9007199254740992
+        });
+
+        test('the prefix (:n) modifier truncates a bigint by decimal digits', () => {
+            expect(expandPath('/{id:4}', { id })).toBe('/9007');
+        });
+
+        test('0n expands to "0" rather than vanishing as an empty value', () => {
+            // `0n` is falsy — it must still take the scalar arm, like the number `0` does.
+            expect(expandPath('/v1/things/{id}', { id: 0n })).toBe(
+                '/v1/things/0',
+            );
+            expect(expandPath('/v1{?id}', { id: 0n })).toBe('/v1?id=0');
+        });
+
+        test('bigints inside lists and objects keep working', () => {
+            // These arms already routed through `String()`/`stringifyLeaf`; pin them so a future
+            // refactor of the scalar arm cannot regress the composite ones.
+            expect(expandPath('/{ids}', { ids: [1n, 2n] })).toBe('/1,2');
+            expect(expandPath('{?ids*}', { ids: [1n, 2n] })).toBe(
+                '?ids=1&ids=2',
+            );
+            expect(expandPath('/{o}', { o: { a: 1n } })).toBe('/a,1');
+            expect(expandPath('{?o*}', { o: { a: 1n } })).toBe('?a=1');
+        });
+
+        test('the path and query builders agree on a bigint', () => {
+            // The bug was the two URL-building paths disagreeing: `buildQuery`/`stringifyLeaf`
+            // rendered a bigint while `expandPath` erased it. Same value, same rendering.
+            expect(expandPath('/v1{?since}', { since: id })).toBe(
+                `/v1${buildQuery({ since: id })}`,
+            );
+        });
+    });
 });
 
 // ---- qs-style query encoding ----------------------------------------------


### PR DESCRIPTION
## The bug

```ts
stitch({ baseUrl: 'https://api.test', path: '/v1/things/{id}' })
await call({ params: { id: 1234567890123456789n } })
```

built `https://api.test/v1/things/` — the id simply **gone**. No error, no event, no drift
finding. A request meant for one item silently addressed the **collection**; against a `DELETE`
that is a different operation than the one the caller wrote.

`expandTemplateVar` branched on `string | number | boolean`, so a bigint matched none of the
scalar arms and fell through to the object arm, where `Object.entries(1n)` is `[]` and nothing
was emitted.

## Blast radius: every scalar position, not just `{id}`

Measured across all six RFC 6570 operators before fixing:

| template | before | after |
| --- | --- | --- |
| `/v1/things/{id}` | `/v1/things/` | `/v1/things/1234567890123456789` |
| `/v1/things/{id:4}` | `/v1/things/` | `/v1/things/1234` |
| `/v1{?since}` | `/v1?since=` | `/v1?since=1234567890123456789` |
| `/v1{/id}` | `/v1` | `/v1/1234567890123456789` |
| `/v1{;id}` | `/v1;id=` | `/v1;id=1234567890123456789` |
| `/v1/{+id}` | `/v1/` | `/v1/1234567890123456789` |

`{/id}` is the worst of them — the whole path segment vanishes rather than leaving a trailing
slash. `0n` was dropped too.

Composite values were never affected: `[1n, 2n]` and `{ a: 1n }` route through
`String()`/`stringifyLeaf`. So a bigint **inside a list** expanded correctly while the same
bigint **on its own** disappeared, and the query builder rendered `?since=1234567890123456789`
for a value the path builder erased.

## The type said the same thing twice

Path-only vars inferred as `string | number`, so the repaired value was **rejected at the call
site** as well as dropped at runtime — fixing either half alone still left the caller stuck.
The folded `params` slot is now `string | number | bigint`, which is what `expandPath` has
always stringified.

A key named by an `input.params` schema still answers to its schema — widening the path-only
fold does not punch through a declared shape. That is pinned as an `expectError`, since it is
the property most at risk from a careless widening.

## Who this hits

Parsing a 64-bit id into a `BigInt` is the standard repair for JSON's double-precision
rounding. Handing that repaired value back to a path parameter was the moment it disappeared —
so the defect landed specifically on the people who had already done the right thing.

## Changes

- **`packages/core/src/util.ts`** — `bigint` added to the scalar branch of `expandTemplateVar`.
- **`packages/core/src/infer.ts`** — path-only vars widened to `string | number | bigint`.
- **`packages/core/test/url-query.spec.ts`** — six expansion tests (all operators, precision,
  prefix modifier, `0n`, cross-check against `buildQuery`).
- **`packages/core/test/input-inference.spec.ts`** — end-to-end test driving a bigint id through
  a real mock server; asserts the lossy `number` path and the bare collection path were never
  requested.
- **`packages/core/test-d/path-vars.test-d.ts`**, **`input-inference.test-d.ts`** — assertions
  widened, plus a new case 12 pinning that a bigint is accepted and that schema-named keys are
  unaffected.
- **`apps/docs/.../migration-notes.mdx`** — the one twoslash example that hand-wrote the type.

## Verification

Repo-wide `test`, `check:types`, `check:types-d` (tsd), `check:lint`, `check:format` and
`check:changelog` all exit 0. `packages/core`: 1446 tests across 137 files.

Both halves were verified by **falsification**, not just by passing:

- Revert `util.ts` → **5 of 6** new expansion tests fail. The sixth (composite arms) passes
  either way by design — it is a pin so a future refactor cannot regress the arms that already
  worked.
- Revert `infer.ts` → **15 tsd errors**, including the new positive cases failing with exactly
  the reported symptom: `Type bigint is not assignable to type string | number`.

## Reviewer note

The docs example still compiles **unchanged** with the widened type, because `TIn` is
contravariant in `Stitch<TOut, TIn>` — a stitch accepting the wider input is assignable to a
field declared narrower. I updated it anyway: a reader who copies `string | number` into their
own annotation gets an error at their call site when they pass the repaired id, so the narrow
spelling is now a trap rather than merely incomplete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)