### PR TITLE
fix(core): an abandoned stream cancels its reader instead of leaking the socket (#686)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -566,6 +566,11 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Fixed
 
+- **Breaking out of a `.stream()` loop cancels the response body instead of leaking the socket.**
+  ([#686](https://github.com/rejifald/StitchAPI/issues/686)) The `'bytes'` (default) and `'json'`
+  decoders released the reader lock without cancelling, so an abandoned stream stayed open and the
+  vendor kept writing into it. Both now tear down on every exit path, as `'lines'`/`'ndjson'` did.
+
 - **Adding `cache: { ttl }` no longer turns a handled vendor failure into a process exit.**
   ([#670](https://github.com/rejifald/StitchAPI/issues/670)) A cached stitch whose vendor returned
   `503` emitted an **unhandled promise rejection**, which under Node's default

--- a/packages/core/src/json-stream.ts
+++ b/packages/core/src/json-stream.ts
@@ -262,6 +262,10 @@ export async function* jsonStream(
             yield slice(valueStart, scan);
         }
     } finally {
+        // Cancel the body on any exit path (early `break` / error / normal end) so an abandoned
+        // consumer proactively closes the connection; then release the lock. `.catch` swallows a
+        // reject from a body already torn down by an abort.
+        await reader.cancel().catch(() => undefined);
         reader.releaseLock();
     }
 }

--- a/packages/core/src/stream.ts
+++ b/packages/core/src/stream.ts
@@ -103,6 +103,10 @@ async function* decodeStream(
             yield r.value;
         }
     } finally {
+        // Cancel the body on any exit path (early `break` / error / normal end) so an abandoned
+        // consumer proactively closes the connection; then release the lock. `.catch` swallows a
+        // reject from a body already torn down by an abort.
+        await reader.cancel().catch(() => undefined);
         reader.releaseLock();
     }
 }

--- a/packages/core/test/json-stream.spec.ts
+++ b/packages/core/test/json-stream.spec.ts
@@ -243,3 +243,40 @@ describe('json-stream tokenizer: max-buffer guard + incomplete streams', () => {
         expect(await decode([])).toEqual([]);
     });
 });
+
+describe('json-stream tokenizer: teardown on abandon (issue #686 §2)', () => {
+    // The tokenizer owns its reader, so it owns the teardown: a consumer that `break`s triggers the
+    // generator `.return()`, and the `finally` must cancel() the body before releasing the lock —
+    // otherwise the response stream stays open and the socket leaks. Same guarantee lineReader
+    // gives the `'lines'`/`'ndjson'` decoders; asserted here at the plumbing level.
+
+    test('an early break cancels the underlying stream before releasing the lock', async () => {
+        // An endless body of concatenated top-level objects: only the consumer can end it, so a
+        // missing cancel() is a stream left open. The `cancel` hook records the client-side tear-down.
+        let cancelled = false;
+        const stream = new ReadableStream<Uint8Array>({
+            pull(controller) {
+                controller.enqueue(enc.encode('{"n":1}'));
+            },
+            cancel() {
+                cancelled = true;
+            },
+        });
+        const seen: unknown[] = [];
+        for await (const v of jsonStream(stream)) {
+            seen.push(v);
+            break; // abandon after the first value
+        }
+        expect(seen).toEqual([{ n: 1 }]);
+        expect(cancelled).toBe(true);
+    });
+
+    test('a normal drain still cancels (a no-op on a closed stream) and yields every value', async () => {
+        // Cancelling unconditionally in `finally` is safe: cancel() on an already-closed stream is a
+        // spec no-op, so a fully-consumed stream still emits all of its values.
+        expect(await decodeText('[{"a":1},{"a":2}]')).toEqual([
+            { a: 1 },
+            { a: 2 },
+        ]);
+    });
+});

