### PR TITLE
fix(docs): stop excluding sharp — it broke `search_docs` in production

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -96,32 +96,29 @@ const config = {
             '../../node_modules/.pnpm/onnxruntime-node@*/node_modules/onnxruntime-node/bin/napi-v6/linux/**/*',
         ],
     },
-    // Drop `sharp` from the deployed function entirely. @huggingface/transformers
-    // pulls it in for image pipelines; search_docs/get_doc only ever do text
-    // feature-extraction, so it's dead weight — and a dangerous kind: sharp's
-    // Node entry (dist/sharp.cjs) does an unconditional, synchronous native-
-    // binding load at require time and THROWS if none of its platform binaries
-    // resolve. That's the exact shape of the Jul 31–Aug 10 2026 outage (~946
-    // "Could not load the 'sharp' module using the linux-x64 runtime /
-    // ERR_DLOPEN_FAILED" errors on this route). Excluding sharp's files only
-    // trades that failure for a guaranteed one (require('sharp') throwing
-    // MODULE_NOT_FOUND instead) UNLESS the import is safe to fail — which it now
-    // is: embed.ts imports @huggingface/transformers lazily, inside the
-    // search_docs call path, specifically so a load failure (this one included)
-    // stays scoped to that one call instead of crashing the whole route at
-    // module load. With that containment in place, dropping sharp is a clean
-    // win — smaller bundle, one less fragile native dependency — instead of a
-    // regression.
-    outputFileTracingExcludes: {
-        '/api/search-docs': [
-            '../../node_modules/.pnpm/sharp@*/node_modules/**',
-            '../../node_modules/.pnpm/@img+sharp-*/node_modules/**',
-        ],
-        '/api/mcp': [
-            '../../node_modules/.pnpm/sharp@*/node_modules/**',
-            '../../node_modules/.pnpm/@img+sharp-*/node_modules/**',
-        ],
-    },
+    // NO `outputFileTracingExcludes` for `sharp` here — #748 added one and it broke
+    // production. Recording why, because the reasoning is genuinely tempting:
+    // @huggingface/transformers pulls sharp in for image pipelines that
+    // search_docs/get_doc never use, so it looks like free dead weight to drop.
+    //
+    // It is not. transformers' Node bundle has an unconditional top-level
+    // `import sharp from 'sharp'`. Excluding sharp's files does not remove that
+    // import — it only makes it unresolvable, so the module graph fails with
+    // ERR_MODULE_NOT_FOUND instead of the ERR_DLOPEN_FAILED it failed with during
+    // the Jul 31 – Aug 10 2026 outage. Both are the same bug wearing a different
+    // error code, and the second one is worse: it fails 100% of the time rather
+    // than only when a native binary is missing.
+    //
+    // #748 shipped the exclusion on the theory that embed.ts's lazy import made
+    // the failure survivable. It does contain the blast radius — `initialize`,
+    // `tools/list` and `get_doc` kept working — but `search_docs`, the tool the
+    // endpoint exists for, failed on every call. Contained is not fixed. The
+    // smoke guard caught it against production within minutes of the deploy.
+    //
+    // sharp is already `serverExternalPackages` (Next externalizes it by default),
+    // so it stays a plain runtime require resolved from the traced node_modules.
+    // Leave it traced in. Its cost is disk, and disk is not the failure mode here.
+    //
     // Keep the runtime embedder OUT of the server bundle. Those same two routes
     // load transformers.js (@huggingface/transformers), whose Node backend is the
     // native `onnxruntime-node` addon (`.node` binaries). Bundling a native addon
