### PR TITLE
fix(core): OAuth2 expiry rides the injected clock; two mocking-kit bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -566,6 +566,55 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Fixed
 
+- **OAuth2 token expiry rides the injected clock, so "does my client refresh before expiry?" is
+  finally a test you can write.** ([#650](https://github.com/rejifald/StitchAPI/issues/650))
+  `oauth2` decided token freshness on the module-global wall clock, so 600,000 **virtual** ms past a
+  60s `expires_in` refetched nothing. The test people actually want to write — advance past the
+  expiry, assert the second token fetch — passed while asserting nothing, because the cached token
+  was still fresh by a clock the test could not move.
+
+    [ADR 0010](docs/adr/0010-injectable-clock.md) had already scoped this correctly — the clock owns
+    **control-flow** time — and token freshness is control flow: it decides whether the next call
+    fetches. It was simply out of reach. `auth.ts` contained zero occurrences of `clock` and
+    `AuthContext` carried none, so this was never one line pointing at the wrong function; the seam
+    did not extend that far.
+
+    `AuthContext` now carries the stitch's resolved `clock`, threaded by the engine from the same
+    place `Runtime.clock` comes from — the fifth injectable arriving the way `store`, `vault`,
+    `principal` and `run` already do. Both halves of the freshness math (`expiresAt` at fetch time,
+    and the `refresh.skew` window at read time) read it. **Nothing changes under the default
+    `systemClock`**, which is ADR 0010's own guarantee; the capability activates only when a clock is
+    injected. The field is optional, so a hand-built `AuthContext` in a custom strategy's unit test
+    still type-checks and falls back to the wall clock.
+
+    The mocking guide now carries the full map of which time-driven features `manualClock` drives and
+    which read wall-clock, because ADR 0010 §4 and a `types.ts` JSDoc are not where someone writing a
+    test looks. **`timeout.total`, event `at`/`done.ms` and store/cache TTL remain deliberately
+    wall-clock** — decisions, not gaps — and are now documented as such where testers will find them.
+
+- **`stubStitch(...).safe()` no longer throws when the stub's impl throws synchronously.**
+  ([#650](https://github.com/rejifald/StitchAPI/issues/650)) `.safe()` is the never-throws accessor —
+  that is the entire reason it exists — and a synchronous `throw` inside a function impl escaped it,
+  while the async twin (`() => Promise.reject(e)`) correctly resolved `{ ok: false }` and the **real**
+  stitch reported an adapter's synchronous throw as `ok: false`. The stub was the only one of the
+  three that threw.
+
+    `resolve()` evaluated `impl(input)` as an **argument** to `Promise.resolve`, so the throw escaped
+    before there was a chain to catch it. It is now an `async` function, whose body turns the throw
+    into a rejection. `.unwrap()` and the awaited call result are fixed by the same change;
+    `.stream()` was never affected (an async generator already caught it).
+
+- **`mockAdapter` honours an aborted signal on every route, not just delayed ones.**
+  ([#650](https://github.com/rejifald/StitchAPI/issues/650)) `verifyAdapterContract(mockAdapter(…))`
+  passed 8 of 9 rules and failed **"abort: a pre-aborted signal rejects"** — the mock answered a
+  cancelled request. `req.signal` was consulted only inside the `delay` branch, so any route without
+  a `delay` ignored a signal every real transport honours, and a cancellation test written against a
+  delay-less route asserted the **opposite** of production behaviour.
+
+    The signal is now checked before anything else happens. Nothing was sent, so a pre-aborted
+    request records no spy entry and consumes no slot of a route's response sequence — `callCount()`
+    keeps meaning "requests that reached the wire", which is what a cancellation test asserts on.
+
 - **A `bigint` path parameter no longer vanishes from the URL.** `stitch({ path: '/v1/things/{id}' })`
   called with `{ params: { id: 1234567890123456789n } }` built `https://api.test/v1/things/` — the id
   simply gone, no error, no event, no drift finding. A request meant for one item silently addressed

--- a/apps/docs/content/docs/guides/testing/mocking.mdx
+++ b/apps/docs/content/docs/guides/testing/mocking.mdx
@@ -84,6 +84,12 @@ Omit `match` (and `method`) and the route catches every request.
 `body` is the already-decoded body: an object is delivered as-is. `delay` is
 **abortable**, so a stitch `timeout` cancels it just like a real slow endpoint.
 
+Cancellation is honoured on **every** route, delay or not: a request whose
+`signal` is already aborted rejects without being answered, matching what a real
+transport does (and what [`verifyAdapterContract`](/docs/reference/conformance-kits)
+requires of one). Nothing is sent, so such a request is absent from the spy and
+leaves a response sequence at its current position.
+
 A status sequence drives [retry](/docs/guides/resilience/retry), and the call
 spy proves how many attempts happened:
 
@@ -293,9 +299,10 @@ asserting that your code consumed the stream it was given.
 
 ## Controlling time — `manualClock`
 
-Retry backoff, throttle pacing, and the per-attempt timeout are time-driven, so
-testing them used to mean real waiting. Inject a `manualClock()` as `clock` and
-drive that time by hand with `advance(ms)` — no real delay, no fake-timer library:
+Retry backoff, throttle pacing, the per-attempt timeout and OAuth2 token expiry
+are time-driven, so testing them used to mean real waiting. Inject a
+`manualClock()` as `clock` and drive that time by hand with `advance(ms)` — no
+real delay, no fake-timer library:
 
 ```ts twoslash
 import { stitch } from 'stitchapi';
@@ -324,7 +331,92 @@ await p; // { ok: true } — with zero real waiting
 order, and `pending()` reports the timers still waiting. The default is the real
 `systemClock` (exported from the main entry), so this changes nothing until you
 inject a clock; you can also supply your own object implementing `Clock`.
-`timeout.total` and event timestamps stay on wall-clock.
+
+### Token expiry
+
+`oauth2` decides token freshness on the same clock, so "does my client refresh
+before the token expires?" is a test you can write — `advance` past
+`expires_in` minus `refresh.skew` and assert the second fetch:
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+import { oauth2 } from 'stitchapi/auth';
+import { manualClock, mockAdapter } from 'stitchapi/testing';
+
+const clock = manualClock();
+const api = mockAdapter([
+    {
+        method: 'POST',
+        match: '/token',
+        respond: ({ index }) => ({
+            body: { access_token: `T${index + 1}`, expires_in: 60 },
+        }),
+    },
+    { method: 'GET', match: '/data', respond: { body: { ok: true } } },
+]);
+
+const call = stitch({
+    baseUrl: 'https://api.test',
+    path: '/data',
+    adapter: api,
+    clock,
+    auth: oauth2({
+        tokenUrl: 'https://api.test/token',
+        clientId: 'cid',
+        clientSecret: 'csecret',
+        adapter: api,
+    }),
+});
+
+await call();
+api.callCount('/token'); // 1
+
+await clock.advance(600_000); // ten virtual minutes, past a 60s token
+await call();
+api.callCount('/token'); // 2 — refreshed, with zero real waiting
+```
+
+### What the clock drives, and what it does not
+
+The clock owns **control-flow** time — the waiting and the deciding — not
+bookkeeping. That boundary is deliberate, and knowing where it falls is the
+difference between a test that asserts something and one that only looks like it
+does:
+
+| Feature                | Under `manualClock`                                  |
+| ---------------------- | ---------------------------------------------------- |
+| `retry` backoff        | **virtual** — `advance` fires each backoff           |
+| `retry.respect` delays | **virtual** — a parsed `Retry-After` is a wait       |
+| `throttle` rate        | **virtual** — spacing is exact, `waited` reports it  |
+| `throttle` concurrency | **virtual** — a holder releases on virtual time      |
+| `circuit.cooldown`     | **virtual** — `advance` past it opens the probe      |
+| `timeout.each`         | **virtual** — the per-attempt clamp fires on it      |
+| OAuth2 token expiry    | **virtual** — `expires_in` minus `refresh.skew`      |
+| `timeout.total`        | wall-clock — the budget deadline is wall-anchored    |
+| `cache.ttl`            | wall-clock — cache expiry is a store concern         |
+| `memoryStore` TTL      | wall-clock — same                                    |
+| Event `at` / `done.ms` | wall-clock — timestamps are cosmetic                 |
+| AWS SigV4 signing date | wall-clock — `new Date()`, in `@stitchapi/aws-sigv4` |
+| `paginate`             | no time to drive                                     |
+
+<Callout type="info">
+    The four core wall-clock rows are **decisions, not gaps** — ADR 0010 scoped
+    the clock to control flow on purpose. `timeout.total`'s budget is anchored
+    to a wall-clock deadline, so virtual sleeps never drain it and it does
+    **not** stop a virtual-time retry loop: assert a total budget against the
+    real clock, or assert attempt counts instead. Store and cache TTLs are a
+    separate concern (expiry, not scheduling), and threading the clock through
+    ~30 event builders to move a cosmetic timestamp would buy no determinism.
+</Callout>
+
+<Callout type="warn">
+    `manualClock()` starts at epoch `0`. A `Retry-After` given as an
+    **HTTP-date** is honoured relative to the clock, so a fixture carrying a
+    real date resolves to a wait of roughly twenty thousand days — which
+    presents as a hang, not a failure. Use `retryAfterSeconds` with a **number**
+    in fixtures, or seed the clock with a realistic epoch:
+    `manualClock(Date.now())`.
+</Callout>
 
 ## See also
 

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -424,6 +424,13 @@ interface CachedToken {
     expiresAt: number; // epoch ms; 0 = no known expiry (never proactively refreshed)
 }
 
+// Read time off the engine-threaded Clock (ADR 0010), falling back to the wall clock when the
+// context carries none (a hand-built AuthContext in a strategy's own unit test). Token freshness
+// is CONTROL-FLOW time — it decides whether the next call fetches — so it belongs on the same
+// seam that already drives retry/throttle/timeout/circuit, which is what lets a `manualClock()`
+// advance a test past `expires_in` without real waiting.
+const clockNow = (ctx: AuthContext): number => ctx.clock?.now() ?? now();
+
 /**
  * In-process single-flight: concurrent callers of the same key await ONE shared
  * promise instead of each running `run` themselves (GAP-AUDIT §2.6). The entry
@@ -498,8 +505,8 @@ export function oauth2(opts: OAuth2Options): AuthStrategy {
         return `${baseKey}\u0000${principal}`;
     };
 
-    const isFresh = (t: CachedToken | undefined): boolean =>
-        !!t && (t.expiresAt === 0 || now() < t.expiresAt - skew);
+    const isFresh = (t: CachedToken | undefined, at: number): boolean =>
+        !!t && (t.expiresAt === 0 || at < t.expiresAt - skew);
 
     // Fetch a new token from the endpoint and cache it (with TTL = expires_in). Always hits
     // the network; callers gate on `isFresh` to reuse the cached token instead.
@@ -561,7 +568,7 @@ export function oauth2(opts: OAuth2Options): AuthStrategy {
                 : undefined;
         const cached: CachedToken = {
             token: payload.access_token,
-            expiresAt: ttlMs ? now() + ttlMs : 0,
+            expiresAt: ttlMs ? clockNow(ctx) + ttlMs : 0,
         };
         // The token is a secret → it lives in the vault (off `__config`, redacted from traces),
         // not the inspectable store. A shared seam/store still shares one token across workers.
@@ -573,7 +580,7 @@ export function oauth2(opts: OAuth2Options): AuthStrategy {
         const nsKey = keyFor(ctx);
         const cached = (await ctx.vault.get(nsKey)) as CachedToken | undefined;
         // Cache miss/stale: coalesce concurrent callers into ONE in-flight fetch.
-        return isFresh(cached)
+        return isFresh(cached, clockNow(ctx))
             ? cached!.token
             : flight(nsKey, () => fetchToken(ctx, nsKey));
     };

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -89,11 +89,15 @@ export function makeRuntime(
     store: StitchStore,
     opts?: { vault?: StitchStore; principal?: string; clock?: Clock },
 ): Runtime {
+    const clock = opts?.clock ?? systemClock;
     const authCtx: AuthContext = {
         store,
         // Secrets live in the vault, off `__config` and redacted from traces. Standalone stitches
         // get a reserved namespace over their own store; a seam injects its shared vault.
         vault: opts?.vault ?? vaultView(store),
+        // The SAME clock the engine schedules on (ADR 0010), so a strategy's time-driven control
+        // flow — oauth2's token freshness window — is deterministic under an injected clock.
+        clock,
         emit: () => {
             /* progress surfaces via yielded events, not authCtx */
         },
@@ -106,7 +110,7 @@ export function makeRuntime(
         throttle,
         trace,
         store,
-        clock: opts?.clock ?? systemClock,
+        clock,
         authCtx,
     };
 }

--- a/packages/core/src/test-mock.ts
+++ b/packages/core/src/test-mock.ts
@@ -161,6 +161,12 @@ export function mockAdapter(
     };
 
     const adapter = (async (req: AdapterRequest): Promise<AdapterResponse> => {
+        // The adapter contract's abort rule: a pre-aborted signal REJECTS. Checked here rather
+        // than only in the `delay` branch below, so a delay-less route can't answer a cancelled
+        // request — every real transport refuses it, and a cancellation test written against a
+        // mock that answered was asserting the opposite of production. Nothing was sent, so the
+        // spy records no call and the route's response sequence keeps its place.
+        if (req.signal?.aborted) throw new Error('aborted');
         log.push(req);
         const idx = list.findIndex(
             (r) =>

--- a/packages/core/src/test-stub.ts
+++ b/packages/core/src/test-stub.ts
@@ -56,15 +56,18 @@ const toError = (e: unknown): StitchError =>
           ? new StitchError(e.message, { cause: e })
           : new StitchError(String(e));
 
-const resolve = <TOut>(
+// `async` is load-bearing, not style: written as `Promise.resolve(impl(input))` the call is an
+// ARGUMENT, so a SYNCHRONOUS throw escaped before there was a chain to catch it — and `.safe()`,
+// the never-throws accessor, threw. An async function body turns that throw into a rejection, so
+// a sync throw and an async rejection are indistinguishable to every caller (matching the real
+// stitch, which reports an adapter's sync throw as `ok: false`).
+const resolve = async <TOut>(
     impl: StubImpl<TOut>,
     input: StitchInput,
 ): Promise<TOut> =>
-    Promise.resolve(
-        typeof impl === 'function'
-            ? (impl as (i: StitchInput) => TOut | Promise<TOut>)(input)
-            : impl,
-    );
+    typeof impl === 'function'
+        ? (impl as (i: StitchInput) => TOut | Promise<TOut>)(input)
+        : impl;
 
 function defaultEvents<TOut>(
     name: string,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1361,6 +1361,15 @@ export interface AuthContext {
      */
     run?: RunContext;
     /**
+     * The stitch's resolved {@link Clock} (ADR 0010), threaded by the engine — `systemClock`
+     * unless one was injected as `clock`. A strategy whose CONTROL FLOW is time-driven reads it
+     * instead of the wall clock, so a `manualClock()` drives it: `oauth2` decides token freshness
+     * (`expires_in` minus `refresh.skew`) on this, which is what makes "does my client refresh
+     * before expiry" testable without real waiting. Optional so a hand-built context (a unit test
+     * of a custom strategy) still type-checks; fall back to the system clock when it is absent.
+     */
+    clock?: Clock;
+    /**
      * Announce an `info` StitchEvent onto the run's event stream — a strategy reporting a
      * decision it made (e.g. which env var a `bearer` token resolved from via `optionalEnv`, or
      * that `oauth2` fetched a token). NEVER carries the secret itself. The engine buffers these

--- a/packages/core/test/clock-seam.spec.ts
+++ b/packages/core/test/clock-seam.spec.ts
@@ -1,9 +1,11 @@
 // ADR 0010 — the injectable Clock. A `manualClock()` injected as `clock` makes retry backoff,
-// throttle pacing, and the per-attempt timeout deterministic with zero real waiting: `advance(ms)`
-// drives them. Verified against the REAL engine via the published mock adapter.
+// throttle pacing, the per-attempt timeout and OAuth2 token expiry deterministic with zero real
+// waiting: `advance(ms)` drives them. Verified against the REAL engine via the published mock
+// adapter.
 import { seam, stitch } from '../src';
+import { oauth2 } from '../src/auth';
 import { manualClock, mockAdapter } from '../src/testing';
-import type { Adapter } from '../src/types';
+import type { Adapter, Clock } from '../src/types';
 
 describe('manualClock drives retry backoff (ADR 0010)', () => {
     test('each backoff elapses only when the clock is advanced', async () => {
@@ -117,6 +119,113 @@ describe('manualClock drives throttle rate spacing (ADR 0010)', () => {
         await clock.advance(500);
         await Promise.all([a, b]);
         expect(api.callCount()).toBe(2);
+    });
+});
+
+// The token cache's freshness math (`expiresAt` and the `refresh.skew` window) is control-flow
+// time — it decides whether the next call fetches — so ADR 0010's seam has to reach it. Before
+// this, `oauth2` read the module-global wall clock: 600,000 virtual ms past a 60s `expires_in`
+// refetched nothing, so "does my client refresh the token before it expires" could not be tested.
+describe('manualClock drives OAuth2 token expiry (ADR 0010)', () => {
+    // One mock serves both the token endpoint and the protected resource, so a single spy reports
+    // how many token fetches happened.
+    const api = () =>
+        mockAdapter([
+            {
+                method: 'POST',
+                match: '/token',
+                respond: ({ index }) => ({
+                    body: {
+                        access_token: `T${index + 1}`,
+                        token_type: 'Bearer',
+                        expires_in: 60, // 60s, and the default refresh skew is 30s
+                    },
+                }),
+            },
+            { method: 'GET', match: '/data', respond: { body: { ok: true } } },
+        ]);
+
+    const protectedStitch = (mock: ReturnType<typeof api>, clock: Clock) =>
+        stitch({
+            baseUrl: 'https://api.test',
+            path: '/data',
+            adapter: mock,
+            clock,
+            auth: oauth2({
+                tokenUrl: 'https://api.test/token',
+                clientId: 'cid',
+                clientSecret: 'csecret',
+                adapter: mock,
+            }),
+        });
+
+    test('advancing past `expires_in` refetches the token', async () => {
+        const clock = manualClock();
+        const mock = api();
+        const call = protectedStitch(mock, clock);
+
+        await call();
+        expect(mock.callCount('/token')).toBe(1);
+        expect(mock.lastRequest()?.headers['authorization']).toBe('Bearer T1');
+
+        // Still inside the freshness window (60s expiry − 30s skew = fresh until virtual 30s).
+        await clock.advance(20_000);
+        await call();
+        expect(mock.callCount('/token')).toBe(1); // reused, not refetched
+
+        // Past it, on virtual time alone — no real waiting.
+        await clock.advance(580_000); // virtual 600s, ten minutes past a 60s token
+        await call();
+        expect(mock.callCount('/token')).toBe(2);
+        expect(mock.lastRequest()?.headers['authorization']).toBe('Bearer T2');
+    });
+
+    test('the `refresh.skew` window is honoured on virtual time', async () => {
+        const clock = manualClock();
+        const mock = api();
+        const call = stitch({
+            baseUrl: 'https://api.test',
+            path: '/data',
+            adapter: mock,
+            clock,
+            auth: oauth2({
+                tokenUrl: 'https://api.test/token',
+                clientId: 'cid',
+                clientSecret: 'csecret',
+                adapter: mock,
+                refresh: { skew: '10s' }, // fresh until virtual 50s (60s expiry − 10s skew)
+            }),
+        });
+
+        await call();
+        expect(mock.callCount('/token')).toBe(1);
+
+        await clock.advance(49_999);
+        await call();
+        expect(mock.callCount('/token')).toBe(1); // one ms inside the window
+
+        await clock.advance(1);
+        await call();
+        expect(mock.callCount('/token')).toBe(2); // the skew boundary, on the injected clock
+    });
+
+    test('with no clock injected, expiry still rides the system clock', async () => {
+        const mock = api();
+        const call = stitch({
+            baseUrl: 'https://api.test',
+            path: '/data',
+            adapter: mock,
+            auth: oauth2({
+                tokenUrl: 'https://api.test/token',
+                clientId: 'cid',
+                clientSecret: 'csecret',
+                adapter: mock,
+            }),
+        });
+
+        await call();
+        await call();
+        expect(mock.callCount('/token')).toBe(1); // a 60s token is fresh across two calls
     });
 });
 

--- a/packages/core/test/mock-adapter-extras.spec.ts
+++ b/packages/core/test/mock-adapter-extras.spec.ts
@@ -99,3 +99,55 @@ describe('mockAdapter spy', () => {
         expect((await api(req('http://h/a'))).body).toBe(1); // sequence replays from the start
     });
 });
+
+// `verifyAdapterContract`'s abort rule — "a pre-aborted AbortSignal rejects" — is one of the nine
+// the library holds every transport to, and the mock used to fail it: `req.signal` was consulted
+// only inside the `delay` branch, so a delay-less route answered a cancelled request. A
+// cancellation test written against such a route asserted the OPPOSITE of production behaviour.
+describe('mockAdapter honours an aborted signal (adapter contract)', () => {
+    const aborted = (): AbortSignal => {
+        const c = new AbortController();
+        c.abort();
+        return c.signal;
+    };
+
+    test('a pre-aborted signal rejects on a route with NO delay', async () => {
+        const api = mockAdapter({ respond: { body: 'ok' } });
+        await expect(
+            api({ ...req('http://h/a'), signal: aborted() }),
+        ).rejects.toThrow(/abort/i);
+    });
+
+    test('a pre-aborted signal rejects before the route is matched at all', async () => {
+        // `onUnmatched: 'throw'` would otherwise be the only rejection path here.
+        const api = mockAdapter({ match: '/known', respond: { body: 'ok' } });
+        await expect(
+            api({ ...req('http://h/unknown'), signal: aborted() }),
+        ).rejects.toThrow(/abort/i);
+    });
+
+    test('a pre-aborted signal sends nothing: no spy entry, no sequence slot consumed', async () => {
+        const api = mockAdapter({ respond: [{ body: 1 }, { body: 2 }] });
+        await expect(
+            api({ ...req('http://h/a'), signal: aborted() }),
+        ).rejects.toThrow(/abort/i);
+        expect(api.callCount()).toBe(0); // a cancelled request never reached the wire
+        expect((await api(req('http://h/a'))).body).toBe(1); // the sequence is still at its head
+    });
+
+    test('a live (un-aborted) signal is unaffected', async () => {
+        const api = mockAdapter({ respond: { body: 'ok' } });
+        const c = new AbortController();
+        const res = await api({ ...req('http://h/a'), signal: c.signal });
+        expect(res.body).toBe('ok');
+        expect(api.callCount()).toBe(1);
+    });
+
+    test('the existing delay branch still aborts mid-flight', async () => {
+        const api = mockAdapter({ respond: { body: 'ok', delay: 50 } });
+        const c = new AbortController();
+        const p = api({ ...req('http://h/a'), signal: c.signal });
+        c.abort();
+        await expect(p).rejects.toThrow(/abort/i);
+    });
+});

--- a/packages/core/test/stub-stitch-extras.spec.ts
+++ b/packages/core/test/stub-stitch-extras.spec.ts
@@ -52,6 +52,51 @@ describe('stubStitch call spy', () => {
     });
 });
 
+// `.safe()` is the never-throws accessor — that is the whole reason it exists. A function impl
+// that throws SYNCHRONOUSLY used to escape it, because `resolve()` evaluated `impl(input)` as an
+// ARGUMENT to `Promise.resolve` (no chain to catch it yet). The async twin already resolved
+// `{ ok: false }`, and so does the real stitch when its adapter throws synchronously — the stub
+// was the odd one out.
+describe('stubStitch: a synchronous throw in the impl', () => {
+    const boom = () =>
+        stubStitch<string>(() => {
+            throw new Error('boom');
+        });
+
+    test('.safe() resolves { ok: false } instead of throwing', async () => {
+        const res = await boom().safe();
+        expect(res.ok).toBe(false);
+        expect(res.error?.message).toBe('boom');
+    });
+
+    test("the call result's .safe() resolves { ok: false } too", async () => {
+        const res = await boom()().safe();
+        expect(res.ok).toBe(false);
+        expect(res.error?.message).toBe('boom');
+    });
+
+    test('.unwrap() REJECTS rather than throwing synchronously', async () => {
+        const s = boom();
+        let p: Promise<string> | undefined;
+        expect(() => {
+            p = s.unwrap();
+        }).not.toThrow();
+        await expect(p).rejects.toThrow('boom');
+    });
+
+    test('an async rejection behaves identically (the two twins agree)', async () => {
+        const s = stubStitch<string>(() => Promise.reject(new Error('boom')));
+        const res = await s.safe();
+        expect(res.ok).toBe(false);
+        expect(res.error?.message).toBe('boom');
+    });
+
+    test('.stream() still yields start → error → done', async () => {
+        const types = (await collect(boom().stream())).map((e) => e.type);
+        expect(types).toEqual(['start', 'error', 'done']);
+    });
+});
+
 describe('stubStitch options', () => {
     test('opts.events overrides the synthesized stream', async () => {
         const s = stubStitch('ignored', {


### PR DESCRIPTION
Refs #650. **Not** `Closes` — §2 is deliberately left open (below).

Three of the issue's findings, plus the documentation half of §1. §2 and SigV4 are untouched by design.

---

## §1(a) — OAuth2 token expiry rides the injected clock

**Before:** 600,000 virtual ms past a 60s `expires_in` refetched nothing. The test people actually want to write — advance past the expiry, assert the second token fetch — passed while asserting nothing, because the cached token was still fresh by a clock the test could not move.

**After:** `advance(600_000)` past a 60s token refetches, and the `refresh.skew` boundary is exact on virtual time (pinned to the millisecond: fresh at 49,999, stale at 50,000 for a 10s skew).

### The plumbing, and why it matches ADR 0010

ADR 0010's load-bearing sentence is that **the clock owns control-flow time, not bookkeeping**. Token freshness is control flow — it decides whether the next call fetches — so it belongs on the seam, and §4's deliberate exclusions (`timeout.total`, event timestamps, store/cache TTL) are all *bookkeeping*. This is not an exception to the ADR's scope; it is a case that fell inside it and was never wired.

The issue is right that this was never a one-line misreach: `auth.ts` contained **zero** occurrences of `clock` and `AuthContext` carried none.

`AuthContext` now carries the stitch's resolved `clock`. That is the ADR's own threading pattern applied one level further — the engine already resolves `shared?.clock ?? cfg.clock ?? systemClock` once in `makeStitch` and hands it to `makeRuntime`, which is the same function that builds the `authCtx`. The strategy receives it exactly the way it already receives `store`, `vault`, `principal` and `run`: engine-provided, never caller-supplied.

```ts
// engine.ts — makeRuntime
const clock = opts?.clock ?? systemClock;
const authCtx: AuthContext = { store, vault: …, clock, emit: … };
return { …, clock, authCtx };
```

```ts
// auth.ts
const clockNow = (ctx: AuthContext): number => ctx.clock?.now() ?? now();
```

Both halves of the freshness math read it — `expiresAt` at fetch time and the `refresh.skew` window at read time. Fixing only one leaves the test still failing, which is why the test covers both.

**Three properties kept this design-free rather than an architecture decision:**

1. **The field is optional.** Purely additive: no existing user code breaks, and a hand-built `AuthContext` in a custom strategy's unit test still type-checks and falls back to the wall clock. It sits alongside `principal?` and `run?`, the other two engine-provided optionals on the same interface.
2. **No behaviour change under `systemClock`** — ADR 0010's own guarantee. The capability activates only when a clock is injected.
3. **`emitInto` spreads `...authCtx`**, so the per-call view carries the clock with no change.

The vault's own TTL stays wall-clock, which is the ADR 0010 §4 decision and is *correct* here: it means a virtual-time test still finds the cached entry and `isFresh` gets to be the thing that decides.

## §3 — BUG: `stubStitch(...).safe()` threw on a synchronous throw

**Before:** `stub, impl throws synchronously -> THREW boom`, while `stub, impl rejects asynchronously -> ok=false` and `REAL stitch, adapter throws sync -> ok=false`. The never-throws accessor was the only one of the three that threw.

**After:** all three agree on `{ ok: false, error: StitchError('boom') }`.

`resolve()` evaluated `impl(input)` as an **argument** to `Promise.resolve`, so the throw escaped before there was a chain to catch it. `resolve` is now an `async` function, whose body turns the throw into a rejection. `.unwrap()` and the awaited call result are fixed by the same change; `.stream()` was never affected (an async generator already caught it).

## §4 — BUG: `mockAdapter` failed the library's own adapter contract

**Before:** `verifyAdapterContract(mockAdapter(…))` passed 8 of 9 and failed **"abort: a pre-aborted signal rejects"** — *"adapter resolved although the signal was already aborted"*. `req.signal` was consulted only inside the `delay` branch, so any route **without** a `delay` answered a cancelled request, and a cancellation test written against a delay-less route asserted the opposite of production.

**After:** the signal is checked before anything else happens, so every route honours it.

One judgement call worth flagging: a pre-aborted request records **no spy entry** and consumes **no slot** of a route's response sequence. Rationale — a real transport sends nothing, so `callCount()` keeps meaning "requests that reached the wire", which is what `expect(api.callCount()).toBe(0)` after a cancellation is asking. Documented in the guide.

## §1(b) — docs

The mocking guide gains the full 12-feature map of what `manualClock` drives and what reads wall-clock, plus a worked token-expiry example. ADR 0010 §4 and a `types.ts` JSDoc are not where someone writing a test looks.

The four ADR-0010 §4 cases are presented as **decisions, not gaps**, with the reasoning: `timeout.total`'s budget is wall-anchored so virtual sleeps never drain it (and the guide says what to assert instead); store/cache TTL is expiry rather than scheduling; event timestamps are cosmetic and would cost ~30 threaded builders for no determinism.

## §5 — assessed, nothing fixed

Every item needs a decision, so all five are left. Reporting what I found rather than guessing:

| Item | Why it is not design-free |
| --- | --- |
| `mockAdapter` fixture validation (`wireShape`) | A new opt-in public API and a policy on what "wire shape" means. |
| `stubStitch` runs no `input` schemas | Needs a new slot on `StubStitchOptions` — `config` is `Partial<RedactedStitchConfig>`, which carries no schema. Public API addition. |
| Retry backoff absent from the event stream | The `progress{phase:'retry'}` event is emitted **before** the sleep, so populating `waited` would put a not-yet-elapsed duration under a past-tense name that the throttle and reconnect paths use for a genuinely elapsed one. Event-contract decision. |
| `.with()` returns a fresh spy | Two defensible semantics (a derived stitch's calls are the parent's calls / a bound stub is its own subject). A call, not a bug. |
| Circuit breaker has no distinct error name | **Partly stale, and the remaining half is a breaking change.** `CircuitOpenError` already exists (`resilience.ts:255`) with `name = 'CircuitOpenError'` and is what `engine.ts:877` throws. It is flattened on the way out: `asStitchError` (`stitch.ts:749`) rebuilds anything that is not already a `StitchError` into a plain one, so the caller measures `name: 'StitchError'`, `message: 'circuit open'`, `status: 503` — verified on this branch. The fix is exactly the shape of #662 (`RateLimitError extends StitchError`), i.e. a `refactor(core)!` of its own. |

---

## Deliberately NOT done

- **§2 — `Retry-After` as an HTTP-date.** Its ask is an either/or — default `manualClock()` to a realistic epoch, **or** warn when a parsed `Retry-After` exceeds a sane ceiling. Both change published behaviour in different directions (one alters every existing `manualClock()` test's `now()`; the other adds a runtime warning and a threshold to pick), and choosing is a maintainer call. **Left open — hence `Refs`, not `Closes`.** The guide now warns about the trap and shows the two workarounds (`retryAfterSeconds` as a number, or `manualClock(Date.now())`); that documents the sharp edge without picking either arm.
- **AWS SigV4's signing date.** The other undocumented wall-clock case, but it lives in `@stitchapi/aws-sigv4` and is tracked in #658. Behaviour untouched; it appears as a row in the doc table so a reader is not misled into writing a signing-date test that silently passes.
- **The four deliberate ADR-0010 §4 behaviours.** Documented as intentional, not changed.

## Tests

**Written first, and confirmed failing against unmodified `src`: 8 failed, 24 passed.** After the fix: 32 passed.

- `clock-seam.spec.ts` — 3 tests: advance past `expires_in` refetches; the `refresh.skew` boundary is exact on virtual time; and a control proving expiry still rides `systemClock` with no clock injected. (2 of 3 failed before; the control passed, as it should.)
- `stub-stitch-extras.spec.ts` — 5 tests: `.safe()`, the call result's `.safe()`, `.unwrap()` rejecting rather than throwing, plus controls that the async twin and `.stream()` already agreed. (3 of 5 failed before.)
- `mock-adapter-extras.spec.ts` — 5 tests: pre-aborted rejects with no delay; rejects before route matching; no spy entry and no sequence slot consumed; plus controls that a live signal and mid-flight delay abort still work. (3 of 5 failed before.)

### No regression to the six that already worked

Re-measured against the issue's "First, what works", all exact:

- retry backoff at virtual **`0 / 1000 / 3000`**; `advance(0)` → 1 call, 1 pending; `advance(5000)` → 3 calls
- throttle rate `advance(3000)` → 3 calls; `waited` = **`500` then `1000`** for `'2/s'`
- circuit trace **`1, 2, 2 (blocked: circuit open), 3, 4`**
- per-attempt timeout: `advance(2000)` past a 1s timeout → error
- `Retry-After` honoured on the clock (`advance(5000)` → 2nd attempt at virtual 5000)

Full suite: **core 1460 tests / 137 files, all workspace packages green.**

## Bundle size — no budget raise

Measured on this branch vs. its merge base (`521011f`), gzip bytes:

| Scenario | Before | After | Δ | Budget | Headroom |
| --- | --- | --- | --- | --- | --- |
| whole entry | 24578 | 24583 | **+5 B** | 24678 | 95 B |
| `import { stitch }` | 21927 | 21931 | **+4 B** | 22016 | 85 B |
| `stitchapi/auth` | 5283 | 5309 | **+26 B** | 5478 | 169 B |

Two things kept this cheap. ADR 0021 already moved `oauth2` behind `stitchapi/auth`, so the `clockNow` helper is charged to the subpath, not the core path. And `makeRuntime` computed `opts?.clock ?? systemClock` once for `Runtime.clock`; hoisting it into a `const` shared with `authCtx` paid for most of the new property — the core path grew 4–5 bytes rather than the ~0.1 KB a naive threading would have cost. **`bundle-size.mjs` is unmodified.**

## Verification

Every command run from the repo root, on the final tree:

| Command | Result |
| --- | --- |
| `pnpm check:lint` | ✅ pass (36 packages, no suppressions added) |
| `pnpm check:types` | ✅ pass |
| `pnpm test` | ✅ pass |
| `pnpm check:format` | ✅ pass (needed one `pnpm format` for the new MDX table; it does cover `CHANGELOG.md`) |
| `pnpm check:contract` | ✅ pass |
| `pnpm check:unknown-keys` | ✅ pass |
| `pnpm check:types-d` | ✅ pass |
| `pnpm check:size` | ✅ pass |
| `pnpm check:changelog` | ✅ pass |
| `pnpm check:docs-links` | ✅ pass |
| docs build (twoslash) | ✅ pass |

The pre-push hook's full sequence — format, lint, contract, unknown-keys, changelog, media-fresh, typecheck, typecheck-d, test, exports, build-docs, yakir — passed on the pushed commit. Nothing was failing on `origin/main` beforehand, so there is nothing to stash-prove. No drive-by refactors; no `eslint-disable`; no baseline entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
