### PR TITLE
feat(docs): attribute npm-referred traffic with a canonical `utm_source` tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">
-  <a href="https://stitchapi.dev"><strong>📚 stitchapi.dev</strong></a> — documentation, guides &amp; live playground
+  <a href="https://stitchapi.dev?from=gh"><strong>📚 stitchapi.dev</strong></a> — documentation, guides &amp; live playground
 </p>
 
 <p align="center">
@@ -42,7 +42,7 @@
 </p>
 
 <p align="center">
-  <a href="https://stitchapi.dev/demo">
+  <a href="https://stitchapi.dev/demo?from=gh">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="docs/media/demo-dark.webp 1x, docs/media/demo-dark@2x.webp 2x" />
       <img src="docs/media/demo.webp" srcset="docs/media/demo.webp 1x, docs/media/demo@2x.webp 2x" width="1280" alt="StitchAPI demo — a stitch streaming a reply, validating output, retrying a 502, and answering an agent tool call" />
@@ -51,7 +51,7 @@
 </p>
 
 <p align="center">
-  <sub><a href="https://stitchapi.dev/demo">Watch more</a></sub>
+  <sub><a href="https://stitchapi.dev/demo?from=gh">Watch more</a></sub>
 </p>
 
 > [!NOTE]
@@ -172,7 +172,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 npm install stitchapi@rc   # or: pnpm add stitchapi@rc · yarn add stitchapi@rc
 ```
 
-Validation is bring-your-own — pass a [Zod](https://zod.dev) schema or any [Standard Schema](https://standardschema.dev) validator; none is bundled. The examples below use Zod for familiarity, and `api.example.com` as an illustrative host — point them at your own API to run them, or try them as-is in the [playground](https://stitchapi.dev/#playground), which serves that host from an in-browser simulator.
+Validation is bring-your-own — pass a [Zod](https://zod.dev) schema or any [Standard Schema](https://standardschema.dev) validator; none is bundled. The examples below use Zod for familiarity, and `api.example.com` as an illustrative host — point them at your own API to run them, or try them as-is in the [playground](https://stitchapi.dev/?from=gh#playground), which serves that host from an in-browser simulator.
 
 ## Quick start
 
@@ -238,7 +238,7 @@ const getUser = api.stitch({
 });
 ```
 
