### PR TITLE
refactor(core)!: `RateLimitError` extends `StitchError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,33 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Changed
 
+- **BREAKING CHANGE: `RateLimitError` now extends `StitchError`.**
+  ([CONTRACT.md P10](docs/CONTRACT.md#p10--error-class-taxonomy-parity)) The two classes were
+  siblings, and P10 held them in parity by having `RateLimitError` re-declare `status` / `attempts` /
+  `body` / `url` by hand — a rule enforcing exactly what `extends` gives for free. They are now one
+  taxonomy rooted at `StitchError`.
+
+    **The bug this fixes.** `SafeResult.error` is typed `StitchError`, so `.safe()` had to coerce a
+    delegate-backoff `RateLimitError` into a bare one: the instance moved to `.cause`, the
+    `instanceof` test stopped working, and **`error.body` came back `undefined`** — dropping the
+    payload (`X-RateLimit-*` siblings, a vendor's cost envelope) an outer gate reads to pace itself.
+    The mode whose whole point is handing back-pressure outward lost its signal on the path this
+    codebase otherwise recommends. `.safe()` now returns the same instance `await` throws.
+
+    Migration — **check the order of your `instanceof` arms**:
+
+    ```ts
+    // before: order was free, the classes were disjoint
+    // after: a leading StitchError arm SWALLOWS the rate-limit signal
+    if (e instanceof RateLimitError) gate.penalize(e.retryAfter ?? 1000);
+    else if (e instanceof StitchError) report(e.status);
+    ```
+
+    Everything else is additive: `RateLimitError` keeps `name`, `retryAfter` and `response`, gains a
+    `cause`, and a generic `catch (e instanceof StitchError)` now sees rate limits like any other
+    failure. Serialising hosts (`@stitchapi/rtk-query`) are unaffected — they branch on `name` and
+    project own fields, both unchanged.
+
 - **BREAKING CHANGE: `timeout.perAttempt` is renamed to `timeout.each`.**
   ([CONTRACT.md P1](docs/CONTRACT.md#p1--one-word-one-concept-one-value-space) +
   [P4](docs/CONTRACT.md#p4--one-cap-vocabulary)) `timeout` already names the subject, so by

--- a/apps/docs/content/docs/errors/index.mdx
+++ b/apps/docs/content/docs/errors/index.mdx
@@ -105,7 +105,9 @@ try {
     await report();
 } catch (e) {
     if (e instanceof RateLimitError) {
-        // The one catalog entry that IS a runtime identity of its own.
+        // The one catalog entry that IS a runtime identity of its own. It
+        // subclasses StitchError, so this arm MUST come before the one below —
+        // otherwise the generic arm swallows it.
         console.error('back off for', e.retryAfter);
     } else if (e instanceof StitchError) {
         if (e.attempts === 0) {

--- a/apps/docs/content/docs/errors/rate-limit.mdx
+++ b/apps/docs/content/docs/errors/rate-limit.mdx
@@ -7,9 +7,11 @@ description: 'The delegate-backoff error: a rate-limit response surfaced for an 
 
 A stitch with [`throttle: { delegate: true }`](/docs/guides/resilience/delegate-backoff)
 that gets a rate-limit response (status in `throttle.on`, default `[429]`)
-rejects with a **`RateLimitError`** instead of retrying. Unlike most failures,
-this is _not_ a `StitchError` — it's its own exported class, so you can catch it
-specifically and hand the signal to whatever owns your backoff:
+rejects with a **`RateLimitError`** instead of retrying. It is a `StitchError`
+— a **subclass** — so it carries the usual `status` / `attempts` / `body` / `url`
+and is caught by a generic `instanceof StitchError` arm, while remaining its own
+exported class you can catch specifically to hand the signal to whatever owns
+your backoff:
 
 ```ts twoslash
 import { RateLimitError, stitch } from 'stitchapi';
