### PR TITLE
fix(core): an abort surfaces the caller's reason; a cancel is never a retry

### DIFF
--- a/packages/core/scripts/bundle-size.mjs
+++ b/packages/core/scripts/bundle-size.mjs
@@ -300,13 +300,36 @@ const KB = 1024;
 // home-page metrics component, and the docs' source blurb — propagated by hand and verified with
 // the tether. (The core README's "~21 kB brotli" moves with them and is more accurate for it: the
 // whole entry's brotli is 21.6 KB, which rounds to 22, not 21.)
+// `stitchapi — whole entry` raised for the abort-reason fix — #674 (24.10→24.15 KB; measured
+// 24.10 = 24681 B against a `main` at 24677 B, so the fix is +4 B). A caller's `abort(reason)`
+// came back as a minted `Error('aborted')` whenever the abort landed in a retry-backoff sleep,
+// and a mid-flight abort still emitted a `retry` progress event (and fired onRetry) before dying
+// there — a phantom retry for a deliberately cancelled call. The bytes are the attempt-loop
+// guard that rethrows on an aborted caller signal instead of entering the retry path.
+//
+// The reason-preserving rejection itself is minified-SMALLER (−102 B on the entry, −98 B on
+// `import { stitch }`): `sleep`, the engine's abort paths and `withTimeout`'s link now share one
+// `abortReason` where each carried a private copy. gzip still charges for the dedup (+14 B on
+// `import { stitch }`) — the deleted copies were near-free backreferences — but collapsing three
+// hand-copies, one of which had already drifted, IS the fix, so the dedup stays.
+//
+// It cannot move behind a subpath: this is `sleep` and the attempt loop — the resilience chain
+// `stitch()` IS — on the core path by construction.
+//
+// A MINIMUM step again, the #676 shape (matching #477/#524/#485): a fix squeezing past a ceiling
+// `main` had run down to 1.4 B of, not a new capability. Headroom lands at 49 B. `import
+// { stitch }` is NOT raised — it measures 22053 B against its 22067 B budget and still fits, with
+// 14 B to spare, so the next core-path byte trips that one and sizing its step stays the
+// maintainer's call. The advertised rounded kB are UNCHANGED (24 / 22, and the entry's 21.64 KB
+// brotli still rounds to the ~22 the core README quotes), verified with the
+// `bundle-advertised-size` tether rather than assumed.
 // `advertised: true` means the READMEs/docs quote this scenario's rounded gzip kB — see the
 // `--json` note below for why that flag, not the row's presence, drives the drift tether.
 const SCENARIOS = [
     {
         name: 'stitchapi — whole entry',
         code: `export * from './index.mjs';`,
-        budget: 24.1 * KB,
+        budget: 24.15 * KB,
         advertised: true,
     },
     {

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -40,6 +40,7 @@ import type {
 } from './types';
 import { StitchError } from './types';
 import {
+    abortReason,
     appendQueryString,
     buildQuery,
     expandPath,
@@ -565,15 +566,6 @@ async function acquireWithin(
     }
 }
 
-// The Error to reject with when a caller's signal is already/just aborted — its own `reason` when
-// that is an Error (the default AbortError, or a caller-supplied one), else a generic abort Error.
-function abortReason(signal: AbortSignal): Error {
-    const reason: unknown = signal.reason;
-    return reason instanceof Error
-        ? reason
-        : new Error('the operation was aborted');
-}
-
 // Materialize a streaming-path error body for StitchError.body. A streaming adapter hands back the
 // live `ReadableStream` unparsed (so it can be decoded into deltas); on the error branch the stream
 // is never decoded, so read it to text and best-effort JSON-parse it — the same shape the buffered
@@ -701,6 +693,9 @@ async function* attemptLoop(
                     attempt,
                     error: err,
                 });
+                // A caller's abort is a deliberate cancel, not a failed attempt to try again: no
+                // `retry` event, no onRetry, no backoff — the run ends here with the abort error.
+                if (baseReq.signal?.aborted) throw err;
                 if (attempt < max) {
                     yield {
                         type: 'progress',

--- a/packages/core/src/resilience.ts
+++ b/packages/core/src/resilience.ts
@@ -16,7 +16,7 @@ import type {
 // extends `StitchError` per CONTRACT.md P10. `types.ts` imports nothing at runtime — its own
 // imports are all type-only — so this edge adds no cycle.
 import { StitchError } from './types';
-import { parseDuration, parseRate, systemClock } from './util';
+import { abortReason, parseDuration, parseRate, systemClock } from './util';
 
 export class TimeoutError extends Error {}
 
@@ -193,15 +193,6 @@ export function createThrottle(
 /** Internal: keys the non-enumerable per-key state Map probe used by the resource-leak suite. */
 export const THROTTLE_STATES = Symbol('stitch.throttle.states');
 
-// The Error to reject with when a linked signal is already aborted — its own `reason` when that is
-// an Error (the default AbortError, or a caller-supplied one), else a generic abort Error.
-function abortError(signal: AbortSignal): Error {
-    const reason: unknown = signal.reason;
-    return reason instanceof Error
-        ? reason
-        : new Error('the operation was aborted');
-}
-
 /**
  * Run `fn` with an AbortSignal that aborts after `ms`. On timeout, reject with TimeoutError and
  * ensure the signal is aborted. If `ms` is undefined, just run `fn` with a non-aborting signal.
@@ -218,7 +209,7 @@ export function withTimeout<T>(
     const controller = new AbortController();
     let unlink: (() => void) | undefined;
     if (linkSignal) {
-        if (linkSignal.aborted) return Promise.reject(abortError(linkSignal));
+        if (linkSignal.aborted) return Promise.reject(abortReason(linkSignal));
         const onAbort = () => {
             controller.abort(linkSignal.reason);
         };

--- a/packages/core/src/test-clock.ts
+++ b/packages/core/src/test-clock.ts
@@ -3,6 +3,7 @@
 // resolve with zero real waiting — drive them with `advance(ms)`. (Per ADR 0010, `timeout.total`
 // and event `at`/`ms` timestamps stay on wall-clock.) Browser-safe: no `node:*`.
 import type { Clock, TimerHandle } from './types';
+import { abortReason } from './util';
 
 /** A {@link Clock} whose time only moves when you call {@link ManualClock.advance}. */
 export interface ManualClock extends Clock {
@@ -63,19 +64,25 @@ export function manualClock(start = 0): ManualClock {
         clearTimer: cancel,
         sleep: (ms, signal) =>
             new Promise<void>((resolve, reject) => {
+                // Reject with the signal's reason, exactly as `systemClock.sleep` does — a test
+                // that aborts with a custom reason must see it through the injected clock too.
                 if (signal?.aborted) {
-                    reject(new Error('aborted'));
+                    reject(abortReason(signal));
+                    return;
+                }
+                if (!signal) {
+                    schedule(resolve, ms);
                     return;
                 }
                 const onAbort = () => {
                     cancel(handle);
-                    reject(new Error('aborted'));
+                    reject(abortReason(signal));
                 };
                 const handle = schedule(() => {
-                    signal?.removeEventListener('abort', onAbort);
+                    signal.removeEventListener('abort', onAbort);
                     resolve();
                 }, ms);
-                signal?.addEventListener('abort', onAbort, { once: true });
+                signal.addEventListener('abort', onAbort, { once: true });
             }),
         async advance(ms: number): Promise<void> {
             const target = current + Math.max(0, ms);

--- a/packages/core/src/test-mock.ts
+++ b/packages/core/src/test-mock.ts
@@ -11,7 +11,7 @@ import type {
     AdapterResponse,
     AtLeastOne,
 } from './types';
-import { parseDuration } from './util';
+import { abortReason, parseDuration } from './util';
 
 /** One canned response. Omitted fields default sensibly (`status` 200, empty headers). */
 export interface MockResponse {
@@ -105,11 +105,12 @@ const matches = (req: AdapterRequest, m: MockMatch | undefined): boolean => {
 const at = <T>(arr: T[], i: number): T => arr[Math.min(i, arr.length - 1)] as T;
 
 // An abortable delay: rejects the moment `signal` aborts, so a stitch `timeout` (which aborts the
-// per-attempt signal) cancels a slow mock response exactly as it would a real socket.
+// per-attempt signal) cancels a slow mock response exactly as it would a real socket. Rejects with
+// the signal's reason — real `fetch` surfaces `signal.reason`, so a caller's custom abort must too.
 const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
     new Promise((resolve, reject) => {
         if (signal?.aborted) {
-            reject(new Error('aborted'));
+            reject(abortReason(signal));
             return;
         }
         const t = setTimeout(resolve, ms);
@@ -117,7 +118,7 @@ const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
             'abort',
             () => {
                 clearTimeout(t);
-                reject(new Error('aborted'));
+                reject(abortReason(signal));
             },
             { once: true },
         );
@@ -166,7 +167,7 @@ export function mockAdapter(
         // request — every real transport refuses it, and a cancellation test written against a
         // mock that answered was asserting the opposite of production. Nothing was sent, so the
         // spy records no call and the route's response sequence keeps its place.
-        if (req.signal?.aborted) throw new Error('aborted');
+        if (req.signal?.aborted) throw abortReason(req.signal);
         log.push(req);
         const idx = list.findIndex(
             (r) =>

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -36,20 +36,6 @@ export function newRunContext(parent?: {
     };
 }
 
-/**
- * The Error an aborted wait rejects with: the signal's own `reason` when that is an Error (the
- * default AbortError, or a caller-supplied `abort(reason)`), else a generic abort Error. The one
- * spelling of "which error does an abort surface?" — shared by {@link sleep}, the engine's abort
- * paths, and `withTimeout`'s signal link, so a caller's custom reason survives no matter where in
- * the resilience chain the abort lands.
- */
-export function abortReason(signal: AbortSignal): Error {
-    const reason: unknown = signal.reason;
-    return reason instanceof Error
-        ? reason
-        : new Error('the operation was aborted');
-}
-
 export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
     return new Promise((resolve, reject) => {
         if (signal?.aborted) {
@@ -66,6 +52,20 @@ export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
             { once: true },
         );
     });
+}
+
+/**
+ * The Error an aborted wait rejects with: the signal's own `reason` when that is an Error (the
+ * default AbortError, or a caller-supplied `abort(reason)`), else a generic abort Error. The one
+ * spelling of "which error does an abort surface?" — shared by {@link sleep}, the engine's abort
+ * paths, and `withTimeout`'s signal link, so a caller's custom reason survives no matter where in
+ * the resilience chain the abort lands.
+ */
+export function abortReason(signal: AbortSignal): Error {
+    const reason: unknown = signal.reason;
+    return reason instanceof Error
+        ? reason
+        : new Error('the operation was aborted');
 }
 
 /**

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -36,10 +36,24 @@ export function newRunContext(parent?: {
     };
 }
 
+/**
+ * The Error an aborted wait rejects with: the signal's own `reason` when that is an Error (the
+ * default AbortError, or a caller-supplied `abort(reason)`), else a generic abort Error. The one
+ * spelling of "which error does an abort surface?" — shared by {@link sleep}, the engine's abort
+ * paths, and `withTimeout`'s signal link, so a caller's custom reason survives no matter where in
+ * the resilience chain the abort lands.
+ */
+export function abortReason(signal: AbortSignal): Error {
+    const reason: unknown = signal.reason;
+    return reason instanceof Error
+        ? reason
+        : new Error('the operation was aborted');
+}
+
 export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
     return new Promise((resolve, reject) => {
         if (signal?.aborted) {
-            reject(new Error('aborted'));
+            reject(abortReason(signal));
             return;
         }
         const t = setTimeout(resolve, ms);
@@ -47,7 +61,7 @@ export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
             'abort',
             () => {
                 clearTimeout(t);
-                reject(new Error('aborted'));
+                reject(abortReason(signal));
             },
             { once: true },
         );

--- a/packages/core/test/abort-reason.spec.ts
+++ b/packages/core/test/abort-reason.spec.ts
@@ -1,0 +1,120 @@
+// A caller's abort must surface the caller's OWN error, and a deliberate cancel must never read
+// as a retry. Two engine guarantees pinned here, plus the clock primitive they rest on:
+//   • an abort DURING a retry backoff rejects with the signal's `reason` — `sleep` (systemClock
+//     and manualClock alike) rejects with the reason when it is an Error, so a custom
+//     `abort(reason)` (or the default AbortError) rides out of the engine instead of a generic
+//     `Error('aborted')` minted by the sleep;
+//   • an abort MID-FLIGHT ends the run at the attempt-loop catch: no `retry` progress event, no
+//     `onRetry` hook, no backoff — before the guard, a cancelled call emitted a phantom retry and
+//     only then died in the backoff sleep.
+import { stitch, systemClock } from '../src';
+import { manualClock, mockAdapter } from '../src/testing';
+import type { StitchEvent } from '../src/types';
+
+describe('abort during a retry backoff preserves the reason', () => {
+    test('a custom abort(reason) surfaces as the call error, not a generic abort', async () => {
+        const clock = manualClock();
+        const api = mockAdapter({
+            match: '/flaky',
+            respond: [{ status: 503 }, { body: { ok: true } }],
+        });
+        const ac = new AbortController();
+        const call = stitch({
+            baseUrl: 'https://api.test',
+            path: '/flaky',
+            adapter: api,
+            retry: {
+                attempts: 2,
+                on: [503],
+                backoff: { curve: 'fixed', base: 10_000 },
+            },
+            clock,
+        });
+
+        const p = call({ signal: ac.signal }).safe();
+        await clock.advance(0); // first attempt → 503 → the backoff sleep is armed
+        expect(api.callCount()).toBe(1);
+        expect(clock.pending()).toBe(1); // parked on the backoff
+
+        ac.abort(new Error('user closed the panel')); // mid-backoff, with a custom reason
+
+        const res = await p; // settles on the abort alone — no advance needed
+        expect(res.ok).toBe(false);
+        expect(res.error?.message).toBe('user closed the panel');
+        expect(api.callCount()).toBe(1); // the second attempt never ran
+        expect(clock.pending()).toBe(0); // the backoff timer was dropped, not leaked
+    });
+});
+
+describe('abort mid-flight is a cancel, not a retry', () => {
+    test('no retry event, no onRetry hook, and the reason still surfaces', async () => {
+        const api = mockAdapter({
+            match: '/slow',
+            // Long enough that only the abort can end the attempt; the delay is abortable, so the
+            // cancel cuts it short like a real socket.
+            respond: { body: { ok: true }, delay: 5_000 },
+        });
+        const ac = new AbortController();
+        const retried: unknown[] = [];
+        const call = stitch({
+            baseUrl: 'https://api.test',
+            path: '/slow',
+            adapter: api,
+            retry: { attempts: 3, on: [503], backoff: { base: 5 } },
+            hooks: {
+                onRetry: (ctx) => {
+                    retried.push(ctx);
+                },
+            },
+        });
+
+        const events: StitchEvent[] = [];
+        const drained = (async () => {
+            for await (const ev of call({ signal: ac.signal }).stream())
+                events.push(ev);
+        })();
+
+        // Let the attempt reach the transport, then cancel deliberately.
+        await new Promise((r) => setTimeout(r, 10));
+        expect(api.callCount()).toBe(1); // in flight
+        ac.abort(new Error('nevermind, user cancelled'));
+        await drained;
+
+        expect(
+            events.filter((e) => e.type === 'progress' && e.phase === 'retry'),
+        ).toHaveLength(0);
+        expect(retried).toHaveLength(0);
+        expect(events.find((e) => e.type === 'error')).toMatchObject({
+            type: 'error',
+            message: 'nevermind, user cancelled',
+        });
+        expect(api.callCount()).toBe(1); // no second attempt after the cancel
+    });
+});
+
+// The primitive the backoff guarantee rests on: `systemClock.sleep` rejects with the signal's
+// reason — the SAME instance, so `instanceof`/`cause` chains the caller built stay intact.
+describe('systemClock.sleep rejects with the abort reason', () => {
+    test('an abort mid-sleep rejects with the caller-supplied Error instance', async () => {
+        const ac = new AbortController();
+        const reason = new Error('caller reason');
+        const p = systemClock.sleep(60_000, ac.signal);
+        ac.abort(reason);
+        await expect(p).rejects.toBe(reason);
+    });
+
+    test('a pre-aborted signal rejects with its existing reason', async () => {
+        const ac = new AbortController();
+        const reason = new RangeError('already gone');
+        ac.abort(reason);
+        await expect(systemClock.sleep(60_000, ac.signal)).rejects.toBe(reason);
+    });
+
+    test('a non-Error reason falls back to a generic abort Error', async () => {
+        const ac = new AbortController();
+        ac.abort('just a string');
+        await expect(systemClock.sleep(0, ac.signal)).rejects.toThrow(
+            'the operation was aborted',
+        );
+    });
+});

--- a/packages/core/test/manual-clock.spec.ts
+++ b/packages/core/test/manual-clock.spec.ts
@@ -106,4 +106,14 @@ describe('manualClock: sleep', () => {
         await expect(p).rejects.toThrow('aborted');
         expect(c.pending()).toBe(0);
     });
+
+    test('sleep rejects with the caller-supplied abort reason (mirrors systemClock)', async () => {
+        const c = manualClock();
+        const ac = new AbortController();
+        const reason = new Error('deliberate cancel');
+        const p = c.sleep(100, ac.signal);
+        ac.abort(reason);
+        await expect(p).rejects.toBe(reason); // the same instance, not a re-minted Error
+        expect(c.pending()).toBe(0);
+    });
 });


### PR DESCRIPTION
## What

Two abort-semantics bugs in the resilience chain, plus the mocking kit's mirrors of them:

- **`systemClock.sleep` swallowed the abort reason.** It rejected every abort with a minted `Error('aborted')`, so a caller who aborted a call parked in a retry-backoff sleep lost their `AbortError` / custom `abort(reason)`. The same prefer-the-signal's-reason logic already existed twice — `abortReason()` in engine.ts and `abortError()` in resilience.ts — three hand-copies, one drifted. `util.ts` now exports the one `abortReason` helper and `sleep`, the engine's abort paths, and `withTimeout`'s signal link all share it.
- **A mid-flight abort read as a retry.** When a caller aborted during a non-final attempt, the attempt-loop catch still emitted a `retry` progress event and fired the `onRetry` hook before dying in the backoff sleep — a phantom retry for a deliberately cancelled call. The catch now rethrows immediately when `baseReq.signal` is aborted (after `onError`, which legitimately observed the attempt ending).
- **Mocking-kit fidelity:** `manualClock.sleep` now rejects with the reason exactly like `systemClock.sleep` (the clock seam's whole contract), and `mockAdapter`'s abortable delay / pre-aborted check reject like real `fetch` does (which surfaces `signal.reason`). Without these, neither fix is observable under injected-clock tests.

The guard keys on `baseReq.signal` — the caller's own signal — so per-attempt and total **timeouts** are untouched and still retry normally. Only a deliberate cancel short-circuits.

This also makes an already-published claim true: the [cancel-an-in-flight-call recipe](apps/docs/content/docs/recipes/cancel-an-in-flight-call.mdx), which landed on `main` while this sat, promises that an abort makes "a retry's backoff sleep and a throttle's rate-spacing pause reject promptly."

## Tests

New `test/abort-reason.spec.ts` plus one case in `manual-clock.spec.ts`:

- abort with a custom reason during backoff surfaces that reason via `safe()` — one attempt only, backoff timer dropped, not leaked (manualClock, fully virtual);
- abort mid-flight emits **zero** `retry` events, never fires `onRetry`, and the error event carries the reason;
- direct pins that both clocks' `sleep` reject with the **same Error instance** the caller aborted with, plus the non-Error-reason fallback.

All six re-verified as load-bearing against the current base: removing the engine guard fails the mid-flight test; reverting the reason-preserving rejection fails the other five. Core suite 1521 passed; eslint, `tsc --noEmit`, prettier clean; all nine yakir tethers ok.

## Reviewer notes — rebased onto current `main`

The original branch was cut before #676 and #712; both changed the ground under the size gate, so the budget half of this PR was re-measured from scratch and is **not** what the first revision proposed.

- **Only the whole-entry budget moves: 24.10 → 24.15 KB.** Measured 24681 B gzip against a `main` at 24677 B — **+4 B** onto a ceiling `main` had run down to 1.4 B of. A MINIMUM step (the #676 shape, matching #477/#524/#485): a fix squeezing past a full ceiling is not a new capability, and sizing a real step stays the maintainer's call. Headroom lands at 49 B.
- **`import { stitch }` is NOT raised.** It measures 22053 B against its existing 22067 B budget and still fits — with **14 B** to spare. Worth knowing: the next core-path byte trips that gate.
- **No advertised figure moves.** The ~21 → ~22 kB propagation this branch originally carried landed on `main` first with #676, so those six doc-site edits rebased away as no-ops. Verified with the `bundle-advertised-size` tether (all sites agree on "22, 24"), not assumed.
- The dedup is minified-**smaller** (−102 B on the entry, −98 B on `import { stitch }`); gzip charges +4 / +14 B because the deleted copies were near-free backreferences. Collapsing three hand-copies, one already drifted, is the fix, so it stays.
- Scope note: only the transport-error catch path gets the abort guard. The narrow status-driven race (abort landing between a completed response and the status check) can still emit one legitimate `retry` event — but the subsequent backoff now rejects promptly with the caller's reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
