### PR TITLE
docs(reference): add the missing `seam()` props reference page

### DIFF
--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -695,6 +695,13 @@ export const pages: Page[] = [
         kind: 'reference',
     },
     {
+        path: 'reference/seam',
+        title: 'seam()',
+        description:
+            'SeamOptions — every prop a seam takes, the eight per-endpoint keys it refuses — plus the Seam handle and the lifecycle-free PrincipalSeam that seam.as() returns.',
+        kind: 'reference',
+    },
+    {
         path: 'reference/auth-strategies',
         title: 'Auth strategies',
         description:

--- a/apps/docs/content/docs/concepts/the-seam.mdx
+++ b/apps/docs/content/docs/concepts/the-seam.mdx
@@ -63,6 +63,7 @@ Because the seam is surface-agnostic, it can [mint members of any surface](/docs
 <Cards>
     <Card title="The stitch primitive" href="/docs/concepts/the-stitch" />
     <Card title="Guide: seam" href="/docs/guides/authoring/seam" />
+    <Card title="Reference: seam()" href="/docs/reference/seam" />
     <Card title="extends" href="/docs/guides/authoring/extends" />
     <Card
         title="Capability, not credential"

--- a/apps/docs/content/docs/guides/authoring/seam.mdx
+++ b/apps/docs/content/docs/guides/authoring/seam.mdx
@@ -45,7 +45,7 @@ const user = await getUser({ params: { id: 7 } });
 
 ## Options
 
-A seam takes the same fields a stitch does — `baseUrl`, `auth`, `retry`, `throttle`, `timeout`, `store`, `trace`, and the rest — as the base its members extend, plus a `secretStore` for a hardened auth vault. See [Reference → Config types](/docs/reference/config-types) for every field.
+A seam takes the same fields a stitch does — `baseUrl`, `auth`, `retry`, `throttle`, `timeout`, `store`, `trace`, and the rest — as the base its members extend, plus a `secretStore` for a hardened auth vault. The eight per-endpoint keys (`path`, `url`, `method`, `document`, `name`, `input`, `output`, `kind`) belong to a member, not the seam. See [Reference → seam()](/docs/reference/seam) for every prop and both handles.
 
 **Members extend the base; a member's own throttle stacks on the seam's.** Anything a member declares layers on top of the shared config — and a member's own `throttle` is _tighten-only_: it gates only that stitch on top of the shared bucket, so it can be stricter than the seam's budget but never escape it.
 
@@ -82,6 +82,7 @@ await api.close(); // flush the trace sink, close the shared store
 ## See also
 
 <Cards>
+    <Card title="Reference: seam()" href="/docs/reference/seam" />
     <Card title="Concept: the seam" href="/docs/concepts/the-seam" />
     <Card title="extends" href="/docs/guides/authoring/extends" />
     <Card

--- a/apps/docs/content/docs/reference/config-types.mdx
+++ b/apps/docs/content/docs/reference/config-types.mdx
@@ -190,6 +190,7 @@ every page.
 
 <Cards>
     <Card title="stitch()" href="/docs/reference/stitch" />
+    <Card title="seam()" href="/docs/reference/seam" />
     <Card title="Auth strategies" href="/docs/reference/auth-strategies" />
     <Card title="Guide: stitch()" href="/docs/guides/authoring/stitch" />
 </Cards>

--- a/apps/docs/content/docs/reference/meta.json
+++ b/apps/docs/content/docs/reference/meta.json
@@ -3,6 +3,7 @@
     "icon": "Code",
     "pages": [
         "stitch",
+        "seam",
         "auth-strategies",
         "config-types",
         "surfaces",

--- a/apps/docs/content/docs/reference/seam.mdx
+++ b/apps/docs/content/docs/reference/seam.mdx
@@ -1,0 +1,115 @@
+---
+title: 'seam()'
+description: 'SeamOptions — every prop a seam takes, the eight per-endpoint keys it refuses — plus the Seam handle and the lifecycle-free PrincipalSeam that seam.as() returns.'
+prerequisites: ['/docs/concepts/the-seam']
+---
+
+Every prop `seam()` accepts, and the two handles it hands back. The option shapes
+those props take — `retry`, `throttle`, `cache`, and the rest — are documented
+once in [Reference → Config types](/docs/reference/config-types).
+
+## seam()
+
+`seam(options?)` takes a [`SeamOptions`](#seamoptions) fragment and returns a
+[`Seam`](#seam): the long-lived entity its members belong to, owning one store,
+one auth vault, one throttle bucket, and one trace sink. Members come from
+`.stitch()` and `.graphql()`, and inherit the seam's props as the base they
+extend.
+
+```ts twoslash
+import { seam } from 'stitchapi';
+import { bearer, env } from 'stitchapi/auth';
+
+const api = seam({
+    baseUrl: 'https://api.example.com',
+    auth: bearer(env('API_TOKEN')),
+    retry: { attempts: 3, on: [429, 503] },
+});
+
+const getUser = api.stitch({ path: '/users/{id}', pick: 'data' });
+```
+
+## SeamOptions
+
+<AutoTypeTable path="../../packages/core/src/types.ts" name="SeamOptions" />
+
+### The eight keys a seam refuses
+
+`SeamConfig` — the shared fragment inside `SeamOptions` — is `StitchConfig` minus
+the keys that are intrinsically per-endpoint: the address (`path`, `url`,
+`method`, `document`) and the request and response shape (`name`, `input`,
+`output`, `kind`). A member sets those. Naming one on the seam is a type error
+rather than a silently-dropped field, so the type answers what belongs at the
+seam on its own.
+
+```ts twoslash
+// @errors: 2353
+import { seam } from 'stitchapi';
+
+const api = seam({
+    baseUrl: 'https://api.example.com',
+    path: '/users/{id}',
+});
+```
+
+### Four props name shared runtime, not a copied value
+
+**`throttle` is one bucket, not one per member.** Every member acquires under a
+single seam-stable key, so the rate and concurrency budget pools across the whole
+surface; `pool: 'host'` keeps the engine's per-host key instead. A member's own
+`throttle` stacks on top — it gates that one stitch tighter, and never escapes the
+shared budget.
+
+**`store` is one instance the members share**, not a copy each: the same cache
+entries, throttle counters, and sessions. It defaults to an in-memory store.
+
+**`trace` is one sink for the whole surface.** Every member's events land in it,
+and `flush()` drains it.
+
+**`secretStore` splits the vault off by visibility, not by backend.** Auth state
+lives in the vault, which defaults to a reserved, redacted namespace over `store`;
+pass a KMS- or Vault-backed store here to harden it. Either may be distributed.
+
+## Seam
+
+The root handle: the member builders, the principal boundary, and the lifecycle
+over the runtime it owns.
+
+<AutoTypeTable path="../../packages/core/src/types.ts" name="Seam" />
+
+## PrincipalSeam
+
+`seam.as(id)` binds a principal in the closure and returns a `PrincipalSeam` — the
+same member builders, minus `flush`, `close`, and `invalidate`. Its members carry
+the principal in their auth context, so each principal gets its own sessions while
+the throttle bucket stays shared.
+
+<AutoTypeTable path="../../packages/core/src/types.ts" name="PrincipalSeam" />
+
+```ts twoslash
+import { seam } from 'stitchapi';
+
+const api = seam({ baseUrl: 'https://api.example.com' });
+
+// One handle per request — bind the caller's identity, then create members.
+const forTenant = api.as('tenant-42');
+const getUser = forTenant.stitch({ path: '/users/{id}', pick: 'data' });
+```
+
+<Callout type="warn">
+    **Anti-pattern:** don't hand the root `seam` to the least-trusted caller —
+    it carries `close()` and `invalidate()` over the runtime every principal
+    shares. Pass a `seam.as(id)` handle instead: it creates members and re-binds
+    the principal, and has no lifecycle lever to pull.
+</Callout>
+
+## See also
+
+<Cards>
+    <Card title="stitch()" href="/docs/reference/stitch" />
+    <Card title="Config types" href="/docs/reference/config-types" />
+    <Card title="Guide: seam" href="/docs/guides/authoring/seam" />
+    <Card title="Concept: the seam" href="/docs/concepts/the-seam" />
+    <Card title="Guide: extends" href="/docs/guides/authoring/extends" />
+    <Card title="Request surfaces" href="/docs/reference/surfaces" />
+</Cards>

--- a/apps/docs/content/docs/reference/stitch.mdx
+++ b/apps/docs/content/docs/reference/stitch.mdx
@@ -38,6 +38,7 @@ See [Guide → graphql](/docs/guides/data/graphql) for usage.
 ## See also
 
 <Cards>
+    <Card title="seam()" href="/docs/reference/seam" />
     <Card title="Config types" href="/docs/reference/config-types" />
     <Card title="Guide: stitch()" href="/docs/guides/authoring/stitch" />
     <Card title="Guide: extends" href="/docs/guides/authoring/extends" />


### PR DESCRIPTION
## The gap

Reference carried a `stitch()` page but nothing for `seam()`. So `SeamOptions`, `Seam`,
and `PrincipalSeam` had **no generated table anywhere on the site** — and the seam guide
sent readers to Config types for "every field", which documents `StitchConfig` only.
That page can't answer what a seam takes: it omits `secretStore` entirely and still lists
the eight per-endpoint keys a seam refuses.

## What this adds

`apps/docs/content/docs/reference/seam.mdx`, following the `kind: reference` template
(prose for orientation, `AutoTypeTable` for the shapes):

- **`seam()`** — the signature, and what the returned entity owns (one store, one auth
  vault, one throttle bucket, one trace sink).
- **`SeamOptions`** — the full generated table (25 props).
- **The eight keys a seam refuses** — `path`, `url`, `method`, `document`, `name`,
  `input`, `output`, `kind`. Shown as a real `// @errors: 2353` twoslash block, so the
  page demonstrates the type error instead of asserting it, and the build breaks if
  `SeamConfig` ever stops omitting them.
- **The four props that name shared runtime rather than a copied value** — `throttle`
  (one seam-stable bucket; `pool: 'host'` opts out; a member's own `throttle` stacks
  tighten-only), `store`, `trace`, and `secretStore` (vault split by visibility, not
  backend). This is the part `config-types` structurally cannot say, since these props
  mean something different at seam scope than on a lone stitch.
- **`Seam` and `PrincipalSeam`** tables, plus an inline anti-pattern callout: don't hand
  the root seam to the least-trusted caller — it carries `close()` and `invalidate()`
  over the runtime every principal shares (ADR 0002 §2).

## Wiring

- Manifest entry after `reference/stitch`; `reference/meta.json` regenerated with
  `gen:docs` (which stays a no-op on the synced tree).
- `See also` links added from `reference/stitch`, `reference/config-types`,
  `concepts/the-seam`, and `guides/authoring/seam` — whose "see Config types for every
  field" sentence now points here and names the eight member-only keys.
- `prerequisites: ['/docs/concepts/the-seam']`, since the lede assumes the concept.

## Verification

Rendered locally at `/docs/reference/seam`: sidebar slot correct, `SeamOptions` renders
all 25 props with the 8 per-endpoint keys correctly absent, `PrincipalSeam` correctly
lacks `flush`/`close`/`invalidate`, and the twoslash error renders inline.

Green locally: `pnpm test` (apps/docs, 69 passed — includes the manifest two-way-sync and
prerequisites gates), `check:types`, `check:lint`, `check:docs-links` (117 routes),
`check:format`, and `gen:docs` producing no diff.

## For the reviewer

Documentation only — no runtime or type changes, and no TSDoc backfill was needed
(the seam types in `packages/core/src/types.ts` already carry it, which is what makes the
generated tables read well).

One thing worth a look: `SeamOptions` reproduces most of the `StitchConfig` table that
`config-types` already renders. Both are generated from the same source so they can't
drift, and the omitted-keys list is the load-bearing fact this page exists to state — but
if you'd rather this page carried only `secretStore` plus the handles and deep-linked the
rest, say so and I'll trim it.

## Follow-up (not in this PR)

Swept the whole root barrel for the same class of gap — a public core export with no
Reference entry. Seven are absent from the entire `content/docs` tree: `httpSurface`,
`registerSecretKey`, `isSecretKey`, `redactSecretsDeep`, `parseDuration`, `parseBytes`,
`parseRate` (`graphqlSurface`, `verdictOf`, and `systemClock` have only 1–2 passing
mentions). That spans `helpers.mdx` and `surfaces.mdx` and is a bigger diff than this
page, so it is deliberately left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
