### PR TITLE
fix(core): an accepted non-2xx no longer becomes a cached absence (#704)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -566,6 +566,13 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Fixed
 
+- **An accepted non-2xx no longer becomes a cached absence.**
+  ([#704](https://github.com/rejifald/StitchAPI/issues/704)) The store gate was `out.ok` alone, so
+  `verdict: { accept: [404] }` cached the absence behind the `404` — masking a record created after
+  it for the whole TTL, and (a hit replays without re-running `interpret`/`verdict`) letting that
+  entry reach a reader whose own verdict rejects the status. The gate is now accept-blind (`< 400`),
+  so only a status every reader counts as a success on its own merits is stored.
+
 - **Adding `cache: { ttl }` no longer turns a handled vendor failure into a process exit.**
   ([#670](https://github.com/rejifald/StitchAPI/issues/670)) A cached stitch whose vendor returned
   `503` emitted an **unhandled promise rejection**, which under Node's default

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -1665,8 +1665,22 @@ async function* runCached(
     }
 
     yield cacheEvt('miss');
+    // What may be WRITTEN is a narrower question than what succeeded (issue #704 §1). `verdict.accept`
+    // makes a declared non-2xx a successful outcome, so gating on `out.ok` alone commits the ABSENCE
+    // behind a `404` to the store: a record created a second later stays masked for the whole TTL. And
+    // the hit path above replays an entry as `resultEvt(found.data, found.status, 0)` WITHOUT re-running
+    // `interpret`/`verdict`, so that stored `404` would also reach a reader whose own verdict rejects it
+    // — the entry's accept list belonging to its WRITER rather than its reader.
+    //
+    // `< 400` is `classifyStatus`'s own threshold minus the accept term: exactly the statuses every
+    // reader counts as a success on its own merits, so a stored entry is sound no matter who reads it
+    // back. Deliberately inline and accept-BLIND by construction rather than a `ctl.` predicate or a
+    // `bypass:` trace event: `runCached` is in the core entry, which sits under a full bundle budget
+    // (scripts/bundle-size.mjs), and neither spelling fits in the headroom. Comments are free at
+    // runtime, so the reasoning lives here instead — the skip is silent, but nothing unsound is kept.
     const store = async (out: RunOutcome): Promise<void> => {
-        if (out.ok) await op.set(out.value, out.status, out.vary);
+        if (out.ok && out.status < 400)
+            await op.set(out.value, out.status, out.vary);
     };
 
     // Coalescing disabled: run the chain, write the cache last.
@@ -1686,6 +1700,11 @@ async function* runCached(
             throw e;
         }
         if (out.ok) {
+            // `settle` stays ungated: coalescing is in-process and the coalescer belongs to THIS
+            // stitch, so every follower shares the leader's verdict and its accept list. Sharing one
+            // concurrent accepted `404` among identical callers is the live behaviour they'd each
+            // have got anyway — only the durable write, which outlives the burst and can be read
+            // back by a different reader, is the one the status gate holds back.
             await store(out);
             claim.settle({ data: out.value, status: out.status });
         } else {

--- a/packages/core/test/cache.spec.ts
+++ b/packages/core/test/cache.spec.ts
@@ -4,7 +4,7 @@
 // eviction, the `sensitive` bypass, principal scope isolation, re-validate-on-hit + the
 // `version` fast path, and the cacheable-method gate (GraphQL opt-in).
 import { graphql, memoryStore, seam, stitch } from '../src';
-import type { Adapter, CacheOptions } from '../src';
+import type { Adapter, CacheOptions, StitchConfig } from '../src';
 import { clearFingerprinters, registerFingerprinter } from '../src/fingerprint';
 import type { SchemaFingerprinter } from '../src/fingerprint';
 import type { StandardSchemaV1 } from '../src/standard-schema';
@@ -836,5 +836,92 @@ describe('cache — non-storable pass-through', () => {
         expect(bypass).toBe(true);
         await s();
         expect(calls()).toBe(2); // not cached
+    });
+});
+
+describe('cache — an accepted non-2xx is never stored (#704 §1)', () => {
+    // A resource that does not exist YET: the first call 404s, every call after it finds the
+    // record. With `verdict: { accept: [404] }` that 404 is a normal result, so it arrives at the
+    // cache's store gate looking exactly like a success — which is the whole trap.
+    function lateArrival(): { adapter: Adapter; calls: () => number } {
+        let calls = 0;
+        const adapter: Adapter = async () => {
+            const n = (calls += 1);
+            return n === 1
+                ? { status: 404, headers: {}, body: { error: 'not found' } }
+                : { status: 200, headers: {}, body: { id: 1 } };
+        };
+        return { adapter, calls: () => calls };
+    }
+
+    const accepting = (adapter: Adapter): Partial<StitchConfig> => ({
+        url: URL,
+        adapter,
+        trace: false,
+        verdict: { accept: [404] },
+        cache: { ttl: '60s', tenancy: 'app' },
+    });
+
+    test('the absence behind an accepted 404 does not mask the record created after it', async () => {
+        const { adapter, calls } = lateArrival();
+        const s = stitch(accepting(adapter));
+        // Accepted, so it resolves with the error body as the value — that part is unchanged.
+        expect(await s()).toEqual({ error: 'not found' });
+        // The record exists now. Before the fix the stored ABSENCE answered here instead, for the
+        // whole 60s TTL, and the origin was never asked a second time.
+        expect(await s()).toEqual({ id: 1 });
+        expect(calls()).toBe(2);
+    });
+
+    test('the cache is still consulted — the 404 is read past, not bypassed', async () => {
+        // The skip is on the WRITE only: the run still misses the cache and still runs the chain,
+        // so a later 200 on the same key caches normally. (The skip itself is deliberately silent
+        // — a `bypass:` event did not fit the core entry's bundle budget; see the note at the
+        // store gate in engine.ts.)
+        const { adapter, calls } = lateArrival();
+        const s = stitch(accepting(adapter));
+        expect(await cacheTrace(s.stream())).toContain('miss'); // 404 — consulted, not stored
+        expect(await s()).toEqual({ id: 1 }); // so this reaches the origin and finds the record
+        expect(await cacheTrace(s.stream())).toContain('hit'); // …and THAT is what caches
+        expect(calls()).toBe(2); // the 404 and the record; the hit cost nothing
+    });
+
+    test('an accepted 404 cannot be replayed to a reader whose own verdict rejects it', async () => {
+        // A hit replays as `resultEvt(found.data, found.status, 0)` WITHOUT re-running
+        // `interpret`/`verdict`, so a stored entry's accept list would govern whoever reads it
+        // next. Two stitches over one store landing on one derived key (same method + url, and
+        // both fall back to the same default cache id): the WRITER accepts 404, the READER does
+        // not. Before the fix the reader was handed the writer's 404 body as a success.
+        const store = memoryStore();
+        let calls = 0;
+        const adapter: Adapter = async () => {
+            calls += 1;
+            return { status: 404, headers: {}, body: { error: 'not found' } };
+        };
+        const base: Partial<StitchConfig> = {
+            url: URL,
+            adapter,
+            trace: false,
+            store,
+            cache: { ttl: '60s', tenancy: 'app' } satisfies CacheOptions,
+        };
+        const writer = stitch({ ...base, verdict: { accept: [404] } });
+        const reader = stitch(base); // no accept list — here a 404 is a failure
+
+        expect(await writer()).toEqual({ error: 'not found' });
+        await expect(reader()).rejects.toThrow(/404/);
+        expect(calls).toBe(2); // the reader reached the origin instead of inheriting the entry
+    });
+
+    test('a 200 still caches and replays exactly as it always has', async () => {
+        const { adapter, calls } = counting(); // always 200
+        // Same accept list — it simply never fires, so the healthy path must be byte-identical.
+        const s = stitch(accepting(adapter));
+        expect(await s()).toEqual({ n: 1 });
+        expect(await s()).toEqual({ n: 1 }); // served from cache, not the origin
+        expect(calls()).toBe(1);
+        const trace = await cacheTrace(s.stream());
+        expect(trace).toContain('hit');
+        expect(trace.some((d) => d.startsWith('bypass'))).toBe(false);
     });
 });


### PR DESCRIPTION
## The bug

`verdict: { accept: [404] }` makes a declared non-2xx a **successful** outcome. The cache's store
gate was `out.ok` and nothing else, so the **absence** behind that 404 was written to the store.

[`packages/core/src/engine.ts:1668-1670`](https://github.com/rejifald/StitchAPI/blob/44a9fcc/packages/core/src/engine.ts#L1668-L1670)
(on `origin/main`):

```ts
const store = async (out: RunOutcome) => {
    if (out.ok) await op.set(out.value, out.status, out.vary);
};
```

Two consequences, both verified live on `origin/main`:

**1. A record created after the 404 is masked for the whole TTL.** The absence is cached, so the
stitch keeps answering "not found" long after the thing exists.

**2. The cached 404 crosses into a stitch that never accepted it.**
[`engine.ts:1658-1662`](https://github.com/rejifald/StitchAPI/blob/44a9fcc/packages/core/src/engine.ts#L1658-L1662)
replays a hit as `resultEvt(found.data, found.status, 0)` — **without running the reader's
`interpret`/`verdict` at all**:

```ts
if (!stale) {
    yield cacheEvt(ctl.revalidateOnHit ? 'hit (revalidated)' : 'hit');
    yield resultEvt(found.data, found.status, 0);
    yield doneEvt(true, t0, 0);
    return;
}
```

So an entry's accept list ends up belonging to its **writer** rather than its **reader**. Two
stitches reach one key easily: `cacheStitchId` falls back to `cfg.name ?? cfg.path ?? 'stitch'`
([`cache.ts:294-296`](https://github.com/rejifald/StitchAPI/blob/44a9fcc/packages/core/src/cache.ts#L294-L296)),
so two unnamed stitches over one URL already share a namespace. That collision is **#704 §3** and
stays open — this fix makes the replay unreachable through an accepted non-2xx regardless of it.

## The fix

The gate now reads the **status**, accept-blind:

```ts
if (out.ok && out.status < 400)
    await op.set(out.value, out.status, out.vary);
```

`< 400` is `classifyStatus`'s own threshold minus the accept term
([`surface.ts:147`](https://github.com/rejifald/StitchAPI/blob/44a9fcc/packages/core/src/surface.ts#L147)) —
exactly the set every reader counts as a success **on its own merits**. Nothing a `verdict.accept`
had to rescue becomes durable, so consequence 2 is closed by construction: there is no stored
non-2xx left to replay.

It is the narrowest gate that does the job. 2xx/3xx still cache exactly as before (a `301` under
`redirect: 'manual'` is canonically cacheable and keeps working); only the accepted-≥400 set, which
is precisely the buggy set, stops being written.

**Coalescing is deliberately untouched.** `claim.settle` stays ungated: the coalescer belongs to the
stitch that owns it, so every follower shares the leader's verdict, and sharing one concurrent
accepted 404 among identical in-flight callers is the live behaviour each would have got anyway.
Only the *durable* write — which outlives the burst and can be read back by someone else — is held
back.

### Why inline, and not a predicate plus a trace event

This started as `ctl.storableStatus(status)` on the cache controller with a
`cacheEvt('bypass: non-storable status 404')` alongside it, mirroring the nearby
`bypass: non-storable responseType`. It did not fit the bundle budget. `runCached` is in the core
entry, and #676 left it 14 B of headroom:

| variant | whole entry | vs budget 24.10 KB |
| --- | --- | --- |
| `main` | 24664 B | ✓ 14 B left |
| predicate + `bypass:` event | 24694 B (+30 B) | ✗ **over by 16 B** |
| bare predicate, no event | ~24685 B (+21 B) | ✗ **over by 7 B** |
| **inline `out.status < 400`** | **24670 B (+6 B)** | **✓ 8 B left** |

That file says sizing a budget step is the maintainer's call, not a bug fix's, so **no budget is
raised here** — the fix fits under the existing ceiling instead. `import { stitch }` is +7 B
(22026 → 22033 B) against a 22067 B budget, 34 B left. The advertised **24 / 22 kB** figures do not
move, verified via `bundle-size.mjs --json` against the `bundle-advertised-size` tether.

The cost is that the skipped write is **silent**. The reasoning lives in a comment at the gate,
which costs nothing at runtime.

## Semver: a `fix`, not a breaking change

Filed under `### Fixed`.

A caller who today deliberately caches an accepted 404 does lose that caching and pays a live call
per call — the one visible consequence, and the CHANGELOG entry says so. It is still a fix, not a
break:

- The entry it loses **was never sound**. ADR 0003 decision 2 has it that a stored entry is always a
  known-good value; this one could be handed to a reader whose verdict rejects it.
- The success **value** a caller sees is unchanged. Only staleness and the origin-call count move,
  and both move toward correct: where the old behaviour returned a stale absence, the new one
  returns the record that now exists.
- The one case where a *result* changes — a reader being handed the writer's accepted 404 as a
  success — is the bug itself. Restoring the reader's declared verdict is a correction, not a
  removal.

## What I tested

Four tests in `packages/core/test/cache.spec.ts`, matching the existing counting-adapter style:

1. **The absence does not mask the record created after it** — an adapter that 404s once then
   serves the record; the second call reaches the origin and returns it.
2. **The cache is still consulted** — the 404 run still `miss`es and runs the chain, and the 200
   that follows caches and replays normally (so the skip is on the write only, not a full bypass).
3. **Cross-stitch replay (consequence 2)** — two stitches over one `memoryStore` landing on one
   derived key; the writer accepts 404, the reader does not. The reader reaches the origin and fails
   on its own verdict instead of inheriting the writer's entry.
4. **A plain 200 caches and replays exactly as before** — same `accept: [404]` list, which simply
   never fires.

Tests 1-3 **fail on `main`** (verified by reverting the guard to `if (out.ok)`); test 4 passes both
ways, which is the point of it.

### Gates

All green from the repo root: `prettier --write`, `check:lint`, `check:types`, `test`
(139 files, 1495 passed), `check-changelog.mjs`, `check-contract.mjs`, `check-unknown-keys.mjs`, and
`check:size` (added after noticing CI runs it as its own job).

`check-contract.mjs` is worth a note: the original `cacheableStatus` spelling tripped **R8/P24** —
`cacheableMethod` + `cacheableStatus` share a leading-word prefix and would have had to fold into an
envelope. Moot now that the check is inline, but it is a second, independent reason the controller
predicate was the wrong shape here.

## Scope

§2 (no working `invalidate` spelling), §3 (`cacheStitchId` collision) and §4 are untouched — hence
`Refs`, not `Fixes`.

Refs #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)
