### PR TITLE
build(ts): drop the redundant `baseUrl` so TypeScript 6 typechecks

### DIFF
--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -24,7 +24,6 @@
 
         "types": ["node", "vitest/globals"],
 
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"],

--- a/packages/aws-sigv4/tsconfig.json
+++ b/packages/aws-sigv4/tsconfig.json
@@ -21,7 +21,6 @@
 
         "types": ["node", "vitest/globals"],
 
-        "baseUrl": ".",
         "paths": {
             "stitchapi/auth": ["../core/src/auth.ts"],
             "stitchapi/testing": ["../core/src/testing.ts"],

--- a/packages/cloudflare-kv/tsconfig.json
+++ b/packages/cloudflare-kv/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (the pre-push gate typechecks
         // before it builds). The published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"]

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -18,12 +18,7 @@
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "verbatimModuleSyntax": true,
-        "isolatedModules": true,
-
-        "baseUrl": "./",
-        "paths": {
-            "@/*": ["src/*"]
-        }
+        "isolatedModules": true
     },
     "include": ["src/**/*.ts"],
     "exclude": ["lib", "node_modules"]

--- a/packages/deno-kv/tsconfig.json
+++ b/packages/deno-kv/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (the pre-push gate typechecks
         // before it builds). The published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"]

--- a/packages/elysia/tsconfig.json
+++ b/packages/elysia/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (the pre-push gate typechecks
         // before it builds). The published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi/sse": ["../core/src/sse.ts"],

--- a/packages/eval-harness/tsconfig.json
+++ b/packages/eval-harness/tsconfig.json
@@ -14,7 +14,6 @@
         // Resolve the workspace `stitchapi` import to its SOURCE so typecheck
         // doesn't depend on core being built first (the published `exports` map
         // still points at `lib/`). Mirrors the sibling integration packages.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/auth": ["../core/src/auth.ts"],
             "stitchapi": ["../core/src/index.ts"]

--- a/packages/expo/tsconfig.json
+++ b/packages/expo/tsconfig.json
@@ -23,7 +23,6 @@
 
         // Resolve the workspace packages to their SOURCE so typecheck + tests don't
         // depend on a build ordering. The published `exports` maps point at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"],

--- a/packages/express/tsconfig.json
+++ b/packages/express/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (the pre-push gate typechecks
         // before it builds). The published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi/sse-emit": ["../core/src/sse-emit.ts"],

--- a/packages/fastify/tsconfig.json
+++ b/packages/fastify/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (the pre-push gate typechecks
         // before it builds). The published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi/sse-emit": ["../core/src/sse-emit.ts"],

--- a/packages/fingerprint-arktype/tsconfig.json
+++ b/packages/fingerprint-arktype/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (the pre-push gate typechecks
         // before it builds). The published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/fingerprint": ["../core/src/fingerprint.ts"],
             "stitchapi/testing": ["../core/src/testing.ts"],

--- a/packages/fingerprint-effect/tsconfig.json
+++ b/packages/fingerprint-effect/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (the pre-push gate typechecks
         // before it builds). The published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/fingerprint": ["../core/src/fingerprint.ts"],
             "stitchapi/testing": ["../core/src/testing.ts"],

--- a/packages/fingerprint-typebox/tsconfig.json
+++ b/packages/fingerprint-typebox/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (the pre-push gate typechecks
         // before it builds). The published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/fingerprint": ["../core/src/fingerprint.ts"],
             "stitchapi/testing": ["../core/src/testing.ts"],

--- a/packages/fingerprint-valibot/tsconfig.json
+++ b/packages/fingerprint-valibot/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (the pre-push gate typechecks
         // before it builds). The published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/fingerprint": ["../core/src/fingerprint.ts"],
             "stitchapi/testing": ["../core/src/testing.ts"],

--- a/packages/fingerprint-zod/tsconfig.json
+++ b/packages/fingerprint-zod/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (the pre-push gate typechecks
         // before it builds). The published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/fingerprint": ["../core/src/fingerprint.ts"],
             "stitchapi/testing": ["../core/src/testing.ts"],

--- a/packages/hono/tsconfig.json
+++ b/packages/hono/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (the pre-push gate typechecks
         // before it builds). The published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi/sse": ["../core/src/sse.ts"],

--- a/packages/json-schema/tsconfig.json
+++ b/packages/json-schema/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't depend on
         // `stitchapi` being built first (the pre-push gate typechecks before it builds). The
         // published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi": ["../core/src/index.ts"]
         }

--- a/packages/nest/tsconfig.json
+++ b/packages/nest/tsconfig.json
@@ -25,7 +25,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (the pre-push gate typechecks
         // before it builds). The published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/auth": ["../core/src/auth.ts"],
             "stitchapi/sse-emit": ["../core/src/sse-emit.ts"],

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -21,7 +21,6 @@
 
         "types": ["node", "vitest/globals"],
 
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi/sse-emit": ["../core/src/sse-emit.ts"],

--- a/packages/pino/tsconfig.json
+++ b/packages/pino/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (the pre-push gate typechecks
         // before it builds). The published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"]

--- a/packages/query-core/tsconfig.json
+++ b/packages/query-core/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (the pre-push gate typechecks
         // before it builds). The published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"]

--- a/packages/react-native/tsconfig.json
+++ b/packages/react-native/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace packages to their SOURCE so typecheck + tests
         // don't depend on `stitchapi` / `@stitchapi/query-core` / `@stitchapi/react`
         // being built first. The published `exports` maps still point at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"],

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -26,7 +26,6 @@
         // Resolve the workspace packages to their SOURCE so typecheck + tests
         // don't depend on `stitchapi` / `@stitchapi/query-core` being built
         // first. The published `exports` maps still point at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"],

--- a/packages/redis/tsconfig.json
+++ b/packages/redis/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (the pre-push gate typechecks
         // before it builds). The published `exports` map still points at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"]

--- a/packages/rtk-query/tsconfig.json
+++ b/packages/rtk-query/tsconfig.json
@@ -21,7 +21,6 @@
 
         "types": ["node", "vitest/globals"],
 
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"]

--- a/packages/sentry/tsconfig.json
+++ b/packages/sentry/tsconfig.json
@@ -21,7 +21,6 @@
 
         "types": ["node", "vitest/globals"],
 
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"]

--- a/packages/shell/tsconfig.json
+++ b/packages/shell/tsconfig.json
@@ -26,7 +26,6 @@
 
         // Resolve the workspace package to its SOURCE so typecheck + tests don't
         // depend on `stitchapi` being built first (mirrors @stitchapi/nest).
-        "baseUrl": ".",
         "paths": {
             "stitchapi": ["../core/src/index.ts"]
         }

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace packages to their SOURCE so typecheck + tests
         // don't depend on `stitchapi` / `@stitchapi/query-core` being built
         // first. The published `exports` maps still point at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"],

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace packages to their SOURCE so typecheck + tests
         // don't depend on `stitchapi` / `@stitchapi/query-core` being built
         // first. The published `exports` maps still point at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"],

--- a/packages/swr/tsconfig.json
+++ b/packages/swr/tsconfig.json
@@ -22,7 +22,6 @@
 
         "types": ["node", "vitest/globals"],
 
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"]

--- a/packages/vercel-ai/tsconfig.json
+++ b/packages/vercel-ai/tsconfig.json
@@ -21,7 +21,6 @@
 
         "types": ["node", "vitest/globals"],
 
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"]

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -24,7 +24,6 @@
         // Resolve the workspace packages to their SOURCE so typecheck + tests
         // don't depend on `stitchapi` / `@stitchapi/query-core` being built
         // first. The published `exports` maps still point at `lib/`.
-        "baseUrl": ".",
         "paths": {
             "stitchapi/testing": ["../core/src/testing.ts"],
             "stitchapi": ["../core/src/index.ts"],


### PR DESCRIPTION
## What

Unblocks [#733](https://github.com/rejifald/StitchAPI/pull/733) (TypeScript 5.9.3 → 6.0.3), which currently fails 7 CI jobs on a single root cause:

```
packages/core check:types: tsconfig.json(23,9): error TS5101: Option 'baseUrl' is
deprecated and will stop functioning in TypeScript 7.0.
```

`packages/core` is the first project to typecheck, so that one error masked whatever else may be behind it.

## Why this is a no-op

All 32 tsconfigs set `baseUrl` to their own directory (`"."`; core's `"./"`), and when `baseUrl` is absent `paths` resolve relative to the tsconfig's own directory — the same place. Every one of the 31 workspace mappings was already relative (`../core/src/index.ts` and friends).

The single exception was core's `"@/*": ["src/*"]`, whose target is non-relative and so *requires* `baseUrl` (TS5090). It is dead config — `@/` has zero import sites anywhere under `packages/`, and the only match in the repo was its own declaration — so the mapping is removed rather than given a `./`. `apps/docs`, which does use `@/` (79 imports), already declares `paths` without `baseUrl` and is untouched.

## Verification

- `pnpm check:types` green across all 38 workspace projects on the current TypeScript.
- `packages/core` typechecks **clean under TypeScript 6.0.3** with this change applied (checked against a pinned 6.0.3 compiler out of tree).
- Full pre-push gauntlet green (12 gates).

Whether TS 6 raises further issues in projects *behind* core will show when #733 re-runs; this clears the error that is stopping it from getting that far. #733 should be refreshed with `@dependabot rebase` after this lands — not `update-branch`, which would lock dependabot out of the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)