### PR TITLE
fix(core)!: an `input` schema shapes the request, not just gates it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -566,6 +566,50 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Fixed
 
+- **BREAKING — an `input` schema now SHAPES the request, not just gates it.**
+  ([#648](https://github.com/rejifald/StitchAPI/issues/648)) `validateInput` awaited the validator,
+  checked `r.ok`, threw on failure — and dropped `r.value` on the floor. Its return type was
+  `Promise<void>`, so it structurally could not do otherwise, and the original **unparsed** input
+  went to the transport. `validateOutput` had done the opposite since
+  [ADR 0015](docs/adr/0015-schema-anchored-drift.md) — "on success returns the PARSED value —
+  coerced, defaulted, stripped — so the result matches the declared contract" — which left the two
+  halves of one feature behaving in opposite directions, and only the stripping half documented as
+  doing so.
+
+    Measured: a `query` validator that returned `{ limit: 10 }` still put
+    `?tenant=globex&limit=10&include=internal_notes` on the wire, overwriting a `tenant=acme`
+    pinned in the configured endpoint — and the vendor duly returned the other tenant's data.
+
+    ```ts
+    const getOrders = stitch({
+        url: 'https://api.vendor.test/v1/orders?tenant=acme',
+        input: { query: z.object({ limit: z.number() }) }, // strips by default
+    });
+    await getOrders({ query: { limit: 10, tenant: 'globex' } });
+    // before: /v1/orders?tenant=globex&limit=10   after: /v1/orders?tenant=acme&limit=10
+    ```
+
+    Two properties compounded. A schema constrains **one slot**, so an undeclared slot is a full
+    passthrough; and a pinned query pair is a **default**, not a pin (`{ ...predefined,
+...input.query }`). The one mechanism a reader would reach for to close the second — declare a
+    strict schema — silently did nothing, because stripping unknown keys is the DEFAULT in Zod,
+    Valibot and ArkType alike. It bit hardest on the MCP surface, where `run_stitch` forwards a
+    **model's** argument object, but nothing about it was MCP-specific.
+
+    Every declared slot — `params`, `query`, `body`, `headers`, and GraphQL `variables` — now
+    contributes its parsed value to the request, its cache key, and the events that echo it. The
+    parsed values land in a **copy**, so the object a caller passed is never rewritten.
+
+    **What did NOT change.** A slot with no schema stays the full passthrough it has always been:
+    this filters, it does not lock down. And the graphql surface's `input.variables ?? input.body`
+    fallback is intact — an absent optional slot parses to `undefined`, which is nullish.
+
+    Migration — **a declared slot now sends only what its schema returns.** If a call relied on
+    extra keys riding along beside a declared schema, name them in the schema, or use a passthrough
+    shape (`z.object({…}).loose()` in Zod 4, `.passthrough()` in Zod 3) to keep the old behaviour
+    for that slot. Coercions and defaults a schema declares now reach the wire, where they were
+    previously computed and discarded.
+
 - **A `bigint` path parameter no longer vanishes from the URL.** `stitch({ path: '/v1/things/{id}' })`
   called with `{ params: { id: 1234567890123456789n } }` built `https://api.test/v1/things/` — the id
   simply gone, no error, no event, no drift finding. A request meant for one item silently addressed

--- a/apps/docs/content/docs/guides/validation/validation.mdx
+++ b/apps/docs/content/docs/guides/validation/validation.mdx
@@ -36,6 +36,20 @@ keeps the resolved value typed as `{ id: number; name: string }`.
 the request — the fail-fast guarantee — so the request never goes out with input
 the API would reject.
 
+A declared slot also **shapes** the request: the request is built from the value
+the schema returned, so whatever it coerces, defaults or strips is what goes on
+the wire. A `z.object(...)` strips unknown keys by default, so an extra key a
+caller tacked onto a declared slot never reaches the API — which matters most
+when the caller is untrusted, such as a model calling through
+[the MCP surface](/docs/surfaces/mcp).
+
+<Callout type="warn">
+    A schema constrains **one slot**. An undeclared slot stays a full
+    passthrough, so declaring `params` does nothing about `query`. And a query
+    pair written into the endpoint (`?tenant=acme`) is a _default_ that
+    `input.query` overrides — declare the slot if callers must not move it.
+</Callout>
+
 `output` is a single `Validator` that checks the response body after it returns.
 (Pass a `drift()` spec here instead to report changes without throwing — see
 [Schema drift detection](/docs/guides/validation/drift).)

--- a/apps/docs/content/docs/surfaces/mcp.mdx
+++ b/apps/docs/content/docs/surfaces/mcp.mdx
@@ -36,6 +36,11 @@ input. The tool call looks like this:
 stitch behind the [capability boundary](/docs/concepts/capability-not-credential)
 and returns its validated result.
 
+The agent's object is the _call_ input, not the request: a slot with a declared
+[`input` schema](/docs/guides/validation/validation) is rebuilt from what that
+schema returned, so a key the model invented is stripped before the request. A
+slot with no schema stays a passthrough — declare the slots an agent may fill.
+
 ## Options
 
 `run_stitch` takes `{ name, input }` and covers **every** registered stitch with

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -383,10 +383,23 @@ const doneEvt = (ok: boolean, t0: number, attempts: number): StitchEvent => ({
     at: now(),
 });
 
+// Validate the call input against the declared per-slot schemas and RETURN the input the request is
+// built from. On success a declared slot's PARSED value replaces the one the caller passed —
+// coerced, defaulted, stripped — so the request matches the declared contract, which is the same
+// rule `validateValue` states for `output` (ADR 0015). Before issue #648 this returned `void` and
+// dropped `r.value`, so a schema gated the call without shaping it: the unparsed input went on the
+// wire, and an unknown `?tenant=` a caller tacked on still overwrote one pinned in the endpoint.
+//
+// It filters; it does not lock down. A slot with NO schema is untouched — an undeclared slot stays
+// the full passthrough it has always been (a schema constrains one slot, not the call). The parsed
+// values land in a COPY: the caller still holds the object it passed, so filtering the request can
+// never rewrite a bound partial or a literal reused across a loop.
 async function validateInput(
     cfg: ResolvedStitchConfig,
     input: StitchInput,
-): Promise<void> {
+): Promise<StitchInput> {
+    if (!cfg.input) return input;
+    const out = { ...input } as Record<string, unknown>;
     for (const part of [
         'params',
         'query',
@@ -396,11 +409,13 @@ async function validateInput(
     ] as const) {
         // `input.*` is widened to SchemaLike for authoring ergonomics, but `compose` →
         // `normalizeInput` has already coerced every present slot to a Validator by now.
-        // `variables` (the graphql surface's primary input) validates here too; the validated
-        // value still flows untouched into the `{ query, variables }` body the surface packs.
-        const v = cfg.input?.[part] as Validator | undefined;
+        // `variables` (the graphql surface's primary input) validates here too, and its parsed
+        // value reaches the `{ query, variables }` body because the surface's `buildRequest` is
+        // handed THIS object. An absent optional slot parses to `undefined`, which leaves the
+        // surface's `input.variables ?? input.body` fallback intact.
+        const v = cfg.input[part] as Validator | undefined;
         if (!v) continue;
-        const r = await v.validate((input as Record<string, unknown>)[part]);
+        const r = await v.validate(out[part]);
         if (!r.ok) {
             const e = new Error(
                 `invalid ${part}: ${r.issues.map((i) => i.message).join(', ')}`,
@@ -408,7 +423,9 @@ async function validateInput(
             e.name = 'ValidationError';
             throw e;
         }
+        out[part] = r.value;
     }
+    return out;
 }
 
 // Validate ONE value against the output schema (ADR 0015). On success returns the PARSED value —
@@ -1689,7 +1706,7 @@ async function* runCached(
 
 export async function* execute(
     rt: Runtime,
-    input: StitchInput = {},
+    callInput: StitchInput = {},
     // Run identity (ADR 0007). Defaults to a fresh root run; the caller supplies one to make
     // this a CHILD run — `newRunContext(parent)` inherits the parent's `traceId` and sets
     // `parentSpanId` (a `cookieSession` login, a `linked` step). Stamped on the `start` event and
@@ -1707,8 +1724,12 @@ export async function* execute(
     if (flags?.retainRaw) state.retainRaw = true;
     const budget = totalBudget(cfg, t0);
 
+    // Everything below runs on the VALIDATED input — the parsed value of every declared slot
+    // (issue #648) — so the request, the cache key it derives, and the events that echo it all
+    // describe the same call.
+    let input: StitchInput;
     try {
-        await validateInput(cfg, input);
+        input = await validateInput(cfg, callInput);
     } catch (e) {
         yield errEvt(e, name, 0);
         yield doneEvt(false, t0, 0);
@@ -1753,12 +1774,18 @@ export async function* execute(
  *  non-cacheable-method stitch. Backs `stitch.invalidate(input)` (ADR 0003 §8). */
 export async function cacheInvalidateExact(
     rt: Runtime,
-    input: StitchInput = {},
+    callInput: StitchInput = {},
 ): Promise<void> {
     const ctl = await ensureCache(rt);
     if (!ctl) return;
     let baseReq: AdapterRequest;
+    let input: StitchInput;
     try {
+        // The stored key mirrors the RESOLVED request, so eviction must derive it from the same
+        // VALIDATED input the run stored under (issue #648) — otherwise this computes the key of a
+        // request that was never made and evicts nothing. Input the schema rejects was never cached
+        // either, so it exits as the same no-op a failed `buildRequest` already is.
+        input = await validateInput(rt.cfg, callInput);
         baseReq = buildRequest(rt.cfg, input);
     } catch {
         return;

--- a/packages/core/test/input-schema-filters.spec.ts
+++ b/packages/core/test/input-schema-filters.spec.ts
@@ -1,0 +1,256 @@
+// Issue #648: an `input` schema FILTERS, it does not merely gate. `validateInput` used to await the
+// validator, check `r.ok`, throw on failure — and drop `r.value` on the floor, so the original
+// unparsed input reached the transport. `validateOutput` had done the opposite since ADR 0015 ("on
+// success returns the PARSED value — coerced, defaulted, stripped — so the result matches the
+// declared contract"), which left the two halves of one feature behaving in opposite directions.
+//
+// That mattered because stripping unknown keys is the DEFAULT in Zod, Valibot and ArkType alike: a
+// reader who declares an input schema reasonably believes the request is now shaped by it. It was
+// not — and since a pinned `?tenant=acme` in the configured path is a default that caller input
+// overwrites (`{ ...predefined, ...input.query }`), the one mechanism that would close that hole
+// silently did nothing.
+//
+// These tests pin the wire, not the internals: what the transport actually received.
+import { graphql, stitch } from '../src';
+import { startMockServer } from './support/mock-server';
+import type { MockServer } from './support/mock-server';
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { z } from 'zod';
+
+process.env['STITCH_TRACE_FILE'] = join(
+    tmpdir(),
+    `stitch-input-filter-${process.pid}.jsonl`,
+);
+
+let server: MockServer;
+beforeAll(async () => {
+    server = await startMockServer();
+});
+afterAll(async () => {
+    await server.close();
+});
+beforeEach(() => {
+    server.reset();
+});
+
+describe('a declared input schema shapes the request (issue #648)', () => {
+    test('query: the parsed value goes on the wire — an unknown key cannot overwrite a pinned default', async () => {
+        server.route('GET', '/v1/orders', { body: { ok: true } });
+        const getOrders = stitch({
+            // `?tenant=acme` is pinned in the configured endpoint; the engine treats a predefined
+            // query pair as a DEFAULT that `input.query` overrides, so this is the exact pairing
+            // the issue measured.
+            url: `${server.url}/v1/orders?tenant=acme`,
+            input: { query: z.object({ limit: z.number() }) }, // strips by default
+        });
+
+        await getOrders({
+            query: {
+                limit: 10,
+                tenant: 'globex',
+                include: 'internal_notes',
+            } as unknown as { limit: number },
+        });
+
+        const call = server.calls('/v1/orders')[0]!;
+        // The validator returned `{ limit: 10 }`; that — and only that — is what merges over the
+        // pinned default. Before the fix the wire read `?tenant=globex&limit=10&include=internal_notes`
+        // and the vendor duly answered for the other tenant.
+        expect(call.query).toEqual({ tenant: 'acme', limit: '10' });
+    });
+
+    test('query: a schema default is applied, the way an output schema default already was', async () => {
+        server.route('GET', '/v1/orders', { body: { ok: true } });
+        const getOrders = stitch({
+            url: `${server.url}/v1/orders`,
+            input: { query: z.object({ limit: z.number().default(20) }) },
+        });
+
+        await getOrders({ query: {} });
+
+        expect(server.calls('/v1/orders')[0]!.query).toEqual({ limit: '20' });
+    });
+
+    test('params: the parsed value expands the path template', async () => {
+        server.route('GET', '/orders/42', { body: { ok: true } });
+        const getOrder = stitch({
+            baseUrl: server.url,
+            path: '/orders/{id}',
+            input: { params: z.object({ id: z.string().trim() }) },
+        });
+
+        await getOrder({ params: { id: '  42  ' } });
+
+        // Coercion reaches the URL: the untrimmed id would have expanded to `/orders/%20%2042%20%20`.
+        expect(server.calls()[0]!.path).toBe('/orders/42');
+    });
+
+    test('body: the parsed value is what is sent', async () => {
+        server.route('POST', '/payments', { body: { ok: true } });
+        const pay = stitch({
+            url: `${server.url}/payments`,
+            method: 'POST',
+            input: { body: z.object({ amount: z.number() }) },
+        });
+
+        await pay({
+            body: { amount: 5, approved: true } as unknown as {
+                amount: number;
+            },
+        });
+
+        expect(server.calls('/payments')[0]!.body).toEqual({ amount: 5 });
+    });
+
+    test('headers: the parsed value is what is sent — an undeclared header is stripped', async () => {
+        server.route('GET', '/h', { body: { ok: true } });
+        const call = stitch({
+            url: `${server.url}/h`,
+            input: { headers: z.object({ 'x-tenant': z.string() }) },
+        });
+
+        await call({
+            headers: {
+                'x-tenant': 'acme',
+                'x-forwarded-for': '10.0.0.1',
+            } as unknown as { 'x-tenant': string },
+        });
+
+        const seen = server.calls('/h')[0]!.headers;
+        expect(seen['x-tenant']).toBe('acme');
+        expect(seen['x-forwarded-for']).toBeUndefined();
+    });
+
+    test('an UNDECLARED slot stays a full passthrough — this fix filters, it does not lock down', async () => {
+        server.route('GET', '/orders/7', { body: { ok: true } });
+        const getOrder = stitch({
+            baseUrl: server.url,
+            path: '/orders/{id}',
+            // Only `params` is declared. A schema constrains ONE slot; `query` keeps the loose
+            // passthrough it has always had (defensible on its own — see the issue).
+            input: { params: z.object({ id: z.string() }) },
+        });
+
+        await getOrder({ params: { id: '7' }, query: { anything: 'kept' } });
+
+        expect(server.calls('/orders/7')[0]!.query).toEqual({
+            anything: 'kept',
+        });
+    });
+
+    test("the caller's own input object is not mutated", async () => {
+        server.route('GET', '/v1/orders', { body: { ok: true } });
+        const getOrders = stitch({
+            url: `${server.url}/v1/orders`,
+            input: { query: z.object({ limit: z.number() }) },
+        });
+
+        // A variable, not a fresh literal — so the extra `tenant` reaches the engine (excess
+        // property checking only bites on literals) exactly as an untrusted caller's would.
+        const arg = { limit: 10, tenant: 'globex' };
+        await getOrders({ query: arg });
+
+        // The engine validates into a COPY: filtering the request must never rewrite an object the
+        // caller still holds (a bound `.with(...)` partial, a loop reusing one literal, …).
+        expect(arg).toEqual({ limit: 10, tenant: 'globex' });
+    });
+
+    // Not a repro — a consequence guard. The cache key mirrors the RESOLVED request, so the moment
+    // a run resolves it from the parsed input, `invalidate(input)` has to as well or it computes
+    // the key of a request that was never made and evicts nothing.
+    test('cache: `invalidate(input)` still evicts the entry that same input stored', async () => {
+        let calls = 0;
+        const s = stitch({
+            url: 'https://api.test/resource',
+            trace: false,
+            cache: { ttl: '60s', tenancy: 'app' },
+            input: { query: z.object({ id: z.number() }) },
+            adapter: () => {
+                calls += 1;
+                return Promise.resolve({
+                    status: 200,
+                    headers: {},
+                    body: { n: calls },
+                });
+            },
+        });
+
+        const arg = { id: 1, noise: 'stripped' };
+        await s({ query: arg });
+        await s({ query: arg }); // served from cache
+        expect(calls).toBe(1);
+
+        await s.invalidate({ query: arg });
+        await s({ query: arg }); // evicted → refetch
+        expect(calls).toBe(2);
+    });
+});
+
+// The one path the issue flagged to check first: `variables` is a validated slot, but the value is
+// consumed by the graphql surface's `buildRequest` (`{ query, variables }`), not by the generic
+// request builder. The engine hands the surface the same input object it validated, so the parsed
+// variables reach the packed body — and the `input.variables ?? input.body` fallback still stands.
+describe('graphql: the parsed `variables` reach the packed { query, variables } body', () => {
+    test('a declared variables schema strips unknown keys from the wire body', async () => {
+        server.route('POST', '/graphql', { body: { data: { ok: true } } });
+        const query = graphql({
+            baseUrl: server.url,
+            document: 'query($id: ID!) { thing(id: $id) { name } }',
+            input: { variables: z.object({ id: z.string() }) },
+        });
+
+        await query({
+            variables: { id: 'abc', admin: true } as unknown as {
+                id: string;
+            },
+        });
+
+        const call = server.calls('/graphql')[0]!;
+        expect((call.body as { variables: unknown }).variables).toEqual({
+            id: 'abc',
+        });
+    });
+
+    test('a `body` schema on a graphql stitch feeds the same slot, parsed', async () => {
+        server.route('POST', '/graphql', { body: { data: { ok: true } } });
+        const query = graphql({
+            baseUrl: server.url,
+            document: 'query($id: ID!) { thing(id: $id) { name } }',
+            input: { body: z.object({ id: z.string() }) },
+        });
+
+        // `variables` absent ⇒ the surface falls back to `body` (`input.variables ?? input.body`).
+        await query({
+            body: { id: 'abc', admin: true } as unknown as { id: string },
+        });
+
+        const call = server.calls('/graphql')[0]!;
+        expect((call.body as { variables: unknown }).variables).toEqual({
+            id: 'abc',
+        });
+    });
+
+    test('an optional variables schema with no variables passed still falls back to `body`', async () => {
+        server.route('POST', '/graphql', { body: { data: { ok: true } } });
+        const query = graphql({
+            baseUrl: server.url,
+            document: 'query($id: ID!) { thing(id: $id) { name } }',
+            input: { variables: z.object({ id: z.string() }).optional() },
+        });
+
+        // The parsed value of an absent optional slot is `undefined`, so the surface's nullish
+        // fallback is untouched and `body` still supplies the variables. (`body` keeps no loose
+        // passthrough in the call-arg type once another slot is declared — only `variables`,
+        // `params` and `query` do — so the runtime slot is reached with a cast.)
+        await query({ body: { id: 'abc' } } as unknown as Parameters<
+            typeof query
+        >[0]);
+
+        const call = server.calls('/graphql')[0]!;
+        expect((call.body as { variables: unknown }).variables).toEqual({
+            id: 'abc',
+        });
+    });
+});

--- a/packages/core/test/mcp.spec.ts
+++ b/packages/core/test/mcp.spec.ts
@@ -167,6 +167,41 @@ test('run_stitch drops an agent-injected header when the stitch declares no inpu
     expect(JSON.stringify(seen)).not.toContain('INJECTED');
 });
 
+// Issue #648 on the surface where it bit hardest: `run_stitch` forwards a MODEL's argument object,
+// so the keys a stitch never declared are keys nobody wrote. Nothing here is MCP-specific — the
+// filtering happens in the engine, for every caller — but this is the call site that made a
+// validating-but-not-filtering `input` schema a security property rather than a surprise.
+test('run_stitch cannot smuggle an undeclared query key past a declared input.query schema', async () => {
+    let url = '';
+    const search = stitch({
+        // `?tenant=acme` is pinned in the endpoint, and a predefined query pair is a DEFAULT that
+        // caller input overrides — so before the fix a model could name another tenant.
+        url: 'https://x.test/search?tenant=acme',
+        input: { query: asValidator(z.object({ q: z.string() })) },
+        adapter: (request) => {
+            url = request.url;
+            return Promise.resolve({
+                status: 200,
+                headers: {},
+                body: { ok: true },
+            });
+        },
+    });
+    const mcp = createMcpServer({ search });
+    const res = await mcp.handle(
+        req('tools/call', {
+            name: 'run_stitch',
+            arguments: {
+                name: 'search',
+                input: { query: { q: 'widgets', tenant: 'globex' } },
+            },
+        }),
+    );
+    expect((res?.result as ToolCallResult).isError).toBeFalsy();
+    expect(url).toContain('tenant=acme');
+    expect(url).not.toContain('globex');
+});
+
 test('tools/call run_stitch on an unknown stitch is a tool error, not a crash', async () => {
     const res = await server.handle(
         req('tools/call', { name: 'run_stitch', arguments: { name: 'nope' } }),


### PR DESCRIPTION
Closes #648

## Root cause

`validateInput` (`packages/core/src/engine.ts`) awaited the validator, checked `r.ok`, threw on failure — and **dropped `r.value` on the floor**. Its return type was `Promise<void>`, so it structurally could not do otherwise, and the original **unparsed** input went to the transport.

`validateOutput` had done the opposite since ADR 0015, and the comment above `validateValue` states the contract explicitly: on success it returns the PARSED value — coerced, defaulted, **stripped** — so the result matches the declared contract. The two halves of one feature behaved in opposite directions, and only the stripping half was documented as doing so.

That mattered because stripping unknown keys is the **default** in Zod, Valibot and ArkType alike. Two properties compounded: a schema constrains **one slot**, and a query pair pinned into the endpoint is a *default* that `input.query` overrides (`{ ...predefined, ...input.query }`). The one mechanism a reader would reach for to close the second — declare a strict schema — silently did nothing.

## The fix

`validateInput` returns the input the request is built from; `execute` runs everything downstream on it. One line per slot:

```ts
out[part] = r.value;
```

The parsed values land in a **copy** (`{ ...input }`), not the caller's object — `streamFn` passes the call argument straight through when a stitch has no bound partial, so mutating in place (the issue's literal snippet) would have rewritten an object the caller still holds. There is a test pinning that.

## The graphql `variables` path — what I found

The issue flagged this as the thing to check first, because of the comment at `engine.ts:397-398`: *"the validated value still flows untouched into the `{ query, variables }` body the surface packs."*

What that comment was protecting is that `variables` is validated by the **engine** but consumed by the **surface**: `graphqlSurface.buildRequest` reads `input.variables ?? input.body ?? {}` and packs it as the wire body, so it never passes through the generic `buildRequest` query/header/body assembly the other slots go through.

**It needed no special handling, and nothing broke.** The engine hands `cfg.kind.buildRequest` the same object it validated, so the parsed variables reach the packed body for free — the path was already correct, it was simply being fed an unparsed value. Two follow-on checks, both now pinned by tests:

- **The `?? input.body` fallback survives.** An absent optional slot parses to `undefined`, which is nullish, so `variables` absent + `body` present still resolves to `body` exactly as before.
- **A `body` schema on a graphql stitch** feeds the same slot, now parsed — consistent rather than a special case.

The comment's "untouched" wording was the stale part, and it is corrected in place. Verdict: no architecture decision needed.

## Slots that changed behaviour

All five `validateInput` handles — `params`, `query`, `body`, `headers`, and GraphQL `variables` — now contribute their parsed value. Only slots **with a declared schema**; an undeclared slot is untouched and stays the full passthrough it has always been (existing, defensible behaviour per the issue, with a test pinning it).

The **MCP surface** needed no change: `run_stitch` forwards the model's argument object into `stitch(...)` → `execute` → `validateInput`, so it inherits the fix. `sanitizeAgentInput`'s existing header-drop is unaffected. A test was added there anyway, because that is the call site where an undeclared key is a key *nobody wrote*.

## Measured repro, before/after

```ts
const getOrders = stitch({
    url: 'https://api.vendor.test/v1/orders?tenant=acme',
    input: { query: z.object({ limit: z.number() }) }, // strips by default
});
await getOrders({ query: { limit: 10, tenant: 'globex', include: 'internal_notes' } });
```

| | wire |
|---|---|
| before | `/v1/orders?tenant=globex&limit=10&include=internal_notes` |
| after | `/v1/orders?tenant=acme&limit=10` |

The pinned `tenant=acme` is no longer overwritable by caller input once the slot is declared.

## One consequence I had to fix with it

`cacheInvalidateExact` (`stitch.invalidate(input)`) built its request — and therefore its key — from the **raw** input. The cache key mirrors the *resolved* request, so the moment a run resolves from the parsed input, eviction had to as well, or `invalidate(input)` computes the key of a request that was never made and evicts nothing. It now validates through the same function, inside the `try` it already had, so schema-rejected input stays the no-op a failed `buildRequest` already was. Verified by removing just that half and watching the test fail (`calls` stays 1 instead of going to 2).

Called out explicitly per the "no unrelated drive-by" rule: this is not a drive-by, it is the other end of the same invariant.

## Tests

New `packages/core/test/input-schema-filters.spec.ts` (11 tests). **Written first — 7 of them failed against `main` before `src` was touched**, including the issue's measured `?tenant=globex` case verbatim:

- `query` — the measured repro; a schema default reaching the wire
- `params` — coercion (`z.string().trim()`) reaching the expanded path
- `body`, `headers` — the parsed value is what is sent; an undeclared header is stripped
- **undeclared slot stays a full passthrough** (does not fail before the fix — it pins what must *not* change)
- **the caller's own input object is not mutated** (likewise)
- **cache `invalidate(input)` still evicts what that input stored** (a consequence guard, proven to bite)
- graphql: declared `variables` stripped in the packed body; a `body` schema feeding the same slot parsed; an optional `variables` schema still falling back to `body`

Plus one in `packages/core/test/mcp.spec.ts`: `run_stitch` cannot smuggle an undeclared `query` key past a declared `input.query` schema. Proven failing without the fix (`https://x.test/search?tenant=globex&q=widgets`).

Core suite goes from 1447 to 1459 tests: 12 new — 11 in the new spec file, 1 in `mcp.spec.ts`.

## Breaking-change migration

**A declared input slot now sends only what its schema returns.** If a call relied on extra keys riding along beside a declared schema, either name them in the schema or use a passthrough shape (`z.object({…}).loose()` in Zod 4, `.passthrough()` in Zod 3) to keep the old behaviour for that slot. Coercions and defaults a schema declares now reach the wire, where they were previously computed and discarded. **A slot with no schema is unchanged.** Documented in `CHANGELOG.md` under `[Unreleased] → Fixed`.

Docs updated, since this changes documented behaviour: the validation guide now states that a declared slot *shapes* the request (with a callout that a schema constrains one slot and that a pinned query pair is a default), and the MCP surface page says the agent's object is the call input, not the request.

## Verification — every command, exact result

Run from the repo root on the final tree:

| command | result |
|---|---|
| `pnpm check:format` | **PASS** (needed `prettier --write CHANGELOG.md` first) |
| `pnpm check:lint` | **PASS** — clean across 36 packages, no suppressions added |
| `pnpm check:types` | **PASS** |
| `pnpm test` | **PASS** — core 138 files / 1459 tests |
| `pnpm check:contract` | **PASS** — 0 known violations, baseline untouched |
| `pnpm check:unknown-keys` | **PASS** |
| `pnpm check:types-d` | **PASS** |
| `pnpm check:changelog` | **PASS** |
| `pnpm check:docs-links` | **PASS** |
| `pnpm check:exports` | **PASS** |
| `pnpm check:size` | **PASS** — see below |
| `pnpm --filter @stitchapi/docs build` | **PASS** (render gate) |
| `yakir check` (full, measured) | **PASS** — 9/9 tethers ok, `bundle-advertised-size` still agrees on "21, 24" |

The full `lefthook` pre-push sequence (12 jobs) ran green on push.

### `check:size` — the number

| scenario | gzip | budget | headroom | vs `main` |
|---|---|---|---|---|
| `stitchapi` — whole entry | 24.04 KB | 24.10 KB | **0.06 KB left (~61 B)** | 0.10 KB → 0.06 KB (+0.04) |
| `import { stitch }` | 21.46 KB | 21.50 KB | **0.04 KB left (~41 B)** | 0.09 KB → 0.04 KB (+0.05) |
| `stitchapi/auth` | 5.16 KB | 5.35 KB | 0.19 KB left | unchanged |

Within budget, so **no ceiling was raised** — but flagging it plainly: `import { stitch }` is down to ~41 bytes of headroom, well under the ~0.2 KB this gate is meant to hold. The next small core-path change will likely need a budget PR. The cost is the shallow copy plus the write-back; the `if (!cfg.input) return input` early exit keeps the allocation off stitches that declare no schemas and pays for itself by letting the loop drop its `?.`.

Nothing was already failing on `main`.

## Not in scope

- The issue's fallback alternatives (`input: { strict: true }`, or a docs-only note) are **not** implemented — they were conditioned on the primary fix being too breaking, and this repo ships breaking fixes routinely.
- The "Related, same area" note — `describe_stitch` reporting a declared contract as `"params": true` rather than surfacing the JSON-Schema-representable shape — is a separate enhancement and is left for a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
