### PR TITLE
fix(docs): bundle the embedding model so `/api/mcp` stops timing out, and smoke-test it so it can't break silently

### DIFF
--- a/.github/workflows/mcp-smoke.yml
+++ b/.github/workflows/mcp-smoke.yml
@@ -1,0 +1,62 @@
+# Production health guard for the hosted docs MCP server (stitchapi.dev/api/mcp).
+#
+# This runs against the DEPLOYMENT, not the repo, and that is the whole point.
+# From 2026-07-31 to 2026-08-10 the endpoint errored on every request (~946
+# "Could not load the 'sharp' module using the linux-x64 runtime" across 89
+# clients) and nothing caught it for ten days. No test in `verify.yml` could
+# have: the fault was in Vercel's function file tracing, so the source was fine
+# and CI — running the search library out of a complete node_modules — passed
+# throughout. A tracing bug is only observable by talking to the deployed
+# artifact over the wire.
+#
+# The schedule matters as much as the probe. Running every six hours means most
+# runs land on a COLD instance, which is the only condition under which the
+# cold-start regression (25 "Task timed out after 60 seconds" errors through
+# 2026-08-16) is visible at all. A post-deploy-only check would usually hit a
+# warm function and miss it.
+#
+# A failure here opens no PR and blocks no merge — it fails a scheduled run,
+# which is what surfaces the notification. Treat a red run as production being
+# down for every agent that has this server configured.
+name: MCP smoke
+
+on:
+    schedule:
+        # Every 6 hours. Offset off the hour so this does not pile onto the
+        # top-of-hour scheduling spike on GitHub's shared runners.
+        - cron: '17 */6 * * *'
+    workflow_dispatch:
+        inputs:
+            base_url:
+                description: 'Base URL to probe (defaults to production)'
+                required: false
+                default: 'https://stitchapi.dev'
+    # Also probe whenever this guard or the route it covers changes, so a broken
+    # probe or a regressed route is caught in the PR rather than six hours later.
+    pull_request:
+        paths:
+            - 'apps/docs/scripts/smoke-mcp.mts'
+            - 'apps/docs/app/api/mcp/**'
+            - 'apps/docs/lib/search-index/**'
+            - 'apps/docs/next.config.mjs'
+            - '.github/workflows/mcp-smoke.yml'
+
+permissions:
+    contents: read
+
+jobs:
+    smoke:
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+            - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+            - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+              with:
+                  node-version-file: .nvmrc
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile
+            # The probe is pure fetch + tsx — no docs build, no model load, no
+            # Playwright. It needs nothing from the repo except the script.
+            - name: Probe the deployed MCP endpoint
+              run: pnpm --filter @stitchapi/docs smoke:mcp ${{ github.event.inputs.base_url || 'https://stitchapi.dev' }}

--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,12 @@ lib
 # See docs/proposals/search-docs.md.
 apps/docs/.search-index/
 
+# Vendored embedding-model files (search_docs P3 cold-start fix): fetched from
+# HuggingFace by scripts/fetch-embed-model.mts as a deploy build step, never
+# committed — same rationale as apps/docs/.search-index/ above. See
+# apps/docs/lib/search-index/embed.ts.
+apps/docs/.model-cache/
+
 # @stitchapi/docs-mcp's bundled docs snapshot: copied in from apps/docs's
 # .search-index by scripts/copy-bundle.mjs at package build time, not committed —
 # same rationale as apps/docs/.search-index/ above.

--- a/apps/docs/lib/search-index/config.ts
+++ b/apps/docs/lib/search-index/config.ts
@@ -49,3 +49,14 @@ export const MAX_QUERY_LEN = 512;
 export const INDEX_DIR = '.search-index';
 export const INDEX_FILE = 'docs-index.json';
 export const MANIFEST_FILE = 'manifest.json';
+
+// Vendored copy of EMBED_MODEL's files, relative to apps/docs. scripts/
+// fetch-embed-model.mts populates it as a deploy build step; embed.ts's
+// Vercel-only env.localModelPath reads from it at runtime (no HuggingFace CDN
+// fetch, no cold-start-vs-maxDuration race); next.config.mjs's
+// outputFileTracingIncludes ships it into the serverless functions. Same
+// "regenerated every deploy, never committed" treatment as INDEX_DIR above —
+// see .gitignore. Kept here, next to EMBED_MODEL/EMBED_DTYPE, so the fetch
+// script, the runtime, and the bundler config can't drift apart on where the
+// model lives.
+export const MODEL_DIR = '.model-cache';

--- a/apps/docs/lib/search-index/embed.ts
+++ b/apps/docs/lib/search-index/embed.ts
@@ -1,39 +1,81 @@
 // Local-open text embeddings via transformers.js. Shared by the build pipeline
 // (P1, embeds every chunk) and, later, the retrieval route (P2, embeds the
 // query). The model loads lazily and is reused across calls.
