### PR TITLE
test(core): de-flake the slow-vs-stall download pin (drive both halves)

### DIFF
--- a/packages/core/test/gaps/download-slow-vs-stall.spec.ts
+++ b/packages/core/test/gaps/download-slow-vs-stall.spec.ts
@@ -17,11 +17,24 @@
 // `onProgress` byte stream. No `src/` change is made here — this pins present behavior and documents
 // the gap.
 //
-// Real-timer, LOOSE bounds (a socket test): chunk cadence (120ms × 8 = ~960ms of streaming) is set
-// well above the 400ms budget so the timeout reliably fires mid-stream after a few progress ticks,
-// with wide margins against scheduler jitter. `chunkDelay` streams a real chunked body; teardown
-// force-destroys any lingering socket (mock-server tracks live sockets), so the suite exits.
+// DRIVEN, NOT RACED (why this one is not a loose real-timer test like its download siblings): the
+// two halves of the finding — "several chunks arrived" and "the budget fired anyway" — used to race
+// each other on the wall clock, chunk cadence tuned to land inside the budget. Under a full parallel
+// suite the budget could win before the second chunk was read, tripping `seen.length > 1`. Both
+// halves are now driven:
+//   • the transport stays REAL — a real socket, a real chunked body, undici's reader and the real
+//     `readWithProgress` (http-adapter.ts) — but the fixture's `chunkForever` trickle NEVER ends, so
+//     the call cannot resolve out from under the test however slowly the chunks arrive. The test
+//     WAITS for real progress instead of assuming it landed in time;
+//   • the budget rides an injected `manualClock` (ADR 0010): with one attempt, `timeout.total` IS
+//     this attempt's abort (engine.ts clamps `attemptMs` to what's left of the budget), and
+//     `withTimeout` arms that abort on `clock.setTimer` — so it fires exactly when this test spends
+//     it, and only AFTER real bytes have been observed. (Per ADR 0010 the budget's DEADLINE
+//     arithmetic stays wall-clock; what the clock drives is the countdown it is clamped into.)
+// The guarantee is unchanged, and sharper: real bytes arrived, the countdown was never re-armed by
+// them (exactly ONE pending timer throughout), and spending the budget still killed a live transfer.
 import { download } from '../../src/download';
+import { manualClock } from '../../src/test-clock';
 import type { AdapterProgress } from '../../src/types';
 import { startMockServer } from '../support/mock-server';
 import type { MockServer } from '../support/mock-server';
@@ -37,50 +50,90 @@ beforeEach(() => {
     server.reset();
 });
 