-For lighter reuse, `extends: [fragment | stitch]` merges config left→right (own fields win), and `.with()` pre-binds part of the input while reusing the same runtime. Full guide: [Authoring](https://stitchapi.dev/docs/guides/authoring/stitch).
+For lighter reuse, `extends: [fragment | stitch]` merges config left→right (own fields win), and `.with()` pre-binds part of the input while reusing the same runtime. Full guide: [Authoring](https://stitchapi.dev/docs/guides/authoring/stitch?from=gh).
 
 ## Validation & leveled drift
 
@@ -268,7 +268,7 @@ const listOrders = stitch({
 });
 ```
 
-Drift is schema-anchored — no snapshot to manage. Severity lives in the schema: a required field missing/incompatible is a hard `invalid` that **throws**; everything else is non-fatal drift on the event stream. Declared variance (an optional field, a nullable, an empty array) validates clean, so it's never a false alarm; `ignore` silences known-but-unconsumed fields and `severity` filters or re-levels the soft signals. The request side validates too: `input` takes a schema per part and fails fast before any request is sent. Full guide: [Validation & drift](https://stitchapi.dev/docs/guides/validation/drift).
+Drift is schema-anchored — no snapshot to manage. Severity lives in the schema: a required field missing/incompatible is a hard `invalid` that **throws**; everything else is non-fatal drift on the event stream. Declared variance (an optional field, a nullable, an empty array) validates clean, so it's never a false alarm; `ignore` silences known-but-unconsumed fields and `severity` filters or re-levels the soft signals. The request side validates too: `input` takes a schema per part and fails fast before any request is sent. Full guide: [Validation & drift](https://stitchapi.dev/docs/guides/validation/drift?from=gh).
 
 ## Resilience: retry, throttle, timeout
 
@@ -284,7 +284,7 @@ const listUsers = stitch({
 });
 ```
 
-`throttle` is proactive (keeps you under a limit before it bites; `pool: 'host'` shares a limiter across stitches), `retry` is reactive (backoff + `Retry-After`), and `timeout` aborts with a real `AbortSignal`. Three more knobs round it out: **`circuit`** fast-fails a dependency that's already down, **`idempotency`** injects a stable `Idempotency-Key` on writes, and **`verdict`** declares what counts as success — `accept` treats a non-2xx (e.g. `404`) as a normal result instead of a throw, `flag` fails a `200` whose body says it failed. Full guide: [Resilience](https://stitchapi.dev/docs/guides/resilience/retry).
+`throttle` is proactive (keeps you under a limit before it bites; `pool: 'host'` shares a limiter across stitches), `retry` is reactive (backoff + `Retry-After`), and `timeout` aborts with a real `AbortSignal`. Three more knobs round it out: **`circuit`** fast-fails a dependency that's already down, **`idempotency`** injects a stable `Idempotency-Key` on writes, and **`verdict`** declares what counts as success — `accept` treats a non-2xx (e.g. `404`) as a normal result instead of a throw, `flag` fails a `200` whose body says it failed. Full guide: [Resilience](https://stitchapi.dev/docs/guides/resilience/retry?from=gh).
 
 ## Caching
 
@@ -328,7 +328,7 @@ const getUser = stitch({
 });
 ```
 
-`bearer`, `apiKey`, and `basic` are header strategies; `oauth2()` runs the client-credentials grant and caches/refreshes the token; and `cookieSession` runs a login, captures the cookie, replays it, and re-logs-in when the wall returns — the caller never sees the password or writes the cookie dance. Full guide: [Auth](https://stitchapi.dev/docs/guides/auth/bearer).
+`bearer`, `apiKey`, and `basic` are header strategies; `oauth2()` runs the client-credentials grant and caches/refreshes the token; and `cookieSession` runs a login, captures the cookie, replays it, and re-logs-in when the wall returns — the caller never sees the password or writes the cookie dance. Full guide: [Auth](https://stitchapi.dev/docs/guides/auth/bearer?from=gh).
 
 ## Surfaces: any request style
 
@@ -345,7 +345,7 @@ A **surface** is the request _style_ a stitch speaks. `http` is the default; the
 | `shell`       | `@stitchapi/shell` (peer pkg) | a local command, args + stdin             | the command's stdout           |
 | `postmessage` | `stitchapi/postmessage`       | a typed iframe ↔ parent RPC / event call  | the typed RPC response         |
 
-Full guide: [Surfaces](https://stitchapi.dev/docs/reference/surfaces).
+Full guide: [Surfaces](https://stitchapi.dev/docs/reference/surfaces?from=gh).
 
 ## Four front doors
 
@@ -358,7 +358,7 @@ The same typed unit is reachable four ways, so humans and agents call exactly th
 | **HTTP endpoint**       | `stitch serve`  | `GET /list-users`         |
 | **MCP / agent tool**    | `stitch mcp`    | `tool: list_users`        |
 
-`stitch run` streams every event as one JSON line on stdout (ready for `jq`); `stitch trace` summarizes the run log — runs, failures, retries, drift, and latency percentiles. Full guide: [Surfaces → CLI](https://stitchapi.dev/docs/surfaces/cli).
+`stitch run` streams every event as one JSON line on stdout (ready for `jq`); `stitch trace` summarizes the run log — runs, failures, retries, drift, and latency percentiles. Full guide: [Surfaces → CLI](https://stitchapi.dev/docs/surfaces/cli?from=gh).
 
 ## Agent-native
 
@@ -371,7 +371,7 @@ $ stitch from-curl 'curl https://api.example.com/users/7 -H "authorization: Bear
 # prints a ready-to-commit stitch: id-like segments lifted to {params}, secrets → env()
 ```
 
-`stitch init` writes the “declare a stitch, don't hand-roll `fetch`” rule into the files coding agents read (`AGENTS.md`, Cursor/Windsurf/Cline rules, a `CLAUDE.md` section), and the docs build emits an auto-generated [`llms.txt`](https://stitchapi.dev/llms.txt). Full guide: [Use from an agent](https://stitchapi.dev/docs/agents).
+`stitch init` writes the “declare a stitch, don't hand-roll `fetch`” rule into the files coding agents read (`AGENTS.md`, Cursor/Windsurf/Cline rules, a `CLAUDE.md` section), and the docs build emits an auto-generated [`llms.txt`](https://stitchapi.dev/llms.txt). Full guide: [Use from an agent](https://stitchapi.dev/docs/agents?from=gh).
 
 ## Errors & pitfalls
 
@@ -387,7 +387,7 @@ A failed stitch throws a `StitchError` — an `Error` subclass carrying `.status
 | `STITCH_GRAPHQL`      | a GraphQL response came back `200` but carried an `errors` array  |
 | `RateLimitError`      | a delegate-backoff stitch surfaced a rate-limit for an outer gate |
 
-Full catalog: [Errors & pitfalls](https://stitchapi.dev/docs/errors).
+Full catalog: [Errors & pitfalls](https://stitchapi.dev/docs/errors?from=gh).
 
 ## Zero-infra observability
 
@@ -399,7 +399,7 @@ STITCH_TRACE_FILE=./run.jsonl node app.js   # append JSONL to a path
 STITCH_EXPORT=otlp node app.js              # also fan events to an OTLP collector
 ```
 
-Built-in sinks scrub secrets at the sink boundary (the live request is never touched). `stitch trace` summarizes the JSONL; [`@stitchapi/pino`](https://stitchapi.dev/docs/integrations/pino) ships the same events as structured logs.
+Built-in sinks scrub secrets at the sink boundary (the live request is never touched). `stitch trace` summarizes the JSONL; [`@stitchapi/pino`](https://stitchapi.dev/docs/integrations/pino?from=gh) ships the same events as structured logs.
 
 ## Packages
 
@@ -462,7 +462,7 @@ This repository is a [pnpm](https://pnpm.io) workspace. The published library is
 
 ## Documentation
 
-The full documentation site lives at **[stitchapi.dev](https://stitchapi.dev)** — [Quickstart](https://stitchapi.dev/docs/getting-started/quickstart), per-feature [Guides](https://stitchapi.dev/docs/guides/authoring/stitch), [Concepts](https://stitchapi.dev/docs/concepts/the-stitch), [Surfaces](https://stitchapi.dev/docs/surfaces/function), [For agents](https://stitchapi.dev/docs/agents), and the generated [Reference](https://stitchapi.dev/docs/reference/stitch).
+The full documentation site lives at **[stitchapi.dev](https://stitchapi.dev?from=gh)** — [Quickstart](https://stitchapi.dev/docs/getting-started/quickstart?from=gh), per-feature [Guides](https://stitchapi.dev/docs/guides/authoring/stitch?from=gh), [Concepts](https://stitchapi.dev/docs/concepts/the-stitch?from=gh), [Surfaces](https://stitchapi.dev/docs/surfaces/function?from=gh), [For agents](https://stitchapi.dev/docs/agents?from=gh), and the generated [Reference](https://stitchapi.dev/docs/reference/stitch?from=gh).
 
 The published library's own README (what npm renders) is in [`packages/core/README.md`](packages/core/README.md). Design notes live in [`docs/`](docs): [Feature Lenses](docs/FEATURE-LENSES.md), [Overview](docs/OVERVIEW.md), [Design](docs/DESIGN.md).
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 
 <p align="center">
-  <a href="https://stitchapi.dev?from=gh"><strong>📚 stitchapi.dev</strong></a> — documentation, guides &amp; live playground
+  <a href="https://stitchapi.dev?utm_source=github"><strong>📚 stitchapi.dev</strong></a> — documentation, guides &amp; live playground
 </p>
 
 <p align="center">
@@ -42,7 +42,7 @@
 </p>
 
 <p align="center">
-  <a href="https://stitchapi.dev/demo?from=gh">
+  <a href="https://stitchapi.dev/demo?utm_source=github">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="docs/media/demo-dark.webp 1x, docs/media/demo-dark@2x.webp 2x" />
       <img src="docs/media/demo.webp" srcset="docs/media/demo.webp 1x, docs/media/demo@2x.webp 2x" width="1280" alt="StitchAPI demo — a stitch streaming a reply, validating output, retrying a 502, and answering an agent tool call" />
@@ -51,7 +51,7 @@
 </p>
 
 <p align="center">
-  <sub><a href="https://stitchapi.dev/demo?from=gh">Watch more</a></sub>
+  <sub><a href="https://stitchapi.dev/demo?utm_source=github">Watch more</a></sub>
 </p>
 
 > [!NOTE]
@@ -172,7 +172,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 npm install stitchapi@rc   # or: pnpm add stitchapi@rc · yarn add stitchapi@rc
 ```
 
-Validation is bring-your-own — pass a [Zod](https://zod.dev) schema or any [Standard Schema](https://standardschema.dev) validator; none is bundled. The examples below use Zod for familiarity, and `api.example.com` as an illustrative host — point them at your own API to run them, or try them as-is in the [playground](https://stitchapi.dev/?from=gh#playground), which serves that host from an in-browser simulator.
+Validation is bring-your-own — pass a [Zod](https://zod.dev) schema or any [Standard Schema](https://standardschema.dev) validator; none is bundled. The examples below use Zod for familiarity, and `api.example.com` as an illustrative host — point them at your own API to run them, or try them as-is in the [playground](https://stitchapi.dev/?utm_source=github#playground), which serves that host from an in-browser simulator.
 
 ## Quick start
 
@@ -238,7 +238,7 @@ const getUser = api.stitch({
 });
 ```
 
-For lighter reuse, `extends: [fragment | stitch]` merges config left→right (own fields win), and `.with()` pre-binds part of the input while reusing the same runtime. Full guide: [Authoring](https://stitchapi.dev/docs/guides/authoring/stitch?from=gh).
+For lighter reuse, `extends: [fragment | stitch]` merges config left→right (own fields win), and `.with()` pre-binds part of the input while reusing the same runtime. Full guide: [Authoring](https://stitchapi.dev/docs/guides/authoring/stitch?utm_source=github).
 
 ## Validation & leveled drift
 
@@ -268,7 +268,7 @@ const listOrders = stitch({
 });
 ```
 
-Drift is schema-anchored — no snapshot to manage. Severity lives in the schema: a required field missing/incompatible is a hard `invalid` that **throws**; everything else is non-fatal drift on the event stream. Declared variance (an optional field, a nullable, an empty array) validates clean, so it's never a false alarm; `ignore` silences known-but-unconsumed fields and `severity` filters or re-levels the soft signals. The request side validates too: `input` takes a schema per part and fails fast before any request is sent. Full guide: [Validation & drift](https://stitchapi.dev/docs/guides/validation/drift?from=gh).
+Drift is schema-anchored — no snapshot to manage. Severity lives in the schema: a required field missing/incompatible is a hard `invalid` that **throws**; everything else is non-fatal drift on the event stream. Declared variance (an optional field, a nullable, an empty array) validates clean, so it's never a false alarm; `ignore` silences known-but-unconsumed fields and `severity` filters or re-levels the soft signals. The request side validates too: `input` takes a schema per part and fails fast before any request is sent. Full guide: [Validation & drift](https://stitchapi.dev/docs/guides/validation/drift?utm_source=github).
 
 ## Resilience: retry, throttle, timeout
 
@@ -284,7 +284,7 @@ const listUsers = stitch({
 });
 ```
 
-`throttle` is proactive (keeps you under a limit before it bites; `pool: 'host'` shares a limiter across stitches), `retry` is reactive (backoff + `Retry-After`), and `timeout` aborts with a real `AbortSignal`. Three more knobs round it out: **`circuit`** fast-fails a dependency that's already down, **`idempotency`** injects a stable `Idempotency-Key` on writes, and **`verdict`** declares what counts as success — `accept` treats a non-2xx (e.g. `404`) as a normal result instead of a throw, `flag` fails a `200` whose body says it failed. Full guide: [Resilience](https://stitchapi.dev/docs/guides/resilience/retry?from=gh).
+`throttle` is proactive (keeps you under a limit before it bites; `pool: 'host'` shares a limiter across stitches), `retry` is reactive (backoff + `Retry-After`), and `timeout` aborts with a real `AbortSignal`. Three more knobs round it out: **`circuit`** fast-fails a dependency that's already down, **`idempotency`** injects a stable `Idempotency-Key` on writes, and **`verdict`** declares what counts as success — `accept` treats a non-2xx (e.g. `404`) as a normal result instead of a throw, `flag` fails a `200` whose body says it failed. Full guide: [Resilience](https://stitchapi.dev/docs/guides/resilience/retry?utm_source=github).
 
 ## Caching
 
@@ -328,7 +328,7 @@ const getUser = stitch({
 });
 ```
 
-`bearer`, `apiKey`, and `basic` are header strategies; `oauth2()` runs the client-credentials grant and caches/refreshes the token; and `cookieSession` runs a login, captures the cookie, replays it, and re-logs-in when the wall returns — the caller never sees the password or writes the cookie dance. Full guide: [Auth](https://stitchapi.dev/docs/guides/auth/bearer?from=gh).
+`bearer`, `apiKey`, and `basic` are header strategies; `oauth2()` runs the client-credentials grant and caches/refreshes the token; and `cookieSession` runs a login, captures the cookie, replays it, and re-logs-in when the wall returns — the caller never sees the password or writes the cookie dance. Full guide: [Auth](https://stitchapi.dev/docs/guides/auth/bearer?utm_source=github).
 
 ## Surfaces: any request style
 
@@ -345,7 +345,7 @@ A **surface** is the request _style_ a stitch speaks. `http` is the default; the
 | `shell`       | `@stitchapi/shell` (peer pkg) | a local command, args + stdin             | the command's stdout           |
 | `postmessage` | `stitchapi/postmessage`       | a typed iframe ↔ parent RPC / event call  | the typed RPC response         |
 
-Full guide: [Surfaces](https://stitchapi.dev/docs/reference/surfaces?from=gh).
+Full guide: [Surfaces](https://stitchapi.dev/docs/reference/surfaces?utm_source=github).
 
 ## Four front doors
 
@@ -358,7 +358,7 @@ The same typed unit is reachable four ways, so humans and agents call exactly th
 | **HTTP endpoint**       | `stitch serve`  | `GET /list-users`         |
 | **MCP / agent tool**    | `stitch mcp`    | `tool: list_users`        |
 
-`stitch run` streams every event as one JSON line on stdout (ready for `jq`); `stitch trace` summarizes the run log — runs, failures, retries, drift, and latency percentiles. Full guide: [Surfaces → CLI](https://stitchapi.dev/docs/surfaces/cli?from=gh).
+`stitch run` streams every event as one JSON line on stdout (ready for `jq`); `stitch trace` summarizes the run log — runs, failures, retries, drift, and latency percentiles. Full guide: [Surfaces → CLI](https://stitchapi.dev/docs/surfaces/cli?utm_source=github).
 
 ## Agent-native
 
@@ -371,7 +371,7 @@ $ stitch from-curl 'curl https://api.example.com/users/7 -H "authorization: Bear
 # prints a ready-to-commit stitch: id-like segments lifted to {params}, secrets → env()
 ```
 
-`stitch init` writes the “declare a stitch, don't hand-roll `fetch`” rule into the files coding agents read (`AGENTS.md`, Cursor/Windsurf/Cline rules, a `CLAUDE.md` section), and the docs build emits an auto-generated [`llms.txt`](https://stitchapi.dev/llms.txt). Full guide: [Use from an agent](https://stitchapi.dev/docs/agents?from=gh).
+`stitch init` writes the “declare a stitch, don't hand-roll `fetch`” rule into the files coding agents read (`AGENTS.md`, Cursor/Windsurf/Cline rules, a `CLAUDE.md` section), and the docs build emits an auto-generated [`llms.txt`](https://stitchapi.dev/llms.txt). Full guide: [Use from an agent](https://stitchapi.dev/docs/agents?utm_source=github).
 
 ## Errors & pitfalls
 
@@ -387,7 +387,7 @@ A failed stitch throws a `StitchError` — an `Error` subclass carrying `.status
 | `STITCH_GRAPHQL`      | a GraphQL response came back `200` but carried an `errors` array  |
 | `RateLimitError`      | a delegate-backoff stitch surfaced a rate-limit for an outer gate |
 
-Full catalog: [Errors & pitfalls](https://stitchapi.dev/docs/errors?from=gh).
+Full catalog: [Errors & pitfalls](https://stitchapi.dev/docs/errors?utm_source=github).
 
 ## Zero-infra observability
 
@@ -399,7 +399,7 @@ STITCH_TRACE_FILE=./run.jsonl node app.js   # append JSONL to a path
 STITCH_EXPORT=otlp node app.js              # also fan events to an OTLP collector
 ```
 
-Built-in sinks scrub secrets at the sink boundary (the live request is never touched). `stitch trace` summarizes the JSONL; [`@stitchapi/pino`](https://stitchapi.dev/docs/integrations/pino?from=gh) ships the same events as structured logs.
+Built-in sinks scrub secrets at the sink boundary (the live request is never touched). `stitch trace` summarizes the JSONL; [`@stitchapi/pino`](https://stitchapi.dev/docs/integrations/pino?utm_source=github) ships the same events as structured logs.
 
 ## Packages
 
@@ -462,7 +462,7 @@ This repository is a [pnpm](https://pnpm.io) workspace. The published library is
 
 ## Documentation
 
-The full documentation site lives at **[stitchapi.dev](https://stitchapi.dev?from=gh)** — [Quickstart](https://stitchapi.dev/docs/getting-started/quickstart?from=gh), per-feature [Guides](https://stitchapi.dev/docs/guides/authoring/stitch?from=gh), [Concepts](https://stitchapi.dev/docs/concepts/the-stitch?from=gh), [Surfaces](https://stitchapi.dev/docs/surfaces/function?from=gh), [For agents](https://stitchapi.dev/docs/agents?from=gh), and the generated [Reference](https://stitchapi.dev/docs/reference/stitch?from=gh).
+The full documentation site lives at **[stitchapi.dev](https://stitchapi.dev?utm_source=github)** — [Quickstart](https://stitchapi.dev/docs/getting-started/quickstart?utm_source=github), per-feature [Guides](https://stitchapi.dev/docs/guides/authoring/stitch?utm_source=github), [Concepts](https://stitchapi.dev/docs/concepts/the-stitch?utm_source=github), [Surfaces](https://stitchapi.dev/docs/surfaces/function?utm_source=github), [For agents](https://stitchapi.dev/docs/agents?utm_source=github), and the generated [Reference](https://stitchapi.dev/docs/reference/stitch?utm_source=github).
 
 The published library's own README (what npm renders) is in [`packages/core/README.md`](packages/core/README.md). Design notes live in [`docs/`](docs): [Feature Lenses](docs/FEATURE-LENSES.md), [Overview](docs/OVERVIEW.md), [Design](docs/DESIGN.md).
 

--- a/apps/docs/app/analytics.tsx
+++ b/apps/docs/app/analytics.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { foldReferralSource } from '@/lib/referral-attribution';
+
+import { Analytics, type BeforeSendEvent } from '@vercel/analytics/next';
+
+/* A client component because `beforeSend` is a function prop: it cannot cross the
+   server/client boundary from the root layout, and marking the layout itself
+   `'use client'` would strip its `metadata` export. The rewrite rule — and why the
+   npm front door is invisible without it — lives in lib/referral-attribution.ts. */
+export function AnalyticsWithReferrals() {
+    return (
+        <Analytics
+            beforeSend={(event: BeforeSendEvent) => ({
+                ...event,
+                url: foldReferralSource(event.url),
+            })}
+        />
+    );
+}

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,10 +1,10 @@
+import { AnalyticsWithReferrals } from './analytics';
 import './global.css';
 
 import { jsonLdHtml } from '@/lib/json-ld';
 import { releaseVersion } from '@/lib/release';
 import { appName, gitConfig, siteUrl } from '@/lib/shared';
 
-import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import 'fumadocs-twoslash/twoslash.css';
 import { Banner } from 'fumadocs-ui/components/banner';
@@ -184,7 +184,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
                     </Banner>
                     {children}
                 </RootProvider>
-                <Analytics />
+                <AnalyticsWithReferrals />
                 <SpeedInsights />
             </body>
         </html>

--- a/apps/docs/lib/referral-attribution.ts
+++ b/apps/docs/lib/referral-attribution.ts
@@ -1,0 +1,65 @@
+/* Referral attribution, folded into the page path.
+
+   Vercel Web Analytics already records referrers — the analytics script sends
+   `document.referrer` with every initial pageview, and the dashboard's Referrers
+   panel breaks it down. That covers GitHub: github.com serves
+   `referrer-policy: no-referrer-when-downgrade` and marks README links
+   `rel="nofollow"` (NOT `rel="noreferrer"`, the attribute that would suppress it),
+   so an HTTPS→HTTPS click from the repo arrives with its referrer intact.
+
+   npm does not. www.npmjs.com serves `referrer-policy: same-origin`, so every click
+   from the package page lands as `Direct` — indistinguishable from someone who read
+   the README in their editor, ran `npm docs`, or typed the URL. That is the blind
+   spot this closes, and npm is plausibly the larger of the two front doors.
+
+   The obvious fixes are all unavailable on the Hobby plan: UTM parameters are a Web
+   Analytics Plus feature, custom events via `track()` are Pro-and-up, and a server
+   redirect (`/r/npm` → destination) records nothing at all, because Web Analytics is
+   a client script and a 308 never renders a page to run it.
+
+   What IS available on every plan is the page path. So a tagged link (`?from=npm`)
+   is folded into a synthetic path — `/from/npm/docs/agents` — which lands in the
+   ordinary Pages panel with the destination still legible in the path.
+
+   Two consequences worth knowing when reading the dashboard:
+     - Only the LANDING pageview carries `?from=`; soft navigations after it are
+       recorded normally. So these rows count referred sessions, not referred views.
+     - A referred landing is recorded under `/from/…` INSTEAD of the bare path. To
+       rank pages by true popularity, sum `/docs/x` with every
+       `/from/<source>/docs/x`. */
+
+/* Known sources. An unrecognized value has its param stripped but is NOT folded, so
+   a crawler or a spammed `?from=` cannot inflate the Pages panel's cardinality. */
+export const REFERRAL_SOURCES: ReadonlySet<string> = new Set([
+    'gh', // repo README on github.com
+    'npm', // package page on npmjs.com
+    'hn', // Show HN
+    'reddit',
+    'x', // X / Bluesky posts
+    'ph', // Product Hunt
+    'dou', // dou.ua article
+    'newsletter',
+]);
+
+/** Rewrite a pageview URL so a tagged referral lands on its own `/from/<source>` path.
+ *  Returns the URL unchanged when there is no `from` param. */
+export function foldReferralSource(rawUrl: string): string {
+    let url: URL;
+    try {
+        url = new URL(rawUrl);
+    } catch {
+        // A malformed URL is not worth losing the pageview over — record it as-is.
+        return rawUrl;
+    }
+
+    const from = url.searchParams.get('from');
+    if (!from) return rawUrl;
+
+    url.searchParams.delete('from');
+    if (REFERRAL_SOURCES.has(from)) {
+        // `/` would otherwise fold to `/from/npm/` — keep the root row unsuffixed.
+        const path = url.pathname === '/' ? '' : url.pathname;
+        url.pathname = `/from/${from}${path}`;
+    }
+    return url.toString();
+}

--- a/apps/docs/lib/referral-attribution.ts
+++ b/apps/docs/lib/referral-attribution.ts
@@ -17,32 +17,47 @@
    redirect (`/r/npm` → destination) records nothing at all, because Web Analytics is
    a client script and a 308 never renders a page to run it.
 
-   What IS available on every plan is the page path. So a tagged link (`?from=npm`)
-   is folded into a synthetic path — `/from/npm/docs/agents` — which lands in the
-   ordinary Pages panel with the destination still legible in the path.
+   What IS available on every plan is the page path. So a tagged link
+   (`?utm_source=npm`) is folded into a synthetic path — `/utm/npm/docs/agents` —
+   which lands in the ordinary Pages panel with the destination still legible.
+
+   The param is spelled `utm_source` rather than something private like `from`
+   because that is the name Vercel's own `utmSource` dimension reads (see the
+   `by`/`filter` vocabulary on /docs/rest-api/web-analytics/aggregates-page-views),
+   and the name every other analytics tool reads too. That makes the upgrade path
+   free: ON WEB ANALYTICS PLUS, DELETE THIS FOLD — Vercel then captures `utmSource`
+   natively and the READMEs need no edit at all. Leaving the fold in place after an
+   upgrade would be actively harmful, since it strips the param before Vercel sees it.
 
    Two consequences worth knowing when reading the dashboard:
-     - Only the LANDING pageview carries `?from=`; soft navigations after it are
+     - Only the LANDING pageview carries the tag; soft navigations after it are
        recorded normally. So these rows count referred sessions, not referred views.
-     - A referred landing is recorded under `/from/…` INSTEAD of the bare path. To
+     - A referred landing is recorded under `/utm/…` INSTEAD of the bare path. To
        rank pages by true popularity, sum `/docs/x` with every
-       `/from/<source>/docs/x`. */
+       `/utm/<source>/docs/x`. */
 
-/* Known sources. An unrecognized value has its param stripped but is NOT folded, so
-   a crawler or a spammed `?from=` cannot inflate the Pages panel's cardinality. */
+/* Known sources, named as conventional `utm_source` values so they carry over
+   unchanged if the fold is ever removed in favour of native UTM capture.
+
+   These do NOT need to match `referrerHostname` (github.com, …): the tag earns its
+   keep precisely where a referrer hostname is absent, so there is nothing to join
+   against on the rows that matter.
+
+   An unrecognized value has its param stripped but is NOT folded, so a crawler or a
+   spammed `?utm_source=` cannot inflate the Pages panel's cardinality. */
 export const REFERRAL_SOURCES: ReadonlySet<string> = new Set([
-    'gh', // repo README on github.com
+    'github', // repo README on github.com
     'npm', // package page on npmjs.com
-    'hn', // Show HN
+    'hackernews', // Show HN
     'reddit',
     'x', // X / Bluesky posts
-    'ph', // Product Hunt
+    'producthunt',
     'dou', // dou.ua article
     'newsletter',
 ]);
 
-/** Rewrite a pageview URL so a tagged referral lands on its own `/from/<source>` path.
- *  Returns the URL unchanged when there is no `from` param. */
+/** Rewrite a pageview URL so a tagged referral lands on its own `/utm/<source>` path.
+ *  Returns the URL unchanged when there is no `utm_source` param. */
 export function foldReferralSource(rawUrl: string): string {
     let url: URL;
     try {
@@ -52,14 +67,14 @@ export function foldReferralSource(rawUrl: string): string {
         return rawUrl;
     }
 
-    const from = url.searchParams.get('from');
-    if (!from) return rawUrl;
+    const source = url.searchParams.get('utm_source');
+    if (!source) return rawUrl;
 
-    url.searchParams.delete('from');
-    if (REFERRAL_SOURCES.has(from)) {
-        // `/` would otherwise fold to `/from/npm/` — keep the root row unsuffixed.
+    url.searchParams.delete('utm_source');
+    if (REFERRAL_SOURCES.has(source)) {
+        // `/` would otherwise fold to `/utm/npm/` — keep the root row unsuffixed.
         const path = url.pathname === '/' ? '' : url.pathname;
-        url.pathname = `/from/${from}${path}`;
+        url.pathname = `/utm/${source}${path}`;
     }
     return url.toString();
 }

--- a/apps/docs/test/referral-attribution.spec.ts
+++ b/apps/docs/test/referral-attribution.spec.ts
@@ -1,6 +1,6 @@
-// Unit coverage for the `?from=` → `/from/<source>` rewrite that gives npm-originated
-// traffic a countable row on the Hobby plan. Pure — no analytics script — so it runs in
-// the normal vitest job.
+// Unit coverage for the `?utm_source=` → `/utm/<source>` rewrite that gives
+// npm-originated traffic a countable row on the Hobby plan. Pure — no analytics
+// script — so it runs in the normal vitest job.
 import { foldReferralSource } from '../lib/referral-attribution';
 
 import { describe, expect, it } from 'vitest';
@@ -15,27 +15,30 @@ describe('foldReferralSource', () => {
         expect(
             path(
                 foldReferralSource(
-                    'https://stitchapi.dev/docs/agents?from=npm',
+                    'https://stitchapi.dev/docs/agents?utm_source=npm',
                 ),
             ),
-        ).toBe('/from/npm/docs/agents');
+        ).toBe('/utm/npm/docs/agents');
     });
 
-    it('keeps the root row unsuffixed rather than emitting `/from/npm/`', () => {
+    it('keeps the root row unsuffixed rather than emitting `/utm/npm/`', () => {
         expect(
-            path(foldReferralSource('https://stitchapi.dev/?from=npm')),
-        ).toBe('/from/npm');
+            path(foldReferralSource('https://stitchapi.dev/?utm_source=npm')),
+        ).toBe('/utm/npm');
     });
 
-    // Regression: `…/#playground?from=gh` puts the query INSIDE the fragment, so the
-    // param never parses and the referral is silently lost. The README must spell it
-    // `/?from=gh#playground` — this pins that the fragment survives the rewrite.
+    // Regression: `…/#playground?utm_source=github` puts the query INSIDE the
+    // fragment, so the param never parses and the referral is silently lost. The
+    // README must spell it `/?utm_source=github#playground` — this pins that the
+    // fragment survives the rewrite.
     it('preserves a fragment when the query precedes it', () => {
         expect(
             path(
-                foldReferralSource('https://stitchapi.dev/?from=gh#playground'),
+                foldReferralSource(
+                    'https://stitchapi.dev/?utm_source=github#playground',
+                ),
             ),
-        ).toBe('/from/gh#playground');
+        ).toBe('/utm/github#playground');
     });
 
     it('leaves an untagged url untouched', () => {
@@ -44,30 +47,37 @@ describe('foldReferralSource', () => {
     });
 
     // Cardinality guard: an unknown value is stripped, never folded, so a crawler or a
-    // spammed `?from=` cannot mint unbounded rows in the Pages panel.
+    // spammed `?utm_source=` cannot mint unbounded rows in the Pages panel.
     it('strips an unknown source without folding it', () => {
         expect(
             path(
                 foldReferralSource(
-                    'https://stitchapi.dev/docs/agents?from=evil',
+                    'https://stitchapi.dev/docs/agents?utm_source=evil',
                 ),
             ),
         ).toBe('/docs/agents');
     });
 
-    it('preserves unrelated query params', () => {
+    // The old private spelling must NOT be honoured — if a stale link survives
+    // somewhere, it should record the real page rather than a phantom source row.
+    it('ignores the pre-canonical `from` param', () => {
+        const url = 'https://stitchapi.dev/docs/agents?from=npm';
+        expect(foldReferralSource(url)).toBe(url);
+    });
+
+    it('preserves unrelated query params, including sibling utm tags', () => {
         expect(
             path(
                 foldReferralSource(
-                    'https://stitchapi.dev/docs/agents?from=npm&q=1',
+                    'https://stitchapi.dev/docs/agents?utm_source=npm&utm_campaign=ga',
                 ),
             ),
-        ).toBe('/from/npm/docs/agents?q=1');
+        ).toBe('/utm/npm/docs/agents?utm_campaign=ga');
     });
 
     it('records a malformed url as-is rather than dropping the pageview', () => {
-        expect(foldReferralSource('not-a-url?from=npm')).toBe(
-            'not-a-url?from=npm',
+        expect(foldReferralSource('not-a-url?utm_source=npm')).toBe(
+            'not-a-url?utm_source=npm',
         );
     });
 });

--- a/apps/docs/test/referral-attribution.spec.ts
+++ b/apps/docs/test/referral-attribution.spec.ts
@@ -1,0 +1,73 @@
+// Unit coverage for the `?from=` → `/from/<source>` rewrite that gives npm-originated
+// traffic a countable row on the Hobby plan. Pure — no analytics script — so it runs in
+// the normal vitest job.
+import { foldReferralSource } from '../lib/referral-attribution';
+
+import { describe, expect, it } from 'vitest';
+
+const path = (url: string) => {
+    const u = new URL(url);
+    return u.pathname + u.search + u.hash;
+};
+
+describe('foldReferralSource', () => {
+    it('folds a known source into the path, keeping the destination legible', () => {
+        expect(
+            path(
+                foldReferralSource(
+                    'https://stitchapi.dev/docs/agents?from=npm',
+                ),
+            ),
+        ).toBe('/from/npm/docs/agents');
+    });
+
+    it('keeps the root row unsuffixed rather than emitting `/from/npm/`', () => {
+        expect(
+            path(foldReferralSource('https://stitchapi.dev/?from=npm')),
+        ).toBe('/from/npm');
+    });
+
+    // Regression: `…/#playground?from=gh` puts the query INSIDE the fragment, so the
+    // param never parses and the referral is silently lost. The README must spell it
+    // `/?from=gh#playground` — this pins that the fragment survives the rewrite.
+    it('preserves a fragment when the query precedes it', () => {
+        expect(
+            path(
+                foldReferralSource('https://stitchapi.dev/?from=gh#playground'),
+            ),
+        ).toBe('/from/gh#playground');
+    });
+
+    it('leaves an untagged url untouched', () => {
+        const url = 'https://stitchapi.dev/docs/agents';
+        expect(foldReferralSource(url)).toBe(url);
+    });
+
+    // Cardinality guard: an unknown value is stripped, never folded, so a crawler or a
+    // spammed `?from=` cannot mint unbounded rows in the Pages panel.
+    it('strips an unknown source without folding it', () => {
+        expect(
+            path(
+                foldReferralSource(
+                    'https://stitchapi.dev/docs/agents?from=evil',
+                ),
+            ),
+        ).toBe('/docs/agents');
+    });
+
+    it('preserves unrelated query params', () => {
+        expect(
+            path(
+                foldReferralSource(
+                    'https://stitchapi.dev/docs/agents?from=npm&q=1',
+                ),
+            ),
+        ).toBe('/from/npm/docs/agents?q=1');
+    });
+
+    it('records a malformed url as-is rather than dropping the pageview', () => {
+        expect(foldReferralSource('not-a-url?from=npm')).toBe(
+            'not-a-url?from=npm',
+        );
+    });
+});

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,7 +8,7 @@
 
 **Turn any REST, GraphQL, SSE, or LLM API into a typed, resilient function.** Its one primitive — a **stitch** — takes a single endpoint and hands you back a callable: declare the endpoint's contract once (input, output, auth, resilience) and call it like a local function. No server, no codegen, no config files — only explicit composition. The same definition your code calls, the CLI runs and an AI agent can invoke without ever touching a credential.
 
-**Full documentation, guides, and a live playground live at [stitchapi.dev](https://stitchapi.dev?from=npm).**
+**Full documentation, guides, and a live playground live at [stitchapi.dev](https://stitchapi.dev?utm_source=npm).**
 
 ## Table of Contents
 
@@ -76,7 +76,7 @@ There are plenty of ways to get a typed API client — spec-based generators, ha
 
 - **A library, not a platform.** Zero runtime dependencies, embeds in your project, nothing to operate. Workflow platforms (Windmill, n8n, …) solve integration with a server and a visual builder; StitchAPI keeps it a code primitive — stitches compose in plain TypeScript.
 
-- **Composes with your data layer.** Already using TanStack Query, SWR, or RTK Query? A stitch _is_ the `queryFn` — it owns the call's resilience (retries, throttle, validation, drift); your query layer owns view state (subscriptions, cache, invalidation). They stack; they do not compete. See the [TanStack Query guide](https://stitchapi.dev/docs/integrations/tanstack-query?from=npm).
+- **Composes with your data layer.** Already using TanStack Query, SWR, or RTK Query? A stitch _is_ the `queryFn` — it owns the call's resilience (retries, throttle, validation, drift); your query layer owns view state (subscriptions, cache, invalidation). They stack; they do not compete. See the [TanStack Query guide](https://stitchapi.dev/docs/integrations/tanstack-query?utm_source=npm).
 
 - **First-party framework integrations.** Thin peer-dependency packages wire a stitch into the framework you already run — server frameworks, client/UI bindings, state stores, observability sinks, and more — each adding no capability of its own (core stays untouched). See the full [Ecosystem](#ecosystem) below.
 
@@ -124,7 +124,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 
 ## Documentation
 
-The full documentation site lives at **[stitchapi.dev](https://stitchapi.dev?from=npm)** — start with the [Quickstart](https://stitchapi.dev/docs/getting-started/quickstart?from=npm), then the per-feature guides, [Concepts](https://stitchapi.dev/docs/concepts/the-stitch?from=npm), [Surfaces](https://stitchapi.dev/docs/surfaces/function?from=npm), [For agents](https://stitchapi.dev/docs/agents?from=npm), and the generated [Reference](https://stitchapi.dev/docs/reference/stitch?from=npm).
+The full documentation site lives at **[stitchapi.dev](https://stitchapi.dev?utm_source=npm)** — start with the [Quickstart](https://stitchapi.dev/docs/getting-started/quickstart?utm_source=npm), then the per-feature guides, [Concepts](https://stitchapi.dev/docs/concepts/the-stitch?utm_source=npm), [Surfaces](https://stitchapi.dev/docs/surfaces/function?utm_source=npm), [For agents](https://stitchapi.dev/docs/agents?utm_source=npm), and the generated [Reference](https://stitchapi.dev/docs/reference/stitch?utm_source=npm).
 
 Design notes and positioning live in the repo:
 
@@ -862,7 +862,7 @@ $ stitch from-curl 'curl https://api.example.com/users/7 -H "authorization: Bear
 # credentials replaced with env()
 ```
 
-For reasoning over docs, the docs build emits an auto-generated [`llms.txt`](https://stitchapi.dev/llms.txt) and a per-page `llms.mdx`, so an agent pulls just the page it needs into context. Full guide: [Use from an agent](https://stitchapi.dev/docs/agents?from=npm).
+For reasoning over docs, the docs build emits an auto-generated [`llms.txt`](https://stitchapi.dev/llms.txt) and a per-page `llms.mdx`, so an agent pulls just the page it needs into context. Full guide: [Use from an agent](https://stitchapi.dev/docs/agents?utm_source=npm).
 
 ## Errors & pitfalls
 
@@ -894,7 +894,7 @@ Prefer to branch rather than wrap in `try`/`catch`? `.safe()` never throws — i
 | `STITCH_GRAPHQL`      | a GraphQL response came back `200` but carried an `errors` array    |
 | `RateLimitError`      | a delegate-backoff stitch surfaced a rate-limit for an outer gate   |
 
-Full catalog with one page per code: [Errors & pitfalls](https://stitchapi.dev/docs/errors?from=npm).
+Full catalog with one page per code: [Errors & pitfalls](https://stitchapi.dev/docs/errors?utm_source=npm).
 
 ## Ecosystem
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,7 +8,7 @@
 
 **Turn any REST, GraphQL, SSE, or LLM API into a typed, resilient function.** Its one primitive — a **stitch** — takes a single endpoint and hands you back a callable: declare the endpoint's contract once (input, output, auth, resilience) and call it like a local function. No server, no codegen, no config files — only explicit composition. The same definition your code calls, the CLI runs and an AI agent can invoke without ever touching a credential.
 
-**Full documentation, guides, and a live playground live at [stitchapi.dev](https://stitchapi.dev).**
+**Full documentation, guides, and a live playground live at [stitchapi.dev](https://stitchapi.dev?from=npm).**
 
 ## Table of Contents
 
@@ -76,7 +76,7 @@ There are plenty of ways to get a typed API client — spec-based generators, ha
 
 - **A library, not a platform.** Zero runtime dependencies, embeds in your project, nothing to operate. Workflow platforms (Windmill, n8n, …) solve integration with a server and a visual builder; StitchAPI keeps it a code primitive — stitches compose in plain TypeScript.
 
-- **Composes with your data layer.** Already using TanStack Query, SWR, or RTK Query? A stitch _is_ the `queryFn` — it owns the call's resilience (retries, throttle, validation, drift); your query layer owns view state (subscriptions, cache, invalidation). They stack; they do not compete. See the [TanStack Query guide](https://stitchapi.dev/docs/integrations/tanstack-query).
+- **Composes with your data layer.** Already using TanStack Query, SWR, or RTK Query? A stitch _is_ the `queryFn` — it owns the call's resilience (retries, throttle, validation, drift); your query layer owns view state (subscriptions, cache, invalidation). They stack; they do not compete. See the [TanStack Query guide](https://stitchapi.dev/docs/integrations/tanstack-query?from=npm).
 
 - **First-party framework integrations.** Thin peer-dependency packages wire a stitch into the framework you already run — server frameworks, client/UI bindings, state stores, observability sinks, and more — each adding no capability of its own (core stays untouched). See the full [Ecosystem](#ecosystem) below.
 
@@ -124,7 +124,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 
 ## Documentation
 
-The full documentation site lives at **[stitchapi.dev](https://stitchapi.dev)** — start with the [Quickstart](https://stitchapi.dev/docs/getting-started/quickstart), then the per-feature guides, [Concepts](https://stitchapi.dev/docs/concepts/the-stitch), [Surfaces](https://stitchapi.dev/docs/surfaces/function), [For agents](https://stitchapi.dev/docs/agents), and the generated [Reference](https://stitchapi.dev/docs/reference/stitch).
+The full documentation site lives at **[stitchapi.dev](https://stitchapi.dev?from=npm)** — start with the [Quickstart](https://stitchapi.dev/docs/getting-started/quickstart?from=npm), then the per-feature guides, [Concepts](https://stitchapi.dev/docs/concepts/the-stitch?from=npm), [Surfaces](https://stitchapi.dev/docs/surfaces/function?from=npm), [For agents](https://stitchapi.dev/docs/agents?from=npm), and the generated [Reference](https://stitchapi.dev/docs/reference/stitch?from=npm).
 
 Design notes and positioning live in the repo:
 
@@ -862,7 +862,7 @@ $ stitch from-curl 'curl https://api.example.com/users/7 -H "authorization: Bear
 # credentials replaced with env()
 ```
 
-For reasoning over docs, the docs build emits an auto-generated [`llms.txt`](https://stitchapi.dev/llms.txt) and a per-page `llms.mdx`, so an agent pulls just the page it needs into context. Full guide: [Use from an agent](https://stitchapi.dev/docs/agents).
+For reasoning over docs, the docs build emits an auto-generated [`llms.txt`](https://stitchapi.dev/llms.txt) and a per-page `llms.mdx`, so an agent pulls just the page it needs into context. Full guide: [Use from an agent](https://stitchapi.dev/docs/agents?from=npm).
 
 ## Errors & pitfalls
 
@@ -894,7 +894,7 @@ Prefer to branch rather than wrap in `try`/`catch`? `.safe()` never throws — i
 | `STITCH_GRAPHQL`      | a GraphQL response came back `200` but carried an `errors` array    |
 | `RateLimitError`      | a delegate-backoff stitch surfaced a rate-limit for an outer gate   |
 
-Full catalog with one page per code: [Errors & pitfalls](https://stitchapi.dev/docs/errors).
+Full catalog with one page per code: [Errors & pitfalls](https://stitchapi.dev/docs/errors?from=npm).
 
 ## Ecosystem
 


### PR DESCRIPTION
## Why

This week's traffic said the **READMEs, not the homepage, are the front door**. Every deep docs page with traffic is one the root or core README links to, and the homepage sits at exactly **1.00 views/visitor** — nobody ever returns to it. Confirming that split needs referrer data.

**Half of it already worked.** `<Analytics />` has been mounted all along, and Vercel records `document.referrer` on every initial pageview — the dashboard has had a Referrers panel the whole time. GitHub is already visible:

```
github.com  →  referrer-policy: no-referrer-when-downgrade,  rel="nofollow"
```

`nofollow`, not `noreferrer` — and `noreferrer` is the attribute that would suppress it. So an HTTPS→HTTPS click from the repo arrives intact.

**npm is the blind spot:**

```
www.npmjs.com  →  referrer-policy: same-origin
```

Every click from the package page lands as `Direct`, indistinguishable from an editor read, `npm docs`, or a typed URL — and npm is plausibly the larger of the two doors.

## Why not the obvious fixes

All three are gated on this project's **Hobby** plan:

| Approach | Blocked by |
|---|---|
| UTM parameters | Web Analytics **Plus** add-on only |
| `track()` custom events | **Pro** and up |
| `/r/npm` server redirect | Records nothing — Web Analytics is a client script, and a 308 never renders a page to run it |

## What this does

What *is* available on every plan is the page path, so `beforeSend` folds a tagged link into a synthetic one:

| Link | Recorded as |
|---|---|
| `/docs/agents?utm_source=npm` | `/utm/npm/docs/agents` |
| `/?utm_source=github#playground` | `/utm/github` |
| `/docs/agents` | `/docs/agents` *(unchanged)* |
| `/docs/agents?utm_source=evil` | `/docs/agents` *(stripped, not folded)* |

Both READMEs are tagged at their `stitchapi.dev` links — `utm_source=npm` for `packages/core/README.md` (what npm renders), `utm_source=github` for the root `README.md`.

## Naming

The param is **`utm_source`**, not a private `from`, because that is the name Vercel's own dimension reads — the `by`/`filter` vocabulary on [the visits aggregate endpoint](https://vercel.com/docs/rest-api/web-analytics/aggregates-page-views) is `referrerHostname`, `referrerUrl`, `utmSource`, `utmMedium`, `utmCampaign`, `utmContent`, `utmTerm`.

That makes the upgrade path free: **on Web Analytics Plus, delete the fold** — Vercel then captures `utmSource` natively and the READMEs need no edit. Leaving the fold in after an upgrade would be actively harmful, since it strips the param before Vercel sees it. The comment says so at the source. `utm_source` is also what GA, Plausible, and Fathom read.

Values are deliberately **not** aligned to `referrerHostname` (`github.com`, …): the tag earns its keep precisely where a referrer hostname is absent — npm strips it — so on the rows that actually matter there is nothing to join against.

## Reviewer notes

- **These rows count referred _sessions_, not views.** Only the landing pageview carries the tag; soft navigations after it are recorded normally.
- **A referred landing is recorded under `/utm/…` _instead of_ the bare path.** To rank pages by true popularity, sum `/docs/x` with every `/utm/<source>/docs/x`. Both caveats are documented at the source.
- **Cardinality guard:** an unrecognized source is stripped but never folded, so a crawler or a spammed param cannot mint unbounded rows.
- **SEO:** docs and blog pages already emit `alternates.canonical`, so the tagged URLs carry no duplicate-content risk. GitHub/npm README links are `nofollow` anyway.
- The fold is a **pure function in `lib/`** rather than inline in the component, so it is testable without the React shell. `analytics.tsx` is a client component because `beforeSend` is a function prop — it cannot cross the boundary from a layout that exports `metadata`.
- The **fragment case is pinned by regression test**: `/#playground?utm_source=github` puts the query *inside* the fragment, so the param never parses and the referral is silently lost. The README must spell it `/?utm_source=github#playground`.

## Verification

- 8/8 unit tests, full typecheck, lint, prettier — all green; 12/12 pre-push gates green on both commits.
- `beforeSend` wiring confirmed against the installed package: `@vercel/analytics@2.0.1`'s `/next` entry registers it via `window.va('beforeSend', …)` both at script-inject time and in a `useEffect`.
- **Not** verified in a live browser: `.claude/.preview-root` points at another session's worktree, and repointing it would have hijacked that preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)