### PR TITLE
feat(core)!: reject a `baseUrl`/`path` authored beside a `url` (P24 carve-out (b))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,39 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Changed
 
+- **BREAKING CHANGE (types only): a `baseUrl`/`path` beside a `url` in ONE config literal is now a
+  compile error.**
+  ([CONTRACT.md P24 carve-out (b)](docs/CONTRACT.md#p24--a-shared-field-name-prefix-in-a-house-contract-is-an-envelope))
+  The endpoint slot has two spellings — the atomic `url`, and the `baseUrl` + `path` pair — and the
+  engine reads exactly one of them: when `url` is set it **is** the whole endpoint, no base is
+  joined, and neither sibling is ever read. Pairing them in one literal was dead config that the
+  type system nonetheless accepted.
+
+    **The bug this fixes.** `stitch({ url: 'https://a.test/x', baseUrl: 'https://b.test' })`
+    typechecked and silently discarded the base — the request went to `a.test`. The engine's own
+    diagnostic fires only when the **joined** result is not absolute, so it caught the relative-`url`
+    slip (`url: '/users'` alongside a `baseUrl`) and nothing else; the absolute-`url` case resolved to
+    a perfectly fetchable URL aimed at the wrong host, with nothing said anywhere. Only the JSDoc
+    recorded that `url` wins. `OneEndpointSpelling` now brands the inert sibling with a `ConfigError`
+    naming it, on every surface that authors a stitch (`stitch`, `graphql`, `download`, and their
+    `Seam` members).
+
+    Migration — the rejected pairing had no working meaning, so there is nothing to preserve. Drop
+    the field that was being ignored, or keep it and drop `url`:
+
+    ```ts
+    // before: compiled, silently ignored `baseUrl` — the request went to a.test
+    stitch({ url: 'https://a.test/users', baseUrl: 'https://b.test' });
+    // after: say which one you meant
+    stitch({ url: 'https://a.test/users' });
+    stitch({ baseUrl: 'https://b.test', path: '/users' });
+    ```
+
+    **Composition is unchanged.** The guard reads the config literal only, so across `extends`
+    fragments the two spellings remain a last-writer-wins override: a seam's shared `baseUrl` with
+    one member's absolute `url` — the ordinary way to point a single endpoint off-origin — still
+    compiles and still behaves exactly as before.
+
 - **BREAKING CHANGE: `RateLimitError` now extends `StitchError`.**
   ([CONTRACT.md P10](docs/CONTRACT.md#p10--error-class-taxonomy-parity)) The two classes were
   siblings, and P10 held them in parity by having `RateLimitError` re-declare `status` / `attempts` /

--- a/apps/docs/app/(home)/playground/playground-completions.generated.ts
+++ b/apps/docs/app/(home)/playground/playground-completions.generated.ts
@@ -45,19 +45,19 @@ export const PLAYGROUND_COMPLETIONS: Record<string, Completion[]> = {
             label: "url",
             type: "property",
             detail: "string | (() => string)",
-            info: "Full request endpoint as one string — the atomic spelling, when a stitch is exactly one endpoint with no base to share. Templated (`{param}`, incl. the host) and `?query`-aware like `path`; may be a thunk for lazy/env resolution. ⚠️ `url` is the COMPLETE endpoint and is **not** joined to `baseUrl` — setting `url` makes `baseUrl` ignored. To address an endpoint *relative to* a shared `baseUrl` (e.g. a seam/fragment origin), use `path`, not a relative `url`: `url: '/users'` resolves to the un-fetchable `/users`, whereas `path: '/users'` resolves to `${baseUrl}/users`. Mutually exclusive with `baseUrl`/`path`: when both are set `url` wins, and across composed fragments the last fragment to write either spelling wins the whole slot.",
+            info: "Full request endpoint as one string — the atomic spelling, when a stitch is exactly one endpoint with no base to share. Templated (`{param}`, incl. the host) and `?query`-aware like `path`; may be a thunk for lazy/env resolution. ⚠️ `url` is the COMPLETE endpoint and is **not** joined to `baseUrl`. To address an endpoint *relative to* a shared `baseUrl` (e.g. a seam/fragment origin), use `path`, not a relative `url`: `url: '/users'` resolves to the un-fetchable `/users`, whereas `path: '/users'` resolves to `${baseUrl}/users`. Mutually exclusive with `baseUrl`/`path`, enforced at two different depths: pairing the spellings in ONE config literal is a **compile error** (OneEndpointSpelling), while across composed fragments they stay a legal last-writer-wins override — the last fragment to write either spelling wins the whole slot.",
         },
         {
             label: "baseUrl",
             type: "property",
             detail: "string | (() => string)",
-            info: "Origin that `path` is appended to, as a string or a thunk resolved at call time. Ignored when `url` is set (which carries its own origin).",
+            info: "Origin that `path` is appended to, as a string or a thunk resolved at call time. Cannot sit beside `url` in one literal (OneEndpointSpelling); a `url` from a later fragment overrides it (which carries its own origin).",
         },
         {
             label: "path",
             type: "property",
             detail: "string",
-            info: "Path appended to `baseUrl` — use THIS (not a relative `url`) for an endpoint relative to a shared `baseUrl`; may include `{param}` slots and a `?query` string. Ignored when `url` is set.",
+            info: "Path appended to `baseUrl` — use THIS (not a relative `url`) for an endpoint relative to a shared `baseUrl`; may include `{param}` slots and a `?query` string. Cannot sit beside `url` in one literal (OneEndpointSpelling); a `url` from a later fragment overrides it.",
         },
         {
             label: "headers",

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -718,6 +718,14 @@ the envelope, and `MultipartOnlyOnMultipartBody` makes `wire.multipart` unsatisf
 `wire.body` is `'multipart'` — so `wire: { body: 'json', multipart: 'dot' }` is a compile error
 rather than silently inert config.
 
+_Second case for (b) (2026-08-16):_ the **endpoint slot** — `url` vs `baseUrl` + `path`. It stays
+flat because its members do not share a level (`SeamConfig` omits `url`/`path`, so `baseUrl` is
+seam vocabulary and the other two are per-endpoint) and because a dominant-field shorthand would
+mean two different things on the two surfaces, a P2 collision. `OneEndpointSpelling` supplies the
+(b) obligation the slot was missing: `baseUrl`/`path` beside a `url` in the SAME literal is a
+compile error, while across `extends` fragments the spellings stay a legal last-writer-wins
+override. See the migration record for the silent case that motivated it.
+
 Applied on every surface that authors a stitch (`stitch`, `graphql`, `Seam.stitch`,
 `Seam.graphql` — both the inferring and the fallback overload, or a rejected config falls through
 to the loose one and typechecks after all). **`seam()` itself is exempt and stays non-generic:**
@@ -1137,6 +1145,35 @@ shape, not as today's surface: nothing on the surface carries an alias.
     `fingerprint: { transform: 3 }` ≡ `{ transform: { version: 3 } }`) — the only two-level fold on
     the surface, and `NestedEnvelopes` carries it to that depth so a misspelling inside either
     envelope is a compile error. Genuine breaking flat→envelope, no alias.
+
+- **P24 carve-out (b) (endpoint slot, 2026-08-16)** the endpoint spellings — `url` vs
+  `baseUrl` + `path` — are one capability wearing two spellings, and they **stay flat**, because
+  they do not share a level: `SeamConfig` is `Omit<StitchConfig, 'path' | 'url' | …>`, so `baseUrl`
+  is cross-cutting seam vocabulary while `url`/`path` are per-endpoint, and that boundary is a
+  declarative one-line `Omit` an envelope would turn into a hand-written nested override on both
+  types. A P12 shorthand would also read as two different things
+  (`endpoint: 'https://api.example.com'` = the whole URL on a stitch, the base on a seam) — the
+  [P2](#p2--dont-reuse-one-word-for-genuinely-different-concepts--rename-one) collision an envelope
+  is supposed to avoid, not create. What was **missing** is (b)'s own obligation: the dead
+  combinations were representable. `stitch({ url: 'https://a.test/x', baseUrl: 'https://b.test' })`
+  typechecked and silently dropped the base — the engine's diagnostic fires only when the JOINED
+  result is not absolute, so the absolute-`url` case (a fetchable URL aimed at the wrong host)
+  passed with nothing said anywhere. **Fixed** — `OneEndpointSpelling<C>` brands `baseUrl`/`path`
+  with a `ConfigError` when `url` sits beside them in the same literal, the mutual-exclusion shape
+  R8 already recognises, applied on every surface that authors a stitch (`stitch`, `graphql`,
+  `download` and their `Seam` members, both overloads). Additive: no rename, no runtime bytes, and a
+  repo-wide sweep found zero existing sites to fix.
+
+    Deliberately **literal-only**, unlike its `AnyLayer`/`Layers` siblings: across fragments the two
+    spellings are a supported last-writer-wins override (`stitch.ts`'s endpoint-slot reconcile), and
+    a seam supplying `baseUrl` while one member supplies an absolute `url` is the ordinary way to
+    point a single endpoint off-origin — a composed read would reject it. **R8 never flagged this
+    group**: `url`/`baseUrl`/`path` share no leading-word prefix, the same gap recorded above for
+    `total`/`perAttempt` and the cache-transform pair. One consequence is recorded with it:
+    `PathVarsOf`'s `path`-wins-over-`url` tie-break reads the literal `C`, so the pairing it
+    arbitrates is no longer reachable through any authoring surface — it survives for configs
+    arriving by cast or widened fragment, and its assertion moved onto `InputOf` directly
+    (`path-vars.test-d.ts` case 8).
 
 - **P20/P12/P13 (empty-object rejection)** the five bare all-optional `StitchConfig` slots R6 flagged
   now type their object form so `{}` is a **compile error**: `hooks?: AtLeastOne<Hooks>` and

--- a/packages/core/src/download.ts
+++ b/packages/core/src/download.ts
@@ -19,6 +19,7 @@ import {
     type NoRequestShapeOnDownload,
     type NoUnknownConfigKeys,
     type NoUnknownNestedKeys,
+    type OneEndpointSpelling,
     type Seam,
     type SeamOptions,
     type Stitch,
@@ -180,6 +181,7 @@ export interface DownloadSeamApi {
         config: C &
             NoUnknownConfigKeys<C> &
             NoUnknownNestedKeys<C> &
+            OneEndpointSpelling<C> &
             NoRequestShapeOnDownload<C> &
             NoKindOnDownload<C>,
     ) => Stitch<DownloadResult, InputOf<C>>;
@@ -204,6 +206,7 @@ const downloadStitch = <
     config: C &
         NoUnknownConfigKeys<C> &
         NoUnknownNestedKeys<C> &
+        OneEndpointSpelling<C> &
         NoRequestShapeOnDownload<C> &
         NoKindOnDownload<C>,
 ): Stitch<DownloadResult, InputOf<C>> =>

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -49,6 +49,7 @@ import {
     type NoUnknownConfigKeys,
     type NoUnknownNestedKeys,
     type NoWireBodyOnGraphql,
+    type OneEndpointSpelling,
     type RedactedStitchConfig,
     type RequestShapeFixedByDownload,
     type ResolvedStitchConfig,
@@ -1229,6 +1230,7 @@ export interface StitchFn {
         config: C &
             NoUnknownConfigKeys<C> &
             NoUnknownNestedKeys<C> &
+            OneEndpointSpelling<C> &
             MultipartOnlyOnMultipartBody<C> &
             FlagPathInOutput<C> &
             GraphqlOnlyOnGraphqlSurface<C> &
@@ -1241,7 +1243,8 @@ export interface StitchFn {
      * match the inferring overload above, so the result is `Stitch<unknown>` — override with `<T>`.
      *
      * `C` is captured here ONLY to re-apply the dead-config guards
-     * ({@link NoUnknownConfigKeys}, {@link MultipartOnlyOnMultipartBody},
+     * ({@link NoUnknownConfigKeys}, {@link OneEndpointSpelling},
+     * {@link MultipartOnlyOnMultipartBody},
      * {@link GraphqlOnlyOnGraphqlSurface}, {@link WireBodyFixedByGraphql},
      * {@link RequestShapeFixedByDownload}); the result stays `Stitch<T>`. Without it a config
      * rejected by the inferring overload would silently fall through to this one and typecheck
@@ -1257,6 +1260,7 @@ export interface StitchFn {
         config: C &
             NoUnknownConfigKeys<C> &
             NoUnknownNestedKeys<C> &
+            OneEndpointSpelling<C> &
             MultipartOnlyOnMultipartBody<C> &
             FlagPathInOutput<C> &
             GraphqlOnlyOnGraphqlSurface<C> &
@@ -1302,6 +1306,7 @@ export function graphql<
     config: C &
         NoUnknownConfigKeys<C> &
         NoUnknownNestedKeys<C> &
+        OneEndpointSpelling<C> &
         MultipartOnlyOnMultipartBody<C> &
         FlagPathInOutput<C> &
         NoWireBodyOnGraphql<C>,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -573,6 +573,43 @@ export type MultipartOnlyOnMultipartBody<C> =
               }
         : unknown;
 /**
+ * Compile-time guard: `url` is the COMPLETE endpoint, so a `baseUrl`/`path` authored beside it in
+ * the SAME config literal is dead config — `buildRequest` (`engine.ts`) takes the `url` branch and
+ * neither sibling is ever read. Intersecting the config with this makes the offending slot
+ * unsatisfiable (CONTRACT.md P24 carve-out (b), which requires a flat group kept flat to make its
+ * dead combinations unrepresentable). The endpoint slot is exactly such a group — one capability,
+ * two spellings — and **R8 never flagged it**: `url`/`baseUrl`/`path` share no leading-word prefix,
+ * the lint's documented gap (§7).
+ *
+ * Until this guard the JSDoc on {@link StitchConfig.url} was the only thing saying `url` wins:
+ * `stitch({ url: 'https://a.test/x', baseUrl: 'https://b.test' })` typechecked and silently dropped
+ * the base. The engine's own diagnostic only fires when the JOINED result is not absolute, so the
+ * absolute-`url` case — the one that quietly aims at the wrong host — passed with nothing said
+ * anywhere. That asymmetry is the whole reason this belongs in the type: the runtime can only catch
+ * the spelling that fails loudly on its own.
+ *
+ * LITERAL-ONLY, and deliberately NOT the {@link AnyLayer}/{@link Layers} composed read its siblings
+ * use. Across fragments the two spellings are a SUPPORTED last-writer-wins override — `stitch.ts`'s
+ * endpoint-slot reconcile clears an inherited `baseUrl`/`path` when a child writes `url`, and
+ * clears an inherited `url` when a child writes either sibling. A seam supplying `baseUrl` while
+ * one member supplies an absolute `url` is the ordinary way to point a single endpoint off-origin,
+ * and a composed read would reject it. Only the single-literal pairing, where no override can be
+ * meant, is dead.
+ *
+ * RESIDUAL LIMIT, shared with the sibling guards: a fragment typed as `Partial<StitchConfig>`
+ * rather than inferred from its literal has optional properties, which satisfy no probe, so it
+ * reads as supplying nothing. The literal-level case, which is the one people write, errors
+ * precisely.
+ */
+export type OneEndpointSpelling<C> = C extends { url: unknown }
+    ? C extends { baseUrl: unknown } | { path: unknown }
+        ? {
+              baseUrl?: ConfigError<'`url` is the COMPLETE endpoint and is NOT joined to `baseUrl` — this `baseUrl` is ignored. Drop it, or drop `url` and address the endpoint as `baseUrl` + a relative `path`'>;
+              path?: ConfigError<'`url` is the COMPLETE endpoint and carries its own path — this `path` is ignored. Fold it into `url`, or replace `url` with `baseUrl` + `path`'>;
+          }
+        : unknown
+    : unknown;
+/**
  * Compile-time guard: `document` and `operationName` are read ONLY by the graphql surface's
  * `buildRequest` (`surface.ts`), so authoring either without selecting that surface is silently
  * dead config — the document is dropped and a plain request goes out. Intersecting a config with
@@ -1645,17 +1682,18 @@ export interface StitchConfig {
      * endpoint with no base to share. Templated (`{param}`, incl. the host) and `?query`-aware
      * like `path`; may be a thunk for lazy/env resolution.
      *
-     * ⚠️ `url` is the COMPLETE endpoint and is **not** joined to `baseUrl` — setting `url` makes
-     * `baseUrl` ignored. To address an endpoint *relative to* a shared `baseUrl` (e.g. a
-     * seam/fragment origin), use `path`, not a relative `url`: `url: '/users'` resolves to the
-     * un-fetchable `/users`, whereas `path: '/users'` resolves to `${baseUrl}/users`. Mutually
-     * exclusive with `baseUrl`/`path`: when both are set `url` wins, and across composed
-     * fragments the last fragment to write either spelling wins the whole slot.
+     * ⚠️ `url` is the COMPLETE endpoint and is **not** joined to `baseUrl`. To address an endpoint
+     * *relative to* a shared `baseUrl` (e.g. a seam/fragment origin), use `path`, not a relative
+     * `url`: `url: '/users'` resolves to the un-fetchable `/users`, whereas `path: '/users'`
+     * resolves to `${baseUrl}/users`. Mutually exclusive with `baseUrl`/`path`, enforced at two
+     * different depths: pairing the spellings in ONE config literal is a **compile error**
+     * ({@link OneEndpointSpelling}), while across composed fragments they stay a legal
+     * last-writer-wins override — the last fragment to write either spelling wins the whole slot.
      */
     url?: string | (() => string);
-    /** Origin that `path` is appended to, as a string or a thunk resolved at call time. Ignored when `url` is set (which carries its own origin). */
+    /** Origin that `path` is appended to, as a string or a thunk resolved at call time. Cannot sit beside `url` in one literal ({@link OneEndpointSpelling}); a `url` from a later fragment overrides it (which carries its own origin). */
     baseUrl?: string | (() => string);
-    /** Path appended to `baseUrl` — use THIS (not a relative `url`) for an endpoint relative to a shared `baseUrl`; may include `{param}` slots and a `?query` string. Ignored when `url` is set. */
+    /** Path appended to `baseUrl` — use THIS (not a relative `url`) for an endpoint relative to a shared `baseUrl`; may include `{param}` slots and a `?query` string. Cannot sit beside `url` in one literal ({@link OneEndpointSpelling}); a `url` from a later fragment overrides it. */
     path?: string;
     /** Static default headers merged into every request. */
     headers?: Record<string, string>;
@@ -2333,6 +2371,7 @@ export interface Seam {
         config: C &
             NoUnknownConfigKeys<C> &
             NoUnknownNestedKeys<C> &
+            OneEndpointSpelling<C> &
             MultipartOnlyOnMultipartBody<C> &
             FlagPathInOutput<C> &
             GraphqlOnlyOnGraphqlSurface<C> &
@@ -2342,7 +2381,8 @@ export interface Seam {
     /**
      * Non-inferring fallback: a path string or a `string | Partial<StitchConfig>` value (see
      * {@link StitchFn}). `C` is captured only to re-apply the dead-config guards
-     * ({@link NoUnknownConfigKeys}, {@link MultipartOnlyOnMultipartBody},
+     * ({@link NoUnknownConfigKeys}, {@link OneEndpointSpelling},
+     * {@link MultipartOnlyOnMultipartBody},
      * {@link GraphqlOnlyOnGraphqlSurface}, {@link WireBodyFixedByGraphql},
      * {@link RequestShapeFixedByDownload}) — see {@link StitchFn}'s fallback for why.
      */
@@ -2354,6 +2394,7 @@ export interface Seam {
         config: C &
             NoUnknownConfigKeys<C> &
             NoUnknownNestedKeys<C> &
+            OneEndpointSpelling<C> &
             MultipartOnlyOnMultipartBody<C> &
             FlagPathInOutput<C> &
             GraphqlOnlyOnGraphqlSurface<C> &
@@ -2372,6 +2413,7 @@ export interface Seam {
         config: C &
             NoUnknownConfigKeys<C> &
             NoUnknownNestedKeys<C> &
+            OneEndpointSpelling<C> &
             MultipartOnlyOnMultipartBody<C> &
             FlagPathInOutput<C> &
             NoWireBodyOnGraphql<C>,

--- a/packages/core/test-d/endpoint-spelling.test-d.ts
+++ b/packages/core/test-d/endpoint-spelling.test-d.ts
@@ -1,0 +1,132 @@
+// The endpoint slot has two spellings — the atomic `url`, and the `baseUrl` + `path` pair — and
+// `buildRequest` (`engine.ts`) reads exactly one of them: when `url` is set it IS the whole
+// endpoint, no base is joined, and neither sibling is ever read. Pairing them in ONE config literal
+// is therefore dead config, and must not typecheck (CONTRACT.md P24 carve-out (b): a flat group
+// kept flat MUST make its dead combinations unrepresentable).
+//
+// Why the type has to carry this at all — the runtime cannot. The engine's own diagnostic fires
+// only when the JOINED result is not absolute, which catches the relative-`url` slip
+// (`url: '/users'` beside a `baseUrl`) and nothing else. The absolute-`url` case —
+// `url: 'https://a.test/x'` beside `baseUrl: 'https://b.test'` — resolves to a perfectly fetchable
+// URL aimed at the wrong host, so it shipped silently. That asymmetry is the whole reason for the
+// guard, and the silent case is the first assertion below.
+//
+// The guard is LITERAL-ONLY, and the composed cases in the second half are as load-bearing as the
+// rejections. Across `extends` fragments the two spellings are a SUPPORTED last-writer-wins
+// override (`stitch.ts`'s endpoint-slot reconcile): a seam supplying `baseUrl` while one member
+// supplies an absolute `url` is the ordinary way to point a single endpoint off-origin. Reading
+// composed layers here — the way the `graphql`/`multipart` guards do — would reject that, so the
+// divergence from the sibling guards is deliberate and pinned here.
+import { graphql, seam, stitch } from '../src';
+import type { Stitch, StitchConfig } from '../src';
+import { download } from '../src/download';
+import type { DownloadResult } from '../src/download';
+
+import { expectAssignable, expectError, expectType } from 'tsd';
+
+const URL_ = 'https://files.example.com/report.csv';
+const BASE = 'https://api.example.com';
+const DOC = 'query Me { me { id } }';
+
+// ── Legal: each spelling on its own ─────────────────────────────────────────
+expectType<Stitch<unknown>>(stitch({ url: `${BASE}/users` }));
+expectType<Stitch<unknown>>(stitch({ baseUrl: BASE, path: '/users' }));
+expectType<Stitch<unknown>>(stitch({ baseUrl: BASE }));
+expectType<Stitch<unknown>>(stitch({ path: '/users' }));
+// The thunk form of either is just as legal on its own.
+expectType<Stitch<unknown>>(stitch({ url: () => `${BASE}/users` }));
+expectType<Stitch<unknown>>(stitch({ baseUrl: () => BASE, path: '/users' }));
+
+// ── Illegal: both spellings in ONE literal ──────────────────────────────────
+// THE silent case: both absolute, so the joined result is fetchable and the engine never complains.
+// `baseUrl` is dropped and the request goes to `a.test`.
+expectError(stitch({ url: 'https://a.test/x', baseUrl: 'https://b.test' }));
+// The relative-`url` slip the engine already catches at runtime — now caught at authoring time.
+expectError(stitch({ url: '/users', baseUrl: BASE }));
+// `path` is inert beside `url` for the same reason: `url` carries its own path.
+expectError(stitch({ url: `${BASE}/users`, path: '/users' }));
+// All three at once — the guard reports the offending siblings, not the `url`.
+expectError(stitch({ url: `${BASE}/users`, baseUrl: BASE, path: '/users' }));
+// Thunks do not launder it: the pairing is dead whatever the values resolve to.
+expectError(stitch({ url: () => `${BASE}/users`, baseUrl: BASE }));
+expectError(stitch({ url: `${BASE}/users`, baseUrl: () => BASE }));
+
+// ── The same guard on every surface that authors a stitch ───────────────────
+// `graphql()` — its `/graphql` endpoint default keys off BOTH `url` and `path` being absent, so a
+// dead pairing here is exactly as silent as on `stitch()`.
+expectType<Stitch<unknown>>(graphql({ baseUrl: BASE, document: DOC }));
+expectType<Stitch<unknown>>(graphql({ url: `${BASE}/graphql`, document: DOC }));
+expectError(graphql({ url: `${BASE}/graphql`, baseUrl: BASE, document: DOC }));
+expectError(
+    graphql({ url: `${BASE}/graphql`, path: '/graphql', document: DOC }),
+);
+
+// `download()` — the preset whose single most common spelling IS a bare `url`.
+expectType<Stitch<DownloadResult>>(download({ url: URL_ }));
+expectError(download({ url: URL_, baseUrl: 'https://files.example.com' }));
+expectError(download({ url: URL_, path: '/report.csv' }));
+expectError(
+    download.stitch({ url: URL_, baseUrl: 'https://files.example.com' }),
+);
+
+// Seam members, both overloads.
+const api = seam({ baseUrl: BASE });
+expectType<Stitch<unknown>>(api.stitch({ path: '/users' }));
+expectError(api.stitch({ url: `${BASE}/users`, baseUrl: BASE }));
+expectError(api.stitch({ url: `${BASE}/users`, path: '/users' }));
+expectError(api.graphql({ url: `${BASE}/gql`, baseUrl: BASE, document: DOC }));
+// The non-inferring fallback overload carries the guard as well, and every `expectError` above is
+// what proves it: without the re-application a config the INFERRING overload rejects would simply
+// fall through to the fallback and typecheck after all. There is no separate assertion to write —
+// on a genuinely loose `string | Partial<StitchConfig>` argument the guards distribute over the
+// union and every arm resolves to `unknown`, which is the escape hatch the fallback exists to be.
+
+// ── Legal across fragments: the last-writer-wins override, NOT dead config ───
+// A seam supplies the origin; one member overrides the whole endpoint with an absolute `url`. The
+// reconcile in `stitch.ts` clears the inherited `baseUrl`, so nothing here is inert.
+expectType<Stitch<unknown>>(api.stitch({ url: 'https://other.test/health' }));
+// The same thing spelled with an explicit `extends` fragment, in both directions.
+expectType<Stitch<unknown>>(
+    stitch({ extends: [{ baseUrl: BASE }], url: 'https://other.test/health' }),
+);
+expectType<Stitch<unknown>>(
+    stitch({
+        extends: [{ url: 'https://other.test/x' }],
+        baseUrl: BASE,
+        path: '/users',
+    }),
+);
+// Two fragments disagreeing is likewise legal — the later one wins the whole slot.
+expectType<Stitch<unknown>>(
+    stitch({
+        extends: [
+            { baseUrl: BASE, path: '/users' },
+            { url: 'https://other.test/x' },
+        ],
+    }),
+);
+
+// ── Residual limit, pinned rather than fixed ────────────────────────────────
+// A fragment typed as `Partial<StitchConfig>` rather than inferred from its literal has OPTIONAL
+// properties, which satisfy no probe, so it reads as supplying nothing and the pairing inside it is
+// not reported. This is the same fail-open the sibling guards document as their first residual
+// limit; the literal-level case, which is the one people write, errors precisely (above).
+const widened: Partial<StitchConfig> = {
+    url: `${BASE}/users`,
+    baseUrl: BASE,
+};
+expectAssignable<Partial<StitchConfig>>(widened);
+expectType<Stitch<unknown>>(stitch({ extends: [widened] }));
+
+// The same fail-open reached a second way, and worth naming because it looks like it should work:
+// supplying an EXPLICIT result generic (`stitch<T>({ … })`) fills `TExplicit` only, so the second
+// type parameter `C` falls back to its declared default `Partial<StitchConfig>` instead of being
+// inferred from the literal — all-optional again, so no probe matches and the guard goes inert.
+// This is a property of the guard IDIOM, not of this guard: `MultipartOnlyOnMultipartBody` and
+// `GraphqlOnlyOnGraphqlSurface` were verified to have the identical hole
+// (`stitch<{ id: string }>({ wire: { multipart: 'dot' } })` compiles too). Pinned here as a
+// decision on record rather than fixed — closing it means making `C` inferable alongside an
+// explicit `TExplicit`, which is a change to every overload in the family, not to this rule.
+expectType<Stitch<{ id: string }>>(
+    stitch<{ id: string }>({ url: '/u', baseUrl: BASE }),
+);

--- a/packages/core/test-d/path-vars.test-d.ts
+++ b/packages/core/test-d/path-vars.test-d.ts
@@ -10,6 +10,7 @@
 // `stitch({ path: '…' })` forms (no `as const`) exercise that capture too.
 import { seam, stitch } from '..';
 import type { StitchInput } from '..';
+import type { InputOf } from '../src/infer';
 import { type CallArg } from './_util';
 
 import { expectAssignable, expectError, expectType } from 'tsd';
@@ -80,11 +81,17 @@ expectType<{ tenant: string | number | bigint }>(
 expectError(host());
 
 // 8) `path` wins the var source when both `path` and `url` are literals (the engine never expands both;
-//    reading `path` first is the stable choice).
-const both = stitch({ path: '/p/{p}', url: 'https://x/u/{u}' });
+//    reading `path` first is the stable choice). That pairing is now a compile error at every
+//    authoring surface (`OneEndpointSpelling` — the engine reading only one of them is exactly what
+//    makes it dead config), so the rule is asserted on `InputOf` DIRECTLY: `PathVarsOf` reads the
+//    literal `C` rather than the composed layers, so no `extends` spelling reaches this branch, and
+//    a call site is the one place it can no longer be observed. The tie-break stays the
+//    deterministic answer for a config that arrives via a cast or a widened fragment.
+type BothSpellings = { path: '/p/{p}'; url: 'https://x/u/{u}' };
 expectType<{ p: string | number | bigint }>(
-    null as unknown as NonNullable<CallArg<typeof both>>['params'],
+    null as unknown as NonNullable<InputOf<BothSpellings>>['params'],
 );
+expectError(stitch({ path: '/p/{p}', url: 'https://x/u/{u}' }));
 
 // 9) a non-templated stitch is byte-for-byte Phase 2: no `{…}` → loose, OPTIONAL argument (backward compat).
 const plain = stitch({ path: '/ping' });

--- a/packages/core/test/url-contract.spec.ts
+++ b/packages/core/test/url-contract.spec.ts
@@ -1,4 +1,5 @@
 import { stitch } from '../src';
+import type { StitchConfig } from '../src';
 import { startMockServer } from './support/mock-server';
 import type { MockServer } from './support/mock-server';
 
@@ -45,13 +46,21 @@ test('url may be a function (lazy/env resolution)', async () => {
 });
 
 // Precedence: when both spellings are present, `url` wins (resolved away at compose time).
+//
+// `OneEndpointSpelling` makes this pairing a compile error at every authoring surface (see
+// endpoint-spelling.test-d.ts), so the config is laundered through `Partial<StitchConfig>` — the
+// shape the guard cannot see, and exactly the shape a runtime config takes when it did not come
+// from a TS literal: a deserialised `__config`, `fromCurl`, or plain JS with no types at all. The
+// precedence must stay deterministic for those callers rather than going unspecified along with
+// the authoring spelling, which is why this test survives the guard instead of being deleted by it.
 test('url takes precedence over baseUrl + path', async () => {
     server.route('GET', '/right', { body: { hit: 'url' } });
-    const s = stitch({
+    const rebuilt: Partial<StitchConfig> = {
         url: `${server.url}/right`,
         baseUrl: 'https://wrong.example.com',
         path: '/wrong',
-    });
+    };
+    const s = stitch(rebuilt);
     expect(s.__config.url).toBe(`${server.url}/right`);
     expect(s.__config.baseUrl).toBeUndefined();
     expect(s.__config.path).toBeUndefined();


### PR DESCRIPTION
## What

The endpoint slot has two spellings — the atomic `url`, and the `baseUrl` + `path` pair — and `buildRequest` reads exactly **one** of them: when `url` is set it *is* the whole endpoint, no base is joined, and neither sibling is ever read. Pairing them in one config literal was dead config that the type system accepted anyway.

`OneEndpointSpelling<C>` now brands the inert sibling with a `ConfigError` naming it, on every surface that authors a stitch: `stitch` and `Seam.stitch` (both overloads each), `graphql` and `Seam.graphql`, and the three `download` entry points.

## Why

The case that motivated it is the silent one:

```ts
stitch({ url: 'https://a.test/x', baseUrl: 'https://b.test' })
```

This typechecked and discarded the base — the request went to `a.test`. The engine's own diagnostic fires only when the **joined** result is not absolute, so it caught the relative-`url` slip (`url: '/users'` beside a `baseUrl`) and nothing else; the absolute-`url` case resolves to a perfectly fetchable URL aimed at the wrong host, with nothing said anywhere. Only the JSDoc recorded that `url` wins.

That is exactly what [CONTRACT.md P24 carve-out (b)](docs/CONTRACT.md#p24--a-shared-field-name-prefix-in-a-house-contract-is-an-envelope) forbids: *staying flat is a licence to skip the envelope, never a licence to let a tag/option pairing typecheck when the option is inert.*

## Why a guard and not an `endpoint` envelope

This started as "should `url`/`baseUrl` fold into an envelope?" The answer was no, for reasons specific to this slot:

- **The fields don't share a level.** `SeamConfig` is `Omit<StitchConfig, 'path' | 'url' | …>`, so `baseUrl` is cross-cutting seam vocabulary while `url`/`path` are per-endpoint. That boundary is a declarative one-line `Omit` an envelope would turn into a hand-written nested override on both types.
- **A P12 shorthand would mean two different things.** `endpoint: 'https://api.example.com'` reads as the whole URL on a stitch and as the base on a seam — the P2 collision an envelope is supposed to avoid, not create.
- **It wouldn't remove the reconcile.** `deepMerge` folds plain objects, so a seam's `endpoint: { base }` plus a child's `endpoint: { url }` still merges to `{ base, url }`; the delete-pair in `stitch.ts` would just move inside the envelope.

So the slot stays flat and gains the (b) obligation it was missing. Type-only: no rename, no runtime bytes (core bundle unmoved at 0.07/0.08 KB headroom), and a repo-wide sweep found **zero** existing sites to fix.

## Reviewer notes

**The guard is deliberately literal-only**, unlike its `AnyLayer`/`Layers` siblings. Across `extends` fragments the two spellings are a *supported* last-writer-wins override (the endpoint-slot reconcile in `stitch.ts`), and a seam supplying `baseUrl` while one member supplies an absolute `url` is the ordinary way to point a single endpoint off-origin — a composed read would reject it. Both directions are pinned in the new type test; the composed cases matter as much as the rejections.

**Two pre-existing sites paired the spellings and moved rather than broke:**

- `test/url-contract.spec.ts` pinned the *runtime* precedence, which still matters for configs that never came from a TS literal (a deserialised `__config`, `fromCurl`, plain JS). Kept, laundered through `Partial<StitchConfig>` — the `download.spec.ts` idiom for a shape the guard cannot see.
- `test-d/path-vars.test-d.ts` case 8 pinned `PathVarsOf`'s `path`-wins-over-`url` tie-break. `PathVarsOf` reads the literal `C`, not composed layers, so the pairing it arbitrates is no longer reachable through any authoring surface. The assertion moved onto `InputOf` directly; the tie-break survives for configs arriving by cast or widened fragment.

**One hole is pinned rather than closed, and it belongs to the guard *idiom*:** an explicit result generic (`stitch<T>({ … })`) fills `TExplicit` only, so `C` falls back to its declared default `Partial<StitchConfig>` and no probe matches. Verified identical on `MultipartOnlyOnMultipartBody` and `GraphqlOnlyOnGraphqlSurface`. Closing it means making `C` inferable alongside an explicit `TExplicit` across every overload in the family — a separate change.

## Breaking change

Authoring `baseUrl` or `path` beside `url` in one config literal no longer compiles. The pairing had no working meaning — one half was always discarded — so the migration is to drop the ignored field, or drop `url` and address the endpoint as `baseUrl` + a relative `path`. Composition across fragments is unaffected. Alias-free per P19/D5 (`rc` channel, pre-GA).

## Verification

Full pre-push gate green (it replays CI locally): format, lint, contract ratchet, unknown-keys, changelog, media-fresh, typecheck, typecheck-d, test, exports, build-docs, yakir tethers. Plus the whole workspace — 40 packages typechecked and tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)