### PR TITLE
docs(reference): document httpSurface, the redaction trio, and the token parsers

### DIFF
--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -890,7 +890,7 @@ export const pages: Page[] = [
         path: 'reference/helpers',
         title: 'Helpers',
         description:
-            'fetchAdapter, createTrace, multiplex, the OTLP exporters, and memoryStore.',
+            'fetchAdapter, createTrace, multiplex, the OTLP exporters, memoryStore, the secret-redaction hooks, and the duration, size, and rate parsers.',
         kind: 'reference',
     },
     {

--- a/apps/docs/content.manifest.ts
+++ b/apps/docs/content.manifest.ts
@@ -890,7 +890,7 @@ export const pages: Page[] = [
         path: 'reference/helpers',
         title: 'Helpers',
         description:
-            'fetchAdapter, createTrace, multiplex, the OTLP exporters, memoryStore, the secret-redaction hooks, and the duration, size, and rate parsers.',
+            'fetchAdapter, createTrace, multiplex, the OTLP exporters, memoryStore, the secret-redaction hooks, and the duration, size, and rate token grammars.',
         kind: 'reference',
     },
     {

--- a/apps/docs/content/docs/guides/resilience/throttle.mdx
+++ b/apps/docs/content/docs/guides/resilience/throttle.mdx
@@ -34,8 +34,8 @@ be set on its own.
 ### The rate grammar
 
 A rate is `<count>/<duration>`. The count is a whole number; the denominator is
-any [duration token](/docs/reference/config-types), and a bare unit means one of
-that unit — so `'2/s'` is `'2/1s'`.
+any [duration token](/docs/reference/helpers#parseduration), and a bare unit
+means one of that unit — so `'2/s'` is `'2/1s'`.
 
 | Rate        | Means              | Spacing |
 | ----------- | ------------------ | ------- |

--- a/apps/docs/content/docs/guides/resilience/throttle.mdx
+++ b/apps/docs/content/docs/guides/resilience/throttle.mdx
@@ -34,7 +34,7 @@ be set on its own.
 ### The rate grammar
 
 A rate is `<count>/<duration>`. The count is a whole number; the denominator is
-any [duration token](/docs/reference/helpers#parseduration), and a bare unit
+any [duration token](/docs/reference/helpers#duration), and a bare unit
 means one of that unit — so `'2/s'` is `'2/1s'`.
 
 | Rate        | Means              | Spacing |

--- a/apps/docs/content/docs/reference/helpers.mdx
+++ b/apps/docs/content/docs/reference/helpers.mdx
@@ -368,13 +368,19 @@ const store = memoryStore();
 
 ## Duration, size, and rate tokens
 
-Three parsers, one per house token grammar. A stitch reads its own config through
-them; they are exported so a peer package that takes an authored token — a
-distributed limiter's rate, a command runner's buffer cap — resolves it to the
-same number a stitch would, instead of mirroring the grammar in a second regexp
-that then drifts from it.
+Three grammars, one namespace each, every one a `parse`/`format` pair. A stitch
+reads its own config through `parse`; the pair is exported so a peer package that
+takes an authored token — a distributed limiter's rate, a command runner's buffer
+cap — resolves it to the same number a stitch would, instead of mirroring the
+grammar in a second regexp that then drifts from it.
 
-### parseDuration
+`format` is the **exact** inverse, not a pretty-printer: `parse(format(v))`
+returns `v` unchanged for every value `parse` can produce. That is what makes it
+safe to write a token back — into a config file, a CLI flag, an error message
+quoting the limit it enforced — and it is where these differ from `ms`, whose
+`ms(90_000)` is `'2m'` and reads back as 120 000.
+
+### duration
 
 `5_000`, `'5s'`, `'1m'` → milliseconds. This is the grammar behind every authored
 duration on a stitch: `timeout.total`, `timeout.each`, `cache.ttl`,
@@ -382,16 +388,33 @@ duration on a stitch: `timeout.total`, `timeout.each`, `cache.ttl`,
 number is already ms; `<number><unit>` takes `ms` | `s` | `m` | `h` | `d`, with
 fractions allowed.
 
-```ts twoslash
-import { parseDuration } from 'stitchapi';
+`duration.format` picks the largest unit that stays exact **and** readable, and
+falls back to plain milliseconds when no unit divides the value cleanly.
 
-parseDuration('1.5s'); // 1500
-parseDuration('2m'); // 120_000
-parseDuration(5_000); // 5000 — a number is already ms
-parseDuration('soon'); // undefined
+```ts twoslash
+import { duration } from 'stitchapi';
+
+duration.parse('1.5s'); // 1500
+duration.parse('2m'); // 120_000
+duration.parse(5_000); // 5000 — a number is already ms
+duration.parse('soon'); // undefined
+
+duration.format(90_000); // '1.5m'
+duration.format(3_600_000); // '1h'
+duration.format(90_001); // '90001ms' — no unit divides it exactly
 ```
 
-### parseBytes
+<Callout type="warn">
+    **Anti-pattern:** don't format a duration StitchAPI emitted into a field
+    something else will read — keep it a number. Every emitted duration
+    (`event.waited`, a result's `elapsed`, `retryAfter`) is raw milliseconds,
+    and that is the contract a consumer parses against. `format` is for values a
+    _person_ reads, or for writing a token back into config; putting one in an
+    emitted payload turns a number every reader can use into a string each of
+    them has to parse.
+</Callout>
+
+### size
 
 `4096`, `'64kb'`, `'1mb'` → bytes, in **powers of 1024** — the npm-`bytes`
 convention every Node config parser already speaks, so `'1mb'` is `1_048_576`.
@@ -400,38 +423,58 @@ spellings (`kib`, `mib`, …) name the same values for callers who want the base
 explicit. It backs the byte caps — `serve.body.max`, and `buffer.max` on
 `@stitchapi/shell`.
 
-```ts twoslash
-import { parseBytes } from 'stitchapi';
+`size.format` emits the short spelling, and prefers the base unit over an exact
+but unreadable quotient — 1024 is a power of two, so almost every byte count
+divides into `kb` exactly and almost none of them divide into it _legibly_.
 
-parseBytes('64kb'); // 65_536
-parseBytes('1mb'); // 1_048_576
-parseBytes(4096); // 4096 — a number is already bytes
-parseBytes('big'); // undefined
+```ts twoslash
+import { size } from 'stitchapi';
+
+size.parse('64kb'); // 65_536
+size.parse('1mb'); // 1_048_576
+size.parse(4096); // 4096 — a number is already bytes
+size.parse('big'); // undefined
+
+size.format(1_048_576); // '1mb'
+size.format(1536); // '1.5kb'
+size.format(1537); // '1537b' — '1.5009765625kb' is exact and useless
 ```
 
 <Callout type="warn">
     **Anti-pattern:** don't reach for this on a `chars` field —
     [`stream.buffer.chars`](/docs/reference/surfaces#streambuffer) and
     `trace.body.chars` count UTF-16 code units of decoded text, not bytes off
-    the socket, so a `'64kb'` token there measures the wrong thing. The `Bytes`
-    / `Chars` half of a field's name is what tells you which parser reads it.
+    the socket, so a `'64kb'` token there measures the wrong thing. Those fields
+    take a bare number and reject a string at compile time. Worth holding onto
+    now that the name is `size` rather than `parseBytes` — the call site no
+    longer says "bytes" out loud, so the type is the only thing left warning
+    you.
 </Callout>
 
-### parseRate
+### rate
 
 `'2/s'`, `'1000/h'` → `{ count, per }`, where `per` is the window length in ms.
-The denominator is a `parseDuration` token and a bare unit means one of that unit
+The denominator is a `duration` token and a bare unit means one of that unit
 (`'2/s'` ≡ `'2/1s'`), so this is the grammar behind
 [`throttle.rate`](/docs/guides/resilience/throttle#the-rate-grammar), in-process
-and store-backed alike.
+and store-backed alike. `rate.format` writes the pair back, using the bare-unit
+spelling for a one-unit window.
 
 ```ts twoslash
-import { parseRate } from 'stitchapi';
+import { rate } from 'stitchapi';
 
-parseRate('2/s'); // { count: 2, per: 1000 }
-parseRate('1000/h'); // { count: 1000, per: 3_600_000 }
-parseRate('100/15m'); // { count: 100, per: 900_000 }
+rate.parse('2/s'); // { count: 2, per: 1000 }
+rate.parse('1000/h'); // { count: 1000, per: 3_600_000 }
+rate.parse('100/15m'); // { count: 100, per: 900_000 }
+
+rate.format({ count: 2, per: 1000 }); // '2/s'
+rate.format({ count: 100, per: 900_000 }); // '100/15m'
 ```
+
+A rate declares a minimum spacing rather than a bucket, so `'2/500ms'`, `'4/s'`
+and `'240/m'` all describe the same limiter. `format` returns the token for the
+pair it was handed rather than reducing it to one canonical member of that set —
+`{ count: 2, per: 500 }` comes back as `'2/500ms'`, the numbers the author wrote.
 
 **An unreadable token throws here, where the other two resolve to `undefined`.**
 The divergence runs with their fallback rather than against it. For a cap,
@@ -439,7 +482,9 @@ falling back to the field's default leaves the ceiling where it was, so a typo
 can never widen it to "unbounded". A rate has no such safe default —
 `undefined` means _no rate limit at all_ — so a fallback would let a typo
 silently remove the limit instead of narrowing it. `'fast'`, `'0/s'`, and
-`'1/30d'` (a spacing past the ~24.8-day timer ceiling) all throw.
+`'1/30d'` (a spacing past the ~24.8-day timer ceiling) all throw, and
+`rate.format` rejects the same three rather than writing a token that would
+throw on the way back in.
 
 ## See also
 

--- a/apps/docs/content/docs/reference/helpers.mdx
+++ b/apps/docs/content/docs/reference/helpers.mdx
@@ -1,11 +1,12 @@
 ---
 title: 'Helpers'
-description: 'fetchAdapter, axiosAdapter, xhrAdapter, consoleSink, fileSink, createTrace, multiplex, loggerSink, the OTLP exporters, and memoryStore.'
+description: 'fetchAdapter, axiosAdapter, xhrAdapter, consoleSink, fileSink, createTrace, multiplex, loggerSink, the OTLP exporters, memoryStore, the secret-redaction hooks, and the duration, size, and rate parsers.'
 ---
 
 The exported helper functions you wire into a stitch: the default transport, the
-trace sinks (including OTLP export), the default store, and the schema adapter.
-Each signature is below; the guides cover usage in depth and are linked under
+trace sinks (including OTLP export), the secret-redaction hooks, the default
+store, and the parsers behind the duration, size, and rate tokens. Each signature
+is below; the guides cover usage in depth and are linked under
 [See also](#see-also).
 
 ## Transport
@@ -252,6 +253,105 @@ const body = toOtlpJson([]);
 
 <AutoTypeTable path="../../packages/core/src/otlp.ts" name="OtlpOptions" />
 
+## Secret redaction
+
+Reach for these three when a credential of yours rides under a name the built-in
+denylist doesn't know. Before an event reaches a sink, the value of any
+secret-bearing key is replaced with `REDACTED` — matched by exact name (`key`,
+`sig`, `access_key`) or by a contained stem (`token`, `secret`, `signature`,
+`credential`, `api_key`), which is how `access_token`, `client_secret`, and
+`x-amz-signature` are all caught without listing every vendor spelling. A host
+that calls its credential `session_ref` matches neither, so you name it yourself.
+
+### registerSecretKey
+
+Add one key name to that denylist. Every scrubber reads from it: the console and
+JSONL `start.url`, the OTLP `url.full` attribute, the structured `input.query`,
+and the traced request body.
+
+```ts twoslash
+import { registerSecretKey, stitch } from 'stitchapi';
+
+registerSecretKey('session_ref');
+
+const listUsers = stitch({
+    baseUrl: 'https://api.example.com',
+    path: '/users',
+    trace: 'console',
+});
+
+// The traced URL reads …/users?role=admin&session_ref=REDACTED
+await listUsers({ query: { role: 'admin', session_ref: 'sr_live_x' } });
+```
+
+Additive and process-wide, mirroring the built-in list — a name goes in and never
+comes out. Registering the same name twice is a no-op, and the match is
+case-insensitive, so one lowercase registration covers `SESSION_REF` too.
+
+`apiKey({ in: 'query', name })` registers its configured `name` at construction,
+so a key the [apiKey strategy](/docs/guides/auth/api-key) puts in the URL is
+covered already. This is the hook for a credential no strategy declares — one
+your own code appends to a query, or one that arrives in a body field.
+
+### isSecretKey
+
+The predicate the scrubbers run, exported so you can ask it yourself: does this
+key name — a query param, a body field — already redact? Audit your own config
+with it before deciding whether `registerSecretKey` has anything left to add.
+
+```ts twoslash
+import { isSecretKey } from 'stitchapi';
+
+isSecretKey('access_token'); // true — carries the `token` stem
+isSecretKey('Client_Secret'); // true — the match is case-insensitive
+isSecretKey('page'); // false — benign params survive for observability
+isSecretKey('session_ref'); // false — until you register it
+```
+
+<Callout type="warn">
+    **Anti-pattern:** don't reach for this to decide whether a **header** is
+    secret. It answers about query params and body keys, so
+    `isSecretKey('authorization')` and `isSecretKey('x-api-key')` both come back
+    `false` even though a sink redacts both headers. Headers are matched against
+    their own denylist at the sink boundary, which you widen with
+    [`redactHeaders`](/docs/guides/observability/trace-sinks#default-secret-redaction),
+    not with `registerSecretKey`.
+</Callout>
+
+### redactSecretsDeep
+
+Deep-clone a value and replace every secret-named key inside it with `REDACTED`,
+so a payload you are about to log or forward carries no credential. It walks
+plain objects and arrays, leaves primitives alone, and hands back a new value —
+the input is never mutated.
+
+```ts twoslash
+import { redactSecretsDeep } from 'stitchapi';
+
+const safe = redactSecretsDeep({
+    id: 7,
+    profile: { email: 'ada@example.com', api_key: 'sk_live_x' },
+});
+// { id: 7, profile: { email: 'ada@example.com', api_key: 'REDACTED' } }
+```
+
+A second argument adds patterns on top of the shared denylist — an exact key
+name, a dotted path, a `*` single-segment wildcard, or a prefix that claims
+everything under it — for a field only this payload treats as sensitive:
+
+```ts twoslash
+import { redactSecretsDeep } from 'stitchapi';
+
+redactSecretsDeep({ note: 'kept', meta: { note: 'gone' } }, ['meta.note']);
+// { note: 'kept', meta: { note: 'REDACTED' } }
+```
+
+This is what
+[`.inspect({ redact: true })`](/docs/recipes/inspect-what-the-server-sent) runs
+over its otherwise-unredacted `raw` body, and an array there
+(`{ redact: ['meta.note'] }`) is forwarded as this second argument. Call it
+directly for a value that didn't come from `.inspect()`.
+
 ## Store
 
 ### memoryStore
@@ -265,6 +365,81 @@ import { memoryStore } from 'stitchapi';
 
 const store = memoryStore();
 ```
+
+## Duration, size, and rate tokens
+
+Three parsers, one per house token grammar. A stitch reads its own config through
+them; they are exported so a peer package that takes an authored token — a
+distributed limiter's rate, a command runner's buffer cap — resolves it to the
+same number a stitch would, instead of mirroring the grammar in a second regexp
+that then drifts from it.
+
+### parseDuration
+
+`5_000`, `'5s'`, `'1m'` → milliseconds. This is the grammar behind every authored
+duration on a stitch: `timeout.total`, `timeout.each`, `cache.ttl`,
+`backoff.base`, `circuit.cooldown`, a surface `interpret` hook's `after`. A
+number is already ms; `<number><unit>` takes `ms` | `s` | `m` | `h` | `d`, with
+fractions allowed.
+
+```ts twoslash
+import { parseDuration } from 'stitchapi';
+
+parseDuration('1.5s'); // 1500
+parseDuration('2m'); // 120_000
+parseDuration(5_000); // 5000 — a number is already ms
+parseDuration('soon'); // undefined
+```
+
+### parseBytes
+
+`4096`, `'64kb'`, `'1mb'` → bytes, in **powers of 1024** — the npm-`bytes`
+convention every Node config parser already speaks, so `'1mb'` is `1_048_576`.
+Units are `b` | `kb` | `mb` | `gb` | `tb`, case-insensitive, and the IEC
+spellings (`kib`, `mib`, …) name the same values for callers who want the base
+explicit. It backs the byte caps — `serve.body.max`, and `buffer.max` on
+`@stitchapi/shell`.
+
+```ts twoslash
+import { parseBytes } from 'stitchapi';
+
+parseBytes('64kb'); // 65_536
+parseBytes('1mb'); // 1_048_576
+parseBytes(4096); // 4096 — a number is already bytes
+parseBytes('big'); // undefined
+```
+
+<Callout type="warn">
+    **Anti-pattern:** don't reach for this on a `chars` field —
+    [`stream.buffer.chars`](/docs/reference/surfaces#streambuffer) and
+    `trace.body.chars` count UTF-16 code units of decoded text, not bytes off
+    the socket, so a `'64kb'` token there measures the wrong thing. The `Bytes`
+    / `Chars` half of a field's name is what tells you which parser reads it.
+</Callout>
+
+### parseRate
+
+`'2/s'`, `'1000/h'` → `{ count, per }`, where `per` is the window length in ms.
+The denominator is a `parseDuration` token and a bare unit means one of that unit
+(`'2/s'` ≡ `'2/1s'`), so this is the grammar behind
+[`throttle.rate`](/docs/guides/resilience/throttle#the-rate-grammar), in-process
+and store-backed alike.
+
+```ts twoslash
+import { parseRate } from 'stitchapi';
+
+parseRate('2/s'); // { count: 2, per: 1000 }
+parseRate('1000/h'); // { count: 1000, per: 3_600_000 }
+parseRate('100/15m'); // { count: 100, per: 900_000 }
+```
+
+**An unreadable token throws here, where the other two resolve to `undefined`.**
+The divergence runs with their fallback rather than against it. For a cap,
+falling back to the field's default leaves the ceiling where it was, so a typo
+can never widen it to "unbounded". A rate has no such safe default —
+`undefined` means _no rate limit at all_ — so a fallback would let a typo
+silently remove the limit instead of narrowing it. `'fast'`, `'0/s'`, and
+`'1/30d'` (a spacing past the ~24.8-day timer ceiling) all throw.
 
 ## See also
 
@@ -290,5 +465,12 @@ const store = memoryStore();
         title="Guide: Standard Schema"
         href="/docs/guides/validation/standard-schema"
     />
+    <Card title="Guide: apiKey" href="/docs/guides/auth/api-key" />
+    <Card title="Guide: throttle" href="/docs/guides/resilience/throttle" />
+    <Card
+        title="Recipe: inspect what the server sent"
+        href="/docs/recipes/inspect-what-the-server-sent"
+    />
     <Card title="Config types" href="/docs/reference/config-types" />
+    <Card title="Request surfaces" href="/docs/reference/surfaces" />
 </Cards>

--- a/apps/docs/content/docs/reference/surfaces.mdx
+++ b/apps/docs/content/docs/reference/surfaces.mdx
@@ -320,6 +320,7 @@ unknown style", never a crash.
     <Card title="Guide: verdict" href="/docs/guides/resilience/verdict" />
     <Card title="Guide: extends" href="/docs/guides/authoring/extends" />
     <Card title="The event stream" href="/docs/concepts/event-stream" />
+    <Card title="seam()" href="/docs/reference/seam" />
     <Card title="Config types" href="/docs/reference/config-types" />
     <Card title="Helpers" href="/docs/reference/helpers" />
 </Cards>

--- a/apps/docs/content/docs/reference/surfaces.mdx
+++ b/apps/docs/content/docs/reference/surfaces.mdx
@@ -38,6 +38,59 @@ import { stitch } from 'stitchapi';
 const getUser = stitch('https://api.example.com/users/{id}');
 ```
 
+### httpSurface
+
+The default is a **named value, not an engine branch**. Composing a stitch
+resolves an omitted `kind` to `httpSurface`, so `__config.kind` reads back
+`'http'` on a plain stitch the same way it reads `'download'` on a download one —
+a surface is always selected, and a consumer reading a declaration never has to
+special-case an empty slot.
+
+```ts twoslash
+import { httpSurface, stitch } from 'stitchapi';
+
+const getUser = stitch({ url: 'https://api.example.com/users/{id}' });
+
+getUser.__config.kind; // 'http' — resolved at compose time, never absent
+
+// The same stitch, with the default said out loud.
+stitch({ kind: httpSurface, url: 'https://api.example.com/users/{id}' });
+```
+
+Importing it by name pays off in one place: a base that supplies `kind` passes
+that surface down through [`extends`](/docs/guides/authoring/extends), and
+`kind: httpSurface` is how a single member declares itself a plain HTTP call
+against that base instead of inheriting the surface.
+
+```ts twoslash
+import { graphqlSurface, httpSurface, stitch } from 'stitchapi';
+
+const gqlBase = { baseUrl: 'https://api.example.com', kind: graphqlSurface };
+
+// Every other member POSTs a document; this one is an ordinary GET.
+const getUser = stitch({
+    extends: [gqlBase],
+    kind: httpSurface,
+    path: '/users/{id}',
+});
+```
+
+`graphqlSurface` is the generic spelling of the `graphql()` helper below, and it
+shares the root barrel with `httpSurface`. Every other surface exports its
+`*Surface` value from its own subpath — `sseSurface` from `stitchapi/sse`,
+`downloadSurface` from `stitchapi/download`.
+
+<Callout type="warn">
+    **Anti-pattern:** don't compose `httpSurface.interpret` into a surface of
+    your own. It is reachable, and it is the rule `sse` and `stream` fall back
+    to when they declare no `interpret` themselves — but it ends in "the body is
+    the value", which is the http surface's own choice of result rather than a
+    shared one. Compose
+    [`verdictOf`](/docs/guides/resilience/verdict#beyond-configuration) instead:
+    that is the caller's `verdict` config applied to a response, and it leaves
+    the success value to you.
+</Callout>
+
 ## graphql
 
 `graphql()` POSTs `{ query, variables }` and picks `data`; a `200` carrying
@@ -258,3 +311,15 @@ Either way the surface is named in `__config` by a stable string `id`
 for MCP, the playground, and `llms.txt` — the behaviour hooks stay a runtime
 detail. An `id` a consumer doesn't recognise degrades to "an http-shaped call of
 unknown style", never a crash.
+
+## See also
+
+<Cards>
+    <Card title="Guide: stitch()" href="/docs/guides/authoring/stitch" />
+    <Card title="Guide: GraphQL" href="/docs/guides/data/graphql" />
+    <Card title="Guide: verdict" href="/docs/guides/resilience/verdict" />
+    <Card title="Guide: extends" href="/docs/guides/authoring/extends" />
+    <Card title="The event stream" href="/docs/concepts/event-stream" />
+    <Card title="Config types" href="/docs/reference/config-types" />
+    <Card title="Helpers" href="/docs/reference/helpers" />
+</Cards>


### PR DESCRIPTION
Seven value exports on the `stitchapi` root barrel appeared on **no page** under `apps/docs/content/docs` — not in Reference, not in any guide:

| Export | Source | Status before |
| --- | --- | --- |
| `httpSurface` | `./surface` | undocumented (`graphqlSurface` / `verdictOf` had one mention each) |
| `registerSecretKey`, `isSecretKey`, `redactSecretsDeep` | `./util` | undocumented |
| `duration`, `size`, `rate` | `./util` | undocumented |

## Are any of them internal-but-exported?

No — that was the first thing checked, and all seven are deliberately public with a written reason. The barrel comments in [`packages/core/src/index.ts`](https://github.com/rejifald/StitchAPI/blob/main/packages/core/src/index.ts) argue each one, and `public-api-surface.spec.ts` pins the parsers and `verdictOf` **present** while pinning `classifyStatus` / `httpInterpret` **absent** ("three names on the barrel for one decision invites composing the wrong one"). So all seven are documented, on the Reference pages that already own their neighbours — no new pages, no manifest entries beyond a description re-sync.

## What changed

**`reference/helpers.mdx`** — two new sections:

- **Secret redaction** — the trio, framed off the denylist they widen (exact names vs. contained stems), with `apiKey({ in: 'query', name })`'s automatic registration named as the reason most callers never touch the manual hook.
- **Duration, size, and rate tokens** — the three grammars (CONTRACT.md P17/P25), each tied to the fields it actually backs (`timeout.total`, `cache.ttl`, `circuit.cooldown` · `serve.body.max`, `@stitchapi/shell`'s `buffer.max` · `throttle.rate`), plus why `rate.parse` **throws** where the other two fall back to `undefined`: a cap's fallback leaves the ceiling where it was, but a rate's would silently *remove* the limit. Both directions are documented — see the note on the stacked core change below.

**`reference/surfaces.mdx`** — a `httpSurface` subsection under "http — the default": the default as a named value (`compose` resolves an omitted `kind` to it, so `__config.kind` is never an empty slot), and the one place importing it earns its keep — `kind: httpSurface` opting a member out of a surface inherited via `extends`. This page was also the only Reference page with **no `See also`** (AUTHORING rule 7); it has one now.

## Reviewer notes

Three anti-pattern callouts (AUTHORING rule 10), the first two from behaviour **verified against the built runtime**, not inferred from source:

- **`isSecretKey('authorization')` and `isSecretKey('x-api-key')` are `false`.** Headers are scrubbed against a *separate* denylist (`redactHeaders`), so reaching for this predicate as a header check silently under-redacts. This is the one finding here I'd most want a second pair of eyes on.
- **`size` on a `*.chars` field is a category error** — `stream.buffer.chars` / `trace.body.chars` count UTF-16 code units of decoded text, not bytes off the socket. This one got *sharper* under the rename: the old `parseBytes` said "bytes" at the call site and `size` does not, so the type is now the only thing warning the reader.
- **Don't compose `httpSurface.interpret` into your own surface** — it ends in "the body is the value", the http surface's own choice of result. Compose `verdictOf` instead. This is exactly the mis-composition the barrel comment warns about.

Two adjacent fixes the sweep turned up:

- `guides/resilience/throttle.mdx` linked "duration token" at `/docs/reference/config-types`, a page that says **nothing** about the grammar. It now points at `helpers#parseduration`, which does (rule 6, one source of truth per fact).
- The manifest description for `reference/helpers` was stale; re-synced.

**Known gap left out of scope:** `registerSecretKey` / `isSecretKey` / `redactSecretsDeep` are *not* in the `FUNCTIONS` pin list in `packages/core/test/public-api-surface.spec.ts`, so an accidental removal of the trio would still slip past the suite. Deliberately not fixed here rather than widening a docs-only diff into core's tests; being handled separately.


## Stacked on the core rename

The three parsers this page was written to document became **`parse`/`format` pairs** while this
PR was open — `parseDuration`/`parseBytes`/`parseRate` are now `duration`/`size`/`rate`, one
namespace per dimension, in the shape `bytes` uses. That core change is merged into this branch so
twoslash has a surface to check against; **it drops out of this diff once it lands on `main`.**
Review it as a stack — the core commit first, this docs commit second.

The three subsections are written against the new API and gained the encode direction:

```ts
duration.format(90_000); // '1.5m'
size.format(1537); // '1537b' — '1.5009765625kb' is exact and useless
rate.format({ count: 2, per: 1000 }); // '2/s'
```

`format` is the **exact** inverse of `parse` — `parse(format(v))` returns `v` unchanged — which is
the clause the page leans on when it says a token is safe to write back. It is also where these
differ from `ms`, whose `ms(90_000)` is `'2m'` and reads back as 120 000.

One new anti-pattern callout came with the new direction rather than with the rename: **`format` is
for values a person reads or re-authors, never for an emitted field.** Every emitted duration stays
a raw-ms `number` (P17's complement), and formatting one into a payload turns a number every reader
can use into a string each of them has to parse.

**The known gap named below is now closed** — `public-api-surface.spec.ts` pins `duration`/`size`/
`rate` present as parse/format pairs, pins the three old names **absent**, and the redaction trio is
no longer the only unpinned group. That landed with the core change, not here.

## Gates

| Gate | Result |
| --- | --- |
| `pnpm test` (apps/docs) | 69 passed, 1 skipped |
| `pnpm check:types` (apps/docs) | clean |
| `pnpm check:docs-links` | 116 routes, all resolve |
| `pnpm check:format` | clean |
| `pnpm gen:docs` | no-op (0 stubs, no diff) |

Re-verified after the rename: the real `next build` ran end to end on the merged branch, so twoslash type-checked every block against the new surface, and it was confirmed non-vacuous by putting a stale `parseDuration` import back into one block and watching the build fail on it. Twoslash runs at `next build`, not in the gates above, so all 25 blocks on the three edited pages were first run through `createTwoslasher` with the `drafts-twoslash.spec.ts` config — 25/25 green, and the harness was confirmed to *fail* a deliberately broken block rather than pass vacuously. The pre-push `build-docs` hook then ran the real `next build` end to end, so twoslash has since verified them for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

