### PR TITLE
build(format): stop the pre-push format gate failing on Claude Code's local settings

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -29,6 +29,15 @@ docs/sandbox/dist/
 # scope. See lefthook.yml's pre-push `format` job.
 .claude/worktrees/
 
+# Claude Code's per-machine permission file. Written by the tool, gitignored (in
+# most setups globally, via ~/.config/git/ignore, so it is not in this repo's
+# .gitignore and is easy to miss), and never committed — but `prettier --check .`
+# walks the working tree, not the index, so an unformatted one blocks the
+# pre-push `format` gate for anyone who has ever granted a permission. Note this
+# is `settings.local.json` only: the tracked `.claude/settings.json` and
+# `.claude/launch.json` stay in scope, per the block above.
+.claude/settings.local.json
+
 # Playwright run artifacts (apps/docs, written by test:e2e). Already gitignored,
 # so CI checks out clean and never sees them — but `prettier --check .` (the
 # pre-push format gate) walks the working tree, not the index, and Playwright


### PR DESCRIPTION
## Problem

`prettier --check .` (the pre-push `format` job in `lefthook.yml`) walks the **working tree, not the index**, so it descends into `.claude/settings.local.json` — Claude Code's per-machine permission file. The tool writes it unformatted, so the check fails and the push is blocked, for a file that is never committed and that CI never sees.

It's a nasty one to diagnose because that file is usually ignored via `~/.config/git/ignore` rather than this repo's `.gitignore`. It never appears in `git status`, so the failure looks like it's coming from your own changes. Hit while pushing #748 — cost a couple of confused round trips before I traced it.

Anyone who has ever granted a Claude Code permission in this repo has the file, so this reproduces for them.

## Fix

One `.prettierignore` entry, following the two neighbours that exist for exactly this reason — `.claude/worktrees/` and `apps/docs/test-results/`, both "already gitignored, but prettier walks the tree".

**Scoped to `settings.local.json` only.** The existing comment block deliberately keeps the tracked `.claude/settings.json` and `.claude/launch.json` in prettier's scope, and this preserves that.

## Verification

Reintroduced the exact failure (minified `settings.local.json`) and confirmed `prettier --check .` passes, then confirmed the scope is precise rather than inferring it from a green run:

```
.claude/settings.local.json      ignored=true
.claude/settings.json            ignored=false
.claude/launch.json              ignored=false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)