@@ -129,8 +126,8 @@ const config = {
     // — which 500s every request (even paths that never embed, like the MCP
     // `initialize` handshake or an empty query), not just searches. Marking these
     // external leaves them as a plain runtime require, resolved from the traced
-    // node_modules, so the binary loads. Next externalizes `sharp` by default too
-    // (see outputFileTracingExcludes above for why this route ships none of it).
+    // node_modules, so the binary loads. Next externalizes `sharp` by default too,
+    // and it must stay traced in — see the block above.
     serverExternalPackages: ['@huggingface/transformers', 'onnxruntime-node'],
     // The playground consumes the in-repo sandbox engine (@stitchapi/sandbox), a
     // workspace package that ships raw TS/TSX source — Next must transpile it.


### PR DESCRIPTION
## ⚠️ This fixes a production regression I introduced in #748

`search_docs` — the tool the hosted MCP server exists for — currently fails on **every call** in production. Caught by the smoke guard #748 added, minutes after that deploy promoted:

```
MCP smoke → https://stitchapi.dev/api/mcp

  ✓ initialize   — stitchapi-docs v1.0.0 (750ms)
  ✓ tools/list   — search_docs, get_doc (626ms)
  ✗ search_docs
      Cannot find package 'sharp' imported from
      /var/task/node_modules/.pnpm/@huggingface+transformers@4.2.0/…/transformers.mjs
  ✓ get_doc      — 3583 chars of Markdown (170ms)

MCP smoke FAILED — 1 check(s) failed
```

## What I got wrong

#748 dropped `sharp` from the two search functions via `outputFileTracingExcludes`, on the reasoning that `@huggingface/transformers` only pulls it in for image pipelines these routes never touch. The premise is true. The conclusion was wrong.

`@huggingface/transformers`'s Node bundle has an **unconditional top-level `import sharp from 'sharp'`**. Excluding sharp's files doesn't remove the import — it makes it *unresolvable*. So the module graph fails with `ERR_MODULE_NOT_FOUND` where it previously failed with `ERR_DLOPEN_FAILED` during the Jul 31 – Aug 10 outage.

Same bug, different error code — and **strictly worse**. The old one needed a missing native binary to trigger. This one fails 100% of the time.

Worth being precise about what went wrong in my reasoning: the subagent that wrote #748 identified this exact trade and said excluding sharp would only be safe *because* it had made the transformers import lazy. The lazy import genuinely helps — it's why `initialize`, `tools/list` and `get_doc` still work above, instead of the whole route dying at module load like it did in July. But **containment isn't a fix**. I treated "the failure is now survivable" as "the failure is now acceptable," and the thing it was survivable *around* was the endpoint's primary tool.

## The fix

Remove the exclusion. `sharp` is already in `serverExternalPackages`, so it stays a plain runtime require resolved from the traced `node_modules`. Its cost is disk, and disk was never the failure mode.

The reasoning stays as a comment rather than being deleted silently — "transformers doesn't need sharp for text embeddings" is true and tempting, and the next person to look at that bundle deserves to know why it still can't be excluded.

## What #748 got right, and keeps

Nothing else is reverted. Both remaining halves are confirmed working in Vercel's own build:

```
[fetch-embed-model] vendored 86.9 MB at /vercel/path0/apps/docs/.model-cache/…
[search-index] embeddings deterministic ✓ (dim 384, maxDiff 0)
```

- **Model vendoring** — the build resolved the model purely from the vendored copy under `allowRemoteModels = false` and produced byte-identical vectors.
- **The lazy import** — kept, and it earned its place: it's the reason this regression degraded one tool instead of taking the route down.
- **The smoke guard** — caught a production-only failure that no CI job could have, within minutes. Exactly what it was built for.

## Verification

Local, since Vercel file tracing can't be reproduced off-platform:

- `next.config.mjs` parses; `outputFileTracingExcludes` is now `undefined`
- `embedOne()` under `VERCEL=1` → 384-dim vector, still from the vendored copy
- `check:lint` exit 0, `check:types` exit 0

**Real verification is the deploy.** I'll run the smoke against production once this promotes and report the result either way.

## Unrelated but worth flagging

The #748 deploy took **36.9 minutes** (`buildingAt` → `ready`), against an 8.4-minute baseline for the previous production deploy. Removing these exclusion globs (which walked the pnpm store) may recover some of it, but the 87 MB model now traced into two functions is the likelier cause. Worth a separate look — filed here so it isn't lost, not fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)