-// 64 bytes streamed as 8 chunks of 8 bytes, 120ms apart (~960ms total) — a steady trickle. A 400ms
-// budget cuts it after ~3 chunks. The body is HEALTHY (bytes flowing), yet the wall-clock timeout
-// kills it anyway; `onProgress` proves the progress was real before the reject.
+// Poll a real condition (real bytes landing off a real socket) up to a ceiling — an event-wait, not
+// a timing measure: it waits as long as a loaded machine needs, and fails LOUDLY if the bytes never
+// come. Same helper, and same reason, as download-retry-after.spec.ts.
+const until = async (cond: () => boolean, ms = 2000): Promise<void> => {
+    const start = Date.now();
+    while (!cond()) {
+        if (Date.now() - start > ms)
+            throw new Error(`until: condition not met within ${ms}ms`);
+        await new Promise((r) => setTimeout(r, 5));
+    }
+};
+
+const BUDGET = 400; // the whole wall-clock budget for the call — spent by hand, on the manual clock
+const CHUNKS_BEFORE_KILL = 3; // real chunks that must land off the socket before we spend it
+
+// A steady 8-bytes-per-chunk trickle that never finishes (`chunkForever` wraps the 64-byte body), so
+// the transfer is still HEALTHY — bytes arriving — at the instant the budget is spent. The
+// wall-clock timeout kills it anyway; `onProgress` proves the progress was real before the reject.
 test('a healthy-but-slow (steadily progressing) download is killed by the same wall-clock timeout as a stall', async () => {
+    const clock = manualClock();
     server.route('GET', '/trickle', {
         statuses: [200],
         rawBody:
             'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ012', // 64 bytes
         chunkBytes: 8, // 8 bytes per chunk…
-        chunkDelay: 120, // …every 120ms → ~960ms to stream the whole body
+        chunkDelay: 20, // …every 20ms — a steady trickle…
+        chunkForever: true, // …that never completes: only the timeout below can end this call
     });
 
     const seen: AdapterProgress[] = [];
+    let settled = false;
     const getTrickle = download({
         baseUrl: server.url,
         path: '/trickle',
-        timeout: 400, // ≡ { total: 400 } — wall-clock; no idle/progress timeout exists
-        retry: { attempts: 1 },
+        timeout: BUDGET, // ≡ { total: 400 } — wall-clock; no idle/progress timeout exists
+        retry: { attempts: 1 }, // one attempt → the total budget IS this attempt's abort…
+        clock, // …which `withTimeout` arms on this clock, so the test spends it by hand
     });
 
     const started = Date.now();
-    const err = await getTrickle({
+    const outcome = getTrickle({
         onProgress: (p) => {
             seen.push(p);
         },
     }).then(
         () => {
+            settled = true;
             throw new Error(
                 'slow-but-progressing download unexpectedly resolved',
             );
         },
-        (e: unknown) => e,
+        (e: unknown) => {
+            settled = true;
+            return e;
+        },
     );
+
+    // Wait for REAL forward progress off the socket. Virtual time is frozen while we wait, so the
+    // budget cannot fire underneath us — this is a synchronization point, not a race.
+    await until(() => seen.length >= CHUNKS_BEFORE_KILL);
+    const beforeKill = seen.length;
+
+    // The transfer is healthy right now: bytes have been arriving and the call is still in flight…
+    expect(settled).toBe(false);
+    // …and the countdown was armed ONCE, at attempt start, and NOT re-armed by any of those chunks —
+    // exactly one pending timer. That missing per-chunk re-arm IS the absent idle/forward-progress
+    // timeout this test documents.
+    expect(clock.pending()).toBe(1);
+
+    // Spend the budget. Nothing else changed — the body is still trickling — and it dies anyway.
+    await clock.advance(BUDGET);
+    const err = await outcome;
     const elapsed = Date.now() - started;
 
-    // It REJECTED (the wall-clock budget fired), promptly, and cut by the timeout — not resolved.
+    // It REJECTED (the wall-clock budget fired) and was cut by the timeout — not resolved.
     expect(err).toBeInstanceOf(Error);
-    expect(elapsed).toBeLessThan(5000);
     expect((err as Error).message).toMatch(/timeout|timed out|abort|aborted/i);
+    expect(elapsed).toBeLessThan(5000); // real time: the call never hangs past its virtual budget
+    expect(clock.pending()).toBe(0); // the budget's timer fired; nothing leaked
 
     // …and it was HEALTHY, not stalled: progress fired and `loaded` climbed across chunks BEFORE the
     // reject. This is the evidence that a *progressing* transfer — not a dead one — was killed by the
     // wall-clock timeout, which is exactly the finding an idle/forward-progress timeout would fix.
-    expect(seen.length).toBeGreaterThan(1);
+    expect(beforeKill).toBeGreaterThan(1);
     expect(seen.every((p) => p.direction === 'download')).toBe(true);
     const loaded = seen.map((p) => p.loaded);
     const lastLoaded = loaded[loaded.length - 1] ?? 0;

--- a/packages/core/test/support/mock-server.ts
+++ b/packages/core/test/support/mock-server.ts
@@ -105,6 +105,17 @@ export interface RouteBehavior {
      */
     chunkDelay?: number;
     /**
+     * Never finish the chunked body: once the last slice of `rawBody` is written, wrap back to byte 0
+     * and keep trickling instead of `end()`ing — an ENDLESS steady transfer that only the CLIENT can
+     * end (abort / timeout), modelling a body larger than the caller's budget. Distinct from
+     * `stallAfterBytes`, whose held socket goes idle: here bytes are still arriving at the moment the
+     * caller cuts the call, which is what makes the transfer *healthy-but-slow* rather than stalled.
+     * It also removes a race a finite trickle can't: the body can never complete out from under a test
+     * that is waiting to observe progress first. The socket is tracked (teardown destroys it) and the
+     * write loop bails as soon as the client goes away. Only honoured on the `rawBody` chunked path.
+     */
+    chunkForever?: boolean;
+    /**
      * Answer with an HTTP redirect to `redirectTo` (M3 redirect-fault rig). The response is the
      * route's status (drawn from the `statuses` array so 301/302/303/307/308 can be scripted per
      * call; **defaults to 302** when the resolved status isn't itself a 3xx redirect code) plus a
@@ -480,10 +491,15 @@ export function startMockServer(): Promise<MockServer> {
                 buildHeaders('application/octet-stream', extra),
             );
             const size = extra.chunkBytes ?? bytes.length;
-            for (let off = 0; off < bytes.length; off += size) {
+            let off = 0;
+            while (off < bytes.length) {
                 if (extra.chunkDelay) await sleep(extra.chunkDelay);
-                if (res.writableEnded || res.destroyed) break;
+                if (res.writableEnded || res.destroyed) return;
                 res.write(bytes.subarray(off, off + size));
+                off += size;
+                // `chunkForever`: wrap instead of finishing, so the trickle never ends and the only
+                // way out of this loop is the client going away (the `return` above).
+                if (off >= bytes.length && extra.chunkForever) off = 0;
             }
             if (!res.writableEnded && !res.destroyed) res.end();
         };


### PR DESCRIPTION
## The flake

`a healthy-but-slow (steadily progressing) download is killed by the same wall-clock timeout as a stall` failed inside a full `pnpm test` run (169 core test files in parallel) with:

```
AssertionError: expected 1 to be greater than 1
 ❯ test/gaps/download-slow-vs-stall.spec.ts:83   expect(seen.length).toBeGreaterThan(1)
```

Run alone (`pnpm exec vitest run test/gaps/download-slow-vs-stall.spec.ts`) it passed 3/3. Arrived with #639.

## Why

The test asserted two things that were **racing each other on the wall clock**: *"several progress events arrived"* and *"the 400ms budget fired anyway"*. The chunk cadence (8 × 8 bytes, 120ms apart) was tuned so the timeout would land mid-stream.

The mock server shares the test's event loop, so a stall — parallel vitest workers, a concurrent build — delays the server's writes and the client's reads **together**, while the abort timer keeps its wall-clock date. libuv drains the whole timers phase before polling I/O, so the abort can fire with only the first chunk read, leaving `seen.length` at 1.

## What changed

Neither half is left to timing now, and the transport stays real — a real socket, a real chunked body, undici's reader and the real `readWithProgress`:

- **The budget rides an injected `manualClock`** (ADR 0010). With one attempt, `timeout.total` *is* this attempt's abort — `engine.ts` clamps `attemptMs` to what's left of the budget, and `withTimeout` arms that countdown on `clock.setTimer` — so it fires exactly when the test spends it, and only *after* real bytes have been observed. Same seam the Retry-After pin next door already uses. (Per ADR 0010 the budget's *deadline arithmetic* stays wall-clock; what the clock drives is the countdown it is clamped into.)
- **The body can no longer finish out from under the test.** New `chunkForever` knob on the mock server's chunked path: it wraps back to byte 0 instead of `end()`ing, so bytes are still arriving at the instant of the kill — which is also what keeps the transfer *healthy-but-slow* rather than a stall, the distinction this file exists to draw. (Distinct from `stallAfterBytes`, whose held socket goes idle.)
- **The test waits for 3 real chunks** (`until(...)`, the helper from `download-retry-after.spec.ts`) instead of assuming they landed in time.

The guarantee is **stronger, not weaker**:

- the count assertion moved to `beforeKill`, so it pins that progress happened *before* the kill rather than merely at some point;
- `clock.pending()` is asserted to be exactly `1` while chunks are arriving — one countdown, armed once at attempt start and **never re-armed by a chunk**, which is the literal absence of the idle / forward-progress timeout this file documents;
- nothing was lowered to `>= 1`, and nothing retries.

No `src/` change — this stays a pin of present behavior plus a documented design gap.

## Verification

**A/B against the reported failure.** With a deliberate 1.2s event-loop stall injected mid-flight, a scratch copy of the pre-fix spec reproduces it exactly (`expected 1 to be greater than 1`); the fixed spec passes that same stall, and a harsher variant that burns ~2.8s of real time (7× the budget) before advancing the clock — which also confirms the budget has no other wall-clock enforcement on this path.

- full root `pnpm test` — green: 35 package/app runs, core **169/169 files, 1574 tests**
- 4 × full core suite (170 files, incl. the pre-fix copy) and 12 × single file, under 20 CPU spinners on 14 cores — 0 failures
- `check:lint` (37 packages), `check:types`, `prettier --check`, `check:changelog`
- the file's test time dropped from ~400ms to ~100ms

## For the reviewer

- `sendChunked` is refactored from a `for` to a `while` so the offset can wrap; behavior for every existing caller (and the empty-body case) is unchanged — `chunkBytes`/`chunkDelay` on the `rawBody` path has exactly one other user, and `stream.chunkDelay` (SSE) is a different path.
- **Sibling sweep** for the same defect shape — *a minimum count of real-time-arriving stream events asserted against a wall-clock deadline that ends the call* — found no other instance. The other `onProgress` specs (`download.spec.ts`, `adapter-streaming`, `xhr-adapter*`) assert `> 0` on transfers that run to completion with no timeout cutting them off, and `resilience.spec.ts`'s `>= 2` / `>= 1` counts are driven by scripted statuses and concurrency, not by a budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