+//
+// @huggingface/transformers itself is imported lazily too (inside
+// loadEmbedder(), not at module top level) — not just the pipeline it builds.
+// Its Node bundle has an unconditional top-level `import sharp from 'sharp'`
+// (pulled in for image pipelines search_docs/get_doc never use). A static
+// top-level import here would mean any sharp load failure — missing native
+// binary, ERR_DLOPEN_FAILED, whatever — throws while THIS MODULE is being
+// evaluated, i.e. at route-module load, which fails the whole /api/mcp route
+// (get_doc and the MCP handshake included, neither of which touches
+// embeddings) for the rest of that warm instance's life. That is exactly what
+// the Jul 31–Aug 10 2026 outage was: ~946 "Failed to load external module
+// @huggingface/transformers" errors, one per request, because a module-load
+// failure doesn't stay scoped to the request that triggered it. Deferring the
+// import to first call scopes a load failure to the one search_docs call that
+// needed it — get_doc and initialize keep working, and the failed call just
+// surfaces a rejected promise, same as any other runtime error here.
+import { EMBED_DTYPE, EMBED_MODEL, MODEL_DIR } from './config';
 
-import {
-    env,
-    pipeline,
-    type FeatureExtractionPipeline,
-} from '@huggingface/transformers';
-
-import { EMBED_DTYPE, EMBED_MODEL } from './config';
-
-// On Vercel the deployed node_modules (the default model cache dir) is read-only,
-// so point the cache at the function's writable /tmp. The model is then fetched
-// on the first request per warm instance — the cold-start cost the proposal's §6
-// flags as the P3 watch-item (mitigations: bundle the model, a smaller/quantized
-// model, edge runtime, or keep-warm — chosen after a real Vercel measurement).
-if (process.env.VERCEL) {
-    env.cacheDir = '/tmp/.transformers-cache';
-}
+import type { FeatureExtractionPipeline } from '@huggingface/transformers';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // Embed in modest batches: one call per chunk is slow, but one call for the
 // whole corpus builds a single enormous tensor that thrashes memory. 32 balances
 // throughput against footprint.
 const BATCH_SIZE = 32;
 
+/** apps/docs/<MODEL_DIR> — the vendored copy scripts/fetch-embed-model.mts
+ * populates at build time (see next.config.mjs's outputFileTracingIncludes for
+ * how it reaches the deployed function). */
+function modelDirPath(): string {
+    // this file: apps/docs/lib/search-index/embed.ts → apps/docs/<MODEL_DIR>
+    const here = dirname(fileURLToPath(import.meta.url));
+    return resolve(here, '..', '..', MODEL_DIR);
+}
+
 let extractor: Promise<FeatureExtractionPipeline> | undefined;
 
