### PR TITLE
feat(core)!: the token grammars become `parse`/`format` pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,58 @@ npm release are grouped under the in-development version that introduced them.
 
 ### Changed
 
+- **BREAKING CHANGE: the three token parsers are now `parse`/`format` pairs — `parseDuration`,
+  `parseBytes` and `parseRate` are replaced by `duration`, `size` and `rate`.**
+  ([CONTRACT.md P17](docs/CONTRACT.md#p17--one-canonical-duration-form) /
+  [P25](docs/CONTRACT.md#p25--one-canonical-size-form))
+  The house grammars only ever decoded. Making them public gave them callers who need the other
+  direction too — a CLI printing the cap it enforced, a config round-trip, an error message
+  quoting a limit in the grammar its author wrote — and each of those would have hand-rolled an
+  encoder, which is the drift the export existed to prevent.
+
+    Each dimension is now one namespace with both directions, following `bytes`'s shape
+    (`bytes.parse` / `bytes.format`) rather than adding three more verb-prefixed names:
+
+    | Was                | Now                 | Gained                                           |
+    | ------------------ | ------------------- | ------------------------------------------------ |
+    | `parseDuration(d)` | `duration.parse(d)` | `duration.format(90_000)` → `'1.5m'`             |
+    | `parseBytes(s)`    | `size.parse(s)`     | `size.format(1_048_576)` → `'1mb'`               |
+    | `parseRate(r)`     | `rate.parse(r)`     | `rate.format({ count: 2, per: 1000 })` → `'2/s'` |
+
+    Behaviour of the decode direction is byte-for-byte what it was — same grammars, same 1024-based
+    size units, same `undefined` fallback for a bad duration or size token, same throw for a bad
+    rate. Only the spelling moved. A `Rate` type is now exported for the `{ count, per }` pair.
+
+    **`format` is the exact inverse of `parse`, not a pretty-printer.** `parse(format(v))` returns
+    `v` unchanged for every value `parse` can produce, pinned as a property over the whole numeric
+    range rather than a table of cases. This is the one place the pair deliberately departs from
+    `ms`, whose `ms(90_000)` is `'2m'` and reads back as 120_000: a lossy encode is fine in a log
+    line and disqualifying in anything that writes a value back, and P25's "a typo can never widen
+    a cap" only holds if the encode direction cannot widen one either. Where no unit divides a
+    value cleanly the base unit wins — `90_001` is `'90001ms'`, and `1537` is `'1537b'` rather than
+    the exact-but-unreadable `'1.5009765625kb'`.
+
+    **Migration** is a rename at every call site; there is no alias
+    ([P19](docs/CONTRACT.md#p19--the-alias-obligation-is-scoped-to-the-ga-channel) scopes the alias
+    obligation to the GA channel, and this is `rc`). The old names are pinned **absent** from the
+    barrel, so a stale import fails at build rather than resolving to something else:
+
+    ```diff
+    - import { parseDuration, parseBytes, parseRate } from 'stitchapi';
+    - const ttl = parseDuration(opts.ttl);
+    - const cap = parseBytes(opts.max);
+    - const { count, per } = parseRate(opts.rate);
+    + import { duration, size, rate } from 'stitchapi';
+    + const ttl = duration.parse(opts.ttl);
+    + const cap = size.parse(opts.max);
+    + const { count, per } = rate.parse(opts.rate);
+    ```
+
+    One caveat worth naming: `size` no longer spells `Bytes`, so the `Bytes`/`Chars` distinction is
+    no longer visible at the call site. `stream.buffer.chars` and `trace.body.chars` count UTF-16
+    code units, not bytes, and still reject a token at compile time — but the name no longer warns
+    you before the type does.
+
 - **BREAKING CHANGE (types only): a `baseUrl`/`path` beside a `url` in ONE config literal is now a
   compile error.**
   ([CONTRACT.md P24 carve-out (b)](docs/CONTRACT.md#p24--a-shared-field-name-prefix-in-a-house-contract-is-an-envelope))

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/stitchapi?activeTab=dependencies"><img alt="Dependencies: 0" src="https://img.shields.io/badge/dependencies-0-brightgreen" /></a>
-  <img alt="Bundle: ~24 kB min+gzip" src="https://img.shields.io/badge/min%2Bgzip-~24%20kB-2563EB" />
+  <img alt="Bundle: ~25 kB min+gzip" src="https://img.shields.io/badge/min%2Bgzip-~25%20kB-2563EB" />
   <a href="https://scorecard.dev/viewer/?uri=github.com/rejifald/StitchAPI"><img alt="OpenSSF Scorecard" src="https://api.scorecard.dev/projects/github.com/rejifald/StitchAPI/badge" /></a>
   <a href="https://www.npmjs.com/package/stitchapi"><img alt="npm provenance: signed" src="https://img.shields.io/badge/provenance-signed-brightgreen" /></a>
 </p>
@@ -34,7 +34,7 @@
 <!-- /yakir:readme-badges -->
 
 <p align="center">
-  <strong>Zero runtime dependencies · ~24&nbsp;kB min+gzip</strong> — a typical <code>import { stitch }</code> tree-shakes to ~22&nbsp;kB, and with no transitive tree there is nothing else to install or audit. The size is an <a href="packages/core/scripts/bundle-size.mjs">enforced budget in CI</a>, not an aspiration.
+  <strong>Zero runtime dependencies · ~25&nbsp;kB min+gzip</strong> — a typical <code>import { stitch }</code> tree-shakes to ~22&nbsp;kB, and with no transitive tree there is nothing else to install or audit. The size is an <a href="packages/core/scripts/bundle-size.mjs">enforced budget in CI</a>, not an aspiration.
 </p>
 
 <p align="center">
@@ -164,7 +164,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 - **Pluggable state store** — throttle counters and sessions behind a 3-method store; swap in Redis/Postgres to go distributed.
 - **Zero-infra observability** — tracing is **off by default**; opt in per stitch or via `STITCH_TRACE_*` env vars. No collector, no dashboard.
 - **Four front doors, one definition** — in-process function, CLI (`stitch run`), HTTP (`stitch serve`), and MCP (`stitch mcp`).
-- **Zero runtime dependencies** — `"dependencies": {}`, built on global `fetch`, tree-shakeable; **~24 kB min+gzip** for the whole entry, **~22 kB** for a typical `import { stitch }`.
+- **Zero runtime dependencies** — `"dependencies": {}`, built on global `fetch`, tree-shakeable; **~25 kB min+gzip** for the whole entry, **~22 kB** for a typical `import { stitch }`.
 
 ## Install
 

--- a/apps/docs/app/(home)/components/metrics.tsx
+++ b/apps/docs/app/(home)/components/metrics.tsx
@@ -5,7 +5,7 @@ const metrics = [
         body: 'Built on the platform’s global fetch — nothing to install, nothing to audit, nothing in your transitive tree.',
     },
     {
-        value: '~24 kB',
+        value: '~25 kB',
         unit: 'min + gzip',
         body: 'The whole stitchapi entry, tree-shaken — and it is an enforced budget in CI, not an aspiration.',
     },

--- a/apps/docs/content/docs/concepts/principles.mdx
+++ b/apps/docs/content/docs/concepts/principles.mdx
@@ -105,7 +105,7 @@ behind its own import — so an app never ships bytes for a CLI it will not run.
 The same frugality the event stream practices with an agent's context, the
 package practices with your bundle.
 
-Concretely, the whole `stitch` entry is **~24 kB minified + gzipped**
+Concretely, the whole `stitch` entry is **~25 kB minified + gzipped**
 (≈61 kB raw), and because every surface beyond `http` is a separate subpath
 import, a typical `import { stitch }` tree-shakes to **~22 kB**. With zero
 runtime dependencies, that figure is the entire cost — not the tip of a

--- a/apps/docs/content/docs/getting-started/installation.mdx
+++ b/apps/docs/content/docs/getting-started/installation.mdx
@@ -5,7 +5,7 @@ description: 'Install stitchapi and set up the zero-dependency runtime in Node o
 
 Install the package, import `stitch`, and turn your first endpoint into a typed,
 callable function. `stitchapi` has zero dependencies and runs anywhere `fetch`
-does — Node, the browser, and edge runtimes. The whole entry is **~24 kB
+does — Node, the browser, and edge runtimes. The whole entry is **~25 kB
 minified + gzipped** — and with no dependencies, there is no transitive tree
 behind it (a typical `import { stitch }` tree-shakes to ~22 kB).
 

--- a/apps/docs/lib/source.ts
+++ b/apps/docs/lib/source.ts
@@ -25,7 +25,7 @@ Search these docs instead of loading the whole file: this site is also a hosted 
 - Capability, not credential: an agent invokes a stitch and gets structured, validated, traceable data; the secret stays behind the boundary.
 - One context-frugal **code-mode** tool (run_stitch + list_stitches + describe_stitch), not one tool per endpoint — adding APIs never floods the context window.
 - No server, no codegen, no config files — a URL and one example response is enough; only explicit composition (no ambient/global config a stitch silently inherits).
-- Zero-dependency core, ~24 kB min+gzip for the whole entry (~22 kB for a tree-shaken import { stitch }), validator-agnostic (bring your own Standard Schema / Zod), and it runs in the browser.
+- Zero-dependency core, ~25 kB min+gzip for the whole entry (~22 kB for a tree-shaken import { stitch }), validator-agnostic (bring your own Standard Schema / Zod), and it runs in the browser.
 - Composes with your data layer: a stitch is the queryFn for TanStack Query / SWR — it owns the call's resilience; your query layer owns view state.
 
 ## Quickstart

--- a/docs/CONTRACT.md
+++ b/docs/CONTRACT.md
@@ -35,7 +35,7 @@ Five forks were decided by the maintainer; the rules below assume them.
 | --- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | D1  | Success-payload field name | **`data`** (align with axios / React Query / SWR / RTK Query, which every hook package wraps; `SafeResult` already uses it). Stream increments keep **`chunk`**; the Standard-Schema validation layer keeps spec-mandated **`value`/`issues`**.                  | [P5](#p5--one-success-field-one-failure-field)                            |
 | D2  | Cap-word convention        | **Bare nouns, no `max-` prefix**, for **count** caps (`attempts`, `entries`, `pages`, `failures`, `concurrency`). `max-` is retained only where it bounds a continuous **magnitude** and a bare noun would be ambiguous (a delay ceiling).                       | [P4](#p4--one-cap-vocabulary)                                             |
-| D3  | Duration style             | **ms is the one house unit; drop the `Ms` suffix _everywhere_** (input and emitted; the unit lives in JSDoc). Consumer-authored durations additionally accept **`number \| string`** (`'5s'` or raw ms) via one `parseDuration`.                                 | [P17](#p17--one-canonical-duration-form)                                  |
+| D3  | Duration style             | **ms is the one house unit; drop the `Ms` suffix _everywhere_** (input and emitted; the unit lives in JSDoc). Consumer-authored durations additionally accept **`number \| string`** (`'5s'` or raw ms) via one `duration.parse`.                                | [P17](#p17--one-canonical-duration-form)                                  |
 | D4  | Home of the contract       | **This `CONTRACT.md` (living doc) + an enforcement lint** in the verify gate.                                                                                                                                                                                    | [§7](#7-enforcement)                                                      |
 | D5  | Pre-GA break policy        | **Alias-free hard breaks are maintainer-sanctioned before 1.0 GA** (exercised once — the 2026-07-08 sweep, few adopters, every prior `@deprecated` shim deleted). From 1.0 GA, every rename/narrowing/removal requires a deprecation cycle and lands in a major. | [P19](#p19--breaking-changes-sanctioned-pre-ga-deprecation-cycle-from-ga) |
 
@@ -428,7 +428,7 @@ spellings (nor the interim `payload` name).
 Per **D3**, **ms is the single house time unit** and **no duration field carries the
 `Ms` suffix** — input or emitted. Every **consumer-authored** duration additionally
 **MUST** accept **`number | string`** (raw ms or a token like `'5s'`/`'1m'`), parsed by
-one shared `parseDuration`. Every **emitted** duration is a raw-ms `number`; its unit is
+one shared `duration.parse`. Every **emitted** duration is a raw-ms `number`; its unit is
 stated in its JSDoc, not its name.
 
 **The test is the value, not the slot.** Read the widening forwards, as the one question
@@ -453,12 +453,23 @@ a value core passes _into_ a contract the consumer implements (`StitchStore.set`
 there would be a shape the reader must handle and the writer can never send.
 
 **A widened type is only half the rule; the parse is the other half.** The value **MUST**
-reach `parseDuration` before any arithmetic or sleep site. Widening a type without
+reach `duration.parse` before any arithmetic or sleep site. Widening a type without
 widening its read site is _worse_ than not widening it: the token then arrives where a
 number is assumed, and JS coerces rather than throws — `remaining <= '700ms'` is `false`
 and `setTimeout('700ms')` fires immediately, so the wait silently collapses to ~0 with no
 error anyone can see. That is the failure `SurfaceOutcome.after` shipped with until #609,
 and the reason this clause names the parser rather than only the type.
+
+**The parser is one half of a pair.** As of 2026-08-16 the grammar is exposed as a
+`duration` namespace with `parse` and `format`, replacing the free `parseDuration` (the
+`bytes` library's shape: one name per dimension, the direction named at the call site).
+`format` is the **exact** inverse — `duration.parse(duration.format(ms)) === ms` for every
+finite `ms`, never a rounded approximation — because a lossy encode could widen the value it
+round-trips, and this rule's whole point is that a cap only ever moves where the author put
+it. **The complement above is unchanged and `format` does not soften it:** an emitted
+duration is still a raw-ms `number`. Rendering one for a CLI table, an error message, or a
+config file a human will re-author is display; writing a formatted token into an emitted
+field is the same violation it always was.
 
 _Why:_ every JS-native time API (`Date.now()`, `setTimeout`, `performance.now()`) is
 **already ms**, so ms is the unambiguous default and the suffix is redundant noise
@@ -473,7 +484,7 @@ too, then **removed** in the 2026-08-04 P1 fix below — the two named one insta
 `ReconnectOptions.delay` (was `backoffMs`, de-suffixed to `backoff` and later renamed
 under P2), `OAuth2Options.refreshSkew` (now `refresh.skew`), `CookieSessionOptions.ttl`,
 and `verifyStoreContract`'s `ttl` knob — all `number | string` via the one shared
-`parseDuration`.
+`duration.parse`.
 _Resolved (seam-authored, 2026-08):_ the two positions where a **`Surface`** supplies a
 duration — `SurfaceOutcome.after` (#609) and `Surface.resumeRetry`'s return — take
 `number | string` and are parsed at the engine's sleep site. Both were missed by the
@@ -763,7 +774,7 @@ plugin-extension-hook bag, are all real shapes this rule does not reach.
 
 **Bytes are the house size unit.** Every **consumer-authored** byte cap **MUST** accept
 **`number | string`** — a raw byte count or a token like `'64kb'`/`'1mb'` — parsed by one
-shared `parseBytes`, whose units are **powers of 1024** (`'1mb'` = 1_048_576). Every
+shared `size.parse`, whose units are **powers of 1024** (`'1mb'` = 1_048_576). Every
 **emitted** size is a raw-byte `number`.
 
 **Same test as [P17](#p17--one-canonical-duration-form), same four positions: if a
@@ -773,7 +784,7 @@ are one rule over two dimensions, so read this section and P17's widening clause
 question is only whether a consumer can choose the value. The complement holds too: a
 size **core produces** (`AdapterProgress.total`, a resolved internal like `execFile`'s
 `maxBuffer`) is a raw-byte `number` and takes no string arm. And the widening is only
-real once the value passes through `parseBytes` — an unparsed `'1mb'` compared against a
+real once the value passes through `size.parse` — an unparsed `'1mb'` compared against a
 byte count is the size analogue of P17's silently-collapsing sleep.
 
 **The one place the two dimensions diverge is the counterpoint that proves the rule:** a
@@ -812,6 +823,15 @@ envelopes ([§6](#6-migration-record-2026-07-08-hard-break-sweep)): `serve`'s
 `stream`'s `buffer: 4_000_000` ≡ `{ chars: 4_000_000 }`. The contrast the old clause
 protected did not dissolve — it moved into names and types, where the compiler holds it.
 
+**Same pairing as [P17](#p17--one-canonical-duration-form).** The grammar is the `size`
+namespace's `parse`/`format`, replacing the free `parseBytes`, and `format` is the exact
+inverse across every finite byte count. Because 1024 is a power of two a byte count's `kb`
+quotient is nearly always exact and nearly always unreadable, so the encoder uses a unit only
+when the quotient is exact **and** short — `1536` is `'1.5kb'`, `1537` is `'1537b'`, never
+`'1.5009765625kb'` and never a rounded `'2kb'`. The `Chars` carve-out is untouched and now
+matters slightly more: `size` no longer spells `Bytes` in its name, so the one place the
+category error was visible at the call site is gone and the JSDoc carries it alone.
+
 _Why:_ every JS-native size API (`byteLength`, `Buffer.length`, `execFile`'s `maxBuffer`)
 is already bytes, so a bare number needs no unit; and 1024-based `kb`/`mb` is what the
 Node ecosystem's de-facto parser already means by those tokens
@@ -825,13 +845,13 @@ _Canonical case:_ the two **byte** envelopes — `serve`'s `body`
 (`ShellBufferOptions.max`, shorthand `buffer: '2mb'`) — each take `2 * 1024 * 1024` or
 `'2mb'`; the two **chars** envelopes — trace's `body` (`TraceBodyOptions.chars`,
 shorthand `body: 2048`) and `stream`'s `buffer` (`StreamBufferOptions.chars`, shorthand
-`buffer: 4_000_000`) — take a bare count, never a token. `parseBytes` is exported from
+`buffer: 4_000_000`) — take a bare count, never a token. `size` is exported from
 `stitchapi` so a peer package parses the grammar instead of mirroring it.
 
 Enforced by lint **R9** (§7), together with P17 — one rule, one gate, both directions: a
 `max` that takes only `number` and a `chars` that took a `string` are the same finding
 seen from either end. R9 pins the **type**; the other half of the rule — that the value
-reaches `parseBytes`/`parseDuration` before it is compared or slept on — is dataflow, and
+reaches `size.parse`/`duration.parse` before it is compared or slept on — is dataflow, and
 is pinned by test instead.
 
 ---
@@ -954,6 +974,33 @@ against both — the findings sit at the end of the list:
   Everything else the sweep touched was already conformant, and the R9 baseline is
   **zero** — the one match was fixed at the source rather than baselined, the same call
   the P24/R8 addition made.
+
+- **P17/P25 (the encode direction, 2026-08-16)** — both rules named a **parser** and
+  stopped there, which was the whole contract for as long as the only consumer of a token
+  was the engine reading config. Making the grammars public (#746) changed who else needs
+  them: a peer package that parses an authored value the way core does will eventually
+  want to _write_ one back — a CLI printing the cap it enforced, a config round-trip, an
+  error message quoting a limit in the grammar the author used — and had nothing to call.
+  Every such caller would hand-roll an encoder, which is the drift the export existed to
+  prevent, running in the opposite direction. **Fixed** (`parseDuration`/`parseBytes`/
+  `parseRate` replaced by `duration`/`size`/`rate` namespaces, each a `parse`/`format`
+  pair, following `bytes`'s shape rather than adding three more verb-prefixed names to the
+  barrel). Hard break, no alias ([P19](#p19--the-alias-obligation-is-scoped-to-the-ga-channel),
+  `rc` channel); the old names are pinned **absent** in `public-api-surface.spec.ts` so an
+  alias cannot drift back and leave two spellings of one call.
+  _Why not the `ms(…)` one-function overload it resembles:_ `ms` and `bytes` switch on the
+  argument's type — a string decodes, a number encodes. That inversion is unavailable here,
+  because the number arm is already load-bearing in the other direction: P17/P25 widen every
+  authored field to `number | string`, and each read site funnels it through the parser, so
+  `parse(5_000)` **must** return `5_000`. An overload would have broken every call site core
+  makes of its own rule. The explicit pair is the half of those libraries' contract that
+  survives the constraint.
+  _Why `format` is exact where `ms` rounds:_ `ms(90_000)` is `'2m'`, which parses back to
+  120_000. A 33% widening is harmless in a log line and disqualifying in anything that writes
+  a value back — and P25's "a typo can never widen a cap" only holds if the encode direction
+  cannot widen one either. Pinned as a round-trip **property** over the whole numeric range in
+  `parsers-properties.spec.ts`, not a table of pretty cases, and verified non-vacuous by
+  reintroducing `ms`-style rounding and watching all three properties fail.
 
 Everything else this section once listed has **shipped** and moved to the record below —
 the cross-package `StitchStore`/`StitchLike`/`RequestSeam` clashes (qualified per-framework
@@ -1260,7 +1307,7 @@ shape, not as today's surface: nothing on the surface carries an alias.
 - Deferred to a type-aware phase (needs the TS checker, not regex): full
   same-name-different-**shape** detection, default-value inversion (P8), and the
   **parse half** of P17/P25 — R9 pins the type, but whether the widened value actually
-  reaches `parseDuration`/`parseBytes` before a sleep or comparison is dataflow, and a
+  reaches `duration.parse`/`size.parse` before a sleep or comparison is dataflow, and a
   widened type over an unparsed read site is the silent-collapse bug (#609); the parse
   is pinned behaviourally by test instead. Tracked as comments in the lint. R8, R9 and R10
   are also source-text-only in a second sense — they scan exported `interface` bodies,

--- a/docs/adr/0023-a-rate-is-a-minimum-spacing.md
+++ b/docs/adr/0023-a-rate-is-a-minimum-spacing.md
@@ -1,6 +1,12 @@
 # ADR 0023 — A rate is a minimum spacing, not a window budget; the two limiters must agree before the grammar grows
 
 - **Status:** Accepted and implemented (2026-08-04) — Decision 2 landed as shape **(a)**, and Decision 3's extension landed behind it in the same PR, in that order. Decision 1 ratifies existing behaviour, Decision 4 is a decision not to change anything, and Decision 5 shipped with [#618](https://github.com/rejifald/StitchAPI/pull/618). All four open questions resolved; implementing surfaced two defects this ADR had not predicted, recorded under _Found while implementing_. Opened by the question "does the P17/P25 `number | string` widening extend to a rate?" (#618); the answer is no, but establishing why surfaced a live defect in the store-backed limiter that this ADR treated as the blocking issue. Touches the pluggable store ([DESIGN.md §13](../DESIGN.md), which has no ADR of its own) and builds on [ADR 0010](./0010-injectable-clock.md) (the injectable `Clock`, whose tags already include `throttle` — the fix's tests need it).
+- **Renamed, not revisited (2026-08-16):** every decision below stands unchanged; only the
+  spelling moved. `parseRate` is now `rate.parse`, and the grammar gained an inverse,
+  `rate.format({ count, per })`, when the three house token parsers became `parse`/`format`
+  namespace pairs (CONTRACT.md §6). Decision 3's "the denominator is a `parseDuration` token"
+  reads `duration.parse` today. The prose and snippets below are left as the 2026-08-04
+  record; `packages/core/src/util.ts` is the current spelling.
 - **Date:** 2026-08-04
 - **Tags:** resilience, throttle, store, api-surface, correctness, P1, P12, P16, P17, P25
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -120,7 +120,7 @@ No server, no codegen, no config files, no implicit inheritance — **only expli
 - **CLI, HTTP & MCP surfaces** - the definition your code imports is also runnable from the shell (`stitch run <name>` streams JSONL events), served over HTTP (`stitch serve`), or exposed to agents over MCP (`stitch mcp`) — the same stitch behind every front door.
 - **Typed URLs** - full [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) URI templates (`{id}`, `{+path}`, `{?q,sort}`, explode `*`, prefix `:n`), and a `qs`-style query builder that serializes nested objects (`a[b]=c`) and arrays — both dependency-free.
 - **Pluggable transport** - `fetch` by default; drop in the shipped `axiosAdapter`, or any `Adapter` function, to route requests through axios or another HTTP client.
-- **Zero runtime dependencies** - `"dependencies": {}`; built on the platform's global `fetch`; tree-shakeable. The whole entry is **~24 kB min+gzip**; a typical `import { stitch }` trims to **~22 kB** — and with no transitive tree, that is the entire cost.
+- **Zero runtime dependencies** - `"dependencies": {}`; built on the platform's global `fetch`; tree-shakeable. The whole entry is **~25 kB min+gzip**; a typical `import { stitch }` trims to **~22 kB** — and with no transitive tree, that is the entire cost.
 
 ## Documentation
 
@@ -162,7 +162,7 @@ const { stitch } = require("stitchapi");
 
 The runtime ships with zero dependencies. Schema validation is bring-your-own — pass a [Zod](https://zod.dev) schema or any [Standard Schema](https://standardschema.dev) validator ([Valibot](https://valibot.dev), [ArkType](https://arktype.io), …); none of them is bundled. The examples below use Zod for familiarity.
 
-**Bundle size.** The whole `stitchapi` entry is **~24 kB minified + gzipped** (66 kB raw, ~22 kB brotli); because the package is side-effect-free and every surface beyond `http` lives behind its own subpath import, a typical `import { stitch }` tree-shakes to **~22 kB min+gzip**. With zero dependencies, that is the _whole_ cost — there is no transitive tree to install or audit.
+**Bundle size.** The whole `stitchapi` entry is **~25 kB minified + gzipped** (66 kB raw, ~22 kB brotli); because the package is side-effect-free and every surface beyond `http` lives behind its own subpath import, a typical `import { stitch }` tree-shakes to **~22 kB min+gzip**. With zero dependencies, that is the _whole_ cost — there is no transitive tree to install or audit.
 
 ## Quick start
 

--- a/packages/core/scripts/bundle-size.mjs
+++ b/packages/core/scripts/bundle-size.mjs
@@ -348,19 +348,55 @@ const KB = 1024;
 // this change lands on the far side of it — the eight-site propagation the first revision of this
 // PR proposed had already happened by the time it landed. Verified with the
 // `bundle-advertised-size` tether, not assumed.
+// Budgets raised for the token grammars' encode direction (24.25→24.80 / 21.70→22.00 KB; measured
+// 24.59 / 21.82 against a `main` at 24.18 / 21.62, so the capability is +0.41 / +0.20). The three
+// house grammars became `parse`/`format` namespace pairs (`duration`, `size`, `rate`, replacing
+// `parseDuration`/`parseBytes`/`parseRate` — CONTRACT.md §6). Making them public gave them callers
+// who need to WRITE a token, not only read one, and every such caller would otherwise hand-roll an
+// encoder — the drift the export exists to prevent, running backwards.
+//
+// The bytes are the encoder itself: `formatScaled` (the shared largest-exact-and-readable unit
+// walk), `decimals`, and the three `format` bodies with their unit tables. It cannot move behind a
+// subpath without splitting a pair that only makes sense together — `duration.parse` on the root
+// and `duration.format` on a subpath is the API this change exists to stop being.
+//
+// Two thirds of the naive cost was recovered rather than budgeted for, both measured, not assumed:
+//   • the internals call the plain `parseDuration`/`parseBytes`/`parseRate` functions and the
+//     public `duration`/`size`/`rate` objects are a thin facade over them, so a consumer's bundle
+//     is not routed through the namespace and the encoder can shake out (auth 5.44→5.22, back to
+//     ITS baseline and inside the unchanged 5.35 ceiling; `import { stitch }` 21.94→21.82);
+//   • each `format`'s unit table lives INSIDE the function. At module scope the minifier merges
+//     adjacent tables into one `var` statement, where the parse-side lookup being live pinned the
+//     encoder's table for every consumer of `stitch`. Deriving one table from the other with
+//     `Object.fromEntries` measured worse still, for the same reason.
+//
+// What is left on the `import { stitch }` path is ~0.1 KB: `formatDuration` is referenced by the
+// `duration` facade object, whose other half (`parse`) is live on that path, and esbuild will not
+// split an object literal to drop the dead half. Shaking it would mean not shipping the pair as an
+// object, which is the shape of the API. Recorded because it is a real cost of the namespace form,
+// not an oversight — a consumer who never formats a duration still carries the formatter.
+//
+// The ADVERTISED whole-entry figure MOVES: 25183 B is 24.59 KB, which rounds to 25 where `main`'s
+// 24.18 rounded to 24, so every site quoting it goes ~24 → ~25 kB. Six sites under the
+// `bundle-advertised-size` tether — both READMEs, the installation and principles pages, the
+// home-page metrics component, and the docs' own source blurb. `import { stitch }` is unchanged at
+// 22 (21.82 rounds the same way 21.62 did). Verified against the tether rather than assumed.
+//
+// The conventional ~0.2 KB step, not a minimum one: this is a new capability on the public
+// surface, not a fix squeezing past a ceiling. Headroom lands at 0.21 / 0.18.
 // `advertised: true` means the READMEs/docs quote this scenario's rounded gzip kB — see the
 // `--json` note below for why that flag, not the row's presence, drives the drift tether.
 const SCENARIOS = [
     {
         name: 'stitchapi — whole entry',
         code: `export * from './index.mjs';`,
-        budget: 24.25 * KB,
+        budget: 24.8 * KB,
         advertised: true,
     },
     {
         name: 'import { stitch }',
         code: `export { stitch } from './index.mjs';`,
-        budget: 21.7 * KB,
+        budget: 22.0 * KB,
         advertised: true,
     },
     {

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -574,7 +574,7 @@ function traceCommand(args: string[], io: CliIO): number {
 
     let cutoff: number | undefined;
     if (since !== undefined) {
-        // Shared duration grammar (util.parseDuration): "500ms" | "45s" | "30m" | "1h" | "2d",
+        // Shared duration grammar (util.duration.parse): "500ms" | "45s" | "30m" | "1h" | "2d",
         // or a bare number of milliseconds.
         const sinceMs = parseDuration(since);
         if (sinceMs === undefined) {

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -823,7 +823,7 @@ async function* attemptLoop(
                 };
                 await cfg.hooks?.onRetry?.({ name: nameOf(cfg), attempt, res });
                 await sleepWithin(
-                    // `parseDuration`, not the raw value: `after` is authored by a surface, so it
+                    // `duration.parse`, not the raw value: `after` is authored by a surface, so it
                     // takes the house duration form (`500`, `'5s'`) like every other authored
                     // duration. An unparseable value falls through to the computed backoff.
                     parseDuration(outcome.after) ??

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,19 +63,28 @@ export { memoryStore } from './store';
 // The default Clock (ADR 0010) — wall-clock + global timers. Inject a custom `Clock` (or a
 // `manualClock()` from `stitchapi/testing`) via a stitch/seam `clock` to control time.
 export { systemClock } from './util';
-// The one shared duration parser (CONTRACT.md P17): `5_000`, `'5s'`, `'1m'` → ms.
-// Exported so a peer package that takes a consumer-authored duration parses it the
-// same way core does, instead of mirroring the grammar and drifting from it.
-export { parseDuration } from './util';
-// Its size analogue: `4096`, `'64kb'`, `'1mb'` → bytes (powers of 1024). Same reason it is
-// public — a peer package with a `*Bytes` cap parses it the way core does. NOT for the
-// `Chars` family, which counts UTF-16 code units rather than bytes.
-export { parseBytes } from './util';
-// The third house token grammar: `'2/s'`, `'10/m'` → `{ count, per }` (window length in ms).
+// The three house token grammars, one namespace each, every one a `parse`/`format` pair. The
+// shape is `bytes`'s (`bytes.parse` / `bytes.format`): one name per dimension, the direction
+// named at the call site, rather than a barrel of six verb-prefixed functions. `format` is the
+// EXACT inverse of `parse` — `parse(format(v))` returns `v` unchanged, never a rounded
+// approximation the way `ms(90_000)` → `'2m'` does — so a value may be encoded and read back.
+//
+// `duration` (CONTRACT.md P17): `5_000`, `'5s'`, `'1m'` → ms, and `90_000` → `'1.5m'`.
+// Exported so a peer package that takes a consumer-authored duration parses it the same way
+// core does, instead of mirroring the grammar and drifting from it.
+export { duration } from './util';
+// `size` (CONTRACT.md P25), the size analogue: `4096`, `'64kb'`, `'1mb'` → bytes (powers of
+// 1024), and `1536` → `'1.5kb'`. Same reason it is public — a peer package with a byte cap
+// parses it the way core does. NOT for the `Chars` family, which counts UTF-16 code units
+// rather than bytes; the old `parseBytes` name carried that warning and this one does not, so
+// it is stated on the namespace's own JSDoc instead.
+export { size } from './util';
+// `rate` (ADR 0023): `'2/s'`, `'10/m'` → `{ count, per }` (window length in ms), and back.
 // Public for the same reason as the two above — a peer package with an authored rate (a
-// distributed limiter) parses it the way core does. It THROWS on a bad token where those two
-// fall back, because `undefined` for a rate means "unlimited": see its JSDoc.
-export { parseRate } from './util';
+// distributed limiter) parses it the way core does. Its `parse` THROWS on a bad token where
+// those two fall back, because `undefined` for a rate means "unlimited": see its JSDoc.
+export { rate } from './util';
+export type { Rate } from './util';
 // `compact({ ...obj, key: value })` — a shallow copy with `undefined`-valued keys removed, typed so
 // undefined-admitting keys come back optional. Pairs with `exactOptionalPropertyTypes`: it omits an
 // absent optional without the `...(key !== undefined ? { key } : {})` spread dance.

--- a/packages/core/src/resilience.ts
+++ b/packages/core/src/resilience.ts
@@ -105,8 +105,8 @@ export function createThrottle(
     release(key: string): void;
 } {
     const limit = opts?.concurrency;
-    const rate = opts?.rate ? parseRate(opts.rate) : undefined;
-    const spacing = rate ? rate.per / rate.count : 0; // ms between grants
+    const paced = opts?.rate ? parseRate(opts.rate) : undefined;
+    const spacing = paced ? paced.per / paced.count : 0; // ms between grants
     const hostPooled = opts?.pool === 'host';
     const states = hostPooled ? hostStates : new Map<string, KeyState>();
 

--- a/packages/core/src/serve.ts
+++ b/packages/core/src/serve.ts
@@ -43,7 +43,7 @@ export interface ServeBodyOptions {
     /**
      * Ceiling on the buffered request body; past it the request is rejected with 413. A raw byte
      * count or a size token — `4 * 1024 * 1024` or `'4mb'` (powers of 1024), parsed by the shared
-     * {@link parseBytes}. An unparseable token falls back to the default cap, never to
+     * {@link size}. An unparseable token falls back to the default cap, never to
      * "unbounded". Default {@link MAX_REQUEST_BODY_BYTES}.
      */
     max?: number | string;

--- a/packages/core/src/stitch.ts
+++ b/packages/core/src/stitch.ts
@@ -218,7 +218,7 @@ function expandShorthand(cfg: Partial<StitchConfig>): void {
     //
     // **And the fold is where an unusable curve dies** (issue #651 §3), on the value it just
     // produced — `bad backoff`, the same slot-named message and the same construction-time timing
-    // `parseRate` has for an unparseable `throttle.rate`. Silently degrading a resilience
+    // `rate.parse` has for an unparseable `throttle.rate`. Silently degrading a resilience
     // policy is the one place a fallback is worse than a crash, and this one degraded in the
     // PERMISSIVE direction: `backoff: () => 6000` cast past its type folded to `{ curve: <fn> }`,
     // matched neither branch of `backoffDelay`, and walked the plain `expo` curve on the default
@@ -245,7 +245,7 @@ function expandShorthand(cfg: Partial<StitchConfig>): void {
         //   • `'expo-jitter'` FIRST, so the `'expo'` literal after it compresses as a
         //     back-reference into the one already emitted (4 B; alphabetising costs them back);
         //   • a `!==` chain rather than `['expo', …].includes(…)` (the array measured 4 B worse);
-        //   • a message with no interpolated value (5 B). `parseRate` can afford `bad rate: ${r}`
+        //   • a message with no interpolated value (5 B). `rate.parse` can afford `bad rate: ${r}`
         //     and this cannot — the offending value is in the caller's own `stitch({…})` literal,
         //     which is the one consolation. Restore it the moment the budget has room.
         if (

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -221,7 +221,7 @@ export function createStoreThrottle(
     clock: Clock = systemClock,
 ): Throttle {
     const limit = opts?.concurrency;
-    const rate = opts?.rate ? parseRate(opts.rate) : undefined;
+    const paced = opts?.rate ? parseRate(opts.rate) : undefined;
     // The lease pair is all-or-nothing (ADR 0025); resolved once so the hot path is one check.
     const leases =
         store.lease && store.release
@@ -313,8 +313,8 @@ export function createStoreThrottle(
                 if (blocked) waited = clock.now() - blockStart;
             }
         }
-        if (rate) {
-            const spacing = rate.per / rate.count; // ms between grants
+        if (paced) {
+            const spacing = paced.per / paced.count; // ms between grants
             if (store.reserve) {
                 // The GCRA cell (ADR 0024). One atomic read-compute-write over a shared cursor
                 // gives the fleet what neither half of the fallback below can: the cursor carries
@@ -329,7 +329,7 @@ export function createStoreThrottle(
                     `rl:${key}`,
                     spacing,
                     clock.now(),
-                    rate.per + 100,
+                    paced.per + 100,
                 );
                 const wait = at - clock.now();
                 if (wait > 0) {
@@ -347,7 +347,7 @@ export function createStoreThrottle(
             // scheduled at windowStart + (N-1)·spacing. Slot count+1 lands exactly at the next
             // windowStart, so grants stay one `spacing` apart across the boundary — no fixed-window
             // burst. No re-check loop: each caller owns a distinct, non-colliding slot.
-            const windowStart = Math.floor(clock.now() / rate.per) * rate.per;
+            const windowStart = Math.floor(clock.now() / paced.per) * paced.per;
             // Track the window we minted a key for; when it rolls over, DELETE the previous
             // window's `rl:` key eagerly instead of waiting for its TTL to expire (the store's
             // own sweep is opportunistic). Without this, a long-lived rate-limited seam leaves a
@@ -358,7 +358,7 @@ export function createStoreThrottle(
             s.lastWindow = windowStart;
             const n = await store.increment(
                 `rl:${key}:${windowStart}`,
-                rate.per + 100,
+                paced.per + 100,
             );
             // The slot is a FLOOR on the grant, not the grant time itself. A process that joins
             // mid-window finds every slot up to `n` already scheduled in the PAST, and granting

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1124,9 +1124,9 @@ export interface ThrottleOptions {
      * A minimum spacing between successive calls (`interval / count`, applied before any request
      * leaves), not a token bucket. The dominant field: a bare string is the P12 shorthand for
      * `{ rate }` (`throttle: '2/s'` ≡ `throttle: { rate: '2/s' }`). The grammar is
-     * `<count>/<duration>` with a POSITIVE INTEGER count and any {@link parseDuration} token for
+     * `<count>/<duration>` with a POSITIVE INTEGER count and any {@link duration} token for
      * the denominator, where a bare unit means one of that unit (`'2/s'` ≡ `'2/1s'`) — read by
-     * the shared {@link parseRate}.
+     * the shared {@link rate}.
      *
      * Because it paces rather than buckets, the only thing it reads is the **ratio**: `'2/500ms'`,
      * `'4/s'` and `'240/m'` all declare a 250ms gap and are the same limiter, in-process and
@@ -1141,7 +1141,7 @@ export interface ThrottleOptions {
      * P15/P20 exist to reject. `'2/s'` is not the sugar form of a number here; it IS the value.
      *
      * An unparseable token **throws** at construction rather than falling back to "no limit" —
-     * the one place a house parser fails loud, for the reason spelled out on {@link parseRate}.
+     * the one place a house parser fails loud, for the reason spelled out on {@link rate}.
      * That covers both degenerate ends of the range too, since each would also mean no limit: a
      * zero count, and a spacing past the ~24.8-day timer ceiling.
      */

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -81,12 +81,91 @@ export const systemClock: Clock = {
     },
 };
 
+// ---- house token grammars (CONTRACT.md P17/P25, ADR 0023) ------------------
+// Three dimensions a consumer can author as a token — a duration, a size, a rate — each
+// exposed as one namespace with a `parse`/`format` pair rather than a bare parser. The
+// shape is `bytes`'s (`bytes.parse` / `bytes.format`): one name per dimension, the
+// direction named at the call site. Both directions are public because a peer package
+// that takes an authored value should parse it the way core does instead of mirroring
+// the grammar and drifting from it, and a tool that shows one back — a CLI table, a
+// config round-trip, an error message quoting the cap it enforced — should print it in
+// the same grammar the consumer wrote.
+//
+// **`format` is the exact inverse of `parse`, never an approximation.** For every value
+// each `parse` can produce, `parse(format(v))` returns that value unchanged — pinned as a
+// property in `parsers-properties.spec.ts`. This is where the house pair departs from
+// `ms`, whose `ms(90_000)` rounds to `'2m'` and does not survive a round-trip: a lossy
+// encode is fine for a log line and wrong for anything that writes a value back, and P25's
+// "a typo can never widen a cap" only holds if the encode direction cannot widen one either.
+//
+// Exactness alone would still allow unreadable output — `1537 / 1024` is `1.5009765625`,
+// which multiplies back exactly and is useless to a reader. So a unit is used only when the
+// quotient is BOTH exact and short (at most `MAX_UNIT_DECIMALS` decimal places); otherwise
+// the next smaller unit is tried, down to the base unit (`ms` / `b`), where the quotient is
+// the value itself and both tests always pass. `1537` formats as `'1537b'`, not `'1.5009765625kb'`.
+
+/** Decimal places a unit-scaled quotient may carry before the next smaller unit is preferred. */
+const MAX_UNIT_DECIMALS = 2;
+
+/** Decimal places in a number's canonical string form; `0` for an integer or exponential form. */
+function decimals(n: number): number {
+    const s = String(n);
+    const dot = s.indexOf('.');
+    return dot === -1 ? 0 : s.length - dot - 1;
+}
+
 /**
- * Parse a duration into milliseconds. Grammar: a number (already ms), a numeric
- * string (`"1500"` → 1500), or `<number><unit>` with unit `ms` | `s` | `m` | `h` | `d`
- * (`"500ms"`, `"30s"`, `"2m"`, `"1h"`, `"2d"`; fractions like `"1.5s"` allowed).
- * Anything else → `undefined`.
+ * The shared encode step for the two magnitude grammars. Walks `units` largest-scale first and
+ * returns the first `<quotient><unit>` whose quotient is short enough to read, re-parses to the
+ * exact input under `rescale` (the arithmetic that grammar's `parse` performs — a plain multiply
+ * for durations, a multiply-then-floor for sizes), and matches the `\d+(\.\d+)?` the grammar
+ * accepts. That last test is what keeps exponential forms out: `String(1e-7)` is `'1e-7'`, which
+ * no unit pattern matches.
+ *
+ * Returns `undefined` when no unit fits, which happens only for a negative value (no grammar's
+ * unit pattern admits a sign) or an exponential-form magnitude. Callers fall back to the bare
+ * numeric token both grammars accept — with `0` carved out, since `Number('0') || undefined` is
+ * `undefined` and a bare `'0'` is the one integer that does NOT survive the round-trip.
  */
+function formatScaled(
+    n: number,
+    units: readonly (readonly [string, number])[],
+    rescale: (q: number, scale: number) => number,
+): string | undefined {
+    for (const [unit, scale] of units) {
+        if (n < scale) continue;
+        const q = n / scale;
+        if (decimals(q) > MAX_UNIT_DECIMALS) continue;
+        const s = String(q);
+        if (!/^\d+(?:\.\d+)?$/.test(s)) continue;
+        if (rescale(q, scale) !== n) continue;
+        return `${s}${unit}`;
+    }
+    return undefined;
+}
+
+// The decode-side scale lookup. Its encode-side counterpart — the same numbers as an ordered
+// largest-first list — lives INSIDE `formatDuration` rather than beside this, and the duplication
+// is deliberate: measured, the tidier arrangements both cost bundle size on the parse-only path
+// that every consumer of `stitch` is on. Deriving one from the other (`Object.fromEntries`) welds
+// them into one live reference; declaring them as adjacent module-scope tables lets the minifier
+// merge them into a single `var` statement, where this lookup being live pins the encoder's table
+// too. Split across a function boundary, neither reaches a bundle that never formats. Same shape
+// of trade ADR 0024's budget note records for the throttle's wait/sleep tail — the repetition is
+// the cheaper half, and it is measured rather than assumed.
+//
+// Hoisted out of the function body, though: the `parseDuration` this replaced rebuilt its scale
+// object on every single call, and unlike `format`, `parse` is on the hot path.
+const DURATION_SCALE: Record<string, number> = {
+    ms: 1,
+    s: 1000,
+    m: 60_000,
+    h: 3_600_000,
+    d: 86_400_000,
+};
+
+/** Decode half of {@link duration}; the namespace carries the contract. Internal — the
+ * barrel exports the pair, not this. */
 export function parseDuration(
     d: number | string | undefined,
 ): number | undefined {
@@ -95,31 +174,56 @@ export function parseDuration(
     const m = /^(\d+(?:\.\d+)?)\s*(ms|s|m|h|d)$/.exec(d.trim());
     if (!m) return Number(d) || undefined;
     const n = parseFloat(m[1] ?? '');
-    const scale: Record<string, number> = {
-        ms: 1,
-        s: 1000,
-        m: 60_000,
-        h: 3_600_000,
-        d: 86_400_000,
-    };
-    return n * (scale[m[2] ?? ''] ?? 1);
+    return n * (DURATION_SCALE[m[2] ?? ''] ?? 1);
+}
+
+/** Encode half of {@link duration}; the namespace carries the contract. Internal — the
+ * barrel exports the pair, not this. */
+export function formatDuration(ms: number): string {
+    if (!Number.isFinite(ms))
+        throw new TypeError(`bad duration: ${ms} is not a finite number of ms`);
+    if (ms === 0) return '0ms';
+    // Declared HERE, not at module scope. Minified, adjacent module-scope tables merge into one
+    // `var` statement, and one used declarator in it (the parse-side lookup, which every consumer
+    // of `stitch` reaches) pins the rest — so a parse-only bundle was carrying both unit tables.
+    // Inside the function they exist only when the encoder does. `format` is a display path, not
+    // a hot one, so the per-call literal costs nothing that matters.
+    const units = [
+        ['d', 86_400_000],
+        ['h', 3_600_000],
+        ['m', 60_000],
+        ['s', 1000],
+        ['ms', 1],
+    ] as const;
+    // A duration's `parse` multiplies and nothing else, so the exactness test is the multiply.
+    return formatScaled(ms, units, (q, scale) => q * scale) ?? String(ms);
 }
 
 /**
- * Parse a size into bytes — the size analogue of {@link parseDuration}. Grammar: a number
- * (already bytes), a numeric string (`"4096"` → 4096), or `<number><unit>` with unit
- * `b` | `kb` | `mb` | `gb` | `tb` (`"512b"`, `"64kb"`, `"1mb"`, `"1.5gb"`; case-insensitive,
- * fractions allowed). Anything else → `undefined`.
+ * The one house duration grammar (CONTRACT.md P17), in both directions.
  *
- * Units are **powers of 1024** — `"1mb"` is 1_048_576, the npm-`bytes` convention every
- * Node config parser in the ecosystem already speaks (CONTRACT.md P22) and the base the
- * house defaults are written in (`10 * 1024 * 1024`). The IEC spellings `kib` | `mib` |
- * `gib` | `tib` are accepted for the same values, for callers who want the base explicit.
+ * `duration.parse` takes a number (already ms), a numeric string (`'1500'` → 1500), or
+ * `<number><unit>` with unit `ms` | `s` | `m` | `h` | `d` (`'500ms'`, `'30s'`, `'2m'`, `'1h'`,
+ * `'2d'`; fractions like `'1.5s'` allowed). Anything else → `undefined`, which lands the field
+ * on its default — a typo can never widen a cap to "unbounded".
  *
- * Only for fields that count **bytes**. The `Chars` family (`stream.buffer.chars`,
- * `trace.body.chars`) counts UTF-16 code units of decoded text, where a byte token would
- * be a category error — that distinction is what the `Bytes`/`Chars` suffixes carry (P1).
+ * `duration.format` is its exact inverse: `duration.parse(duration.format(ms)) === ms` for every
+ * finite `ms`. It picks the largest unit that stays exact and readable, so `90_000` is `'1.5m'`
+ * and `90_001` — which no unit divides cleanly — is `'90001ms'` rather than a rounded `'2m'`.
+ *
+ * **Encoding is for values a consumer will read or re-author, not for emitted ones.** P17's
+ * complement holds: a duration core *produces* — a `StitchEvent` field, a `*Result`, a value
+ * passed into a consumer-implemented contract — stays a raw-ms `number` and never grows a string
+ * arm. Formatting one for a CLI table or an error message is display; writing one into an emitted
+ * field is a P17 violation this pair cannot see and will not stop.
  */
+export const duration = {
+    parse: parseDuration,
+    format: formatDuration,
+} as const;
+
+/** Decode half of {@link size}; the namespace carries the contract. Internal — the
+ * barrel exports the pair, not this. */
 export function parseBytes(s: number | string | undefined): number | undefined {
     if (s == null) return undefined;
     if (typeof s === 'number') return s;
@@ -132,61 +236,74 @@ export function parseBytes(s: number | string | undefined): number | undefined {
     return Math.floor(parseFloat(m[1] ?? '') * 1024 ** pow);
 }
 
+/** Encode half of {@link size}; the namespace carries the contract. Internal — the
+ * barrel exports the pair, not this. */
+export function formatBytes(bytes: number): string {
+    if (!Number.isFinite(bytes))
+        throw new TypeError(
+            `bad size: ${bytes} is not a finite number of bytes`,
+        );
+    if (bytes === 0) return '0b';
+    // A size's `parse` floors after scaling, so the exactness test must floor too — otherwise
+    // a quotient that scales back to `n + 0.0000001` would pass here and parse back to `n`
+    // anyway, and one that scales to `n - 0.0000001` would pass here and parse back to `n - 1`.
+    const units = [
+        ['tb', 1024 ** 4],
+        ['gb', 1024 ** 3],
+        ['mb', 1024 ** 2],
+        ['kb', 1024],
+        ['b', 1],
+    ] as const;
+    return (
+        formatScaled(bytes, units, (q, scale) => Math.floor(q * scale)) ??
+        String(bytes)
+    );
+}
+
+/**
+ * The size analogue (CONTRACT.md P25), in both directions.
+ *
+ * `size.parse` takes a number (already bytes), a numeric string (`'4096'` → 4096), or
+ * `<number><unit>` with unit `b` | `kb` | `mb` | `gb` | `tb` (`'512b'`, `'64kb'`, `'1mb'`,
+ * `'1.5gb'`; case-insensitive, fractions allowed). Anything else → `undefined`.
+ *
+ * Units are **powers of 1024** — `'1mb'` is 1_048_576, the npm-`bytes` convention every Node
+ * config parser in the ecosystem already speaks (CONTRACT.md P22) and the base the house
+ * defaults are written in (`10 * 1024 * 1024`). The IEC spellings `kib` | `mib` | `gib` | `tib`
+ * are accepted for the same values, for callers who want the base explicit; `format` emits the
+ * short spelling, since the two denote the same number and one canonical output beats a choice.
+ *
+ * `size.format` is the exact inverse: `size.parse(size.format(b)) === b` for every finite `b`.
+ * `1536` is `'1.5kb'`; `1537`, whose kb quotient is the unreadable-but-exact `1.5009765625`, is
+ * `'1537b'`.
+ *
+ * Only for fields that count **bytes**. The `Chars` family (`stream.buffer.chars`,
+ * `trace.body.chars`) counts UTF-16 code units of decoded text, where a byte token would be a
+ * category error — that distinction is what the `Bytes`/`Chars` suffixes carry (P1), and it is
+ * the one hazard this name no longer spells out the way the old `parseBytes` did.
+ */
+export const size = {
+    parse: parseBytes,
+    format: formatBytes,
+} as const;
+
 /**
  * `setTimeout` clamps any delay past the 32-bit signed ceiling to **1ms**, so a spacing beyond
  * this cannot be honoured — the limiter would run *unlimited* instead of very slowly. Rejected
- * at the grammar (see {@link parseRate}) rather than clamped: clamping would silently pace
- * FASTER than asked, which is the direction that hurts.
+ * at the grammar (see {@link rate}) rather than clamped: clamping would silently pace FASTER
+ * than asked, which is the direction that hurts.
  */
 const MAX_SPACING = 2_147_483_647;
 
-/**
- * Parse a rate into `{ count, per }` — the number of grants and the window length in ms.
- * Grammar: `<count>/<duration>` with a POSITIVE INTEGER count and a {@link parseDuration} token
- * for the denominator, where a **bare unit is its one-unit token** (`"2/s"` ≡ `"2/1s"`); so
- * `"2/s"`, `"10/m"`, `"1000/h"`, `"100/15m"` and `"2/500ms"` all parse, and whitespace around
- * the slash is tolerated. The third house token grammar, alongside {@link parseDuration} and
- * {@link parseBytes}, and exported for the same reason: a peer package that takes an authored
- * rate parses it the way core does instead of mirroring it.
- *
- * The denominator is a duration, so it uses the one house duration grammar (CONTRACT.md P17)
- * rather than a scale table of its own — which is what the old `ms|s|m` was, a hand-copied
- * subset that left the value space with holes. An ordinary 1000/hour quota is a 3600ms spacing,
- * and before ADR 0023 Decision 3 **no legal token denoted it**: `60000/count = 3600` needs a
- * fractional count, and counts are integers.
- *
- * **`"2/500ms"` ≡ `"4/s"` ≡ `"240/m"`, and that is the design, not an approximation.** A rate
- * declares a minimum spacing, not a bucket — there is no capacity parameter for the window
- * length to set — so any two rates with the same ratio ARE the same limiter, in-process and
- * store-backed alike. Pinned across three window lengths in `store.spec.ts`.
- *
- * **Unlike those two, an unparseable token THROWS rather than resolving to `undefined`.** The
- * divergence is deliberate, and it runs in the same direction as their fallback rather than
- * against it. For a cap, falling back to the field's default is the SAFE failure — the ceiling
- * stays where it was, which is why CONTRACT.md P25 can say a typo never widens a cap to
- * "unbounded". A rate has no safe fallback: `undefined` here means *no rate limit at all*, so
- * the quiet path is the unbounded one, and a fallback would let a typo silently REMOVE the
- * limit instead of narrowing it. Same goal, opposite mechanism, because the two value-spaces
- * fail in opposite directions. Both callers guard with a presence check, so an omitted `rate`
- * never reaches here — only a non-empty token that could not be read.
- *
- * **Failing loud is necessary and was not sufficient.** Three values sit inside what a looser
- * grammar would ACCEPT and each would silently mean *no limit at all* — the unbounded quiet
- * path reached through the accepting branch rather than the rejecting one — so each is rejected
- * explicitly:
- * - a **zero count** (`"0/s"`, once legal under `\d+`) → spacing `per / 0` = `Infinity`, which
- *   `setTimeout` clamps to 1ms: it read as "block everything" under an injected {@link Clock},
- *   where the test suite sees it, and was unlimited on the system clock;
- * - a **non-positive or non-finite window** (`"2/0s"`, `"2/-500"`) → `parseDuration` returns a
- *   real `0` / `-500` for those rather than `undefined`, and both limiters read `spacing <= 0`
- *   as "no pacing configured";
- * - a spacing past {@link MAX_SPACING} (`"1/30d"`) → the same `setTimeout` clamp as the first.
- *
- * A rate is a string and only a string (no `number | string` widening): it is two quantities,
- * not a magnitude, so a bare `2` would have to invent a default window to denote anything. See
- * CONTRACT.md P17/P25, which widen a magnitude that already carries a house unit — this has none.
- */
-export function parseRate(r: string): { count: number; per: number } {
+/** The `{ count, per }` a rate token denotes: grants per window, window length in ms. */
+export interface Rate {
+    count: number;
+    per: number;
+}
+
+/** Decode half of {@link rate}; the namespace carries the contract. Internal — the
+ * barrel exports the pair, not this. */
+export function parseRate(r: string): Rate {
     // Split on the first slash by hand rather than matching the whole token in one regex. A
     // single pattern for both halves wants `\s*\/\s*(.+)$`, whose trailing `\s*` and `.+` both
     // match a space — the overlap `js/polynomial-redos` flags on caller-supplied input.
@@ -198,7 +315,7 @@ export function parseRate(r: string): { count: number; per: number } {
     // free of the pattern and no harder to read — the same trade {@link stripTrailingSlashes}
     // takes one function below, where the quadratic behaviour IS real. Each half is now checked
     // by an anchored pattern over a bounded slice with nothing to backtrack across; `indexOf` +
-    // `slice` are linear, and `parseDuration` owns the denominator.
+    // `slice` are linear, and `duration.parse` owns the denominator.
     const t = r.trim();
     const slash = t.indexOf('/');
     if (slash === -1) throw new Error(`bad rate: ${r}`);
@@ -206,12 +323,12 @@ export function parseRate(r: string): { count: number; per: number } {
     if (!/^[1-9]\d*$/.test(head)) throw new Error(`bad rate: ${r}`);
     const count = parseInt(head, 10);
     const denom = t.slice(slash + 1).trim();
-    // A bare unit is the one-unit token: `'s'` ≡ `'1s'`. Anything else goes to `parseDuration`
+    // A bare unit is the one-unit token: `'s'` ≡ `'1s'`. Anything else goes to `duration.parse`
     // as written, so `'500ms'`, `'15m'` and the raw-ms `'500'` all mean what they mean everywhere.
-    const per = parseDuration(
+    const per = duration.parse(
         /^(?:ms|s|m|h|d)$/.test(denom) ? `1${denom}` : denom,
     );
-    // `parseDuration` resolves a bad token to `undefined`, but also parses `'0s'` to a real 0 and
+    // `duration.parse` resolves a bad token to `undefined`, but also parses `'0s'` to a real 0 and
     // `'-500'` through its numeric-string arm — both of which would disable pacing rather than
     // fail, so the window is checked here rather than trusted.
     if (per === undefined || !Number.isFinite(per) || per <= 0)
@@ -222,6 +339,90 @@ export function parseRate(r: string): { count: number; per: number } {
         );
     return { count, per };
 }
+
+/** Encode half of {@link rate}; the namespace carries the contract. Internal — the
+ * barrel exports the pair, not this. */
+export function formatRate(r: Rate): string {
+    const { count, per } = r;
+    if (!Number.isInteger(count) || count < 1)
+        throw new Error(
+            `bad rate: a count of ${count} is not a positive integer`,
+        );
+    if (!Number.isFinite(per) || per <= 0)
+        throw new Error(`bad rate: a window of ${per}ms is not positive`);
+    if (per / count > MAX_SPACING)
+        throw new Error(
+            `bad rate: a spacing of ${per / count}ms is past the ${MAX_SPACING}ms timer ceiling`,
+        );
+    // The denominator is a duration token, so the one duration encoder writes it. A window of
+    // exactly one unit drops the `1` — `parse` reads a bare unit as its one-unit token, so
+    // `'2/s'` and `'2/1s'` are the same rate and the shorter is the one the docs and the house
+    // defaults are written in.
+    const window = duration.format(per);
+    return `${count}/${window.replace(/^1(?=[a-z])/, '')}`;
+}
+
+/**
+ * The third house token grammar, in both directions: a rate as `{ count, per }` — the number of
+ * grants and the window length in ms.
+ *
+ * `rate.parse` takes `<count>/<duration>` with a POSITIVE INTEGER count and a {@link duration}
+ * token for the denominator, where a **bare unit is its one-unit token** (`'2/s'` ≡ `'2/1s'`); so
+ * `'2/s'`, `'10/m'`, `'1000/h'`, `'100/15m'` and `'2/500ms'` all parse, and whitespace around the
+ * slash is tolerated. Public for the same reason as the two above — a peer package that takes an
+ * authored rate (a distributed limiter) parses it the way core does.
+ *
+ * The denominator is a duration, so it uses the one house duration grammar (CONTRACT.md P17)
+ * rather than a scale table of its own — which is what the old `ms|s|m` was, a hand-copied
+ * subset that left the value space with holes. An ordinary 1000/hour quota is a 3600ms spacing,
+ * and before ADR 0023 Decision 3 **no legal token denoted it**: `60000/count = 3600` needs a
+ * fractional count, and counts are integers.
+ *
+ * **`'2/500ms'` ≡ `'4/s'` ≡ `'240/m'`, and that is the design, not an approximation.** A rate
+ * declares a minimum spacing, not a bucket — there is no capacity parameter for the window
+ * length to set — so any two rates with the same ratio ARE the same limiter, in-process and
+ * store-backed alike. Pinned across three window lengths in `store.spec.ts`.
+ *
+ * `rate.format` is the exact inverse of the *pair*, not of the spacing: it returns the token for
+ * the `{ count, per }` it was handed, so `rate.parse(rate.format(r))` deep-equals `r`. It does
+ * **not** reduce the ratio to a canonical member of the equivalence class above — `{ count: 2,
+ * per: 500 }` formats as `'2/500ms'`, never as the equivalent `'4/s'`. Reducing would be a
+ * defensible other choice, but it would make the round-trip hold only up to equivalence, and
+ * `count` is the number the consumer wrote and the one an error message should quote back.
+ *
+ * **Unlike the two grammars above, an unparseable token THROWS rather than resolving to
+ * `undefined`.** The divergence is deliberate, and it runs in the same direction as their
+ * fallback rather than against it. For a cap, falling back to the field's default is the SAFE
+ * failure — the ceiling stays where it was, which is why CONTRACT.md P25 can say a typo never
+ * widens a cap to "unbounded". A rate has no safe fallback: `undefined` here means *no rate limit
+ * at all*, so the quiet path is the unbounded one, and a fallback would let a typo silently
+ * REMOVE the limit instead of narrowing it. Same goal, opposite mechanism, because the two
+ * value-spaces fail in opposite directions. Both callers guard with a presence check, so an
+ * omitted `rate` never reaches here — only a non-empty token that could not be read.
+ *
+ * **Failing loud is necessary and was not sufficient.** Three values sit inside what a looser
+ * grammar would ACCEPT and each would silently mean *no limit at all* — the unbounded quiet
+ * path reached through the accepting branch rather than the rejecting one — so each is rejected
+ * explicitly:
+ * - a **zero count** (`'0/s'`, once legal under `\d+`) → spacing `per / 0` = `Infinity`, which
+ *   `setTimeout` clamps to 1ms: it read as "block everything" under an injected {@link Clock},
+ *   where the test suite sees it, and was unlimited on the system clock;
+ * - a **non-positive or non-finite window** (`'2/0s'`, `'2/-500'`) → `duration.parse` returns a
+ *   real `0` / `-500` for those rather than `undefined`, and both limiters read `spacing <= 0`
+ *   as "no pacing configured";
+ * - a spacing past {@link MAX_SPACING} (`'1/30d'`) → the same `setTimeout` clamp as the first.
+ *
+ * `format` enforces the same three, so a `{ count, per }` that could not have come from `parse`
+ * is rejected at the encode step instead of producing a token that would throw on the way back in.
+ *
+ * A rate is a string and only a string (no `number | string` widening): it is two quantities,
+ * not a magnitude, so a bare `2` would have to invent a default window to denote anything. See
+ * CONTRACT.md P17/P25, which widen a magnitude that already carries a house unit — this has none.
+ */
+export const rate = {
+    parse: parseRate,
+    format: formatRate,
+} as const;
 
 /**
  * Strip any trailing `/` from a base URL. Done by hand rather than with `replace(/\/+$/, '')`:

--- a/packages/core/test/parsers-properties.spec.ts
+++ b/packages/core/test/parsers-properties.spec.ts
@@ -7,12 +7,7 @@
 // The expectations below are computed from scale tables restated independently of the
 // implementation, never by re-running its own arithmetic. A wrong exponent in `src/util.ts` has
 // to fail one of these rather than be mirrored by it.
-import {
-    parseBytes,
-    parseDuration,
-    parseRate,
-    stripTrailingSlashes,
-} from '../src/util';
+import { duration, rate, size, stripTrailingSlashes } from '../src/util';
 
 import fc from 'fast-check';
 
@@ -49,10 +44,10 @@ const magnitude = fc.integer({ min: 0, max: 1000 });
 // The parsers return `number | undefined`; every input generated here is inside the grammar, so
 // `undefined` is a failure. Folding it to NaN makes that failure loud in whichever assertion
 // follows instead of needing a non-null assertion at each call site.
-const bytes = (s: string): number => parseBytes(s) ?? Number.NaN;
-const ms = (s: string): number => parseDuration(s) ?? Number.NaN;
+const bytes = (s: string): number => size.parse(s) ?? Number.NaN;
+const ms = (s: string): number => duration.parse(s) ?? Number.NaN;
 
-describe('parseBytes (property)', () => {
+describe('size.parse (property)', () => {
     it('scales each unit by its documented power of 1024', () => {
         fc.assert(
             fc.property(
@@ -133,13 +128,13 @@ describe('parseBytes (property)', () => {
     it('passes a number through as already-bytes', () => {
         fc.assert(
             fc.property(fc.integer(), (n) => {
-                expect(parseBytes(n)).toBe(n);
+                expect(size.parse(n)).toBe(n);
             }),
         );
     });
 });
 
-describe('parseDuration (property)', () => {
+describe('duration.parse (property)', () => {
     it('scales each unit by its documented factor', () => {
         fc.assert(
             fc.property(magnitude, fc.constantFrom(...MS_UNITS), (n, unit) => {
@@ -186,14 +181,14 @@ describe('parseDuration (property)', () => {
     it('passes a number through as already-milliseconds', () => {
         fc.assert(
             fc.property(fc.integer(), (n) => {
-                expect(parseDuration(n)).toBe(n);
+                expect(duration.parse(n)).toBe(n);
             }),
         );
     });
 });
 
-describe('parseRate (property)', () => {
-    // A bare unit is its one-unit token, over the SAME unit set as `parseDuration` — `'2/h'` and
+describe('rate.parse (property)', () => {
+    // A bare unit is its one-unit token, over the SAME unit set as `duration.parse` — `'2/h'` and
     // `'2/d'` are the units the old three-entry grammar could not spell.
     it('reads a bare unit as one of that unit, across every duration unit', () => {
         fc.assert(
@@ -201,13 +196,13 @@ describe('parseRate (property)', () => {
                 fc.integer({ min: 1, max: 10_000 }),
                 fc.constantFrom(...MS_UNITS),
                 (count, unit) => {
-                    expect(parseRate(`${count}/${unit}`)).toEqual({
+                    expect(rate.parse(`${count}/${unit}`)).toEqual({
                         count,
                         per: MS_SCALE[unit],
                     });
                     // …and the bare unit is exactly the 1-unit token, not a near-miss of it.
-                    expect(parseRate(`${count}/1${unit}`)).toEqual(
-                        parseRate(`${count}/${unit}`),
+                    expect(rate.parse(`${count}/1${unit}`)).toEqual(
+                        rate.parse(`${count}/${unit}`),
                     );
                 },
             ),
@@ -226,7 +221,7 @@ describe('parseRate (property)', () => {
                 (count, n, unit) => {
                     const per = n * MS_SCALE[unit];
                     fc.pre(per / count <= MAX_SPACING); // past the ceiling is its own property below
-                    expect(parseRate(`${count}/${n}${unit}`)).toEqual({
+                    expect(rate.parse(`${count}/${n}${unit}`)).toEqual({
                         count,
                         per,
                     });
@@ -241,31 +236,31 @@ describe('parseRate (property)', () => {
                 fc.integer({ min: 1, max: 10_000 }),
                 fc.constantFrom(...MS_UNITS),
                 (count, unit) => {
-                    expect(parseRate(`  ${count} / ${unit}  `)).toEqual(
-                        parseRate(`${count}/${unit}`),
+                    expect(rate.parse(`  ${count} / ${unit}  `)).toEqual(
+                        rate.parse(`${count}/${unit}`),
                     );
                 },
             ),
         );
     });
 
-    // The claim Decision 3 rests on: the denominator's grammar IS `parseDuration`'s, so a
+    // The claim Decision 3 rests on: the denominator's grammar IS `duration.parse`'s, so a
     // denominator that parser rejects (or reads as non-positive) is a rate this one rejects.
-    // Using `parseDuration` here is the property, not a mirror of `parseRate`'s own arithmetic —
+    // Using `duration.parse` here is the property, not a mirror of `rate.parse`'s own arithmetic —
     // it asserts the two agree, which is the whole point of deleting the second scale table.
-    it('rejects exactly the denominators parseDuration will not read as a positive window', () => {
+    it('rejects exactly the denominators duration.parse will not read as a positive window', () => {
         fc.assert(
             fc.property(
                 fc
                     .string()
                     // Bare units are the documented exception — `'s'` means `'1s'`, and
-                    // `parseDuration('s')` alone is undefined.
+                    // `duration.parse('s')` alone is undefined.
                     .filter(
                         (d) =>
                             !(MS_UNITS as readonly string[]).includes(d.trim()),
                     )
                     .filter((d) => {
-                        const per = parseDuration(d.trim());
+                        const per = duration.parse(d.trim());
                         return (
                             per === undefined ||
                             !Number.isFinite(per) ||
@@ -273,7 +268,7 @@ describe('parseRate (property)', () => {
                         );
                     }),
                 (d) => {
-                    expect(() => parseRate(`1/${d}`)).toThrow(/bad rate/);
+                    expect(() => rate.parse(`1/${d}`)).toThrow(/bad rate/);
                 },
             ),
         );
@@ -285,7 +280,7 @@ describe('parseRate (property)', () => {
                 fc.constantFrom('0', '00', '0.5', '-1', '1.5', '', ' ', 'x'),
                 fc.constantFrom(...MS_UNITS),
                 (count, unit) => {
-                    expect(() => parseRate(`${count}/${unit}`)).toThrow(
+                    expect(() => rate.parse(`${count}/${unit}`)).toThrow(
                         /bad rate/,
                     );
                 },
@@ -304,7 +299,7 @@ describe('parseRate (property)', () => {
                 (count, days) => {
                     const per = days * MS_SCALE.d;
                     fc.pre(per / count > MAX_SPACING);
-                    expect(() => parseRate(`${count}/${days}d`)).toThrow(
+                    expect(() => rate.parse(`${count}/${days}d`)).toThrow(
                         /bad rate/,
                     );
                 },
@@ -312,7 +307,7 @@ describe('parseRate (property)', () => {
         );
         // …and the largest spacing that CAN be honoured still parses, so the bound is the timer's
         // and not an off-by-one of our own.
-        expect(parseRate('1/24d')).toEqual({ count: 1, per: 24 * MS_SCALE.d });
+        expect(rate.parse('1/24d')).toEqual({ count: 1, per: 24 * MS_SCALE.d });
     });
 
     // The sibling of the `stripTrailingSlashes` property below, with one honest difference: there
@@ -331,8 +326,8 @@ describe('parseRate (property)', () => {
                 (before, after, unit) => {
                     const pad = (k: number) => ' '.repeat(k);
                     expect(
-                        parseRate(`2${pad(before)}/${pad(after)}${unit}`),
-                    ).toEqual(parseRate(`2/${unit}`));
+                        rate.parse(`2${pad(before)}/${pad(after)}${unit}`),
+                    ).toEqual(rate.parse(`2/${unit}`));
                 },
             ),
         );
@@ -344,7 +339,7 @@ describe('parseRate (property)', () => {
             `${' '.repeat(4096)}/s`,
             `2/${' '.repeat(2048)}x${' '.repeat(2048)}`,
         ])
-            expect(() => parseRate(bad)).toThrow(/bad rate/);
+            expect(() => rate.parse(bad)).toThrow(/bad rate/);
     });
 
     // The only thing either limiter consumes is `per / count`, so any two rates with the same
@@ -354,7 +349,7 @@ describe('parseRate (property)', () => {
         fc.assert(
             fc.property(fc.integer({ min: 1, max: 1000 }), (n) => {
                 const spacing = (r: string) => {
-                    const { count, per } = parseRate(r);
+                    const { count, per } = rate.parse(r);
                     return per / count;
                 };
                 expect(spacing(`${n * 60}/m`)).toBe(spacing(`${n}/s`));
@@ -362,6 +357,158 @@ describe('parseRate (property)', () => {
                 expect(spacing(`${n * 2}/2s`)).toBe(spacing(`${n}/s`));
                 expect(spacing(`${n * 3600}/h`)).toBe(spacing(`${n}/s`));
             }),
+        );
+    });
+});
+
+// ---- the encode direction (`format`) --------------------------------------------------------
+// `format` is specified as the EXACT inverse of `parse`, which is a property over the whole
+// numeric range rather than a table of pretty cases — exactly the shape this file exists for.
+// The round-trip is the contract a caller relies on to read a value back after writing it, and
+// it is the clause that separates the house pair from `ms`, whose `ms(90_000)` is `'2m'` and
+// parses back to 120_000.
+//
+// The expectations here are NOT computed from the formatter's own arithmetic: each asserts on
+// `parse(format(n)) === n`, where `parse` is the independently-tested decoder above. A formatter
+// that picked the wrong exponent, rounded, or emitted an exponential form fails the round-trip
+// rather than being mirrored by a re-implementation of its own bug.
+
+describe('duration.format (property)', () => {
+    it('round-trips every non-negative magnitude exactly', () => {
+        fc.assert(
+            fc.property(
+                fc.oneof(
+                    fc.nat({ max: Number.MAX_SAFE_INTEGER }),
+                    fc.double({ min: 0, max: 1e12, noNaN: true }),
+                ),
+                (n) => {
+                    expect(duration.parse(duration.format(n))).toBe(n);
+                },
+            ),
+        );
+    });
+
+    // The base unit is always available (its quotient IS the value and its scale is 1), so no
+    // finite input can fall through to a form the grammar rejects. A `format` that returned an
+    // un-parseable token would surface here as `undefined` rather than a wrong number.
+    it('always emits a token the grammar accepts', () => {
+        fc.assert(
+            fc.property(fc.nat({ max: Number.MAX_SAFE_INTEGER }), (n) => {
+                expect(duration.parse(duration.format(n))).not.toBeUndefined();
+            }),
+        );
+    });
+
+    // `Number('0') || undefined` is `undefined`, so a bare `'0'` is the one integer the numeric
+    // -string arm cannot read back. Zero must therefore carry a unit — the single case where the
+    // "largest exact unit" rule is not what makes the round-trip work.
+    it('gives zero a unit, since a bare "0" does not parse', () => {
+        expect(duration.format(0)).toBe('0ms');
+        expect(duration.parse('0')).toBeUndefined();
+        expect(duration.parse(duration.format(0))).toBe(0);
+    });
+
+    it('prefers the largest unit that stays exact and readable', () => {
+        expect(duration.format(3_600_000)).toBe('1h');
+        expect(duration.format(86_400_000)).toBe('1d');
+        expect(duration.format(1500)).toBe('1.5s');
+        expect(duration.format(90_000)).toBe('1.5m');
+        // 90_001 divides into no unit cleanly — `1.5000166…m` is exact but unreadable, so the
+        // base unit wins rather than a rounded `'2m'`.
+        expect(duration.format(90_001)).toBe('90001ms');
+    });
+
+    // A duration core produces is a raw-ms number and a non-finite one is a bug upstream, not a
+    // config typo, so this is the one direction that throws rather than degrading quietly.
+    it('rejects a non-finite magnitude', () => {
+        expect(() => duration.format(NaN)).toThrow(TypeError);
+        expect(() => duration.format(Infinity)).toThrow(TypeError);
+    });
+});
+
+describe('size.format (property)', () => {
+    it('round-trips every non-negative byte count exactly', () => {
+        fc.assert(
+            fc.property(fc.nat({ max: Number.MAX_SAFE_INTEGER }), (n) => {
+                expect(size.parse(size.format(n))).toBe(n);
+            }),
+        );
+    });
+
+    it('gives zero a unit, since a bare "0" does not parse', () => {
+        expect(size.format(0)).toBe('0b');
+        expect(size.parse('0')).toBeUndefined();
+        expect(size.parse(size.format(0))).toBe(0);
+    });
+
+    // The readability guard matters more for sizes than durations: 1024 is a power of two, so a
+    // byte count's kb quotient is almost always exact — and almost always unreadable. Exactness
+    // alone would emit `'1.5009765625kb'` here.
+    it('falls to the base unit rather than emit an exact but unreadable quotient', () => {
+        expect(size.format(1536)).toBe('1.5kb');
+        expect(size.format(1537)).toBe('1537b');
+        expect(size.format(1_048_576)).toBe('1mb');
+        expect(size.format(10 * 1024 * 1024)).toBe('10mb');
+    });
+
+    it('rejects a non-finite byte count', () => {
+        expect(() => size.format(NaN)).toThrow(TypeError);
+        expect(() => size.format(Infinity)).toThrow(TypeError);
+    });
+});
+
+describe('rate.format (property)', () => {
+    it('round-trips every legal { count, per } exactly', () => {
+        fc.assert(
+            fc.property(
+                fc.integer({ min: 1, max: 1_000_000 }),
+                fc.integer({ min: 1, max: 86_400_000 * 40 }),
+                (count, per) => {
+                    // The spacing ceiling is part of the grammar, so a pair past it is not a
+                    // legal rate in either direction — `format` rejects it exactly as `parse` does.
+                    fc.pre(per / count <= 2_147_483_647);
+                    expect(rate.parse(rate.format({ count, per }))).toEqual({
+                        count,
+                        per,
+                    });
+                },
+            ),
+        );
+    });
+
+    // A one-unit window drops the `1`, because `parse` reads a bare unit as its one-unit token
+    // and the short spelling is the one the docs and house defaults are written in.
+    it('writes a one-unit window as a bare unit', () => {
+        expect(rate.format({ count: 2, per: 1000 })).toBe('2/s');
+        expect(rate.format({ count: 10, per: 60_000 })).toBe('10/m');
+        expect(rate.format({ count: 1000, per: 3_600_000 })).toBe('1000/h');
+        expect(rate.format({ count: 100, per: 900_000 })).toBe('100/15m');
+    });
+
+    // `'2/500ms'` ≡ `'4/s'` is the design (ADR 0023), but `format` returns the pair it was handed
+    // rather than a reduced representative — `count` is the number the consumer wrote, and the
+    // round-trip above is equality, not equivalence.
+    it('does not reduce a rate to an equivalent one', () => {
+        expect(rate.format({ count: 2, per: 500 })).toBe('2/500ms');
+        expect(rate.format({ count: 4, per: 1000 })).toBe('4/s');
+        // Same limiter, different tokens — and each parses back to its own pair.
+        expect(rate.parse('2/500ms')).toEqual({ count: 2, per: 500 });
+        expect(rate.parse('4/s')).toEqual({ count: 4, per: 1000 });
+    });
+
+    // `format` enforces the same three rejections `parse` does, so a pair that could not have
+    // come from `parse` fails at the encode step instead of producing a token that throws on the
+    // way back in.
+    it('rejects what parse would reject', () => {
+        expect(() => rate.format({ count: 0, per: 1000 })).toThrow(/bad rate/);
+        expect(() => rate.format({ count: 1.5, per: 1000 })).toThrow(
+            /bad rate/,
+        );
+        expect(() => rate.format({ count: 1, per: 0 })).toThrow(/bad rate/);
+        expect(() => rate.format({ count: 1, per: -500 })).toThrow(/bad rate/);
+        // 30 days at one grant is past the setTimeout ceiling, the same token `parse` rejects.
+        expect(() => rate.format({ count: 1, per: 86_400_000 * 30 })).toThrow(
+            /timer ceiling/,
         );
     });
 });

--- a/packages/core/test/public-api-surface.spec.ts
+++ b/packages/core/test/public-api-surface.spec.ts
@@ -28,21 +28,28 @@ const FUNCTIONS = [
     'compile',
     'isStitch',
     'isSeam',
-    // The three house token grammars (CONTRACT.md P17/P25). Each is public for one reason — a peer
-    // package that takes an authored duration / size / rate parses it the way core does instead of
-    // mirroring the grammar and drifting from it — and that reason only holds while they stay on
-    // the barrel, which nothing pinned until now. `parseRate` joined them in the same pass that
-    // wrote the reason into P17/P25; the other two had been exported on that argument for releases
-    // without a test holding them there.
-    'parseDuration',
-    'parseBytes',
-    'parseRate',
     // The verdict (ADR 0022 Decision 2), public because a surface author must compose it: an
     // `interpret` hook REPLACES the default rather than layering on it, so a surface with its own
     // body rules needs this to keep the caller's `verdict` config working. The one composition
     // point — its narrower and wider siblings are pinned ABSENT below.
     'verdictOf',
 ] as const;
+
+// The three house token grammars (CONTRACT.md P17/P25, ADR 0023), one namespace per dimension.
+// Each is public for one reason — a peer package that takes an authored duration / size / rate
+// handles it the way core does instead of mirroring the grammar and drifting from it — and that
+// reason only holds while they stay on the barrel.
+//
+// Pinned as a PAIR, not as two independent members. A namespace that kept `parse` and lost
+// `format` would still pass a "is it exported?" check while silently dropping half the contract,
+// and the encode direction is the half with no other caller inside core to notice it missing.
+const TOKEN_GRAMMARS = ['duration', 'size', 'rate'] as const;
+
+// The verb-prefixed functions these namespaces REPLACED, pinned absent so they cannot drift back.
+// `parseDuration` / `parseBytes` / `parseRate` were the whole grammar surface until the pair
+// landed; re-adding one as an alias would put two spellings of one call on the barrel, which is
+// the same "three names for one decision" trap the verdict scopes below are pinned against.
+const REMOVED_PARSERS = ['parseDuration', 'parseBytes', 'parseRate'] as const;
 
 // The other two scopes of the same decision, pinned ABSENT from the root. `classifyStatus` (the
 // status alone) answers the engine's transport-health question and has no surface-author use;
@@ -70,6 +77,31 @@ describe('public API surface (src/index.ts)', () => {
     test.each(FUNCTIONS)('exports %s as a function', (name) => {
         expect(typeof (api as Record<string, unknown>)[name]).toBe('function');
     });
+
+    test.each(TOKEN_GRAMMARS)('exports %s as a parse/format pair', (name) => {
+        const ns = (api as Record<string, unknown>)[name] as
+            Record<string, unknown> | undefined;
+        expect(typeof ns).toBe('object');
+        expect(typeof ns?.['parse']).toBe('function');
+        expect(typeof ns?.['format']).toBe('function');
+    });
+
+    // The property suite proves the round-trip across the whole input space; this pins that the
+    // exported pair is the one that has it, so a barrel wired to some other encoder fails here.
+    test('the exported pairs round-trip through the barrel', () => {
+        expect(api.duration.parse(api.duration.format(90_000))).toBe(90_000);
+        expect(api.size.parse(api.size.format(1536))).toBe(1536);
+        expect(
+            api.rate.parse(api.rate.format({ count: 2, per: 1000 })),
+        ).toEqual({ count: 2, per: 1000 });
+    });
+
+    test.each(REMOVED_PARSERS)(
+        'does NOT export %s — the namespace pair replaced it',
+        (name) => {
+            expect(name in (api as Record<string, unknown>)).toBe(false);
+        },
+    );
 
     test.each(INTERNAL_VERDICT_SCOPES)(
         'does NOT export %s — one composition point, not three',

--- a/packages/core/test/resilience-config-guard.spec.ts
+++ b/packages/core/test/resilience-config-guard.spec.ts
@@ -1,5 +1,5 @@
 // Issue #651 §3 — a `backoff` the retry loop cannot read must THROW at construction, the way an
-// unparseable `throttle.rate` already does (`bad rate: …`, util.ts `parseRate`), rather than
+// unparseable `throttle.rate` already does (`bad rate: …`, util.ts `rate.parse`), rather than
 // degrading to a default nobody asked for. The message names the slot the way that precedent
 // does — `bad backoff` — but stops there rather than quoting the value: the entry's gzip gate had
 // one byte left for this whole check, and the interpolation cost five. The offending value is in

--- a/packages/core/test/serve.spec.ts
+++ b/packages/core/test/serve.spec.ts
@@ -325,7 +325,7 @@ describe('serve caps the request body (413), so an unauthenticated server cannot
     });
 });
 
-describe('the body cap also accepts a size token (`parseBytes`)', () => {
+describe('the body cap also accepts a size token (`size.parse`)', () => {
     // `'1kb'` must resolve to 1024 bytes. The probe body is ~1.1 KB — over a parsed `'1kb'`
     // but far under the 2 MiB default, so a 413 here can only mean the token was honoured
     // (an ignored/unparsed token would fall back to the default and answer 200).

--- a/packages/core/test/util-helpers.spec.ts
+++ b/packages/core/test/util-helpers.spec.ts
@@ -1,5 +1,5 @@
 // Direct unit tests for the dependency-free helpers in src/util.ts. Most of these
-// are exercised only *indirectly* today (parseDuration via cache TTLs, parseRate via
+// are exercised only *indirectly* today (duration.parse via cache TTLs, rate.parse via
 // the throttle, deepMerge via config layering, matchPath/matchAny via drift ignore
 // patterns, dirnameOf/stripTrailingSlashes via the file seams) — so their edge cases
 // (bare-number durations, array-vs-object merge precedence, prefix-without-over-match,
@@ -18,7 +18,7 @@ import {
     stripTrailingSlashes,
 } from '../src/util';
 
-describe('parseDuration', () => {
+describe('duration.parse', () => {
     it('passes a number through unchanged', () => {
         expect(parseDuration(1500)).toBe(1500);
     });
@@ -49,7 +49,7 @@ describe('parseDuration', () => {
     });
 });
 
-describe('parseBytes', () => {
+describe('size.parse', () => {
     it('passes a number through unchanged', () => {
         expect(parseBytes(4096)).toBe(4096);
     });
@@ -107,7 +107,7 @@ describe('parseBytes', () => {
     });
 });
 
-describe('parseRate', () => {
+describe('rate.parse', () => {
     it('parses count and per-unit window', () => {
         expect(parseRate('2/s')).toEqual({ count: 2, per: 1000 });
         expect(parseRate('10/m')).toEqual({ count: 10, per: 60_000 });
@@ -122,7 +122,7 @@ describe('parseRate', () => {
         expect(() => parseRate('fast')).toThrow(/bad rate/);
     });
 
-    // The denominator is a full `parseDuration` token (ADR 0023 Decision 3). These two are the
+    // The denominator is a full `duration.parse` token (ADR 0023 Decision 3). These two are the
     // motivating cases: neither has ANY spelling in the old `<count>/<ms|s|m>` grammar, because
     // both need a fractional count over a bare unit (1000/h is 16.67/m) and counts are integers.
     it('takes a full duration token as the denominator', () => {
@@ -155,7 +155,7 @@ describe('parseRate', () => {
 
     // A window that is zero, negative, or unreadable would leave `spacing <= 0`, which both
     // limiters treat as "no pacing configured" — the same silent-unlimited failure as `'0/s'`.
-    // `parseDuration` reads `'0s'` as a real 0 and `'-500'` through its numeric arm, so neither
+    // `duration.parse` reads `'0s'` as a real 0 and `'-500'` through its numeric arm, so neither
     // arrives as `undefined` and both are checked explicitly.
     it('rejects a non-positive or unreadable window', () => {
         expect(() => parseRate('2/0s')).toThrow(/bad rate/);

--- a/packages/deno-kv/src/index.ts
+++ b/packages/deno-kv/src/index.ts
@@ -16,7 +16,7 @@
 //
 // Compliance with the store contract is proven against `verifyStoreContract` from
 // `stitchapi/testing` (see test/conformance.spec.ts).
-import { parseDuration } from 'stitchapi';
+import { duration } from 'stitchapi';
 import type {
     AtLeastOne,
     BackoffCurve,
@@ -225,8 +225,8 @@ export function denoKvStore(
     const curve: BackoffOptions | undefined =
         typeof b === 'string' ? { curve: b } : b;
     const backoff = curve?.curve ?? (curve ? 'expo-jitter' : undefined);
-    const base = parseDuration(curve?.base) ?? 5;
-    const max = parseDuration(curve?.max) ?? 250;
+    const base = duration.parse(curve?.base) ?? 5;
+    const max = duration.parse(curve?.max) ?? 250;
     // String key → Deno KV array key. With a prefix it's a two-segment key so the
     // namespace is a real KV sub-range; without, a flat one-segment key.
     const k = (key: string): DenoKvKey =>

--- a/packages/download/src/manager.ts
+++ b/packages/download/src/manager.ts
@@ -12,7 +12,7 @@ import type {
     ItemResult,
 } from './types';
 
-import { parseDuration, systemClock } from 'stitchapi';
+import { duration, systemClock } from 'stitchapi';
 import type {
     AdapterProgress,
     Clock,
@@ -74,7 +74,7 @@ export class DownloadManager {
     constructor(opts: BatchOptions = {}) {
         this.#concurrency = Math.max(1, opts.concurrency ?? 4);
         this.#defaults = opts.defaults ?? {};
-        this.#idle = parseDuration(opts.idle);
+        this.#idle = duration.parse(opts.idle);
         this.#dedupe = opts.dedupe ?? false;
         this.#clock = opts.clock ?? systemClock;
         this.#opts = opts;

--- a/packages/download/src/types.ts
+++ b/packages/download/src/types.ts
@@ -83,7 +83,7 @@ export interface BatchOptions {
      * WALL-CLOCK — `{ total, perAttempt }` fire on elapsed time regardless of progress — and it is
      * configurable right here, under `defaults`. Two different clocks must not share one word, so
      * this one is named for what it measures (a stream that has gone idle), not for what it does.
-     * `number | string`, parsed by core's shared `parseDuration` like every other authored duration
+     * `number | string`, parsed by core's shared `duration.parse` like every other authored duration
      * (P17).
      */
     idle?: number | string;

--- a/packages/shell/README.md
+++ b/packages/shell/README.md
@@ -59,7 +59,7 @@ shell(NODE, { buffer: '4mb' }); // ≡ { buffer: { max: '4mb' } }
 shell(NODE, { buffer: 4096 }); // ≡ { buffer: { max: 4096 } }
 ```
 
-Tokens are powers of 1024 (`'1mb'` = 1 048 576), parsed by core's shared `parseBytes`. An
+Tokens are powers of 1024 (`'1mb'` = 1 048 576), parsed by core's shared `size.parse`. An
 unparseable token falls back to the default — never to "unbounded".
 
 ## Contributing

--- a/packages/shell/src/index.ts
+++ b/packages/shell/src/index.ts
@@ -16,7 +16,7 @@
 //     into a child — pass exactly what's needed (incl. `PATH` for a bare command name, or use an
 //     absolute command path).
 import { execFile } from 'node:child_process';
-import { compact, parseBytes, stitch } from 'stitchapi';
+import { compact, size, stitch } from 'stitchapi';
 import type {
     AdapterRequest,
     AdapterResponse,
@@ -45,11 +45,11 @@ interface ShellDefaults {
 
 // Fold the `buffer` slot's scalar shorthand — `'4mb'` ≡ `{ max: '4mb' }` (CONTRACT.md P12) — and
 // resolve it to the byte count `execFile` wants. An unparseable token yields `undefined` from
-// `parseBytes` and lands on the default, so a typo can never widen the cap to "unbounded" (P25).
+// `size.parse` and lands on the default, so a typo can never widen the cap to "unbounded" (P25).
 function resolveMaxBuffer(buffer: ShellOptions['buffer']): number {
     const max =
         typeof buffer === 'object' && buffer !== null ? buffer.max : buffer;
-    return parseBytes(max) ?? DEFAULT_MAX_BUFFER;
+    return size.parse(max) ?? DEFAULT_MAX_BUFFER;
 }
 
 // Run the static command with the call's argv. The ONLY input is the argv array (`req.body`);
@@ -139,7 +139,7 @@ function shellSurface(d: ShellDefaults): Surface {
 export interface ShellBufferOptions {
     /** Ceiling on the buffered stdout/stderr; exceeding it fails the call. A raw byte count or a
      *  size token — `4 * 1024 * 1024` or `'4mb'` (powers of 1024) — parsed by core's shared
-     *  `parseBytes` (CONTRACT.md P25). Default 10 MiB; an unparseable token falls back to that
+     *  `size.parse` (CONTRACT.md P25). Default 10 MiB; an unparseable token falls back to that
      *  default, never to "unbounded". */
     max?: number | string;
 }

--- a/packages/shell/test/shell.spec.ts
+++ b/packages/shell/test/shell.spec.ts
@@ -166,7 +166,7 @@ test('the envelope form `buffer: { max }` binds the same runtime cap as the shor
 });
 
 test('an unparseable size token lands on the default cap, not on 0/NaN', async () => {
-    // `parseBytes('one gigabyte')` → undefined → the 10 MiB default. A `NaN`/`0` cap would
+    // `size.parse('one gigabyte')` → undefined → the 10 MiB default. A `NaN`/`0` cap would
     // reject even this two-byte write; resolving proves the fallback is the real default.
     const bad = shell(NODE, { buffer: 'one gigabyte' });
     await expect(


### PR DESCRIPTION
The three house token grammars only ever **decoded**. [#746](https://github.com/rejifald/StitchAPI/pull/746) made them public contract, which changed who else needs them: a peer package that parses an authored value the way core does will eventually want to *write* one back — a CLI printing the cap it enforced, a config round-trip, an error message quoting a limit in the grammar its author used — and had nothing to call. Every such caller hand-rolls an encoder, which is the drift the export exists to prevent, running in the opposite direction.

Each dimension is now **one namespace carrying both directions**, following `bytes`'s shape (`bytes.parse` / `bytes.format`) rather than adding three more verb-prefixed names to the barrel:

| Was | Now | Gained |
| --- | --- | --- |
| `parseDuration(d)` | `duration.parse(d)` | `duration.format(90_000)` → `'1.5m'` |
| `parseBytes(s)` | `size.parse(s)` | `size.format(1_048_576)` → `'1mb'` |
| `parseRate(r)` | `rate.parse(r)` | `rate.format({ count: 2, per: 1000 })` → `'2/s'` |

The decode direction is byte-for-byte what it was — same grammars, same 1024-based size units, same `undefined` fallback for a bad duration or size token, same throw for a bad rate. Only the spelling moved. A `Rate` type is now exported for the `{ count, per }` pair.

## Why not the `ms(…)` one-function overload it resembles

`ms` and `bytes` switch on the argument's type — a string decodes, a number encodes. **That inversion is structurally unavailable here**, and the reason is this repo's own rule: [P17](../blob/main/docs/CONTRACT.md#p17--one-canonical-duration-form)/[P25](../blob/main/docs/CONTRACT.md#p25--one-canonical-size-form) widen every authored field to `number | string`, and every read site funnels the value through the parser. So `parse(5_000)` **must** return `5_000`:

```ts
// packages/core/src/util.ts
if (typeof d === 'number') return d; // load-bearing: `timeout.total: 5_000` reaches here
```

An overload would have broken every call site core makes of its own rule. The explicit pair is the half of those libraries' contract that survives the constraint — and it is the half `bytes` itself exposes as `.parse` / `.format`.

## `format` is exact where `ms` rounds

`ms(90_000)` is `'2m'`, which parses back to 120 000. A 33% widening is harmless in a log line and disqualifying in anything that writes a value back — and P25's "a typo can never widen a cap" only holds if the **encode** direction cannot widen one either.

So `parse(format(v))` returns `v` unchanged for every value `parse` can produce. Exactness alone would still allow unreadable output (`1537 / 1024` is `1.5009765625`, which multiplies back perfectly and helps nobody), so a unit is used only when the quotient is **both** exact and short; otherwise the next smaller unit is tried, down to the base unit where both tests always pass:

```ts
duration.format(90_000); // '1.5m'
duration.format(90_001); // '90001ms' — no unit divides it cleanly, so not a rounded '2m'
size.format(1536); // '1.5kb'
size.format(1537); // '1537b'  — not '1.5009765625kb'
```

Pinned as a **property over the whole numeric range** in `parsers-properties.spec.ts`, not a table of pretty cases, and the expectations assert `parse(format(n)) === n` against the independently-tested decoder rather than re-running the encoder's own arithmetic. Verified non-vacuous by reintroducing `ms`-style rounding and watching all three round-trip properties plus both readability pins fail.

Two edge cases worth flagging for review, both found by the property run rather than reasoned about:

- **`Number('0') || undefined` is `undefined`**, so a bare `'0'` is the one integer that does *not* survive a round-trip. Zero therefore carries a unit (`'0ms'` / `'0b'`) — the single case where "largest exact unit" is not what makes the round-trip work.
- **`rate.format` does not reduce a rate to an equivalent one.** `'2/500ms'` ≡ `'4/s'` is the design (ADR 0023), but `{ count: 2, per: 500 }` comes back as `'2/500ms'` — the numbers the author wrote, so the round-trip is equality rather than equivalence.

## Bundle: +0.41 / +0.20 KB gzip, and the advertised figure moves

Measured against a `main` at 24.18 / 21.62 / 5.22. **Two thirds of the naive cost was recovered rather than budgeted for**, both measured:

- the internals call the plain `parseDuration`/`parseBytes`/`parseRate` functions and the public objects are a **thin facade** over them, so a consumer's bundle is not routed through the namespace and the encoder can shake out (`stitchapi/auth` 5.44 → 5.22, back to its own baseline and inside the **unchanged** 5.35 ceiling);
- each `format`'s unit table lives **inside** the function. At module scope the minifier merges adjacent tables into one `var` statement, where the parse-side lookup being live pinned the encoder's table for every consumer of `stitch`. Deriving one table from the other with `Object.fromEntries` measured worse still, for the same reason.

**What is left is ~0.1 KB and is a real cost of the namespace form, not an oversight:** `formatDuration` is referenced by the `duration` facade object, whose other half is live on the `stitch` path, and esbuild will not split an object literal to drop the dead half. A consumer who never formats a duration still carries the formatter. Shaking it would mean not shipping the pair as an object — which is the shape of the API. Recorded in the budget note rather than left for someone to rediscover.

| Scenario | `main` | this PR | budget | headroom |
| --- | --- | --- | --- | --- |
| whole entry | 24.18 | **24.59** | 24.25 → **24.80** | 0.21 |
| `import { stitch }` | 21.62 | **21.82** | 21.70 → **22.00** | 0.18 |
| `stitchapi/auth` | 5.22 | **5.22** | 5.35 (unchanged) | 0.13 |

The conventional ~0.2 KB step, not a minimum one — this is a new capability on the public surface, not a fix squeezing past a ceiling.

**The advertised whole-entry figure moves ~24 → ~25 kB** (25183 B is 24.59 KB, which rounds up where `main`'s 24.18 rounded down). Propagated across all six `bundle-advertised-size` sites — both READMEs, the installation and principles pages, the home-page metrics component, and the docs' own source blurb. `import { stitch }` is unchanged at 22. Verified by the yakir tether in the pre-commit hook (3 tethers, 0 drift), not assumed.

## Migration

A rename at every call site; **no alias** ([P19](../blob/main/docs/CONTRACT.md#p19--the-alias-obligation-is-scoped-to-the-ga-channel) scopes that obligation to the GA channel and this is `rc`). The old names are pinned **absent** from the barrel, so a stale import fails at build rather than resolving to something else.

```diff
- import { parseDuration, parseBytes, parseRate } from 'stitchapi';
- const ttl = parseDuration(opts.ttl);
- const cap = parseBytes(opts.max);
- const { count, per } = parseRate(opts.rate);
+ import { duration, size, rate } from 'stitchapi';
+ const ttl = duration.parse(opts.ttl);
+ const cap = size.parse(opts.max);
+ const { count, per } = rate.parse(opts.rate);
```

Internal churn is smaller than the rename suggests: because the implementations keep their original names as module functions, `auth.ts`, `cache.ts`, `test-mock.ts` and `testing.ts` are **byte-identical to `main`**. `resilience.ts` and `store.ts` change only because they declared a local `const rate = parseRate(opts.rate)` that the new import would shadow — renamed to `paced`, which the compiler caught rather than a reviewer.

## Reviewer notes

- **The `Bytes`/`Chars` hazard got quieter.** `parseBytes` said "bytes" at the call site; `size` does not. `stream.buffer.chars` and `trace.body.chars` still reject a token at compile time, so the type still holds the line — but the name no longer warns first. Stated on the namespace's JSDoc and in P25, and it is the change here I would most want a second opinion on.
- **`format` must not touch emitted values.** P17's complement is unchanged: an emitted duration is raw ms. Formatting one for a CLI table is display; writing one into an emitted field is a violation this pair cannot see and will not stop. Called out in the JSDoc, in P17, and as an anti-pattern callout in the docs.
- `CONTRACT.md` P17/P25 gain the pairing clause; the §6 migration record carries the full reasoning. **ADR 0023 is annotated, not rewritten** — every decision in it stands, only the spelling moved, so the body stays as the 2026-08-04 record with a note in its Status block.

## Docs

Reference docs land in **[#746](https://github.com/rejifald/StitchAPI/pull/746)**, which documented the parsers this replaces and is stacked on this branch. That PR is where the pair is written up for readers; merge this one first.

## Gates

| Gate | Result |
| --- | --- |
| `pnpm -r test` | all packages pass — core **1593 passed** |
| `pnpm check:types` / `check:types-d` | clean across 39 projects |
| `pnpm check:lint` | clean across 37 packages |
| `pnpm check:size` | ✓ within budget (raised, documented above) |
| `pnpm check:contract` | ✓ no new violations (0 baselined) |
| `pnpm check:changelog` | ✓ 23 subsections, Keep a Changelog order |
| `pnpm check:docs-links` | ✓ 117 routes resolve |
| `pnpm check:exports` / `check:unknown-keys` / `check:format` | clean |
| yakir tethers (pre-commit) | 3 ok, 0 drift |

Round-trip additionally fuzzed outside the suite over 220k magnitudes × 2 and 100k rates — no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