--- a/packages/core/test/stream.spec.ts
+++ b/packages/core/test/stream.spec.ts
@@ -21,6 +21,7 @@ import {
 import { z } from 'zod';
 
 const td = new TextDecoder();
+const enc = new TextEncoder();
 
 describe('stream surface identity (Decisions 5, 11)', () => {
     test('streamSurface has the stable id "stream" and a stream hook', () => {
@@ -120,6 +121,88 @@ describe('stream decoders (Decision 5)', () => {
         });
 
         expect(await s()).toEqual([{ s: 'a}b]c"d' }]);
+    });
+});
+
+describe('abandoned-stream teardown (issue #686 §2)', () => {
+    // `break`ing out of a `.stream()` loop `.return()`s the generator chain down to the decoder,
+    // whose `finally` must cancel() the body — releasing the lock alone leaves the response stream
+    // open, so the vendor keeps writing (and billing) into a connection nobody reads. `lines`/
+    // `ndjson` already got this from lineReader; these pin the other two decoders to the same
+    // behaviour. A cancel-recording endless body makes the client-side cancel observable, which a
+    // real HTTP body can't, and it is only ever torn down by the consumer.
+    function endlessBody(chunk: string): {
+        body: ReadableStream<Uint8Array>;
+        cancelled: () => boolean;
+    } {
+        let cancelled = false;
+        const body = new ReadableStream<Uint8Array>({
+            pull(controller) {
+                controller.enqueue(enc.encode(chunk));
+            },
+            cancel() {
+                cancelled = true;
+            },
+        });
+        return { body, cancelled: () => cancelled };
+    }
+
+    test('the default "bytes" decoder cancels the body on an early break', async () => {
+        const { body, cancelled } = endlessBody('chunk');
+        const s = stream({
+            url: 'https://x.test/breakable-bytes',
+            adapter: streamAdapter(body),
+        });
+
+        const deltas: unknown[] = [];
+        for await (const e of s.stream()) {
+            if (e.type === 'delta') {
+                deltas.push(e.chunk);
+                break; // abandon the rest of the stream
+            }
+        }
+        expect(deltas.map((c) => td.decode(c as Uint8Array))).toEqual([
+            'chunk',
+        ]);
+        expect(cancelled()).toBe(true); // cancelled, not merely unlocked
+    });
+
+    test('decode "json" cancels the body on an early break', async () => {
+        // Concatenated top-level objects with no separator → one delta each, so the consumer has a
+        // value to break on while the body is still open.
+        const { body, cancelled } = endlessBody('{"n":1}');
+        const s = stream({
+            url: 'https://x.test/breakable-json',
+            stream: { decode: 'json' },
+            adapter: streamAdapter(body),
+        });
+
+        const deltas: unknown[] = [];
+        for await (const e of s.stream()) {
+            if (e.type === 'delta') {
+                deltas.push(e.chunk);
+                break;
+            }
+        }
+        expect(deltas).toEqual([{ n: 1 }]);
+        expect(cancelled()).toBe(true);
+    });
+
+    test('a normal drain still cancels (a no-op on a closed stream) and loses no chunks', async () => {
+        // Cancelling unconditionally in `finally` is safe: cancel() on an already-closed stream is a
+        // spec no-op, so a fully-consumed stream still delivers everything, on both decoders.
+        const bytes = stream({
+            url: 'https://x.test/drained-bytes',
+            adapter: streamAdapter(streamOf(['ab', 'cd'])),
+        });
+        expect((await bytes()).map((c) => td.decode(c)).join('')).toBe('abcd');
+
+        const json = stream({
+            url: 'https://x.test/drained-json',
+            stream: { decode: 'json' },
+            adapter: streamAdapter(streamOf(['[{"a":1},{"a":2}]'])),
+        });
+        expect(await json()).toEqual([{ a: 1 }, { a: 2 }]);
     });
 });
 


### PR DESCRIPTION
## The bug

A consumer who `break`s out of a `.stream()` loop leaks the socket on the **default** decoder.

`break` out of a `for await` calls the generator's `.return()`, which runs the `finally`. That
`finally` only released the reader lock — and releasing a lock does not cancel the body. The
underlying response stream is therefore never torn down, so the vendor keeps writing (and billing)
into a connection nobody is reading.

**Evidence, on `origin/main`:**

- `packages/core/src/stream.ts:105-107` — the `'bytes'` decoder: `finally { reader.releaseLock(); }`
- `packages/core/src/json-stream.ts:264-266` — identical.

`'bytes'` is the default `stream.decode`, so this is reachable through the most natural consumer
idiom without opting into anything.

## The fix

**The correct pattern already existed in the same package.** `packages/core/src/line-reader.ts:70-76`
has done `await reader.cancel().catch(() => undefined)` before `releaseLock()` on every exit path
since the sse teardown work — which is why `'lines'` and `'ndjson'`, which share `lineReader`, were
never affected.

So this is not a new pattern; it brings the other two decoders into line with the third. The three
`finally` bodies are now byte-identical, comment included, deliberately: three decoders doing the
same job should not each carry their own idea of how a reader is let go.

Cancelling unconditionally is safe — `cancel()` on an already-closed stream is a spec no-op — and the
`.catch` swallows a reject from a body an abort already tore down.

## What I tested

New tests, driven by a **cancel-recording endless body**. That shape is what makes the leak
observable at all: a real HTTP body cannot report its own cancellation back to a test, and an endless
one is only ever ended by the consumer, so a missing `cancel()` is a stream left open.

- `packages/core/test/stream.spec.ts` — surface level: an early `break` out of `.stream()` cancels
  the body on the `bytes` default and on `decode: 'json'`; a normal drain still delivers every chunk
  on both, pinning that the unconditional cancel costs nothing.
- `packages/core/test/json-stream.spec.ts` — plumbing level, directly against the tokenizer, mirroring
  the `lineReader` teardown tests that already live in `sse.spec.ts`.

**All three `break` tests fail on the pre-fix tree** (verified by stashing only the two `src` changes
and re-running: 3 failed / 59 passed).

Gates, all green from the repo root: `prettier --write` on every touched file, `check:lint`,
`check:types`, the full `stitchapi` suite (1494 passed, 2 skipped, 138 files), `check-changelog.mjs`,
`check-contract.mjs`, `check-unknown-keys.mjs`. Also ran `check:size` — the root entry does not export
the `stream` subpath, so the bundle budgets are untouched (`whole entry` and `import { stitch }` both
still within budget, unchanged).

## Scope

`Refs #686`, **not** `Fixes` — this is §2 only. §1 (nothing bounds a live stream), §3 (no `done` event
on abandon) and §4–§6 are untouched and stay open. §3 in particular is adjacent and deliberately left
alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