-/** Lazily load (and cache) the feature-extraction pipeline. */
+/** Lazily load (and cache) the feature-extraction pipeline. See the module
+ * header for why the @huggingface/transformers import itself is deferred here
+ * too, not just the pipeline construction. */
 export function getEmbedder(): Promise<FeatureExtractionPipeline> {
     if (!extractor) {
-        extractor = pipeline('feature-extraction', EMBED_MODEL, {
-            dtype: EMBED_DTYPE,
-        });
+        extractor = loadEmbedder();
     }
     return extractor;
+}
+
+async function loadEmbedder(): Promise<FeatureExtractionPipeline> {
+    const { env, pipeline } = await import('@huggingface/transformers');
+
+    if (process.env.VERCEL) {
+        // The deployed node_modules (the default model cache dir) is read-only,
+        // so point the cache dir at the function's writable /tmp. Belt-and-
+        // braces: nothing should actually write here once localModelPath
+        // (below) resolves every file from disk, but a local hit never
+        // attempts a cache write either way — see the transformers.js hub.js
+        // loadResourceFile: caching only applies to a fetched Response, never
+        // to a local FileResponse.
+        env.cacheDir = '/tmp/.transformers-cache';
+        // Serve the model from the copy scripts/fetch-embed-model.mts vendors
+        // at build time instead of the HuggingFace CDN. Was: a ~90 MB fetch on
+        // the first search per warm instance, sometimes past the 60s
+        // maxDuration ceiling — the P3 cold-start watch-item this resolves.
+        env.localModelPath = modelDirPath();
+        // Fail loudly the first time this is called if the vendored copy is
+        // missing or incomplete (transformers.js throws with the missing
+        // path), instead of silently falling back to that slow CDN fetch in
+        // production. build-search-index.ts calls this same path at build
+        // time (see prebuild-search-index.mjs), so a broken vendor copy fails
+        // the deploy, not just the first production request.
+        env.allowRemoteModels = false;
+    }
+
+    return pipeline('feature-extraction', EMBED_MODEL, { dtype: EMBED_DTYPE });
 }
 
 /** Embed texts into mean-pooled, L2-normalized vectors, batched. */

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -71,22 +71,55 @@ const config = {
     // Bundle the build-time search index into the serverless functions that
     // restore the Orama dump at runtime — the human search route (P2) and the MCP
     // server (P3). The file is generated at deploy by scripts/prebuild-search-index.mjs
-    // (never committed); runtime model loading / cold-start is the P3 watch-item.
-    // Each function gets the build-time Orama index (restored at runtime) AND
-    // onnxruntime-node's native shared library. Next traces the require'd
-    // `onnxruntime_binding.node` but NOT the `libonnxruntime.so.1` it dlopen's at
-    // load — so the function 500s with "libonnxruntime.so.1: cannot open shared
-    // object file". Ship the whole linux native dir so the .so lands beside the
-    // .node. The package lives in the pnpm store at the workspace root (../../ from
-    // apps/docs; outputFileTracingRoot bounds the trace to that root).
+    // (never committed); ditto the embedding model itself (./.model-cache/**,
+    // scripts/fetch-embed-model.mts) — bundling it is the P3 cold-start fix:
+    // without it, transformers.js fetches the ~90 MB model from the HuggingFace
+    // CDN on the first search per warm instance, sometimes past the 60s
+    // maxDuration ceiling (see lib/search-index/embed.ts for the matching
+    // localModelPath / allowRemoteModels=false runtime config).
+    // Each function also gets onnxruntime-node's native shared library. Next
+    // traces the require'd `onnxruntime_binding.node` but NOT the
+    // `libonnxruntime.so.1` it dlopen's at load — so the function 500s with
+    // "libonnxruntime.so.1: cannot open shared object file". Ship the whole linux
+    // native dir so the .so lands beside the .node. The package lives in the pnpm
+    // store at the workspace root (../../ from apps/docs; outputFileTracingRoot
+    // bounds the trace to that root).
     outputFileTracingIncludes: {
         '/api/search-docs': [
             './.search-index/**',
+            './.model-cache/**',
             '../../node_modules/.pnpm/onnxruntime-node@*/node_modules/onnxruntime-node/bin/napi-v6/linux/**/*',
         ],
         '/api/mcp': [
             './.search-index/**',
+            './.model-cache/**',
             '../../node_modules/.pnpm/onnxruntime-node@*/node_modules/onnxruntime-node/bin/napi-v6/linux/**/*',
+        ],
+    },
+    // Drop `sharp` from the deployed function entirely. @huggingface/transformers
+    // pulls it in for image pipelines; search_docs/get_doc only ever do text
+    // feature-extraction, so it's dead weight — and a dangerous kind: sharp's
+    // Node entry (dist/sharp.cjs) does an unconditional, synchronous native-
+    // binding load at require time and THROWS if none of its platform binaries
+    // resolve. That's the exact shape of the Jul 31–Aug 10 2026 outage (~946
+    // "Could not load the 'sharp' module using the linux-x64 runtime /
+    // ERR_DLOPEN_FAILED" errors on this route). Excluding sharp's files only
+    // trades that failure for a guaranteed one (require('sharp') throwing
+    // MODULE_NOT_FOUND instead) UNLESS the import is safe to fail — which it now
+    // is: embed.ts imports @huggingface/transformers lazily, inside the
+    // search_docs call path, specifically so a load failure (this one included)
+    // stays scoped to that one call instead of crashing the whole route at
+    // module load. With that containment in place, dropping sharp is a clean
+    // win — smaller bundle, one less fragile native dependency — instead of a
+    // regression.
+    outputFileTracingExcludes: {
+        '/api/search-docs': [
+            '../../node_modules/.pnpm/sharp@*/node_modules/**',
+            '../../node_modules/.pnpm/@img+sharp-*/node_modules/**',
+        ],
+        '/api/mcp': [
+            '../../node_modules/.pnpm/sharp@*/node_modules/**',
+            '../../node_modules/.pnpm/@img+sharp-*/node_modules/**',
         ],
     },
     // Keep the runtime embedder OUT of the server bundle. Those same two routes
@@ -96,7 +129,8 @@ const config = {
     // — which 500s every request (even paths that never embed, like the MCP
     // `initialize` handshake or an empty query), not just searches. Marking these
     // external leaves them as a plain runtime require, resolved from the traced
-    // node_modules, so the binary loads. Next externalizes `sharp` by default.
+    // node_modules, so the binary loads. Next externalizes `sharp` by default too
+    // (see outputFileTracingExcludes above for why this route ships none of it).
     serverExternalPackages: ['@huggingface/transformers', 'onnxruntime-node'],
     // The playground consumes the in-repo sandbox engine (@stitchapi/sandbox), a
     // workspace package that ships raw TS/TSX source — Next must transpile it.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -22,6 +22,7 @@
         "build:docs-pages": "pnpm run build:typed-deps && fumadocs-mdx && node --import tsx/esm scripts/build-docs-pages.mjs",
         "build:mcp-bundle": "pnpm run build:search-index && node --import tsx/esm scripts/build-docs-pages.mjs",
         "check:search-relevance": "pnpm run build:search-index && node --import tsx scripts/search-eval.mts --assert",
+        "smoke:mcp": "node --import tsx scripts/smoke-mcp.mts",
         "test": "vitest run",
         "test:e2e": "playwright test",
         "test:e2e:install": "playwright install chromium"

--- a/apps/docs/scripts/fetch-embed-model.mts
+++ b/apps/docs/scripts/fetch-embed-model.mts
@@ -1,0 +1,80 @@
+// Vendors EMBED_MODEL's files into MODEL_DIR (see lib/search-index/config.ts)
+// so the deployed /api/search-docs and /api/mcp functions never fetch them from
+// the HuggingFace CDN at request time — the P3 cold-start fix (see
+// lib/search-index/embed.ts for the localModelPath / allowRemoteModels=false
+// runtime side, and next.config.mjs's outputFileTracingIncludes for how this
+// directory reaches the deployed function).
+//
+// Downloads through transformers.js's OWN resolution — env.cacheDir pointed at
+// MODEL_DIR, remote models left enabled (the default) — rather than hand-
+// listing filenames. transformers.js's FileCache key (`<repo>/<file>`,
+// relative to cacheDir) and its runtime localModelPath lookup
+// (`<localModelPath>/<repo>/<file>`) resolve to the identical relative layout,
+// so whatever lands here from a normal download is exactly what embed.ts's
+// localModelPath finds later — no manual file list to keep in sync with the
+// model repo.
+//
+// Idempotent: transformers.js checks MODEL_DIR for each file before fetching
+// it (its usual on-disk cache check), so a rerun with the files already
+// present costs nothing — no network, no re-write. That also means this is
+// safe to run on every Vercel build: after the first deploy it's a fast no-op
+// unless the model repo actually changes.
+//
+// Run as a `next build` prebuild step — see prebuild-search-index.mjs, which
+// gates this the same as the search-index build (Vercel/deploy only, so
+// GitHub CI's `verify` build stays network-free). Locally, run by hand to
+// populate the same directory for testing the route with
+// allowRemoteModels=false:
+//   pnpm --filter @stitchapi/docs exec node --import tsx/esm scripts/fetch-embed-model.mts
+import { EMBED_DTYPE, EMBED_MODEL, MODEL_DIR } from '../lib/search-index/config';
+
+import { env, pipeline } from '@huggingface/transformers';
+import { readdirSync, statSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const modelDir = resolve(appRoot, MODEL_DIR);
+
+// Point the cache at the vendor dir directly — downloaded files land at
+// exactly the path embed.ts's localModelPath will read from later (see the
+// header above). Remote models stay enabled (the default): this script's only
+// job is to make sure nothing is fetched at *request* time, so a build-time
+// fetch here is expected and fine.
+env.cacheDir = modelDir;
+
+/** Recursively sum file sizes under `dir` (small tree — a handful of model
+ * files: config, tokenizer, ONNX weights). */
+function dirSize(dir: string): number {
+    let total = 0;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = resolve(dir, entry.name);
+        total += entry.isDirectory() ? dirSize(full) : statSync(full).size;
+    }
+    return total;
+}
+
+async function main(): Promise<void> {
+    console.log(
+        `[fetch-embed-model] ${EMBED_MODEL} (${EMBED_DTYPE}) → ${MODEL_DIR}`,
+    );
+    const extractor = await pipeline('feature-extraction', EMBED_MODEL, {
+        dtype: EMBED_DTYPE,
+    });
+    // Force one real inference, not just pipeline construction: this script's
+    // only job is making sure nothing is fetched at request time, so it needs
+    // to touch whatever files a real embed call touches — not just the ones
+    // pipeline() itself happens to load eagerly.
+    await extractor('warm the vendored cache', {
+        pooling: 'mean',
+        normalize: true,
+    });
+
+    const repoDir = resolve(modelDir, EMBED_MODEL);
+    const bytes = dirSize(repoDir);
+    console.log(
+        `[fetch-embed-model] vendored ${(bytes / (1024 * 1024)).toFixed(1)} MB at ${repoDir}`,
+    );
+}
+
+await main();

--- a/apps/docs/scripts/fetch-embed-model.mts
+++ b/apps/docs/scripts/fetch-embed-model.mts
@@ -26,7 +26,11 @@
 // populate the same directory for testing the route with
 // allowRemoteModels=false:
 //   pnpm --filter @stitchapi/docs exec node --import tsx/esm scripts/fetch-embed-model.mts
-import { EMBED_DTYPE, EMBED_MODEL, MODEL_DIR } from '../lib/search-index/config';
+import {
+    EMBED_DTYPE,
+    EMBED_MODEL,
+    MODEL_DIR,
+} from '../lib/search-index/config';
 
 import { env, pipeline } from '@huggingface/transformers';
 import { readdirSync, statSync } from 'node:fs';

--- a/apps/docs/scripts/prebuild-search-index.mjs
+++ b/apps/docs/scripts/prebuild-search-index.mjs
@@ -3,6 +3,14 @@
 // and network-free (no ~90 MB model download). Locally, run
 // `pnpm --filter @stitchapi/docs build:search-index` by hand to populate
 // apps/docs/.search-index/ for testing the route.
+//
+// Also vendors the embedding model itself (fetch-embed-model.mts) before
+// building the index — build-search-index.ts embeds every chunk with the SAME
+// model, so this doubles as the deploy-time correctness check for the vendored
+// copy: a missing/corrupt model file fails this step (and the whole build)
+// loudly, instead of failing quietly at the first production search_docs call.
+// See lib/search-index/embed.ts for the runtime (localModelPath /
+// allowRemoteModels) side of this P3 cold-start fix.
 import { spawnSync } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -17,9 +25,13 @@ if (!process.env.VERCEL && !process.env.BUILD_SEARCH_INDEX) {
 const here = dirname(fileURLToPath(import.meta.url));
 const appRoot = resolve(here, '..');
 
-// `.source` (fumadocs collections) must exist before the index build reads
-// getText('processed'); generate it, then embed + persist the dump.
+// The model must land before EITHER of the other two steps: build-search-
+// index.ts's embed() call runs under the same Vercel-only localModelPath lock-
+// in as the runtime route (see embed.ts), so it needs the vendored copy to
+// already exist. `.source` (fumadocs collections) must exist before the index
+// build reads getText('processed'); generate it, then embed + persist the dump.
 const steps = [
+    ['node', ['--import', 'tsx/esm', resolve(here, 'fetch-embed-model.mts')]],
     ['pnpm', ['exec', 'fumadocs-mdx']],
     ['node', ['--import', 'tsx/esm', resolve(here, 'build-search-index.mjs')]],
 ];

--- a/apps/docs/scripts/smoke-mcp.mts
+++ b/apps/docs/scripts/smoke-mcp.mts
@@ -1,0 +1,219 @@
+// Production smoke test for the hosted docs MCP server (/api/mcp).
+//
+// WHY THIS EXISTS, AND WHY IT IS NOT A CI TEST
+//
+// From 2026-07-31 to 2026-08-10 this endpoint returned an error on every
+// request — ~946 "Failed to load external module @huggingface/transformers:
+// Could not load the 'sharp' module using the linux-x64 runtime" across 89
+// distinct clients — and nothing noticed for ten days. No test in this repo
+// could have caught it: the bug was in Vercel's file tracing (the deployed
+// function bundle was missing a native binary), NOT in the source. CI runs the
+// search library out of a normal, complete node_modules, so it passes while the
+// deployed artifact is broken. `check-search-relevance` loads the same model on
+// the same OS and still would not have flagged it.
+//
+// The only place a tracing bug is observable is the deployment. So this probe
+// talks to a real base URL over the wire and asserts the things that actually
+// broke:
+//
+//   1. the route's module graph loads at all       (the sharp/ERR_DLOPEN class)
+//   2. the tool surface is still what agents bind  (a silent rename/removal)
+//   3. search_docs returns real ranked results     (index missing or empty)
+//   4. get_doc returns real Markdown               (the non-embedding path,
+//      which must keep working even if embeddings fail — see embed.ts on why
+//      the transformers import is lazy)
+//   5. every call stays well inside maxDuration    (the cold-start timeout
+//      class: 25 "Task timed out after 60 seconds" errors through 2026-08-16)
+//
+// Assertion 5 is why the workflow runs on a schedule rather than only after a
+// deploy: a scheduled probe usually lands on a COLD instance, which is the only
+// condition under which the cold-start regression is visible at all.
+//
+// Usage:
+//   node --import tsx/esm scripts/smoke-mcp.mts [baseUrl]
+//   MCP_SMOKE_URL=https://staging.example.com node --import tsx/esm scripts/smoke-mcp.mts
+//
+// Exits non-zero with a specific message on the first failed assertion.
+
+const DEFAULT_BASE = 'https://stitchapi.dev';
+
+// Well under the route's `maxDuration = 60`. A cold instance that needs the
+// embedding model should now serve from the bundled copy (see embed.ts's
+// localModelPath), so anything approaching this budget means the vendored model
+// is not being found and something is falling back to a network fetch.
+const BUDGET_MS = 25_000;
+
+// The tools agents actually bind to. A rename or removal is a breaking change
+// for every configured client, so it fails here rather than silently degrading.
+const EXPECTED_TOOLS = ['search_docs', 'get_doc'] as const;
+
+const baseUrl = (
+    process.argv[2] ??
+    process.env.MCP_SMOKE_URL ??
+    DEFAULT_BASE
+).replace(/\/$/, '');
+const endpoint = `${baseUrl}/api/mcp`;
+
+let sessionId: string | undefined;
+let failures = 0;
+
+function fail(check: string, detail: string): void {
+    failures += 1;
+    console.error(`  ✗ ${check}\n      ${detail}`);
+}
+
+function pass(check: string, detail: string): void {
+    console.log(`  ✓ ${check} — ${detail}`);
+}
+
+/**
+ * One JSON-RPC round trip. The transport is MCP Streamable HTTP, so a response
+ * is SSE-framed (`event: message\ndata: {…}`) even for a single reply — parse
+ * the last `data:` line rather than assuming a bare JSON body.
+ */
+async function rpc(
+    method: string,
+    params: Record<string, unknown> = {},
+): Promise<{ result?: any; error?: any; ms: number }> {
+    const started = Date.now();
+    const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json, text/event-stream',
+            ...(sessionId ? { 'mcp-session-id': sessionId } : {}),
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: Date.now(), method, params }),
+    });
+    const ms = Date.now() - started;
+
+    // Stateless today (no redisUrl), but honour a session id if one appears so
+    // this keeps working if the server gains state.
+    const sid = res.headers.get('mcp-session-id');
+    if (sid) sessionId = sid;
+
+    const body = await res.text();
+    if (!res.ok) {
+        return { error: `HTTP ${res.status}: ${body.slice(0, 300)}`, ms };
+    }
+
+    const dataLines = body
+        .split('\n')
+        .filter((line) => line.startsWith('data:'))
+        .map((line) => line.slice(5).trim());
+    const payload = dataLines.at(-1) ?? body;
+
+    try {
+        const parsed = JSON.parse(payload);
+        return { result: parsed.result, error: parsed.error, ms };
+    } catch {
+        return { error: `unparseable response: ${payload.slice(0, 300)}`, ms };
+    }
+}
+
+function checkBudget(label: string, ms: number): void {
+    if (ms > BUDGET_MS) {
+        fail(
+            `${label} latency`,
+            `${ms}ms exceeds the ${BUDGET_MS}ms budget — the route is heading back toward its 60s maxDuration ceiling`,
+        );
+    }
+}
+
+console.log(`\nMCP smoke → ${endpoint}\n`);
+
+/* 1. initialize — proves the route's module graph loaded at all. ------------ */
+{
+    const { result, error, ms } = await rpc('initialize', {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'stitchapi-mcp-smoke', version: '1.0.0' },
+    });
+    if (error) {
+        fail('initialize', String(error));
+    } else if (!result?.serverInfo?.name) {
+        fail('initialize', `no serverInfo in response: ${JSON.stringify(result)?.slice(0, 200)}`);
+    } else {
+        pass('initialize', `${result.serverInfo.name} v${result.serverInfo.version} (${ms}ms)`);
+        checkBudget('initialize', ms);
+    }
+}
+
+/* 2. tools/list — the surface agents bind to. ------------------------------ */
+{
+    const { result, error, ms } = await rpc('tools/list');
+    if (error) {
+        fail('tools/list', String(error));
+    } else {
+        const names: string[] = (result?.tools ?? []).map((t: any) => t.name);
+        const missing = EXPECTED_TOOLS.filter((t) => !names.includes(t));
+        if (missing.length > 0) {
+            fail(
+                'tools/list',
+                `missing tool(s): ${missing.join(', ')} — got [${names.join(', ')}]. Every configured client binds these names.`,
+            );
+        } else {
+            pass('tools/list', `${names.join(', ')} (${ms}ms)`);
+            checkBudget('tools/list', ms);
+        }
+    }
+}
+
+/* 3. search_docs — the embedding path, and the index behind it. ------------ */
+{
+    const { result, error, ms } = await rpc('tools/call', {
+        name: 'search_docs',
+        arguments: { query: 'retry with exponential backoff', limit: 3 },
+    });
+    if (error) {
+        fail('search_docs', String(error));
+    } else if (result?.isError) {
+        fail('search_docs', `tool reported an error: ${JSON.stringify(result.content)?.slice(0, 300)}`);
+    } else {
+        let hits: any[] = [];
+        try {
+            hits = JSON.parse(result?.content?.[0]?.text ?? '[]');
+        } catch {
+            /* falls through to the empty check below */
+        }
+        if (hits.length === 0) {
+            fail(
+                'search_docs',
+                'returned zero results for a query that must match the retry guide — the index is missing, empty, or not bundled into the function',
+            );
+        } else if (!hits[0]?.url?.startsWith('http')) {
+            fail('search_docs', `result shape changed — first hit has no absolute url: ${JSON.stringify(hits[0])?.slice(0, 200)}`);
+        } else {
+            pass('search_docs', `${hits.length} hits, top: ${hits[0].title} (${ms}ms)`);
+            checkBudget('search_docs', ms);
+        }
+    }
+}
+
+/* 4. get_doc — must work even when embeddings do not (lazy-import scoping). */
+{
+    const { result, error, ms } = await rpc('tools/call', {
+        name: 'get_doc',
+        arguments: { slug: 'guides/resilience/retry' },
+    });
+    if (error) {
+        fail('get_doc', String(error));
+    } else if (result?.isError) {
+        fail('get_doc', `tool reported an error: ${JSON.stringify(result.content)?.slice(0, 300)}`);
+    } else {
+        const md: string = result?.content?.[0]?.text ?? '';
+        if (md.length < 200) {
+            fail('get_doc', `returned ${md.length} chars — expected a full Markdown page`);
+        } else {
+            pass('get_doc', `${md.length} chars of Markdown (${ms}ms)`);
+            checkBudget('get_doc', ms);
+        }
+    }
+}
+
+console.log('');
+if (failures > 0) {
+    console.error(`MCP smoke FAILED — ${failures} check(s) failed against ${endpoint}\n`);
+    process.exit(1);
+}
+console.log(`MCP smoke passed — ${endpoint} is healthy\n`);

