### PR TITLE
docs(core): name the `input` schema as the request-side transform

### DIFF
--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -81,7 +81,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "input",
             type: "property",
             detail: "AtLeastOne<InputSchemas>",
-            info: "Schemas validating params, query, body, headers, and (GraphQL) variables before the request. At least one slot must be set — the opaque `input: {}` is rejected (CONTRACT.md P20).",
+            info: "Schemas validating params, query, body, headers, and (GraphQL) variables before the request. At least one slot must be set — the opaque `input: {}` is rejected (CONTRACT.md P20). A declared slot also SHAPES the request: it is built from the value the schema returned, so a schema that coerces, defaults, strips — or transforms — is what goes on the wire. That makes this the request-side counterpart of StitchConfig.transform (map your field names onto the API's here), and the call argument is typed from the schema's INPUT side, so callers keep the pre-transform shape. It resolves before the request is built, so the reshaped value is what `auth` signs and what the cache key is derived from.",
         },
         {
             label: "output",
@@ -99,7 +99,7 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "transform",
             type: "property",
             detail: "(body: unknown) => unknown",
-            info: "Reshape the raw body before `pick` and validation (e.g. scrape HTML to structured data).",
+            info: "Reshape the raw RESPONSE body before `pick` and validation (e.g. scrape HTML to structured data). Response-only by design: it runs before `pick` (so `pick` addresses the reshaped body), it is the left side of drift's `diff(raw, validated)`, and it is a declared opacity the cache fingerprint can see (ADR 0004 rung 2) — three guarantees a transform buried inside the `output` schema would defeat. None has a request-side counterpart, so reshaping the REQUEST is StitchConfig.input's job: a slot's schema shapes what goes on the wire, before auth signs it and before the cache key is derived from it.",
         },
         {
             label: "paginate",

--- a/apps/docs/content/docs/guides/authoring/hooks.mdx
+++ b/apps/docs/content/docs/guides/authoring/hooks.mdx
@@ -7,8 +7,10 @@ prerequisites: ['/docs/concepts/the-stitch']
 Hooks are observation points on a stitch's lifecycle: small callbacks that run as a
 call progresses, for logging, metrics, or tracing. They never change what a stitch
 returns — a call's only result is its response — so reach for a hook when you want
-to _watch_ a call, and for [`transform`](/docs/guides/data/transform) when you want
-to _reshape_ its output.
+to _watch_ a call, for [`transform`](/docs/guides/data/transform) when you want to
+_reshape_ its output, and for the
+[`input` schema](/docs/guides/data/transform#reshaping-the-request) when you want to
+reshape what it sends.
 
 ## Example
 
@@ -65,6 +67,19 @@ populated on a network failure or `res` populated on a retryable status.
 <Callout type="info">
     Hooks run on **every attempt**, not once per call: a stitch that retries
     twice fires `onRequest` three times. Use `attempt` to tell them apart.
+</Callout>
+
+<Callout type="warn">
+    **Observe the request; don't reshape it.** `ctx.req` is the live object the
+    transport is about to send, so mutating it in `onRequest` does change the
+    call — but step 3 puts you _after_ `auth.apply`, and a strategy that signs
+    the payload (AWS SigV4 with `signBody`, or any HMAC scheme) has already
+    hashed the body you are replacing. The signature then covers bytes that
+    never went out, and the API rejects the call with a 403 that points at
+    nothing. Reshape the request in its [`input`
+    schema](/docs/guides/data/transform#reshaping-the-request), which resolves
+    before auth signs anything — and before the cache key is derived from the
+    request, which hook mutation also misses.
 </Callout>
 
 ## Order across composed layers

--- a/apps/docs/content/docs/guides/data/transform.mdx
+++ b/apps/docs/content/docs/guides/data/transform.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'transform'
-description: 'Reshape a response before pick and validation — for example, scrape HTML into structured data.'
+description: 'Reshape a response before pick and validation — and reshape a request on the way out, through its input schema.'
 prerequisites: ['/docs/concepts/the-stitch']
 ---
 
@@ -47,6 +47,76 @@ and return any reshaped value. See
     surfaces later as drift. Name the path with `pick` instead, which is
     declarative, round-trips as JSON, and feeds validation and drift directly.
     See [pick](/docs/guides/data/pick).
+</Callout>
+
+## Reshaping the request
+
+`transform` is a response slot. To reshape a body on the way _out_ — your
+field names in, the API's on the wire — put the mapping in the `input` schema.
+A declared slot doesn't only validate: the request is built from the value the
+schema **returned**, so a schema that transforms is a request transform.
+
+```ts twoslash
+import { stitch } from 'stitchapi';
+import { z } from 'zod';
+
+const createUser = stitch({
+    method: 'POST',
+    baseUrl: 'https://api.example.com',
+    path: '/users',
+    input: {
+        // Callers pass the house shape; the API's shape goes on the wire.
+        body: z
+            .object({ userName: z.string(), joinedAt: z.date() })
+            .transform((b) => ({
+                user_name: b.userName,
+                joined_at: b.joinedAt.toISOString(),
+            })),
+    },
+});
+
+await createUser({ body: { userName: 'mango', joinedAt: new Date() } });
+```
+
+The call argument is typed from the schema's **input** side, so callers keep
+`{ userName, joinedAt }` and never see `{ user_name, joined_at }`. The mapping
+lives on the stitch once, instead of at every call site.
+
+It runs in the right place, too: input schemas resolve before the request is
+built, so the reshaped body is what `auth` signs and what the cache key is
+derived from. Every slot works this way — `params`, `query`, `body`, `headers`,
+and GraphQL `variables` — and each is transformed independently.
+
+## Why `transform` is response-only
+
+An `output` schema can reshape too, by the same rule: the stitch serves the
+value the schema returned. So why does `transform` exist as its own slot — and
+why only on the response?
+
+Because on the response side the reshaping has to happen somewhere a schema
+can't reach, and has to stay visible to machinery a schema would hide it from:
+
+- **Ordering.** `transform` runs before [`pick`](/docs/guides/data/pick), so
+  `pick` addresses the reshaped body. A schema's own transform runs _at_
+  validation — after `pick` has already read the raw shape.
+- **Drift.** [Drift](/docs/guides/validation/drift) is anchored on the
+  difference between the raw body and the validated value. A transform inside a
+  `drift()` schema sits on the validated side, so every field it renames is
+  reported as drift.
+- **Caching.** A `transform` is a declared opacity: a stitch that has one
+  refuses to cache until you set `cache.fingerprint.transform`, because
+  re-validation cannot detect that the transform itself changed. A transform
+  buried inside `output` is invisible to that check, so it silently defeats it.
+
+None of the three has a request-side counterpart. There is no request `pick` and
+no request drift, and the cache key is derived from the request _after_ the input
+schema shaped it, so the reshaping is already folded in. A request `transform`
+slot would add a second spelling and no guarantee — which is why there isn't one.
+
+<Callout type="info">
+    The corollary for the response side: prefer `transform` over a transform
+    inside `output`. Keeping the two apart is what keeps `pick`, drift, and the
+    cache fingerprint honest about what reshaped the body.
 </Callout>
 
 ## See also

--- a/apps/docs/content/docs/guides/validation/validation.mdx
+++ b/apps/docs/content/docs/guides/validation/validation.mdx
@@ -43,6 +43,12 @@ caller tacked onto a declared slot never reaches the API — which matters most
 when the caller is untrusted, such as a model calling through
 [the MCP surface](/docs/surfaces/mcp).
 
+A schema that _transforms_ therefore reshapes the request. This is how a stitch
+maps your field names onto the API's — the call argument is typed from the
+schema's input side, so callers keep the house shape while the wire gets the
+API's. See
+[Reshaping the request](/docs/guides/data/transform#reshaping-the-request).
+
 <Callout type="warn">
     A schema constrains **one slot**. An undeclared slot stays a full
     passthrough, so declaring `params` does nothing about `query`. And a query
@@ -78,6 +84,7 @@ See [Reference → Config types](/docs/reference/config-types) for every field o
         href="/docs/guides/validation/standard-schema"
     />
     <Card title="Schema drift detection" href="/docs/guides/validation/drift" />
+    <Card title="Guide: transform" href="/docs/guides/data/transform" />
     <Card title="STITCH_VALIDATION" href="/docs/errors/stitch-validation" />
     <Card title="Reference: Config types" href="/docs/reference/config-types" />
 </Cards>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1443,11 +1443,36 @@ export interface AuthStrategy {
 export interface HookContext {
     name: string;
     attempt: number;
+    /**
+     * The live request this attempt is about to send — for READING (log the method/url, count a
+     * retry). It is the same object handed to the transport, so a mutation does take effect, but
+     * see {@link Hooks.onRequest}: by the time a hook sees it, auth has already signed it.
+     */
     req?: AdapterRequest;
     res?: AdapterResponse;
     error?: unknown;
 }
+/**
+ * Observation points on a call's lifecycle — logging, metrics, tracing. A hook cannot change what
+ * a stitch returns (its return value is discarded); reshaping the RESPONSE is `transform`, and
+ * reshaping the REQUEST is the `input` schema (see {@link Hooks.onRequest}).
+ */
 export interface Hooks {
+    /**
+     * Fires per attempt, just before the request goes out — and deliberately AFTER `auth.apply`,
+     * so it observes the fully-shaped, post-auth request (headers included).
+     *
+     * ⚠️ That ordering makes it the wrong place to RESHAPE the request. `ctx.req` is the live
+     * object, so mutating `req.body` here does reach the wire, but an auth strategy that signs the
+     * payload (`@stitchapi/aws-sigv4` with `signBody`, or any HMAC scheme) has already hashed the
+     * body being replaced — the signature then covers bytes that were never sent, and the API
+     * rejects the call with a 403 that points at nothing. The cache key is likewise derived from
+     * the request BEFORE this hook runs, so a mutation here is invisible to it too.
+     *
+     * Reshape the request in {@link StitchConfig.input} instead: input schemas resolve before the
+     * request is built, so the reshaped value is what auth signs and what the key is derived from
+     * (the request-side counterpart of {@link StitchConfig.transform}).
+     */
     onRequest?: (ctx: HookContext) => void | Promise<void>;
     onResponse?: (ctx: HookContext) => void | Promise<void>;
     onError?: (ctx: HookContext) => void | Promise<void>;
@@ -1670,6 +1695,13 @@ export interface StitchConfig {
     /**
      * Schemas validating params, query, body, headers, and (GraphQL) variables before the request.
      * At least one slot must be set — the opaque `input: {}` is rejected (CONTRACT.md P20).
+     *
+     * A declared slot also SHAPES the request: it is built from the value the schema returned, so
+     * a schema that coerces, defaults, strips — or transforms — is what goes on the wire. That
+     * makes this the request-side counterpart of {@link StitchConfig.transform} (map your field
+     * names onto the API's here), and the call argument is typed from the schema's INPUT side, so
+     * callers keep the pre-transform shape. It resolves before the request is built, so the
+     * reshaped value is what `auth` signs and what the cache key is derived from.
      */
     input?: AtLeastOne<InputSchemas>;
     /**
@@ -1683,7 +1715,15 @@ export interface StitchConfig {
     output?: SchemaLike | DriftSpec;
     /** Dot-path picking the part of the response to return (e.g. `'data.items'`). */
     pick?: string;
-    /** Reshape the raw body before `pick` and validation (e.g. scrape HTML to structured data). */
+    /**
+     * Reshape the raw RESPONSE body before `pick` and validation (e.g. scrape HTML to structured
+     * data). Response-only by design: it runs before `pick` (so `pick` addresses the reshaped
+     * body), it is the left side of drift's `diff(raw, validated)`, and it is a declared opacity
+     * the cache fingerprint can see (ADR 0004 rung 2) — three guarantees a transform buried inside
+     * the `output` schema would defeat. None has a request-side counterpart, so reshaping the
+     * REQUEST is {@link StitchConfig.input}'s job: a slot's schema shapes what goes on the wire,
+     * before auth signs it and before the cache key is derived from it.
+     */
     transform?: (body: unknown) => unknown;
     /** Auto-loop pages, aggregating items, with auth/retry/throttle applied to every page. */
     paginate?: PaginateOptions;

--- a/packages/core/test/input-schema-filters.spec.ts
+++ b/packages/core/test/input-schema-filters.spec.ts
@@ -188,6 +188,80 @@ describe('a declared input schema shapes the request (issue #648)', () => {
     });
 });
 
+// The documented consequence of the same write-back: a slot schema that TRANSFORMS is the
+// request-side counterpart of `transform` (which is response-only — it runs before `pick`, anchors
+// drift's `diff(raw, validated)`, and is a fingerprint-visible opacity, none of which has a request
+// analogue). These pin the two properties the guide promises, so neither can regress silently.
+describe('a transforming input schema is the request-side transform', () => {
+    test('body: the caller passes the house shape, the API shape goes on the wire', async () => {
+        server.route('POST', '/users', { body: { ok: true } });
+        const createUser = stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/users',
+            input: {
+                body: z
+                    .object({ userName: z.string(), joinedAt: z.date() })
+                    .transform((b) => ({
+                        user_name: b.userName,
+                        joined_at: b.joinedAt.toISOString(),
+                    })),
+            },
+        });
+
+        // No cast: the call argument is typed from the schema's INPUT side, so the pre-transform
+        // shape is what typechecks here (a `user_name` literal is a compile error).
+        await createUser({
+            body: { userName: 'mango', joinedAt: new Date(0) },
+        });
+
+        expect(server.calls('/users')[0]!.body).toEqual({
+            user_name: 'mango',
+            joined_at: '1970-01-01T00:00:00.000Z',
+        });
+    });
+
+    test('auth signs the TRANSFORMED body — the ordering that makes `input` the seam and `onRequest` the wrong one', async () => {
+        server.route('POST', '/signed', { body: { ok: true } });
+        const seenByAuth: unknown[] = [];
+        const seenByHook: unknown[] = [];
+
+        const send = stitch({
+            method: 'POST',
+            baseUrl: server.url,
+            path: '/signed',
+            input: {
+                body: z
+                    .object({ amount: z.number() })
+                    .transform((b) => ({ amount_cents: b.amount * 100 })),
+            },
+            // Stands in for a payload-signing strategy (`@stitchapi/aws-sigv4` with `signBody`, or
+            // any HMAC scheme): it hashes `req.body`, so it must see the post-transform value or
+            // the signature covers bytes that never go out.
+            auth: {
+                apply: (req) => {
+                    seenByAuth.push(req.body);
+                    req.headers['x-signed-body'] = JSON.stringify(req.body);
+                },
+            },
+            hooks: { onRequest: ({ req }) => void seenByHook.push(req?.body) },
+        });
+
+        await send({ body: { amount: 5 } });
+
+        const call = server.calls('/signed')[0]!;
+        expect(call.body).toEqual({ amount_cents: 500 });
+        // Auth ran AFTER the transform, so the signature matches the bytes on the wire.
+        expect(seenByAuth).toEqual([{ amount_cents: 500 }]);
+        expect(call.headers['x-signed-body']).toBe(
+            JSON.stringify({ amount_cents: 500 }),
+        );
+        // And `onRequest` is downstream of both — it observes the signed request, which is exactly
+        // why reshaping there would invalidate the signature above.
+        expect(seenByHook).toEqual([{ amount_cents: 500 }]);
+    });
+});
+
 // The one path the issue flagged to check first: `variables` is a validated slot, but the value is
 // consumed by the graphql surface's `buildRequest` (`{ query, variables }`), not by the generic
 // request builder. The engine hands the surface the same input object it validated, so the parsed


### PR DESCRIPTION
## Why

`transform` only reshapes the response, so "how do I transform the request?" has no obvious answer in the docs — and the seam people reach for instead is mutating `ctx.req.body` in an `onRequest` hook, which is the one place it is unsafe.

## The capability already exists

`validateInput` writes back the **parsed** value ([engine.ts](https://github.com/rejifald/StitchAPI/blob/main/packages/core/src/engine.ts)), so a slot schema that transforms *is* a request transform. `SlotInput` types the call argument off `InferInput` — the schema's input side — so callers keep the pre-transform shape while the wire gets the API's:

```ts
const createUser = stitch({
    method: 'POST',
    baseUrl: 'https://api.example.com',
    path: '/users',
    input: {
        body: z.object({ userName: z.string(), joinedAt: z.date() })
               .transform((b) => ({ user_name: b.userName, joined_at: b.joinedAt.toISOString() })),
    },
});

await createUser({ body: { userName: 'mango', joinedAt: new Date() } });
```

It also lands in the right place: input schemas resolve before `buildRequest`, so the reshaped body is what `auth` signs and what the cache key is derived from. None of that was written down.

## Why `transform` stays response-only

The obvious follow-up, since an `output` schema can reshape by the same rule. A schema-embedded transform sits in the wrong place and hides from three mechanisms:

- **Ordering** — `transform` runs before `pick`, so `pick` addresses the reshaped body. A schema's transform runs *at* validation, after `pick` read the raw shape.
- **Drift** — it lands on the `validated` side of `diff(raw, validated)`, so every field it renames reports as drift.
- **Caching** — it is invisible to the fingerprint, which refuses to cache a declared `transform` precisely because re-validation cannot detect that the transform changed (ADR 0004 rung 2).

None of the three has a request-side counterpart — no request `pick`, no request drift, and the key is derived *after* the input schema shaped it. So a request `transform` slot (or a `transform: { request, response }` envelope) would add a second spelling and no guarantee. Recorded as a decision rather than left to be re-litigated.

## The `onRequest` hazard

The hook fires after `auth.apply` by documented design, so a strategy that signs the payload (`@stitchapi/aws-sigv4` with `signBody`, any HMAC scheme) has already hashed the body a hook replaces: the signature covers bytes that never went out and the API answers 403 with nothing pointing at the cause. The cache key is derived earlier too, so a mutation there is invisible to it.

Docs + JSDoc rather than a runtime guard — detecting it soundly means snapshotting body identity across the hook and only for payload-signing strategies, which is a lot of machinery for a footgun a sentence closes.

## Tests

Two, pinning what the guide now promises:

- the caller's shape maps onto the API's on the wire — no cast at the call site, the wire shape is a compile error;
- **auth observes the transformed body**, via an inline body-signing strategy. That is the ordering the whole recommendation rests on, so it should not be able to regress silently.

## Notes

- The JSDoc edits regenerate the playground completions, so the guidance also surfaces on hover in the sandbox.
- Docs + tests only; no library behaviour changes, hence no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