@@ -31,15 +33,25 @@ try {
 }
 ```
 
-`RateLimitError` carries:
+`RateLimitError` carries, on top of the inherited `StitchError` fields
+(`status`, `attempts`, `body`, `url`):
 
-- **`status`** — the rate-limit status (e.g. `429`, or whatever you listed in
-  `throttle.on`).
 - **`retryAfter`** — the wait the server asked for, parsed from `Retry-After`
   (delta-seconds **or** an HTTP-date) into milliseconds; `undefined` when the
   header is absent or unparseable.
 - **`response`** — the raw `AdapterResponse`, so you can read other rate
   headers the API sent (`X-RateLimit-Remaining`, a reset timestamp, and so on).
+
+Its `status` is the rate-limit status (e.g. `429`, or whatever you listed in
+`throttle.on`) — always present, where the base class leaves it optional.
+
+<Callout type="warn">
+    **Test `RateLimitError` before `StitchError`.** Because it subclasses
+    `StitchError`, a `catch` whose first arm is `instanceof StitchError` will
+    swallow the rate-limit signal and never reach a later `RateLimitError` arm —
+    which defeats the point of delegating. Put the specific class first, as the
+    example above does.
+</Callout>
 
 <Callout type="info">
     This is the one entry in the [error catalog](/docs/errors) that is a real
@@ -68,9 +80,10 @@ purpose.
   [the event stream](/docs/concepts/event-stream) rather than awaiting, the same
   outcome arrives as an `error` event carrying `status` and `retryAfter` — no
   `try`/`catch` needed.
-- **Branch without throwing.** `.safe()` returns the failure as a `StitchError`
-  whose `.status` is the rate-limit status and whose `.cause` is the original
-  `RateLimitError` (so `retryAfter` is still reachable via the cause).
+- **Branch without throwing.** `.safe()` returns the very same `RateLimitError`
+  in `error` — `SafeResult.error` is typed `StitchError`, and this is one, so
+  nothing is downgraded. `instanceof RateLimitError`, `retryAfter`, `body` and
+  `response` all work identically whether you `await` or `.safe()`.
 - **Reconsider whether to delegate.** If nothing outside StitchAPI actually
   owns the backoff, you probably want internal handling instead — drop
   `throttle.delegate` and use [retry](/docs/guides/resilience/retry) +

--- a/apps/docs/content/docs/guides/resilience/delegate-backoff.mdx
+++ b/apps/docs/content/docs/guides/resilience/delegate-backoff.mdx
@@ -47,6 +47,14 @@ A `429` no longer retries: the call rejects with a
 the raw `response` so you can read any other rate headers the API sent. The
 internal throttle is bypassed for the call, so it adds no pacing of its own.
 
+`RateLimitError` **subclasses `StitchError`**, so it also carries the usual
+`attempts` / `body` / `url`, and `.safe()` hands back the same instance rather
+than a downgraded copy — branch with `.safe()` or `try`/`catch`, whichever you
+prefer, and `instanceof RateLimitError` works in both. The one rule that follows
+from the subclassing: if you branch on both classes, **test `RateLimitError`
+first**, or a generic `instanceof StitchError` arm will swallow the signal you
+opted in to receive.
+
 ## Options
 
 `delegate` switches the mode on; it defaults to `false`, so a stitch behaves

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -269,6 +269,26 @@ Every thrown error type (`StitchError`, `RateLimitError`, and per-package re-exp
 **MUST** guarantee the same field set (`status?`, `attempts`, `body?`, `url?`, and a
 stable discriminator) so a consumer can branch on any thrown error uniformly.
 
+Parity is achieved by **inheritance, not duplication**: `StitchError` is the root, and
+every other thrown class **MUST** extend it rather than re-declare its fields. A new
+class adds only what is genuinely its own (`RateLimitError` adds `retryAfter` and
+`response`) and **MUST** keep `name` as its own discriminator — that is what the
+serialising hosts branch on once the instance is gone (rtk-query stores a plain object).
+
+Two consequences the surface **MUST** hold to:
+
+- `SafeResult.error` is typed `StitchError`, so `.safe()` **MUST NOT** downgrade a
+  subclass to the base. `await` and `.safe()` hand back the _same_ instance; no field is
+  reachable only through `.cause`.
+- Because the arms overlap, any `instanceof` chain — in this repo or in a doc example —
+  **MUST** test the subclass first. `engine.ts`'s `errEvt` and the delegate-backoff docs
+  are the reference spellings.
+
+_History:_ `RateLimitError` was a sibling of `StitchError` until rc.8, with the field set
+copied by hand. `.safe()` downgraded it (dropping `body`, burying the instance on
+`.cause`) and every dispatch site carried a two-arm `instanceof` check; both went away
+with the subclass.
+
 ### P11 · Async/sync signature parity
 
 The same verb **MUST** keep the same sync/async shape across every surface and adapter.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -882,7 +882,7 @@ try {
 }
 ```
 
