### PR TITLE
docs(recipes): cancel an in-flight call — the AbortSignal recipe

### DIFF
--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -191,6 +191,13 @@ export const pages: Page[] = [
         kind: 'guide',
     },
     {
+        path: 'recipes/cancel-an-in-flight-call',
+        title: 'Cancel an in-flight call',
+        description:
+            'Pass an AbortSignal in the call input — aborting severs the request and stops retries, waits, and pagination with it.',
+        kind: 'guide',
+    },
+    {
         path: 'recipes/idempotent-writes',
         title: 'Retry a write without double-charging',
         description:

--- a/apps/docs/content/docs/recipes/cancel-an-in-flight-call.mdx
+++ b/apps/docs/content/docs/recipes/cancel-an-in-flight-call.mdx
@@ -1,0 +1,76 @@
+---
+title: 'Cancel an in-flight call'
+description: 'Pass an AbortSignal in the call input — aborting severs the request and stops retries, waits, and pagination with it.'
+prerequisites: ['/docs/concepts/the-stitch', '/docs/getting-started/quickstart']
+---
+
+## Task
+
+The user typed a new search, closed the dialog, or navigated away — and the call
+you started for them is still running. You want the stale call actually
+cancelled: connection dropped, retries stopped, rate-limit slot released. Not
+ignored while it quietly burns all three.
+
+## Example
+
+One way: hand the call an `AbortController`'s signal, and abort the old call
+before starting the next one.
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+
+const search = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/search',
+    retry: { attempts: 3, on: [429, 503], backoff: 'expo-jitter' },
+});
+
+let inFlight: AbortController | undefined;
+
+async function onKeystroke(q: string) {
+    inFlight?.abort(); // drop the stale call — request and retries both stop
+    const controller = new AbortController();
+    inFlight = controller;
+    try {
+        return await search({ query: { q }, signal: controller.signal });
+    } catch (err) {
+        if (controller.signal.aborted) return undefined; // cancelled on purpose — not a failure
+        throw err;
+    }
+}
+```
+
+## How it works
+
+There is no cancel callback to register — cancellation is the platform's own
+primitive, threaded through every layer you declared. `signal` rides the call
+input next to `params` and `body`, and the stitch mirrors it onto each attempt's
+transport, linked with the [per-attempt timeout](/docs/guides/resilience/timeout).
+`abort()` severs the in-flight request itself — the connection closes; the
+response is not silently discarded. The same abort cuts every wait around the
+request: a [retry](/docs/guides/resilience/retry)'s backoff sleep and a
+throttle's rate-spacing pause reject promptly, and on a
+[paginated call](/docs/recipes/paginate-into-one-array) the signal carries onto
+every follow-up page, so the loop stops wherever it is.
+
+The cancelled call settles with a rejection. To tell a deliberate cancel from a
+real failure, check your own `controller.signal.aborted` in the catch — it is
+unambiguous and does not depend on the error's shape. Keep the two tools
+distinct: a deadline you can declare (`timeout`) belongs on the stitch, so
+reach for `signal` only for caller-driven cancellation — a user gesture, a
+component unmounting, a shutdown. The framework hooks are built on this same
+signal: [React's](/docs/integrations/react) `useStitch` returns an imperative
+`cancel()`, and [Angular's](/docs/integrations/angular) `injectStitch` aborts
+the in-flight run on its own when the input changes.
+
+## See also
+
+<Cards>
+    <Card title="Timeout" href="/docs/guides/resilience/timeout" />
+    <Card
+        title="Loop a cursor API into one array"
+        href="/docs/recipes/paginate-into-one-array"
+    />
+    <Card title="React" href="/docs/integrations/react" />
+    <Card title="Angular" href="/docs/integrations/angular" />
+</Cards>

--- a/apps/docs/content/docs/recipes/index.mdx
+++ b/apps/docs/content/docs/recipes/index.mdx
@@ -40,6 +40,11 @@ a guide when you want to understand a feature on its own.
         description="Compose timeout, retry, and a circuit breaker so a degraded upstream fails fast instead of hanging."
     />
     <Card
+        title="Cancel an in-flight call"
+        href="/docs/recipes/cancel-an-in-flight-call"
+        description="Pass an AbortSignal in the call input — aborting severs the request and stops retries, waits, and pagination with it."
+    />
+    <Card
         title="Retry a write without double-charging"
         href="/docs/recipes/idempotent-writes"
         description="Attach an idempotency key so a retried POST settles once, not twice."

--- a/apps/docs/content/docs/recipes/meta.json
+++ b/apps/docs/content/docs/recipes/meta.json
@@ -7,6 +7,7 @@
         "paginate-into-one-array",
         "make-a-flaky-call-succeed",
         "survive-a-flaky-dependency",
+        "cancel-an-in-flight-call",
         "idempotent-writes",
         "catch-a-breaking-api-change",
         "catch-a-selector-rename",


### PR DESCRIPTION
## What

Adds a recipe page answering "is there a cancel callback?": [**Cancel an in-flight call**](https://stitchapi.dev/docs/recipes/cancel-an-in-flight-call) — pass an `AbortSignal` in the call input; aborting severs the request and stops retries, waits, and pagination with it.

- `apps/docs/content/docs/recipes/cancel-an-in-flight-call.mdx` — Task / Example / How it works / See also, matching the house recipe structure. The example is abort-before-restart (search-as-you-type) with the `controller.signal.aborted` check in the catch.
- Registered in `content.manifest.ts` (IA source of truth); `meta.json` regenerated via `gen:docs`; card added to the "Stay resilient" section of the recipes index.

## Why

Cancellation was only documented sideways — via the timeout guide and the framework integration pages — so the natural question "do you expose a cancel callback?" had no page to land on. The recipe states the position directly: no callback to register; cancellation is the platform's own primitive, threaded through every layer a stitch declares (per-attempt transport + timeout link, retry backoff, throttle waits, pagination follow-ups — `packages/core/src/engine.ts`), with React's `cancel()` and Angular's auto-abort built on the same signal.

## Notes for review

- The recipe deliberately keys "was this cancelled?" off `signal.aborted` rather than the rejection's identity: today a caller's custom `abort(reason)` is swallowed on the retry-backoff path (`systemClock.sleep` rejects with a generic `Error('aborted')`), and a cancelled call can emit a phantom `retry` event. Engine-side fix tracked separately; the recipe's guidance stays correct either way.
- Verified: the twoslash block type-checks against the real `stitchapi` types (same compiler options as the drafts gate); `content-manifest`, `prerequisites`, and `doc-path` suites pass; `gen:docs` is byte-idempotent over the new `meta.json`; page renders clean in `next dev` (title, prerequisites callout, cards, prev/next slotting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)