### PR TITLE
ci(docs): smoke each deployment as it goes live, not production on every PR

### DIFF
--- a/.github/workflows/mcp-smoke.yml
+++ b/.github/workflows/mcp-smoke.yml
@@ -31,21 +31,31 @@ on:
                 description: 'Base URL to probe (defaults to production)'
                 required: false
                 default: 'https://stitchapi.dev'
-    # Also probe whenever this guard or the route it covers changes, so a broken
-    # probe or a regressed route is caught in the PR rather than six hours later.
-    pull_request:
-        paths:
-            - 'apps/docs/scripts/smoke-mcp.mts'
-            - 'apps/docs/app/api/mcp/**'
-            - 'apps/docs/lib/search-index/**'
-            - 'apps/docs/next.config.mjs'
-            - '.github/workflows/mcp-smoke.yml'
+    # Probe each deployment as it goes live — Vercel reports one of these to GitHub
+    # per deployment, with the URL to hit in `environment_url`.
+    #
+    # This replaces a `pull_request` trigger, which was wrong twice over. It probed
+    # PRODUCTION rather than the change under review, so it went red on every PR
+    # while production was broken — including, on #752, the PR that fixed it. And
+    # it fired when the PR opened, minutes before Vercel had built anything, so
+    # even pointed at the right host it would have raced the deployment.
+    #
+    # `deployment_status` fixes both: it fires AFTER a deployment is live, and
+    # carries that deployment's own URL. It also covers a case the PR trigger never
+    # did — a production deploy is verified the moment it promotes, which is
+    # exactly how the #748 sharp regression reached users unnoticed.
+    deployment_status:
 
 permissions:
     contents: read
 
 jobs:
     smoke:
+        # Vercel reports several deployment_status events per deployment (pending,
+        # in_progress, then a terminal one). Only probe a deployment that is live.
+        if: >-
+            github.event_name != 'deployment_status' ||
+            github.event.deployment_status.state == 'success'
         runs-on: ubuntu-latest
         timeout-minutes: 5
         steps:
@@ -56,7 +66,58 @@ jobs:
                   node-version-file: .nvmrc
                   cache: pnpm
             - run: pnpm install --frozen-lockfile
+
+            # Which host to hit:
+            #   deployment_status → that deployment's own environment_url
+            #   schedule          → production (the cold-start check)
+            #   workflow_dispatch → whatever was asked for, production by default
+            #
+            # A preview URL is SSO-protected (Vercel Authentication, deploymentType
+            # `all_except_custom_domains`), so probing one needs the automation
+            # bypass secret. When it is absent we SKIP rather than fail: the
+            # production paths need no secret and must stay meaningful on their own,
+            # and a repo without the secret configured should not see a permanently
+            # red check it cannot fix from the repo. Configuring
+            # VERCEL_AUTOMATION_BYPASS_SECRET (Vercel → Project → Settings →
+            # Deployment Protection → Protection Bypass for Automation) turns the
+            # preview half on.
+            - name: Resolve target
+              id: target
+              env:
+                  EVENT: ${{ github.event_name }}
+                  ENV_URL: ${{ github.event.deployment_status.environment_url }}
+                  DEPLOY_ENV: ${{ github.event.deployment_status.environment }}
+                  DISPATCH_URL: ${{ github.event.inputs.base_url }}
+                  HAS_BYPASS: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET != '' }}
+              run: |
+                  set -euo pipefail
+                  if [ "$EVENT" = "deployment_status" ]; then
+                    url="$ENV_URL"
+                    if [ -z "$url" ]; then
+                      echo "::notice::deployment_status carried no environment_url — nothing to probe."
+                      echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+                    fi
+                    # Production is reachable on its unprotected custom domain; a
+                    # preview is only reachable with the bypass secret.
+                    case "$url" in
+                      *stitchapi.dev*) ;;
+                      *) if [ "$HAS_BYPASS" != "true" ]; then
+                           echo "::warning::Skipping preview probe for $url — VERCEL_AUTOMATION_BYPASS_SECRET is not configured, so the deployment answers 401 Protected deployment. Add it to enable per-preview MCP smoke checks."
+                           echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+                         fi ;;
+                    esac
+                    echo "Probing $DEPLOY_ENV deployment: $url"
+                  else
+                    url="${DISPATCH_URL:-https://stitchapi.dev}"
+                    echo "Probing $url"
+                  fi
+                  echo "url=$url" >> "$GITHUB_OUTPUT"
+                  echo "skip=false" >> "$GITHUB_OUTPUT"
+
             # The probe is pure fetch + tsx — no docs build, no model load, no
             # Playwright. It needs nothing from the repo except the script.
             - name: Probe the deployed MCP endpoint
-              run: pnpm --filter @stitchapi/docs smoke:mcp ${{ github.event.inputs.base_url || 'https://stitchapi.dev' }}
+              if: steps.target.outputs.skip == 'false'
+              env:
+                  VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+              run: pnpm --filter @stitchapi/docs smoke:mcp "${{ steps.target.outputs.url }}"

--- a/apps/docs/scripts/smoke-mcp.mts
+++ b/apps/docs/scripts/smoke-mcp.mts
@@ -54,6 +54,17 @@ const baseUrl = (
 ).replace(/\/$/, '');
 const endpoint = `${baseUrl}/api/mcp`;
 
