### PR TITLE
fix(core): a {value, type} object is no longer encoded as a file (#701)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -568,10 +568,10 @@ npm release are grouped under the in-development version that introduced them.
   ([#701](https://github.com/rejifald/StitchAPI/issues/701)) `isFileWrapper` accepted any object
   carrying a `type` key, so a domain object like `{ value: 100, type: 'refund' }` was encoded as a
   tiny Blob and its **siblings silently dropped** — a `200` with the money fields gone. A wrapper is
-  now a file only when `value` is binary (Blob/File/ArrayBuffer/TypedArray/Buffer) or an explicit
+  now a file only when `value` is binary (Blob/File/Uint8Array/Buffer/ArrayBuffer) or an explicit
   `filename` names the part; `type` still sets a file part's content type, it just no longer creates
-  one. **Migration:** a non-binary `{ value, type }` upload needs a `filename`, or pass
-  `new Blob([value], { type })`.
+  one. **Migration:** a `{ value, type }` part whose `value` is not one of those binary types needs a
+  `filename`, or pass `new Blob([value], { type })`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -564,6 +564,15 @@ npm release are grouped under the in-development version that introduced them.
     **Migration:** delete the field. No runtime behaviour changed — the stitch was already a
     download. To actually get another surface, use a plain `stitch({ kind })`.
 
+- **BREAKING CHANGE: a multipart `type` no longer makes a value a file part.**
+  ([#701](https://github.com/rejifald/StitchAPI/issues/701)) `isFileWrapper` accepted any object
+  carrying a `type` key, so a domain object like `{ value: 100, type: 'refund' }` was encoded as a
+  tiny Blob and its **siblings silently dropped** — a `200` with the money fields gone. A wrapper is
+  now a file only when `value` is binary (Blob/File/ArrayBuffer/TypedArray/Buffer) or an explicit
+  `filename` names the part; `type` still sets a file part's content type, it just no longer creates
+  one. **Migration:** a non-binary `{ value, type }` upload needs a `filename`, or pass
+  `new Blob([value], { type })`.
+
 ### Fixed
 
 - **Adding `cache: { ttl }` no longer turns a handled vendor failure into a process exit.**

--- a/packages/core/src/http-adapter.ts
+++ b/packages/core/src/http-adapter.ts
@@ -384,20 +384,25 @@ export function decodeResponseBody(
 // A value that becomes a binary file part: a Blob, a raw byte view, or a
 // { value, filename?, type? } file wrapper. Anything else is a nested object/scalar.
 //
-// The wrapper is recognised ONLY when it is actually file-ish: `value` is binary (a Blob /
-// Uint8Array / ArrayBuffer), OR an explicit `filename`/`type` marks it a file part (so
-// `{ value: 'text', filename: 'note.txt' }` is still a named text part). A plain domain object that
-// merely HAPPENS to carry a `value` key — e.g. `{ value: 100, currency: 'USD' }` — is NOT a file:
-// treating it as one encoded `value` as a tiny Blob and silently DROPPED its siblings. Such an
-// object falls through here and recurses as a normal nested object instead.
+// The wrapper is recognised ONLY when it is actually file-ish: `value` is binary (a Blob/File, an
+// ArrayBuffer, or any view over one — TypedArray, Node `Buffer`, DataView), OR an explicit
+// `filename` names the part (so `{ value: 'text', filename: 'note.txt' }` is still a named text
+// part). A plain domain object that merely HAPPENS to carry a `value` key — e.g.
+// `{ value: 100, currency: 'USD' }` — is NOT a file: treating it as one encoded `value` as a tiny
+// Blob and silently DROPPED its siblings. Such an object falls through here and recurses as a
+// normal nested object instead.
+//
+// `type` is deliberately NOT a discriminator (#701 §2). It is a *modifier* — it sets an already-file
+// part's content type, and `appendFilePart` still honours it — but it is far too ordinary a domain
+// key to prove file-ness on its own: `{ value: 100, type: 'refund' }` is money, not an upload, and
+// admitting it here reintroduced exactly the sibling loss the paragraph above exists to prevent.
 function isFileWrapper(v: object): boolean {
-    const w = v as { value?: unknown; filename?: unknown; type?: unknown };
+    const w = v as { value?: unknown; filename?: unknown };
     return (
         w.value instanceof Blob ||
-        w.value instanceof Uint8Array ||
         w.value instanceof ArrayBuffer ||
-        w.filename !== undefined ||
-        w.type !== undefined
+        ArrayBuffer.isView(w.value) ||
+        w.filename !== undefined
     );
 }
 

--- a/packages/core/src/http-adapter.ts
+++ b/packages/core/src/http-adapter.ts
@@ -384,24 +384,29 @@ export function decodeResponseBody(
 // A value that becomes a binary file part: a Blob, a raw byte view, or a
 // { value, filename?, type? } file wrapper. Anything else is a nested object/scalar.
 //
-// The wrapper is recognised ONLY when it is actually file-ish: `value` is binary (a Blob/File, an
-// ArrayBuffer, or any view over one — TypedArray, Node `Buffer`, DataView), OR an explicit
-// `filename` names the part (so `{ value: 'text', filename: 'note.txt' }` is still a named text
-// part). A plain domain object that merely HAPPENS to carry a `value` key — e.g.
-// `{ value: 100, currency: 'USD' }` — is NOT a file: treating it as one encoded `value` as a tiny
-// Blob and silently DROPPED its siblings. Such an object falls through here and recurses as a
-// normal nested object instead.
+// The wrapper is recognised ONLY when it is actually file-ish: `value` is binary (a Blob/File, a
+// Uint8Array/Buffer, or an ArrayBuffer), OR an explicit `filename` names the part (so
+// `{ value: 'text', filename: 'note.txt' }` is still a named text part). A plain domain object that
+// merely HAPPENS to carry a `value` key — e.g. `{ value: 100, currency: 'USD' }` — is NOT a file:
+// treating it as one encoded `value` as a tiny Blob and silently DROPPED its siblings. Such an
+// object falls through here and recurses as a normal nested object instead.
 //
 // `type` is deliberately NOT a discriminator (#701 §2). It is a *modifier* — it sets an already-file
 // part's content type, and `appendFilePart` still honours it — but it is far too ordinary a domain
 // key to prove file-ness on its own: `{ value: 100, type: 'refund' }` is money, not an upload, and
 // admitting it here reintroduced exactly the sibling loss the paragraph above exists to prevent.
+//
+// The binary arm is the three concrete types above and NOT `ArrayBuffer.isView`, so an exotic view
+// (`Float32Array`, `DataView`) in a wrapper is not a file part. That is a real gap, tracked
+// separately — widening it here costs ~11 gzip bytes of a budget with ~14 left, and the failure it
+// prevents is a mis-shaped body the server rejects (`k[value][0]`, `k[value][1]`, …), not the
+// silent sibling loss this predicate exists to stop.
 function isFileWrapper(v: object): boolean {
     const w = v as { value?: unknown; filename?: unknown };
     return (
         w.value instanceof Blob ||
+        w.value instanceof Uint8Array ||
         w.value instanceof ArrayBuffer ||
-        ArrayBuffer.isView(w.value) ||
         w.filename !== undefined
     );
 }

--- a/packages/core/test/multipart-nesting.spec.ts
+++ b/packages/core/test/multipart-nesting.spec.ts
@@ -170,6 +170,83 @@ describe('multipart nesting (ADR 0005 Decision 6)', () => {
         expect(raw).not.toContain('filename=');
     });
 
+    // #701 §2: the same silent-sibling-loss bug, reached through `type` instead of `value`.
+    // `type` is a modifier on a file part (it sets the part's content type), never the thing that
+    // MAKES one — it is far too common a domain key (`{ value, type: 'refund' }`) to discriminate on.
+    test('a { value, type } domain object is a nested object, not a file (every sibling survives)', async () => {
+        server.route('POST', '/u', { body: { ok: true } });
+        const upload = stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/u',
+            wire: { body: 'multipart' },
+        });
+
+        await upload({
+            body: { refund: { value: 100, type: 'refund', currency: 'USD' } },
+        });
+
+        const raw = rawOf('/u');
+        // All three fields survive as normal string parts…
+        expect(raw).toContain('name="refund[value]"');
+        expect(raw).toContain('100');
+        expect(raw).toContain('name="refund[type]"');
+        expect(raw).toContain('refund');
+        expect(raw).toContain('name="refund[currency]"');
+        expect(raw).toContain('USD');
+        // …and `refund` is NOT a file part (the bug encoded it as a 3-byte Blob typed `refund`,
+        // losing `type` and `currency` outright, and the call still returned 200).
+        expect(raw).not.toContain('name="refund"\r\n');
+        expect(raw).not.toContain('filename=');
+    });
+
+    test('a binary wrapper carrying only a `type` (no filename) is still a file part', async () => {
+        server.route('POST', '/u', { body: { ok: true } });
+        const upload = stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/u',
+            wire: { body: 'multipart' },
+        });
+
+        await upload({
+            body: { doc: { value: bytes, type: 'application/x-custom' } },
+        });
+
+        const raw = rawOf('/u');
+        expect(raw).toContain('name="doc"');
+        // the `type` still reaches the wire as the part's content type…
+        expect(raw).toContain('application/x-custom');
+        // …and it did NOT recurse into value/type string fields
+        expect(raw).not.toContain('doc[value]');
+        expect(raw).not.toContain('doc[type]');
+    });
+
+    test("'json' nesting: an explicit { value, filename } still hoists to a file part", async () => {
+        server.route('POST', '/u', { body: { ok: true } });
+        const upload = stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/u',
+            wire: { body: 'multipart', multipart: { nesting: 'json' } },
+        });
+
+        await upload({
+            body: {
+                amount: { value: 100, type: 'refund' },
+                note: { value: 'hello', filename: 'n.txt' },
+            },
+        });
+
+        const raw = rawOf('/u');
+        // the filename arm survives the narrowing — still hoisted out of the JSON part
+        expect(raw).toContain('name="note"');
+        expect(raw).toContain('filename="n.txt"');
+        // the domain object rides inside the JSON part, both keys intact
+        expect(raw).toContain('name="payload"');
+        expect(raw).toContain('"amount":{"value":100,"type":"refund"}');
+    });
+
     test('a real { value: <Uint8Array>, filename } wrapper is still a file part', async () => {
         server.route('POST', '/u', { body: { ok: true } });
         const upload = stitch({


### PR DESCRIPTION
## The bug

A multipart body containing a plain domain object with a `type` key had that object encoded as a
**single tiny file part, with every sibling key silently dropped** — and the call returned `200`.

`packages/core/src/http-adapter.ts:393-402` (on `origin/main`):

```ts
function isFileWrapper(v: object): boolean {
    const w = v as { value?: unknown; filename?: unknown; type?: unknown };
    return (
        w.value instanceof Blob ||
        w.value instanceof Uint8Array ||
        w.value instanceof ArrayBuffer ||
        w.filename !== undefined ||
        w.type !== undefined // ← any object with a `type` key is "a file"
    );
}
```

`type` is one of the most ordinary keys in a domain model. `{ value: 100, type: 'refund' }` is money,
not an upload. Reproduced against the mock server on `origin/main` before touching anything — the
wire showed:

```
Content-Disposition: form-data; name="refund"; filename="blob"
Content-Type: refund

100
```

`currency` and `type` never left the process. Under `multipart.nesting: 'json'` it is worse: the
object is hoisted out of the payload entirely and the JSON part ships as `{}`.

The comment directly above the predicate (`http-adapter.ts:387-392`) already describes this exact
harm and already names `{ value: 100, currency: 'USD' }` as the shape that must **not** be a file.
The guard was written; `type` is the key that slipped through it.

This is §2 of #701.

## The fix

One condition removed. A wrapper is a file only when `value` is binary, or an explicit `filename`
names the part:

```ts
w.value instanceof Blob ||
w.value instanceof Uint8Array ||
w.value instanceof ArrayBuffer ||
w.filename !== undefined
```

`type` stays a **modifier**: `appendFilePart` still reads it to set an already-file part's content
type. It just no longer *creates* one. The comment block above the predicate is updated to say so.

## Semver: breaking, not a plain `fix`

The CHANGELOG entry is under **`### Changed`**, marked `BREAKING CHANGE`, with a matching footer in
the commit body. (The subject stays `fix(core):` — it is the defect being fixed.)

The reasoning:

- The narrowing has a real blast radius: a wrapper with a **non-binary** `value`, a `type`, and
  **no** `filename`. That shape was *documented* —
  `apps/docs/content/blog/upload-a-file-with-a-progress-bar.mdx:65` presents the
  `{ value, filename?, type? }` wrapper as being for when you want to name the part "**or set its
  content type explicitly**". A caller doing `{ value: csv, type: 'text/csv' }` gets a wire change:
  one typed file part becomes `k[value]` + `k[type]` string parts.
- Everything else is unaffected. A **binary** `value` carrying a `type` is still a file part with its
  content type intact (pinned by a new test). Anything with a `filename` is still a file part.
- Calling it a bare `fix` would hide the one shape that moves, from the readers most likely to be
  relying on it.

**Migration is one key:** add a `filename`, or pass `new Blob([value], { type })`.

Shipping now rather than deferring to a later major: the package is at `1.0.0-rc.7`, and the
alternative is cutting `1.0.0` with silent data loss on a money path.

## A widening I tried and then removed — and why

The first commit on this branch also widened the binary arm from `Uint8Array` to
`ArrayBuffer.isView`, so that `{ value: new Float32Array(…), type: 'audio/pcm' }` would not demote
from a file part when `type` stopped qualifying. The second commit takes it back out. Both reasons
are worth stating, because the first draft of this PR argued the opposite:

**It did not pay for itself on the size gate.** `check:size` is its own CI job, and the core entry's
budget has almost nothing left:

| tree | whole-entry gzip | budget | headroom |
| --- | --- | --- | --- |
| `origin/main` | 24664 B | 24678.4 B | 14.4 B |
| with `ArrayBuffer.isView` | 24671 B | 24678.4 B | 7.4 B |
| **as shipped** | **24658 B** | 24678.4 B | **20.4 B** |

The widened version spent half the remaining margin of a budget shared with every core PR in flight.
Reordering the disjunction recovered 2 B; hoisting `w.value` to a local recovered none — the cost is
irreducible because `ArrayBuffer.isView(` is a token the bundle does not otherwise contain. **No
budget was raised** — as shipped this PR is 6 bytes *below* `main` and hands margin back.

**And the correctness argument was overstated.** I claimed an exotic view would "trade one instance
of this bug for another". It does not. `{ value: new Float32Array([1, 2]) }` recurses to
`k[value][0]=1`, `k[value][1]=2` — every byte still on the wire, in a shape the server rejects. That
is a loud 400, not the silent 200-with-fields-missing this predicate exists to stop. Different harm
class; only the second one justifies spending a contended budget.

The exotic-view gap is real and stays real — `appendFilePart` would already encode a `DataView`
correctly, only the detector is narrow. It is recorded in the comment above the predicate and left
for its own change rather than smuggled in here.

## Tested

Three tests added to `packages/core/test/multipart-nesting.spec.ts`, beside the existing
`{ value, currency }` case this bug slipped past — same style, same end-to-end assertion against the
raw multipart body the mock server records:

1. `{ value: 100, type: 'refund', currency: 'USD' }` round-trips as a normal nested object —
   `refund[value]`, `refund[type]`, `refund[currency]` all present, no file part.
2. A genuine binary wrapper carrying **only** a `type` (no filename) is still a file part, and the
   `type` still reaches the wire as the part's content type.
3. Under `json` nesting, `{ value: 'hello', filename: 'n.txt' }` still hoists to a named file part
   while a sibling `{ value, type }` domain object rides intact inside the JSON payload.

Tests 1 and 3 were confirmed **red on `origin/main`** before the fix and green after; test 2 is green
both sides (it is the invariant guarding the narrowing).

Gates, all green:

| gate | result |
| --- | --- |
| `prettier --write` (changed files) | unchanged |
| `pnpm --filter stitchapi check:lint` | pass |
| `pnpm --filter stitchapi check:types` | pass |
| `pnpm --filter stitchapi test` | 1494 passed |
| `pnpm --filter stitchapi build && check:size` | pass — 24.08/24.10 KB entry, 21.50/21.55 KB `stitch` |
| `node scripts/check-changelog.mjs` | pass |
| `node scripts/check-contract.mjs` | pass — 0 new violations |
| `node scripts/check-unknown-keys.mjs` | pass |

Plus the full `lefthook` pre-commit and pre-push sequences (format, lint, contract, unknown-keys,
changelog, media-fresh, typecheck, typecheck-d, test, exports, build-docs, yakir) — all green.
`pnpm -r test` passes across all 30 workspace packages.

## Scope

Three files: the predicate + its comment, the tests, and the CHANGELOG. §1 (JSON body refuses a
bigint), §3 (empty cross-field path), §4 and §5 of #701 are untouched.

One thing I did **not** touch and am flagging rather than fixing: the blog line quoted above
(`upload-a-file-with-a-progress-bar.mdx:65`) still reads as though `type` alone is enough to make a
part a file. Its own example passes a `File`, so the page is not wrong in what it shows, but the
sentence is now looser than the code. Left out to keep the diff to the defect.

Refs #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)
