### PR TITLE
fix(docs): stop twoslash hover popups flickering while scrolling

### DIFF
--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -345,3 +345,15 @@ html .twoslash:hover .twoslash-hover {
 html .twoslash .twoslash-hover:hover {
     border-color: currentColor;
 }
+
+/* --- Twoslash hover affordance: don't flap open while the page is scrolling -
+   Scrolling slides annotated tokens under a stationary cursor; the browser's
+   resulting pointerenter/pointerleave hit-test churn flaps hover popups open
+   and closed (worst on token-dense pages, e.g. reference/helpers.mdx).
+   TwoslashScrollGuard (components/twoslash-scroll-guard.tsx, mounted in
+   app/layout.tsx) stamps this attribute on <html> while a scroll is in
+   flight; killing pointer-events on the trigger for that window stops the
+   spurious events at the source. */
+html[data-scrolling='true'] .twoslash-hover {
+    pointer-events: none;
+}

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,6 +1,7 @@
 import { AnalyticsWithReferrals } from './analytics';
 import './global.css';
 
+import { TwoslashScrollGuard } from '@/components/twoslash-scroll-guard';
 import { jsonLdHtml } from '@/lib/json-ld';
 import { releaseVersion } from '@/lib/release';
 import { appName, gitConfig, siteUrl } from '@/lib/shared';
@@ -186,6 +187,7 @@ export default function Layout({ children }: LayoutProps<'/'>) {
                 </RootProvider>
                 <AnalyticsWithReferrals />
                 <SpeedInsights />
+                <TwoslashScrollGuard />
             </body>
         </html>
     );

--- a/apps/docs/components/twoslash-scroll-guard.tsx
+++ b/apps/docs/components/twoslash-scroll-guard.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const SETTLE_MS = 150;
+
+/**
+ * Twoslash's hover popups (fumadocs-twoslash) open on `pointerenter` over an
+ * annotated token. Browsers re-run hit-testing on scroll, so a token sliding
+ * under a stationary cursor fires real pointerenter/pointerleave events with
+ * no mouse movement at all — on a code block dense with annotated tokens
+ * (e.g. reference/helpers.mdx, 14 of them), that flaps popups open and closed
+ * while scrolling. `capture: true` on window also catches scroll from nested
+ * scrollers (a wide code block's own horizontal scrollbar), which slides
+ * tokens the same way. See global.css for the pointer-events rule this drives.
+ */
+export function TwoslashScrollGuard() {
+    useEffect(() => {
+        const root = document.documentElement;
+        let settleTimer: ReturnType<typeof setTimeout>;
+
+        const onScroll = () => {
+            root.setAttribute('data-scrolling', 'true');
+            clearTimeout(settleTimer);
+            settleTimer = setTimeout(() => {
+                root.setAttribute('data-scrolling', 'false');
+            }, SETTLE_MS);
+        };
+
+        window.addEventListener('scroll', onScroll, {
+            passive: true,
+            capture: true,
+        });
+        return () => {
+            window.removeEventListener('scroll', onScroll, { capture: true });
+            clearTimeout(settleTimer);
+        };
+    }, []);
+
+    return null;
+}


### PR DESCRIPTION
## Summary

- Scrolling slides annotated tokens under a stationary cursor. Browsers re-run hit-testing on scroll, so the cursor's last known position gets real `pointerenter`/`pointerleave` events with no mouse movement at all.
- `fumadocs-twoslash`'s `Popup` schedules open/close purely off those events, so it flaps open and closed while scrolling through a code block dense with hoverable tokens — worst on [`reference/helpers.mdx`](https://stitchapi.dev/docs/reference/helpers) (14 twoslash blocks, 76 hover targets on one page — more than double any other reference page).
- `TwoslashScrollGuard` stamps `data-scrolling="true"` on `<html>` for the duration of any scroll (`capture: true` also catches nested scrollers, e.g. a wide code block's own horizontal scrollbar) and a CSS rule disables `pointer-events` on `.twoslash-hover` triggers for that window, so the spurious hit-test events never reach the popup logic.
- Mounted site-wide (root layout), since blog posts use twoslash too — this is a bug class, not a one-page fix.

## Test plan

- [x] `check:types` and `check:lint` pass for `apps/docs`
- [x] Full pre-push suite passes (format, lint, contract, unknown-keys, changelog, media-fresh, typecheck, typecheck-d, test, exports, build-docs, yakir)
- [x] Verified live in the dev server: real scroll input dispatches genuine `scroll` events → `data-scrolling` flips to `"true"` and settles back to `"false"` after the scroll quiets down → confirmed the CSS rule correctly flips `.twoslash-hover` between `pointer-events: auto` and `none` on that attribute
- [ ] Could not get a clean before/after visual capture of the flicker itself — the automated browser tool available in this session persistently reports the tab as backgrounded (`document.hidden`), which suppresses programmatic-scroll event dispatch and made screenshot-based mid-scroll capture unreliable. The fix is verified structurally and mechanistically (see above); a manual scroll-through on `/docs/reference/helpers` in a real browser is the remaining confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)