### PR TITLE
feat(contract): R6 resolves one level of `type` alias (Refs #564)

### DIFF
--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -1160,7 +1160,13 @@ shape, not as today's surface: nothing on the surface carries an alias.
   identical-by-design host envelopes; **R6** a consumer-input slot — top-level, nested,
   or **inherited** — with an all-optional bag in **any arm** of its union, so `{}`
   type-checks (P20); the bag is resolved across files within a package and against
-  core's, and through `extends` including a non-exported base;
+  core's, through `extends` including a non-exported base, and through **one level** of
+  `type` alias (`type X = A | Bag` makes `X` admit `{}`) — one level and against
+  interfaces only, so an alias naming another alias does not chain. What it still cannot
+  see is a bag reached through an alias in a container **outside** the `*Options` +
+  blessed `*Config` family: `MockRoute.respond: MockResponder` resolves the alias now but
+  `MockRoute` is not an `*Options`, so it stays under-flagged (#564) — widening that
+  filter is the 23-findings/20-noise experiment the family exists to prevent;
   **R7** a `@deprecated` JSDoc **tag** on a published surface (at tag position inside
   a block comment — prose that merely names the marker is documentation, not a shim) —
   the surface is shim-free since the sweep, so a post-GA deprecation alias (mandated by

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -34,12 +34,22 @@
 // not source text. The parse is pinned behaviourally instead, by tests that assert an elapsed
 // floor and fail in milliseconds without it (`sse-reconnect.spec.ts`, `interpret-in-loop.spec.ts`).
 //
+// R6 also resolves ONE level of `type` ALIAS (#564 item 1): `type X = A | B` marks `X` as
+// admitting `{}` when a bare-identifier arm is a known all-optional INTERFACE. One level only,
+// and against interfaces only — an arm naming another alias does not resolve, so the pass is
+// bounded and cannot chain. Arms are filtered by the same `unionArms()` the member check uses,
+// so `AtLeastOne<Bag>` and `Bag[]` are not arms and the prescribed fix clears the finding by
+// construction. Generic aliases (`type X<T> = …`) are skipped: whether they admit `{}` depends
+// on the argument, which is the type-aware phase's problem.
+//
 // Still deferred to a type-aware phase (needs the TS checker): shape-diffing (full P9 —
 // R5's watch list is the by-name proxy), default-value inversion (P8), cross-PACKAGE parity
-// of the same capability (P16), and resolving a `type` ALIAS whose union admits an
-// all-optional bag (so `MockRoute.respond: MockResponder` is under-flagged — an alias is not
-// an interface block; the same blind spot puts `SurfaceOutcome.after`, a union member, out of
-// R9's reach). Under-flagging is deliberate: a ratchet that guesses is a ratchet nobody trusts.
+// of the same capability (P16), and the CONTAINER half of the alias gap — R6 scans only the
+// `*Options` + blessed `*Config` family, so `MockRoute.respond: MockResponder` stays
+// under-flagged even now that the alias resolves, because `MockRoute` is not an `*Options`
+// (#564 item 2: widen the filter and take the noise, or rename the type). The same blind spot
+// puts `SurfaceOutcome.after`, a union member, out of R9's reach.
+// Under-flagging is deliberate: a ratchet that guesses is a ratchet nobody trusts.
 import {
     existsSync,
     readFileSync,
@@ -130,6 +140,51 @@ function interfaceBlocks(src, { includeLocal = false } = {}) {
         });
     }
     return blocks;
+}
+
+// The arms of a union type that are BARE type identifiers — `A | B[] | ((c) => D)` yields
+// `[A]`. Shared by R6's member check and the alias pre-pass so the two can never drift.
+//
+// Bare-only is the precision guarantee, not a shortcut. `AtLeastOne<Bag>` is not an arm, so
+// the fix R6 prescribes clears its own finding; `Bag[]` is not an arm, because an array does
+// not accept `{}`. It also makes the naive `split('|')` safe: any nesting (`(A | Bag)`,
+// `{ a?: A | Bag }`, `Map<K, A | Bag>`) leaves a bracket or paren welded to the token, so a
+// `|` that was never a top-level separator cannot yield a bare identifier.
+const unionArms = (type) =>
+    type
+        .split('|')
+        .map((a) => a.trim())
+        .filter((a) => /^[A-Z]\w*$/.test(a));
+
+// Top-level `type X = …;` aliases in a file, with their right-hand side. NON-generic only:
+// the `=` must follow the name directly, so `type X<T> = …` is skipped (see the header).
+//
+// The RHS runs to the first `;` at depth 0, counting only braces/parens/brackets — NOT angle
+// brackets, whose `>` also closes an arrow (`=> string`) and would end the type early, the
+// same convention depthAt() uses. A missing semicolon (ASI) would otherwise run to EOF and
+// swallow the next declaration's body, where a stray `| Bag` would read as an arm of THIS
+// alias — so the scan also stops at the next top-level declaration.
+function typeAliases(src) {
+    const out = [];
+    const re = /(?:^|\n)\s*(?:export\s+)?type\s+([A-Za-z_]\w*)\s*=\s*/g;
+    const NEXT_DECL =
+        /^\n[ \t]*(?:export|interface|type|class|const|let|function|declare|abstract|enum|\/\*)/;
+    let m;
+    while ((m = re.exec(src))) {
+        let depth = 0;
+        let j = re.lastIndex;
+        for (; j < src.length; j++) {
+            const ch = src[j];
+            if (ch === '{' || ch === '(' || ch === '[') depth++;
+            else if (ch === '}' || ch === ')' || ch === ']') depth--;
+            else if (depth === 0) {
+                if (ch === ';') break;
+                if (ch === '\n' && NEXT_DECL.test(src.slice(j, j + 24))) break;
+            }
+        }
+        out.push({ name: m[1], rhs: src.slice(re.lastIndex, j).trim() });
+    }
+    return out;
 }
 
 // True when the declaration at `idx` is immediately preceded by a JSDoc block carrying
@@ -500,21 +555,54 @@ function collect() {
     // packages declaring the same name is itself a P9 finding (R5), not this rule's problem.
     const allOptionalByPkg = new Map(); // dir -> Set(interface name)
     const ifaceByPkg = new Map(); // dir -> Map(name -> block, incl. non-exported bases)
+    const aliasByPkg = new Map(); // dir -> [{ name, rhs }] (non-generic `type X = …`)
     for (const { dir } of packages) {
         const names = new Set();
         const byName = new Map();
+        const aliases = [];
         for (const file of tsFiles(join(PKGS, dir, 'src'))) {
             const src = readFileSync(file, 'utf8');
             for (const blk of interfaceBlocks(src, { includeLocal: true })) {
                 if (isAllOptional(blk.body)) names.add(blk.name);
                 byName.set(blk.name, { ...blk, file, src });
             }
+            aliases.push(...typeAliases(src));
         }
         allOptionalByPkg.set(dir, names);
         ifaceByPkg.set(dir, byName);
+        aliasByPkg.set(dir, aliases);
     }
+
+    // ALIAS PASS (#564 item 1) — one level, interfaces only. `type X = A | Bag` makes `X`
+    // admit `{}` just as surely as the bag itself does, but an alias is not an interface
+    // block, so the pre-pass above cannot see it.
+    //
+    // The candidate set is SNAPSHOTTED from the interface pass before any alias is added, and
+    // core's snapshot is a copy. That is what bounds this to one level: an arm naming another
+    // alias is never in the snapshot, so aliases cannot chain, in either resolution order.
+    // Anything deeper is the type-aware phase's job.
+    const aliasBagByPkg = new Map(); // dir -> Map(alias name -> the bag it resolves through)
+    {
+        const coreIfaceOnly = new Set(allOptionalByPkg.get('core') ?? []);
+        for (const { dir } of packages) {
+            const resolvable = new Set([
+                ...(allOptionalByPkg.get(dir) ?? []),
+                ...coreIfaceOnly,
+            ]);
+            const bags = new Map();
+            for (const { name, rhs } of aliasByPkg.get(dir) ?? []) {
+                const bag = unionArms(rhs).find((a) => resolvable.has(a));
+                if (!bag) continue;
+                bags.set(name, bag);
+                allOptionalByPkg.get(dir)?.add(name);
+            }
+            aliasBagByPkg.set(dir, bags);
+        }
+    }
+
     const coreAllOptional = allOptionalByPkg.get('core') ?? new Set();
     const coreIfaces = ifaceByPkg.get('core') ?? new Map();
+    const coreAliasBags = aliasBagByPkg.get('core') ?? new Map();
 
     for (const { dir } of packages) {
         const srcRoot = join(PKGS, dir, 'src');
@@ -525,6 +613,12 @@ function collect() {
         const ifaces = new Map([
             ...coreIfaces,
             ...(ifaceByPkg.get(dir) ?? new Map()),
+        ]);
+        // Which of the names in `allOptional` got there through an alias, and the bag each
+        // resolves through — the fix goes on the bag ARM inside the alias, not on the alias.
+        const aliasBags = new Map([
+            ...coreAliasBags,
+            ...(aliasBagByPkg.get(dir) ?? new Map()),
         ]);
         // An envelope plus every interface it extends, transitively — the members a consumer
         // can actually write at that slot. `seen` guards a cyclic `extends`.
@@ -695,10 +789,11 @@ function collect() {
             // ANY arm of its union. The old check only matched a bare `X` or a leading
             // `boolean | X`, which is not what makes `{}` legal — one assignable arm is, in
             // any position. That blind spot hid `delta?: DeltaShaper | DeltaFrameOptions`
-            // (function first), `errorHandler?: StitchErrorOptions | false` (bag first,
-            // non-boolean second), and `respond?: MockResponder` on a non-`*Options` bag.
-            // `AtLeastOne<X>` is never an all-optional interface name, so the canonical fix
-            // clears the finding by construction.
+            // (function first) and `errorHandler?: StitchErrorOptions | false` (bag first,
+            // non-boolean second). The bag may now also be reached through one level of `type`
+            // alias (#564 item 1) — resolved in the alias pass above, reported against the bag
+            // the alias unions in. `AtLeastOne<X>` is never an all-optional interface name and
+            // is never a bare arm, so the canonical fix clears the finding by construction.
             for (const blk of blocks) {
                 // Only CONSUMER-INPUT envelopes — P20 governs what a caller authors, not what
                 // the engine hands back. P3 already draws that line, so reuse it: `*Options`
@@ -720,11 +815,9 @@ function collect() {
                     while ((m6 = mre.exec(owner.body))) {
                         // Arms of the union, minus generic payloads — `AtLeastOne<Foo>` must not
                         // read as bare `Foo`, or the prescribed fix would flag itself.
-                        const arms = m6[2]
-                            .split('|')
-                            .map((a) => a.trim())
-                            .filter((a) => /^[A-Z]\w*$/.test(a));
-                        const bag = arms.find((a) => allOptional.has(a));
+                        const bag = unionArms(m6[2]).find((a) =>
+                            allOptional.has(a),
+                        );
                         if (!bag) continue;
                         const at = owner.bodyStart + m6.index;
                         if (deprecatedBefore(owner.src ?? src, at)) continue;
@@ -735,11 +828,17 @@ function collect() {
                         const site = `${owner.file ?? file}|${at}`;
                         if (seenR6.has(site)) continue;
                         seenR6.add(site);
+                        // Through an alias, the edit belongs on the bag ARM inside the alias
+                        // (`type R = AtLeastOne<Bag> | …`), not on the alias name — wrapping a
+                        // union that also carries a function arm would be nonsense.
+                        const via = aliasBags.get(bag);
                         add(
                             'R6',
                             owner.file ?? file,
                             `${owner.name}.${m6[1]}`,
-                            `all-optional ${bag} in the union — {} type-checks → AtLeastOne<${bag}> (P20)`,
+                            via
+                                ? `all-optional ${via} via alias ${bag} — {} type-checks → AtLeastOne<${via}> inside ${bag} (P20)`
+                                : `all-optional ${bag} in the union — {} type-checks → AtLeastOne<${bag}> (P20)`,
                             lineOf(owner.src ?? src, at),
                         );
                     }

--- a/scripts/check-contract.mjs
+++ b/scripts/check-contract.mjs
@@ -167,8 +167,10 @@ const unionArms = (type) =>
 function typeAliases(src) {
     const out = [];
     const re = /(?:^|\n)\s*(?:export\s+)?type\s+([A-Za-z_]\w*)\s*=\s*/g;
+    // \b matters: without it the `type` alternative also matches the `type` in a `typeof Foo`
+    // arm sitting at the start of a continuation line, ending the RHS one line early.
     const NEXT_DECL =
-        /^\n[ \t]*(?:export|interface|type|class|const|let|function|declare|abstract|enum|\/\*)/;
+        /^\n[ \t]*(?:(?:export|interface|type|class|const|let|function|declare|abstract|enum)\b|\/\*)/;
     let m;
     while ((m = re.exec(src))) {
         let depth = 0;


### PR DESCRIPTION
Implements **item 1 only** of #564: R6 now resolves one level of `type` alias. Item 2 (the container filter) is untouched, which is why this is `Refs`, not `Closes`.

## What alias resolution now handles

R6 finds the all-optional bag that makes `{}` legal **by interface name**, so a bag reached through a `type` alias was invisible — an alias is not an interface block. `type X = A | Bag` admits `{}` exactly as surely as `Bag` does.

The pre-pass now parses non-generic `type X = …;` and marks `X` all-optional when a **bare-identifier arm** names a known all-optional interface.

**Bounded by construction.** The candidate set is snapshotted from the interface pass *before* any alias is added (core's is copied), so an arm naming another alias is never in it. Aliases cannot chain, in either resolution order. One level, against interfaces only — anything deeper is the deferred type-aware phase. Generic aliases (`type X<T> = …`) are skipped: whether they admit `{}` depends on the argument.

**Arms come from a new shared `unionArms()`**, extracted from R6's member check so the two can never drift. Bare-only is the precision guarantee, not a shortcut:

- `AtLeastOne<Bag>` is not an arm → the fix R6 prescribes clears its own finding.
- `Bag[]` is not an arm → an array does not accept `{}`.
- It makes the naive `split('|')` safe: any nesting (`(A | Bag)`, `{ a?: A | Bag }`, `Map<K, A | Bag>`) leaves a bracket welded to the token, so a `|` that was never a top-level separator cannot yield a bare identifier.

A finding reached through an alias names the **bag**, not the alias — the edit goes on the arm inside the alias, since wrapping a union that also carries a function arm would be nonsense:

```
MockAdapterOptions.respond — all-optional MockResponse via alias MockResponder
  — {} type-checks → AtLeastOne<MockResponse> inside MockResponder (P20)
```

## Ratchet findings diff: what this newly catches

**Nothing, today. Stated plainly: this is a latent guard, not a fix.**

| | findings |
|---|---|
| `--list` before | **0** |
| `--list` after | **0** |

Four aliases newly resolve — `type StreamStitchSseOptions = SseEmitOptions` in elysia, fastify, hono and nest. **None produces a finding**, because none is used as an interface member: every one appears only as a function parameter (`options: StreamStitchSseOptions = {}`), which R6 does not scan.

The shape this guards against is real and this repo *had* it: before #573, `MockResponder`'s single-reply arm was a bare all-optional `MockResponse`. That specific violation was fixed at the source, so the alias now reads `AtLeastOne<MockResponse> | MockResponse[] | ((call) => …)` and correctly does not resolve.

**Is it worth landing on those terms?** I think yes, narrowly — it closes a documented blind spot at genuinely zero noise cost, and it is the *smaller* half of #564, so landing it isolates the remaining decision to the one that actually needs a judgment call (item 2). But it should be read as a guard against a shape the codebase does not currently have, not as a bug fix.

## Why `MockRoute.respond` is still missed

For the **second, independent** reason #564 names: `MockRoute` is not `*Options`, and R6 deliberately scans only the consumer-input envelope family (`*Options` + the blessed `*Config` types). Alias resolution gets the bag; the container filter still rejects the container.

This is confirmed empirically below, not just argued: four of the historical trees tested carry `MockResponder` in its pre-#573 vulnerable shape, and the patched script reports **no new finding** on any of them.

**Item 2** is the explicit either/or: widen R6's container filter — scanning every exported interface previously gave 23 findings, 20 of them noise (resolved views, spec mirrors, `*Like` duck-types) — or rename `MockRoute`. That is a contract decision, so it stays out of this PR.

## Verification

There is no test harness for `check-contract.mjs`, so I verified two ways.

**1. Fixture matrix** — each variant written into `packages/core/src/test-mock.ts`, `--list` run, file restored. The alias is put on `MockAdapterOptions` (a real `*Options`) rather than `MockRoute`, precisely because `MockRoute` is out of scope here.

| fixture | before | after |
|---|---|---|
| A. repo as-is | 0 | 0 |
| B. pre-#573 alias + alias-typed `*Options` member | **0 — MISSED** | **1 — CAUGHT** |
| C. `AtLeastOne` alias + same member | 0 | 0 (fix clears it) |
| D. direct bag member (positive control) | 1 | 1 — *identical text* |
| E. alias-of-alias, two hops | 0 | 0 (one level only) |

B is the gap closing. D proves the pre-existing path is untouched. E proves the bound holds.

**2. Existing behavior unchanged — proven against history.** A 0→0 diff on a clean tree cannot show that previously-caught violations are still caught, so I ran the original and patched scripts over **13 historical trees** and diffed the full findings list. **Every one is byte-identical**, including:

| tree | findings | R6 | diff |
|---|---|---|---|
| `9ca6a1b` | 68 | 19 | identical |
| `79761ce` | 61 | 19 | identical |
| `2e4b4b6` | 60 | 18 | identical |
| `11ac432` | 33 | 18 | identical |
| `a8eca88` | 6 | 4 | identical |

`a8eca88` carries the four real P20 slots the #556 widening was written for; all four still report, unchanged. No finding lost, none added, no baseline touched — `scripts/contract-violations.baseline.json` stays at zero and is not modified by this PR.

**3. Full suite** — all green: `check:contract`, `check:lint` (36 packages), `check:types` (38 projects), `check:types-d`, `test` (exit 0), `check:format`, `check:unknown-keys`, `check:changelog`, `check:docs-links`, `check:size`.

`check:size` is unmoved, as expected for a `scripts/` change: `import { stitch }` still reports 0.03 KB left, identical to `main`. Nothing was added to `packages/core`.

## Second commit

`fix(contract): word-boundary the alias RHS declaration guard` — the guard that stops the RHS at the next top-level declaration matched keyword *prefixes*, so its `type` alternative also matched the `type` inside a `typeof Foo` arm at the start of a continuation line, ending the RHS one line early. Only reachable for an alias whose continuation line leads with `typeof`, and it fails toward under-flagging, but a high-precision rule should parse what it claims to. Nothing in the tree hits it: every number above was re-measured after the fix and is unchanged.

## Scope

`scripts/check-contract.mjs` (the rule) and one clause in `docs/CONTRACT.md` — the R6 bullet enumerates exactly which resolutions the rule performs, so leaving it stale would have been a defect. No CHANGELOG entry: this is tooling, not library behavior, matching the precedent of #556 and #528, which also changed this script without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
