### PR TITLE
fix(core): `decode: 'json'` stops buffering the array it is streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -566,6 +566,36 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Fixed
 
+- **`decode: 'json'` no longer buffers the array it is streaming.**
+  ([#659](https://github.com/rejifald/StitchAPI/issues/659)) Streaming a top-level JSON array
+  retained the **whole array text** — 19.48 MB held for a 21.5 MB body (0.90× the wire), growing
+  linearly with the response — and then tripped the decoder's own 8 MB `stream.buffer.chars`
+  default mid-stream. A 60,000-row array delivered **37,288 rows and then an `error` /
+  `done(ok: false)`**, which a loop matching only `delta` never sees, under a message —
+  _"a malformed or never-closing value was streamed"_ — that blamed the vendor for a
+  perfectly well-formed body. Scanning was superlinear too: 43× the time for 10× the rows.
+
+    **Emission was never the problem.** One delta per top-level element, correct under `,` `]` `}`
+    inside string values, escaped quotes, embedded newlines, pretty-printed multi-line records, deep
+    nesting and 1-character chunk boundaries — all of it already right, and now pinned by a test that
+    feeds hard records **one byte per chunk** while compaction runs on every read.
+
+    The window was. `compact()` floors on the start of the value in flight, and a top-level array
+    recorded its opening `[` as that start and held it until the closing `]` — so for the array's
+    whole lifetime the floor was byte zero and `compact()` was a no-op. But an array is **never
+    emitted as a value**; only its elements are (`[{…},{…}]` is one delta per element, by design).
+    It therefore needs no start recorded at all, and now records none: `elementStart` alone floors
+    the window while an element is mid-flight, and between elements the floor is the scan cursor —
+    exactly how the concatenated-value form (`{…}{…}`, the other shape this decoder accepts) has
+    always released. The two shapes now measure alike: **0.11 MB flat for 100,000 rows either way**,
+    against 19.48 MB for the array before, with time linear in the rows.
+
+    **The cap keeps its teeth**, and its meaning sharpens: it bounds one **value**, so an array is
+    now capped by its largest _element_ rather than by its _length_. A single element still in
+    progress across reads still floors the window and still trips the cap — which is the case the
+    cap exists for. Nothing about the public API changes; a stream that used to die at 8 MB now
+    finishes, in bounded memory.
+
 - **A `bigint` path parameter no longer vanishes from the URL.** `stitch({ path: '/v1/things/{id}' })`
   called with `{ params: { id: 1234567890123456789n } }` built `https://api.test/v1/things/` — the id
   simply gone, no error, no event, no drift finding. A request meant for one item silently addressed

--- a/packages/core/src/json-stream.ts
+++ b/packages/core/src/json-stream.ts
@@ -21,8 +21,10 @@
  * Default cap on the chars the `'json'` decoder will buffer for a single in-progress value before
  * it throws — characters of the DECODED text (UTF-16 code units), not bytes off the socket. ~8M:
  * generous for real records, but bounded so a malformed / never-closing value (e.g. an unterminated
- * `[`) can't grow the buffer without limit. Overridable per-stream via `stream.buffer.chars`. The
- * engine (`runStreaming`) turns the throw into an `error` event.
+ * string, or an object whose `}` never arrives) can't grow the buffer without limit. It bounds ONE
+ * value: a top-level array's elements are released as they close, so an array is capped by its
+ * largest ELEMENT, not by its length. Overridable per-stream via `stream.buffer.chars`. The engine
+ * (`runStreaming`) turns the throw into an `error` event.
  */
 export const JSON_STREAM_DEFAULT_MAX_BUFFER_CHARS = 8 * 1024 * 1024;
 
@@ -162,7 +164,14 @@ export async function* jsonStream(
                             pending.push(slice(valueStart, scan));
                         }
                         topIsArray = c === 0x5b;
-                        valueStart = scan;
+                        // A top-level ARRAY is never sliced as a value — only its ELEMENTS are
+                        // (see the emission rules above), so it records no start. Recording one
+                        // would floor `compact()` at the opening `[` for the array's whole
+                        // lifetime: nothing released, heap tracking the wire, quadratic scanning,
+                        // and a long array tripping its own buffer cap (#659). A top-level
+                        // OBJECT/scalar IS sliced whole, so it still keeps its start. `elementStart`
+                        // takes over as the floor while an element is mid-flight.
+                        valueStart = topIsArray ? -1 : scan;
                     } else if (depth === 1 && topIsArray && elementStart < 0) {
                         elementStart = scan;
                     }