-Prefer to branch rather than wrap in `try`/`catch`? `.safe()` never throws — it resolves to `{ ok, data, error }`. Branch on `.status` and `.attempts` (plus `instanceof RateLimitError`) — the `STITCH_*` names below are **documentation IDs, not runtime values**, so there is no `error.code` to match on. Each has a docs page whose slug is a stable URL:
+Prefer to branch rather than wrap in `try`/`catch`? `.safe()` never throws — it resolves to `{ ok, data, error }`, and `error` is the same instance the throwing path raises. Branch on `.status` and `.attempts` (plus `instanceof RateLimitError`, which subclasses `StitchError` — so test it **before** any generic `StitchError` arm) — the `STITCH_*` names below are **documentation IDs, not runtime values**, so there is no `error.code` to match on. Each has a docs page whose slug is a stable URL:
 
 | Catalog ID            | When                                                                |
 | --------------------- | ------------------------------------------------------------------- |

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -355,6 +355,8 @@ function errEvt(err: unknown, name: string, attempts: number): StitchEvent {
     if (e.status !== undefined) evt.status = e.status;
     // Delegate-backoff signal: stamp the structured `retryAfter` onto the event (so `.stream()`
     // consumers get it) and pin the live RateLimitError so the awaited path re-throws it intact.
+    // ORDER IS LOAD-BEARING: a RateLimitError also carries `.response`, so the generic arm below
+    // would swallow it (and drop `retryAfter`) if this subclass test did not come first.
     if (err instanceof RateLimitError) {
         if (err.retryAfter !== undefined) evt.retryAfter = err.retryAfter;
         Object.defineProperty(evt, ERROR_SOURCE, {

--- a/packages/core/src/resilience.ts
+++ b/packages/core/src/resilience.ts
@@ -12,6 +12,10 @@ import type {
     StitchStore,
     ThrottleOptions,
 } from './types';
+// The one VALUE import from `./types` (everything else above is type-only): `RateLimitError`
+// extends `StitchError` per CONTRACT.md P10. `types.ts` imports nothing at runtime — its own
+// imports are all type-only — so this edge adds no cycle.
+import { StitchError } from './types';
 import { parseDuration, parseRate, systemClock } from './util';
 
 export class TimeoutError extends Error {}
@@ -261,23 +265,30 @@ export class CircuitOpenError extends Error {
  * (`throttle.delegate`) and the response carries a rate-limit status (default `429`). Instead of
  * retrying internally or pacing on the built-in throttle, the engine surfaces the outcome so an
  * OUTER gate/circuit — owned by the host — decides the backoff (issue #145). Carries the structured
- * signal that gate needs: the `status`, the `retryAfter` parsed from `Retry-After` (delta-seconds
- * OR HTTP-date; `undefined` when the header is absent/unparseable), and the raw `response` so the
- * host can read other rate headers (`X-RateLimit-*`, etc.). `attempts`/`body`/`url` mirror
- * {@link StitchError}'s field set (CONTRACT.md P10), lifted from the response/run state at
- * construction. The full `response` rides on the live instance only — never the serialized `error`
- * event — so it cannot leak into a trace sink.
+ * signal that gate needs on top of what it inherits: the `retryAfter` parsed from `Retry-After`
+ * (delta-seconds OR HTTP-date; `undefined` when the header is absent/unparseable), and the raw
+ * `response` so the host can read other rate headers (`X-RateLimit-*`, etc.). The full `response`
+ * rides on the live instance only — never the serialized `error` event — so it cannot leak into a
+ * trace sink.
+ *
+ * A **subclass of {@link StitchError}** (CONTRACT.md P10): `status`/`attempts`/`body`/`url` are the
+ * inherited field set rather than a hand-kept copy, so the one identity survives every consumer —
+ * `await` throws it, `.safe()` returns it in `error` (no downgrade to a bare `StitchError`, no
+ * reaching through `.cause` for the body), and a `catch (e instanceof StitchError)` sees it like
+ * any other failure.
+ *
+ * ⚠️ Because it IS a `StitchError`, a handler that branches on both **must test this class first** —
+ * a leading `instanceof StitchError` arm swallows the delegate signal, which defeats delegating.
  */
-export class RateLimitError extends Error {
-    readonly status: number;
+export class RateLimitError extends StitchError {
     /** `Retry-After` parsed to ms (delta-seconds OR HTTP-date); `undefined` when absent/unparseable. */
     readonly retryAfter: number | undefined;
-    /** Attempts made before the rate-limit outcome surfaced (1 = the first request). Mirrors `StitchError.attempts` (P10). */
-    readonly attempts: number;
-    /** The parsed body of the rate-limited response, lifted from `response.body` (P10). */
-    readonly body?: unknown;
-    /** The final request URL of the rate-limited response, when the transport exposes it (P10). */
-    readonly url?: string;
+    /**
+     * The rate-limit status that was hit — narrowed from the base's `number | undefined`, since a
+     * delegate outcome always has one. `declare` (no emit): the value is the base's, and under
+     * `useDefineForClassFields` a real field here would clobber it with `undefined`.
+     */
+    declare readonly status: number;
     readonly response: AdapterResponse;
     constructor(opts: {
         status: number;
@@ -285,17 +296,20 @@ export class RateLimitError extends Error {
         response: AdapterResponse;
         attempts?: number | undefined;
         message?: string;
+        cause?: unknown;
     }) {
-        super(opts.message ?? `rate limited (HTTP ${opts.status})`);
+        // Lift the response's `body`/`url` at construction so a caller reads them off the error
+        // itself — the inherited fields — without reaching into `.response`.
+        super(opts.message ?? `rate limited (HTTP ${opts.status})`, {
+            status: opts.status,
+            attempts: opts.attempts,
+            body: opts.response.body,
+            url: opts.response.url,
+            cause: opts.cause,
+        });
         this.name = 'RateLimitError';
-        this.status = opts.status;
         this.retryAfter = opts.retryAfter;
-        this.attempts = opts.attempts ?? 0;
         this.response = opts.response;
-        // Lift the P10 fields off the response at construction so the error matches StitchError's
-        // shape without the caller reaching into `.response`.
-        if (opts.response.body !== undefined) this.body = opts.response.body;
-        if (opts.response.url !== undefined) this.url = opts.response.url;
     }
 }
 

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -25,7 +25,7 @@ import {
 } from './engine';
 import type { InferOutput, InputOf, ResolveOutput } from './infer';
 import { otlpSink } from './otlp';
-import { RateLimitError, createThrottle } from './resilience';
+import { createThrottle } from './resilience';
 import { createStoreThrottle, memoryStore } from './store';
 import { graphqlSurface, httpSurface } from './surface';
 import { consoleSink, createTrace, exportsFromEnv, multiplex } from './trace';
@@ -475,9 +475,10 @@ export function resolveTrace(trace: StitchConfig['trace']): TraceSink {
 //
 // The non-enumerable ERROR_SOURCE key (engine.ts) pins the live error behind the event without
 // leaking its payload into a trace sink. Two kinds ride it:
-//   • a delegate-backoff RateLimitError (issue #145): re-surface THAT instance unchanged, so the
-//     caller keeps the real class identity plus `retryAfter`/`response`.
-//   • a plain HTTP error carrying `.response` (issue #155): flatten into a StitchError, lifting the
+//   • an error that is already a StitchError — including a delegate-backoff RateLimitError, which
+//     subclasses it (issue #145): re-surface THAT instance unchanged, so the caller keeps the real
+//     class identity plus `retryAfter`/`response`.
+//   • a foreign error carrying `.response` (issue #155): flatten into a StitchError, lifting the
 //     response `body`/`url` onto the error so a result-shaped caller can read the API's error
 //     payload (`{ error: "…" }`) it would otherwise never see.
 async function drain<T>(
@@ -493,12 +494,12 @@ async function drain<T>(
 }
 
 // Rebuild the terminal error from an `error` event, honouring the non-enumerable ERROR_SOURCE channel
-// (engine.ts). Three kinds ride it: a delegate-backoff RateLimitError is re-surfaced UNCHANGED (the
-// caller keeps its class identity + `retryAfter`/`response`); a plain HTTP error (`.response`, but
-// not a StitchError/RateLimitError) is flattened into a StitchError carrying the response `body`/`url`;
-// a contract-violation StitchError (pinned by `.inspect()`'s retain path) passes through. Absent a
-// source, build a StitchError from the event's `status`/`attempts`. Shared by `drain` and
-// `consumeInspect`.
+// (engine.ts). Two kinds ride it: an error that is ALREADY a StitchError is re-surfaced UNCHANGED —
+// that covers both a delegate-backoff RateLimitError (a subclass since P10, so the caller keeps its
+// class identity + `retryAfter`/`response`) and a contract-violation StitchError pinned by
+// `.inspect()`'s retain path; a foreign error carrying `.response` is flattened into a StitchError
+// carrying the response `body`/`url`. Absent a source, build a StitchError from the event's
+// `status`/`attempts`. Shared by `drain` and `consumeInspect`.
 function rebuildError(ev: Extract<StitchEvent, { type: 'error' }>): Error {
     const source = (ev as { [ERROR_SOURCE]?: Error })[ERROR_SOURCE];
     const res =
@@ -506,11 +507,7 @@ function rebuildError(ev: Extract<StitchEvent, { type: 'error' }>): Error {
             ? undefined
             : (source as { response?: { body?: unknown; url?: string } })
                   .response;
-    if (
-        res !== undefined &&
-        !(source instanceof StitchError) &&
-        !(source instanceof RateLimitError)
-    ) {
+    if (res !== undefined && !(source instanceof StitchError)) {
         return new StitchError(ev.message, {
             status: ev.status,
             attempts: ev.attempts,
@@ -744,10 +741,11 @@ async function consume<T>(
     return out.value;
 }
 
-// Coerce any thrown value to a StitchError — a real StitchError passes through unchanged; anything
-// else is wrapped with its message and original `cause`. A numeric `status` on the source (e.g. a
-// delegate-backoff RateLimitError) is carried onto the wrapper so `.safe()` callers still see it.
-// Shared by the safe consumers.
+// Coerce any thrown value to a StitchError — a real StitchError passes through unchanged (which
+// since P10 includes a delegate-backoff RateLimitError, so `.safe()` hands back the SAME instance
+// the awaited path throws: `retryAfter`/`response`/`body` intact, no reaching through `.cause`);
+// anything else is wrapped with its message and original `cause`, carrying a numeric `status` off
+// the source onto the wrapper. Shared by the safe consumers.
 function asStitchError(e: unknown): StitchError {
     if (e instanceof StitchError) return e;
     const status = (e as { status?: unknown }).status;
@@ -759,9 +757,9 @@ function asStitchError(e: unknown): StitchError {
 
 // Safe consumer: `stitch.safe(...)` / `stitch(...).safe()`. Never throws — an `error` event or an
 // unexpected throw both come back as `{ ok: false, data: null, error }`. `SafeResult.error` is
-// always a StitchError by contract, so a non-StitchError terminal (e.g. a delegate-backoff
-// RateLimitError, which the throwing path re-throws verbatim) is coerced via `asStitchError`,
-// preserving the original as `.cause` and its `status`.
+// always a StitchError by contract; a foreign terminal is coerced via `asStitchError`, preserving
+// the original as `.cause` and its `status`. A RateLimitError needs no coercion (it IS a
+// StitchError), so `.safe()` and `await` surface one and the same error.
 async function consumeSafe<T>(
     gen: AsyncGenerator<StitchEvent<T>, void>,
 ): Promise<SafeResult<T>> {

--- a/packages/core/src/test-stub.ts
+++ b/packages/core/src/test-stub.ts
@@ -4,6 +4,7 @@
 // `__config`/`__stitch` — so `isStitch()`, a registry, or a Nest `overrideProvider(useValue:…)`
 // accept it. A call spy records every invocation. Browser-safe: no `node:*`.
 import { compact } from './compact';
+import { RateLimitError } from './resilience';
 import {
     type RedactedStitchConfig,
     type SafeResult,
@@ -45,6 +46,9 @@ export interface StubStitchOptions<TOut = unknown> {
 export type StubImpl<TOut> =
     TOut | ((input: StitchInput) => TOut | Promise<TOut>);
 
+// A thrown StitchError passes through untouched — which since P10 includes a RateLimitError, so a
+// stub that rejects with one keeps that identity all the way to `.safe()` and `.stream()` instead of
+// being flattened to a bare StitchError the way it was when the two classes were siblings.
 const toError = (e: unknown): StitchError =>
     e instanceof StitchError
         ? e
@@ -86,6 +90,10 @@ function defaultEvents<TOut>(
             attempts: 1,
             at,
             status: error.status,
+            // Mirror the engine's delegate-backoff stamp (engine.ts `errEvt`), so a stub that
+            // rejects with a RateLimitError yields the same event shape a real 429 would.
+            retryAfter:
+                error instanceof RateLimitError ? error.retryAfter : undefined,
         });
         return [
             start,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1849,6 +1849,10 @@ export class StitchError extends Error {
  * The outcome of a never-throwing call ({@link Stitch.safe}). A discriminated union: check `error`
  * (or `ok`) — when `error` is `null` the call succeeded and `data` is the result; otherwise `error`
  * is the {@link StitchError} and `data` is `null`.
+ *
+ * `error` is the SAME instance the throwing path raises, never a downgraded copy — so when the
+ * failure is a delegate-backoff `RateLimitError` (a `StitchError` subclass, CONTRACT.md P10) it
+ * arrives here as one, with `retryAfter`/`response` intact and `instanceof` still true.
  */
 export type SafeResult<T> =
     | { ok: true; data: T; error: null }

--- a/packages/core/test/gaps/delegate-backoff.spec.ts
+++ b/packages/core/test/gaps/delegate-backoff.spec.ts
@@ -1,7 +1,12 @@
 // Pins issue #145: an opt-in delegate-backoff mode that SURFACES a rate-limit outcome (status in
 // `throttle.on`, default [429]) as a RateLimitError instead of retrying it internally, and bypasses
 // the built-in throttle so an OUTER gate (owned by the host) — not StitchAPI — paces the backoff.
-import { RateLimitError, type StitchEvent, stitch } from '../../src';
+import {
+    RateLimitError,
+    StitchError,
+    type StitchEvent,
+    stitch,
+} from '../../src';
 import { startMockServer } from '../support/mock-server';
 import type { MockServer } from '../support/mock-server';
 
@@ -239,10 +244,13 @@ test('a success response still runs transform, pick, and output validation', asy
     await expect(call()).resolves.toEqual({ id: 7, label: 'widget' });
 });
 
-// ── H. .safe() returns a StitchError carrying the rate-limit status (never throws) ──
-// `.safe()`'s contract is a StitchError in `error`; a delegate RateLimitError is coerced to one with
-// its `status` and the original kept as `.cause`.
-test('.safe() surfaces the rate-limit status as a non-throwing StitchError', async () => {
+// ── H. .safe() returns the SAME RateLimitError the awaited path throws (never throws) ──
+// `.safe()`'s contract is a StitchError in `error` — and since P10 a RateLimitError IS one, so it
+// needs no coercion: the identity, `retryAfter`, `body` and `response` all survive the safe path.
+// This is the parity that matters for delegate-backoff, whose whole point is handing an outer gate
+// the pacing signal; before the class was a subclass, `.safe()` handed back a bare StitchError with
+// `body: undefined` and buried the real one on `.cause`.
+test('.safe() surfaces the rate-limit failure as the real RateLimitError', async () => {
     server.route('GET', '/rl-safe', {
         statuses: [429],
         retryAfterSeconds: 2,
@@ -257,9 +265,42 @@ test('.safe() surfaces the rate-limit status as a non-throwing StitchError', asy
     const out = await call.safe();
     expect(out.ok).toBe(false);
     expect(out.error?.status).toBe(429);
-    // The real RateLimitError is preserved as the cause.
-    expect(out.error?.cause).toBeInstanceOf(RateLimitError);
-    expect((out.error?.cause as RateLimitError).retryAfter).toBe(2000);
+    // Not a downgraded copy — the real instance, in `error` itself.
+    expect(out.error).toBeInstanceOf(RateLimitError);
+    expect(out.error).toBeInstanceOf(StitchError);
+    const rl = out.error as RateLimitError;
+    expect(rl.retryAfter).toBe(2000);
+    // The pacing payload an outer gate reads is on the error directly, not via `.cause`.
+    expect(rl.body).toEqual({ error: 'slow down' });
+    expect(rl.response.status).toBe(429);
+});
+
+// ── H2. the hierarchy itself (CONTRACT.md P10) ──
+// A RateLimitError satisfies `instanceof StitchError`, carries the whole inherited field set, and
+// keeps `name` as its own discriminator (what the serialising hosts — rtk-query — branch on).
+test('a RateLimitError is a StitchError, with the P10 field set inherited', async () => {
+    server.route('GET', '/rl-hierarchy', {
+        statuses: [429],
+        retryAfterSeconds: 1,
+        body: { error: 'nope' },
+    });
+    const call = stitch({
+        baseUrl: server.url,
+        path: '/rl-hierarchy',
+        throttle: { delegate: true },
+    });
+
+    const err = await rejectionOf(call());
+    expect(err).toBeInstanceOf(RateLimitError);
+    expect(err).toBeInstanceOf(StitchError);
+    expect(err).toBeInstanceOf(Error);
+    // `name` stays the discriminator — inheritance must not make it read 'StitchError'.
+    expect(err.name).toBe('RateLimitError');
+    expect(err.status).toBe(429);
+    expect(err.attempts).toBe(1);
+    expect(err.body).toEqual({ error: 'nope' });
+    expect(typeof err.url).toBe('string');
+    expect(err.retryAfter).toBe(1000);
 });
 
 // ── I. predicate widening (CONTRACT.md P7) ──

--- a/packages/core/test/public-api-surface.spec.ts
+++ b/packages/core/test/public-api-surface.spec.ts
@@ -98,7 +98,7 @@ describe('public API surface (src/index.ts)', () => {
         expect(typeof api.systemClock.clearTimer).toBe('function');
     });
 
-    test('exports the error classes (both extend Error)', () => {
+    test('exports the error classes (RateLimitError extends StitchError extends Error)', () => {
         const response: AdapterResponse = {
             status: 429,
             headers: {},
@@ -106,8 +106,13 @@ describe('public API surface (src/index.ts)', () => {
         };
         const rate = new api.RateLimitError({ status: 429, response });
         expect(rate).toBeInstanceOf(Error);
+        // CONTRACT.md P10: one taxonomy, parity by inheritance rather than a hand-kept copy.
+        expect(rate).toBeInstanceOf(api.StitchError);
         expect(rate.status).toBe(429);
+        expect(rate.name).toBe('RateLimitError');
         expect(new api.StitchError('x')).toBeInstanceOf(Error);
+        // ...but not the other way round: the base is not a rate limit.
+        expect(new api.StitchError('x')).not.toBeInstanceOf(api.RateLimitError);
     });
 });
 


### PR DESCRIPTION
## What

`RateLimitError` and `StitchError` were **siblings**, both extending `Error` directly. This roots the taxonomy at `StitchError` and makes `RateLimitError` a subclass.

Raised while reviewing #639, which adds a *second* copy of the two-arm `instanceof StitchError || instanceof RateLimitError` check inside `rebuildError` — six lines below the one already there.

## Why it wasn't just tidiness

[CONTRACT.md P10](docs/CONTRACT.md) required the two classes to "guarantee the same field set … so a consumer can branch on any thrown error uniformly", and `RateLimitError` satisfied it by re-declaring `status` / `attempts` / `body` / `url` by hand. A written rule enforcing exactly what `extends` gives for free — and it already failed its own goal on one path:

`SafeResult.error` is typed `StitchError`, so `.safe()` had to coerce a delegate-backoff `RateLimitError` into a bare one. The instance moved to `.cause`, `instanceof RateLimitError` stopped working, and **`error.body` came back `undefined`** — dropping the payload an outer gate reads to pace itself. The mode whose entire purpose is handing back-pressure outward lost its signal on the path the docs otherwise recommend (`.safe()` over `try`/`catch`).

That was found independently from the consumer side by the scenario pass in #638 — `docs/scenarios/issue-drafts/body-verdict-footguns.md`, item 2, *"`.safe()` downgrades `RateLimitError` and drops the body"*, severity medium, *"an outer rate-gate backs off blind."* This closes it.

## The one hazard, and how it's handled

Subclassing makes arm order load-bearing: a leading generic `instanceof StitchError` now swallows the delegate signal.

- `engine.ts`'s `errEvt` already had the order right (a `RateLimitError` also carries `.response`, so it always had to be tested first) — now commented as load-bearing.
- P10 states the rule; `docs/errors/index.mdx` and the delegate-backoff guide say it where they branch, and `docs/errors/rate-limit.mdx` carries a warning callout.
- The `errors/index.mdx` catalog example was already ordered correctly.

## Changed

| area | what |
|---|---|
| `resilience.ts` | `RateLimitError extends StitchError`; hand-mirrored P10 fields deleted, `status` narrowed to `number` via `declare` (no emit — a real field would clobber the base under `useDefineForClassFields`), gains `cause` |
| `stitch.ts` | both two-arm checks collapse to one `instanceof StitchError`; `asStitchError` stops downgrading, so `.safe()` returns the instance `await` throws |
| `engine.ts` | ordering comment only — behaviour unchanged |
| `test-stub.ts` | a stubbed `RateLimitError` keeps its identity, and the streamed `error` event now carries `retryAfter` the way the engine's does |
| docs | `errors/rate-limit.mdx`, `errors/index.mdx`, delegate-backoff guide, core README, CONTRACT P10 (parity by inheritance, with the history of why) |

## Verification

`check:types` · `check:types-d` · `check:lint` · `check:format` · `check:contract` · `check:docs-links` · `check:changelog` all green; **1440 core tests pass**, full workspace suite green.

Two tests changed shape, both to assert the better behaviour: `.safe()` now yields the real `RateLimitError` (was: a wrapper with it on `.cause`), and the public-API surface test pins the hierarchy in both directions. A new test pins the whole inherited P10 field set plus `name` as the discriminator.

## Breaking

Yes, for consumers branching on both classes — see the CHANGELOG entry for the migration. Core is `1.0.0-rc.7`, so this is the cheap window; after GA it's a major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)