### PR TITLE
docs(changelog): record the abort-reason fix under Unreleased → Fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -580,6 +580,31 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Fixed
 
+- **A cancelled call surfaces the caller's own abort reason, and is never reported as a retry.**
+  ([#705](https://github.com/rejifald/StitchAPI/issues/705)) With a `retry` block configured, an
+  abort that landed while the call was parked in a backoff sleep came back as a generic
+  `Error('aborted')`: the same stitch, cancelled the same way, answered `user navigated away`
+  without `retry` and `aborted` with it. The backoff `sleep` minted its own error rather than
+  preferring the signal's `reason`.
+
+    The same cancellation also read as a **retry**. The attempt-loop catch emitted a
+    `progress: 'retry'` event and fired the `onRetry` hook before dying in the backoff — a phantom
+    attempt, reported to every trace consumer, for a call the user deliberately cancelled. The catch
+    now rethrows as soon as the caller's signal is aborted: no `retry` event, no `onRetry`, no
+    backoff. `onError` still fires, because that attempt did end.
+
+    "Which error does an abort surface?" now has one spelling — `abortReason` in `util.ts`, shared
+    by `sleep`, the engine's abort paths and `withTimeout`'s signal link, replacing three hand-copies
+    of which one had already drifted. The mocking kit follows the same rule, so the behaviour is
+    observable under injected clocks: `manualClock.sleep` and `mockAdapter` reject with the signal's
+    reason exactly as `systemClock.sleep` and real `fetch` do.
+
+    **Timeouts are untouched** — the guard keys on the caller's own signal, so a per-attempt or
+    total timeout still retries as before. The other two findings in
+    [#705](https://github.com/rejifald/StitchAPI/issues/705) — an abort counting as a circuit
+    failure even when it sent no request, and the coalescer's unreachable cancel path — are
+    unchanged and remain open.
+
 - **Breaking out of a `.stream()` loop cancels the response body instead of leaking the socket.**
   ([#686](https://github.com/rejifald/StitchAPI/issues/686)) The `'bytes'` (default) and `'json'`
   decoders released the reader lock without cancelling, so an abandoned stream stayed open and the


### PR DESCRIPTION
## What

[#674](https://github.com/rejifald/StitchAPI/pull/674) landed the abort-reason fix — a cancelled call now surfaces the caller's own `abort(reason)`, and a deliberate cancel is never reported as a `retry` — but it carried no CHANGELOG entry, and it merged before one could be added to its branch. Every comparable core fix around it (#676, #686, #699, #704) records its behaviour change under `Unreleased → Fixed`, so this carries the missing entry over. Content only; no code changes.

## Notes

- Entered against [#705](https://github.com/rejifald/StitchAPI/issues/705), whose **finding 2** ("`retry` replaces the caller's cancellation reason with a generic one") is precisely what #674 fixed.
- The entry explicitly names the issue's **other two findings as still open** — an abort counting as a circuit failure even when it sent 0 requests, and the coalescer's ref-counted cancel path being unreachable — so it cannot be read as closing #705.
- It also records the deliberate scope call in #674: `onError` still fires on a cancelled attempt (that attempt did end), where #705's ask was to skip it alongside `onRetry`. Timeouts are unaffected — the guard keys on the caller's own signal.

`check:changelog` and `prettier --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)