--- a/apps/docs/scripts/smoke-mcp.mts
+++ b/apps/docs/scripts/smoke-mcp.mts
@@ -83,7 +83,12 @@ async function rpc(
             Accept: 'application/json, text/event-stream',
             ...(sessionId ? { 'mcp-session-id': sessionId } : {}),
         },
-        body: JSON.stringify({ jsonrpc: '2.0', id: Date.now(), method, params }),
+        body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: Date.now(),
+            method,
+            params,
+        }),
     });
     const ms = Date.now() - started;
 
@@ -132,9 +137,15 @@ console.log(`\nMCP smoke → ${endpoint}\n`);
     if (error) {
         fail('initialize', String(error));
     } else if (!result?.serverInfo?.name) {
-        fail('initialize', `no serverInfo in response: ${JSON.stringify(result)?.slice(0, 200)}`);
+        fail(
+            'initialize',
+            `no serverInfo in response: ${JSON.stringify(result)?.slice(0, 200)}`,
+        );
     } else {
-        pass('initialize', `${result.serverInfo.name} v${result.serverInfo.version} (${ms}ms)`);
+        pass(
+            'initialize',
+            `${result.serverInfo.name} v${result.serverInfo.version} (${ms}ms)`,
+        );
         checkBudget('initialize', ms);
     }
 }