@@ -179,8 +188,8 @@ export async function* jsonStream(
                                 pending.push(slice(elementStart, scan));
                                 elementStart = -1;
                             }
-                            // Drop the whole (now-consumed) array including this ']'.
-                            valueStart = -1;
+                            // Nothing to reset: an array records no `valueStart` (see `[` above),
+                            // and its elements have all been emitted and released as they closed.
                         } else {
                             // Top-level object closes → emit the whole object.
                             pending.push(slice(valueStart, scan + 1));
@@ -226,7 +235,9 @@ export async function* jsonStream(
 
             // Compact: drop everything before the earliest live position. When nothing is in
             // progress, that's the scan cursor (we've consumed up to it); otherwise it's the start
-            // of the in-progress value/element.
+            // of the in-progress value/element. Sitting BETWEEN two elements of a top-level array
+            // counts as nothing in progress, so the window falls back to the cursor and the
+            // already-emitted elements are released — the array itself pins nothing.
             const live =
                 valueStart >= 0
                     ? valueStart

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -859,7 +859,8 @@ export interface StreamBufferOptions {
      * the throw into an `error` event). Counts characters of the DECODED text — UTF-16 code
      * units, so an astral character costs 2 — not bytes off the socket. Guards every un-framed /
      * never-closing case against growing client memory without limit (an OOM DoS):
-     *   - `'json'` — a single in-progress value (e.g. an unclosed `[`).
+     *   - `'json'` — a single in-progress value (e.g. an unterminated string). A streamed array is
+     *     bounded by its largest ELEMENT, not its length — elements are released as they close.
      *   - `'lines'` / `'ndjson'` — a single un-terminated line (a run of text with no `\n`).
      *   - the `sse` surface — one un-dispatched event's `data:` payload (a frame with no blank line).
      * Default ~8M characters (see `json-stream.ts`). Not meaningful for `decode: 'bytes'` (raw,

--- a/packages/core/test/json-stream-buffer.spec.ts
+++ b/packages/core/test/json-stream-buffer.spec.ts
@@ -1,10 +1,12 @@
-// Two behaviours of the `'json'` streaming tokenizer (src/json-stream.ts) that json-stream.spec.ts
+// Three behaviours of the `'json'` streaming tokenizer (src/json-stream.ts) that json-stream.spec.ts
 // leaves open. That suite proves chunk-split correctness exhaustively and that a *single*
 // never-closing value trips the buffer.chars guard — but not:
 //   1. that the cap is PER-VALUE, not cumulative: the sliding-window compaction drops each emitted
 //      value, so a long run of small complete values whose TOTAL dwarfs the cap streams fine. This
 //      is the whole reason compact()/base exist; without them this stream would false-trip the guard.
-//   2. that a structurally-complete-but-INVALID slice surfaces its JSON.parse error (the documented
+//   2. that this holds for a top-level ARRAY's elements too, not only for concatenated top-level
+//      values — the two shapes this decoder accepts must release memory alike (issue #659 §2).
+//   3. that a structurally-complete-but-INVALID slice surfaces its JSON.parse error (the documented
 //      "or if a slice fails to parse" contract — the engine turns the throw into an error event).
 import { jsonStream } from '../src/json-stream';
 
@@ -34,6 +36,14 @@ async function decode(
     return out;
 }
 
+/** Cut `text` into `size`-char pieces, each encoded as its own chunk (its own `read()`). */
+function chunksOf(text: string, size: number): Uint8Array[] {
+    const out: Uint8Array[] = [];
+    for (let i = 0; i < text.length; i += size)
+        out.push(enc.encode(text.slice(i, i + size)));
+    return out;
+}
+
 describe('json-stream: the buffer cap bounds a VALUE, not the whole stream', () => {
     test('many small complete values whose total dwarfs the buffer cap all stream (compaction works)', async () => {
         const COUNT = 500;
@@ -49,17 +59,91 @@ describe('json-stream: the buffer cap bounds a VALUE, not the whole stream', () 
     });
 
     test('a long top-level array element-by-element stays bounded element-wise', async () => {
-        // A 300-element array fed one element per chunk; each element is tiny. Under a cap large
-        // enough for the array-so-far this streams every element without tripping the guard.
+        // A 300-element array fed one element per chunk; each element is tiny. The cap is a
+        // QUARTER of the array text, so passing means the window held an element at a time —
+        // an array-sized window would trip the guard around element 60.
         const parts = ['['];
         for (let i = 0; i < 300; i++) parts.push(i === 0 ? `${i}` : `,${i}`);
         parts.push(']');
+        expect(parts.join('').length).toBeGreaterThan(4 * 256);
         const out = await decode(
             parts.map((p) => enc.encode(p)),
-            64 * 1024,
+            256,
         );
         expect(out).toHaveLength(300);
         expect(out[299]).toBe(299);
+    });
+});
+
+// A top-level ARRAY must release the elements it has already emitted, exactly as the
+// concatenated-value form does. It did not (issue #659 §2): `compact()` floors on `valueStart`, and
+// an array's `valueStart` was pinned to the opening `[` until the closing `]`, so the sliding window
+// grew to hold the WHOLE array — quadratic time, heap tracking the wire, and a long array tripping
+// its own cap mid-stream with a message blaming the vendor for "a malformed or never-closing value".
+//
+// The cap is the instrument here, not a side quest. `guard()` runs AFTER `compact()` on every read,
+// so a run that completes under a cap far smaller than the body IS a per-read assertion that the
+// retained window never exceeded that cap — a deterministic memory proof, no heap sampling, no flake.
+describe('json-stream: a top-level array releases each emitted element (#659)', () => {
+    const CAP = 2_048;
+    const PAD = 'x'.repeat(24);
+    const RECORDS = Array.from({ length: 2_000 }, (_, i) => ({ i, pad: PAD }));
+    const AS_ARRAY = JSON.stringify(RECORDS);
+    const AS_CONCAT = RECORDS.map((r) => JSON.stringify(r)).join('');
+
+    test('every element streams under a cap a fraction of the array text', async () => {
+        // ~86 KB of array text through a 2 KB window: the window cannot be holding the array.
+        expect(AS_ARRAY.length).toBeGreaterThan(20 * CAP);
+        const out = await decode(chunksOf(AS_ARRAY, 64), CAP);
+        expect(out).toHaveLength(RECORDS.length);
+        expect(out[0]).toEqual(RECORDS[0]);
+        expect(out.at(-1)).toEqual(RECORDS.at(-1));
+    });
+
+    test('the array form now matches the concatenated form — the issue’s control', async () => {
+        // The same records, the same cap, the other shape this decoder accepts. Concatenated
+        // top-level values always released; the array form is what regressed.
+        expect(await decode(chunksOf(AS_CONCAT, 64), CAP)).toEqual(RECORDS);
+        expect(await decode(chunksOf(AS_ARRAY, 64), CAP)).toEqual(RECORDS);
+    });
+
+    test('no silent truncation: a 60k-row array delivers all 60k rows', async () => {
+        // The reported shape — every ELEMENT is tiny, the ARRAY text is not. The consumer used to
+        // get a prefix of the rows and then a throw (`error` / `done(ok:false)` at the engine),
+        // which a loop matching only `delta` never sees.
+        const rows = Array.from({ length: 60_000 }, (_, i) => ({ i }));
+        const out = await decode(chunksOf(JSON.stringify(rows), 4_096), CAP);
+        expect(out).toHaveLength(60_000);
+        expect(out[0]).toEqual({ i: 0 });
+        expect(out.at(-1)).toEqual({ i: 59_999 });
+    });
+
+    test('compaction mid-array corrupts no slice — hard records, ONE BYTE per chunk', async () => {
+        // Releasing a prefix is only safe if it is never needed again. Maximum compaction pressure
+        // (a compact() per byte) over everything the boundary scanner has to survive: `,` `]` `}`
+        // `"` inside string values, backslash escapes, embedded newlines/tabs, multibyte and astral
+        // characters, deep nesting, and pretty-printed multi-line records.
+        const hard = Array.from({ length: 60 }, (_, i) => ({
+            id: i,
+            s: 'a}b]c,d"e\nf\tg\\hé\u{1f600}',
+            deep: { a: { b: [1, { k: ['x,y]z', i] }] } },
+        }));
+        const pretty = `[\n${hard.map((r) => JSON.stringify(r, null, 2)).join(',\n')}\n]`;
+        const perByte = Array.from(enc.encode(pretty), (b) => Uint8Array.of(b));
+        expect(await decode(perByte, CAP)).toEqual(hard);
+    });
+
+    test('the cap still bounds a single oversized ELEMENT inside an array', async () => {
+        // Releasing FINISHED elements must not release an unfinished one. An element still in
+        // progress across reads keeps flooring the window, so the guard keeps its teeth: this is
+        // the "one value is too large" case the cap exists for.
+        const oneBig = `{"s":"${'x'.repeat(8_000)}"}`;
+        await expect(
+            decode(
+                [enc.encode('['), ...chunksOf(oneBig, 100), enc.encode(']')],
+                CAP,
+            ),
+        ).rejects.toThrow(/stream\.buffer\.chars/);
     });
 });
 


### PR DESCRIPTION
Refs #659 — **§2 only**. §1 and §3 are untouched and stay open; see [What this does not do](#what-this-does-not-do).

Streaming a top-level JSON array with `decode: 'json'` retained the **whole array text**, then killed the stream with its own buffer cap and a message that blamed the vendor for a perfectly well-formed body.

## The defect

| 100,000-row array, 21.5 MB wire | before | after |
| --- | --- | --- |
| retained heap (decoder window) | **19.48 MB** (0.90× the wire) | **0.11 MB** (0.005×) |
| rows delivered, default 8 MB cap | **37,288, then `error`** | **all 100,000** |
| time, 10,000 → 100,000 rows | 30 ms → 1300 ms = **43×** | 20 ms → 142 ms = **7.2×** |

The truncation is the part that bites. The decoder tripped its own `JSON_STREAM_DEFAULT_MAX_BUFFER_CHARS` (8,388,608) partway through and threw — which the engine turns into `error` / `done(ok: false)`, **invisible to any loop matching only `delta`**. A consumer asking for 60,000 rows silently got 37,288 and a truthy-looking `for await`. The message it died with —

> a malformed or never-closing value was streamed

— accused the server of sending something broken. The server sent a valid array.

## Root cause: one branch

`compact()` drops the buffer prefix before the earliest *live* position — the start of the value currently being accumulated. For a top-level array, `valueStart` was set to the opening `[` and only cleared at the closing `]`:

```ts
topIsArray = c === 0x5b;
valueStart = scan;          // ← the `[`, held for the array's whole lifetime
```

So for the entire array the compaction floor was byte zero, `compact(live)` was a no-op, and nothing was ever released. Everything downstream follows: heap tracks the wire, `guard()` measures the array instead of a value and trips, and scanning goes superlinear because each read re-flattens a rope that keeps growing (`buf += text` then `charCodeAt`).

**But a top-level array is never emitted as a value.** `[{…},{…}]` is *one delta per element*, by design — the array itself is never sliced, never parsed, never handed to anyone. It had no reason to record a start at all.

## The fix: mirror the sibling path that already works

```ts
topIsArray = c === 0x5b;
valueStart = topIsArray ? -1 : scan;
```

That is the whole functional change. A top-level **object or scalar** *is* sliced whole, so it still records its start. A top-level **array** records none, and the floor falls through to the machinery that was already there and already correct:

- while an element is mid-flight → `elementStart` floors the window (per element, which is what the cap is *for*);
- between two elements → nothing is in progress, so the floor is the scan cursor and every emitted element is released.

This is exactly how the **concatenated-value** form (`{…}{…}`, the other shape this decoder accepts) has always behaved — it never recorded a container-level start it didn't need, which is why the issue's control ran flat. The array path now does the same thing, and the two shapes measure identically:

```
control — 100,000 records as concatenated top-level values
  before   retained 0.13 MB
  after    retained 0.13 MB     ← unchanged, as expected
array   — the same 100,000 records inside one `[ … ]`
  before   retained 19.48 MB
  after    retained 0.11 MB     ← now matches the control
```

The only other source change is dropping the now-provably-dead `valueStart = -1` at the closing `]` (an array records no start, so there is nothing to reset), plus comments.

**The cap keeps its teeth, and its meaning sharpens.** It bounds one *value*, so a streamed array is now capped by its largest **element** rather than by its **length**. An element still in progress across reads still floors the window and still trips the cap — pinned by a new test, because "release finished elements" must not become "release an unfinished one".

## Measurements

Method: the decoder driven **directly** (no engine, so #659 §1's accumulator can't confound the numbers), every delta discarded, `heapUsed` sampled after a forced GC at 90% through the stream — with the consumer retaining nothing, what remains *is* the decoder's window. Rows are ~225 chars, matching the issue's shape. Node 24.18.1, `--expose-gc`.

**A. Default 8 MB cap — rows actually delivered**

```
  rows        wire      before                   after
   10,000    2.13 MB   all 10,000 ✓             all 10,000 ✓
   38,000    8.17 MB   37,288 then error        all 38,000 ✓
   60,000   12.91 MB   37,288 then error        all 60,000 ✓
  100,000   21.53 MB   37,288 then error        all 100,000 ✓
```

The issue reports 37,000 decoding / 38,000 failing, and 37,312 rows on the 60,000-row case. Reproduced at 37,288 — the difference is row width, and the failure is otherwise identical.

**B. Cap raised to 1 GB so `before` survives, exposing its true memory profile** (the issue's "raising the cap converts the failure into the memory profile the user was trying to avoid")

```
  rows        wire      before retained   ×wire     after retained   ×wire
   10,000    2.13 MB          2.02 MB   0.95×          0.11 MB  0.050×
   50,000   10.76 MB          8.65 MB   0.80×          0.13 MB  0.012×
  100,000   21.53 MB         19.48 MB   0.90×          0.11 MB  0.005×
```

Before: linear in the response, 0.80–0.95× the wire (issue: 0.88×, 18.8 MB for a 21 MB body). After: **flat at 0.11–0.13 MB across a 10× workload change** — the O(1) profile the `ndjson` decoder already had.

**C. Time complexity, cap raised so both complete**

```
  before  10,000 rows    30 ms → 100,000 rows   1300 ms   = 43.0× for 10× the rows
  after   10,000 rows    20 ms → 100,000 rows    142 ms   =  7.2× for 10× the rows
```

## Tests

All new assertions were **confirmed failing against unmodified `src`** first — 5 failed / 4 passed, every failure the same `stream.buffer.chars` throw the issue describes.

The instrument is the cap, not heap sampling: `guard()` runs *after* `compact()` on every read, so **a run that completes under a cap far smaller than the body is a per-read assertion that the retained window never exceeded that cap**. Deterministic, fast (the whole file runs in ~200 ms), no flake, no `--expose-gc` in CI. The heavy A/B heap measurement above stays out of the suite.

In `packages/core/test/json-stream-buffer.spec.ts`:

- **every element streams under a cap a fraction of the array text** — 2,000 records (~86 KB) through a 2 KB window.
- **the array form now matches the concatenated form** — the issue's control, same records, same cap, both shapes.
- **no silent truncation: a 60k-row array delivers all 60k rows** — the reported case, pinned by count.
- **compaction mid-array corrupts no slice — hard records, ONE BYTE per chunk** — the regression pin for the parser. A `compact()` per byte over everything listed as already-correct: `,` `]` `}` `"` inside string values, backslash escapes, embedded newlines/tabs, multibyte + astral characters, deep nesting, pretty-printed multi-line records. Releasing a prefix is only safe if it is never needed again; this is what proves it.
- **the cap still bounds a single oversized ELEMENT inside an array** — an element in progress across reads still trips the guard.

One existing test was **tightened, not added to**: `a long top-level array element-by-element stays bounded element-wise` made exactly the claim this fix repairs, but its own comment conceded it did not verify it ("*under a cap large enough for the array-so-far*" — a 64 KB cap for a 1.1 KB array). Its cap is now a quarter of the array text, so it tests its title. It fails without the fix.

The pre-existing chunk-split matrix in `json-stream.spec.ts` (every two-way byte split + byte-by-byte, across 6 inputs) passes unchanged. Full core suite: **137 files, 1452 tests, all passing.**

## Bundle size

**Zero bytes.** Byte-for-byte identical to `main` on all three gated scenarios — `json-stream.ts` is reached only through the `stitchapi/stream` subpath, and the gate measures the root entry and `/auth`.

| scenario | main | this branch | Δ | budget |
| --- | --- | --- | --- | --- |
| `stitchapi` — whole entry | 24578 B gzip (68463 min) | **24578 B** gzip (68463 min) | **0** | 24678.4 B |
| `import { stitch }` | 21927 B gzip (60391 min) | **21927 B** gzip (60391 min) | **0** | 22016 B |
| `stitchapi/auth` | 5283 B gzip (13735 min) | **5283 B** gzip (13735 min) | **0** | 5478.4 B |

Headroom is unchanged at 100.4 B / 89.0 B / 195.4 B, so the ~56 B and ~37 B expected to remain after the two other in-flight core PRs land is **untouched by this branch** — it neither spends nor needs any of it. No budget was raised.

On the subpath the change actually lands, it is **net negative**: `stitchapi/stream` goes 65318 → 65316 B minified (**−2 B**; +2 B gzip, 23750 → 23752). The ternary costs a few characters and the removed dead assignment pays for them.

## What this does not do

- **§1 (`.stream()` is not memory-bounded).** Its ask is an explicit either/or — opt-out retention vs. automatic-when-iterating — which is an API decision. Untouched. Note the engine's `chunks` accumulator still sits on top of this decoder, so an `await`ing or `.stream()`ing caller keeps paying §1's cost; what this PR fixes is that the decoder underneath is now genuinely O(1) for arrays, as it already was for `ndjson`.
- **§3 (buffered/streaming asymmetries).** Needs maintainer decisions on four separate slots. Untouched.
- **The "failing that" fallback** — splitting the cap message into "value too large" vs. "array too long" — is deliberately **not** implemented. It was conditioned on the primary fix being impossible; the primary fix landed, so the array-too-long failure no longer exists to be named. The message still fits the case it now describes (one oversized value). `types.ts` and the decoder's own doc comment were corrected where they cited "an unclosed `[`" as the example — after this fix an unclosed `[` is bounded, so that example had become false.

Hence `Refs #659`, not `Closes`.

## Verification

`check:format` · `check:lint` · `check:types` · `check:contract` · `check:unknown-keys` · `check:changelog` · `check:docs-links` · `check:size` · `check:types-d` · `test` — **all pass** from the repo root on the committed state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