+// Preview deployments are SSO-protected (the project runs Vercel Authentication
+// with deploymentType `all_except_custom_domains`, so stitchapi.dev is open and
+// every *.vercel.app URL is gated). A protected deployment answers 401 with
+// `{"error":{"code":"401","message":"Protected deployment"}}` — a real response,
+// not a redirect, so it has to be recognised rather than followed.
+//
+// Vercel's "Protection Bypass for Automation" secret lifts that for a single
+// request via this header. Set VERCEL_AUTOMATION_BYPASS_SECRET to probe a preview;
+// production needs nothing, since the custom domain is not protected.
+const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+
 let sessionId: string | undefined;
 let failures = 0;
 
@@ -82,6 +93,9 @@ async function rpc(
             'Content-Type': 'application/json',
             Accept: 'application/json, text/event-stream',
             ...(sessionId ? { 'mcp-session-id': sessionId } : {}),
+            ...(bypassSecret
+                ? { 'x-vercel-protection-bypass': bypassSecret }
+                : {}),
         },
         body: JSON.stringify({
             jsonrpc: '2.0',
@@ -99,6 +113,19 @@ async function rpc(
 
     const body = await res.text();
     if (!res.ok) {
+        // Distinguish "the deployment is gated" from "the endpoint is broken".
+        // Without this they look identical — a non-2xx with an unhelpful body —
+        // and a missing bypass secret would read as a production outage.
+        if (res.status === 401 && body.includes('Protected deployment')) {
+            return {
+                error:
+                    'deployment is SSO-protected and the bypass secret was not accepted. ' +
+                    (bypassSecret
+                        ? 'VERCEL_AUTOMATION_BYPASS_SECRET is set but rejected — regenerate it in Vercel → Project → Settings → Deployment Protection → Protection Bypass for Automation.'
+                        : 'Set VERCEL_AUTOMATION_BYPASS_SECRET to probe a preview URL (production needs no secret — its custom domain is not protected).'),
+                ms,
+            };
+        }
         return { error: `HTTP ${res.status}: ${body.slice(0, 300)}`, ms };
     }
 


### PR DESCRIPTION
## The bug

The `pull_request` trigger I added in #748 was wrong twice over.

**It probed production, not the change under review.** So it went red on any PR whenever production was broken — including, on #752, the PR that fixed the very outage it was reporting. A guard that blocks its own remedy is worse than no guard.

**It fired when the PR opened**, minutes before Vercel had built anything. Even aimed at the right host, it would have raced the deployment it meant to check. I only noticed the first problem; the second was there all along.

## The fix

`deployment_status` replaces `pull_request`. It fires **after** a deployment is live and carries that deployment's own `environment_url`, which fixes both faults at once.

It also covers something the PR trigger never could: **a production deploy is now verified the moment it promotes**. That is exactly how the #748 sharp regression reached users unnoticed — I happened to run the probe by hand. Now it runs itself.

| Event | Probes |
|---|---|
| `deployment_status` (production) | that deployment, right after promotion |
| `deployment_status` (preview) | that preview — needs the bypass secret |
| `schedule` (6h) | production, usually cold — the cold-start check |
| `workflow_dispatch` | any URL, production by default |

## Preview URLs are gated, and that had to be handled precisely

This project runs Vercel Authentication with `deploymentType: all_except_custom_domains` — `stitchapi.dev` is open, every `*.vercel.app` is protected. A gated deployment answers:

```
HTTP 401
{"error":{"code":"401","message":"Protected deployment"}}
```

A **real response, not a redirect**, so it has to be recognised rather than followed. The probe now sends `x-vercel-protection-bypass` when `VERCEL_AUTOMATION_BYPASS_SECRET` is set, and reports that 401 distinctly — without the distinction, a missing secret reads exactly like a production outage, which is the failure mode this whole guard exists to avoid.

**When the secret is absent, the preview probe skips with a warning rather than failing.** The production paths need no secret and must stay meaningful on their own, and a repo that hasn't configured it shouldn't carry a permanently red check it can't fix from the repo.

## To enable the preview half (optional, needs you)

I can't do either of these — one is a Vercel settings change, the other is handling a credential:

1. Vercel → Project → Settings → Deployment Protection → **Protection Bypass for Automation** → generate
2. Add it as GitHub Actions secret `VERCEL_AUTOMATION_BYPASS_SECRET`

Until then production checks run exactly as before, and preview probes skip with a warning naming the secret.

## Verification

Target resolution, all six event shapes:

```
production deploy, no secret  → url=https://stitchapi.dev  skip=false
preview deploy, NO secret     → ::warning:: …  skip=true
preview deploy, WITH secret   → url=…vercel.app  skip=false
deployment_status, empty url  → ::notice:: …  skip=true
schedule                      → url=https://stitchapi.dev  skip=false
dispatch w/ custom url        → url=https://staging.example.com  skip=false
```

Probe behaviour against a **real** protected preview:

- no secret → `Set VERCEL_AUTOMATION_BYPASS_SECRET to probe a preview URL…`
- wrong secret → `…is set but rejected — regenerate it in Vercel → …`
- production, no secret → still passes

`check:lint` exit 0, `check:types` exit 0, YAML parses, `pull_request` trigger confirmed removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)