@@ -168,7 +179,10 @@ console.log(`\nMCP smoke → ${endpoint}\n`);
     if (error) {
         fail('search_docs', String(error));
     } else if (result?.isError) {
-        fail('search_docs', `tool reported an error: ${JSON.stringify(result.content)?.slice(0, 300)}`);
+        fail(
+            'search_docs',
+            `tool reported an error: ${JSON.stringify(result.content)?.slice(0, 300)}`,
+        );
     } else {
         let hits: any[] = [];
         try {
@@ -182,9 +196,15 @@ console.log(`\nMCP smoke → ${endpoint}\n`);
                 'returned zero results for a query that must match the retry guide — the index is missing, empty, or not bundled into the function',
             );
         } else if (!hits[0]?.url?.startsWith('http')) {
-            fail('search_docs', `result shape changed — first hit has no absolute url: ${JSON.stringify(hits[0])?.slice(0, 200)}`);
+            fail(
+                'search_docs',
+                `result shape changed — first hit has no absolute url: ${JSON.stringify(hits[0])?.slice(0, 200)}`,
+            );
         } else {
-            pass('search_docs', `${hits.length} hits, top: ${hits[0].title} (${ms}ms)`);
+            pass(
+                'search_docs',
+                `${hits.length} hits, top: ${hits[0].title} (${ms}ms)`,
+            );
             checkBudget('search_docs', ms);
         }
     }
