### PR TITLE
fix(core): axiosAdapter(axios) typechecks against real axios (#708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -566,6 +566,12 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Fixed
 
+- **`axiosAdapter(axios)` — the adapter's own documented snippet — now typechecks against real
+  axios.** ([#708](https://github.com/rejifald/StitchAPI/issues/708)) `AxiosLikeConfig.responseType`
+  was `string`, which axios types as its narrower `ResponseType` union, so passing `axios` (or
+  `axios.create()`) failed with `TS2345` under `exactOptionalPropertyTypes`. The type-level test
+  missed it by casting a client through `AxiosLike`; it now asserts against real `axios` types.
+
 - **Adding `cache: { ttl }` no longer turns a handled vendor failure into a process exit.**
   ([#670](https://github.com/rejifald/StitchAPI/issues/670)) A cached stitch whose vendor returned
   `503` emitted an **unhandled promise rejection**, which under Node's default

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -328,6 +328,7 @@
         "@types/node": "^22.10.0",
         "@vitest/coverage-v8": "^4.1.10",
         "@vitest/eslint-plugin": "^1.6.24",
+        "axios": "^1.19.0",
         "esbuild": "^0.28.1",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",

--- a/packages/core/src/axios-adapter.ts
+++ b/packages/core/src/axios-adapter.ts
@@ -34,7 +34,11 @@ export interface AxiosLikeConfig {
     method: string;
     headers?: Record<string, string>;
     data?: unknown;
-    responseType?: string;
+    // Narrower than `string` on purpose: axios types this as its own `ResponseType` union, and a
+    // plain `string` makes `AxiosLikeConfig` unassignable to `AxiosRequestConfig` — which made
+    // `axiosAdapter(axios)` itself fail to typecheck against real axios (#708). The adapter only
+    // ever sends 'arraybuffer' (below), so narrowing to a subset of axios's union costs nothing.
+    responseType?: 'arraybuffer' | 'json' | 'text';
     signal?: AbortSignal;
     validateStatus?: ((status: number) => boolean) | null;
     onUploadProgress?: (e: AxiosLikeProgressEvent) => void;

--- a/packages/core/test-d/adapter-capabilities.test-d.ts
+++ b/packages/core/test-d/adapter-capabilities.test-d.ts
@@ -12,6 +12,7 @@ import type {
     AxiosLike,
 } from '../src';
 
+import axios from 'axios';
 import { expectAssignable, expectError, expectType } from 'tsd';
 
 // A plain transport function — no `capabilities` — still satisfies Adapter (backward compatible).
@@ -33,8 +34,19 @@ expectType<AdapterCapabilities | undefined>(fetchAdapter().capabilities);
 // Every built-in resolves to Adapter.
 expectAssignable<Adapter>(fetchAdapter());
 expectAssignable<Adapter>(xhrAdapter());
+
+// The axios seam is structural, so any hand-rolled client that satisfies it is accepted...
 const client = null as unknown as AxiosLike;
 expectAssignable<Adapter>(axiosAdapter(client));
+
+// ...but the assertion that matters is against REAL axios, because that is what the documented
+// snippet passes. The `as unknown as AxiosLike` cast above cannot make it: it ASSERTS the client is
+// an AxiosLike rather than testing whether axios actually is one, so #708 — `AxiosLikeConfig` being
+// unassignable to axios's own `AxiosRequestConfig`, via a too-wide `responseType?: string` — passed
+// this file while `axiosAdapter(axios)` failed to compile for every user. Pin all three call forms.
+expectAssignable<Adapter>(axiosAdapter(axios));
+expectAssignable<Adapter>(axiosAdapter(axios.create()));
+expectAssignable<Adapter>(axiosAdapter(axios, { timeout: 5 }));
 
 // `supports` is a list of the known capability tags; `name` is optional.
 expectAssignable<AdapterCapabilities>({ supports: [] });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -378,6 +378,9 @@ importers:
       '@vitest/eslint-plugin':
         specifier: ^1.6.24
         version: 1.6.24(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10)
+      axios:
+        specifier: ^1.19.0
+        version: 1.19.0
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
@@ -4464,6 +4467,10 @@ packages:
     resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
     engines: {node: '>=14.0'}
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -4631,6 +4638,9 @@ packages:
   axe-core@4.12.1:
     resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
+
+  axios@1.19.0:
+    resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -5923,6 +5933,15 @@ packages:
   flow-enums-runtime@0.0.6:
     resolution: {integrity: sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   fontfaceobserver@2.3.0:
     resolution: {integrity: sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==}
 
@@ -6343,6 +6362,10 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -7893,6 +7916,10 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -12702,6 +12729,12 @@ snapshots:
 
   adm-zip@0.6.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ai@6.0.208(zod@4.4.3):
@@ -12885,6 +12918,16 @@ snapshots:
       fastq: 1.20.1
 
   axe-core@4.12.1: {}
+
+  axios@1.19.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -14470,6 +14513,8 @@ snapshots:
 
   flow-enums-runtime@0.0.6: {}
 
+  follow-redirects@1.16.0: {}
+
   fontfaceobserver@2.3.0: {}
 
   for-each@0.3.5:
@@ -14950,6 +14995,13 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -16839,6 +16891,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
Fixes §1 of #708: `axiosAdapter(axios)` — the snippet in the adapter's own file header at
`packages/core/src/axios-adapter.ts:4-6` — did not typecheck against real axios.

## Reproduced before touching anything

axios `1.19.0`, tsc `5.9.3`, compiled under `packages/core/tsconfig.json` with all three documented
call forms in one file:

```ts
import axios from 'axios';
import { axiosAdapter } from './axios-adapter';

export const a = axiosAdapter(axios);
export const b = axiosAdapter(axios.create());
export const c = axiosAdapter(axios, { timeout: 5 });
```

**BEFORE** — exit 2, every call form rejected (one of the three, elided identically for the others):

```
src/__repro708.ts(6,31): error TS2345: Argument of type 'AxiosStatic' is not assignable to parameter of type 'AxiosLike'.
  Types of property 'request' are incompatible.
    Type '<T = any, R = unique symbol, D = any, P = any>(config: AxiosRequestConfig<D, P>) => Promise<AxiosResponseResult<T, R, D, P>>' is not assignable to type '(config: AxiosLikeConfig) => Promise<AxiosLikeResponse>'.
      Types of parameters 'config' and 'config' are incompatible.
        Type 'AxiosLikeConfig' is not assignable to type 'AxiosRequestConfig<unknown, any>' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
          Types of property 'responseType' are incompatible.
            Type 'string' is not assignable to type 'ResponseType'.
```

`src/__repro708.ts(7,31)` (`axios.create()` → `AxiosInstance`) and `src/__repro708.ts(8,31)` (with
`defaults`) failed with the same chain.

**AFTER** — same command, same file, exit 0 and no output. The temp repro file was then deleted; it
is not part of this PR.

## Root cause — one word

```diff
-    responseType?: string;
+    responseType?: 'arraybuffer' | 'json' | 'text';
```

`AxiosLikeConfig.responseType` was `string`. axios types the same field as its own `ResponseType`
union. Because `config` is a **parameter**, the wider type makes `AxiosLikeConfig` unassignable to
`AxiosRequestConfig`, which makes the whole client unassignable to `AxiosLike` — so `axios`, the one
client the seam exists to accept, was the one client it rejected. The repo's strict
`exactOptionalPropertyTypes` surfaces it rather than causing it.

The narrowing costs nothing: the adapter only ever sends `'arraybuffer'`
(`axios-adapter.ts:109`), and the field is otherwise reachable only through `defaults`, where a
caller-supplied `responseType` is overwritten anyway.

## Why the existing type-level test could not catch it

`packages/core/test-d/adapter-capabilities.test-d.ts` had:

```ts
const client = null as unknown as AxiosLike;
expectAssignable<Adapter>(axiosAdapter(client));
```

The `as unknown as AxiosLike` cast **asserts** the client is an `AxiosLike` rather than **testing**
whether axios actually is one — it asserted away the exact assignability that was broken. The file
stayed green while `axiosAdapter(axios)` failed to compile for every user.

It now asserts against real `axios` types and pins all three call forms:

```ts
expectAssignable<Adapter>(axiosAdapter(axios));
expectAssignable<Adapter>(axiosAdapter(axios.create()));
expectAssignable<Adapter>(axiosAdapter(axios, { timeout: 5 }));
```

The structural hand-rolled client stays alongside it, since the seam is deliberately open.

**Confirmed load-bearing, not decorative:** with the test in place I reverted the one-word fix and
re-ran `pnpm --filter stitchapi check:types-d` — it went red with the original `TS2345` on all three
new lines (`47:39`, `48:39`, `49:39`), then green again once restored. The pre-existing cast line
never failed in either direction.

## The dependency

`axios` becomes a devDependency of `packages/core` — where `zod` already sits for the same reason, a
type-only `test-d` dependency, and where `tsd` resolves it. Resolved offline from the shared pnpm
store. The shipped runtime stays zero-dependency: nothing under `src/` imports axios, and
devDependencies are not installed by consumers.

The lockfile diff is **54 pure insertions, zero deletions** (axios + `follow-redirects`,
`proxy-from-env`, `https-proxy-agent`, `agent-base`). Generating it via `pnpm add --filter` also
re-resolved some unrelated `@types/node` peer keys (`25.9.3` → `22.19.21`); that churn was reverted
and the lockfile regenerated with a plain root install so this PR carries axios and nothing else.

## Gates

All run from the repo root on the final tree, all green:

| Gate | Result |
| --- | --- |
| `prettier --check` (changed files) | pass |
| `pnpm --filter stitchapi check:lint` | pass |
| `pnpm --filter stitchapi check:types` | pass |
| `pnpm --filter stitchapi check:types-d` | pass |
| `pnpm --filter stitchapi test` | pass — 139 files, 1491 tests |
| `node scripts/check-changelog.mjs` | pass |
| `node scripts/check-contract.mjs` | pass |
| `node scripts/check-unknown-keys.mjs` | pass |
| `pnpm install --frozen-lockfile` | pass (lockfile in sync for CI) |

The twelve existing call sites across `test/adapters.spec.ts`,
`test/adapter-streaming.spec.ts`, `test/adapter-upload-progress.spec.ts` and
`test/axios-adapter-normalize.spec.ts` are unaffected — they pass structural stubs, and all 1491
tests pass. (Note: #708 states there is no call site under `packages/`; there are twelve.)

## Scope

`Refs`, not `Fixes` — §2 (`AdapterResponse.url` not set), §3, §4 and §5 are untouched and stay open.

Refs #708

🤖 Generated with [Claude Code](https://claude.com/claude-code)
