### PR TITLE
fix(aws-sigv4): sign with the injected clock, not `new Date()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -566,6 +566,28 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Fixed
 
+- **`@stitchapi/aws-sigv4` stamps `x-amz-date` from the injected clock, so SigV4 is testable on
+  virtual time.** ([#658](https://github.com/rejifald/StitchAPI/issues/658)) The signer called
+  `amzDateOf(new Date())`, so 600 **virtual** seconds moved the shipped stamp **0** seconds and a
+  default `manualClock()` (which starts at epoch `0`) produced a real-time stamp regardless. Every
+  test that wanted to assert anything about signing time — skew handling, a signature's age across a
+  throttle wait — had to inject its own clock-reading signer to measure it.
+
+    [#664](https://github.com/rejifald/StitchAPI/pull/664) put the stitch's `clock` on `AuthContext`
+    for `oauth2`; this is the companion package taking the same seam. The signing timestamp is
+    control-flow time by ADR 0010's own definition — `x-amz-date` is inside the string-to-sign, and
+    AWS refuses a stamp more than ~5 minutes out with `RequestTimeTooSkewed` — so it belongs on the
+    clock that already drives retry, throttle, timeout, circuit and token freshness. It reads it
+    through the identical `ctx.clock?.now() ?? Date.now()` fallback core's `auth.ts` uses, so a
+    hand-built `AuthContext` in a custom strategy's unit test still type-checks.
+
+    **Nothing changes on the wire.** The engine threads `systemClock` unless a clock was injected,
+    and `systemClock.now()` _is_ `Date.now()` — pinned by a test that signs a request on the wall
+    clock, reads back the instant it stamped, re-signs on a clock pinned to that instant, and
+    asserts the `Authorization` header is byte-identical. Payload hashing and the `signBody`
+    branches are untouched. The mocking guide's clock map moves the SigV4 row from wall-clock to
+    **virtual** accordingly.
+
 - **OAuth2 token expiry rides the injected clock, so "does my client refresh before expiry?" is
   finally a test you can write.** ([#650](https://github.com/rejifald/StitchAPI/issues/650))
   `oauth2` decided token freshness on the module-global wall clock, so 600,000 **virtual** ms past a

--- a/apps/docs/content/docs/guides/testing/mocking.mdx
+++ b/apps/docs/content/docs/guides/testing/mocking.mdx
@@ -383,21 +383,21 @@ bookkeeping. That boundary is deliberate, and knowing where it falls is the
 difference between a test that asserts something and one that only looks like it
 does:
 
-| Feature                | Under `manualClock`                                  |
-| ---------------------- | ---------------------------------------------------- |
-| `retry` backoff        | **virtual** — `advance` fires each backoff           |
-| `retry.respect` delays | **virtual** — a parsed `Retry-After` is a wait       |
-| `throttle` rate        | **virtual** — spacing is exact, `waited` reports it  |
-| `throttle` concurrency | **virtual** — a holder releases on virtual time      |
-| `circuit.cooldown`     | **virtual** — `advance` past it opens the probe      |
-| `timeout.each`         | **virtual** — the per-attempt clamp fires on it      |
-| OAuth2 token expiry    | **virtual** — `expires_in` minus `refresh.skew`      |
-| `timeout.total`        | wall-clock — the budget deadline is wall-anchored    |
-| `cache.ttl`            | wall-clock — cache expiry is a store concern         |
-| `memoryStore` TTL      | wall-clock — same                                    |
-| Event `at` / `done.ms` | wall-clock — timestamps are cosmetic                 |
-| AWS SigV4 signing date | wall-clock — `new Date()`, in `@stitchapi/aws-sigv4` |
-| `paginate`             | no time to drive                                     |
+| Feature                | Under `manualClock`                                 |
+| ---------------------- | --------------------------------------------------- |
+| `retry` backoff        | **virtual** — `advance` fires each backoff          |
+| `retry.respect` delays | **virtual** — a parsed `Retry-After` is a wait      |
+| `throttle` rate        | **virtual** — spacing is exact, `waited` reports it |
+| `throttle` concurrency | **virtual** — a holder releases on virtual time     |
+| `circuit.cooldown`     | **virtual** — `advance` past it opens the probe     |
+| `timeout.each`         | **virtual** — the per-attempt clamp fires on it     |
+| OAuth2 token expiry    | **virtual** — `expires_in` minus `refresh.skew`     |
+| AWS SigV4 signing date | **virtual** — `x-amz-date` (`@stitchapi/aws-sigv4`) |
+| `timeout.total`        | wall-clock — the budget deadline is wall-anchored   |
+| `cache.ttl`            | wall-clock — cache expiry is a store concern        |
+| `memoryStore` TTL      | wall-clock — same                                   |
+| Event `at` / `done.ms` | wall-clock — timestamps are cosmetic                |
+| `paginate`             | no time to drive                                    |
 
 <Callout type="info">
     The four core wall-clock rows are **decisions, not gaps** — ADR 0010 scoped
@@ -415,7 +415,9 @@ does:
     real date resolves to a wait of roughly twenty thousand days — which
     presents as a hang, not a failure. Use `retryAfterSeconds` with a **number**
     in fixtures, or seed the clock with a realistic epoch:
-    `manualClock(Date.now())`.
+    `manualClock(Date.now())`. The same seeding applies to SigV4 — an epoch-`0`
+    clock stamps `x-amz-date` as `19700101T000000Z`, which a real AWS endpoint
+    answers with `RequestTimeTooSkewed`.
 </Callout>
 
 ## See also

--- a/apps/docs/content/docs/integrations/aws-sigv4.mdx
+++ b/apps/docs/content/docs/integrations/aws-sigv4.mdx
@@ -77,6 +77,44 @@ the transport sends, chosen by the stitch's
   sent. `signBody: true` with a multipart body **throws** — leave it unset to send
   `UNSIGNED-PAYLOAD`, or pass a pre-serialised string body to sign it.
 
+## Signing time
+
+`x-amz-date` is stamped from the stitch's [`clock`](/docs/guides/testing/mocking),
+the same injectable seam that drives retry backoff, throttle pacing, and OAuth2
+token freshness — not from `new Date()`. On the default `systemClock` that is
+wall-clock time, so nothing changes in production; injecting a `manualClock()`
+makes the signature's timestamp something a test can drive:
+
+```ts
+import { awsSigV4 } from '@stitchapi/aws-sigv4';
+import { stitch } from 'stitchapi';
+import { manualClock } from 'stitchapi/testing';
+
+const clock = manualClock(Date.UTC(2015, 7, 30, 12, 36, 0));
+const call = stitch({
+    baseUrl: 'https://my-bucket.s3.us-east-1.amazonaws.com',
+    path: '/objects',
+    clock,
+    auth: awsSigV4({
+        region: 'us-east-1',
+        service: 's3',
+        accessKeyId: 'AKID…',
+        secretAccessKey: '…',
+    }),
+});
+
+await call(); // signs x-amz-date: 20150830T123600Z
+await clock.advance(600_000); // ten virtual minutes
+await call(); // signs x-amz-date: 20150830T124600Z
+```
+
+<Callout type="warn">
+    `manualClock()` starts at epoch `0`, which stamps `19700101T000000Z` — about
+    twenty thousand days of apparent skew, and a real AWS endpoint answers it
+    with `RequestTimeTooSkewed`. Seed the clock when the signature has to be
+    plausible: `manualClock(Date.now())`.
+</Callout>
+
 ## Low-level signer
 
 `signRequestV4(params)` is the pure signing function the strategy wraps — exported

--- a/packages/aws-sigv4/eslint-suppressions.json
+++ b/packages/aws-sigv4/eslint-suppressions.json
@@ -9,10 +9,5 @@
     "@typescript-eslint/prefer-nullish-coalescing": {
       "count": 1
     }
-  },
-  "test/sigv4.spec.ts": {
-    "@typescript-eslint/no-empty-function": {
-      "count": 1
-    }
   }
 }

--- a/packages/aws-sigv4/src/index.ts
+++ b/packages/aws-sigv4/src/index.ts
@@ -11,7 +11,7 @@
 // Node 20+, edge runtimes (Workers / Deno), and the browser; Node 18 falls back to
 // `node:crypto`'s `webcrypto`. The low-level `signRequestV4` is exported too, so it
 // can be unit-tested against the official AWS test vectors.
-import type { AuthStrategy } from 'stitchapi';
+import type { AuthContext, AuthStrategy } from 'stitchapi';
 import type { Secret } from 'stitchapi/auth';
 
 // ---------------------------------------------------------------------------
@@ -249,6 +249,23 @@ function amzDateOf(d: Date): string {
 }
 
 /**
+ * Read signing time off the engine-threaded `Clock` (ADR 0010), falling back to the wall
+ * clock when the context carries none (a hand-built `AuthContext` in a unit test, or a `stitchapi`
+ * older than the field). Mirrors core's `clockNow` in `packages/core/src/auth.ts` exactly — one
+ * convention, not two.
+ *
+ * The signing timestamp is CONTROL-FLOW time, not bookkeeping: `x-amz-date` is inside the
+ * string-to-sign and AWS rejects a stamp more than ~5 minutes off with `RequestTimeTooSkewed`, so
+ * it decides whether the call is accepted. Putting it on the same seam that already drives
+ * retry/throttle/timeout/circuit and OAuth2 token freshness is what makes SigV4 testable under a
+ * `manualClock()` — before this, 600 virtual seconds moved the stamp 0 seconds (issue #658 §2).
+ *
+ * Nothing changes on the wire: the engine always threads `systemClock` unless a clock was
+ * injected, and `systemClock.now()` IS `Date.now()`.
+ */
+const clockNow = (ctx: AuthContext): number => ctx.clock?.now() ?? Date.now();
+
+/**
  * Serialise a non-string `bodyType: 'form'` body to `application/x-www-form-urlencoded`
  * for payload signing. A byte-for-byte mirror of core's transport — `encodeRequestBody`
  * in `packages/core/src/http-adapter.ts` (a `URLSearchParams`, `String(v)`, null/undefined
@@ -287,6 +304,12 @@ function formEncode(body: unknown): string {
  * Credentials resolve at call time (so an agent never sees them), and the signature
  * is computed on the final request — after path templating and query building — so
  * it always matches the bytes the transport sends.
+ *
+ * `x-amz-date` is stamped from the stitch's {@link https://stitchapi.dev/docs/guides/testing/mocking | injected clock}
+ * (ADR 0010) — wall-clock under the default `systemClock`, and drivable by a
+ * `manualClock()` in a test. Note a default `manualClock()` starts at epoch `0`, which
+ * signs `19700101T000000Z`; seed it (`manualClock(Date.now())`) when the stamp must be
+ * plausible to a real endpoint.
  */
 export function awsSigV4(opts: AwsSigV4Options): AuthStrategy {
     return {
@@ -298,7 +321,7 @@ export function awsSigV4(opts: AwsSigV4Options): AuthStrategy {
                 ? resolveSecret(opts.sessionToken)
                 : undefined;
 
-            const amzDate = amzDateOf(new Date());
+            const amzDate = amzDateOf(new Date(clockNow(ctx)));
             const url = new URL(req.url);
 
             const body = req.body;

--- a/packages/aws-sigv4/test/sigv4.spec.ts
+++ b/packages/aws-sigv4/test/sigv4.spec.ts
@@ -3,6 +3,8 @@
 // that it runs); the strategy is driven with a fake request + context.
 import { EMPTY_PAYLOAD_SHA256, awsSigV4, signRequestV4 } from '../src';
 
+import { stitch } from 'stitchapi';
+import { manualClock, mockAdapter } from 'stitchapi/testing';
 import { describe, expect, test } from 'vitest';
 
 // The canonical AWS SigV4 example credentials (aws-sig-v4-test-suite).
@@ -28,7 +30,25 @@ function fakeReq(
         ...(over.bodyType !== undefined ? { bodyType: over.bodyType } : {}),
     };
 }
-const fakeCtx = { emit: (): void => {} };
+// These tests assert the headers the strategy attaches, not the run's event stream,
+// so `emit` discards. (`=> undefined`, not an empty body — one shared no-op keeps
+// `no-empty-function` satisfied instead of baselined.)
+const noEmit = (): void => undefined;
+const fakeCtx = { emit: noEmit };
+// The same context carrying an injected `Clock` — what the engine threads onto
+// `AuthContext.clock` (types.ts), so the signer's timestamp is testable.
+const ctxAt = (epochMs: number) => ({
+    emit: noEmit,
+    clock: manualClock(epochMs),
+});
+
+/** `'20150830T123600Z'` → epoch ms. The inverse of the signer's `amzDateOf`. */
+function parseAmzDate(stamp: string): number {
+    return Date.parse(
+        `${stamp.slice(0, 4)}-${stamp.slice(4, 6)}-${stamp.slice(6, 8)}T` +
+            `${stamp.slice(9, 11)}:${stamp.slice(11, 13)}:${stamp.slice(13, 15)}Z`,
+    );
+}
 
 // --- signRequestV4 — official vector ---------------------------------------
 
@@ -429,6 +449,163 @@ describe('awsSigV4 strategy', () => {
         await strategy.apply(reqMultipart, fakeCtx as never);
         expect(reqMultipart.headers['x-amz-content-sha256']).toBe(
             'UNSIGNED-PAYLOAD',
+        );
+    });
+});
+
+// --- the injected clock (ADR 0010, issue #658 §2) ---------------------------
+//
+// The signing timestamp is CONTROL-FLOW time — it decides whether AWS accepts the
+// request — so it rides the engine-threaded `Clock` (`AuthContext.clock`), the same
+// seam that drives retry/throttle/timeout/circuit and OAuth2 token freshness. Reading
+// `new Date()` instead made SigV4 untestable on a virtual clock: 600 virtual seconds
+// moved the stamp 0 seconds, and a default `manualClock()` (which starts at epoch)
+// produced a real-time stamp, so nothing about skew could be asserted at all.
+
+const CLOCK_KEYS = {
+    region: 'us-east-1',
+    service: 's3',
+    accessKeyId: ACCESS_KEY,
+    secretAccessKey: SECRET_KEY,
+} as const;
+
+describe('awsSigV4 (the injected clock)', () => {
+    test('the x-amz-date stamp moves with virtual time, not wall-clock time', async () => {
+        const strategy = awsSigV4(CLOCK_KEYS);
+        const start = Date.UTC(2015, 7, 30, 12, 36, 0);
+
+        const first = fakeReq();
+        await strategy.apply(first, ctxAt(start) as never);
+        expect(first.headers['x-amz-date']).toBe('20150830T123600Z');
+
+        // The issue's measurement: 600 virtual seconds must move the stamp 600 seconds.
+        const later = fakeReq();
+        await strategy.apply(later, ctxAt(start + 600_000) as never);
+        expect(later.headers['x-amz-date']).toBe('20150830T124600Z');
+
+        expect(
+            parseAmzDate(later.headers['x-amz-date'] as string) -
+                parseAmzDate(first.headers['x-amz-date'] as string),
+        ).toBe(600_000);
+    });
+
+    test('a default manualClock() signs at the epoch it actually reads', async () => {
+        // `manualClock()` starts at 0. The stamp must say so — that apparent ~20,670-day
+        // skew is the clock the test chose, and being able to SEE it is the point.
+        const strategy = awsSigV4(CLOCK_KEYS);
+        const req = fakeReq();
+        await strategy.apply(req, ctxAt(0) as never);
+        expect(req.headers['x-amz-date']).toBe('19700101T000000Z');
+    });
+
+    test('the signature itself changes with the clock (the stamp is inside it)', async () => {
+        // Not just the header: the timestamp and its derived credential scope are part of
+        // the string-to-sign, so a different virtual instant must yield a different
+        // signature — otherwise the stamp is cosmetic.
+        const strategy = awsSigV4(CLOCK_KEYS);
+        const a = fakeReq();
+        const b = fakeReq();
+        await strategy.apply(
+            a,
+            ctxAt(Date.UTC(2015, 7, 30, 12, 36, 0)) as never,
+        );
+        await strategy.apply(
+            b,
+            ctxAt(Date.UTC(2015, 7, 31, 12, 36, 0)) as never,
+        );
+
+        expect(a.headers['authorization']).not.toBe(b.headers['authorization']);
+        // A day later ⇒ a different credential scope date, too.
+        expect(a.headers['authorization']).toContain('/20150830/us-east-1/s3/');
+        expect(b.headers['authorization']).toContain('/20150831/us-east-1/s3/');
+    });
+
+    // The wire behaviour must not change. With no clock on the context — a hand-built
+    // AuthContext, or any caller on the system clock — the signature must be exactly
+    // what it is today. Proven without a race: sign once on the wall clock, read back
+    // the instant it stamped, then re-sign the identical request on a clock pinned to
+    // that instant. Byte-identical output ⇒ this is a testability fix, not a wire fix.
+    test('no injected clock ⇒ byte-identical to the wall-clock signature', async () => {
+        const strategy = awsSigV4(CLOCK_KEYS);
+
+        const before = Date.now();
+        const wall = fakeReq({ method: 'PUT', body: 'payload' });
+        await strategy.apply(wall, fakeCtx as never);
+        const after = Date.now();
+
+        // It really is wall-clock time (the stamp truncates to the second, so it can
+        // sit up to 999 ms behind the reading taken just before `apply`).
+        const stamped = parseAmzDate(wall.headers['x-amz-date'] as string);
+        expect(stamped).toBeGreaterThanOrEqual(before - 1000);
+        expect(stamped).toBeLessThanOrEqual(after);
+
+        const pinned = fakeReq({ method: 'PUT', body: 'payload' });
+        await strategy.apply(pinned, ctxAt(stamped) as never);
+
+        expect(pinned.headers['x-amz-date']).toBe(wall.headers['x-amz-date']);
+        expect(pinned.headers['x-amz-content-sha256']).toBe(
+            wall.headers['x-amz-content-sha256'],
+        );
+        expect(pinned.headers['authorization']).toBe(
+            wall.headers['authorization'],
+        );
+    });
+
+    // A golden signature, pinned to a fixed instant: proof the on-the-wire bytes for a
+    // known clock reading are what they have always been. If the timestamp path ever
+    // changes shape (precision, format, scope derivation), this literal fails.
+    //
+    // The literal is not "whatever the code emits" — it was cross-checked against an
+    // independent SigV4 implementation that reproduces the official `get-vanilla`
+    // vector above. Same request and instant as that vector, plus the
+    // `x-amz-content-sha256` header the strategy attaches (hence a different signature).
+    test('a pinned clock reproduces the exact Authorization header', async () => {
+        const strategy = awsSigV4({
+            region: 'us-east-1',
+            service: 'service',
+            accessKeyId: ACCESS_KEY,
+            secretAccessKey: SECRET_KEY,
+        });
+        const req = fakeReq({ url: 'https://example.amazonaws.com/' });
+        await strategy.apply(
+            req,
+            ctxAt(Date.UTC(2015, 7, 30, 12, 36, 0)) as never,
+        );
+
+        expect(req.headers['x-amz-date']).toBe('20150830T123600Z');
+        expect(req.headers['authorization']).toBe(
+            'AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, ' +
+                'SignedHeaders=host;x-amz-content-sha256;x-amz-date, ' +
+                'Signature=726c5c4879a6b4ccbbd3b24edbd6b8826d34f87450fbbf4e85546fc7ba9c1642',
+        );
+    });
+
+    // End-to-end through the public API: the engine threads the stitch's `clock` onto
+    // `AuthContext`, so a `manualClock()` on the stitch drives the signature the
+    // transport actually receives. This is the seam the issue asked for.
+    test('a stitch clock drives the signed request the transport receives', async () => {
+        const clock = manualClock(Date.UTC(2015, 7, 30, 12, 36, 0));
+        const api = mockAdapter({
+            match: '/objects',
+            respond: { body: { ok: true } },
+        });
+        const call = stitch({
+            baseUrl: 'https://my-bucket.s3.us-east-1.amazonaws.com',
+            path: '/objects',
+            adapter: api,
+            clock,
+            auth: awsSigV4(CLOCK_KEYS),
+        });
+
+        await call();
+        expect(api.lastRequest()?.headers['x-amz-date']).toBe(
+            '20150830T123600Z',
+        );
+
+        await clock.advance(600_000); // ten virtual minutes
+        await call();
+        expect(api.lastRequest()?.headers['x-amz-date']).toBe(
+            '20150830T124600Z',
         );
     });
 });


### PR DESCRIPTION
Fixes **§2 only** of #658 — *"SigV4 signs with `new Date()` rather than the injected clock"*.

## Root cause

`packages/aws-sigv4/src/index.ts:301` stamped the signature with
`amzDateOf(new Date())`. On real time that is correct, so **nothing was ever wrong on the
wire** — but it put SigV4's one time-driven input outside the `Clock` seam, which made the
strategy untestable on virtual time:

- 600 **virtual** seconds moved the shipped stamp **0** seconds (a clock-reading signer moved 600).
- Under a default `manualClock()`, **0 of 3** calls were accepted — ~20,670 days of apparent
  skew, because the virtual clock starts at epoch while the server's validation reads real time.
- Every proof in that scenario had to inject its own clock-reading signer to measure anything.

The signing timestamp is **control-flow time** by [ADR 0010](docs/adr/0010-injectable-clock.md)'s
own definition: `x-amz-date` is inside the string-to-sign, and AWS refuses a stamp more than
~5 minutes out with `RequestTimeTooSkewed`. It decides whether the call is accepted, so it
belongs on the same seam that already drives retry, throttle, timeout, circuit and OAuth2 token
freshness.

## The fix — core's pattern, mirrored exactly

#664 landed `clock?: Clock` on `AuthContext`, threaded by the engine from the same place
`Runtime.clock` comes from. That is the seam this uses. `packages/core/src/auth.ts:432` consumes
it as:

```ts
const clockNow = (ctx: AuthContext): number => ctx.clock?.now() ?? now();
```

This package now carries the identical helper (`now()` is core-internal, and core's
`now = () => Date.now()`, so the companion inlines that one call rather than spending a core
export on it):

```ts
const clockNow = (ctx: AuthContext): number => ctx.clock?.now() ?? Date.now();
```

The whole behavioural change is one line — `amzDateOf(new Date())` →
`amzDateOf(new Date(clockNow(ctx)))`. `ctx` was already in scope. The optional field plus the
fallback means a hand-built `AuthContext` in a custom strategy's unit test still type-checks.
`AuthContext` is imported as a **type**, from the `stitchapi` peer that is already required — no
new dependency, no structural copy of the type (the same reasoning the package's `Secret`
re-export already documents).

## The real-time wire output is unchanged

This is a testability fix, not a wire fix. The engine threads `systemClock` unless a clock was
injected, and `systemClock.now()` **is** `Date.now()`. Two tests pin it:

1. **Byte-identical, proven without a race.** Sign a request on the wall clock (no `ctx.clock`),
   read back the instant it actually stamped, then re-sign the identical request on a clock
   pinned to that instant. `x-amz-date`, `x-amz-content-sha256` and the full `Authorization`
   header must match exactly. This test **passes both before and after** the change — that is
   the point of it.
2. **A golden signature** at a fixed instant. The literal is not "whatever the code emits": it
   was cross-checked against an independent SigV4 implementation written from the AWS spec
   against `node:crypto`, which first reproduces the official `aws-sig-v4-test-suite`
   `get-vanilla` vector (`5fa00fa3…`) to prove the oracle itself, then produces
   `726c5c4879a6b4ccbbd3b24edbd6b8826d34f87450fbbf4e85546fc7ba9c1642` for the header set the
   strategy attaches. The package agrees.

Payload hashing is untouched, and the `signBody` branches from #401 — including
**multipart + `signBody: true` still throwing** — are unchanged and still covered.

## The failing test

Written first, and **confirmed failing against unmodified `src`**: `5 failed | 18 passed`. The
five that failed were the clock assertions; the byte-identical wire pin was among the 18 that
passed, as it must be. After the one-line fix: **23 passed**.

Coverage added, in `packages/aws-sigv4/test/sigv4.spec.ts`:

- 600 virtual seconds moves the stamp exactly 600 seconds (the issue's own measurement).
- A default `manualClock()` signs `19700101T000000Z` — the ~20,670-day skew becomes something
  a test can *see and assert* rather than something it silently suffers.
- The **signature itself** changes with the clock, and so does the credential scope date — proof
  the stamp is inside the signed canonical request, not cosmetic.
- The two wire-unchanged pins above.
- **End-to-end through the public API**: a `stitch()` with `clock: manualClock(...)` and
  `mockAdapter`, asserting the `x-amz-date` the *transport actually receives*, then
  `clock.advance(600_000)` and asserting it moved ten virtual minutes. This is the seam the
  issue asked for, exercised the way a user would.

## Bundle size — nothing moved

`git diff origin/main -- packages/core` is **empty**. Not one byte was spent in core; the
`AuthContext.clock` field this needs already existed.

| scenario                        | min+gzip  | budget    | headroom       |
| ------------------------------- | --------- | --------- | -------------- |
| `stitchapi` — whole entry       | 24,628 B  | 24,678 B  | 50 B  ✓        |
| `import { stitch }`             | 21,982 B  | 22,016 B  | **34 B**  ✓    |
| `stitchapi/auth` — whole surface| 5,309 B   | 5,478 B   | 169 B  ✓       |

Identical to `main` — same inputs, since core is untouched. `@stitchapi/aws-sigv4` is a
companion and is not part of core's gated entry. The `bundle-advertised-size` drift tether is
in sync (the pre-push `yakir` run reports 9 tethers, 0 drift).

## Docs — §2's second clause

§2's second ask was to *"audit which time-driven features read the injected clock and which read
`Date.now()`, and state the answer in the testing guide."* **#664 already built that table**, so
this PR does the remaining concrete thing: moves the SigV4 row from wall-clock to **virtual**.

The callout below the table still reads "the four core wall-clock rows" and is now *more*
accurate — before this there were five wall-clock rows, four of them core.

Also added: a **Signing time** section on the aws-sigv4 integration page with the `manualClock`
example, and a note (in both places) that an unseeded `manualClock()` signs `19700101T000000Z`,
which a real endpoint answers with `RequestTimeTooSkewed` — the same epoch-`0` trap the guide
already documents for HTTP-date `Retry-After`.

## One non-drive-by cleanup, called out

The new test context has the same no-op `emit` shape as the existing `fakeCtx`, which trips
`@typescript-eslint/no-empty-function` — a rule this package had **baselined** at `count: 1`.
Rather than raise the baseline, both contexts now share one non-empty no-op (`(): void => undefined`)
and the suppression is **dropped** via `--prune-suppressions`. The baseline file shrinks by 5
lines; nothing was added to it. (Per #646, this package is now linted.)

## What remains open on #658

- **§1 — `hooks.onRequest` runs after signing.** Not touched. Its ask is a docs line *plus* a
  "Better:" proposal to emit an `info` when an `onRequest` hook exceeds some duration threshold
  on an `auth`-carrying stitch. The threshold and whether to spend the bytes are maintainer calls.
- **§3 — a skew 403 counts as a circuit failure.** Not touched. Its ask is an explicit either/or
  (a "client fault, don't count it" marker vs. documenting the exclusion), and it is entangled
  with the absent-flag rule in `Surface.interpret` that the issue tracks across three sightings.
- **§4 — smaller findings.** Read, none actioned, none of them trivial-and-design-free:
  - *`refresh` cannot see the response that triggered it* — a **public API change** to
    `AuthStrategy.refresh`'s signature. Out of scope by the "no half-baked API change" bar.
  - *A breaker does not shed a burst already queued behind a throttle* — the issue itself calls
    it "defensible, and worth documenting". A core-engine docs claim, unrelated to this package;
    landing it here would be a drive-by.
  - *`backoff.max` defaults to 10 s* — explicitly framed as the **fourth** silent-clamp in the
    pass, i.e. a pattern-level design decision, not a point fix.
  - *A skew 403 is not retried by default* — the issue states this is **correct behaviour and
    worth keeping**. Nothing to do.

## Verification

All from the repo root, all passing: `check:lint` (36 packages), `check:types`, `test`
(1,477 core + 23 sigv4, whole workspace green), `check:format`, `check:contract`,
`check:unknown-keys`, `check:types-d`, `check:size`, `check:changelog`, `check:docs-links`,
`check:exports:companions`, `check:exports`. The pre-push hook's full verify sequence also ran
clean, including `build-docs` and the `yakir` tethers.

Refs #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)