@@ -199,11 +219,17 @@ console.log(`\nMCP smoke → ${endpoint}\n`);
     if (error) {
         fail('get_doc', String(error));
     } else if (result?.isError) {
-        fail('get_doc', `tool reported an error: ${JSON.stringify(result.content)?.slice(0, 300)}`);
+        fail(
+            'get_doc',
+            `tool reported an error: ${JSON.stringify(result.content)?.slice(0, 300)}`,
+        );
     } else {
         const md: string = result?.content?.[0]?.text ?? '';
         if (md.length < 200) {
-            fail('get_doc', `returned ${md.length} chars — expected a full Markdown page`);
+            fail(
+                'get_doc',
+                `returned ${md.length} chars — expected a full Markdown page`,
+            );
         } else {
             pass('get_doc', `${md.length} chars of Markdown (${ms}ms)`);
             checkBudget('get_doc', ms);
@@ -213,7 +239,9 @@ console.log(`\nMCP smoke → ${endpoint}\n`);
 
 console.log('');
 if (failures > 0) {
-    console.error(`MCP smoke FAILED — ${failures} check(s) failed against ${endpoint}\n`);
+    console.error(
+        `MCP smoke FAILED — ${failures} check(s) failed against ${endpoint}\n`,
+    );
     process.exit(1);
 }
 console.log(`MCP smoke passed — ${endpoint} is healthy\n`);


### PR DESCRIPTION
## Why

The hosted docs MCP server (`stitchapi.dev/api/mcp`) — the endpoint every configured agent binds to — has had two production failures that nobody noticed:

| Window | Failure | Scale |
|---|---|---|
| Jul 31 – Aug 10 | `Could not load the "sharp" module using the linux-x64 runtime` / `ERR_DLOPEN_FAILED` | **~946 errors, 89 distinct clients, 10 days** |
| through Aug 16 | `Vercel Runtime Timeout Error: Task timed out after 60 seconds` | 25 errors, still recurring |

Both surfaced from a Vercel runtime-error pull while investigating something else. Neither was caught by CI, and neither was reported by a user.

## The timeout fix

`embed.ts` pointed transformers.js at `/tmp` because Vercel's deployed `node_modules` is read-only. That meant the ~90 MB `Xenova/all-MiniLM-L6-v2` model was fetched **from the HuggingFace CDN on the first `search_docs` per warm instance** — sometimes past the route's 60s `maxDuration`. The source already flagged this as the P3 cold-start watch-item, deferred to "a deploy step"; the deploy found it.

Vendor the model at build time instead:

- `scripts/fetch-embed-model.mts` populates `apps/docs/.model-cache/` by driving transformers.js itself, so the on-disk layout is exactly what it expects. Runs **before** the index build in `prebuild-search-index.mjs` — `build-search-index.ts` embeds under the same lock-in, so a missing or corrupt copy fails the deploy rather than the first production search.
- `embed.ts` sets `env.localModelPath` + `allowRemoteModels = false` on Vercel: resolve from disk, fail loudly instead of silently falling back to the CDN.
- `next.config.mjs` ships `.model-cache/**` into both search functions.

Gitignored and refetched per deploy, same treatment as `.search-index/`.

## The sharp fix, and a correction worth reading

Dropping `sharp` from the traced bundle looks obvious — these routes only do text feature-extraction. Taken literally it would have been a **regression**: sharp's Node entry does an unconditional synchronous native-binding load at require time and throws if no platform binary resolves, and `@huggingface/transformers` imports it at top level. Excluding sharp's files alone just trades `ERR_DLOPEN_FAILED` for a guaranteed `MODULE_NOT_FOUND`.

So `embed.ts` now imports `@huggingface/transformers` **lazily**, inside the `search_docs` path. A load failure stays scoped to that one call instead of crashing the route at module load and taking `initialize` and `get_doc` with it. That containment is also why the old failure produced ~946 errors rather than a handful: a module-load failure poisons every subsequent request on that warm instance. With it in place, excluding sharp is a clean win.

## The guard

**No test in this repo could have caught the outage, and adding one to `verify.yml` wouldn't help.** The fault was in Vercel's function file tracing — the source was correct, and CI running the search library out of a complete `node_modules` passed throughout. `check-search-relevance` loads the same model on the same OS and would also have stayed green. A tracing bug is only observable by talking to the deployment.

So `scripts/smoke-mcp.mts` probes the real endpoint over the wire and asserts the four things that broke or could break silently:

1. `initialize` — the route's module graph loads at all (the sharp/`ERR_DLOPEN` class)
2. `tools/list` — the tool surface agents bind is unchanged (a silent rename/removal is breaking for every client)
3. `search_docs` — returns ranked results with absolute URLs (index missing, empty, or unbundled)
4. `get_doc` — returns real Markdown; the non-embedding path must survive an embedding failure

Plus a 25s budget per call against the 60s ceiling, so drift back toward the timeout fails before users hit it.

The **schedule is load-bearing**: every 6 hours means most runs land on a cold instance, the only state in which the cold-start regression is visible. A post-deploy-only check would usually hit a warm function and miss it entirely. It also runs on PRs touching the route, the search lib, the bundler config, or the probe itself.

## Verification

Local, verified in both directions:

- `check:types` exit 0, `eslint .` exit 0
- `embedOne()` under `VERCEL=1` → 384-dim vector in ~364 ms, **no network**
- vendored copy renamed away → fails loudly with the `allowRemoteModels=false` error, no silent CDN fallback
- bundle **87 MB** against Vercel's 250 MB limit
- smoke green against production (`initialize` 369 ms, `search_docs` 3 hits, `get_doc` 3583 chars); **exit 1 with all four checks failing** when pointed at a URL where the endpoint doesn't exist

## Reviewer notes

- **New build-time dependency on HuggingFace.** The model is gitignored and refetched each deploy, so a HF outage now fails the build. The alternative — committing 87 MB of binary — seemed worse, but it's a real trade-off you didn't have before.
- **Not confirmed in production.** The timeouts are cold-start-only; proving they're gone needs this deployed plus a fresh `get_runtime_errors` window.
- The scheduled workflow fails a *scheduled run*, not a merge. Treat red as production being down for every agent with this server configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)